### PR TITLE
Sort energy

### DIFF
--- a/json/cards/Aquapolis.json
+++ b/json/cards/Aquapolis.json
@@ -33,9 +33,9 @@
       {
         "name": "Reflect Energy",
         "cost": [
-          "Colorless",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -85,9 +85,9 @@
       {
         "name": "Reflect Energy",
         "cost": [
-          "Colorless",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -227,8 +227,8 @@
       {
         "name": "Spider Force",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
@@ -270,8 +270,8 @@
       {
         "name": "Spider Force",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
@@ -316,9 +316,9 @@
       {
         "name": "Aqua Sonic",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -363,9 +363,9 @@
       {
         "name": "Aqua Sonic",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -411,9 +411,9 @@
       {
         "name": "Knife Leaf",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30×",
@@ -465,9 +465,9 @@
       {
         "name": "Knife Leaf",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30×",
@@ -614,8 +614,8 @@
       {
         "name": "Swift",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -717,9 +717,9 @@
       {
         "name": "Burning Fang",
         "cost": [
+          "Fire",
           "Colorless",
-          "Colorless",
-          "Fire"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -764,8 +764,8 @@
       {
         "name": "Swift",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -807,9 +807,9 @@
       {
         "name": "Damage Blast",
         "cost": [
+          "Psychic",
           "Colorless",
-          "Colorless",
-          "Psychic"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -892,9 +892,9 @@
       {
         "name": "Burning Fang",
         "cost": [
+          "Fire",
           "Colorless",
-          "Colorless",
-          "Fire"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -983,8 +983,8 @@
       {
         "name": "Fireworks",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -993,9 +993,9 @@
       {
         "name": "Dark Impact",
         "cost": [
+          "Darkness",
           "Colorless",
-          "Colorless",
-          "Dark"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -1043,9 +1043,9 @@
       {
         "name": "Damage Blast",
         "cost": [
+          "Psychic",
           "Colorless",
-          "Colorless",
-          "Psychic"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -1139,9 +1139,9 @@
       {
         "name": "Spiral Aura",
         "cost": [
+          "Psychic",
           "Colorless",
-          "Colorless",
-          "Psychic"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -1238,9 +1238,9 @@
       {
         "name": "Lateral Eggsplosion",
         "cost": [
+          "Psychic",
           "Colorless",
-          "Colorless",
-          "Psychic"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -1289,9 +1289,9 @@
       {
         "name": "Burn Up",
         "cost": [
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
@@ -1338,10 +1338,10 @@
       {
         "name": "Rapids",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
@@ -1381,8 +1381,8 @@
       {
         "name": "Fireworks",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -1391,9 +1391,9 @@
       {
         "name": "Dark Impact",
         "cost": [
+          "Darkness",
           "Colorless",
-          "Colorless",
-          "Dark"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -1490,9 +1490,9 @@
       {
         "name": "Spiral Aura",
         "cost": [
+          "Psychic",
           "Colorless",
-          "Colorless",
-          "Psychic"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -1683,8 +1683,8 @@
       {
         "name": "Meditate",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10+",
@@ -1693,9 +1693,9 @@
       {
         "name": "Confuse Ray",
         "cost": [
+          "Psychic",
           "Colorless",
-          "Colorless",
-          "Psychic"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
@@ -1742,10 +1742,10 @@
       {
         "name": "Giant Horn",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50+",
@@ -1798,10 +1798,10 @@
       {
         "name": "Rapids",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
@@ -1850,9 +1850,9 @@
       {
         "name": "Roasting Heat",
         "cost": [
+          "Fire",
           "Colorless",
-          "Colorless",
-          "Fire"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40+",
@@ -1949,9 +1949,9 @@
       {
         "name": "Smokescreen",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -2038,8 +2038,8 @@
       {
         "name": "Snatch",
         "cost": [
-          "Colorless",
-          "Metal"
+          "Metal",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -2156,9 +2156,9 @@
       {
         "name": "Shuffle Attack",
         "cost": [
+          "Psychic",
           "Colorless",
-          "Colorless",
-          "Psychic"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -2257,10 +2257,10 @@
       {
         "name": "Iron Smash",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Metal",
-          "Metal"
+          "Metal",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50+",
@@ -2362,10 +2362,10 @@
       {
         "name": "Giant Horn",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50+",
@@ -2420,9 +2420,9 @@
       {
         "name": "Roasting Heat",
         "cost": [
+          "Fire",
           "Colorless",
-          "Colorless",
-          "Fire"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40+",
@@ -2466,9 +2466,9 @@
       {
         "name": "Hypno Wave",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -2510,8 +2510,8 @@
       {
         "name": "Poison Sting",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -2557,9 +2557,9 @@
       {
         "name": "Smokescreen",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -2754,7 +2754,7 @@
       {
         "name": "Destructive Roar",
         "cost": [
-          "Dark"
+          "Darkness"
         ],
         "convertedEnergyCost": 1,
         "damage": "",
@@ -2763,9 +2763,9 @@
       {
         "name": "Tail Slap",
         "cost": [
+          "Darkness",
           "Colorless",
-          "Colorless",
-          "Dark"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -2774,11 +2774,11 @@
       {
         "name": "Gigacrush",
         "cost": [
+          "Darkness",
+          "Darkness",
           "Colorless",
           "Colorless",
-          "Colorless",
-          "Dark",
-          "Dark"
+          "Colorless"
         ],
         "convertedEnergyCost": 5,
         "damage": "60",
@@ -2877,8 +2877,8 @@
       {
         "name": "Karate Chop",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -2887,9 +2887,9 @@
       {
         "name": "Sudden Charge",
         "cost": [
+          "Fighting",
           "Colorless",
-          "Colorless",
-          "Fighting"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -2988,9 +2988,9 @@
       {
         "name": "Corrosive Acid",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -3089,9 +3089,9 @@
       {
         "name": "Gallop",
         "cost": [
+          "Fire",
           "Colorless",
-          "Colorless",
-          "Fire"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -3145,10 +3145,10 @@
       {
         "name": "Lightning Storm",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -3200,8 +3200,8 @@
       {
         "name": "Snatch",
         "cost": [
-          "Colorless",
-          "Metal"
+          "Metal",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -3258,8 +3258,8 @@
       {
         "name": "Energy Cannon",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
@@ -3308,9 +3308,9 @@
       {
         "name": "Shuffle Attack",
         "cost": [
+          "Psychic",
           "Colorless",
-          "Colorless",
-          "Psychic"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -3363,10 +3363,10 @@
       {
         "name": "Iron Smash",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Metal",
-          "Metal"
+          "Metal",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50+",
@@ -3465,9 +3465,9 @@
       {
         "name": "Hypno Wave",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -3509,8 +3509,8 @@
       {
         "name": "Poison Sting",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -3606,7 +3606,7 @@
       {
         "name": "Destructive Roar",
         "cost": [
-          "Dark"
+          "Darkness"
         ],
         "convertedEnergyCost": 1,
         "damage": "",
@@ -3615,9 +3615,9 @@
       {
         "name": "Tail Slap",
         "cost": [
+          "Darkness",
           "Colorless",
-          "Colorless",
-          "Dark"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -3626,11 +3626,11 @@
       {
         "name": "Gigacrush",
         "cost": [
+          "Darkness",
+          "Darkness",
           "Colorless",
           "Colorless",
-          "Colorless",
-          "Dark",
-          "Dark"
+          "Colorless"
         ],
         "convertedEnergyCost": 5,
         "damage": "60",
@@ -3735,9 +3735,9 @@
       {
         "name": "Corrosive Acid",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -3843,10 +3843,10 @@
       {
         "name": "Lightning Storm",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -3891,8 +3891,8 @@
       {
         "name": "Blot",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -4000,9 +4000,9 @@
       {
         "name": "Spark",
         "cost": [
-          "Colorless",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -4152,9 +4152,9 @@
       {
         "name": "Distortion Beam",
         "cost": [
+          "Psychic",
           "Colorless",
-          "Colorless",
-          "Psychic"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -4193,8 +4193,8 @@
       {
         "name": "Ember",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -4303,8 +4303,8 @@
       {
         "name": "Sleepy Ball",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
@@ -4357,9 +4357,9 @@
       {
         "name": "Bone Rush",
         "cost": [
+          "Fighting",
           "Colorless",
-          "Colorless",
-          "Fighting"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50×",
@@ -4621,9 +4621,9 @@
       {
         "name": "Undulate",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -4764,8 +4764,8 @@
       {
         "name": "Gooey Thread",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -4857,8 +4857,8 @@
       {
         "name": "Thundershock",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -4910,8 +4910,8 @@
       {
         "name": "Double Razor Leaf",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30×",
@@ -5222,8 +5222,8 @@
       {
         "name": "Confuse Ray",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
@@ -5728,8 +5728,8 @@
       {
         "name": "Rush",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10×",
@@ -5789,9 +5789,9 @@
       {
         "name": "Triple Spin",
         "cost": [
+          "Fighting",
           "Colorless",
-          "Colorless",
-          "Fighting"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20×",
@@ -5977,8 +5977,8 @@
       {
         "name": "Flare",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -6020,8 +6020,8 @@
       {
         "name": "Feint Attack",
         "cost": [
-          "Colorless",
-          "Dark"
+          "Darkness",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -6232,8 +6232,8 @@
       {
         "name": "Magnetic Bomb",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
@@ -6336,8 +6336,8 @@
       {
         "name": "Tail Slap",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -6429,8 +6429,8 @@
       {
         "name": "Mind Shock",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -6574,8 +6574,8 @@
       {
         "name": "Crush",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20×",
@@ -6626,8 +6626,8 @@
       {
         "name": "Spore Evolution",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -6678,8 +6678,8 @@
       {
         "name": "Rollout",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -6737,9 +6737,9 @@
       {
         "name": "Super Slice",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "",
@@ -6787,8 +6787,8 @@
       {
         "name": "Ember",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -6984,8 +6984,8 @@
       {
         "name": "Swift",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -7186,7 +7186,7 @@
       {
         "name": "Rob",
         "cost": [
-          "Dark"
+          "Darkness"
         ],
         "convertedEnergyCost": 1,
         "damage": "",
@@ -7297,9 +7297,9 @@
       {
         "name": "Double Kick",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30×",
@@ -7542,8 +7542,8 @@
       {
         "name": "Wave Splash",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -8114,10 +8114,10 @@
       {
         "name": "Dual Burn",
         "cost": [
-          "Colorless",
           "Lightning",
           "Psychic",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -8173,10 +8173,10 @@
       {
         "name": "Steam Blast",
         "cost": [
-          "Colorless",
           "Fire",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
@@ -8218,9 +8218,9 @@
       {
         "name": "Poison Horn",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",

--- a/json/cards/Arceus.json
+++ b/json/cards/Arceus.json
@@ -298,7 +298,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for up to 3 in any combination of Burmy and Wormadam, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
       },
@@ -1394,7 +1394,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Look at the top 5 cards of your deck, choose 1 of them, and put it into your hand. Shuffle the other cards back into your deck."
       }
@@ -1777,7 +1777,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for a card that evolves from 1 of your Pokémon and put it onto that Pokémon. (This counts as evolving that Pokémon.) If you do, put 1 damage counter on Spiritomb. Shuffle your deck afterward."
       },
@@ -5373,7 +5373,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "If you have 6 Arceus in play and each of them is a different type, search your deck for up to 6 basic Energy cards. Attach each of those Energy cards to a different Pokémon you have in play. Shuffle your deck afterward."
       },

--- a/json/cards/BW Black Star Promos.json
+++ b/json/cards/BW Black Star Promos.json
@@ -4644,7 +4644,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
       }

--- a/json/cards/Base Set 2.json
+++ b/json/cards/Base Set 2.json
@@ -428,9 +428,9 @@
       {
         "name": "Special Punch",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -471,9 +471,9 @@
       {
         "name": "Thunder Wave",
         "cost": [
-          "Colorless",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -482,10 +482,10 @@
       {
         "name": "Selfdestruct",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
@@ -530,8 +530,8 @@
       {
         "name": "Psychic",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10+",
@@ -582,9 +582,9 @@
       {
         "name": "Thrash",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -638,8 +638,8 @@
       {
         "name": "Boyfriends",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
@@ -648,10 +648,10 @@
       {
         "name": "Mega Punch",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
@@ -804,9 +804,9 @@
       {
         "name": "Water Gun",
         "cost": [
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -815,10 +815,10 @@
       {
         "name": "Whirlpool",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "40",
@@ -859,9 +859,9 @@
       {
         "name": "Agility",
         "cost": [
+          "Lightning",
           "Colorless",
-          "Colorless",
-          "Lightning"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
@@ -870,10 +870,10 @@
       {
         "name": "Thunder",
         "cost": [
-          "Colorless",
           "Lightning",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -1081,10 +1081,10 @@
       {
         "name": "Thunder",
         "cost": [
-          "Colorless",
           "Lightning",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -1254,9 +1254,9 @@
       {
         "name": "Slash",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -1324,8 +1324,8 @@
       {
         "name": "Thunderpunch",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
@@ -1481,8 +1481,8 @@
       {
         "name": "Meditate",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10+",
@@ -1594,10 +1594,10 @@
       {
         "name": "Guillotine",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
@@ -1800,9 +1800,9 @@
       {
         "name": "Flamethrower",
         "cost": [
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -1811,10 +1811,10 @@
       {
         "name": "Take Down",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
@@ -1923,9 +1923,9 @@
       {
         "name": "Flamethrower",
         "cost": [
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -1971,9 +1971,9 @@
       {
         "name": "Aurora Beam",
         "cost": [
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -1982,10 +1982,10 @@
       {
         "name": "Ice Beam",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "30",
@@ -2286,8 +2286,8 @@
       {
         "name": "Flare",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -2385,9 +2385,9 @@
       {
         "name": "Vine Whip",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -2451,9 +2451,9 @@
       {
         "name": "Meditate",
         "cost": [
-          "Colorless",
           "Psychic",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20+",
@@ -2506,9 +2506,9 @@
       {
         "name": "Super Psy",
         "cost": [
-          "Colorless",
           "Psychic",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -2669,9 +2669,9 @@
       {
         "name": "Karate Chop",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "",
@@ -2680,10 +2680,10 @@
       {
         "name": "Submission",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -2789,9 +2789,9 @@
       {
         "name": "Flamethrower",
         "cost": [
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -2845,9 +2845,9 @@
       {
         "name": "Call for Friend",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "",
@@ -2903,9 +2903,9 @@
       {
         "name": "Double Kick",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30×",
@@ -2949,9 +2949,9 @@
       {
         "name": "Double Kick",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30×",
@@ -2960,10 +2960,10 @@
       {
         "name": "Horn Drill",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
@@ -3126,9 +3126,9 @@
       {
         "name": "Doubleslap",
         "cost": [
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30×",
@@ -3233,9 +3233,9 @@
       {
         "name": "Horn Attack",
         "cost": [
+          "Fighting",
           "Colorless",
-          "Colorless",
-          "Fighting"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -3306,8 +3306,8 @@
       {
         "name": "Waterfall",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -3450,8 +3450,8 @@
       {
         "name": "Withdraw",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -3460,9 +3460,9 @@
       {
         "name": "Bite",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -3747,8 +3747,8 @@
       {
         "name": "Ember",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -4061,8 +4061,8 @@
       {
         "name": "Destiny Bond",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -4256,8 +4256,8 @@
       {
         "name": "Selfdestruct",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
@@ -4670,8 +4670,8 @@
       {
         "name": "Thunder Jolt",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -4814,9 +4814,9 @@
       {
         "name": "Horn Attack",
         "cost": [
+          "Fighting",
           "Colorless",
-          "Colorless",
-          "Fighting"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -4980,8 +4980,8 @@
       {
         "name": "Withdraw",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -5035,9 +5035,9 @@
       {
         "name": "Star Freeze",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
@@ -5121,8 +5121,8 @@
       {
         "name": "Bind",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -5185,8 +5185,8 @@
       {
         "name": "Leech Life",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10",

--- a/json/cards/Base.json
+++ b/json/cards/Base.json
@@ -370,9 +370,9 @@
       {
         "name": "Special Punch",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -420,10 +420,10 @@
       {
         "name": "Seismic Toss",
         "cost": [
-          "Colorless",
           "Fighting",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -464,9 +464,9 @@
       {
         "name": "Thunder Wave",
         "cost": [
-          "Colorless",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -475,10 +475,10 @@
       {
         "name": "Selfdestruct",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
@@ -523,8 +523,8 @@
       {
         "name": "Psychic",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10+",
@@ -575,9 +575,9 @@
       {
         "name": "Thrash",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -685,9 +685,9 @@
       {
         "name": "Water Gun",
         "cost": [
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -696,10 +696,10 @@
       {
         "name": "Whirlpool",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "40",
@@ -740,9 +740,9 @@
       {
         "name": "Agility",
         "cost": [
+          "Lightning",
           "Colorless",
-          "Colorless",
-          "Lightning"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
@@ -751,10 +751,10 @@
       {
         "name": "Thunder",
         "cost": [
-          "Colorless",
           "Lightning",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -846,10 +846,10 @@
       {
         "name": "Thunder",
         "cost": [
-          "Colorless",
           "Lightning",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -1019,9 +1019,9 @@
       {
         "name": "Slash",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -1089,8 +1089,8 @@
       {
         "name": "Thunderpunch",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
@@ -1246,9 +1246,9 @@
       {
         "name": "Flamethrower",
         "cost": [
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -1257,10 +1257,10 @@
       {
         "name": "Take Down",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
@@ -1312,9 +1312,9 @@
       {
         "name": "Flamethrower",
         "cost": [
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -1360,9 +1360,9 @@
       {
         "name": "Aurora Beam",
         "cost": [
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -1371,10 +1371,10 @@
       {
         "name": "Ice Beam",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "30",
@@ -1514,8 +1514,8 @@
       {
         "name": "Flare",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -1613,9 +1613,9 @@
       {
         "name": "Vine Whip",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -1679,9 +1679,9 @@
       {
         "name": "Meditate",
         "cost": [
-          "Colorless",
           "Psychic",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20+",
@@ -1734,9 +1734,9 @@
       {
         "name": "Super Psy",
         "cost": [
-          "Colorless",
           "Psychic",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -1838,9 +1838,9 @@
       {
         "name": "Karate Chop",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "",
@@ -1849,10 +1849,10 @@
       {
         "name": "Submission",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -1958,9 +1958,9 @@
       {
         "name": "Flamethrower",
         "cost": [
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -2004,9 +2004,9 @@
       {
         "name": "Double Kick",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30×",
@@ -2015,10 +2015,10 @@
       {
         "name": "Horn Drill",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
@@ -2072,9 +2072,9 @@
       {
         "name": "Doubleslap",
         "cost": [
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30×",
@@ -2279,8 +2279,8 @@
       {
         "name": "Withdraw",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -2289,9 +2289,9 @@
       {
         "name": "Bite",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -2470,8 +2470,8 @@
       {
         "name": "Ember",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -2672,8 +2672,8 @@
       {
         "name": "Destiny Bond",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -2812,8 +2812,8 @@
       {
         "name": "Selfdestruct",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
@@ -3069,8 +3069,8 @@
       {
         "name": "Thunder Jolt",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -3314,8 +3314,8 @@
       {
         "name": "Withdraw",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -3369,9 +3369,9 @@
       {
         "name": "Star Freeze",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
@@ -3455,8 +3455,8 @@
       {
         "name": "Bind",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",

--- a/json/cards/Burning Shadows.json
+++ b/json/cards/Burning Shadows.json
@@ -1376,7 +1376,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Asleep."
       },
@@ -4202,7 +4202,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "During your next turn, this Pokémon's Bite attack's base damage is 60."
       },
@@ -4262,7 +4262,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10+",
         "text": "If this Pokémon has a Pokémon Tool card attached to it, this attack does 50 more damage."
       },
@@ -4318,7 +4318,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for Alolan Grimer and put it onto your Bench. Then, shuffle your deck."
       },
@@ -4407,7 +4407,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. The new Active Pokémon is now Burned, Paralyzed, and Poisoned. (You can’t use more than 1 GX attack in a game.)"
       }
@@ -6822,7 +6822,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. The new Active Pokémon is now Burned, Paralyzed, and Poisoned. (You can’t use more than 1 GX attack in a game.)"
       }
@@ -7779,7 +7779,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. The new Active Pokémon is now Burned, Paralyzed, and Poisoned. (You can’t use more than 1 GX attack in a game.)"
       }

--- a/json/cards/Call of Legends.json
+++ b/json/cards/Call of Legends.json
@@ -1215,7 +1215,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Shuffle your hand into your deck, then draw 6 cards. Cleffa is now Asleep."
       }
@@ -1848,7 +1848,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "30",
         "text": "This attack's damage isn't affected by Weakness or Resistance. Tyrogue is now Asleep."
       }
@@ -2387,7 +2387,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "The Defending Pokémon is now Burned. Magby is now Asleep."
       }
@@ -2425,7 +2425,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Put the top card of your opponent's deck in the Lost Zone. Mime Jr. is now Asleep."
       }

--- a/json/cards/Crimson Invasion.json
+++ b/json/cards/Crimson Invasion.json
@@ -537,7 +537,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "For each Energy attached to your opponent's Pokémon, attach a Fire Energy card from your discard pile to your Pokémon in any way you like."
       },
@@ -1545,7 +1545,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent's next turn."
       },

--- a/json/cards/Crystal Guardians.json
+++ b/json/cards/Crystal Guardians.json
@@ -4144,8 +4144,8 @@
       {
         "name": "Burn Away",
         "cost": [
-          "Fighting",
           "Fire",
+          "Fighting",
           "Colorless",
           "Colorless"
         ],

--- a/json/cards/Delta Species.json
+++ b/json/cards/Delta Species.json
@@ -262,7 +262,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "50",
         "text": "You may return an Energy card attached to Flareon to your hand. If you do, the Defending Pokémon is now Burned."
       }
@@ -986,8 +986,8 @@
       {
         "name": "Feint Attack",
         "cost": [
-          "Metal",
-          "Darkness"
+          "Darkness",
+          "Metal"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -1409,7 +1409,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "30",
         "text": "If Porygon2 has a Technical Machine card attached to it, the Defending Pokémon is now Asleep and Burned."
       }
@@ -2352,7 +2352,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "30",
         "text": ""
       },
@@ -2904,7 +2904,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "30",
         "text": ""
       }
@@ -3229,7 +3229,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10+",
         "text": "Does 10 damage plus 10 more damage for each damage counter on Cubone."
       }
@@ -3882,7 +3882,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "20+",
         "text": "Flip a coin. If heads, this attack does 20 damage plus 10 more damage."
       }
@@ -4278,7 +4278,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10+",
         "text": "Flip a coin. If heads, this attack does 10 damage plus 20 more damage."
       }
@@ -4654,7 +4654,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Flip 2 coins. For each head, search your deck for a Basic Pokémon card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
       }
@@ -4680,7 +4680,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for a Basic Pokémon (excluding Pokémon-ex) and put it onto your Bench. Shuffle your deck afterward."
       }

--- a/json/cards/Diamond & Pearl.json
+++ b/json/cards/Diamond & Pearl.json
@@ -2281,7 +2281,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Choose 1 card from your opponent's hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
       }
@@ -2329,7 +2329,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for a Trainer card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
       }
@@ -2612,7 +2612,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for a Lightning Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
       }
@@ -3022,7 +3022,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for a  grass Basic Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
       }
@@ -3743,7 +3743,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Put any 1 card from your discard pile into your hand."
       }
@@ -3843,7 +3843,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Flip a coin. If heads, your opponent can't play any Trainer cards from his or her hand during your opponent's next turn, and any damage done to Bonsly by attacks is reduced by 30 (after applying Weakness and Resistance)."
       }
@@ -4096,7 +4096,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10",
         "text": ""
       },
@@ -4207,7 +4207,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Draw a card."
       }
@@ -5011,7 +5011,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10",
         "text": ""
       },
@@ -5570,7 +5570,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10",
         "text": ""
       },

--- a/json/cards/Dragon.json
+++ b/json/cards/Dragon.json
@@ -551,8 +551,8 @@
       {
         "name": "Dragon Claw",
         "cost": [
-          "Water",
           "Fire",
+          "Water",
           "Colorless",
           "Colorless"
         ],
@@ -1008,8 +1008,8 @@
       {
         "name": "Dragon Flame",
         "cost": [
-          "Water",
           "Fire",
+          "Water",
           "Colorless"
         ],
         "convertedEnergyCost": 3,
@@ -1054,8 +1054,8 @@
       {
         "name": "Rolling Attack",
         "cost": [
-          "Water",
           "Fire",
+          "Water",
           "Colorless"
         ],
         "convertedEnergyCost": 3,
@@ -2666,8 +2666,8 @@
       {
         "name": "Dragon Eye",
         "cost": [
-          "Water",
-          "Fire"
+          "Fire",
+          "Water"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -3550,7 +3550,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "After your attack, remove from Nincada the number of damage counters equal to the damage you did to the Defending Pokémon. If Nincada has fewer damage counters than that, remove all of them."
       }
@@ -4637,8 +4637,8 @@
       {
         "name": "Mist Ball",
         "cost": [
-          "Water",
           "Fire",
+          "Water",
           "Colorless"
         ],
         "convertedEnergyCost": 3,

--- a/json/cards/Emerald.json
+++ b/json/cards/Emerald.json
@@ -40,7 +40,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "50+",
         "text": "If the Defending Pokémon already has any damage counters on it, this attack does 50 damage plus 20 more damage."
       }

--- a/json/cards/Expedition Base Set.json
+++ b/json/cards/Expedition Base Set.json
@@ -29,9 +29,9 @@
       {
         "name": "Syncroblast",
         "cost": [
+          "Psychic",
           "Colorless",
-          "Colorless",
-          "Psychic"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "",
@@ -77,10 +77,10 @@
       {
         "name": "Lightning Strike",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "",
@@ -176,9 +176,9 @@
       {
         "name": "Energy Cannon",
         "cost": [
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40+",
@@ -220,9 +220,9 @@
       {
         "name": "Spiral Drain",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -369,9 +369,9 @@
       {
         "name": "Auto Fire",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20×",
@@ -417,9 +417,9 @@
       {
         "name": "Dragon Tail",
         "cost": [
-          "Fighting",
+          "Water",
           "Lightning",
-          "Water"
+          "Fighting"
         ],
         "convertedEnergyCost": 3,
         "damage": "40×",
@@ -462,9 +462,9 @@
       {
         "name": "Magnitude",
         "cost": [
+          "Fighting",
           "Colorless",
-          "Colorless",
-          "Fighting"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -572,10 +572,10 @@
       {
         "name": "Rending Jaws",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "",
@@ -620,9 +620,9 @@
       {
         "name": "Hide in Shadows",
         "cost": [
-          "Colorless",
           "Psychic",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -676,10 +676,10 @@
       {
         "name": "Rock Tumble",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -729,9 +729,9 @@
       {
         "name": "Giant Claw",
         "cost": [
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "",
@@ -777,10 +777,10 @@
       {
         "name": "Iron Fist",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50+",
@@ -865,10 +865,10 @@
       {
         "name": "Poisonpowder",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
@@ -913,8 +913,8 @@
       {
         "name": "Super Psywave",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -963,9 +963,9 @@
       {
         "name": "Psychic",
         "cost": [
-          "Colorless",
           "Psychic",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20+",
@@ -1005,8 +1005,8 @@
       {
         "name": "Mislead",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -1152,10 +1152,10 @@
       {
         "name": "Water Punch",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "40+",
@@ -1204,9 +1204,9 @@
       {
         "name": "Shock Bolt",
         "cost": [
-          "Colorless",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
@@ -1253,9 +1253,9 @@
       {
         "name": "Flame Tail",
         "cost": [
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -1295,8 +1295,8 @@
       {
         "name": "Steel Beak",
         "cost": [
-          "Colorless",
-          "Metal"
+          "Metal",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
@@ -1359,10 +1359,10 @@
       {
         "name": "Super Singe",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
@@ -1410,10 +1410,10 @@
       {
         "name": "Stamp",
         "cost": [
-          "Dark",
-          "Dark",
-          "Dark",
-          "Dark"
+          "Darkness",
+          "Darkness",
+          "Darkness",
+          "Darkness"
         ],
         "convertedEnergyCost": 4,
         "damage": "50+",
@@ -1465,10 +1465,10 @@
       {
         "name": "Body Slam",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "40",
@@ -1514,8 +1514,8 @@
       {
         "name": "Petal Dance",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30×",
@@ -1556,8 +1556,8 @@
       {
         "name": "Foul Gas",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -1566,9 +1566,9 @@
       {
         "name": "Misfire",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
@@ -1614,9 +1614,9 @@
       {
         "name": "Syncroblast",
         "cost": [
+          "Psychic",
           "Colorless",
-          "Colorless",
-          "Psychic"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "",
@@ -1662,10 +1662,10 @@
       {
         "name": "Lightning Strike",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "",
@@ -1811,9 +1811,9 @@
       {
         "name": "Energy Cannon",
         "cost": [
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40+",
@@ -1855,9 +1855,9 @@
       {
         "name": "Spiral Drain",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -1907,9 +1907,9 @@
       {
         "name": "Flamethrower",
         "cost": [
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
@@ -2056,9 +2056,9 @@
       {
         "name": "Auto Fire",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20×",
@@ -2104,9 +2104,9 @@
       {
         "name": "Dragon Tail",
         "cost": [
-          "Fighting",
+          "Water",
           "Lightning",
-          "Water"
+          "Fighting"
         ],
         "convertedEnergyCost": 3,
         "damage": "40×",
@@ -2149,9 +2149,9 @@
       {
         "name": "Magnitude",
         "cost": [
+          "Fighting",
           "Colorless",
-          "Colorless",
-          "Fighting"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -2262,9 +2262,9 @@
       {
         "name": "Double Claw",
         "cost": [
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -2311,10 +2311,10 @@
       {
         "name": "Rending Jaws",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "",
@@ -2359,9 +2359,9 @@
       {
         "name": "Hide in Shadows",
         "cost": [
-          "Colorless",
           "Psychic",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -2415,10 +2415,10 @@
       {
         "name": "Rock Tumble",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -2468,9 +2468,9 @@
       {
         "name": "Giant Claw",
         "cost": [
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "",
@@ -2516,10 +2516,10 @@
       {
         "name": "Iron Fist",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50+",
@@ -2609,9 +2609,9 @@
       {
         "name": "Solarbeam",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -2663,10 +2663,10 @@
       {
         "name": "Poisonpowder",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "40",
@@ -2711,8 +2711,8 @@
       {
         "name": "Super Psywave",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -2761,9 +2761,9 @@
       {
         "name": "Psychic",
         "cost": [
-          "Colorless",
           "Psychic",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20+",
@@ -2803,8 +2803,8 @@
       {
         "name": "Mislead",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -2950,10 +2950,10 @@
       {
         "name": "Water Punch",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "40+",
@@ -3002,9 +3002,9 @@
       {
         "name": "Shock Bolt",
         "cost": [
-          "Colorless",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
@@ -3051,9 +3051,9 @@
       {
         "name": "Flame Tail",
         "cost": [
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -3093,8 +3093,8 @@
       {
         "name": "Steel Beak",
         "cost": [
-          "Colorless",
-          "Metal"
+          "Metal",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
@@ -3161,9 +3161,9 @@
       {
         "name": "Thermal Blast",
         "cost": [
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -3209,10 +3209,10 @@
       {
         "name": "Super Singe",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
@@ -3260,10 +3260,10 @@
       {
         "name": "Stamp",
         "cost": [
-          "Dark",
-          "Dark",
-          "Dark",
-          "Dark"
+          "Darkness",
+          "Darkness",
+          "Darkness",
+          "Darkness"
         ],
         "convertedEnergyCost": 4,
         "damage": "50+",
@@ -3319,9 +3319,9 @@
       {
         "name": "Fury Swipes",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30×",
@@ -3367,10 +3367,10 @@
       {
         "name": "Body Slam",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "40",
@@ -3416,8 +3416,8 @@
       {
         "name": "Petal Dance",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30×",
@@ -3458,8 +3458,8 @@
       {
         "name": "Foul Gas",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -3468,9 +3468,9 @@
       {
         "name": "Misfire",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
@@ -3519,8 +3519,8 @@
       {
         "name": "Razor Leaf",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -3634,9 +3634,9 @@
       {
         "name": "Flamethrower",
         "cost": [
+          "Fire",
           "Colorless",
-          "Colorless",
-          "Fire"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -3735,8 +3735,8 @@
       {
         "name": "Spiral Wave",
         "cost": [
-          "Lightning",
-          "Water"
+          "Water",
+          "Lightning"
         ],
         "convertedEnergyCost": 2,
         "damage": "20×",
@@ -3782,8 +3782,8 @@
       {
         "name": "Reflect Energy",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -3836,9 +3836,9 @@
       {
         "name": "Thunder Jolt",
         "cost": [
-          "Colorless",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -3881,8 +3881,8 @@
       {
         "name": "Razor Leaf",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -3891,9 +3891,9 @@
       {
         "name": "Foul Odor",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -3939,8 +3939,8 @@
       {
         "name": "Rock Hurl",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -3949,9 +3949,9 @@
       {
         "name": "Rock Slide",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -3994,8 +3994,8 @@
       {
         "name": "Nightmare",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -4004,8 +4004,8 @@
       {
         "name": "Dream Eater",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -4063,9 +4063,9 @@
       {
         "name": "Stretch Kick",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -4105,8 +4105,8 @@
       {
         "name": "Sleep Seed",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -4115,9 +4115,9 @@
       {
         "name": "Vine Whip",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -4159,8 +4159,8 @@
       {
         "name": "Ice Punch",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
@@ -4169,9 +4169,9 @@
       {
         "name": "Powder Snow",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
@@ -4220,8 +4220,8 @@
       {
         "name": "Confuse Ray",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -4274,9 +4274,9 @@
       {
         "name": "Mega Kick",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -4318,8 +4318,8 @@
       {
         "name": "Flaming Punch",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
@@ -4328,9 +4328,9 @@
       {
         "name": "Thrash",
         "cost": [
+          "Fire",
           "Colorless",
-          "Colorless",
-          "Fire"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -4479,9 +4479,9 @@
       {
         "name": "Bubblebeam",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -4568,8 +4568,8 @@
       {
         "name": "Super Singe",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -4735,8 +4735,8 @@
       {
         "name": "Poison Seed",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -4787,8 +4787,8 @@
       {
         "name": "Vine Whip",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -4891,8 +4891,8 @@
       {
         "name": "Flare",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -4943,8 +4943,8 @@
       {
         "name": "Searing Flame",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
@@ -4995,8 +4995,8 @@
       {
         "name": "Double Scratch",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20×",
@@ -5154,8 +5154,8 @@
       {
         "name": "Tackle",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -5164,9 +5164,9 @@
       {
         "name": "Spike Cannon",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20×",
@@ -5214,8 +5214,8 @@
       {
         "name": "Bone Smash",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -5324,8 +5324,8 @@
       {
         "name": "Ember",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -5412,8 +5412,8 @@
       {
         "name": "Dragon Smash",
         "cost": [
-          "Lightning",
-          "Water"
+          "Water",
+          "Lightning"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -5823,8 +5823,8 @@
       {
         "name": "Mud Slap",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -6115,8 +6115,8 @@
       {
         "name": "Sleep Seed",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
@@ -6225,8 +6225,8 @@
       {
         "name": "Tackle",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -6277,8 +6277,8 @@
       {
         "name": "Rollout",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -6563,8 +6563,8 @@
       {
         "name": "Doubleslap",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20×",
@@ -6770,8 +6770,8 @@
       {
         "name": "Bite",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -6822,8 +6822,8 @@
       {
         "name": "Flare",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",

--- a/json/cards/FireRed & LeafGreen.json
+++ b/json/cards/FireRed & LeafGreen.json
@@ -1578,7 +1578,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Flip a coin. If heads, the Defending Pokémon is now Confused. If tails, the Defending Pokémon is now Poisoned."
       }

--- a/json/cards/Fossil.json
+++ b/json/cards/Fossil.json
@@ -272,8 +272,8 @@
       {
         "name": "Nightmare",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
@@ -527,8 +527,8 @@
       {
         "name": "Sonicboom",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -1022,8 +1022,8 @@
       {
         "name": "Nightmare",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
@@ -1278,8 +1278,8 @@
       {
         "name": "Sonicboom",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -1535,9 +1535,9 @@
       {
         "name": "Poison Fang",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -1689,9 +1689,9 @@
       {
         "name": "Leech Life",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
@@ -1750,9 +1750,9 @@
       {
         "name": "Hyper Beam",
         "cost": [
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
@@ -1796,10 +1796,10 @@
       {
         "name": "Avalanche",
         "cost": [
-          "Colorless",
           "Fighting",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -1863,9 +1863,9 @@
       {
         "name": "Rock Throw",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -1920,9 +1920,9 @@
       {
         "name": "Crabhammer",
         "cost": [
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -2017,8 +2017,8 @@
       {
         "name": "Water Gun",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
@@ -2127,8 +2127,8 @@
       {
         "name": "Water Gun",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
@@ -2137,9 +2137,9 @@
       {
         "name": "Agility",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
@@ -2288,9 +2288,9 @@
       {
         "name": "Selfdestruct",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
@@ -2339,8 +2339,8 @@
       {
         "name": "Wrap",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -2383,8 +2383,8 @@
       {
         "name": "Stone Barrage",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10×",
@@ -2577,8 +2577,8 @@
       {
         "name": "Irongrip",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -2879,8 +2879,8 @@
       {
         "name": "Leech Life",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10",

--- a/json/cards/Generations.json
+++ b/json/cards/Generations.json
@@ -1464,7 +1464,6 @@
     "nationalPokedexNumber": 135,
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/28_hires.png"
   },
-
   {
     "id": "g1-28a",
     "name": "Jolteon-EX",

--- a/json/cards/Great Encounters.json
+++ b/json/cards/Great Encounters.json
@@ -128,7 +128,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for an Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
       },
@@ -1273,7 +1273,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Choose 1 face-down Prize card (yours or your opponent's) and put it face up. If that card is a Supporter card, use the effect of that card as the effect of this attack. (That card remains face up for the rest of the game.)"
       },
@@ -1885,7 +1885,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Flip a coin. If heads, search your deck for any 1 card and put it into your hand. Shuffle your deck afterward."
       },
@@ -1985,7 +1985,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. This attack does 10 damage to the new Defending Pokémon."
       },
@@ -2091,7 +2091,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for up to 2 Grass Energy cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
       },
@@ -2206,7 +2206,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Flip a coin. If heads, the Defending Pokémon can't attack or retreat during your opponent's next turn."
       },
@@ -2254,7 +2254,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Move a Pokémon Tool card attached to 1 of your opponent's Pokémon to another of your opponent's Pokémon (excluding Pokémon that already has a Pokémon Tool attached to it). (If an effect of this attack is prevented, this attack does nothing.)"
       },
@@ -2521,7 +2521,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Choose up to 2 basic Water Energy cards from your hand and attach them to Pelipper. Remove 2 damage counters for each Energy card attached in this way."
       },
@@ -2683,7 +2683,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for up to 3 Trainer cards that have Fossil in their names, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
       },
@@ -3210,7 +3210,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10",
         "text": ""
       },
@@ -3693,7 +3693,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Draw a card. If you didn't play any Supporter card from your hand during this turn, draw 2 more cards."
       }
@@ -3837,7 +3837,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "During your opponent's next turn, any damage done to Kakuna by attacks is reduced by 30 (after applying Weakness and Resistance)."
       },
@@ -4677,7 +4677,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10",
         "text": ""
       },
@@ -4932,7 +4932,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10",
         "text": ""
       },

--- a/json/cards/Guardians Rising.json
+++ b/json/cards/Guardians Rising.json
@@ -904,7 +904,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent's next turn."
       },
@@ -1005,7 +1005,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for up to 2 Pokémon, reveal them, and put them into your hand. Then, shuffle your deck."
       },
@@ -1972,7 +1972,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "During your next turn, this Pokémon has no Retreat Cost."
       },

--- a/json/cards/Gym Challenge.json
+++ b/json/cards/Gym Challenge.json
@@ -26,9 +26,9 @@
       {
         "name": "Heat Tackle",
         "cost": [
+          "Fire",
           "Colorless",
-          "Colorless",
-          "Fire"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -252,10 +252,10 @@
       {
         "name": "Dragon Tornado",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "40",
@@ -309,10 +309,10 @@
       {
         "name": "Hurricane Punch",
         "cost": [
-          "Colorless",
           "Fighting",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "30×",
@@ -364,10 +364,10 @@
       {
         "name": "Tumbling Attack",
         "cost": [
-          "Colorless",
           "Grass",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "40+",
@@ -581,10 +581,10 @@
       {
         "name": "Thundertackle",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "40",
@@ -625,8 +625,8 @@
       {
         "name": "Electro Beam",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
@@ -635,8 +635,8 @@
       {
         "name": "Super Removal",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -753,10 +753,10 @@
       {
         "name": "Psyburn",
         "cost": [
-          "Colorless",
           "Psychic",
           "Psychic",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -806,10 +806,10 @@
       {
         "name": "Electroburn",
         "cost": [
-          "Colorless",
           "Lightning",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "70",
@@ -857,10 +857,10 @@
       {
         "name": "Mega Burn",
         "cost": [
+          "Psychic",
           "Colorless",
           "Colorless",
-          "Colorless",
-          "Psychic"
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -1026,9 +1026,9 @@
       {
         "name": "Earthdrill",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "",
@@ -1077,9 +1077,9 @@
       {
         "name": "Mega Kick",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -1088,10 +1088,10 @@
       {
         "name": "Love Lariat",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50+",
@@ -1132,8 +1132,8 @@
       {
         "name": "Snapping Pincers",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10+",
@@ -1142,9 +1142,9 @@
       {
         "name": "Overhead Toss",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -1244,9 +1244,9 @@
       {
         "name": "Sludge Whirlpool",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -1348,8 +1348,8 @@
       {
         "name": "High Voltage",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -1466,9 +1466,9 @@
       {
         "name": "Water Spray",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20+",
@@ -1620,9 +1620,9 @@
       {
         "name": "Stamp",
         "cost": [
+          "Fire",
           "Colorless",
-          "Colorless",
-          "Fire"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -1768,8 +1768,8 @@
       {
         "name": "Swift",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -2101,9 +2101,9 @@
       {
         "name": "Headlock",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20+",
@@ -2207,8 +2207,8 @@
       {
         "name": "Poison Sting Tackle",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -2217,9 +2217,9 @@
       {
         "name": "Body Slam",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
@@ -2264,9 +2264,9 @@
       {
         "name": "Rend",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20+",
@@ -2430,8 +2430,8 @@
       {
         "name": "Obscuring Gas",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -2545,9 +2545,9 @@
       {
         "name": "Toxic Cloud",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "",
@@ -2660,9 +2660,9 @@
       {
         "name": "Power Ball",
         "cost": [
-          "Colorless",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -2771,10 +2771,10 @@
       {
         "name": "Take Down",
         "cost": [
+          "Water",
           "Colorless",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -2928,8 +2928,8 @@
       {
         "name": "Hug",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -2979,9 +2979,9 @@
       {
         "name": "Psyshot",
         "cost": [
+          "Psychic",
           "Colorless",
-          "Colorless",
-          "Psychic"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -3024,8 +3024,8 @@
       {
         "name": "Magic Darts",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10×",
@@ -3173,9 +3173,9 @@
       {
         "name": "Body Slam",
         "cost": [
+          "Fire",
           "Colorless",
-          "Colorless",
-          "Fire"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
@@ -3433,8 +3433,8 @@
       {
         "name": "Tremor",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
@@ -3743,8 +3743,8 @@
       {
         "name": "Flail Around",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10×",
@@ -4005,8 +4005,8 @@
       {
         "name": "Sludge Toss",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -4162,8 +4162,8 @@
       {
         "name": "Grasping Vine",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -4215,8 +4215,8 @@
       {
         "name": "Sharp Stinger",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -4256,8 +4256,8 @@
       {
         "name": "Group Attack",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10×",
@@ -4403,8 +4403,8 @@
       {
         "name": "Bouncing Ball",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -4645,8 +4645,8 @@
       {
         "name": "Mirage",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
@@ -4738,8 +4738,8 @@
       {
         "name": "Synchronize",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
@@ -4843,8 +4843,8 @@
       {
         "name": "Mind Shock",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",

--- a/json/cards/Gym Heroes.json
+++ b/json/cards/Gym Heroes.json
@@ -77,10 +77,10 @@
       {
         "name": "Lariat",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "",
@@ -412,10 +412,10 @@
       {
         "name": "Mega Shock",
         "cost": [
-          "Colorless",
           "Lightning",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
@@ -516,10 +516,10 @@
       {
         "name": "Jellyfish Poison",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "",
@@ -569,9 +569,9 @@
       {
         "name": "Magnum Punch",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -663,9 +663,9 @@
       {
         "name": "Blinding Scythe",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -855,9 +855,9 @@
       {
         "name": "Rock Slide",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
@@ -866,10 +866,10 @@
       {
         "name": "Fissure",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
@@ -976,9 +976,9 @@
       {
         "name": "Take Down",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -1367,9 +1367,9 @@
       {
         "name": "Triple Cannon",
         "cost": [
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20×",
@@ -1452,10 +1452,10 @@
       {
         "name": "Water Ring",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "30",
@@ -1501,8 +1501,8 @@
       {
         "name": "Jellyfish Pod",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -1668,8 +1668,8 @@
       {
         "name": "Fire Tackle",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -1836,8 +1836,8 @@
       {
         "name": "Lucky Shot",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -1943,9 +1943,9 @@
       {
         "name": "Rock Toss",
         "cost": [
+          "Fighting",
           "Colorless",
-          "Colorless",
-          "Fighting"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20×",
@@ -2109,8 +2109,8 @@
       {
         "name": "Egg Bomb",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -2164,9 +2164,9 @@
       {
         "name": "Stomp",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -2260,8 +2260,8 @@
       {
         "name": "Dream Dance",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
@@ -2270,9 +2270,9 @@
       {
         "name": "Vile Smell",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -2421,8 +2421,8 @@
       {
         "name": "Sleep Poison",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
@@ -2431,9 +2431,9 @@
       {
         "name": "Vine Whip",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -2625,8 +2625,8 @@
       {
         "name": "Rapids",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -2837,8 +2837,8 @@
       {
         "name": "Crystal Beam",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -2933,8 +2933,8 @@
       {
         "name": "Good Morning",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -2985,9 +2985,9 @@
       {
         "name": "Screaming Headbutt",
         "cost": [
+          "Psychic",
           "Colorless",
-          "Colorless",
-          "Psychic"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -3121,8 +3121,8 @@
       {
         "name": "Agility",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -3228,9 +3228,9 @@
       {
         "name": "Tail Fan",
         "cost": [
+          "Fire",
           "Colorless",
-          "Colorless",
-          "Fire"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
@@ -3282,8 +3282,8 @@
       {
         "name": "Hook Shot",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -3381,8 +3381,8 @@
       {
         "name": "Karate Chop",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -3436,9 +3436,9 @@
       {
         "name": "Rock Throw",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -3483,8 +3483,8 @@
       {
         "name": "Drill Tackle",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -3542,8 +3542,8 @@
       {
         "name": "Rolling Attack",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -3701,8 +3701,8 @@
       {
         "name": "Poison Fang",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -3856,8 +3856,8 @@
       {
         "name": "Psychic",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10+",
@@ -3909,8 +3909,8 @@
       {
         "name": "Sporadic Sponging",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -3963,9 +3963,9 @@
       {
         "name": "Stretch Vine",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
@@ -4239,8 +4239,8 @@
       {
         "name": "Double Spin",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20×",
@@ -4394,8 +4394,8 @@
       {
         "name": "Tail Rap",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20×",
@@ -4438,8 +4438,8 @@
       {
         "name": "Aurora Beam",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -4491,8 +4491,8 @@
       {
         "name": "Clamp",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -4535,8 +4535,8 @@
       {
         "name": "Swift",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -4672,8 +4672,8 @@
       {
         "name": "Spook",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -4726,8 +4726,8 @@
       {
         "name": "Slap",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -4767,8 +4767,8 @@
       {
         "name": "Lazy Attack",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -4821,8 +4821,8 @@
       {
         "name": "Removal Beam",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",

--- a/json/cards/HS—Triumphant.json
+++ b/json/cards/HS—Triumphant.json
@@ -1087,7 +1087,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance. Elekid is now Asleep."
       }
@@ -2133,7 +2133,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "The Defending Pokémon is now Burned. Magby is now Asleep."
       }

--- a/json/cards/HeartGold & SoulSilver.json
+++ b/json/cards/HeartGold & SoulSilver.json
@@ -849,7 +849,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Shuffle your hand into your deck, then draw 6 cards. Cleffa is now Asleep."
       }
@@ -1411,7 +1411,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Each player may search his or her deck for as many Basic Pokémon as he or she likes, put them onto his or her Bench, and shuffle his or her deck afterward. (You put your Pokémon on the Bench first.) Pichu is now Asleep."
       }
@@ -1499,7 +1499,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Move an Energy card attached to 1 of your opponent's Pokémon to another of your opponent's Pokémon. Smoochum is now Asleep."
       }
@@ -1637,7 +1637,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "30",
         "text": "This attack's damage isn't affected by Weakness or Resistance. Tyrogue is now Asleep."
       }
@@ -2219,7 +2219,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Igglybuff is now Asleep. During your opponent's next turn, the attack cost of each of the Defending Pokémon's attacks is Colorless more."
       }

--- a/json/cards/Hidden Legends.json
+++ b/json/cards/Hidden Legends.json
@@ -4181,7 +4181,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for a card that evolves from Vulpix and put it on Vulpix. (This counts as evolving Vulpix.) Shuffle your deck afterward."
       }

--- a/json/cards/Holon Phantoms.json
+++ b/json/cards/Holon Phantoms.json
@@ -3016,7 +3016,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10",
         "text": ""
       },
@@ -3177,7 +3177,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10",
         "text": ""
       },

--- a/json/cards/Jungle.json
+++ b/json/cards/Jungle.json
@@ -145,10 +145,10 @@
       {
         "name": "Flamethrower",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -199,9 +199,9 @@
       {
         "name": "Pin Missile",
         "cost": [
-          "Colorless",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20×",
@@ -307,8 +307,8 @@
       {
         "name": "Meditate",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10+",
@@ -351,8 +351,8 @@
       {
         "name": "Boyfriends",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
@@ -361,10 +361,10 @@
       {
         "name": "Mega Punch",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
@@ -470,10 +470,10 @@
       {
         "name": "Guillotine",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
@@ -639,9 +639,9 @@
       {
         "name": "Water Gun",
         "cost": [
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -1013,10 +1013,10 @@
       {
         "name": "Flamethrower",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -1067,9 +1067,9 @@
       {
         "name": "Pin Missile",
         "cost": [
-          "Colorless",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20×",
@@ -1175,8 +1175,8 @@
       {
         "name": "Meditate",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10+",
@@ -1219,8 +1219,8 @@
       {
         "name": "Boyfriends",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
@@ -1229,10 +1229,10 @@
       {
         "name": "Mega Punch",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
@@ -1338,10 +1338,10 @@
       {
         "name": "Guillotine",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
@@ -1507,9 +1507,9 @@
       {
         "name": "Water Gun",
         "cost": [
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -2102,9 +2102,9 @@
       {
         "name": "Call for Friend",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "",
@@ -2160,9 +2160,9 @@
       {
         "name": "Double Kick",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30×",
@@ -2325,9 +2325,9 @@
       {
         "name": "Tantrum",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -2375,9 +2375,9 @@
       {
         "name": "Agility",
         "cost": [
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -2420,9 +2420,9 @@
       {
         "name": "Horn Attack",
         "cost": [
+          "Fighting",
           "Colorless",
-          "Colorless",
-          "Fighting"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -2493,8 +2493,8 @@
       {
         "name": "Waterfall",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -3287,9 +3287,9 @@
       {
         "name": "Horn Attack",
         "cost": [
+          "Fighting",
           "Colorless",
-          "Colorless",
-          "Fighting"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -3404,8 +3404,8 @@
       {
         "name": "Leech Life",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10",

--- a/json/cards/Legend Maker.json
+++ b/json/cards/Legend Maker.json
@@ -3234,7 +3234,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Damage done to your opponent's Pokémon by your Omanyte, Omastar, Kabuto, Kabutops, or Kabutops ex isn't affected by Resistance."
       },
@@ -4054,7 +4054,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "When Pokémon-ex has been Knocked Out, your opponent takes 2 Prize cards."
       },

--- a/json/cards/Legendary Collection.json
+++ b/json/cards/Legendary Collection.json
@@ -197,9 +197,9 @@
       {
         "name": "Rocket Tackle",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -446,9 +446,9 @@
       {
         "name": "Whirlpool",
         "cost": [
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
@@ -499,10 +499,10 @@
       {
         "name": "Flamethrower",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -716,9 +716,9 @@
       {
         "name": "Pin Missile",
         "cost": [
-          "Colorless",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20×",
@@ -766,10 +766,10 @@
       {
         "name": "Seismic Toss",
         "cost": [
-          "Colorless",
           "Fighting",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -964,10 +964,10 @@
       {
         "name": "Thunder",
         "cost": [
-          "Colorless",
           "Lightning",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -1242,10 +1242,10 @@
       {
         "name": "Avalanche",
         "cost": [
-          "Colorless",
           "Fighting",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -1360,9 +1360,9 @@
       {
         "name": "Meditate",
         "cost": [
-          "Colorless",
           "Psychic",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20+",
@@ -1458,8 +1458,8 @@
       {
         "name": "Sonicboom",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -1621,9 +1621,9 @@
       {
         "name": "Thrash",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -1677,8 +1677,8 @@
       {
         "name": "Boyfriends",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
@@ -1687,10 +1687,10 @@
       {
         "name": "Mega Punch",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
@@ -1851,9 +1851,9 @@
       {
         "name": "Horn Attack",
         "cost": [
+          "Fighting",
           "Colorless",
-          "Colorless",
-          "Fighting"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -1917,9 +1917,9 @@
       {
         "name": "Flamethrower",
         "cost": [
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -1928,10 +1928,10 @@
       {
         "name": "Take Down",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
@@ -1983,9 +1983,9 @@
       {
         "name": "Flamethrower",
         "cost": [
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -2090,8 +2090,8 @@
       {
         "name": "Mirror Shell",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -2137,9 +2137,9 @@
       {
         "name": "Aurora Beam",
         "cost": [
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -2148,10 +2148,10 @@
       {
         "name": "Ice Beam",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "30",
@@ -2310,9 +2310,9 @@
       {
         "name": "Hyper Beam",
         "cost": [
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
@@ -2364,9 +2364,9 @@
       {
         "name": "Rock Throw",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -2409,8 +2409,8 @@
       {
         "name": "Flare",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -2456,8 +2456,8 @@
       {
         "name": "Nightmare",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
@@ -2501,9 +2501,9 @@
       {
         "name": "Vine Whip",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -2618,9 +2618,9 @@
       {
         "name": "Super Psy",
         "cost": [
-          "Colorless",
           "Psychic",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -2722,9 +2722,9 @@
       {
         "name": "Karate Chop",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "",
@@ -2733,10 +2733,10 @@
       {
         "name": "Submission",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -2947,9 +2947,9 @@
       {
         "name": "Double Kick",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30×",
@@ -2993,9 +2993,9 @@
       {
         "name": "Double Kick",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30×",
@@ -3004,10 +3004,10 @@
       {
         "name": "Horn Drill",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
@@ -3099,8 +3099,8 @@
       {
         "name": "Water Gun",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
@@ -3161,9 +3161,9 @@
       {
         "name": "Tantrum",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -3211,9 +3211,9 @@
       {
         "name": "Agility",
         "cost": [
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -3370,8 +3370,8 @@
       {
         "name": "Water Gun",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
@@ -3380,9 +3380,9 @@
       {
         "name": "Agility",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
@@ -3721,8 +3721,8 @@
       {
         "name": "Ember",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -4069,8 +4069,8 @@
       {
         "name": "Stone Barrage",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10×",
@@ -4229,8 +4229,8 @@
       {
         "name": "Selfdestruct",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
@@ -4279,8 +4279,8 @@
       {
         "name": "Anger",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
@@ -4732,9 +4732,9 @@
       {
         "name": "Horn Attack",
         "cost": [
+          "Fighting",
           "Colorless",
-          "Colorless",
-          "Fighting"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -4995,8 +4995,8 @@
       {
         "name": "Withdraw",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",

--- a/json/cards/Legends Awakened.json
+++ b/json/cards/Legends Awakened.json
@@ -247,7 +247,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Choose either Burned or Poisoned. The Defending Pokémon is now affected by that Special Condition. You may return Gliscor and all cards attached to it to your hand."
       },
@@ -355,7 +355,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10x",
         "text": "Search your discard pile for as many Water Energy cards as you like, show them to your opponent, and this attack does 10 damage for each Water Energy card you chose. Put those cards on top of your deck. Shuffle your deck afterward."
       },
@@ -885,7 +885,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10",
         "text": "Does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon."
       },
@@ -1485,7 +1485,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Choose up to 2 basic Fighting Energy cards from your hand and attach them to 1 of your Pokémon."
       },
@@ -1591,7 +1591,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for any 1 card. Shuffle your deck, then put that card on top of your deck."
       },
@@ -1649,7 +1649,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Choose up to 2 basic Water Energy cards from your hand and attach them to 1 of your Pokémon."
       },
@@ -1706,7 +1706,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Draw 3 cards."
       },
@@ -2236,7 +2236,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "The Defending Pokémon is now Burned and Poisoned. Before applying these effects, you may switch 1 of the Defending Pokémon with 1 of your opponent's Benched Pokémon. The new Defending Pokémon is now Burned and Poisoned."
       },
@@ -2741,7 +2741,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Each player counts the number of cards in his or her opponent's hand. Each player shuffles his or her hand into his or her deck. Then, each player draws a number of cards equal to the number of cards his or her opponent had."
       },
@@ -2849,7 +2849,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "The Defending Pokémon is now Confused. Put 6 damage counters instead of 3 on the Confused Pokémon."
       },
@@ -3901,7 +3901,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your opponent's discard pile for up to 2 Energy cards and attach them to any of your opponent's Pokémon in any way you like. For each Energy card attached in this way, this attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       },
@@ -4002,7 +4002,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Move any number of basic Energy cards attached to your Pokémon to your other Pokémon in any way you like."
       }
@@ -4232,7 +4232,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Discard up to 2 cards from your hand. For each card you discarded, draw a card."
       }
@@ -4874,7 +4874,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10",
         "text": "Flip a coin. If tails, this attack does nothing. If heads, the Defending Pokémon is now Poisoned."
       },
@@ -5048,7 +5048,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Remove 2 damage counters from Gloom. Gloom is now Asleep."
       },
@@ -5586,7 +5586,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for a basic Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
       },
@@ -7155,7 +7155,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Remove 3 damage counters from each of your Benched Pokémon."
       },
@@ -7262,7 +7262,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "50x",
         "text": "Discard the top 5 cards from your deck. This attack does 50 damage for each Energy card you discarded."
       },

--- a/json/cards/Majestic Dawn.json
+++ b/json/cards/Majestic Dawn.json
@@ -472,7 +472,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your discard pile for up to 2 Energy cards and attach them to Mewtwo."
       },
@@ -693,7 +693,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your discard pile for up to 2 basic Energy cards and attach them to 1 of your Pokémon."
       },
@@ -864,7 +864,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Put 1 damage counter on each of your opponent's Pokémon that already has damage counters on it."
       },
@@ -1132,7 +1132,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "20",
         "text": "Search your discard pile for a Fighting Energy card and attach it to Hippowdon."
       },
@@ -2317,7 +2317,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your discard pile for a Lightning Energy card, show it to your opponent, and put it into your hand."
       },
@@ -2858,7 +2858,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for an Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
       },
@@ -2960,7 +2960,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Shuffle your hand into your deck. Then, draw a number of cards equal to the number of cards in your opponent's hand."
       },
@@ -3120,7 +3120,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       }
@@ -3274,7 +3274,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Flip a coin. If heads, put any 1 card from your discard pile into your hand."
       },
@@ -3391,7 +3391,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10",
         "text": ""
       },
@@ -4599,7 +4599,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your discard pile for a Pokémon (excluding Pokémon LV.X) and put it onto your Bench as a Basic Pokémon. Then, you may search your discard pile for up to 3 basic Energy cards and attach them to that Pokémon."
       }

--- a/json/cards/Mysterious Treasures.json
+++ b/json/cards/Mysterious Treasures.json
@@ -337,7 +337,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for a Grass Energy card and attach it to Celebi. Shuffle your deck afterward."
       },
@@ -748,7 +748,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for up to 2 Lightning Energy cards and attach them to 1 of your Pokémon. Shuffle your deck afterward."
       },
@@ -2158,7 +2158,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for a Supporter card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
       }
@@ -2410,7 +2410,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Draw a card."
       },
@@ -2419,7 +2419,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10",
         "text": "Switch Dunsparce with 1 of your Benched Pokémon."
       }
@@ -2679,7 +2679,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Remove 2 damage counters from 1 of your Pokémon."
       }
@@ -3980,7 +3980,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Flip a coin. If heads, the Defending Pokémon is now Asleep."
       },
@@ -4091,7 +4091,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10",
         "text": ""
       },
@@ -4558,7 +4558,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Flip a coin. If heads, the Defending Pokémon is now Burned."
       }
@@ -4654,7 +4654,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for Murkrow and put it onto your Bench. Shuffle your deck afterward."
       },
@@ -4824,7 +4824,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "20",
         "text": "Flip a coin. If tails, this attack does nothing."
       }
@@ -5234,7 +5234,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Look at your opponent's hand."
       },
@@ -5489,7 +5489,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10",
         "text": ""
       },

--- a/json/cards/Neo Destiny.json
+++ b/json/cards/Neo Destiny.json
@@ -30,9 +30,9 @@
       {
         "name": "Shock Bolt",
         "cost": [
+          "Lightning",
           "Colorless",
-          "Colorless",
-          "Lightning"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -135,9 +135,9 @@
       {
         "name": "Giant Tusk",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -190,9 +190,9 @@
       {
         "name": "Psysplash",
         "cost": [
+          "Psychic",
           "Colorless",
-          "Colorless",
-          "Psychic"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "",
@@ -341,8 +341,8 @@
       {
         "name": "Dark Fire",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
@@ -561,10 +561,10 @@
       {
         "name": "Fling Away",
         "cost": [
-          "Colorless",
           "Fighting",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "",
@@ -617,9 +617,9 @@
       {
         "name": "Gentle Flames",
         "cost": [
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "",
@@ -669,9 +669,9 @@
       {
         "name": "Bubble Jump",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -937,8 +937,8 @@
       {
         "name": "Dark Tentacle",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -1200,9 +1200,9 @@
       {
         "name": "Comet Punch",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20×",
@@ -1645,8 +1645,8 @@
       {
         "name": "MAX Burst",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20×",
@@ -1696,8 +1696,8 @@
       {
         "name": "Stun Wave",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -2063,8 +2063,8 @@
       {
         "name": "Tackle",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -2167,7 +2167,7 @@
       {
         "name": "Corner",
         "cost": [
-          "Dark"
+          "Darkness"
         ],
         "convertedEnergyCost": 1,
         "damage": "",
@@ -2334,9 +2334,9 @@
       {
         "name": "Burning Flame",
         "cost": [
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -2386,9 +2386,9 @@
       {
         "name": "Core Blast",
         "cost": [
+          "Psychic",
           "Colorless",
-          "Colorless",
-          "Psychic"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -2435,9 +2435,9 @@
       {
         "name": "Thunder Needle",
         "cost": [
-          "Colorless",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20×",
@@ -2595,8 +2595,8 @@
       {
         "name": "Slash About",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
@@ -2646,9 +2646,9 @@
       {
         "name": "Hypno Shower",
         "cost": [
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -2695,8 +2695,8 @@
       {
         "name": "Synchronize",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
@@ -2800,8 +2800,8 @@
       {
         "name": "Agility",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
@@ -3143,8 +3143,8 @@
       {
         "name": "Tentacle Wrap",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -3370,8 +3370,8 @@
       {
         "name": "Stun Poison",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -3524,8 +3524,8 @@
       {
         "name": "Rock Throw",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -3571,8 +3571,8 @@
       {
         "name": "Swift",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -3971,8 +3971,8 @@
       {
         "name": "Migraine",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -4055,8 +4055,8 @@
       {
         "name": "Take Down",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -4198,8 +4198,8 @@
       {
         "name": "Generate Cold",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -4341,8 +4341,8 @@
       {
         "name": "Hidden Power",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -4387,8 +4387,8 @@
       {
         "name": "Hidden Power",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -4482,8 +4482,8 @@
       {
         "name": "Poisonpowder",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -4526,8 +4526,8 @@
       {
         "name": "Ember",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -5018,9 +5018,9 @@
       {
         "name": "Flashing Eyes",
         "cost": [
-          "Colorless",
           "Psychic",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",

--- a/json/cards/Neo Discovery.json
+++ b/json/cards/Neo Discovery.json
@@ -31,9 +31,9 @@
       {
         "name": "Psychic",
         "cost": [
-          "Colorless",
           "Psychic",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -81,9 +81,9 @@
       {
         "name": "Rapid Spin",
         "cost": [
+          "Metal",
           "Colorless",
-          "Colorless",
-          "Metal"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -181,9 +181,9 @@
       {
         "name": "Crunch",
         "cost": [
+          "Darkness",
           "Colorless",
-          "Colorless",
-          "Dark"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "",
@@ -192,9 +192,9 @@
       {
         "name": "Flamethrower",
         "cost": [
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -347,8 +347,8 @@
       {
         "name": "Electric Bolt",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -405,10 +405,10 @@
       {
         "name": "Doubleslap",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "",
@@ -450,8 +450,8 @@
       {
         "name": "Corkscrew Punch",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -460,10 +460,10 @@
       {
         "name": "Submission",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "70",
@@ -623,10 +623,10 @@
       {
         "name": "Trample",
         "cost": [
+          "Darkness",
+          "Darkness",
           "Colorless",
-          "Colorless",
-          "Dark",
-          "Dark"
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
@@ -677,9 +677,9 @@
       {
         "name": "Feint Attack",
         "cost": [
-          "Colorless",
-          "Dark",
-          "Dark"
+          "Darkness",
+          "Darkness",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -932,9 +932,9 @@
       {
         "name": "Pin Missile",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "",
@@ -981,8 +981,8 @@
       {
         "name": "Magic Dust",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -991,9 +991,9 @@
       {
         "name": "Hyper Reverse",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "10×",
@@ -1050,9 +1050,9 @@
       {
         "name": "Psybeam",
         "cost": [
-          "Colorless",
           "Psychic",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -1100,9 +1100,9 @@
       {
         "name": "Rapid Spin",
         "cost": [
+          "Metal",
           "Colorless",
-          "Colorless",
-          "Metal"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -1200,9 +1200,9 @@
       {
         "name": "Crunch",
         "cost": [
+          "Darkness",
           "Colorless",
-          "Colorless",
-          "Dark"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -1211,9 +1211,9 @@
       {
         "name": "Flamethrower",
         "cost": [
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -1366,8 +1366,8 @@
       {
         "name": "Electric Bolt",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -1424,10 +1424,10 @@
       {
         "name": "Doubleslap",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "",
@@ -1469,8 +1469,8 @@
       {
         "name": "Corkscrew Punch",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -1479,10 +1479,10 @@
       {
         "name": "Submission",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "70",
@@ -1642,10 +1642,10 @@
       {
         "name": "Trample",
         "cost": [
+          "Darkness",
+          "Darkness",
           "Colorless",
-          "Colorless",
-          "Dark",
-          "Dark"
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
@@ -1696,9 +1696,9 @@
       {
         "name": "Pursuit",
         "cost": [
+          "Darkness",
           "Colorless",
-          "Colorless",
-          "Dark"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -2064,8 +2064,8 @@
       {
         "name": "Plunder",
         "cost": [
-          "Colorless",
-          "Dark"
+          "Darkness",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -2304,9 +2304,9 @@
       {
         "name": "Water Gun",
         "cost": [
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -2686,9 +2686,9 @@
       {
         "name": "Super Psy",
         "cost": [
-          "Colorless",
           "Psychic",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -2871,8 +2871,8 @@
       {
         "name": "Work Together",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10+",
@@ -2964,8 +2964,8 @@
       {
         "name": "Thunder Jolt",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -3260,8 +3260,8 @@
       {
         "name": "Poison Sting",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",

--- a/json/cards/Neo Genesis.json
+++ b/json/cards/Neo Genesis.json
@@ -131,9 +131,9 @@
       {
         "name": "Flower Dance",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30×",
@@ -372,9 +372,9 @@
       {
         "name": "Agility",
         "cost": [
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -421,9 +421,9 @@
       {
         "name": "Elemental Blast",
         "cost": [
-          "Lightning",
           "Fire",
-          "Water"
+          "Water",
+          "Lightning"
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
@@ -477,10 +477,10 @@
       {
         "name": "Body Slam",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "40",
@@ -618,9 +618,9 @@
       {
         "name": "Steel Wing",
         "cost": [
+          "Metal",
           "Colorless",
-          "Colorless",
-          "Metal"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -730,9 +730,9 @@
       {
         "name": "Tail Crush",
         "cost": [
+          "Metal",
           "Colorless",
-          "Colorless",
-          "Metal"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -1109,7 +1109,7 @@
       {
         "name": "Mean Look",
         "cost": [
-          "Dark"
+          "Darkness"
         ],
         "convertedEnergyCost": 1,
         "damage": "",
@@ -1118,8 +1118,8 @@
       {
         "name": "Feint Attack",
         "cost": [
-          "Colorless",
-          "Dark"
+          "Darkness",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -1168,8 +1168,8 @@
       {
         "name": "Beat Up",
         "cost": [
-          "Dark",
-          "Dark"
+          "Darkness",
+          "Darkness"
         ],
         "convertedEnergyCost": 2,
         "damage": "20×",
@@ -1317,8 +1317,8 @@
       {
         "name": "Poisonpowder",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -1327,9 +1327,9 @@
       {
         "name": "Pollen Shield",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -1500,9 +1500,9 @@
       {
         "name": "Jaw Clamp",
         "cost": [
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -1557,9 +1557,9 @@
       {
         "name": "Sweep Away",
         "cost": [
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -1771,8 +1771,8 @@
       {
         "name": "Strange Powder",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -1781,9 +1781,9 @@
       {
         "name": "Sticky Nectar",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20+",
@@ -1990,9 +1990,9 @@
       {
         "name": "Magma Punch",
         "cost": [
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -2278,10 +2278,10 @@
       {
         "name": "Earthquake",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -2328,8 +2328,8 @@
       {
         "name": "Ember",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -2751,8 +2751,8 @@
       {
         "name": "Razor Leaf",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -2856,8 +2856,8 @@
       {
         "name": "Swift",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -3587,9 +3587,9 @@
       {
         "name": "Agility",
         "cost": [
-          "Colorless",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
@@ -3965,8 +3965,8 @@
       {
         "name": "Rock Throw",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -4119,8 +4119,8 @@
       {
         "name": "Rage",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10+",

--- a/json/cards/Neo Revelation.json
+++ b/json/cards/Neo Revelation.json
@@ -35,10 +35,10 @@
       {
         "name": "Gigavolt",
         "cost": [
-          "Colorless",
           "Lightning",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "40+",
@@ -186,9 +186,9 @@
       {
         "name": "Cross Attack",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20×",
@@ -409,9 +409,9 @@
       {
         "name": "Black Fang",
         "cost": [
+          "Darkness",
           "Colorless",
-          "Colorless",
-          "Dark"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -511,9 +511,9 @@
       {
         "name": "Plasma",
         "cost": [
-          "Colorless",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -967,10 +967,10 @@
       {
         "name": "Twister",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "",
@@ -1055,8 +1055,8 @@
       {
         "name": "Thundershock",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -1161,9 +1161,9 @@
       {
         "name": "Agility",
         "cost": [
+          "Metal",
           "Colorless",
-          "Colorless",
-          "Metal"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
@@ -1206,7 +1206,7 @@
       {
         "name": "Swipe",
         "cost": [
-          "Dark"
+          "Darkness"
         ],
         "convertedEnergyCost": 1,
         "damage": "",
@@ -1269,9 +1269,9 @@
       {
         "name": "Core Stream",
         "cost": [
-          "Colorless",
           "Psychic",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
@@ -1413,9 +1413,9 @@
       {
         "name": "Tail Shock",
         "cost": [
+          "Lightning",
           "Colorless",
-          "Colorless",
-          "Lightning"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -1465,8 +1465,8 @@
       {
         "name": "Poison Bite",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -1517,8 +1517,8 @@
       {
         "name": "Earthquake",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
@@ -1582,9 +1582,9 @@
       {
         "name": "Strange Dance",
         "cost": [
-          "Colorless",
           "Psychic",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20+",
@@ -1631,9 +1631,9 @@
       {
         "name": "Blinding Light",
         "cost": [
+          "Lightning",
           "Colorless",
-          "Colorless",
-          "Lightning"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -1832,10 +1832,10 @@
       {
         "name": "High-Speed Charge",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
@@ -2445,10 +2445,10 @@
       {
         "name": "Whirlpool",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "40",
@@ -2901,8 +2901,8 @@
       {
         "name": "Take Down",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",

--- a/json/cards/POP Series 1.json
+++ b/json/cards/POP Series 1.json
@@ -293,7 +293,7 @@
       {
         "name": "Blot",
         "cost": [
-          "Green",
+          "Grass",
           "Colorless"
         ],
         "convertedEnergyCost": 2,

--- a/json/cards/POP Series 2.json
+++ b/json/cards/POP Series 2.json
@@ -32,9 +32,9 @@
       {
         "name": "Fire Spin",
         "cost": [
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -132,9 +132,9 @@
       {
         "name": "Thunder",
         "cost": [
-          "Colorless",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -178,8 +178,8 @@
       {
         "name": "Bubblebeam",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -272,9 +272,9 @@
       {
         "name": "Wide Solarbeam",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
@@ -283,10 +283,10 @@
       {
         "name": "Hard Plant",
         "cost": [
-          "Colorless",
           "Grass",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
@@ -335,9 +335,9 @@
       {
         "name": "Razor Leaf",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -456,8 +456,8 @@
       {
         "name": "Razor Leaf",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -550,8 +550,8 @@
       {
         "name": "Fast Stream",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -651,8 +651,8 @@
       {
         "name": "Thunder Jolt",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -699,8 +699,8 @@
       {
         "name": "Psychic Shield",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",

--- a/json/cards/POP Series 3.json
+++ b/json/cards/POP Series 3.json
@@ -34,10 +34,10 @@
       {
         "name": "Rocket Tackle",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -87,9 +87,9 @@
       {
         "name": "Fire Spin",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
@@ -126,8 +126,8 @@
       {
         "name": "Thundershock",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -136,9 +136,9 @@
       {
         "name": "Pin Missile",
         "cost": [
+          "Lightning",
           "Colorless",
-          "Colorless",
-          "Lightning"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20×",
@@ -192,8 +192,8 @@
       {
         "name": "Negative Ion",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -257,8 +257,8 @@
       {
         "name": "Positive Ion",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
@@ -323,8 +323,8 @@
       {
         "name": "Water Gun",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
@@ -372,9 +372,9 @@
       {
         "name": "Flamethrower",
         "cost": [
+          "Fire",
           "Colorless",
-          "Colorless",
-          "Fire"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -425,9 +425,9 @@
       {
         "name": "Fury Attack",
         "cost": [
+          "Fighting",
           "Colorless",
-          "Colorless",
-          "Fighting"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30×",
@@ -477,9 +477,9 @@
       {
         "name": "Toxic",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -552,8 +552,8 @@
       {
         "name": "Psybeam",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -660,9 +660,9 @@
       {
         "name": "Poisonpowder",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",

--- a/json/cards/POP Series 4.json
+++ b/json/cards/POP Series 4.json
@@ -31,8 +31,8 @@
       {
         "name": "Sonicboom",
         "cost": [
-          "Colorless",
-          "Metal"
+          "Metal",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -123,8 +123,8 @@
       {
         "name": "Bite",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -133,10 +133,10 @@
       {
         "name": "Sand Pit",
         "cost": [
+          "Fighting",
           "Colorless",
           "Colorless",
-          "Colorless",
-          "Fighting"
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "70",
@@ -180,8 +180,8 @@
       {
         "name": "Psyshock",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -228,9 +228,9 @@
       {
         "name": "Tail Rap",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50×",
@@ -285,9 +285,9 @@
       {
         "name": "Sky Uppercut",
         "cost": [
+          "Fire",
           "Colorless",
-          "Colorless",
-          "Fire"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -339,8 +339,8 @@
       {
         "name": "Blot",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -439,8 +439,8 @@
       {
         "name": "Super Hypno Wave",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -531,8 +531,8 @@
       {
         "name": "Spark",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -688,8 +688,8 @@
       {
         "name": "Expand",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",

--- a/json/cards/POP Series 5.json
+++ b/json/cards/POP Series 5.json
@@ -23,8 +23,8 @@
       {
         "name": "Fire Wing",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -33,10 +33,10 @@
       {
         "name": "Fire Blast",
         "cost": [
-          "Colorless",
           "Fire",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -76,8 +76,8 @@
       {
         "name": "Super Psy Bolt",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -86,9 +86,9 @@
       {
         "name": "Aerowing",
         "cost": [
+          "Psychic",
           "Colorless",
-          "Colorless",
-          "Psychic"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "",
@@ -203,9 +203,9 @@
       {
         "name": "Thunder Jolt",
         "cost": [
+          "Lightning",
           "Colorless",
-          "Colorless",
-          "Lightning"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -324,8 +324,8 @@
       {
         "name": "Bite",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -418,9 +418,9 @@
       {
         "name": "Thunderbolt",
         "cost": [
+          "Lightning",
           "Colorless",
-          "Colorless",
-          "Lightning"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -517,9 +517,9 @@
       {
         "name": "Lightning Wing",
         "cost": [
+          "Lightning",
           "Colorless",
-          "Colorless",
-          "Lightning"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -573,9 +573,9 @@
       {
         "name": "Metal Claw",
         "cost": [
+          "Metal",
           "Colorless",
-          "Colorless",
-          "Metal"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -619,9 +619,9 @@
       {
         "name": "Psychic Boom",
         "cost": [
-          "Colorless",
           "Psychic",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",

--- a/json/cards/POP Series 6.json
+++ b/json/cards/POP Series 6.json
@@ -31,9 +31,9 @@
       {
         "name": "Anger Revenge",
         "cost": [
-          "Colorless",
           "Metal",
-          "Metal"
+          "Metal",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
@@ -236,8 +236,8 @@
       {
         "name": "Assurance",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -297,8 +297,8 @@
       {
         "name": "Ominous Wind",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
@@ -434,8 +434,8 @@
       {
         "name": "Spark",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
@@ -656,8 +656,8 @@
       {
         "name": "Leech Seed",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -707,13 +707,16 @@
         "name": "Scratch",
         "convertedEnergyCost": 0,
         "damage": "10",
-        "text": ""
+        "text": "",
+        "cost": [
+          "Free"
+        ]
       },
       {
         "name": "Ember",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -757,13 +760,16 @@
         "name": "Peck",
         "convertedEnergyCost": 0,
         "damage": "10",
-        "text": ""
+        "text": "",
+        "cost": [
+          "Free"
+        ]
       },
       {
         "name": "Water Splash",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
@@ -867,7 +873,10 @@
         "name": "Tackle",
         "convertedEnergyCost": 0,
         "damage": "10",
-        "text": ""
+        "text": "",
+        "cost": [
+          "Free"
+        ]
       },
       {
         "name": "Razor Leaf",

--- a/json/cards/POP Series 7.json
+++ b/json/cards/POP Series 7.json
@@ -31,9 +31,9 @@
       {
         "name": "Cluster Bolt",
         "cost": [
+          "Lightning",
           "Colorless",
-          "Colorless",
-          "Lightning"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
@@ -81,8 +81,8 @@
       {
         "name": "Sonic Blade",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -91,9 +91,9 @@
       {
         "name": "Psychic Cut",
         "cost": [
+          "Psychic",
           "Colorless",
-          "Colorless",
-          "Psychic"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "",
@@ -142,9 +142,9 @@
       {
         "name": "Mist Ball",
         "cost": [
-          "Colorless",
           "Fire",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
@@ -200,10 +200,10 @@
       {
         "name": "Luster Purge",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Grass",
-          "Lightning"
+          "Lightning",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
@@ -248,13 +248,16 @@
         "name": "Silver Wind",
         "convertedEnergyCost": 0,
         "damage": "",
-        "text": "During your next turn, if an attack does damage to the Defending Pokémon (after applying Weakness and Resistance), that attack does 40 more damage."
+        "text": "During your next turn, if an attack does damage to the Defending Pokémon (after applying Weakness and Resistance), that attack does 40 more damage.",
+        "cost": [
+          "Free"
+        ]
       },
       {
         "name": "Raging Scales",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
@@ -304,7 +307,10 @@
         "name": "Present",
         "convertedEnergyCost": 0,
         "damage": "",
-        "text": "Flip a coin. If heads, search your deck for any 1 card and put it into your hand. Shuffle your deck afterward."
+        "text": "Flip a coin. If heads, search your deck for any 1 card and put it into your hand. Shuffle your deck afterward.",
+        "cost": [
+          "Free"
+        ]
       },
       {
         "name": "Ice Ball",
@@ -359,9 +365,9 @@
       {
         "name": "Electromagnetic Kick",
         "cost": [
-          "Colorless",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
@@ -420,9 +426,9 @@
       {
         "name": "Telekinesis",
         "cost": [
+          "Psychic",
           "Colorless",
-          "Colorless",
-          "Psychic"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -467,7 +473,10 @@
         "name": "Lead",
         "convertedEnergyCost": 0,
         "damage": "",
-        "text": "Search your deck for a Supporter card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
+        "text": "Search your deck for a Supporter card, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
+        "cost": [
+          "Free"
+        ]
       },
       {
         "name": "Frighten Horn",
@@ -519,9 +528,9 @@
       {
         "name": "Push Over",
         "cost": [
+          "Fighting",
           "Colorless",
-          "Colorless",
-          "Fighting"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40+",
@@ -675,8 +684,8 @@
       {
         "name": "Hook",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -725,8 +734,8 @@
       {
         "name": "Static Shock",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",

--- a/json/cards/POP Series 8.json
+++ b/json/cards/POP Series 8.json
@@ -35,10 +35,10 @@
       {
         "name": "Fire Spin",
         "cost": [
-          "Colorless",
           "Fire",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "90",
@@ -79,8 +79,8 @@
       {
         "name": "Blocking Punch",
         "cost": [
-          "Colorless",
-          "Metal"
+          "Metal",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
@@ -89,9 +89,9 @@
       {
         "name": "Striking Kick",
         "cost": [
+          "Fighting",
           "Colorless",
-          "Colorless",
-          "Fighting"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
@@ -137,10 +137,10 @@
       {
         "name": "Thunder",
         "cost": [
-          "Colorless",
           "Lightning",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
@@ -189,8 +189,8 @@
       {
         "name": "Rock Slide",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -199,9 +199,9 @@
       {
         "name": "Triple Nose",
         "cost": [
+          "Metal",
           "Colorless",
-          "Colorless",
-          "Metal"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50+",
@@ -361,8 +361,8 @@
       {
         "name": "Swallow Up",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -527,13 +527,16 @@
         "name": "Scratch",
         "convertedEnergyCost": 0,
         "damage": "10",
-        "text": ""
+        "text": "",
+        "cost": [
+          "Free"
+        ]
       },
       {
         "name": "Ember",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -635,7 +638,10 @@
         "name": "Lively",
         "convertedEnergyCost": 0,
         "damage": "",
-        "text": "Remove 2 damage counters from 1 of your Pokémon."
+        "text": "Remove 2 damage counters from 1 of your Pokémon.",
+        "cost": [
+          "Free"
+        ]
       }
     ],
     "weaknesses": [
@@ -675,13 +681,16 @@
         "name": "Peck",
         "convertedEnergyCost": 0,
         "damage": "10",
-        "text": ""
+        "text": "",
+        "cost": [
+          "Free"
+        ]
       },
       {
         "name": "Water Splash",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
@@ -774,7 +783,10 @@
         "name": "Tackle",
         "convertedEnergyCost": 0,
         "damage": "10",
-        "text": ""
+        "text": "",
+        "cost": [
+          "Free"
+        ]
       },
       {
         "name": "Razor Leaf",

--- a/json/cards/POP Series 9.json
+++ b/json/cards/POP Series 9.json
@@ -566,7 +566,10 @@
         "name": "Find a Friend",
         "convertedEnergyCost": 0,
         "damage": "",
-        "text": "Flip a coin. If heads, search your deck for a Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
+        "text": "Flip a coin. If heads, search your deck for a Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
+        "cost": [
+          "Free"
+        ]
       }
     ],
     "weaknesses": [

--- a/json/cards/Phantom Forces.json
+++ b/json/cards/Phantom Forces.json
@@ -4964,7 +4964,9 @@
     "attacks": [
       {
         "name": "Pokémon Tool Flare Rule",
-        "cost": [],
+        "cost": [
+          "Free"
+        ],
         "convertedEnergyCost": 0,
         "damage": "",
         "text": "Attach this Pokémon Tool to 1 of your opponent's Pokémon-EX that doesn't already have a Pokémon Tool attached to it."

--- a/json/cards/Platinum.json
+++ b/json/cards/Platinum.json
@@ -840,7 +840,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Attach a Grass Energy card from your hand to Shaymin."
       },
@@ -945,7 +945,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for up to 2 basic Pokémon SP and put them onto your Bench. Shuffle your deck afterward."
       },
@@ -1660,7 +1660,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "30",
         "text": "If your opponent has any Water Energy attached to any of his or her Pokémon, you may do 30 damage to any 1 Benched Pokémon instead. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       },
@@ -1983,7 +1983,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Choose 1 of your opponent's Pokémon. Search your deck for a Pokémon that is the same type as the Pokémon you chose, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
       },
@@ -2030,7 +2030,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Flip a coin until you get tails. Search your deck for a number of Fire Energy cards up to the number of heads and attach them to any of your Pokémon in any way you like. Shuffle your deck afterward."
       },
@@ -2133,7 +2133,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10+",
         "text": "Does 10 damage plus 10 more damage for each Energy attached to Shaymin."
       },
@@ -2472,7 +2472,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for a card that evolves from Cascoon and put it onto Cascoon. (This counts as evolving Cascoon.) Shuffle your deck afterward."
       },
@@ -3259,7 +3259,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "50×",
         "text": "Reveal the top 5 cards of your deck. Flip a coin for each Energy card you find there. This attack does 50 damage times the number of heads. Shuffle the revealed cards back into your deck."
       },
@@ -3419,7 +3419,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Remove 4 damage counters from Seviper."
       },
@@ -3541,7 +3541,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for a card that evolves from Silcoon and put it onto Silcoon. (This counts as evolving Silcoon.) Shuffle your deck afterward."
       },
@@ -3818,7 +3818,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Flip a coin. If heads, the Defending Pokémon is now Poisoned."
       },
@@ -3981,7 +3981,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Draw a card."
       },
@@ -4099,7 +4099,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for a Basic Pokémon and put it onto your Bench. Shuffle your deck afterward."
       },
@@ -4205,7 +4205,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for Grimer and put it onto your Bench. Shuffle your deck afterward."
       },
@@ -4262,7 +4262,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon. Remove 2 damage counters from the new Defending Pokémon."
       }
@@ -4305,7 +4305,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for up to 2 in any combination of Stadium cards or Trainer cards that has Team Galactic's Invention in its name, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
       },
@@ -4574,7 +4574,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for a basic Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
       },
@@ -4632,7 +4632,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Flip a coin. If heads, search your discard pile for a Trainer card, show it to your opponent, and put it into your hand."
       },
@@ -4796,7 +4796,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for Poochyena and put it onto your Bench. Shuffle your deck afterward."
       },
@@ -4855,7 +4855,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Flip a coin. If heads, your opponent can't play any Trainer, Supporter, or Stadium cards from his or her hand during his or her next turn."
       },
@@ -4961,7 +4961,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Look at the top 5 cards of either player's deck and put them back on top of that player's deck in any order."
       },
@@ -5066,7 +5066,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10",
         "text": ""
       },
@@ -5119,7 +5119,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "The Defending Pokémon is now Asleep."
       },
@@ -5177,7 +5177,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Remove 1 damage counter from each of your Pokémon."
       },
@@ -5437,7 +5437,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for a basic Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
       },
@@ -5486,7 +5486,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "During your next turn, Torchic's Fire Shard attack's base damage is 80."
       },
@@ -5650,7 +5650,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Discard up to 2 Energy cards from your hand. For each card you discarded, draw 2 cards."
       },
@@ -6637,7 +6637,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Remove 4 damage counters from Swablu. Swablu can't retreat during your next turn."
       },
@@ -6704,7 +6704,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for up to 2 Fire Energy cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
       },

--- a/json/cards/Rising Rivals.json
+++ b/json/cards/Rising Rivals.json
@@ -200,7 +200,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your discard pile for up to 2 Supporter cards, show them to your opponent, and put them into your hand."
       },
@@ -363,7 +363,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "If you have a Supporter card in play, use the effect of that card as the effect of this attack."
       },
@@ -868,7 +868,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Each player shuffles his or her hand into his or her deck and draws up to 4 cards. (You draw your cards first.)"
       },
@@ -1343,7 +1343,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "During your next turn, Heracross 's Megahorn attack's base damage is 100."
       },
@@ -1576,7 +1576,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Flip 3 coins. Remove a number of damage counters equal to the number of heads from your Pokémon in any way you like."
       },
@@ -1875,7 +1875,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your discard pile for up to 4 basic Energy cards, show them to your opponent, and put them into your hand."
       },
@@ -2655,7 +2655,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Flip 3 coins. For each heads, search your discard pile for a basic Energy card, show it to your opponent, and put it into your hand."
       },
@@ -3336,7 +3336,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for up to 2 cards that evolve from Eevee, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
       },
@@ -4317,7 +4317,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for up to 2 Water Energy cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
       },
@@ -4481,7 +4481,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Flip 2 coins. Choose 1 of your Pokémon. For each heads, remove 1 damage counter from that Pokémon."
       },
@@ -4813,7 +4813,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your discard pile for up to 5 Pokémon, show them to your opponent, and shuffle them into your deck."
       },

--- a/json/cards/Secret Wonders.json
+++ b/json/cards/Secret Wonders.json
@@ -781,7 +781,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "If you have less cards in your hand than your opponent, draw cards until you have the same number of cards as your opponent. (If you have more or the same number of cards in your hand as your opponent, this attack does nothing.)"
       },
@@ -1203,7 +1203,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Put as many damage counters as you like on Banette. (You can't put more than Banette's remaining HP.) Put that many damage counters on the Defending Pokémon."
       },
@@ -1422,7 +1422,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for up to 2 cards and put them into your hand. Shuffle your deck afterward."
       },
@@ -1747,7 +1747,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "During your next turn, if an attack does damage to the Defending Pokémon (after applying Weakness and Resistance), that attack does 40 more damage."
       },
@@ -2120,7 +2120,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for up to 2 Darkness Energy cards and attach them to any of your Pokémon in any way you like. Shuffle your deck afterward."
       },
@@ -2499,7 +2499,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Flip a coin. If heads, prevent all damage done to Cloyster by attacks during your opponent's next turn."
       },
@@ -2942,7 +2942,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Flip 2 coins. For each heads, remove 3 damage counters from 1 of your Pokémon."
       },
@@ -3524,7 +3524,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for up to 3 basic Energy cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
       },
@@ -3578,7 +3578,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Flip a coin. If heads, choose a Special Energy card attached to 1 of your opponent's Pokémon and have your opponent shuffle that card into his or her deck."
       }
@@ -4076,7 +4076,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "The Defending Pokémon is now Asleep."
       },
@@ -4332,7 +4332,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10",
         "text": ""
       },
@@ -5938,7 +5938,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
       },
@@ -5991,7 +5991,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for a Supporter card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
       },

--- a/json/cards/Skyridge.json
+++ b/json/cards/Skyridge.json
@@ -76,8 +76,8 @@
       {
         "name": "Rising Lunge",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
@@ -132,9 +132,9 @@
       {
         "name": "White Flames",
         "cost": [
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
@@ -236,10 +236,10 @@
       {
         "name": "Ice Cyclone",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
@@ -300,9 +300,9 @@
       {
         "name": "White Flames",
         "cost": [
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
@@ -399,10 +399,10 @@
       {
         "name": "Ice Cyclone",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
@@ -493,9 +493,9 @@
       {
         "name": "Double Cross",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40×",
@@ -537,9 +537,9 @@
       {
         "name": "Double Cross",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40×",
@@ -580,8 +580,8 @@
       {
         "name": "Freeze Lock",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -590,10 +590,10 @@
       {
         "name": "Crushing Ice",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "40+",
@@ -634,8 +634,8 @@
       {
         "name": "Freeze Lock",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -644,10 +644,10 @@
       {
         "name": "Crushing Ice",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "40+",
@@ -810,9 +810,9 @@
       {
         "name": "Scatterbomb",
         "cost": [
+          "Metal",
           "Colorless",
-          "Colorless",
-          "Metal"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -864,10 +864,10 @@
       {
         "name": "Hydrokinesis",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Psychic",
-          "Psychic"
+          "Psychic",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "40",
@@ -924,9 +924,9 @@
       {
         "name": "Scatterbomb",
         "cost": [
+          "Metal",
           "Colorless",
-          "Colorless",
-          "Metal"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -978,10 +978,10 @@
       {
         "name": "Hydrokinesis",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Psychic",
-          "Psychic"
+          "Psychic",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "40",
@@ -1033,10 +1033,10 @@
       {
         "name": "Dragon's Vengeance",
         "cost": [
+          "Water",
           "Colorless",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "",
@@ -1086,7 +1086,7 @@
       {
         "name": "Lonely Fang",
         "cost": [
-          "Dark",
+          "Darkness",
           "Colorless",
           "Colorless"
         ],
@@ -1140,10 +1140,10 @@
       {
         "name": "Dragon's Vengeance",
         "cost": [
+          "Water",
           "Colorless",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "",
@@ -1194,9 +1194,9 @@
       {
         "name": "Thunderspark",
         "cost": [
+          "Lightning",
           "Colorless",
-          "Colorless",
-          "Lightning"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -1246,9 +1246,9 @@
       {
         "name": "Lonely Fang",
         "cost": [
+          "Darkness",
           "Colorless",
-          "Colorless",
-          "Dark"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -1300,9 +1300,9 @@
       {
         "name": "Dual Cut",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50×",
@@ -1353,9 +1353,9 @@
       {
         "name": "Thunderspark",
         "cost": [
+          "Lightning",
           "Colorless",
-          "Colorless",
-          "Lightning"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -1401,9 +1401,9 @@
       {
         "name": "Dual Cut",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50×",
@@ -1449,9 +1449,9 @@
       {
         "name": "Swift",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -1497,8 +1497,8 @@
       {
         "name": "Drag Off",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -1507,10 +1507,10 @@
       {
         "name": "Hurricane Punch",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "30×",
@@ -1556,9 +1556,9 @@
       {
         "name": "Swift",
         "cost": [
-          "Colorless",
           "Grass",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -1604,8 +1604,8 @@
       {
         "name": "Drag Off",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -1614,10 +1614,10 @@
       {
         "name": "Hurricane Punch",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "30×",
@@ -1669,10 +1669,10 @@
       {
         "name": "Fire Stream",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -1719,9 +1719,9 @@
       {
         "name": "Crushing Lava",
         "cost": [
+          "Fighting",
           "Colorless",
-          "Colorless",
-          "Fighting"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40+",
@@ -1773,10 +1773,10 @@
       {
         "name": "Fire Stream",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -1823,9 +1823,9 @@
       {
         "name": "Crushing Lava",
         "cost": [
+          "Fighting",
           "Colorless",
-          "Colorless",
-          "Fighting"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40+",
@@ -1870,9 +1870,9 @@
       {
         "name": "Electric Blast",
         "cost": [
+          "Lightning",
           "Colorless",
-          "Colorless",
-          "Lightning"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -2037,9 +2037,9 @@
       {
         "name": "Magnetic Wave",
         "cost": [
-          "Colorless",
           "Metal",
-          "Metal"
+          "Metal",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -2102,10 +2102,10 @@
       {
         "name": "Burning Tail",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -2165,10 +2165,10 @@
       {
         "name": "Burning Tail",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
@@ -2221,9 +2221,9 @@
       {
         "name": "Double Claw",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -2270,9 +2270,9 @@
       {
         "name": "Double Claw",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -2314,9 +2314,9 @@
       {
         "name": "Freezing Breath",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
@@ -2325,10 +2325,10 @@
       {
         "name": "Trample",
         "cost": [
+          "Fighting",
           "Colorless",
           "Colorless",
-          "Colorless",
-          "Fighting"
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "40",
@@ -2381,9 +2381,9 @@
       {
         "name": "Frog Hop",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -2392,11 +2392,11 @@
       {
         "name": "Energy Splash",
         "cost": [
-          "Colorless",
-          "Colorless",
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 5,
         "damage": "70",
@@ -2442,9 +2442,9 @@
       {
         "name": "Spook",
         "cost": [
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -2486,9 +2486,9 @@
       {
         "name": "Freezing Breath",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
@@ -2497,10 +2497,10 @@
       {
         "name": "Trample",
         "cost": [
+          "Fighting",
           "Colorless",
           "Colorless",
-          "Colorless",
-          "Fighting"
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "40",
@@ -2549,9 +2549,9 @@
       {
         "name": "Spiral Punch",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40+",
@@ -2601,9 +2601,9 @@
       {
         "name": "Lightning Storm",
         "cost": [
+          "Lightning",
           "Colorless",
-          "Colorless",
-          "Lightning"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -2653,9 +2653,9 @@
       {
         "name": "Frog Hop",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -2664,11 +2664,11 @@
       {
         "name": "Energy Splash",
         "cost": [
-          "Colorless",
-          "Colorless",
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 5,
         "damage": "70",
@@ -2712,9 +2712,9 @@
       {
         "name": "Lightning Sphere",
         "cost": [
+          "Lightning",
           "Colorless",
-          "Colorless",
-          "Lightning"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40+",
@@ -2760,9 +2760,9 @@
       {
         "name": "Spiral Punch",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40+",
@@ -2803,9 +2803,9 @@
       {
         "name": "Stomp",
         "cost": [
+          "Fighting",
           "Colorless",
-          "Colorless",
-          "Fighting"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -2814,11 +2814,11 @@
       {
         "name": "Giant Tail",
         "cost": [
-          "Colorless",
-          "Colorless",
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 5,
         "damage": "",
@@ -2877,9 +2877,9 @@
       {
         "name": "Lightning Storm",
         "cost": [
+          "Lightning",
           "Colorless",
-          "Colorless",
-          "Lightning"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -2928,9 +2928,9 @@
       {
         "name": "Star Back",
         "cost": [
+          "Psychic",
           "Colorless",
-          "Colorless",
-          "Psychic"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -2974,9 +2974,9 @@
       {
         "name": "Lightning Sphere",
         "cost": [
+          "Lightning",
           "Colorless",
-          "Colorless",
-          "Lightning"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40+",
@@ -3024,9 +3024,9 @@
       {
         "name": "Squeeze",
         "cost": [
-          "Colorless",
           "Metal",
-          "Metal"
+          "Metal",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20+",
@@ -3035,10 +3035,10 @@
       {
         "name": "Metal Tail",
         "cost": [
-          "Colorless",
           "Metal",
           "Metal",
-          "Metal"
+          "Metal",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "",
@@ -3085,9 +3085,9 @@
       {
         "name": "Stomp",
         "cost": [
+          "Fighting",
           "Colorless",
-          "Colorless",
-          "Fighting"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -3096,11 +3096,11 @@
       {
         "name": "Giant Tail",
         "cost": [
-          "Colorless",
-          "Colorless",
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 5,
         "damage": "",
@@ -3154,8 +3154,8 @@
       {
         "name": "Sharp Claws",
         "cost": [
-          "Colorless",
-          "Dark"
+          "Darkness",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10+",
@@ -3210,9 +3210,9 @@
       {
         "name": "Star Back",
         "cost": [
+          "Psychic",
           "Colorless",
-          "Colorless",
-          "Psychic"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -3267,9 +3267,9 @@
       {
         "name": "Aqua Trick",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -3317,9 +3317,9 @@
       {
         "name": "Squeeze",
         "cost": [
-          "Colorless",
           "Metal",
-          "Metal"
+          "Metal",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20+",
@@ -3328,10 +3328,10 @@
       {
         "name": "Metal Tail",
         "cost": [
-          "Colorless",
           "Metal",
           "Metal",
-          "Metal"
+          "Metal",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "",
@@ -3382,8 +3382,8 @@
       {
         "name": "Sharp Claws",
         "cost": [
-          "Colorless",
-          "Dark"
+          "Darkness",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10+",
@@ -3491,9 +3491,9 @@
       {
         "name": "Aqua Trick",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -3637,10 +3637,10 @@
       {
         "name": "Self destruct",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
@@ -3684,8 +3684,8 @@
       {
         "name": "Scratch",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -3737,9 +3737,9 @@
       {
         "name": "Mega Punch",
         "cost": [
+          "Fighting",
           "Colorless",
-          "Colorless",
-          "Fighting"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -3790,8 +3790,8 @@
       {
         "name": "Gift of Spite",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -3894,8 +3894,8 @@
       {
         "name": "Drag Off",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -3994,9 +3994,9 @@
       {
         "name": "Impaling Tusk",
         "cost": [
+          "Fighting",
           "Colorless",
-          "Colorless",
-          "Fighting"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -4005,10 +4005,10 @@
       {
         "name": "Continuous Charge",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "30+",
@@ -4113,8 +4113,8 @@
       {
         "name": "Return Attack",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10×",
@@ -4267,8 +4267,8 @@
       {
         "name": "Kick Away",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -4400,8 +4400,8 @@
       {
         "name": "Burrow",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -4621,8 +4621,8 @@
       {
         "name": "Shell Rupture",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
@@ -4631,9 +4631,9 @@
       {
         "name": "Double Spin",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40×",
@@ -4729,8 +4729,8 @@
       {
         "name": "Syncroblast",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -4778,8 +4778,8 @@
       {
         "name": "Sharp Stinger",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -4822,8 +4822,8 @@
       {
         "name": "Poison Sound Wave",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -4992,9 +4992,9 @@
       {
         "name": "Shadow Hand",
         "cost": [
+          "Psychic",
           "Colorless",
-          "Colorless",
-          "Psychic"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -5052,9 +5052,9 @@
       {
         "name": "Angry Horn",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "",
@@ -5302,9 +5302,9 @@
       {
         "name": "Mind Shock",
         "cost": [
+          "Psychic",
           "Colorless",
-          "Colorless",
-          "Psychic"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -5406,9 +5406,9 @@
       {
         "name": "Hypnoblast",
         "cost": [
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -5565,8 +5565,8 @@
       {
         "name": "Fling",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -5720,9 +5720,9 @@
       {
         "name": "Aqua Sonic",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -5809,7 +5809,7 @@
       {
         "name": "Evil Eye",
         "cost": [
-          "Dark"
+          "Darkness"
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
@@ -6025,9 +6025,9 @@
       {
         "name": "Poison Claws",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "",
@@ -6151,8 +6151,8 @@
       {
         "name": "Double-edge",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -6409,8 +6409,8 @@
       {
         "name": "Retaliate",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10×",
@@ -6516,8 +6516,8 @@
       {
         "name": "Sand Trap",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
@@ -6526,9 +6526,9 @@
       {
         "name": "Poison Needle Rush",
         "cost": [
+          "Fighting",
           "Colorless",
-          "Colorless",
-          "Fighting"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20×",
@@ -6624,8 +6624,8 @@
       {
         "name": "Ice Beam",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
@@ -6673,8 +6673,8 @@
       {
         "name": "Poisonous Saliva",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -6723,9 +6723,9 @@
       {
         "name": "Spinning Head",
         "cost": [
+          "Metal",
           "Colorless",
-          "Colorless",
-          "Metal"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -6823,8 +6823,8 @@
       {
         "name": "Singe",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
@@ -7075,8 +7075,8 @@
       {
         "name": "Confuse Ray",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
@@ -7119,8 +7119,8 @@
       {
         "name": "Energy Plant",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -7129,9 +7129,9 @@
       {
         "name": "Trip Over",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -7457,9 +7457,9 @@
       {
         "name": "Miracle Powder",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "",
@@ -7507,8 +7507,8 @@
       {
         "name": "Supersonic",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
@@ -7559,8 +7559,8 @@
       {
         "name": "Spin Tackle",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -7695,8 +7695,8 @@
       {
         "name": "Agility",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
@@ -7705,9 +7705,9 @@
       {
         "name": "Triple Smash",
         "cost": [
+          "Grass",
           "Colorless",
-          "Colorless",
-          "Grass"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20+",
@@ -7821,8 +7821,8 @@
       {
         "name": "Poison Spray",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -8321,9 +8321,9 @@
       {
         "name": "Mind Bend",
         "cost": [
-          "Colorless",
           "Grass",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
@@ -8382,10 +8382,10 @@
       {
         "name": "Dragon Tail",
         "cost": [
-          "Colorless",
           "Lightning",
           "Lightning",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50×",
@@ -8427,9 +8427,9 @@
       {
         "name": "Poison Flame",
         "cost": [
-          "Colorless",
           "Grass",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "",
@@ -8488,9 +8488,9 @@
       {
         "name": "Rock Throw",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -8499,10 +8499,10 @@
       {
         "name": "Earth Bomb",
         "cost": [
-          "Colorless",
           "Fighting",
           "Grass",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
@@ -8558,10 +8558,10 @@
       {
         "name": "Scalding Steam",
         "cost": [
-          "Colorless",
           "Fire",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "40",
@@ -8608,9 +8608,9 @@
       {
         "name": "Draining Cut",
         "cost": [
-          "Colorless",
           "Water",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
@@ -8619,10 +8619,10 @@
       {
         "name": "Triple Cutter",
         "cost": [
-          "Colorless",
           "Fighting",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "30×",

--- a/json/cards/Stormfront.json
+++ b/json/cards/Stormfront.json
@@ -209,7 +209,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance."
       },
@@ -380,7 +380,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "20x",
         "text": "Choose up to 4 in any combination of Pokémon Tool cards and Technical Machine cards in play (both yours and your opponent's) and discard them. This attack does 20 damage times the number of cards discarded in this way."
       },
@@ -434,7 +434,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "30",
         "text": "Raichu can't use Slice during your next turn."
       },
@@ -828,7 +828,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "20",
         "text": "Remove 2 damage counters from 1 of your Pokémon."
       },
@@ -888,7 +888,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10",
         "text": "Flip a coin. If heads, the Defending Pokémon is now Paralyzed. If tails, the Defending Pokémon can't retreat during your opponent's next turn."
       },
@@ -947,7 +947,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Put any 1 card from your discard pile into your hand."
       },
@@ -956,7 +956,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for up to 2 Basic Pokémon and put them onto your Bench. For each Basic Pokémon you put onto your Bench, you may search your deck for a basic Energy card and attach it to that Pokémon. Shuffle your deck afterward."
       },
@@ -1129,7 +1129,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "30x",
         "text": "Does 30 damage times the number of Magikarp in your discard pile."
       },
@@ -2012,7 +2012,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for a Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
       }
@@ -2409,7 +2409,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "The Defending Pokémon is now Poisoned."
       },
@@ -2710,7 +2710,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your discard pile for up to 4 Lightning Energy cards, show them to your opponent, and put them into your hand."
       }
@@ -2885,7 +2885,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for a Supporter card and discard it. Shuffle your deck afterward. Then, use the effect of that card as the effect of this attack."
       },
@@ -3341,7 +3341,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Remove 2 damage counters from Cherubi."
       },
@@ -3624,7 +3624,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Choose 1 of your opponent's Benched Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       },
@@ -3676,7 +3676,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "You opponent can't play any Trainer cards from his or her hand during your opponent's next turn."
       },
@@ -3846,7 +3846,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Flip a coin until you get tails. For each heads, draw a card."
       },
@@ -3948,7 +3948,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10",
         "text": ""
       },
@@ -4007,7 +4007,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "The Defending Pokémon is now Asleep."
       },
@@ -4687,7 +4687,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "If an attack does damage to the Defending Pokémon (after applying Weakness and Resistance), that attack does 20 more damage to that Pokémon until the end of your next turn."
       },
@@ -5528,7 +5528,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Put up to 3 damage counters on Duskull.  Then, put that many damage counters on the Defending Pokémon."
       },

--- a/json/cards/Sun & Moon.json
+++ b/json/cards/Sun & Moon.json
@@ -2956,7 +2956,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Poisoned."
       },
@@ -3957,7 +3957,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "20",
         "text": ""
       }
@@ -4065,7 +4065,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10×",
         "text": "Flip 3 coins. This attack does 10 damage for each heads."
       }
@@ -4114,7 +4114,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon."
       },
@@ -4531,7 +4531,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Look at the top 3 cards of your deck and put them back in any order."
       },

--- a/json/cards/Supreme Victors.json
+++ b/json/cards/Supreme Victors.json
@@ -2228,7 +2228,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10",
         "text": ""
       },
@@ -2925,7 +2925,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for a Trainer card, show it to your opponent, and put it into your hand. Put Chatot and all cards attached to it on top of your deck. Shuffle your deck afterward."
       }
@@ -2972,7 +2972,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "20",
         "text": ""
       },
@@ -3202,7 +3202,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Remove 1 damage counter from each of your Pokémon."
       },
@@ -3577,7 +3577,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your discard pile for up to 2 Energy cards and attach them to Manectric ."
       },
@@ -3844,7 +3844,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for up to 2 Lightning Basic Pokémon and put them onto your Bench. Shuffle your deck afterward."
       },
@@ -3899,7 +3899,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Move a Pokémon Tool card attached to 1 of your opponent's Pokémon to another of your opponent's Pokémon (excluding Pokémon that already has a Pokémon Tool attached to it). (If an effect of this attack is prevented, this attack does nothing.)"
       },
@@ -4122,7 +4122,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "If you have the same number of cards or less in your hand as your opponent, draw cards until you have 1 more card than your opponent. (If you have more cards in your hand than your opponent, this attack does nothing.)"
       },
@@ -4665,7 +4665,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Draw a card."
       },
@@ -5207,7 +5207,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Attach a Grass Energy card from your hand to Cherubi."
       },
@@ -5323,7 +5323,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your opponent's discard pile for a Supporter card and use the effect of that card as the effect of this attack. (The Supporter card remains in your opponent's discard pile.)"
       }
@@ -5634,7 +5634,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "20",
         "text": "Flip a coin. If tails, this attack does nothing."
       },

--- a/json/cards/Team Rocket.json
+++ b/json/cards/Team Rocket.json
@@ -26,9 +26,9 @@
       {
         "name": "Teleport Blast",
         "cost": [
-          "Colorless",
           "Psychic",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -145,9 +145,9 @@
       {
         "name": "Rocket Tackle",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -464,9 +464,9 @@
       {
         "name": "Bench Manipulation",
         "cost": [
-          "Colorless",
           "Psychic",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20×",
@@ -519,10 +519,10 @@
       {
         "name": "Fling",
         "cost": [
-          "Colorless",
           "Fighting",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "",
@@ -716,8 +716,8 @@
       {
         "name": "Mass Explosion",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20×",
@@ -822,9 +822,9 @@
       {
         "name": "Teleport Blast",
         "cost": [
-          "Colorless",
           "Psychic",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -941,9 +941,9 @@
       {
         "name": "Rocket Tackle",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -1265,9 +1265,9 @@
       {
         "name": "Bench Manipulation",
         "cost": [
-          "Colorless",
           "Psychic",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20×",
@@ -1320,10 +1320,10 @@
       {
         "name": "Fling",
         "cost": [
-          "Colorless",
           "Fighting",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "",
@@ -1517,8 +1517,8 @@
       {
         "name": "Mass Explosion",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20×",
@@ -1843,9 +1843,9 @@
       {
         "name": "Super Psy",
         "cost": [
-          "Colorless",
           "Psychic",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
@@ -1895,9 +1895,9 @@
       {
         "name": "Thunder Attack",
         "cost": [
-          "Colorless",
           "Lightning",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -1990,9 +1990,9 @@
       {
         "name": "Drag Off",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
@@ -2001,9 +2001,9 @@
       {
         "name": "Knock Back",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -2256,9 +2256,9 @@
       {
         "name": "Whirlpool",
         "cost": [
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
@@ -2308,8 +2308,8 @@
       {
         "name": "Mirror Shell",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -2633,8 +2633,8 @@
       {
         "name": "Scratch",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
@@ -2732,8 +2732,8 @@
       {
         "name": "Nightmare",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
@@ -2957,8 +2957,8 @@
       {
         "name": "Poison Gas",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "",
@@ -3011,9 +3011,9 @@
       {
         "name": "Kick",
         "cost": [
+          "Fighting",
           "Colorless",
-          "Colorless",
-          "Fighting"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -3066,8 +3066,8 @@
       {
         "name": "Magnetism",
         "cost": [
-          "Colorless",
-          "Lightning"
+          "Lightning",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10+",
@@ -3116,8 +3116,8 @@
       {
         "name": "Anger",
         "cost": [
-          "Colorless",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
@@ -3262,8 +3262,8 @@
       {
         "name": "Ember",
         "cost": [
-          "Colorless",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
@@ -3315,8 +3315,8 @@
       {
         "name": "Water Gun",
         "cost": [
-          "Colorless",
-          "Water"
+          "Water",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
@@ -3556,8 +3556,8 @@
       {
         "name": "Bite",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20",

--- a/json/cards/Unseen Forces.json
+++ b/json/cards/Unseen Forces.json
@@ -2594,7 +2594,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "40",
         "text": "Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
       }
@@ -3493,7 +3493,7 @@
         "cost": [
           "Free"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10",
         "text": ""
       }

--- a/json/cards/Wizards Black Star Promos.json
+++ b/json/cards/Wizards Black Star Promos.json
@@ -137,9 +137,9 @@
       {
         "name": "Psyburn",
         "cost": [
-          "Colorless",
           "Psychic",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -701,9 +701,9 @@
       {
         "name": "Psyburn",
         "cost": [
-          "Colorless",
           "Psychic",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -930,8 +930,8 @@
       {
         "name": "Synchronize",
         "cost": [
-          "Colorless",
-          "Psychic"
+          "Psychic",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
@@ -1573,9 +1573,9 @@
       {
         "name": "Metal Pincer",
         "cost": [
+          "Metal",
           "Colorless",
-          "Colorless",
-          "Metal"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
@@ -1748,9 +1748,9 @@
       {
         "name": "Rapid Spin",
         "cost": [
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -1946,10 +1946,10 @@
       {
         "name": "Fling",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fighting",
-          "Fighting"
+          "Fighting",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
@@ -1998,9 +1998,9 @@
       {
         "name": "Magma Punch",
         "cost": [
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
@@ -2193,10 +2193,10 @@
       {
         "name": "Ice Beam",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Water",
-          "Water"
+          "Water",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "30",
@@ -2290,8 +2290,8 @@
       {
         "name": "Leaf Slice",
         "cost": [
-          "Colorless",
-          "Grass"
+          "Grass",
+          "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "20×",
@@ -2337,9 +2337,9 @@
       {
         "name": "Super Singe",
         "cost": [
+          "Fire",
           "Colorless",
-          "Colorless",
-          "Fire"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
@@ -2378,10 +2378,10 @@
       {
         "name": "Sacred Fire",
         "cost": [
-          "Colorless",
-          "Colorless",
           "Fire",
-          "Fire"
+          "Fire",
+          "Colorless",
+          "Colorless"
         ],
         "convertedEnergyCost": 4,
         "damage": "",
@@ -2430,9 +2430,9 @@
       {
         "name": "Hypno Wave",
         "cost": [
+          "Water",
           "Colorless",
-          "Colorless",
-          "Water"
+          "Colorless"
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",


### PR DESCRIPTION
Change sort order for many cards to match the order specified on the cards.  Nearly all sets follow a similar order (exceptions below).  Made several corrections to convertedEnergyCost when attacks are ‘Free’ and therefore don’t have a cost.  The following sets are not sorted as they don't follow the  convention:
  "dont_sort_energy": [
      "ecard",
      "ecard2",
      "ecard3",
      "pl4",
      "ex8",
      "ex13",
      "dp2",
      "neo3",
      "neo4",
      "ex10"
    ]
For these sets (some of which only have one or two cards with attacks requring multiple energy types) I’ll likely review manually and submit an additional PR if necessary. 

For all sets, colorless is put to the end (same as on the card - this is consistent across all sets)

Lastly, fixed a few instances of “Green” vs. “Grass” energy and “Dark” vs. “Darkness”