### PR TITLE
Fix apostrophe

### DIFF
--- a/json/cards/Aquapolis.json
+++ b/json/cards/Aquapolis.json
@@ -3445,7 +3445,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Pure Body",
-      "text": "Whenever you attach a Water Energy from your hand to Suicune, discard an Energy card attached to Suicune. (You can’t attach a Water Energy card from your hand if Suicune has no Energy cards attached.)",
+      "text": "Whenever you attach a Water Energy from your hand to Suicune, discard an Energy card attached to Suicune. (You can't attach a Water Energy card from your hand if Suicune has no Energy cards attached.)",
       "type": "Poké-Body"
     },
     "hp": "70",

--- a/json/cards/BREAKthrough.json
+++ b/json/cards/BREAKthrough.json
@@ -6911,7 +6911,7 @@
     "set": "BREAKthrough",
     "setCode": "xy8",
     "text": [
-      "Choose which way this card faces before you play it. Any damage done by attacks from this ↓ player’s Grass, Fire, or Water Pokémon is reduced by 20 (before applying Weakness and Resistance).",
+      "Choose which way this card faces before you play it. Any damage done by attacks from this ↓ player's Grass, Fire, or Water Pokémon is reduced by 20 (before applying Weakness and Resistance).",
       "Choose which way this card faces before you play it. This ↓ player can't have more than 3 Benched Pokémon. (When this card comes into play, this ↓ player discards Benched Pokémon until he or she has 3 Pokémon on the Bench.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/145_hires.png"

--- a/json/cards/Burning Shadows.json
+++ b/json/cards/Burning Shadows.json
@@ -822,7 +822,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "150",
-        "text": "Switch this Pokémon with 1 of your Benched Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Switch this Pokémon with 1 of your Benched Pokémon. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -1070,7 +1070,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Put 3 in any combination of Fire Pokémon-GX or Fire Pokémon-EX from your discard pile onto your Bench. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Put 3 in any combination of Fire Pokémon-GX or Fire Pokémon-EX from your discard pile onto your Bench. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -1279,7 +1279,7 @@
         "text": ""
       },
       {
-        "name": "Queen’s Haze-GX",
+        "name": "Queen's Haze-GX",
         "cost": [
           "Fire",
           "Fire"
@@ -1976,7 +1976,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Shuffle your opponent’s Active Pokémon and all cards attached to it into their deck. If your opponent has no Benched Pokémon, this attack does nothing. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Shuffle your opponent's Active Pokémon and all cards attached to it into their deck. If your opponent has no Benched Pokémon, this attack does nothing. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/39_hires.png"
@@ -2294,7 +2294,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "If your opponent's Active Pokémon’s maximum HP is 100 or more, this attack does nothing."
+        "text": "If your opponent's Active Pokémon's maximum HP is 100 or more, this attack does nothing."
       }
     ],
     "weaknesses": [
@@ -2660,7 +2660,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 1 damage counter on each Pokémon (both yours and your opponent’s)."
+        "text": "Put 1 damage counter on each Pokémon (both yours and your opponent's)."
       },
       {
         "name": "Ambush",
@@ -3046,7 +3046,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "The Defending Pokémon’s Weakness is now Psychic until the end of your next turn. (The amount of Weakness doesn’t change.)"
+        "text": "The Defending Pokémon's Weakness is now Psychic until the end of your next turn. (The amount of Weakness doesn't change.)"
       }
     ],
     "weaknesses": [
@@ -3232,7 +3232,7 @@
     "supertype": "Pokémon",
     "level": "GX",
     "ability": {
-      "name": "Light’s End",
+      "name": "Light's End",
       "text": "Prevent all damage done to this Pokémon by attacks from Colorless Pokémon.",
       "type": "Ability"
     },
@@ -3274,7 +3274,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 100 damage to each of your opponent's Pokémon-GX and Pokémon-EX. This damage isn't affected by Weakness or Resistance. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 100 damage to each of your opponent's Pokémon-GX and Pokémon-EX. This damage isn't affected by Weakness or Resistance. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -3343,7 +3343,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "180",
-        "text": "This attack's damage isn't affected by Resistance. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack's damage isn't affected by Resistance. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -3677,7 +3677,7 @@
     "evolvesFrom": "Riolu",
     "ability": {
       "name": "Stance",
-      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may prevent all effects of your opponent’s attacks, including damage, done to this Pokémon until the end of your opponent’s next turn.",
+      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may prevent all effects of your opponent's attacks, including damage, done to this Pokémon until the end of your opponent's next turn.",
       "type": "Ability"
     },
     "hp": "120",
@@ -4409,7 +4409,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. The new Active Pokémon is now Burned, Paralyzed, and Poisoned. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. The new Active Pokémon is now Burned, Paralyzed, and Poisoned. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -4934,7 +4934,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Shuffle 10 cards from your discard pile into your deck. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Shuffle 10 cards from your discard pile into your deck. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -5181,7 +5181,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Heal from this Pokémon 30 damage times the amount of Energy attached to your opponent’s Active Pokémon."
+        "text": "Heal from this Pokémon 30 damage times the amount of Energy attached to your opponent's Active Pokémon."
       },
       {
         "name": "Sleep Pulse",
@@ -5262,7 +5262,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 50 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -5448,7 +5448,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at 1 of your opponent’s face-down Prize cards."
+        "text": "Look at 1 of your opponent's face-down Prize cards."
       },
       {
         "name": "Beam",
@@ -5959,7 +5959,7 @@
     "set": "Burning Shadows",
     "setCode": "sm3",
     "text": [
-      "Switch 1 of your opponent’s Benched Pokémon with their Active Pokémon. If you do, switch your Active Pokémon with 1 of your Benched Pokémon."
+      "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. If you do, switch your Active Pokémon with 1 of your Benched Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/115_hires.png"
   },
@@ -6240,7 +6240,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "150",
-        "text": "Switch this Pokémon with 1 of your Benched Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Switch this Pokémon with 1 of your Benched Pokémon. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6288,7 +6288,7 @@
         "text": ""
       },
       {
-        "name": "Nature’s Judgment",
+        "name": "Nature's Judgment",
         "cost": [
           "Grass",
           "Grass",
@@ -6369,7 +6369,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Put 3 in any combination of Fire Pokémon-GX or Fire Pokémon-EX from your discard pile onto your Bench. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Put 3 in any combination of Fire Pokémon-GX or Fire Pokémon-EX from your discard pile onto your Bench. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6434,7 +6434,7 @@
         "text": ""
       },
       {
-        "name": "Queen’s Haze-GX",
+        "name": "Queen's Haze-GX",
         "cost": [
           "Fire",
           "Fire"
@@ -6504,7 +6504,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Shuffle your opponent’s Active Pokémon and all cards attached to it into their deck. If your opponent has no Benched Pokémon, this attack does nothing. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Shuffle your opponent's Active Pokémon and all cards attached to it into their deck. If your opponent has no Benched Pokémon, this attack does nothing. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/133_hires.png"
@@ -6517,7 +6517,7 @@
     "supertype": "Pokémon",
     "level": "GX",
     "ability": {
-      "name": "Light’s End",
+      "name": "Light's End",
       "text": "Prevent all damage done to this Pokémon by attacks from Colorless Pokémon.",
       "type": "Ability"
     },
@@ -6559,7 +6559,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 100 damage to each of your opponent's Pokémon-GX and Pokémon-EX. This damage isn't affected by Weakness or Resistance. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 100 damage to each of your opponent's Pokémon-GX and Pokémon-EX. This damage isn't affected by Weakness or Resistance. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6628,7 +6628,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "180",
-        "text": "This attack's damage isn't affected by Resistance. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack's damage isn't affected by Resistance. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6824,7 +6824,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. The new Active Pokémon is now Burned, Paralyzed, and Poisoned. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. The new Active Pokémon is now Burned, Paralyzed, and Poisoned. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6957,7 +6957,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Shuffle 10 cards from your discard pile into your deck. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Shuffle 10 cards from your discard pile into your deck. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7027,7 +7027,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 50 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7069,7 +7069,7 @@
     "set": "Burning Shadows",
     "setCode": "sm3",
     "text": [
-      "Switch 1 of your opponent’s Benched Pokémon with their Active Pokémon. If you do, switch your Active Pokémon with 1 of your Benched Pokémon."
+      "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. If you do, switch your Active Pokémon with 1 of your Benched Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/143_hires.png"
   },
@@ -7197,7 +7197,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "150",
-        "text": "Switch this Pokémon with 1 of your Benched Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Switch this Pokémon with 1 of your Benched Pokémon. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7245,7 +7245,7 @@
         "text": ""
       },
       {
-        "name": "Nature’s Judgment",
+        "name": "Nature's Judgment",
         "cost": [
           "Grass",
           "Grass",
@@ -7326,7 +7326,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Put 3 in any combination of Fire Pokémon-GX or Fire Pokémon-EX from your discard pile onto your Bench. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Put 3 in any combination of Fire Pokémon-GX or Fire Pokémon-EX from your discard pile onto your Bench. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7391,7 +7391,7 @@
         "text": ""
       },
       {
-        "name": "Queen’s Haze-GX",
+        "name": "Queen's Haze-GX",
         "cost": [
           "Fire",
           "Fire"
@@ -7461,7 +7461,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Shuffle your opponent’s Active Pokémon and all cards attached to it into their deck. If your opponent has no Benched Pokémon, this attack does nothing. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Shuffle your opponent's Active Pokémon and all cards attached to it into their deck. If your opponent has no Benched Pokémon, this attack does nothing. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/152_hires.png"
@@ -7474,7 +7474,7 @@
     "supertype": "Pokémon",
     "level": "GX",
     "ability": {
-      "name": "Light’s End",
+      "name": "Light's End",
       "text": "Prevent all damage done to this Pokémon by attacks from Colorless Pokémon.",
       "type": "Ability"
     },
@@ -7516,7 +7516,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 100 damage to each of your opponent's Pokémon-GX and Pokémon-EX. This damage isn't affected by Weakness or Resistance. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 100 damage to each of your opponent's Pokémon-GX and Pokémon-EX. This damage isn't affected by Weakness or Resistance. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7585,7 +7585,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "180",
-        "text": "This attack's damage isn't affected by Resistance. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack's damage isn't affected by Resistance. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7781,7 +7781,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. The new Active Pokémon is now Burned, Paralyzed, and Poisoned. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. The new Active Pokémon is now Burned, Paralyzed, and Poisoned. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7914,7 +7914,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Shuffle 10 cards from your discard pile into your deck. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Shuffle 10 cards from your discard pile into your deck. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7984,7 +7984,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 50 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [

--- a/json/cards/Crimson Invasion.json
+++ b/json/cards/Crimson Invasion.json
@@ -1284,7 +1284,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Shuffle 1 of your opponent’s Benched Pokémon that has any damage counters on it and all cards attached to it into their deck."
+        "text": "Shuffle 1 of your opponent's Benched Pokémon that has any damage counters on it and all cards attached to it into their deck."
       },
       {
         "name": "Ocean Cyclone",
@@ -1702,7 +1702,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "Your opponent can't play any cards from their hand during their next turn. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Your opponent can't play any cards from their hand during their next turn. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -2454,7 +2454,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Add the top 2 cards of your opponent's deck to their Prize cards. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Add the top 2 cards of your opponent's deck to their Prize cards. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -3226,7 +3226,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "100",
-        "text": "If your opponent's Pokémon is Knocked Out by damage from this attack, take 2 more Prize cards. (You can’t use more than 1 GX attack in a game.)"
+        "text": "If your opponent's Pokémon is Knocked Out by damage from this attack, take 2 more Prize cards. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -3304,7 +3304,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "100",
-        "text": "If your opponent's Pokémon is Knocked Out by damage from this attack, take 2 more Prize cards. (You can’t use more than 1 GX attack in a game.)"
+        "text": "If your opponent's Pokémon is Knocked Out by damage from this attack, take 2 more Prize cards. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -3842,7 +3842,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "If any of your opponent’s Pokémon have any Darkness Energy attached to them, this attack does 60 more damage."
+        "text": "If any of your opponent's Pokémon have any Darkness Energy attached to them, this attack does 60 more damage."
       }
     ],
     "weaknesses": [
@@ -3975,7 +3975,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "180",
-        "text": "Move any number of Energy from your Pokémon to your other Pokémon in any way you like. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Move any number of Energy from your Pokémon to your other Pokémon in any way you like. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -4593,7 +4593,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 2 cards from your discard pile. Then, ask your opponent if you may put them into your hand. If yes, put those cards into your hand. If no, this attack does 80 damage to your opponent’s Active Pokémon."
+        "text": "Choose 2 cards from your discard pile. Then, ask your opponent if you may put them into your hand. If yes, put those cards into your hand. If no, this attack does 80 damage to your opponent's Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -4900,7 +4900,7 @@
     "set": "Crimson Invasion",
     "setCode": "sm4",
     "text": [
-      "Look at your face-down Prize cards and put 1 of them into your hand. Then, shuffle this Gladion into your remaining Prize cards and put them back face down. If you didn’t play this Gladion from your hand, it does nothing."
+      "Look at your face-down Prize cards and put 1 of them into your hand. Then, shuffle this Gladion into your remaining Prize cards and put them back face down. If you didn't play this Gladion from your hand, it does nothing."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm4/95_hires.png"
   },
@@ -4968,7 +4968,7 @@
     "set": "Crimson Invasion",
     "setCode": "sm4",
     "text": [
-      "Special Conditions are not removed when Pokémon (both yours and your opponent’s) evolve or devolve."
+      "Special Conditions are not removed when Pokémon (both yours and your opponent's) evolve or devolve."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm4/99_hires.png"
   },
@@ -5121,7 +5121,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "Your opponent can't play any cards from their hand during their next turn. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Your opponent can't play any cards from their hand during their next turn. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -5189,7 +5189,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Add the top 2 cards of your opponent's deck to their Prize cards. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Add the top 2 cards of your opponent's deck to their Prize cards. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -5327,7 +5327,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "100",
-        "text": "If your opponent's Pokémon is Knocked Out by damage from this attack, take 2 more Prize cards. (You can’t use more than 1 GX attack in a game.)"
+        "text": "If your opponent's Pokémon is Knocked Out by damage from this attack, take 2 more Prize cards. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -5468,7 +5468,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "180",
-        "text": "Move any number of Energy from your Pokémon to your other Pokémon in any way you like. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Move any number of Energy from your Pokémon to your other Pokémon in any way you like. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -5556,7 +5556,7 @@
     "set": "Crimson Invasion",
     "setCode": "sm4",
     "text": [
-      "Look at your face-down Prize cards and put 1 of them into your hand. Then, shuffle this Gladion into your remaining Prize cards and put them back face down. If you didn’t play this Gladion from your hand, it does nothing."
+      "Look at your face-down Prize cards and put 1 of them into your hand. Then, shuffle this Gladion into your remaining Prize cards and put them back face down. If you didn't play this Gladion from your hand, it does nothing."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm4/109_hires.png"
   },
@@ -5726,7 +5726,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "Your opponent can't play any cards from their hand during their next turn. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Your opponent can't play any cards from their hand during their next turn. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -5794,7 +5794,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Add the top 2 cards of your opponent's deck to their Prize cards. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Add the top 2 cards of your opponent's deck to their Prize cards. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -5932,7 +5932,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "100",
-        "text": "If your opponent's Pokémon is Knocked Out by damage from this attack, take 2 more Prize cards. (You can’t use more than 1 GX attack in a game.)"
+        "text": "If your opponent's Pokémon is Knocked Out by damage from this attack, take 2 more Prize cards. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6073,7 +6073,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "180",
-        "text": "Move any number of Energy from your Pokémon to your other Pokémon in any way you like. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Move any number of Energy from your Pokémon to your other Pokémon in any way you like. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [

--- a/json/cards/Diamond & Pearl.json
+++ b/json/cards/Diamond & Pearl.json
@@ -3125,7 +3125,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, discard an Energy card attached to 1 of your opponent’s Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy card attached to 1 of your opponent's Pokémon."
       },
       {
         "name": "Razor Wind",

--- a/json/cards/Evolutions.json
+++ b/json/cards/Evolutions.json
@@ -3593,7 +3593,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose Grass, Fire, Water, Lightning, Psychic, Fighting, Darkness, Metal, Fairy, or Dragon type. The Defending Pokémon’s Weakness is now that type until the end of your next turn. (The amount of Weakness doesn’t change.)"
+        "text": "Choose Grass, Fire, Water, Lightning, Psychic, Fighting, Darkness, Metal, Fairy, or Dragon type. The Defending Pokémon's Weakness is now that type until the end of your next turn. (The amount of Weakness doesn't change.)"
       }
     ],
     "weaknesses": [

--- a/json/cards/Generations.json
+++ b/json/cards/Generations.json
@@ -1464,7 +1464,6 @@
     "nationalPokedexNumber": 135,
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/28_hires.png"
   },
-
   {
     "id": "g1-28a",
     "name": "Jolteon-EX",

--- a/json/cards/Guardians Rising.json
+++ b/json/cards/Guardians Rising.json
@@ -867,7 +867,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Attach 5 Fire Energy cards from your discard pile to your Pokémon in any way you like. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Attach 5 Fire Energy cards from your discard pile to your Pokémon in any way you like. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -1086,7 +1086,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Move all damage counters from this Pokémon to your opponent's Active Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Move all damage counters from this Pokémon to your opponent's Active Pokémon. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -1125,7 +1125,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "The Defending Pokémon can’t be healed during your opponent's next turn."
+        "text": "The Defending Pokémon can't be healed during your opponent's next turn."
       }
     ],
     "weaknesses": [
@@ -1760,7 +1760,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put a Basic Pokémon from either player’s discard pile onto its owner’s Bench."
+        "text": "Put a Basic Pokémon from either player's discard pile onto its owner's Bench."
       },
       {
         "name": "Hydro Splash",
@@ -1883,7 +1883,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "220",
-        "text": "Move all Energy from this Pokémon to your Benched Pokémon in any way you like. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Move all Energy from this Pokémon to your Benched Pokémon in any way you like. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -2296,7 +2296,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "This attack does 60 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 60 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -2418,7 +2418,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50×",
-        "text": "This attack does 50 damage times the amount of Energy attached to all of your opponent's Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage times the amount of Energy attached to all of your opponent's Pokémon. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/47_hires.png"
@@ -2858,7 +2858,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "For each Pokémon in your opponent’s discard pile, put 1 damage counter on your opponent's Pokémon in any way you like."
+        "text": "For each Pokémon in your opponent's discard pile, put 1 damage counter on your opponent's Pokémon in any way you like."
       },
       {
         "name": "Revelation Dance",
@@ -2941,7 +2941,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "150",
-        "text": "Prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -3095,7 +3095,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Heal all damage from 2 of your Benched Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Heal all damage from 2 of your Benched Pokémon. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/60_hires.png"
@@ -3255,7 +3255,7 @@
     "evolvesFrom": "Machop",
     "ability": {
       "name": "Daunting Pose",
-      "text": "Prevent all damage done to your Benched Pokémon by your opponent's attacks. Your opponent’s attacks and Abilities can't put damage counters on your Benched Pokémon.",
+      "text": "Prevent all damage done to your Benched Pokémon by your opponent's attacks. Your opponent's attacks and Abilities can't put damage counters on your Benched Pokémon.",
       "type": "Ability"
     },
     "hp": "100",
@@ -3359,7 +3359,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Roadblock",
-      "text": "Your opponent can’t have more than 4 Benched Pokémon. If they have 5 or more Benched Pokémon, they discard Benched Pokémon until they have 4 Pokémon on the Bench. If more than one effect changes the number of Benched Pokémon allowed, use the smaller number.",
+      "text": "Your opponent can't have more than 4 Benched Pokémon. If they have 5 or more Benched Pokémon, they discard Benched Pokémon until they have 4 Pokémon on the Bench. If more than one effect changes the number of Benched Pokémon allowed, use the smaller number.",
       "type": "Ability"
     },
     "hp": "100",
@@ -3801,7 +3801,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50×",
-        "text": "This attack does 50 damage for each of your opponent's Benched Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage for each of your opponent's Benched Pokémon. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -4393,7 +4393,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Search your deck for up to 5 cards and put them into your hand. Then, shuffle your deck. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Search your deck for up to 5 cards and put them into your hand. Then, shuffle your deck. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -4802,7 +4802,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Put 2 of your opponent's Benched Pokémon and all cards attached to them into your opponent’s hand. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Put 2 of your opponent's Benched Pokémon and all cards attached to them into your opponent's hand. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -5243,7 +5243,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "240",
-        "text": "(You can’t use more than 1 GX attack in a game.)"
+        "text": "(You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6045,7 +6045,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Shuffle your hand into your deck. Then, draw 10 cards. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Shuffle your hand into your deck. Then, draw 10 cards. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6366,7 +6366,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Attach 5 Fire Energy cards from your discard pile to your Pokémon in any way you like. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Attach 5 Fire Energy cards from your discard pile to your Pokémon in any way you like. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6432,7 +6432,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Move all damage counters from this Pokémon to your opponent's Active Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Move all damage counters from this Pokémon to your opponent's Active Pokémon. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6503,7 +6503,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "220",
-        "text": "Move all Energy from this Pokémon to your Benched Pokémon in any way you like. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Move all Energy from this Pokémon to your Benched Pokémon in any way you like. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6571,7 +6571,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "This attack does 60 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 60 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6639,7 +6639,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50×",
-        "text": "This attack does 50 damage times the amount of Energy attached to all of your opponent's Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage times the amount of Energy attached to all of your opponent's Pokémon. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/135_hires.png"
@@ -6700,7 +6700,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "150",
-        "text": "Prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6758,7 +6758,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Heal all damage from 2 of your Benched Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Heal all damage from 2 of your Benched Pokémon. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/137_hires.png"
@@ -6813,7 +6813,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50×",
-        "text": "This attack does 50 damage for each of your opponent's Benched Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage for each of your opponent's Benched Pokémon. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6875,7 +6875,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Search your deck for up to 5 cards and put them into your hand. Then, shuffle your deck. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Search your deck for up to 5 cards and put them into your hand. Then, shuffle your deck. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6948,7 +6948,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Put 2 of your opponent's Benched Pokémon and all cards attached to them into your opponent’s hand. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Put 2 of your opponent's Benched Pokémon and all cards attached to them into your opponent's hand. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7023,7 +7023,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "240",
-        "text": "(You can’t use more than 1 GX attack in a game.)"
+        "text": "(You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7087,7 +7087,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Shuffle your hand into your deck. Then, draw 10 cards. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Shuffle your hand into your deck. Then, draw 10 cards. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7199,7 +7199,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 3 cards from your discard pile into your hand. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Put 3 cards from your discard pile into your hand. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7333,7 +7333,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Attach 5 Fire Energy cards from your discard pile to your Pokémon in any way you like. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Attach 5 Fire Energy cards from your discard pile to your Pokémon in any way you like. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7467,7 +7467,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Move all damage counters from this Pokémon to your opponent's Active Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Move all damage counters from this Pokémon to your opponent's Active Pokémon. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7538,7 +7538,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "220",
-        "text": "Move all Energy from this Pokémon to your Benched Pokémon in any way you like. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Move all Energy from this Pokémon to your Benched Pokémon in any way you like. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7606,7 +7606,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "This attack does 60 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 60 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7674,7 +7674,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50×",
-        "text": "This attack does 50 damage times the amount of Energy attached to all of your opponent's Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage times the amount of Energy attached to all of your opponent's Pokémon. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/153_hires.png"
@@ -7735,7 +7735,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "150",
-        "text": "Prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7793,7 +7793,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Heal all damage from 2 of your Benched Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Heal all damage from 2 of your Benched Pokémon. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/155_hires.png"
@@ -7848,7 +7848,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50×",
-        "text": "This attack does 50 damage for each of your opponent's Benched Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage for each of your opponent's Benched Pokémon. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7910,7 +7910,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Search your deck for up to 5 cards and put them into your hand. Then, shuffle your deck. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Search your deck for up to 5 cards and put them into your hand. Then, shuffle your deck. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7983,7 +7983,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Put 2 of your opponent's Benched Pokémon and all cards attached to them into your opponent’s hand. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Put 2 of your opponent's Benched Pokémon and all cards attached to them into your opponent's hand. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -8058,7 +8058,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "240",
-        "text": "(You can’t use more than 1 GX attack in a game.)"
+        "text": "(You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -8122,7 +8122,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Shuffle your hand into your deck. Then, draw 10 cards. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Shuffle your hand into your deck. Then, draw 10 cards. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [

--- a/json/cards/HS—Unleashed.json
+++ b/json/cards/HS—Unleashed.json
@@ -1139,7 +1139,7 @@
     "evolvesFrom": "Roselia",
     "ability": {
       "name": "Energy Signal",
-      "text": "When you attach a Grass Energy card or Psychic Energy card from your hand to Roserade during your turn, you may use this power. If you attach a Grass Energy card, the Defending Pokémon is now Confused. If you attach a Psychic Energy card, the Defending Pokémon is now Poisoned. This power can’t be used if Roserade is affected by a Special Condition.",
+      "text": "When you attach a Grass Energy card or Psychic Energy card from your hand to Roserade during your turn, you may use this power. If you attach a Grass Energy card, the Defending Pokémon is now Confused. If you attach a Psychic Energy card, the Defending Pokémon is now Poisoned. This power can't be used if Roserade is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",

--- a/json/cards/Legends Awakened.json
+++ b/json/cards/Legends Awakened.json
@@ -1376,7 +1376,7 @@
     "level": "33",
     "ability": {
       "name": "Ditto DNA",
-      "text": "As long as Ditto is your Active Pokémon, its maximum HP is the same as your opponent's Active Pokémon. Ditto can use the attacks of that Pokémon as its own. (You still need the necessary Energy to use each attack.) If that Pokémon is no longer your opponent’s Active Pokémon, choose 1 of your opponent’s Active Pokémon for Ditto to copy.",
+      "text": "As long as Ditto is your Active Pokémon, its maximum HP is the same as your opponent's Active Pokémon. Ditto can use the attacks of that Pokémon as its own. (You still need the necessary Energy to use each attack.) If that Pokémon is no longer your opponent's Active Pokémon, choose 1 of your opponent's Active Pokémon for Ditto to copy.",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -3294,7 +3294,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Metang during your opponent’s next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Metang during your opponent's next turn."
       },
       {
         "name": "Metal Claw",

--- a/json/cards/Majestic Dawn.json
+++ b/json/cards/Majestic Dawn.json
@@ -1618,7 +1618,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "60",
-        "text": "Does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Frenzy Plant",

--- a/json/cards/Mysterious Treasures.json
+++ b/json/cards/Mysterious Treasures.json
@@ -2049,7 +2049,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "Does 20 damage to each Benched Pokémon (both yours and your opponent’s). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -5781,7 +5781,7 @@
     "setCode": "dp2",
     "text": [
       "Play Skull Fossil as if it were a Colorless Basic Pokémon. (Skull Fossil counts as a Trainer card as well, but if Skull Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Skull Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Skull Fossil from play. (This doesn't count as a Knocked Out Pokémon.)",
-      "During your opponent's turn, if Skull Fossil would be Knocked Out by damage from an opponent’s attack, flip a coin until you get tails. For each heads, put 1 damage counter on the Attacking Pokémon."
+      "During your opponent's turn, if Skull Fossil would be Knocked Out by damage from an opponent's attack, flip a coin until you get tails. For each heads, put 1 damage counter on the Attacking Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp2/117_hires.png"
   },

--- a/json/cards/POP Series 1.json
+++ b/json/cards/POP Series 1.json
@@ -140,7 +140,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of an attack, including damage, done to Rayquaza during your opponent’s next turn."
+        "text": "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of an attack, including damage, done to Rayquaza during your opponent's next turn."
       },
       {
         "name": "Dragon Claw",
@@ -260,7 +260,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "If your opponent has any Benched Pokémon, choose 1 of them and flip a coin. If heads, this attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, choose 1 of them and flip a coin. If heads, this attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -383,7 +383,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Insomnia",
-      "text": "Murkrow can’t be Asleep.",
+      "text": "Murkrow can't be Asleep.",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -408,7 +408,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
+        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
       }
     ],
     "weaknesses": [
@@ -501,7 +501,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
+        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
       },
       {
         "name": "Body Slam",
@@ -550,7 +550,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -602,7 +602,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Choose 2 of your opponent’s Benched Pokémon. This attack does 10 damage to each of those Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon."
+        "text": "Choose 2 of your opponent's Benched Pokémon. This attack does 10 damage to each of those Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -657,7 +657,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Plusle during your opponent’s next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Plusle during your opponent's next turn."
       }
     ],
     "weaknesses": [
@@ -745,7 +745,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, base damage of Swellow’s Agility is 70 instead of 30."
+        "text": "During your next turn, base damage of Swellow's Agility is 70 instead of 30."
       },
       {
         "name": "Agility",
@@ -755,7 +755,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Swellow during your opponent’s next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Swellow during your opponent's next turn."
       }
     ],
     "weaknesses": [
@@ -817,7 +817,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "80",
-        "text": "This attack’s damage is not affected by Resistance."
+        "text": "This attack's damage is not affected by Resistance."
       }
     ],
     "weaknesses": [

--- a/json/cards/Phantom Forces.json
+++ b/json/cards/Phantom Forces.json
@@ -1298,7 +1298,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "The Defending Pokémon’s Weakness is now Lightning until the end of your next turn. (The amount of Weakness doesn’t change.)"
+        "text": "The Defending Pokémon's Weakness is now Lightning until the end of your next turn. (The amount of Weakness doesn't change.)"
       },
       {
         "name": "Pachi",
@@ -4985,7 +4985,7 @@
     "set": "Phantom Forces",
     "setCode": "xy4",
     "text": [
-      "The attacks of the Pokémon this card is attached to do 20 less damage to all Defending Pokémon (before applying Weakness and Resistance). (Don’t apply Weakness and Resistance for Benched Pokémon.) When this card is removed from a Pokémon for any reason, put this card in its owner's discard pile."
+      "The attacks of the Pokémon this card is attached to do 20 less damage to all Defending Pokémon (before applying Weakness and Resistance). (Don't apply Weakness and Resistance for Benched Pokémon.) When this card is removed from a Pokémon for any reason, put this card in its owner's discard pile."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/98_hires.png"
   },

--- a/json/cards/Plasma Storm.json
+++ b/json/cards/Plasma Storm.json
@@ -3881,7 +3881,7 @@
     "evolvesFrom": "Riolu",
     "ability": {
       "name": "Dual Armor",
-      "text": "If this Pokémon has any { Metal } Energy attached to it, this Pokémon’s type is both { Fighting } and { Metal }.",
+      "text": "If this Pokémon has any { Metal } Energy attached to it, this Pokémon's type is both { Fighting } and { Metal }.",
       "type": "Ability"
     },
     "hp": "100",

--- a/json/cards/Platinum.json
+++ b/json/cards/Platinum.json
@@ -112,7 +112,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Discard 2 Water Energy attached to Blastoise. Choose 2 of your opponent's Benched Pokémon. This attack does 60 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.) Blastoise can't use Double Launcher during your next turn."
+        "text": "Discard 2 Water Energy attached to Blastoise. Choose 2 of your opponent's Benched Pokémon. This attack does 60 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.) Blastoise can't use Double Launcher during your next turn."
       }
     ],
     "weaknesses": [
@@ -6180,7 +6180,7 @@
     "level": "X",
     "ability": {
       "name": "Invisible Tentacles",
-      "text": "Whenever your opponent's Pokémon tries to attack, your opponent discards 1 card from his or her hand. (If your opponent can’t discard 1 card, your opponent's Pokémon can't attack.) You can't use more than 1 Invisible Tentacles Poké-Body each turn.",
+      "text": "Whenever your opponent's Pokémon tries to attack, your opponent discards 1 card from his or her hand. (If your opponent can't discard 1 card, your opponent's Pokémon can't attack.) You can't use more than 1 Invisible Tentacles Poké-Body each turn.",
       "type": "Poké-Body"
     },
     "hp": "130",

--- a/json/cards/Rising Rivals.json
+++ b/json/cards/Rising Rivals.json
@@ -5004,7 +5004,7 @@
     "setCode": "pl2",
     "text": [
       "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "Once during each player’s turn, if that player’s Bench isn’t full, the player may flip a coin. If heads, that player searches his or her deck for a Basic Pokémon and puts it onto his or her Bench. If the player does, he or she may search his or her deck for a Pokémon Tool card and attach it to that Pokémon. If that player searched his or her deck, the player shuffles his or her deck afterward."
+      "Once during each player's turn, if that player's Bench isn't full, the player may flip a coin. If heads, that player searches his or her deck for a Basic Pokémon and puts it onto his or her Bench. If the player does, he or she may search his or her deck for a Pokémon Tool card and attach it to that Pokémon. If that player searched his or her deck, the player shuffles his or her deck afterward."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl2/93_hires.png"
   },
@@ -5146,7 +5146,7 @@
     "set": "Rising Rivals",
     "setCode": "pl2",
     "text": [
-      "SP Energy provides Colorless Energy. If the Pokémon SP Energy is attached to is a Pokémon SP, SP Energy provides every type of Energy but provides only 1 Energy at a time. (Doesn’t count as a basic Energy card.)"
+      "SP Energy provides Colorless Energy. If the Pokémon SP Energy is attached to is a Pokémon SP, SP Energy provides every type of Energy but provides only 1 Energy at a time. (Doesn't count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl2/101_hires.png"
   },
@@ -5227,7 +5227,7 @@
     "level": "X",
     "ability": {
       "name": "Water Rescue",
-      "text": "Whenever any of your Water Pokémon (excluding any Floatzel ) is Knocked Out by damage from your opponent’s attack, you may put that Pokémon and all cards that were attached to it from your discard pile into your hand.",
+      "text": "Whenever any of your Water Pokémon (excluding any Floatzel ) is Knocked Out by damage from your opponent's attack, you may put that Pokémon and all cards that were attached to it from your discard pile into your hand.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -5409,7 +5409,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Discard 2 Fighting Energy attached to Hippowdon and choose 2 of your opponent's Benched Pokémon. This attack does 40 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard 2 Fighting Energy attached to Hippowdon and choose 2 of your opponent's Benched Pokémon. This attack does 40 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [

--- a/json/cards/Shining Legends.json
+++ b/json/cards/Shining Legends.json
@@ -499,7 +499,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 150 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 150 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -1992,7 +1992,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "200",
-        "text": "This attack's damage isn't affected by any effects on your opponent's Active Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack's damage isn't affected by any effects on your opponent's Active Pokémon. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -2127,7 +2127,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If your opponent’s Active Pokémon is an evolved Pokémon, devolve it by putting all of the Evolution cards on it into your opponent's hand."
+        "text": "If your opponent's Active Pokémon is an evolved Pokémon, devolve it by putting all of the Evolution cards on it into your opponent's hand."
       }
     ],
     "weaknesses": [
@@ -2736,7 +2736,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon's attacks and use it as this attack. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Choose 1 of your opponent's Pokémon's attacks and use it as this attack. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -2925,7 +2925,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Fabled Defense",
-      "text": "As long as this Pokémon is your Active Pokémon, prevent all damage done to your Benched Pokémon by your opponent’s attacks.",
+      "text": "As long as this Pokémon is your Active Pokémon, prevent all damage done to your Benched Pokémon by your opponent's attacks.",
       "type": "Ability"
     },
     "hp": "130",
@@ -3241,7 +3241,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 150 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 150 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -3306,7 +3306,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "200",
-        "text": "This attack's damage isn't affected by any effects on your opponent's Active Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack's damage isn't affected by any effects on your opponent's Active Pokémon. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -3390,7 +3390,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 150 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 150 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -3528,7 +3528,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "200",
-        "text": "This attack's damage isn't affected by any effects on your opponent's Active Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack's damage isn't affected by any effects on your opponent's Active Pokémon. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -3589,7 +3589,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon's attacks and use it as this attack. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Choose 1 of your opponent's Pokémon's attacks and use it as this attack. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -3660,7 +3660,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "200",
-        "text": "This attack's damage isn't affected by any effects on your opponent's Active Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack's damage isn't affected by any effects on your opponent's Active Pokémon. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [

--- a/json/cards/Steam Siege.json
+++ b/json/cards/Steam Siege.json
@@ -314,7 +314,7 @@
     "evolvesFrom": "Yanma",
     "ability": {
       "name": "Sonic Vision",
-      "text": "If you have exactly 4 cards in your hand, ignore all Energy in the attack cost of each of this Pokémon’s attacks.",
+      "text": "If you have exactly 4 cards in your hand, ignore all Energy in the attack cost of each of this Pokémon's attacks.",
       "type": "Ability"
     },
     "hp": "110",

--- a/json/cards/Stormfront.json
+++ b/json/cards/Stormfront.json
@@ -220,7 +220,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Lumineon during your opponent’s next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Lumineon during your opponent's next turn."
       }
     ],
     "weaknesses": [
@@ -1547,7 +1547,7 @@
     "evolvesFrom": "Stunky",
     "ability": {
       "name": "Evolutionary Gas",
-      "text": "Once during your turn (before your attack), when you play Skuntank from your hand to evolve 1 of your Active Pokémon, you may choose 1 of the Defending Pokémon. If that Pokémon tries to attack during your opponent’s next turn, that attack does nothing.",
+      "text": "Once during your turn (before your attack), when you play Skuntank from your hand to evolve 1 of your Active Pokémon, you may choose 1 of the Defending Pokémon. If that Pokémon tries to attack during your opponent's next turn, that attack does nothing.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -4195,7 +4195,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Ponyta during your opponent’s next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Ponyta during your opponent's next turn."
       }
     ],
     "weaknesses": [

--- a/json/cards/Sun & Moon Black Star Promos.json
+++ b/json/cards/Sun & Moon Black Star Promos.json
@@ -110,7 +110,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent’s Active Pokémon is now Asleep."
+        "text": "Your opponent's Active Pokémon is now Asleep."
       }
     ],
     "weaknesses": [
@@ -152,7 +152,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
       },
       {
         "name": "Electro Ball",
@@ -855,7 +855,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "For each Pokémon in your opponent’s discard pile, put 1 damage counter on your opponent's Pokémon in any way you like."
+        "text": "For each Pokémon in your opponent's discard pile, put 1 damage counter on your opponent's Pokémon in any way you like."
       },
       {
         "name": "Revelation Dance",
@@ -1536,7 +1536,7 @@
         "text": ""
       },
       {
-        "name": "Nature’s Judgment",
+        "name": "Nature's Judgment",
         "cost": [
           "Grass",
           "Grass",
@@ -1610,7 +1610,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50×",
-        "text": "This attack does 50 damage times the amount of Energy attached to all of your opponent's Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage times the amount of Energy attached to all of your opponent's Pokémon. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/smp/SM33_hires.png"
@@ -1736,7 +1736,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 3 cards from your discard pile into your hand. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Put 3 cards from your discard pile into your hand. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -2147,7 +2147,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50x",
-        "text": "This attack does 50 damage for each Prize card your opponent has taken. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage for each Prize card your opponent has taken. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -2218,7 +2218,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "180",
-        "text": "Turn all of your Prize cards face up. (Those Prize cards remain face up for the rest of the game.) (You can’t use more than 1 GX attack in a game.)"
+        "text": "Turn all of your Prize cards face up. (Those Prize cards remain face up for the rest of the game.) (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -2278,7 +2278,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent reveals their hand. Add a card you find there to their Prize cards face down. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Your opponent reveals their hand. Add a card you find there to their Prize cards face down. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "ability": {
@@ -2408,7 +2408,7 @@
           "Darkness"
         ],
         "name": "Trickster-GX",
-        "text": "Choose 1 of your opponent's Pokémon's attacks and use it as this attack. (You can’t use more than 1 GX attack in a game.)",
+        "text": "Choose 1 of your opponent's Pokémon's attacks and use it as this attack. (You can't use more than 1 GX attack in a game.)",
         "damage": "",
         "convertedEnergyCost": 2
       }

--- a/json/cards/Sun & Moon.json
+++ b/json/cards/Sun & Moon.json
@@ -591,7 +591,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 3 cards from your discard pile into your hand. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Put 3 cards from your discard pile into your hand. (You can't use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [

--- a/json/cards/Unseen Forces.json
+++ b/json/cards/Unseen Forces.json
@@ -90,7 +90,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "The Defending Pokémon is now Asleep and Poisoned. Before applying this effect, you may switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon. If you do, the new Defending Pokémon is now Asleep and Poisoned. Your opponent chooses the Defending Pokémon to switch."
+        "text": "The Defending Pokémon is now Asleep and Poisoned. Before applying this effect, you may switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. If you do, the new Defending Pokémon is now Asleep and Poisoned. Your opponent chooses the Defending Pokémon to switch."
       }
     ],
     "weaknesses": [

--- a/json/cards/XY Black Star Promos.json
+++ b/json/cards/XY Black Star Promos.json
@@ -1274,7 +1274,7 @@
     "evolvesFrom": "Frogadier",
     "ability": {
       "name": "Mist Concealment",
-      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may prevent all effects of attacks, including damage, done to this Pokémon by your opponent's Pokémon during your opponent’s next turn.",
+      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may prevent all effects of attacks, including damage, done to this Pokémon by your opponent's Pokémon during your opponent's next turn.",
       "type": "Ability"
     },
     "hp": "130",
@@ -5701,7 +5701,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "This attack does 10 damage to each Benched Pokémon (both yours and your opponent’s). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Aqua Tail",
@@ -6674,7 +6674,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "If this Pokémon has any Fire Energy attached to it, this attack does 20 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If this Pokémon has any Fire Energy attached to it, this attack does 20 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Blizzard Burn",
@@ -6685,7 +6685,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "130",
-        "text": "This Pokémon can’t attack during your next turn."
+        "text": "This Pokémon can't attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -6726,7 +6726,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
+        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
       },
       {
         "name": "Geostrike",
@@ -6737,7 +6737,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -6876,7 +6876,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Asleep and Poisoned."
+        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Asleep and Poisoned."
       }
     ],
     "weaknesses": [
@@ -6973,7 +6973,7 @@
     ],
     "attacks": [
       {
-        "name": "Emperor’s Command",
+        "name": "Emperor's Command",
         "cost": [
           "Water",
           "Colorless"
@@ -7086,7 +7086,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent’s Active Pokémon is now Confused and Poisoned."
+        "text": "Your opponent's Active Pokémon is now Confused and Poisoned."
       },
       {
         "name": "Powder",
@@ -7095,7 +7095,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30+",
-        "text": "This attack does 30 more damage for each Fire Energy attached to your opponent’s Active Pokémon."
+        "text": "This attack does 30 more damage for each Fire Energy attached to your opponent's Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -7134,7 +7134,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -7414,7 +7414,7 @@
     "evolvesFrom": "Yanma",
     "ability": {
       "name": "Sonic Vision",
-      "text": "If you have exactly 4 cards in your hand, ignore all Energy in the attack cost of each of this Pokémon’s attacks.",
+      "text": "If you have exactly 4 cards in your hand, ignore all Energy in the attack cost of each of this Pokémon's attacks.",
       "type": "Ability"
     },
     "hp": "110",


### PR DESCRIPTION
Standarize use of single quote instead of apostrophe.  Easier for editors to maintain and original data appeaed to have little consistency - sometimes swapping between the two in the same sentence.  **Only** 's and 't are updated and only then when followed by a word break.