### PR TITLE
Added the Giratina XY184 Promo

### DIFF
--- a/json/cards/XY Black Star Promos.json
+++ b/json/cards/XY Black Star Promos.json
@@ -8749,5 +8749,59 @@
     ],
     "nationalPokedexNumber": 359,
     "imageUrlHiRes": "https://images.pokemontcg.io/xyp/XY178_hires.png"
+  },
+  {
+    "id": "xyp-XY184",
+    "name": "Giratina",
+    "imageUrl": "https://images.pokemontcg.io/xyp/XY184.png",
+    "subtype": "Basic",
+    "supertype": "Pokémon",
+    "ability": {
+      "name": "Devour Light",
+      "text": "Each Pokemon BREAK has no Abilities (this includes Abilities of its previous Evolution).",
+      "type": "Ability"
+    },
+    "hp": "130",
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
+    "number": "XY184",
+    "artist": "5ban Graphics",
+    "rarity": "Rare Holo",
+    "series": "XY",
+    "set": "XY Black Star Promos",
+    "setCode": "xyp",
+    "types": [
+      "Psychic"
+    ],
+    "attacks": [
+      {
+        "name": "Shadow Claw",
+        "cost": [
+          "Psychic",
+          "Psychic",
+          "Colorless",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 4,
+        "damage": "110",
+        "text": "Discard a random card from your opponent's hand."
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Darkness",
+        "value": "×2"
+      }
+    ],
+    "resistances": [
+      {
+        "type": "Fighting",
+        "value": "-20"
+      }
+    ],
+    "nationalPokedexNumber": 487,
+    "imageUrlHiRes": "https://images.pokemontcg.io/xyp/XY184_hires.png"
   }
 ]


### PR DESCRIPTION
Added the Giratina XY184 Promo to the XY Black Start Promos set json file

I updated the `imageUrl` and `imageUrlHiRes` to what they value _should_ be, but obviously don't exist

Here is a copy of the `hiRes`: https://pkmncards.com/wp-content/uploads/giratina-xy-promos-xy184.jpg

Here is a copy of the `imageUrl`: https://52f4e29a8321344e30ae-0f55c9129972ac85d6b1f4e703468e6b.ssl.cf2.rackcdn.com/products/pictures/1109114.jpg