### PR TITLE
Fix quote

### DIFF
--- a/json/cards/Ancient Origins.json
+++ b/json/cards/Ancient Origins.json
@@ -95,7 +95,7 @@
     "evolvesFrom": "Gloom",
     "ability": {
       "name": "Irritating Pollen",
-      "text": "Each player can't play any Item cards from his or her hand.",
+      "text": "Each player can’t play any Item cards from his or her hand.",
       "type": "Ability"
     },
     "hp": "130",
@@ -212,7 +212,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -261,7 +261,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -303,7 +303,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Asleep and Poisoned."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Asleep and Poisoned."
       },
       {
         "name": "Unseen Claw",
@@ -313,7 +313,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "60+",
-        "text": "If your opponent's Active Pokémon is affected by a Special Condition, this attack does 70 more damage."
+        "text": "If your opponent’s Active Pokémon is affected by a Special Condition, this attack does 70 more damage."
       }
     ],
     "weaknesses": [
@@ -346,7 +346,7 @@
     "setCode": "xy7",
     "text": [
       "When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards.",
-      "Prevent all effects of your opponent's Pokémon's Abilities done to this Pokémon.",
+      "Prevent all effects of your opponent’s Pokémon’s Abilities done to this Pokémon.",
       "When 1 of your Pokémon becomes a Mega Evolution Pokémon, your turn ends."
     ],
     "types": [
@@ -493,7 +493,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Heal from this Pokémon the same amount of damage you did to your opponent's Active Pokémon."
+        "text": "Heal from this Pokémon the same amount of damage you did to your opponent’s Active Pokémon."
       },
       {
         "name": "Fury Swipes",
@@ -649,7 +649,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "This attack does 20 more damage for each of your opponent's Benched Pokémon."
+        "text": "This attack does 20 more damage for each of your opponent’s Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -693,7 +693,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 30 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 30 (after applying Weakness and Resistance)."
       },
       {
         "name": "Heat Tackle",
@@ -830,7 +830,7 @@
     "set": "Ancient Origins",
     "setCode": "xy7",
     "text": [
-      "Prevent all effects of your opponent's Pokémon's Abilities done to this Pokémon."
+      "Prevent all effects of your opponent’s Pokémon’s Abilities done to this Pokémon."
     ],
     "types": [
       "Fire"
@@ -940,7 +940,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "This attack does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each Benched Pokémon (both yours and your opponent’s). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Aqua Tail",
@@ -1149,7 +1149,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Resistance Blizzard",
@@ -1160,7 +1160,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "During your opponent's next turn, prevent all effects of attacks, including damage, done to this Pokémon by Pokémon-EX."
+        "text": "During your opponent’s next turn, prevent all effects of attacks, including damage, done to this Pokémon by Pokémon-EX."
       }
     ],
     "weaknesses": [
@@ -1206,7 +1206,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 30 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Icecalibur",
@@ -1218,7 +1218,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "130",
-        "text": "Discard an Energy attached to this Pokémon. The Defending Pokémon can't attack during your opponent's next turn."
+        "text": "Discard an Energy attached to this Pokémon. The Defending Pokémon can’t attack during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1323,7 +1323,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, or any other effects on your opponent's Active Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, or any other effects on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -1379,7 +1379,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120+",
-        "text": "You may do 50 more damage and leave your opponent's Active Pokémon Paralyzed. If you do, this Pokémon does 30 damage to itself."
+        "text": "You may do 50 more damage and leave your opponent’s Active Pokémon Paralyzed. If you do, this Pokémon does 30 damage to itself."
       }
     ],
     "weaknesses": [
@@ -1434,7 +1434,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip 3 coins. For each heads, choose a random card from your opponent's hand. Your opponent reveals that card and shuffles it into his or her deck."
+        "text": "Flip 3 coins. For each heads, choose a random card from your opponent’s hand. Your opponent reveals that card and shuffles it into his or her deck."
       }
     ],
     "weaknesses": [
@@ -1565,7 +1565,7 @@
     "set": "Ancient Origins",
     "setCode": "xy7",
     "text": [
-      "Prevent all effects of your opponent's Pokémon's Abilities done to this Pokémon."
+      "Prevent all effects of your opponent’s Pokémon’s Abilities done to this Pokémon."
     ],
     "types": [
       "Psychic"
@@ -1578,7 +1578,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at the top 3 cards of either player's deck and put them back on top of that player's deck in any order."
+        "text": "Look at the top 3 cards of either player’s deck and put them back on top of that player’s deck in any order."
       }
     ],
     "weaknesses": [
@@ -1622,7 +1622,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Devolve each of your opponent's evolved Pokémon and put the highest Stage Evolution card on it into your opponent's hand."
+        "text": "Devolve each of your opponent’s evolved Pokémon and put the highest Stage Evolution card on it into your opponent’s hand."
       },
       {
         "name": "Hyper Beam",
@@ -1632,7 +1632,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -1721,7 +1721,7 @@
     "set": "Ancient Origins",
     "setCode": "xy7",
     "text": [
-      "Prevent all effects of your opponent's Pokémon's Abilities done to this Pokémon."
+      "Prevent all effects of your opponent’s Pokémon’s Abilities done to this Pokémon."
     ],
     "types": [
       "Psychic"
@@ -1793,7 +1793,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Discard 2 Energy attached to this Pokémon. This attack does 100 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard 2 Energy attached to this Pokémon. This attack does 100 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1956,7 +1956,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -2009,7 +2009,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "If your opponent's Active Pokémon is a Pokémon-EX, this attack does 60 more damage."
+        "text": "If your opponent’s Active Pokémon is a Pokémon-EX, this attack does 60 more damage."
       }
     ],
     "weaknesses": [
@@ -2123,7 +2123,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "130",
-        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2181,7 +2181,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "110+",
-        "text": "This attack does 60 more damage for each damage counter on your opponent's Active Pokémon."
+        "text": "This attack does 60 more damage for each damage counter on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -2226,7 +2226,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose a Supporter card from your opponent's discard pile and use it as the effect of this attack."
+        "text": "Choose a Supporter card from your opponent’s discard pile and use it as the effect of this attack."
       },
       {
         "name": "Furtive Drop",
@@ -2236,7 +2236,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Put 3 damage counters on your opponent's Active Pokémon."
+        "text": "Put 3 damage counters on your opponent’s Active Pokémon."
       }
     ],
     "nationalPokedexNumber": 302,
@@ -2269,7 +2269,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -2318,7 +2318,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with his or her Active Pokémon. The new Active Pokémon is now Confused."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with his or her Active Pokémon. The new Active Pokémon is now Confused."
       },
       {
         "name": "Trash Tentacle",
@@ -2572,7 +2572,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -2631,7 +2631,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "If your opponent's Active Pokémon is a Pokémon-EX, discard an Energy attached to that Pokémon."
+        "text": "If your opponent’s Active Pokémon is a Pokémon-EX, discard an Energy attached to that Pokémon."
       }
     ],
     "weaknesses": [
@@ -2804,7 +2804,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 50 damage to 1 of your opponent's Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "This attack does 50 damage to 1 of your opponent’s Pokémon. This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -2849,7 +2849,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       }
     ],
     "weaknesses": [
@@ -2898,7 +2898,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Move all damage counters from 1 of your Benched Pokémon to your opponent's Active Pokémon."
+        "text": "Move all damage counters from 1 of your Benched Pokémon to your opponent’s Active Pokémon."
       },
       {
         "name": "Rolling Tackle",
@@ -2934,7 +2934,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Renegade Pulse",
-      "text": "Prevent all effects of attacks, including damage, done to this Pokémon by your opponent's Mega Evolution Pokémon.",
+      "text": "Prevent all effects of attacks, including damage, done to this Pokémon by your opponent’s Mega Evolution Pokémon.",
       "type": "Ability"
     },
     "hp": "170",
@@ -2966,7 +2966,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "Your opponent can't play any Pokémon Tool, Special Energy, or Stadium cards from his or her hand during his or her next turn."
+        "text": "Your opponent can’t play any Pokémon Tool, Special Energy, or Stadium cards from his or her hand during his or her next turn."
       }
     ],
     "weaknesses": [
@@ -3057,7 +3057,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Melt",
@@ -3113,7 +3113,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "This attack does 20 damage to 1 of your opponent's Pokémon for each Colorless in its Retreat Cost. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 1 of your opponent’s Pokémon for each Colorless in its Retreat Cost. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Shining Breath",
@@ -3125,7 +3125,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "110",
-        "text": "During your opponent's next turn, this Pokémon can't be affected by any Special Conditions."
+        "text": "During your opponent’s next turn, this Pokémon can’t be affected by any Special Conditions."
       }
     ],
     "weaknesses": [
@@ -3207,7 +3207,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Ambush",
@@ -3424,7 +3424,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Discard all Special Energy attached to each of your opponent's Pokémon."
+        "text": "Discard all Special Energy attached to each of your opponent’s Pokémon."
       },
       {
         "name": "Slowing Beam",
@@ -3435,7 +3435,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "During your opponent's next turn, the Defending Pokémon's attacks cost Colorless more."
+        "text": "During your opponent’s next turn, the Defending Pokémon’s attacks cost Colorless more."
       }
     ],
     "weaknesses": [
@@ -3466,7 +3466,7 @@
     "set": "Ancient Origins",
     "setCode": "xy7",
     "text": [
-      "Prevent all effects of your opponent's Pokémon's Abilities done to this Pokémon."
+      "Prevent all effects of your opponent’s Pokémon’s Abilities done to this Pokémon."
     ],
     "types": [
       "Colorless"
@@ -3489,7 +3489,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -3661,7 +3661,7 @@
     "set": "Ancient Origins",
     "setCode": "xy7",
     "text": [
-      "Each player's Grass Pokémon can evolve during his or her first turn or the turn he or she plays those Pokémon."
+      "Each player’s Grass Pokémon can evolve during his or her first turn or the turn he or she plays those Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy7/74_hires.png"
   },
@@ -3678,7 +3678,7 @@
     "set": "Ancient Origins",
     "setCode": "xy7",
     "text": [
-      "Until the end of your opponent's next turn, each Pokémon in play, in each player's hand, and in each player's discard pile has no Abilities. (This includes cards that come into play on that turn.)"
+      "Until the end of your opponent’s next turn, each Pokémon in play, in each player’s hand, and in each player’s discard pile has no Abilities. (This includes cards that come into play on that turn.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy7/75_hires.png"
   },
@@ -3695,7 +3695,7 @@
     "set": "Ancient Origins",
     "setCode": "xy7",
     "text": [
-      "Until the end of your opponent's next turn, each Pokémon in play, in each player's hand, and in each player's discard pile has no Abilities. (This includes cards that come into play on that turn.)"
+      "Until the end of your opponent’s next turn, each Pokémon in play, in each player’s hand, and in each player’s discard pile has no Abilities. (This includes cards that come into play on that turn.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy7/75a_hires.png"
   },
@@ -3729,7 +3729,7 @@
     "set": "Ancient Origins",
     "setCode": "xy7",
     "text": [
-      "Whenever the Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent's attack (even if that Pokémon is Knocked Out), draw 2 cards."
+      "Whenever the Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent’s attack (even if that Pokémon is Knocked Out), draw 2 cards."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy7/77_hires.png"
   },
@@ -3746,7 +3746,7 @@
     "set": "Ancient Origins",
     "setCode": "xy7",
     "text": [
-      "Switch 1 of your opponent's Benched Pokémon with his or her Active Pokémon."
+      "Switch 1 of your opponent’s Benched Pokémon with his or her Active Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy7/78_hires.png"
   },
@@ -3814,7 +3814,7 @@
     "set": "Ancient Origins",
     "setCode": "xy7",
     "text": [
-      "This card can only be attached to Darkness Pokémon. This card provides Darkness Energy only while this card is attached to a Darkness Pokémon. Whenever the Darkness Pokémon this card is attached to is your Active Pokémon and is damaged by an attack from your opponent's Pokémon-EX (even if that Pokémon is Knocked Out), put 2 damage counters on the Attacking Pokémon-EX. (If this card is attached to anything other than a Darkness Pokémon, discard this card.)"
+      "This card can only be attached to Darkness Pokémon. This card provides Darkness Energy only while this card is attached to a Darkness Pokémon. Whenever the Darkness Pokémon this card is attached to is your Active Pokémon and is damaged by an attack from your opponent’s Pokémon-EX (even if that Pokémon is Knocked Out), put 2 damage counters on the Attacking Pokémon-EX. (If this card is attached to anything other than a Darkness Pokémon, discard this card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy7/82_hires.png"
   },
@@ -3865,7 +3865,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Asleep and Poisoned."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Asleep and Poisoned."
       },
       {
         "name": "Unseen Claw",
@@ -3875,7 +3875,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "60+",
-        "text": "If your opponent's Active Pokémon is affected by a Special Condition, this attack does 70 more damage."
+        "text": "If your opponent’s Active Pokémon is affected by a Special Condition, this attack does 70 more damage."
       }
     ],
     "weaknesses": [
@@ -3908,7 +3908,7 @@
     "setCode": "xy7",
     "text": [
       "When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards.",
-      "Prevent all effects of your opponent's Pokémon's Abilities done to this Pokémon.",
+      "Prevent all effects of your opponent’s Pokémon’s Abilities done to this Pokémon.",
       "When 1 of your Pokémon becomes a Mega Evolution Pokémon, your turn ends."
     ],
     "types": [
@@ -3969,7 +3969,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 30 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Icecalibur",
@@ -3981,7 +3981,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "130",
-        "text": "Discard an Energy attached to this Pokémon. The Defending Pokémon can't attack during your opponent's next turn."
+        "text": "Discard an Energy attached to this Pokémon. The Defending Pokémon can’t attack during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -4036,7 +4036,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, or any other effects on your opponent's Active Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, or any other effects on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -4092,7 +4092,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120+",
-        "text": "You may do 50 more damage and leave your opponent's Active Pokémon Paralyzed. If you do, this Pokémon does 30 damage to itself."
+        "text": "You may do 50 more damage and leave your opponent’s Active Pokémon Paralyzed. If you do, this Pokémon does 30 damage to itself."
       }
     ],
     "weaknesses": [
@@ -4148,7 +4148,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Discard 2 Energy attached to this Pokémon. This attack does 100 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard 2 Energy attached to this Pokémon. This attack does 100 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4263,7 +4263,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "130",
-        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4321,7 +4321,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "110+",
-        "text": "This attack does 60 more damage for each damage counter on your opponent's Active Pokémon."
+        "text": "This attack does 60 more damage for each damage counter on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -4347,7 +4347,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Renegade Pulse",
-      "text": "Prevent all effects of attacks, including damage, done to this Pokémon by your opponent's Mega Evolution Pokémon.",
+      "text": "Prevent all effects of attacks, including damage, done to this Pokémon by your opponent’s Mega Evolution Pokémon.",
       "type": "Ability"
     },
     "hp": "170",
@@ -4379,7 +4379,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "Your opponent can't play any Pokémon Tool, Special Energy, or Stadium cards from his or her hand during his or her next turn."
+        "text": "Your opponent can’t play any Pokémon Tool, Special Energy, or Stadium cards from his or her hand during his or her next turn."
       }
     ],
     "weaknesses": [
@@ -4508,7 +4508,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "150",
-        "text": "Move 2 Energy from this Pokémon to 1 of your Benched Pokémon. This attack does 30 damage to each of your opponent's Benched Pokémon-EX. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Move 2 Energy from this Pokémon to 1 of your Benched Pokémon. This attack does 30 damage to each of your opponent’s Benched Pokémon-EX. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [

--- a/json/cards/Aquapolis.json
+++ b/json/cards/Aquapolis.json
@@ -210,7 +210,7 @@
     "evolvesFrom": "Spinarak",
     "ability": {
       "name": "Gluey Slime",
-      "text": "As long as Ariados is in play, each player must pay an additional Colorless to retreat his or her Active Pokémon. Gluey Slime can't make a player pay more than an additional Colorless to retreat a Pokémon, even if there is more than 1 Ariados in play.",
+      "text": "As long as Ariados is in play, each player must pay an additional Colorless to retreat his or her Active Pokémon. Gluey Slime can’t make a player pay more than an additional Colorless to retreat a Pokémon, even if there is more than 1 Ariados in play.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -253,7 +253,7 @@
     "evolvesFrom": "Spinarak",
     "ability": {
       "name": "Gluey Slime",
-      "text": "As long as Ariados is in play, each player must pay an additional Colorless to retreat his or her Active Pokémon. Gluey Slime can't make a player pay more than an additional Colorless to retreat a Pokémon, even if there is more than 1 Ariados in play.",
+      "text": "As long as Ariados is in play, each player must pay an additional Colorless to retreat his or her Active Pokémon. Gluey Slime can’t make a player pay more than an additional Colorless to retreat a Pokémon, even if there is more than 1 Ariados in play.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -322,7 +322,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Don't apply Resistance."
+        "text": "Don’t apply Resistance."
       }
     ],
     "weaknesses": [
@@ -369,7 +369,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Don't apply Resistance."
+        "text": "Don’t apply Resistance."
       }
     ],
     "weaknesses": [
@@ -390,7 +390,7 @@
     "evolvesFrom": "Gloom",
     "ability": {
       "name": "Flower Supplement",
-      "text": "Once during your turn (before your attack), if you have any Basic Energy cards in your hand, you may flip a coin. If heads, attach 1 of those Energy cards to 1 of your Benched Pokémon, if any. You can't use this power if Bellossom is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if you have any Basic Energy cards in your hand, you may flip a coin. If heads, attach 1 of those Energy cards to 1 of your Benched Pokémon, if any. You can’t use this power if Bellossom is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -444,7 +444,7 @@
     "evolvesFrom": "Gloom",
     "ability": {
       "name": "Flower Supplement",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, attach 1 basic Energy card from your hand to 1 of your Benched Pokémon. This power can't be used if Bellossom is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, attach 1 basic Energy card from your hand to 1 of your Benched Pokémon. This power can’t be used if Bellossom is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -498,7 +498,7 @@
     "evolvesFrom": "Chansey",
     "ability": {
       "name": "Happy Healing",
-      "text": "Once during your turn (before your attack), if you have any Benched Pokémon, you may flip a coin. If heads, choose 1 of those Pokémon. Remove 1 damage counter from that Pokémon for each Energy attached to Blissey. This power can't be used if Blissey is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if you have any Benched Pokémon, you may flip a coin. If heads, choose 1 of those Pokémon. Remove 1 damage counter from that Pokémon for each Energy attached to Blissey. This power can’t be used if Blissey is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -546,7 +546,7 @@
     "evolvesFrom": "Chansey",
     "ability": {
       "name": "Happy Healing",
-      "text": "Once during your turn (before your attack), choose 1 of your Benched Pokémon and flip a coin. If heads, count the number of Energy attached to Blissey and then remove that many damage counters from the chosen Benched Pokémon. This power can't be used if Blissey is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), choose 1 of your Benched Pokémon and flip a coin. If heads, count the number of Energy attached to Blissey and then remove that many damage counters from the chosen Benched Pokémon. This power can’t be used if Blissey is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -594,7 +594,7 @@
     "evolvesFrom": "Voltorb",
     "ability": {
       "name": "Super Dynamo",
-      "text": "Once during your turn (before your attack), if Electrode is your Active Pokémon, you may flip a coin. If heads, choose a Lightning Energy card from your discard pile and attach it to 1 of your Pokémon. This power can't be used if Electrode is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Electrode is your Active Pokémon, you may flip a coin. If heads, choose a Lightning Energy card from your discard pile and attach it to 1 of your Pokémon. This power can’t be used if Electrode is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -619,7 +619,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -660,7 +660,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Double Stab",
@@ -744,7 +744,7 @@
     "evolvesFrom": "Voltorb",
     "ability": {
       "name": "Super Dynamo",
-      "text": "Once during your turn (before your attack), if Electrode is your Active Pokémon, you may flip a coin. If heads, choose 1 Lightning Energy card in your discard pile, if any, and attach it to 1 of your Pokémon. This power can't be used if Electrode is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Electrode is your Active Pokémon, you may flip a coin. If heads, choose 1 Lightning Energy card in your discard pile, if any, and attach it to 1 of your Pokémon. This power can’t be used if Electrode is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -769,7 +769,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -790,7 +790,7 @@
     "evolvesFrom": "Eevee",
     "ability": {
       "name": "Energy Return",
-      "text": "As often as you like during your turn (before your attack), you choose an Energy card attached to 1 of your Pokémon and return to your hand. This power can't be used if Espeon is affected by a Special Condition.",
+      "text": "As often as you like during your turn (before your attack), you choose an Energy card attached to 1 of your Pokémon and return to your hand. This power can’t be used if Espeon is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -856,7 +856,7 @@
       }
     ],
     "text": [
-      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent's turn ends without an attack."
+      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent’s turn ends without an attack."
     ],
     "nationalPokedexNumber": 239,
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/9_hires.png",
@@ -872,7 +872,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Pure Body",
-      "text": "Whenever you attach a Fire Energy card to Entei from your hand, you must discard 1 other Energy card attached to Entei. (If you can't discard Energy cards, you can't attach the Fire Energy card.)",
+      "text": "Whenever you attach a Fire Energy card to Entei from your hand, you must discard 1 other Energy card attached to Entei. (If you can’t discard Energy cards, you can’t attach the Fire Energy card.)",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -947,7 +947,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Choose 1 of your opponent's Benched Pokémon. This attack does 10 damage times the amount of Energy attached to Exeggutor. (Don't apply Weakness or Resistance for Benched Pokémon)"
+        "text": "Choose 1 of your opponent’s Benched Pokémon. This attack does 10 damage times the amount of Energy attached to Exeggutor. (Don’t apply Weakness or Resistance for Benched Pokémon)"
       }
     ],
     "weaknesses": [
@@ -999,7 +999,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "The Defending Pokémon can't use any Poké-Powers untill the end of your opponent's next turn."
+        "text": "The Defending Pokémon can’t use any Poké-Powers untill the end of your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1026,7 +1026,7 @@
     "evolvesFrom": "Eevee",
     "ability": {
       "name": "Energy Return",
-      "text": "As often as you like during your turn (before your attack), you may return an Energy card attached to 1 of your Pokémon to your hand. This power can't be used if Espeon is affected by a Special Condition.",
+      "text": "As often as you like during your turn (before your attack), you may return an Energy card attached to 1 of your Pokémon to your hand. This power can’t be used if Espeon is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -1098,7 +1098,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon for each of those Energy attached to Exeggutor. (Don't apply Weakness or Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon for each of those Energy attached to Exeggutor. (Don’t apply Weakness or Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1119,7 +1119,7 @@
     "evolvesFrom": "Drowzee",
     "ability": {
       "name": "Sleep Pendulum",
-      "text": "Once during your turn (before your attack), if Hypno is your Active Pokémon, you may make the Defending Pokémon Asleep. This power can't be used if Hypno is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Hypno is your Active Pokémon, you may make the Defending Pokémon Asleep. This power can’t be used if Hypno is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -1145,7 +1145,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "If the Defending Pokémon isn't Knocked Out by the damage from this attack, you may choose 1 of your opponent's Benched Pokémon and switch the Defending Pokémon with it."
+        "text": "If the Defending Pokémon isn’t Knocked Out by the damage from this attack, you may choose 1 of your opponent’s Benched Pokémon and switch the Defending Pokémon with it."
       }
     ],
     "weaknesses": [
@@ -1166,7 +1166,7 @@
     "evolvesFrom": "Skiploom",
     "ability": {
       "name": "Fluff",
-      "text": "During your opponent's turn, if Jumpluff would be damaged or affected by an opponent's attack and it already has at least 1 damage counter on it, flip a coin. If heads, prevent all effects of that attack (including damage).",
+      "text": "During your opponent’s turn, if Jumpluff would be damaged or affected by an opponent’s attack and it already has at least 1 damage counter on it, flip a coin. If heads, prevent all effects of that attack (including damage).",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -1284,7 +1284,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If the defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Burn Up",
@@ -1316,7 +1316,7 @@
     "evolvesFrom": "Seadra",
     "ability": {
       "name": "Water Cyclone",
-      "text": "As often as you like during your turn (before your attack), you may move a Water Energy card from your Active Pokémon to 1 of your Benched Pokémon. This power can't be used if Kingdra is affected by a Special Condition.",
+      "text": "As often as you like during your turn (before your attack), you may move a Water Energy card from your Active Pokémon to 1 of your Benched Pokémon. This power can’t be used if Kingdra is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -1397,7 +1397,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "The Defending Pokémon can't use any Poké-Powers until the end of your opponent's next turn."
+        "text": "The Defending Pokémon can’t use any Poké-Powers until the end of your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1424,7 +1424,7 @@
     "evolvesFrom": "Chinchou",
     "ability": {
       "name": "Ion Coating",
-      "text": "You may use this power once during each of your turn (before your attack). All Lightning Energy attached to your Active Pokémon becomes Water Energy for the rest of your turn. (This effect ends if your Active Pokémon retreats or is returned to your hand). This power can't be used if Lanturn is affected by a Special Condition.",
+      "text": "You may use this power once during each of your turn (before your attack). All Lightning Energy attached to your Active Pokémon becomes Water Energy for the rest of your turn. (This effect ends if your Active Pokémon retreats or is returned to your hand). This power can’t be used if Lanturn is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -1470,7 +1470,7 @@
     "evolvesFrom": "Drowzee",
     "ability": {
       "name": "Sleep Pendulum",
-      "text": "Once during your turn (before your attack), if Hypno is your Active Pokémon, you may use this power. The Defending Pokémon is now Asleep. This power can't be used if Hypno is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Hypno is your Active Pokémon, you may use this power. The Defending Pokémon is now Asleep. This power can’t be used if Hypno is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -1517,7 +1517,7 @@
     "evolvesFrom": "Magnemite",
     "ability": {
       "name": "Magnetic Flow",
-      "text": "Once during your turn (before your attack), if Magneton is your Active Pokémon, you may flip a coin. If heads, choose 2 of your opponent's Pokémon that have Energy cards attached to them. Choose 1 of the Energy cards attached to each of those Pokémon and switch them between the Pokémon. This power can't be used if Magneton is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Magneton is your Active Pokémon, you may flip a coin. If heads, choose 2 of your opponent’s Pokémon that have Energy cards attached to them. Choose 1 of the Energy cards attached to each of those Pokémon and switch them between the Pokémon. This power can’t be used if Magneton is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -1544,7 +1544,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "This attack does 10 damage to each of your opponent's Benched Pokémon that are the same type (color) as the Defending Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon)"
+        "text": "This attack does 10 damage to each of your opponent’s Benched Pokémon that are the same type (color) as the Defending Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon)"
       }
     ],
     "weaknesses": [
@@ -1574,7 +1574,7 @@
     "evolvesFrom": "Skiploom",
     "ability": {
       "name": "Fluff",
-      "text": "During your opponent's turn, if Jumpluff would be damaged or affected by an opponent's attack and it already has at least 1 damage counter on it, flip a coin. If heads, prevent all effects of that attack (including damage).",
+      "text": "During your opponent’s turn, if Jumpluff would be damaged or affected by an opponent’s attack and it already has at least 1 damage counter on it, flip a coin. If heads, prevent all effects of that attack (including damage).",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -1720,7 +1720,7 @@
     "evolvesFrom": "Nidorino",
     "ability": {
       "name": "Earth Rage",
-      "text": "Once during your turn (before your attack), if Nidoking is your Active Pokémon, you may flip a coin. If heads, put a damage counter on each of your opponent's Benched Pokémon. This power can't be used if Nidoking is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Nidoking is your Active Pokémon, you may flip a coin. If heads, put a damage counter on each of your opponent’s Benched Pokémon. This power can’t be used if Nidoking is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -1776,7 +1776,7 @@
     "evolvesFrom": "Seadra",
     "ability": {
       "name": "Water Cyclone",
-      "text": "As often as you like during your turn (before your attack), you may move a Water Energy from your Active Pokémon to 1 of your Benched Pokémon. This power can't be used if Kingdra is affected by a Special Condition.",
+      "text": "As often as you like during your turn (before your attack), you may move a Water Energy from your Active Pokémon to 1 of your Benched Pokémon. This power can’t be used if Kingdra is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -1955,7 +1955,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -2017,7 +2017,7 @@
     "evolvesFrom": "Scyther",
     "ability": {
       "name": "Poison Resistance",
-      "text": "Scizor can't be Poisoned.",
+      "text": "Scizor can’t be Poisoned.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -2043,7 +2043,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Before doing damage, you may choose 1 of your opponent's Benched Pokémon with no damage counters on it and snatch the Defending Pokémon with it."
+        "text": "Before doing damage, you may choose 1 of your opponent’s Benched Pokémon with no damage counters on it and snatch the Defending Pokémon with it."
       },
       {
         "name": "Heavy Metal",
@@ -2075,7 +2075,7 @@
     "evolvesFrom": "Magnemite",
     "ability": {
       "name": "Magnetic Flow",
-      "text": "Once during your turn (before your attack), if Magneton is your Active Pokémon, you may flip a coin. If heads, choose 2 of your opponent's Pokémon that have Energy cards attached to them. Choose 1 of the Energy cards attached to each of those Pokémon and switch them between the Pokémon. This power can't be used if Magneton is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Magneton is your Active Pokémon, you may flip a coin. If heads, choose 2 of your opponent’s Pokémon that have Energy cards attached to them. Choose 1 of the Energy cards attached to each of those Pokémon and switch them between the Pokémon. This power can’t be used if Magneton is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -2102,7 +2102,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "This attack does 10 damage to each of your opponent's Benched Pokémon that are the same type (color) as the Defending Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Benched Pokémon that are the same type (color) as the Defending Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2151,7 +2151,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10×",
-        "text": "Look at your opponent's hand. This attack does 10 damage times the number of Energy cards there."
+        "text": "Look at your opponent’s hand. This attack does 10 damage times the number of Energy cards there."
       },
       {
         "name": "Shuffle Attack",
@@ -2162,7 +2162,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Look at a number of cards on top of your opponent's deck equal to the number of Energy cards attached to the Defending Pokémon. Put these cards in any order, and then put them back on top of your opponent's deck."
+        "text": "Look at a number of cards on top of your opponent’s deck equal to the number of Energy cards attached to the Defending Pokémon. Put these cards in any order, and then put them back on top of your opponent’s deck."
       }
     ],
     "weaknesses": [
@@ -2252,7 +2252,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "This attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness or Resistance for Benched Pokémon.) Then, flip a coin. If tails, this attack can't be used during your next turn. 10"
+        "text": "This attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness or Resistance for Benched Pokémon.) Then, flip a coin. If tails, this attack can’t be used during your next turn. 10"
       },
       {
         "name": "Iron Smash",
@@ -2310,7 +2310,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. Copy copies that attack. This attack does nothing if Sudowoodo doesn't have the Energy necessary to use that attack. (You must still do anything else required in order to use that attack.)"
+        "text": "Choose 1 of the Defending Pokémon’s attacks. Copy copies that attack. This attack does nothing if Sudowoodo doesn’t have the Energy necessary to use that attack. (You must still do anything else required in order to use that attack.)"
       },
       {
         "name": "Energy Draw",
@@ -2340,7 +2340,7 @@
     "evolvesFrom": "Nidorino",
     "ability": {
       "name": "Earth Rage",
-      "text": "Once during your turn (before your attack), if Nidoking is your Active Pokémon, you may flip a coin. If heads, put a damage counter on each of your opponent's Benched Pokémon. This power can't be used if Nidoking is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Nidoking is your Active Pokémon, you may flip a coin. If heads, put a damage counter on each of your opponent’s Benched Pokémon. This power can’t be used if Nidoking is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -2493,7 +2493,7 @@
     "evolvesFrom": "Tentacool",
     "ability": {
       "name": "Strange Tentacles",
-      "text": "Once during your turn (before your attack), as long as the number of Energy cards attached to the Defending Pokémon is less than the number of Energy cards attached to your Active Pokémon, you may choose an Energy card, if any, in your opponent's discard pile and attach it to the Defending Pokémon. This power can't be used if Tentacruel is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), as long as the number of Energy cards attached to the Defending Pokémon is less than the number of Energy cards attached to your Active Pokémon, you may choose an Energy card, if any, in your opponent’s discard pile and attach it to the Defending Pokémon. This power can’t be used if Tentacruel is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -2563,7 +2563,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -2584,7 +2584,7 @@
     "evolvesFrom": "Togepi",
     "ability": {
       "name": "Miracle Shift",
-      "text": "Once during your turn (before your attack), discard a basic Energy card attached to 1 of your Pokémon. Then, choose a basic Energy card from your discard pile and attach it to that Pokémon. This power can't be used if Togetic is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), discard a basic Energy card attached to 1 of your Pokémon. Then, choose a basic Energy card from your discard pile and attach it to that Pokémon. This power can’t be used if Togetic is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -2608,7 +2608,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, choose 1 of the Defending Pokémon's attacks. Mini-Metronome copies that attack except for its Energy cost. (You must still do anything else required in order to use that attack.) (No matter what type the Defending Pokémon is, Togetic is still ). Togetic performs that attack."
+        "text": "Flip a coin. If heads, choose 1 of the Defending Pokémon’s attacks. Mini-Metronome copies that attack except for its Energy cost. (You must still do anything else required in order to use that attack.) (No matter what type the Defending Pokémon is, Togetic is still ). Togetic performs that attack."
       }
     ],
     "weaknesses": [
@@ -2688,7 +2688,7 @@
     "evolvesFrom": "Porygon",
     "ability": {
       "name": "Backup",
-      "text": "Once during your turn (before your attack), if you have 2 or fewer cards in your hand, you may draw cards until you have exactly 3 cards in your hand. This power can't be used if Porygon2 is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if you have 2 or fewer cards in your hand, you may draw cards until you have exactly 3 cards in your hand. This power can’t be used if Porygon2 is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -2758,7 +2758,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, discard 1 Energy card attached to 1 of your opponent's Pokémon."
+        "text": "Flip a coin. If heads, discard 1 Energy card attached to 1 of your opponent’s Pokémon."
       },
       {
         "name": "Tail Slap",
@@ -2809,7 +2809,7 @@
     "evolvesFrom": "Eevee",
     "ability": {
       "name": "Dark Moon",
-      "text": "As long as Umbreon is your Active Pokémon and has a Dark Energy attached to it, once during your turn (before your attack), you may look at your opponent's hand. Choose from it a number of cards up to the number of Dark Energy attached to Umbreon and shuffle them into your opponent's deck. Your opponent then draws the same number of cards from his or her deck. This power can't be used if Umbreon is affected by a Special Condition.",
+      "text": "As long as Umbreon is your Active Pokémon and has a Dark Energy attached to it, once during your turn (before your attack), you may look at your opponent’s hand. Choose from it a number of cards up to the number of Dark Energy attached to Umbreon and shuffle them into your opponent’s deck. Your opponent then draws the same number of cards from his or her deck. This power can’t be used if Umbreon is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -2832,7 +2832,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2934,7 +2934,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20+",
-        "text": "This attack does 20 damage plus 10 more damage for each Energy attached to Quagsire but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "This attack does 20 damage plus 10 more damage for each Energy attached to Quagsire but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       },
       {
         "name": "Slam",
@@ -2967,7 +2967,7 @@
     "evolvesFrom": "Weepinbell",
     "ability": {
       "name": "Fragrance Trap",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, choose 1 of your opponent's Benched Pokémon and switch the Defending Pokémon with it. This power can't be used if Victreebel is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, choose 1 of your opponent’s Benched Pokémon and switch the Defending Pokémon with it. This power can’t be used if Victreebel is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -3046,7 +3046,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Flip a coin. If heads, your opponent can't play Supporter cards during his or her next turn."
+        "text": "Flip a coin. If heads, your opponent can’t play Supporter cards during his or her next turn."
       }
     ],
     "weaknesses": [
@@ -3084,7 +3084,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Rapidash."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Rapidash."
       },
       {
         "name": "Gallop",
@@ -3115,7 +3115,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Anti",
-      "text": "Lightning - You can't attach Lightning Energy cards to Zapdos from your hand to Zapdos.",
+      "text": "Lightning - You can’t attach Lightning Energy cards to Zapdos from your hand to Zapdos.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -3179,7 +3179,7 @@
     "evolvesFrom": "Scyther",
     "ability": {
       "name": "Poison Resistance",
-      "text": "Scizor can't become Poisoned.",
+      "text": "Scizor can’t become Poisoned.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -3263,7 +3263,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "This attack does 30 damage plus 10 more damage for each Energy attached to Slowbro but not used to pay for this attack's Energy cost. You can't add more than 20 damage this way. y."
+        "text": "This attack does 30 damage plus 10 more damage for each Energy attached to Slowbro but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage this way. y."
       }
     ],
     "weaknesses": [
@@ -3303,7 +3303,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10×",
-        "text": "Look at your opponent's hand. This attack does 10 damage times the number of Energy cards in your opponent's hand."
+        "text": "Look at your opponent’s hand. This attack does 10 damage times the number of Energy cards in your opponent’s hand."
       },
       {
         "name": "Shuffle Attack",
@@ -3314,7 +3314,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Look at a number of cards on top of your opponent's deck equal to the number of Energy cards attached to the Defending Pokémon. Put those cards in any order, and then put them back on top of your opponent's deck."
+        "text": "Look at a number of cards on top of your opponent’s deck equal to the number of Energy cards attached to the Defending Pokémon. Put those cards in any order, and then put them back on top of your opponent’s deck."
       }
     ],
     "weaknesses": [
@@ -3358,7 +3358,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "This attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness or Resistance for Benched Pokémon.) Then, flip a coin. If tails, this attack can't be used during your next turn."
+        "text": "This attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness or Resistance for Benched Pokémon.) Then, flip a coin. If tails, this attack can’t be used during your next turn."
       },
       {
         "name": "Iron Smash",
@@ -3416,7 +3416,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. Copy copies that attack. This attack does nothing if Sudowoodo doesn't have the Energy necessary to use that attack. (You must still do anything else required in order to use that attack.)"
+        "text": "Choose 1 of the Defending Pokémon’s attacks. Copy copies that attack. This attack does nothing if Sudowoodo doesn’t have the Energy necessary to use that attack. (You must still do anything else required in order to use that attack.)"
       },
       {
         "name": "Energy Draw",
@@ -3492,7 +3492,7 @@
     "evolvesFrom": "Tentacool",
     "ability": {
       "name": "Strange Tentacles",
-      "text": "Once during your turn (before your attack), as long as the number of Energy cards attached to the Defending Pokémon is less than the number of Energy cards attached to your Active Pokémon, you may choose an Energy card, if any, in your opponent's discard pile and attach it to the Defending Pokémon. This power can't be used if Tentacruel is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), as long as the number of Energy cards attached to the Defending Pokémon is less than the number of Energy cards attached to your Active Pokémon, you may choose an Energy card, if any, in your opponent’s discard pile and attach it to the Defending Pokémon. This power can’t be used if Tentacruel is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -3535,7 +3535,7 @@
     "evolvesFrom": "Togepi",
     "ability": {
       "name": "Miracle Shift",
-      "text": "Once during your turn (before your attack), discard a basic Energy card attached to one of your Pokémon. Then choose a basic Energy card from your discard pile and attach it to that Pokémon. This power can't be used if Togetic is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), discard a basic Energy card attached to one of your Pokémon. Then choose a basic Energy card from your discard pile and attach it to that Pokémon. This power can’t be used if Togetic is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -3559,7 +3559,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, choose 1 of the Defending Pokémon's attacks. Mini-Metronome copies that attack except for its Energy cost. (You must still do anything else required in order to use that attack.) (No matter what type the Defending Pokémon is, Togetic is still ). Togetic performs the attack."
+        "text": "Flip a coin. If heads, choose 1 of the Defending Pokémon’s attacks. Mini-Metronome copies that attack except for its Energy cost. (You must still do anything else required in order to use that attack.) (No matter what type the Defending Pokémon is, Togetic is still ). Togetic performs the attack."
       }
     ],
     "weaknesses": [
@@ -3610,7 +3610,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, discard 1 Energy card attached to 1 of your opponent's Pokémon."
+        "text": "Flip a coin. If heads, discard 1 Energy card attached to 1 of your opponent’s Pokémon."
       },
       {
         "name": "Tail Slap",
@@ -3661,7 +3661,7 @@
     "evolvesFrom": "Eevee",
     "ability": {
       "name": "Dark Moon",
-      "text": "As long as Umbreon is your Active Pokémon and has a Dark Energy attached to it, once during your turn (before your attack), you may look at your opponent's hand. Choose from it a number of cards up to the number of Dark Energy cards attached to Umbreon and shuffle them into your opponent's deck. Your opponent then draws the same number of cards from his or her deck. This power can't be used if Umbreon is affected by a Special Condition.",
+      "text": "As long as Umbreon is your Active Pokémon and has a Dark Energy attached to it, once during your turn (before your attack), you may look at your opponent’s hand. Choose from it a number of cards up to the number of Dark Energy cards attached to Umbreon and shuffle them into your opponent’s deck. Your opponent then draws the same number of cards from his or her deck. This power can’t be used if Umbreon is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -3687,7 +3687,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3714,7 +3714,7 @@
     "evolvesFrom": "Weepinbell",
     "ability": {
       "name": "Fragrance Trap",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, choose 1 of your opponent's Benched Pokémon and switch the Defending Pokémon with it. This power can't be used if Victreebel is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, choose 1 of your opponent’s Benched Pokémon and switch the Defending Pokémon with it. This power can’t be used if Victreebel is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -3793,7 +3793,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Flip a coin. If heads, your opponent can't play any Supporter cards during his or her next turn."
+        "text": "Flip a coin. If heads, your opponent can’t play any Supporter cards during his or her next turn."
       }
     ],
     "weaknesses": [
@@ -3813,7 +3813,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Anti",
-      "text": "Lightning - You can't attach Lightning Energy cards from your hand to Zapdos.",
+      "text": "Lightning - You can’t attach Lightning Energy cards from your hand to Zapdos.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -4006,7 +4006,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4030,7 +4030,7 @@
     "evolvesFrom": "Sentret",
     "ability": {
       "name": "Scavenger Hunt",
-      "text": "Once during your turn (before your attack), you may put 2 cards from your hand into your deck. Then search your deck for an Energy card, show it to your opponent, and put it in your hand. Shuffle your deck afterward. This power can't be used if Furret is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may put 2 cards from your hand into your deck. Then search your deck for an Energy card, show it to your opponent, and put it in your hand. Shuffle your deck afterward. This power can’t be used if Furret is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -4076,7 +4076,7 @@
     "evolvesFrom": "Oddish",
     "ability": {
       "name": "Enervating Pollen",
-      "text": "As long as Gloom is in play, Resistance on each player's Pokémon only reduces damage by 10.",
+      "text": "As long as Gloom is in play, Resistance on each player’s Pokémon only reduces damage by 10.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -4240,7 +4240,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Benched Pokémon and switch the Defending Pokémon with it."
+        "text": "Choose 1 of your opponent’s Benched Pokémon and switch the Defending Pokémon with it."
       },
       {
         "name": "Tackle",
@@ -4352,7 +4352,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Benched Pokémon. Flip 3 coins. This attack does 10 damage times the number of heads to that Pokémon. Don't apply Weakness and Resistance."
+        "text": "Choose 1 of your opponent’s Benched Pokémon. Flip 3 coins. This attack does 10 damage times the number of heads to that Pokémon. Don’t apply Weakness and Resistance."
       },
       {
         "name": "Bone Rush",
@@ -4627,7 +4627,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Seaking."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Seaking."
       }
     ],
     "weaknesses": [
@@ -4724,7 +4724,7 @@
       }
     ],
     "text": [
-      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent's turn ends without an attack."
+      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent’s turn ends without an attack."
     ],
     "nationalPokedexNumber": 238,
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/61_hires.png",
@@ -4769,7 +4769,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -4815,7 +4815,7 @@
       }
     ],
     "text": [
-      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent's turn ends without an attack."
+      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent’s turn ends without an attack."
     ],
     "nationalPokedexNumber": 236,
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/63_hires.png",
@@ -5008,7 +5008,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, choose 1 of your opponent's Benched Pokémon and this attack does 10 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, choose 1 of your opponent’s Benched Pokémon and this attack does 10 damage to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Skedaddle",
@@ -5165,7 +5165,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Chinchou."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Chinchou."
       },
       {
         "name": "Headbutt",
@@ -5269,7 +5269,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done to Cubone by attacks is reduced by 20."
+        "text": "During your opponent’s next turn, any damage done to Cubone by attacks is reduced by 20."
       },
       {
         "name": "Tackle",
@@ -5326,7 +5326,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Doduo."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Doduo."
       },
       {
         "name": "Rear Kick",
@@ -5733,7 +5733,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10×",
-        "text": "Flip 5 coins. This attack does 10 damage times the number of heads. Hitmonchan can't attack during your next turn."
+        "text": "Flip 5 coins. This attack does 10 damage times the number of heads. Hitmonchan can’t attack during your next turn."
       },
       {
         "name": "Smash Punch",
@@ -6025,7 +6025,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
       }
     ],
     "weaknesses": [
@@ -6178,7 +6178,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. Don't apply Weakness and Resistance."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. Don’t apply Weakness and Resistance."
       },
       {
         "name": "Body Slam",
@@ -6434,7 +6434,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Don't apply Weakness and Resistance."
+        "text": "Don’t apply Weakness and Resistance."
       }
     ],
     "weaknesses": [
@@ -6937,7 +6937,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. Don't apply Weakness and Resistance."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. Don’t apply Weakness and Resistance."
       }
     ],
     "weaknesses": [
@@ -6989,7 +6989,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -7037,7 +7037,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at the top 3 cards of your opponent's deck. Put them back in the same order."
+        "text": "Look at the top 3 cards of your opponent’s deck. Put them back in the same order."
       },
       {
         "name": "Double Scratch",
@@ -7190,7 +7190,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at your opponent's hand. Choose all Technical Machine and Pokémon Tool cards there and put them into his or her deck. Your opponent shuffles the deck afterward."
+        "text": "Look at your opponent’s hand. Choose all Technical Machine and Pokémon Tool cards there and put them into his or her deck. Your opponent shuffles the deck afterward."
       },
       {
         "name": "Claw",
@@ -7292,7 +7292,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack during your opponent’s next turn."
       },
       {
         "name": "Double Kick",
@@ -7453,7 +7453,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -7575,7 +7575,7 @@
     "set": "Aquapolis",
     "setCode": "ecard2",
     "text": [
-      "Once during each player's turn (before attacking), if that player's Bench isn't full, that player flips a coin. If heads, that player shows his or her opponent a basic Energy card from his or her hand. Then, that player searches his or her deck for a Basic Pokémon card of the same type (color) as the revealed Energy card and puts it onto his or her Bench. The player shuffles his or her deck afterward."
+      "Once during each player’s turn (before attacking), if that player’s Bench isn’t full, that player flips a coin. If heads, that player shows his or her opponent a basic Energy card from his or her hand. Then, that player searches his or her deck for a Basic Pokémon card of the same type (color) as the revealed Energy card and puts it onto his or her Bench. The player shuffles his or her deck afterward."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/118_hires.png"
   },
@@ -7745,7 +7745,7 @@
     "set": "Aquapolis",
     "setCode": "ecard2",
     "text": [
-      "The Pokémon this card is attached to can use any attack from its Basic Pokémon card or any Evolution card from which the Pokémon evolved. (You still have to pay for that attack's Energy cost.) Discard this card at the end of any turn the Pokémon attacks."
+      "The Pokémon this card is attached to can use any attack from its Basic Pokémon card or any Evolution card from which the Pokémon evolved. (You still have to pay for that attack’s Energy cost.) Discard this card at the end of any turn the Pokémon attacks."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/128_hires.png"
   },
@@ -7762,7 +7762,7 @@
     "set": "Aquapolis",
     "setCode": "ecard2",
     "text": [
-      "Before doing damage, you may choose 1 of your opponent's Benched Pokémon and switch it with the Defending Pokémon."
+      "Before doing damage, you may choose 1 of your opponent’s Benched Pokémon and switch it with the Defending Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/129_hires.png"
   },
@@ -7864,7 +7864,7 @@
     "set": "Aquapolis",
     "setCode": "ecard2",
     "text": [
-      "If the Pokémon this card is attached to is Knocked Out by damage from the Defending Pokémon's attack during your opponent's next turn, you may return up to 2 basic Energy cards attached to that Pokémon to your hand."
+      "If the Pokémon this card is attached to is Knocked Out by damage from the Defending Pokémon’s attack during your opponent’s next turn, you may return up to 2 basic Energy cards attached to that Pokémon to your hand."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/135_hires.png"
   },
@@ -7915,7 +7915,7 @@
     "set": "Aquapolis",
     "setCode": "ecard2",
     "text": [
-      "Once during each player's turn (before attacking), that player may flip a coin. If heads, that player chooses 1 of his or her Evolved Pokémon in play and discards the top Evolution card from that Pokémon, devolving it."
+      "Once during each player’s turn (before attacking), that player may flip a coin. If heads, that player chooses 1 of his or her Evolved Pokémon in play and discards the top Evolution card from that Pokémon, devolving it."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/138_hires.png"
   },
@@ -7949,7 +7949,7 @@
     "set": "Aquapolis",
     "setCode": "ecard2",
     "text": [
-      "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. Don't apply Weakness and Resistance."
+      "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. Don’t apply Weakness and Resistance."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/140_hires.png"
   },
@@ -7983,7 +7983,7 @@
     "set": "Aquapolis",
     "setCode": "ecard2",
     "text": [
-      "If the Pokémon Darkness Energy is attached to damages the Defending Pokémon (after applying Weakness and Resistance), the attack does 10 more damage to the Defending Pokémon. At the end of every turn, put 1 damage counter on the Pokémon Darkness Energy is attached to, unless it's or has Dark in its name. Darkness Energy provides Energy. (Doesn't count as a basic Energy card.)"
+      "If the Pokémon Darkness Energy is attached to damages the Defending Pokémon (after applying Weakness and Resistance), the attack does 10 more damage to the Defending Pokémon. At the end of every turn, put 1 damage counter on the Pokémon Darkness Energy is attached to, unless it’s or has Dark in its name. Darkness Energy provides Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/142_hires.png"
   },
@@ -8000,7 +8000,7 @@
     "set": "Aquapolis",
     "setCode": "ecard2",
     "text": [
-      "Damage done to the Pokémon Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). If the Pokémon Metal Energy is attached to isn't , whenever it damages a Pokémon, reduce that damage by 10 (before applying Weakness and Resistance). Metal Energy provides Energy. (Doesn't count as a basic Energy card.)"
+      "Damage done to the Pokémon Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). If the Pokémon Metal Energy is attached to isn’t , whenever it damages a Pokémon, reduce that damage by 10 (before applying Weakness and Resistance). Metal Energy provides Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/143_hires.png"
   },
@@ -8034,7 +8034,7 @@
     "set": "Aquapolis",
     "setCode": "ecard2",
     "text": [
-      "Boost Energy can be attached only to an Evolved Pokémon. Discard Boost Energy at the end of the turn it was attached. Boost Energy provides Energy. The Pokémon Boost Energy is attached to can't retreat. If the Pokémon Boost Energy is attached to isn't an Evolved Pokémon, discard Boost Energy."
+      "Boost Energy can be attached only to an Evolved Pokémon. Discard Boost Energy at the end of the turn it was attached. Boost Energy provides Energy. The Pokémon Boost Energy is attached to can’t retreat. If the Pokémon Boost Energy is attached to isn’t an Evolved Pokémon, discard Boost Energy."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/145_hires.png"
   },
@@ -8081,7 +8081,7 @@
     "evolvesFrom": "Seadra",
     "ability": {
       "name": "Crystal Type",
-      "text": "Whenever you attach a Water, Lightning, or Psychic basic Energy card from your hand to Kingdra, Kingdra's type (color) becomes the same as that Energy card type until the end of the turn.",
+      "text": "Whenever you attach a Water, Lightning, or Psychic basic Energy card from your hand to Kingdra, Kingdra’s type (color) becomes the same as that Energy card type until the end of the turn.",
       "type": "Poké-Body"
     },
     "hp": "110",
@@ -8109,7 +8109,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Kingdra does 10 damage to itself. (Don't apply Weakness or Resistance when Kingdra damages itself with this attack.)"
+        "text": "Kingdra does 10 damage to itself. (Don’t apply Weakness or Resistance when Kingdra damages itself with this attack.)"
       },
       {
         "name": "Dual Burn",
@@ -8141,7 +8141,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Crystal Type",
-      "text": "Whenever you attach a Fire, Water, or Psychic basic Energy card from your hand to Lugia, Lugia's type (color) becomes the same as that as that Energy card type until the end of the turn.",
+      "text": "Whenever you attach a Fire, Water, or Psychic basic Energy card from your hand to Lugia, Lugia’s type (color) becomes the same as that as that Energy card type until the end of the turn.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -8236,7 +8236,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
-        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Benched Pokémon. If tails, this attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent’s Benched Pokémon. If tails, this attack does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [

--- a/json/cards/Arceus.json
+++ b/json/cards/Arceus.json
@@ -9,7 +9,7 @@
     "evolvesFrom": "Charmeleon",
     "ability": {
       "name": "Fire Formation",
-      "text": "Each of Charizard's attacks does 10 more damage for each Fire Pokémon on your Bench to your opponent's Active Pokémon (before applying Weakness and Resistance).",
+      "text": "Each of Charizard’s attacks does 10 more damage for each Fire Pokémon on your Bench to your opponent’s Active Pokémon (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "140",
@@ -207,7 +207,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Does 10 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -245,7 +245,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Gadget Bolt",
@@ -340,7 +340,7 @@
     "evolvesFrom": "Nosepass",
     "ability": {
       "name": "Competitiveness",
-      "text": "If you don't have a Supporter card in play, each of Probopass's attacks does 30 more damage to the Active Pokémon (before applying Weakness and Resistance).",
+      "text": "If you don’t have a Supporter card in play, each of Probopass’s attacks does 30 more damage to the Active Pokémon (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -406,7 +406,7 @@
     "evolvesFrom": "Shelgon",
     "ability": {
       "name": "Top Accelerator",
-      "text": "Once during your turn (before your attack), you may reveal the top card of your deck. If that card is a basic Energy card, attach it to 1 of your Pokémon. If that card isn't a basic Energy card, discard it. This power can't be used if Salamence is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may reveal the top card of your deck. If that card is a basic Energy card, attach it to 1 of your Pokémon. If that card isn’t a basic Energy card, discard it. This power can’t be used if Salamence is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "140",
@@ -433,7 +433,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Dragon Claw",
@@ -505,7 +505,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50+",
-        "text": "You may do 50 damage plus 30 more damage. If you do, this attack does 30 damage to 1 of your Pokémon, and don't apply Weakness and Resistance to this damage."
+        "text": "You may do 50 damage plus 30 more damage. If you do, this attack does 30 damage to 1 of your Pokémon, and don’t apply Weakness and Resistance to this damage."
       }
     ],
     "weaknesses": [
@@ -549,7 +549,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "During your opponent's next turn, any damage done to Tangrowth by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Tangrowth by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Swallow Up",
@@ -561,7 +561,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
-        "text": "Before doing damage, count the remaining HP of the Defending Pokémon and Tangrowth. If the Defending Pokémon has fewer remaining HP than Tangrowth's, this attack does 120 damage instead."
+        "text": "Before doing damage, count the remaining HP of the Defending Pokémon and Tangrowth. If the Defending Pokémon has fewer remaining HP than Tangrowth’s, this attack does 120 damage instead."
       }
     ],
     "weaknesses": [
@@ -608,7 +608,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Convert Blow",
@@ -670,7 +670,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "You may discard all Lightning Energy attached to Zapdos . If you do, this attack's base damage is 80 instead of 40."
+        "text": "You may discard all Lightning Energy attached to Zapdos . If you do, this attack’s base damage is 80 instead of 40."
       }
     ],
     "weaknesses": [
@@ -698,7 +698,7 @@
     "evolvesFrom": "Old Amber",
     "ability": {
       "name": "Unearth",
-      "text": "Once during your turn (before your attack), you may search your deck for Helix Fossil, Dome Fossil, or Old Amber, show it to your opponent, and put it into your hand. Shuffle your deck afterward. This power can't be used if Aerodactyl is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may search your deck for Helix Fossil, Dome Fossil, or Old Amber, show it to your opponent, and put it into your hand. Shuffle your deck afterward. This power can’t be used if Aerodactyl is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -773,7 +773,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon that has any damage counters on it. This attack does 40 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon that has any damage counters on it. This attack does 40 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Antigravity",
@@ -865,7 +865,7 @@
     "evolvesFrom": "Haunter",
     "ability": {
       "name": "Curse",
-      "text": "Once during your turn (before your attack), you may move 1 damage counter from 1 of your opponent's Pokémon to another of your opponent's Pokémon. This power can't be used if Gengar is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may move 1 damage counter from 1 of your opponent’s Pokémon to another of your opponent’s Pokémon. This power can’t be used if Gengar is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -888,7 +888,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) You may switch Gengar with 1 of your Benched Pokémon."
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) You may switch Gengar with 1 of your Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -933,7 +933,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 40 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Poison Jab",
@@ -1003,7 +1003,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1071,7 +1071,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -1135,7 +1135,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "If the Defending Pokémon has any Resistance, this attack's base damage is 120 instead of 60."
+        "text": "If the Defending Pokémon has any Resistance, this attack’s base damage is 120 instead of 60."
       }
     ],
     "weaknesses": [
@@ -1157,7 +1157,7 @@
     "evolvesFrom": "Buneary",
     "ability": {
       "name": "Relaxing Shower",
-      "text": "Once during your turn (before your attack), you may discard an Energy card from your hand. If you do, remove 1 damage counter from each of your Pokémon. This power can't be used if Lopunny is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may discard an Energy card from your hand. If you do, remove 1 damage counter from each of your Pokémon. This power can’t be used if Lopunny is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -1232,7 +1232,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -1280,7 +1280,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Evolved Pokémon. Remove the highest Stage Evolution card from that Pokémon and have your opponent shuffle that card into his or her deck."
+        "text": "Choose 1 of your opponent’s Evolved Pokémon. Remove the highest Stage Evolution card from that Pokémon and have your opponent shuffle that card into his or her deck."
       },
       {
         "name": "Primal Tentacles",
@@ -1493,7 +1493,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "If Raichu has a Pokémon Tool card attached to it, this attack does 20 damage to each of your opponent's Benched Pokémon that isn't an Evolved Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If Raichu has a Pokémon Tool card attached to it, this attack does 20 damage to each of your opponent’s Benched Pokémon that isn’t an Evolved Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Thunder Blast",
@@ -1532,7 +1532,7 @@
     "evolvesFrom": "Ponyta",
     "ability": {
       "name": "Wild Guard",
-      "text": "Prevent all effects of attacks, including damage, done to Rapidash by your opponent's Pokémon SP.",
+      "text": "Prevent all effects of attacks, including damage, done to Rapidash by your opponent’s Pokémon SP.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -1602,7 +1602,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at your opponent's hand, choose a Supporter card you find there, and discard it. Then, use the effect of that card as the effect of this attack."
+        "text": "Look at your opponent’s hand, choose a Supporter card you find there, and discard it. Then, use the effect of that card as the effect of this attack."
       },
       {
         "name": "Extend Fang",
@@ -1755,7 +1755,7 @@
     "level": "39",
     "ability": {
       "name": "Keystone Seal",
-      "text": "As long as Spiritomb is your Active Pokémon, each player can't play any Trainer cards from his or her hand.",
+      "text": "As long as Spiritomb is your Active Pokémon, each player can’t play any Trainer cards from his or her hand.",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -1831,7 +1831,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Hyper Beam",
@@ -2015,7 +2015,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2129,7 +2129,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Grovyle during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Grovyle during your opponent’s next turn."
       },
       {
         "name": "Blade Arms",
@@ -2251,7 +2251,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, during your opponent's next turn, if Gulpin would be Knocked Out by damage from an attack, Gulpin is not Knocked Out and its remaining HP becomes 10 instead."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, if Gulpin would be Knocked Out by damage from an attack, Gulpin is not Knocked Out and its remaining HP becomes 10 instead."
       },
       {
         "name": "Pound",
@@ -2285,7 +2285,7 @@
     "evolvesFrom": "Gastly",
     "ability": {
       "name": "Hidden Poison",
-      "text": "If Haunter is your Active Pokémon and is damaged by an opponent's attack (even if Haunter is Knocked Out), the Attacking Pokémon is now Poisoned.",
+      "text": "If Haunter is your Active Pokémon and is damaged by an opponent’s attack (even if Haunter is Knocked Out), the Attacking Pokémon is now Poisoned.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -2310,7 +2310,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2370,7 +2370,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2696,7 +2696,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to Shelgon by attacks during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all damage done to Shelgon by attacks during your opponent’s next turn."
       },
       {
         "name": "Dragon Bump",
@@ -2867,7 +2867,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. If you have Wormadam Plant Cloak in play, this attack does 40 damage to that Pokémon instead. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. If you have Wormadam Plant Cloak in play, this attack does 40 damage to that Pokémon instead. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Serve Trash",
@@ -2877,7 +2877,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "You may search your opponent's discard pile for any 1 card, show it to your opponent, and put it on top of his or her deck."
+        "text": "You may search your opponent’s discard pile for any 1 card, show it to your opponent, and put it on top of his or her deck."
       }
     ],
     "weaknesses": [
@@ -2979,7 +2979,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If you played Beedrill from your hand during this turn, this attack's base damage is 40 instead of 10."
+        "text": "If you played Beedrill from your hand during this turn, this attack’s base damage is 40 instead of 10."
       },
       {
         "name": "Fury Attack",
@@ -3090,7 +3090,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon that doesn't have any damage counters on it. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon that doesn’t have any damage counters on it. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3392,7 +3392,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 card from your opponent's hand without looking. Look at that card you chose, then have your opponent shuffle that card into his or her deck."
+        "text": "Choose 1 card from your opponent’s hand without looking. Look at that card you chose, then have your opponent shuffle that card into his or her deck."
       },
       {
         "name": "Punch",
@@ -3770,7 +3770,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Magnum Punch",
@@ -3823,7 +3823,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, if Nosepass would be damaged by an attack, prevent that attack's damage done to Nosepass if that damage is 30 or less."
+        "text": "During your opponent’s next turn, if Nosepass would be damaged by an attack, prevent that attack’s damage done to Nosepass if that damage is 30 or less."
       },
       {
         "name": "Knock Away",
@@ -3941,7 +3941,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Discard all Lightning Energy attached to Pikachu and then choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard all Lightning Energy attached to Pikachu and then choose 1 of your opponent’s Pokémon. This attack does 40 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4435,7 +4435,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "During your next turn, Wingull can't use Slashing Strike."
+        "text": "During your next turn, Wingull can’t use Slashing Strike."
       }
     ],
     "weaknesses": [
@@ -4537,8 +4537,8 @@
     "set": "Arceus",
     "setCode": "pl4",
     "text": [
-      "Attach Bench Shield to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
-      "As long as the Pokémon this card is attached to is on your Bench, prevent all damage done to that Pokémon by attacks (both yours and your opponent's)."
+      "Attach Bench Shield to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
+      "As long as the Pokémon this card is attached to is on your Bench, prevent all damage done to that Pokémon by attacks (both yours and your opponent’s)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl4/83_hires.png"
   },
@@ -4556,8 +4556,8 @@
     "set": "Arceus",
     "setCode": "pl4",
     "text": [
-      "Attach Buffer Piece to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
-      "Any damage done to the Pokémon this card is attached to by an opponent's attack is reduced by 20 (after applying Weakness and Resistance). At the end of your opponent's turn after you played Buffer Piece, discard Buffer Piece."
+      "Attach Buffer Piece to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
+      "Any damage done to the Pokémon this card is attached to by an opponent’s attack is reduced by 20 (after applying Weakness and Resistance). At the end of your opponent’s turn after you played Buffer Piece, discard Buffer Piece."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl4/84_hires.png"
   },
@@ -4594,7 +4594,7 @@
     "set": "Arceus",
     "setCode": "pl4",
     "text": [
-      "Flip 3 coins. For each heads, put a basic Energy card from your discard pile into your hand. If you don't have that many basic Energy cards in your discard pile, put all of them into your hand."
+      "Flip 3 coins. For each heads, put a basic Energy card from your discard pile into your hand. If you don’t have that many basic Energy cards in your discard pile, put all of them into your hand."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl4/86_hires.png"
   },
@@ -4612,8 +4612,8 @@
     "set": "Arceus",
     "setCode": "pl4",
     "text": [
-      "Attach Expert Belt to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
-      "The Pokémon this card is attached to gets +20 HP and that Pokémon's attacks do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance). When the Pokémon this card is attached to is Knocked Out, your opponent takes 1 more Prize card."
+      "Attach Expert Belt to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
+      "The Pokémon this card is attached to gets +20 HP and that Pokémon’s attacks do 20 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance). When the Pokémon this card is attached to is Knocked Out, your opponent takes 1 more Prize card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl4/87_hires.png"
   },
@@ -4631,8 +4631,8 @@
     "set": "Arceus",
     "setCode": "pl4",
     "text": [
-      "Attach Lucky Egg to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
-      "When the Pokémon this card is attached to is Knocked Out by damage from an opponent's attack, draw cards until you have 7 cards in your hand."
+      "Attach Lucky Egg to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
+      "When the Pokémon this card is attached to is Knocked Out by damage from an opponent’s attack, draw cards until you have 7 cards in your hand."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl4/88_hires.png"
   },
@@ -4650,14 +4650,14 @@
     "set": "Arceus",
     "setCode": "pl4",
     "text": [
-      "Play Old Amber as if it were a Colorless Basic Pokémon. (Old Amber counts as a Trainer card as well, but if Old Amber is Knocked Out, this counts as a Knocked Out Pokémon.) Old Amber can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Old Amber from play. (This doesn't count as a Knocked Out Pokémon.)",
-      "As long as Old Amber is on your Bench, prevent all damage done to Old Amber by attacks (both yours and your opponent's)."
+      "Play Old Amber as if it were a Colorless Basic Pokémon. (Old Amber counts as a Trainer card as well, but if Old Amber is Knocked Out, this counts as a Knocked Out Pokémon.) Old Amber can’t be affected by any Special Conditions and can’t retreat. At any time during your turn before your attack, you may discard Old Amber from play. (This doesn’t count as a Knocked Out Pokémon.)",
+      "As long as Old Amber is on your Bench, prevent all damage done to Old Amber by attacks (both yours and your opponent’s)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl4/89_hires.png"
   },
   {
     "id": "pl4-90",
-    "name": "Professor Oak's Visit",
+    "name": "Professor Oak’s Visit",
     "imageUrl": "https://images.pokemontcg.io/pl4/90.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4687,8 +4687,8 @@
     "set": "Arceus",
     "setCode": "pl4",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "During each player's turn, the player may move an Energy card attached to 1 of his or her Benched Pokémon to his or her Active Arceus as often as he or she likes."
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
+      "During each player’s turn, the player may move an Energy card attached to 1 of his or her Benched Pokémon to his or her Active Arceus as often as he or she likes."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl4/91_hires.png"
   },
@@ -4706,7 +4706,7 @@
     "set": "Arceus",
     "setCode": "pl4",
     "text": [
-      "Play Dome Fossil as if it were a Colorless Basic Pokémon. (Dome Fossil counts as a Trainer card as well, but if Dome Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Dome Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Dome Fossil from play. (This doesn't count as a Knocked Out Pokémon.)",
+      "Play Dome Fossil as if it were a Colorless Basic Pokémon. (Dome Fossil counts as a Trainer card as well, but if Dome Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Dome Fossil can’t be affected by any Special Conditions and can’t retreat. At any time during your turn before your attack, you may discard Dome Fossil from play. (This doesn’t count as a Knocked Out Pokémon.)",
       "When you attach a Fighting Energy card from your hand to Dome Fossil (excluding effects of attacks or Poké-Powers), search your deck for a card that evolves from Dome Fossil and put it onto Dome Fossil (this counts as evolving Dome Fossil). Shuffle your deck afterward."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl4/92_hires.png"
@@ -4725,7 +4725,7 @@
     "set": "Arceus",
     "setCode": "pl4",
     "text": [
-      "Play Helix Fossil as if it were a Colorless Basic Pokémon. (Helix Fossil counts as a Trainer card as well, but if Helix Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Helix Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Helix Fossil from play. (This doesn't count as a Knocked Out Pokémon.)",
+      "Play Helix Fossil as if it were a Colorless Basic Pokémon. (Helix Fossil counts as a Trainer card as well, but if Helix Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Helix Fossil can’t be affected by any Special Conditions and can’t retreat. At any time during your turn before your attack, you may discard Helix Fossil from play. (This doesn’t count as a Knocked Out Pokémon.)",
       "When you attach a Water Energy card from your hand to Helix Fossil (excluding effects of attacks or Poké-Powers), search your deck for a card that evolves from Helix Fossil and put it onto Helix Fossil (this counts as evolving Helix Fossil). Shuffle your deck afterward."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl4/93_hires.png"
@@ -4739,7 +4739,7 @@
     "level": "X",
     "ability": {
       "name": "Multitype",
-      "text": "Arceus LV.X's type is the same type as its previous Level.",
+      "text": "Arceus LV.X’s type is the same type as its previous Level.",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -4770,7 +4770,7 @@
     "level": "X",
     "ability": {
       "name": "Multitype",
-      "text": "Arceus LV.X's type is the same type as its previous Level.",
+      "text": "Arceus LV.X’s type is the same type as its previous Level.",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -4799,7 +4799,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "Flip a coin. If tails, this attack's base damage is 50 instead of 100."
+        "text": "Flip a coin. If tails, this attack’s base damage is 50 instead of 100."
       }
     ],
     "nationalPokedexNumber": 493,
@@ -4814,7 +4814,7 @@
     "level": "X",
     "ability": {
       "name": "Multitype",
-      "text": "Arceus LV.X's type is the same type as its previous Level.",
+      "text": "Arceus LV.X’s type is the same type as its previous Level.",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -4858,7 +4858,7 @@
     "level": "X",
     "ability": {
       "name": "Level-Down",
-      "text": "Once during your turn (before your attack), you may choose 1 of your opponent's Pokémon LV.X. Remove the Level-Up card from that Pokémon and have your opponent shuffle that card into his or her deck. This power can't be used if Gengar is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may choose 1 of your opponent’s Pokémon LV.X. Remove the Level-Up card from that Pokémon and have your opponent shuffle that card into his or her deck. This power can’t be used if Gengar is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "140",
@@ -4884,7 +4884,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 30 damage to each of your opponent's Pokémon that already has any damage counters on it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to each of your opponent’s Pokémon that already has any damage counters on it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4911,7 +4911,7 @@
     "level": "X",
     "ability": {
       "name": "Double Fall",
-      "text": "Once during your turn (before your attack), when you put Salamence LV.X from your hand onto your Active Salamence, you may use this power. For each of your opponent's Pokémon that is Knocked Out by damage from Salamence's attacks this turn, take 1 more Prize card.",
+      "text": "Once during your turn (before your attack), when you put Salamence LV.X from your hand onto your Active Salamence, you may use this power. For each of your opponent’s Pokémon that is Knocked Out by damage from Salamence’s attacks this turn, take 1 more Prize card.",
       "type": "Poké-Power"
     },
     "hp": "160",
@@ -4969,7 +4969,7 @@
     "level": "X",
     "ability": {
       "name": "Healing Growth",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, remove 4 damage counters from 1 of your Pokémon. This power can't be used if Tangrowth is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, remove 4 damage counters from 1 of your Pokémon. This power can’t be used if Tangrowth is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "130",
@@ -5335,7 +5335,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "This attack's damage isn't affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -5386,7 +5386,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 80 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Remove all Energy cards attached to Arceus and put them in the Lost Zone."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 80 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) Remove all Energy cards attached to Arceus and put them in the Lost Zone."
       }
     ],
     "weaknesses": [
@@ -5518,7 +5518,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -5567,7 +5567,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Prevent all effects of attacks, including damage, done to Arceus by Pokémon LV.X during your opponent's next turn."
+        "text": "Prevent all effects of attacks, including damage, done to Arceus by Pokémon LV.X during your opponent’s next turn."
       }
     ],
     "weaknesses": [

--- a/json/cards/BREAKpoint.json
+++ b/json/cards/BREAKpoint.json
@@ -80,7 +80,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Vine Whip",
@@ -114,7 +114,7 @@
     "evolvesFrom": "Bayleef",
     "ability": {
       "name": "Overgrow",
-      "text": "If this Pokémon's remaining HP is 50 or less, its attacks do 70 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
+      "text": "If this Pokémon’s remaining HP is 50 or less, its attacks do 70 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "150",
@@ -142,7 +142,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Heal from this Pokémon the same amount of damage you did to your opponent's Active Pokémon."
+        "text": "Heal from this Pokémon the same amount of damage you did to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -406,7 +406,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Discard the top card of your opponent's deck."
+        "text": "Discard the top card of your opponent’s deck."
       },
       {
         "name": "Scrape Down",
@@ -416,7 +416,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "If this Pokémon has any damage counters on it, discard the top 4 cards of your opponent's deck."
+        "text": "If this Pokémon has any damage counters on it, discard the top 4 cards of your opponent’s deck."
       }
     ],
     "weaknesses": [
@@ -813,7 +813,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Discard a Special Energy attached to your opponent's Active Pokémon."
+        "text": "Discard a Special Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Hydro Splash",
@@ -979,7 +979,7 @@
     "evolvesFrom": "Slowpoke",
     "ability": {
       "name": "Royal Flash",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, move an Energy from your opponent's Active Pokémon to 1 of his or her Benched Pokémon.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, move an Energy from your opponent’s Active Pokémon to 1 of his or her Benched Pokémon.",
       "type": "Ability"
     },
     "hp": "100",
@@ -1005,7 +1005,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "During your next turn, this Pokémon's Psych Up attack does 40 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s Psych Up attack does 40 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -1088,7 +1088,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If tails, this attack does nothing. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If tails, this attack does nothing. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -1132,7 +1132,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If this Pokémon evolved from Shellder during this turn, your opponent's Active Pokémon is now Paralyzed."
+        "text": "If this Pokémon evolved from Shellder during this turn, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Surf",
@@ -1239,7 +1239,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "130",
-        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1410,7 +1410,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Wind Charm",
-      "text": "As long as this Pokémon is your Active Pokémon, prevent all effects of your opponent's attacks, except damage, done to each of your Pokémon. (Existing effects are not removed.)",
+      "text": "As long as this Pokémon is your Active Pokémon, prevent all effects of your opponent’s attacks, except damage, done to each of your Pokémon. (Existing effects are not removed.)",
       "type": "Ability"
     },
     "hp": "120",
@@ -1492,7 +1492,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1703,7 +1703,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "90",
-        "text": "Your opponent's Active Pokémon is now Confused. That Pokémon can't retreat during your opponent's next turn."
+        "text": "Your opponent’s Active Pokémon is now Confused. That Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1844,7 +1844,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -1927,7 +1927,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "40",
-        "text": "Until the end of your opponent's next turn, each Pokémon your opponent has in play, in his or her hand, and in his or her discard pile has no Abilities. (This includes cards that come into play on that turn.)"
+        "text": "Until the end of your opponent’s next turn, each Pokémon your opponent has in play, in his or her hand, and in his or her discard pile has no Abilities. (This includes cards that come into play on that turn.)"
       },
       {
         "name": "Moonlight Slash",
@@ -1957,7 +1957,7 @@
     "evolvesFrom": "Greninja",
     "ability": {
       "name": "Giant Water Shuriken",
-      "text": "Once during your turn (before your attack), if this Pokémon is your Active Pokémon, you may discard a Water Energy card from your hand. If you do, put 6 damage counters on 1 of your opponent's Pokémon.",
+      "text": "Once during your turn (before your attack), if this Pokémon is your Active Pokémon, you may discard a Water Energy card from your hand. If you do, put 6 damage counters on 1 of your opponent’s Pokémon.",
       "type": "Ability"
     },
     "hp": "170",
@@ -2169,7 +2169,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -2230,7 +2230,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -2342,7 +2342,7 @@
     "evolvesFrom": "Blitzle",
     "ability": {
       "name": "Zap Zone",
-      "text": "Damage from the attacks of your Lightning Pokémon isn't affected by any effects on your opponent's Active Pokémon.",
+      "text": "Damage from the attacks of your Lightning Pokémon isn’t affected by any effects on your opponent’s Active Pokémon.",
       "type": "Ability"
     },
     "hp": "100",
@@ -2367,7 +2367,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50+",
-        "text": "If your opponent's Active Pokémon has Fighting Resistance, this attack does 60 more damage."
+        "text": "If your opponent’s Active Pokémon has Fighting Resistance, this attack does 60 more damage."
       }
     ],
     "weaknesses": [
@@ -2515,7 +2515,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Devolve each of your opponent's evolved Pokémon and put the highest Stage Evolution card on it into your opponent's hand."
+        "text": "Devolve each of your opponent’s evolved Pokémon and put the highest Stage Evolution card on it into your opponent’s hand."
       },
       {
         "name": "Psyshock",
@@ -2526,7 +2526,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "This attack's damage isn't affected by any effects on your opponent's Active Pokémon."
+        "text": "This attack’s damage isn’t affected by any effects on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -2615,7 +2615,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       },
       {
         "name": "Heavy Impact",
@@ -2666,7 +2666,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, if this Pokémon is damaged by an attack (even if this Pokémon is Knocked Out), put 5 damage counters on the Attacking Pokémon."
+        "text": "During your opponent’s next turn, if this Pokémon is damaged by an attack (even if this Pokémon is Knocked Out), put 5 damage counters on the Attacking Pokémon."
       },
       {
         "name": "Psy Report",
@@ -2722,7 +2722,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -2746,7 +2746,7 @@
     "evolvesFrom": "Trubbish",
     "ability": {
       "name": "Garbotoxin",
-      "text": "If this Pokémon has a Pokémon Tool card attached to it, each Pokémon in play, in each player's hand, and in each player's discard pile has no Abilities (except for Garbotoxin).",
+      "text": "If this Pokémon has a Pokémon Tool card attached to it, each Pokémon in play, in each player’s hand, and in each player’s discard pile has no Abilities (except for Garbotoxin).",
       "type": "Ability"
     },
     "hp": "100",
@@ -2775,7 +2775,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "Your opponent's Active Pokémon is now Confused and Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Confused and Poisoned."
       }
     ],
     "weaknesses": [
@@ -2907,7 +2907,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 1 damage counter on your opponent's Active Pokémon."
+        "text": "Put 1 damage counter on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -2958,7 +2958,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Put 3 damage counters on your opponent's Active Pokémon."
+        "text": "Put 3 damage counters on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -3011,7 +3011,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Double the number of damage counters on each of your opponent's Pokémon."
+        "text": "Double the number of damage counters on each of your opponent’s Pokémon."
       },
       {
         "name": "Megaton Slash",
@@ -3023,7 +3023,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "This attack does 10 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3068,7 +3068,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3141,7 +3141,7 @@
     "evolvesFrom": "Phantump",
     "ability": {
       "name": "Nervous Seed",
-      "text": "As long as this Pokémon is your Active Pokémon, your opponent's Basic Pokémon's attacks cost Colorless more.",
+      "text": "As long as this Pokémon is your Active Pokémon, your opponent’s Basic Pokémon’s attacks cost Colorless more.",
       "type": "Ability"
     },
     "hp": "110",
@@ -3169,7 +3169,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70+",
-        "text": "This attack does 10 more damage for each Energy attached to your opponent's Active Pokémon."
+        "text": "This attack does 10 more damage for each Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -3216,7 +3216,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Put 3 damage counters on each of your opponent's Pokémon."
+        "text": "Put 3 damage counters on each of your opponent’s Pokémon."
       }
     ],
     "nationalPokedexNumber": 709,
@@ -3251,7 +3251,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "If your opponent's Pokémon used an attack during his or her last turn, use it as this attack."
+        "text": "If your opponent’s Pokémon used an attack during his or her last turn, use it as this attack."
       }
     ],
     "weaknesses": [
@@ -3333,7 +3333,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3383,7 +3383,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "80+",
-        "text": "If your opponent's Active Pokémon is a Pokémon-EX, this attack does 80 more damage."
+        "text": "If your opponent’s Active Pokémon is a Pokémon-EX, this attack does 80 more damage."
       }
     ],
     "weaknesses": [
@@ -3536,7 +3536,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip 3 coins. If any of them are heads, your opponent reveals his or her hand. Then, for each heads, discard a card from your opponent's hand."
+        "text": "Flip 3 coins. If any of them are heads, your opponent reveals his or her hand. Then, for each heads, discard a card from your opponent’s hand."
       },
       {
         "name": "Otherworldly Return",
@@ -3608,7 +3608,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80+",
-        "text": "If your opponent's Active Pokémon is Asleep, this attack does 80 more damage."
+        "text": "If your opponent’s Active Pokémon is Asleep, this attack does 80 more damage."
       }
     ],
     "weaknesses": [
@@ -3656,7 +3656,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Switch this Pokémon with 1 of your Benched Pokémon. During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 60 (before applying Weakness and Resistance)."
+        "text": "Switch this Pokémon with 1 of your Benched Pokémon. During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 60 (before applying Weakness and Resistance)."
       },
       {
         "name": "Buster Swing",
@@ -3667,7 +3667,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -3716,7 +3716,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Gale Thrust",
@@ -3779,7 +3779,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "120",
-        "text": "You may discard a Special Energy attached to your opponent's Active Pokémon or a Stadium card in play."
+        "text": "You may discard a Special Energy attached to your opponent’s Active Pokémon or a Stadium card in play."
       }
     ],
     "weaknesses": [
@@ -3824,7 +3824,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Cavernous Chomp",
@@ -3882,7 +3882,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "During your opponent's next turn, if this Pokémon would be damaged by an attack, prevent that attack's damage done to this Pokémon if that damage is 60 or less."
+        "text": "During your opponent’s next turn, if this Pokémon would be damaged by an attack, prevent that attack’s damage done to this Pokémon if that damage is 60 or less."
       }
     ],
     "weaknesses": [
@@ -3945,7 +3945,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 10 damage to each of your opponent's Pokémon for each Colorless in that Pokémon's Retreat Cost. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Pokémon for each Colorless in that Pokémon’s Retreat Cost. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3990,7 +3990,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Double Slap",
@@ -4049,7 +4049,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "During your opponent's next turn, prevent all effects of attacks, including damage, done to this Pokémon by Dragon Pokémon."
+        "text": "During your opponent’s next turn, prevent all effects of attacks, including damage, done to this Pokémon by Dragon Pokémon."
       },
       {
         "name": "Tumbling Attack",
@@ -4214,7 +4214,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20+",
-        "text": "If your opponent's Active Pokémon is a Pokémon-EX, this attack does 40 more damage."
+        "text": "If your opponent’s Active Pokémon is a Pokémon-EX, this attack does 40 more damage."
       },
       {
         "name": "Fairy Wind",
@@ -4271,7 +4271,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Poisoned. Put 4 damage counters instead of 1 on that Pokémon between turns."
+        "text": "Your opponent’s Active Pokémon is now Poisoned. Put 4 damage counters instead of 1 on that Pokémon between turns."
       },
       {
         "name": "Dragon Pulse",
@@ -4344,7 +4344,7 @@
     "evolvesFrom": "Rattata",
     "ability": {
       "name": "Antibodies",
-      "text": "This Pokémon can't be affected by any Special Conditions. (Remove any Special Conditions affecting this Pokémon.)",
+      "text": "This Pokémon can’t be affected by any Special Conditions. (Remove any Special Conditions affecting this Pokémon.)",
       "type": "Ability"
     },
     "hp": "70",
@@ -4365,7 +4365,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Poisoned. Discard all Pokémon Tool cards attached to that Pokémon."
+        "text": "Your opponent’s Active Pokémon is now Poisoned. Discard all Pokémon Tool cards attached to that Pokémon."
       }
     ],
     "weaknesses": [
@@ -4406,7 +4406,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Put damage counters on your opponent's Active Pokémon until its remaining HP is 10."
+        "text": "Put damage counters on your opponent’s Active Pokémon until its remaining HP is 10."
       }
     ],
     "nationalPokedexNumber": 20,
@@ -4487,7 +4487,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Confused."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Confused."
       },
       {
         "name": "Big Charge",
@@ -4547,7 +4547,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "130",
-        "text": "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4658,7 +4658,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40+",
-        "text": "Flip a coin. If heads, this attack does 40 more damage. If tails, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, this attack does 40 more damage. If tails, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -4707,7 +4707,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -4732,7 +4732,7 @@
     "set": "BREAKpoint",
     "setCode": "xy9",
     "text": [
-      "Once during each player's turn, if that player's Active Pokémon is Asleep, he or she may remove that Special Condition and heal 30 damage from that Pokémon."
+      "Once during each player’s turn, if that player’s Active Pokémon is Asleep, he or she may remove that Special Condition and heal 30 damage from that Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy9/96_hires.png"
   },
@@ -4749,7 +4749,7 @@
     "set": "BREAKpoint",
     "setCode": "xy9",
     "text": [
-      "If this card is attached to 1 of your Pokémon, discard it at the end of your opponent's turn. If the Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent's attack (even if that Pokémon is Knocked Out), put 6 damage counters on the Attacking Pokémon."
+      "If this card is attached to 1 of your Pokémon, discard it at the end of your opponent’s turn. If the Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent’s attack (even if that Pokémon is Knocked Out), put 6 damage counters on the Attacking Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy9/97_hires.png"
   },
@@ -4800,7 +4800,7 @@
     "set": "BREAKpoint",
     "setCode": "xy9",
     "text": [
-      "The Basic Pokémon this card is attached to gets +40 HP and its attacks do 10 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance)."
+      "The Basic Pokémon this card is attached to gets +40 HP and its attacks do 10 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy9/99_hires.png"
   },
@@ -4874,7 +4874,7 @@
   },
   {
     "id": "xy9-104",
-    "name": "Misty's Determination",
+    "name": "Misty’s Determination",
     "imageUrl": "https://images.pokemontcg.io/xy9/104.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4902,7 +4902,7 @@
     "set": "BREAKpoint",
     "setCode": "xy9",
     "text": [
-      "Flip a coin. If heads, switch 1 of your opponent's Benched Pokémon with his or her Active Pokémon."
+      "Flip a coin. If heads, switch 1 of your opponent’s Benched Pokémon with his or her Active Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy9/105_hires.png"
   },
@@ -4959,7 +4959,7 @@
   },
   {
     "id": "xy9-108",
-    "name": "Psychic's Third Eye",
+    "name": "Psychic’s Third Eye",
     "imageUrl": "https://images.pokemontcg.io/xy9/108.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -5004,8 +5004,8 @@
     "set": "BREAKpoint",
     "setCode": "xy9",
     "text": [
-      "Choose which way this card faces before you play it. Any damage done to this ↓ player's Metal Pokémon by an opponent's attack is reduced by 10 (after applying Weakness and Resistance).",
-      "Choose which way this card faces before you play it. The attacks of this ↓ player's Darkness Pokémon do 10 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance)."
+      "Choose which way this card faces before you play it. Any damage done to this ↓ player’s Metal Pokémon by an opponent’s attack is reduced by 10 (after applying Weakness and Resistance).",
+      "Choose which way this card faces before you play it. The attacks of this ↓ player’s Darkness Pokémon do 10 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy9/110_hires.png"
   },
@@ -5056,7 +5056,7 @@
     "set": "BREAKpoint",
     "setCode": "xy9",
     "text": [
-      "This card can only be attached to Water Pokémon. This card provides Water Energy only while this card is attached to a Water Pokémon. If the Water Pokémon this card is attached to is Knocked Out by damage from an opponent's attack, put that Pokémon into your hand. (Discard all cards attached to it.) (If this card is attached to anything other than a Water Pokémon, discard this card.)"
+      "This card can only be attached to Water Pokémon. This card provides Water Energy only while this card is attached to a Water Pokémon. If the Water Pokémon this card is attached to is Knocked Out by damage from an opponent’s attack, put that Pokémon into your hand. (Discard all cards attached to it.) (If this card is attached to anything other than a Water Pokémon, discard this card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy9/113_hires.png"
   },
@@ -5105,7 +5105,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "130",
-        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -5244,7 +5244,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Devolve each of your opponent's evolved Pokémon and put the highest Stage Evolution card on it into your opponent's hand."
+        "text": "Devolve each of your opponent’s evolved Pokémon and put the highest Stage Evolution card on it into your opponent’s hand."
       },
       {
         "name": "Psyshock",
@@ -5255,7 +5255,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "This attack's damage isn't affected by any effects on your opponent's Active Pokémon."
+        "text": "This attack’s damage isn’t affected by any effects on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -5310,7 +5310,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80+",
-        "text": "If your opponent's Active Pokémon is Asleep, this attack does 80 more damage."
+        "text": "If your opponent’s Active Pokémon is Asleep, this attack does 80 more damage."
       }
     ],
     "weaknesses": [
@@ -5359,7 +5359,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Gale Thrust",
@@ -5422,7 +5422,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "120",
-        "text": "You may discard a Special Energy attached to your opponent's Active Pokémon or a Stadium card in play."
+        "text": "You may discard a Special Energy attached to your opponent’s Active Pokémon or a Stadium card in play."
       }
     ],
     "weaknesses": [
@@ -5478,7 +5478,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "130",
-        "text": "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -5558,7 +5558,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "130",
-        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [

--- a/json/cards/BREAKthrough.json
+++ b/json/cards/BREAKthrough.json
@@ -120,7 +120,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "This attack does 20 damage to 1 of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 1 of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Heavy Suplex",
@@ -131,7 +131,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40+",
-        "text": "This attack does 20 more damage for each Colorless in your opponent's Active Pokémon's Retreat Cost."
+        "text": "This attack does 20 more damage for each Colorless in your opponent’s Active Pokémon’s Retreat Cost."
       }
     ],
     "weaknesses": [
@@ -170,7 +170,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -526,7 +526,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "If your opponent's Active Pokémon already has any damage counters on it, this attack does 60 more damage."
+        "text": "If your opponent’s Active Pokémon already has any damage counters on it, this attack does 60 more damage."
       },
       {
         "name": "Adamantine Press",
@@ -538,7 +538,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -581,7 +581,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "160",
-        "text": "This Pokémon does 30 damage to itself. This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This Pokémon does 30 damage to itself. This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "nationalPokedexNumber": 652,
@@ -614,7 +614,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Tackle",
@@ -668,7 +668,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       },
       {
         "name": "Tackle",
@@ -728,7 +728,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       }
     ],
     "weaknesses": [
@@ -822,7 +822,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Horn Leech",
@@ -982,7 +982,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "130",
-        "text": "Discard an Energy attached to this Pokémon. Then, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Discard an Energy attached to this Pokémon. Then, discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -1025,7 +1025,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Discard the top 2 cards of your opponent's deck."
+        "text": "Discard the top 2 cards of your opponent’s deck."
       },
       {
         "name": "Grand Flame",
@@ -1445,7 +1445,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "If you and your opponent have the same number of Benched Pokémon, your opponent's Active Pokémon is now Paralyzed."
+        "text": "If you and your opponent have the same number of Benched Pokémon, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -1597,7 +1597,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1641,7 +1641,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Instant Freeze",
@@ -1785,7 +1785,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -1809,7 +1809,7 @@
     "evolvesFrom": "Prinplup",
     "ability": {
       "name": "Dignified Fighter",
-      "text": "Each of your Basic Pokémon's attacks does 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
+      "text": "Each of your Basic Pokémon’s attacks does 20 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "140",
@@ -1876,7 +1876,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Double Smash",
@@ -1935,7 +1935,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "If your opponent's Active Pokémon is a Dragon Pokémon, it is now Paralyzed."
+        "text": "If your opponent’s Active Pokémon is a Dragon Pokémon, it is now Paralyzed."
       },
       {
         "name": "Frost Breath",
@@ -2078,7 +2078,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Icy Snow",
@@ -2142,7 +2142,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       }
     ],
     "weaknesses": [
@@ -2186,7 +2186,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Until the end of your next turn, each player can't play any Supporter or Stadium cards from his or her hand."
+        "text": "Until the end of your next turn, each player can’t play any Supporter or Stadium cards from his or her hand."
       },
       {
         "name": "Deep Freeze",
@@ -2197,7 +2197,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed. If tails, your opponent's Active Pokémon is now Confused."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed. If tails, your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -2332,7 +2332,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2379,7 +2379,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "This attack does 50 damage to each of your opponent's Pokémon-EX. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 50 damage to each of your opponent’s Pokémon-EX. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Electrosmash",
@@ -2525,7 +2525,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Lightning Ball",
@@ -2584,7 +2584,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Electro Ball",
@@ -2753,7 +2753,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "If any of your Pokémon were Knocked Out by damage from an opponent's attack during his or her last turn, this attack does 80 more damage."
+        "text": "If any of your Pokémon were Knocked Out by damage from an opponent’s attack during his or her last turn, this attack does 80 more damage."
       },
       {
         "name": "Thunder Blast",
@@ -2809,7 +2809,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -2854,7 +2854,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Asleep and Poisoned."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Asleep and Poisoned."
       }
     ],
     "weaknesses": [
@@ -2909,7 +2909,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Poisoned. That Pokémon can't retreat during your opponent's next turn."
+        "text": "Your opponent’s Active Pokémon is now Poisoned. That Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2955,7 +2955,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Poisoned. Put 1 damage counter on each of your opponent's Benched Pokémon."
+        "text": "Your opponent’s Active Pokémon is now Poisoned. Put 1 damage counter on each of your opponent’s Benched Pokémon."
       },
       {
         "name": "Creep Show",
@@ -2965,7 +2965,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "If your opponent's Active Pokémon has 3 or more damage counters on it, that Pokémon is Knocked Out."
+        "text": "If your opponent’s Active Pokémon has 3 or more damage counters on it, that Pokémon is Knocked Out."
       }
     ],
     "weaknesses": [
@@ -3015,7 +3015,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 30 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 30 (before applying Weakness and Resistance)."
       },
       {
         "name": "Psyburn",
@@ -3082,7 +3082,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Switch all damage counters on this Pokémon with those on your opponent's Active Pokémon."
+        "text": "Switch all damage counters on this Pokémon with those on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -3132,7 +3132,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "150+",
-        "text": "If there is any Stadium card in play, this attack does 50 more damage, and this attack's damage isn't affected by Resistance or any effects on your opponent's Active Pokémon."
+        "text": "If there is any Stadium card in play, this attack does 50 more damage, and this attack’s damage isn’t affected by Resistance or any effects on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -3178,7 +3178,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10+",
-        "text": "This attack does 30 more damage times the amount of Energy attached to both Active Pokémon. This attack's damage isn't affected by Weakness."
+        "text": "This attack does 30 more damage times the amount of Energy attached to both Active Pokémon. This attack’s damage isn’t affected by Weakness."
       }
     ],
     "weaknesses": [
@@ -3217,7 +3217,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 2 damage counters on your opponent's Active Pokémon."
+        "text": "Put 2 damage counters on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -3273,7 +3273,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -3320,7 +3320,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent’s next turn."
       },
       {
         "name": "Rolling Tackle",
@@ -3581,7 +3581,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, this Pokémon's Returning Echo attack does 60 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s Returning Echo attack does 60 more damage (before applying Weakness and Resistance)."
       },
       {
         "name": "Returning Echo",
@@ -3635,7 +3635,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "During your next turn, this Pokémon's Psych Up attack does 20 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s Psych Up attack does 20 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -3678,7 +3678,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 20 damage to 1 of your opponent's Pokémon times the amount of Energy attached to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 1 of your opponent’s Pokémon times the amount of Energy attached to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Psybeam",
@@ -3688,7 +3688,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -3737,7 +3737,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3791,7 +3791,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, or any other effects on your opponent's Active Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, or any other effects on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -3876,7 +3876,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 30 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Bone Windmill",
@@ -3886,7 +3886,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "60",
-        "text": "If your opponent's Active Pokémon is a Pokémon-EX, switch this Pokémon with 1 of your Benched Pokémon."
+        "text": "If your opponent’s Active Pokémon is a Pokémon-EX, switch this Pokémon with 1 of your Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -3960,7 +3960,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Mud-Slap",
@@ -4051,7 +4051,7 @@
     "evolvesFrom": "Piloswine",
     "ability": {
       "name": "Thick Fat",
-      "text": "Any damage done to this Pokémon by attacks from your opponent's Fire or Water Pokémon is reduced by 30 (after applying Weakness and Resistance).",
+      "text": "Any damage done to this Pokémon by attacks from your opponent’s Fire or Water Pokémon is reduced by 30 (after applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "160",
@@ -4124,7 +4124,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -4265,7 +4265,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Discard a random card from your opponent's hand."
+        "text": "Discard a random card from your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -4317,7 +4317,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -4363,7 +4363,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Discard a Special Energy attached to your opponent's Active Pokémon."
+        "text": "Discard a Special Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Pin Missile",
@@ -4419,7 +4419,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       },
       {
         "name": "Dark Edge",
@@ -4477,7 +4477,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose a random card from your opponent's hand. Your opponent reveals that card and shuffles it into his or her deck."
+        "text": "Choose a random card from your opponent’s hand. Your opponent reveals that card and shuffles it into his or her deck."
       },
       {
         "name": "Dark Edge",
@@ -4543,7 +4543,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10+",
-        "text": "This attack does 30 more damage for each of your opponent's Benched Pokémon."
+        "text": "This attack does 30 more damage for each of your opponent’s Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -4589,7 +4589,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Active Pokémon's attacks and use it as this attack."
+        "text": "Choose 1 of your opponent’s Active Pokémon’s attacks and use it as this attack."
       }
     ],
     "nationalPokedexNumber": 571,
@@ -4679,7 +4679,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "This attack does 60 damage to 1 of your opponent's Benched Pokémon-EX. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 60 damage to 1 of your opponent’s Benched Pokémon-EX. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4778,7 +4778,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Put 3 damage counters on each of your opponent's Pokémon that has any damage counters on it."
+        "text": "Put 3 damage counters on each of your opponent’s Pokémon that has any damage counters on it."
       },
       {
         "name": "Knock Away",
@@ -4949,7 +4949,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, choose 3 random cards from your opponent's hand. Your opponent reveals those cards and shuffles them into his or her deck."
+        "text": "Flip a coin. If heads, choose 3 random cards from your opponent’s hand. Your opponent reveals those cards and shuffles them into his or her deck."
       },
       {
         "name": "Tantrum",
@@ -5152,7 +5152,7 @@
     "evolvesFrom": "Floette",
     "ability": {
       "name": "Calming Aroma",
-      "text": "Each of your Pokémon's attacks costs Fairy less.",
+      "text": "Each of your Pokémon’s attacks costs Fairy less.",
       "type": "Ability"
     },
     "hp": "110",
@@ -5178,7 +5178,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -5300,7 +5300,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Confused. Put 6 damage counters instead of 3 on that Pokémon for this Special Condition."
+        "text": "Your opponent’s Active Pokémon is now Confused. Put 6 damage counters instead of 3 on that Pokémon for this Special Condition."
       },
       {
         "name": "Hug",
@@ -5309,7 +5309,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -5535,7 +5535,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "If your opponent's Active Pokémon is a Dragon Pokémon, this attack does 40 more damage (before applying Weakness and Resistance)."
+        "text": "If your opponent’s Active Pokémon is a Dragon Pokémon, this attack does 40 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -5580,7 +5580,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "As long as this Haxorus is your Active Pokémon, each of its attacks does 100 more damage (before applying Weakness and Resistance). You can't add more than 100 damage in this way."
+        "text": "As long as this Haxorus is your Active Pokémon, each of its attacks does 100 more damage (before applying Weakness and Resistance). You can’t add more than 100 damage in this way."
       },
       {
         "name": "Sharp Fang",
@@ -5639,7 +5639,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Shuffle your hand into your deck. Then, draw a number of cards equal to the number of cards in your opponent's hand."
+        "text": "Shuffle your hand into your deck. Then, draw a number of cards equal to the number of cards in your opponent’s hand."
       },
       {
         "name": "Air Slash",
@@ -5725,7 +5725,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, this attack does 30 damage to your opponent's Active Pokémon. If tails, this Pokémon does 30 damage to itself."
+        "text": "Flip a coin. If heads, this attack does 30 damage to your opponent’s Active Pokémon. If tails, this Pokémon does 30 damage to itself."
       }
     ],
     "weaknesses": [
@@ -5865,7 +5865,7 @@
     "evolvesFrom": "Doduo",
     "ability": {
       "name": "Retreat Aid",
-      "text": "As long as this Pokémon is on your Bench, your Active Pokémon's Retreat Cost is ColorlessColorless less.",
+      "text": "As long as this Pokémon is on your Bench, your Active Pokémon’s Retreat Cost is ColorlessColorless less.",
       "type": "Ability"
     },
     "hp": "90",
@@ -5987,7 +5987,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Your opponent can't play any Item cards from his or her hand during his or her next turn."
+        "text": "Your opponent can’t play any Item cards from his or her hand during his or her next turn."
       }
     ],
     "weaknesses": [
@@ -6142,7 +6142,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with his or her Active Pokémon. This attack does 50 damage to the new Active Pokémon."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with his or her Active Pokémon. This attack does 50 damage to the new Active Pokémon."
       },
       {
         "name": "Swing Around",
@@ -6451,7 +6451,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Aerial Ace",
@@ -6663,7 +6663,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Gust",
@@ -6707,7 +6707,7 @@
     "set": "BREAKthrough",
     "setCode": "xy8",
     "text": [
-      "Any damage done to the Pokémon this card is attached to by attacks from your opponent's Pokémon that have any Special Energy attached to them is reduced by 40 (after applying Weakness and Resistance)."
+      "Any damage done to the Pokémon this card is attached to by attacks from your opponent’s Pokémon that have any Special Energy attached to them is reduced by 40 (after applying Weakness and Resistance)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/133_hires.png"
   },
@@ -6781,7 +6781,7 @@
   },
   {
     "id": "xy8-138",
-    "name": "Giovanni's Scheme",
+    "name": "Giovanni’s Scheme",
     "imageUrl": "https://images.pokemontcg.io/xy8/138.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -6792,7 +6792,7 @@
     "set": "BREAKthrough",
     "setCode": "xy8",
     "text": [
-      "Choose 1: •Draw cards until you have 5 cards in your hand. •During this turn, your Pokémon's attacks do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance)."
+      "Choose 1: •Draw cards until you have 5 cards in your hand. •During this turn, your Pokémon’s attacks do 20 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/138_hires.png"
   },
@@ -6843,7 +6843,7 @@
     "set": "BREAKthrough",
     "setCode": "xy8",
     "text": [
-      "If the Retreat Cost of the Pokémon this card is attached to is 3 or more, that Pokémon gets +20 HP and can't be Confused. (If that Pokémon is currently Confused, remove that Special Condition.)"
+      "If the Retreat Cost of the Pokémon this card is attached to is 3 or more, that Pokémon gets +20 HP and can’t be Confused. (If that Pokémon is currently Confused, remove that Special Condition.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/141_hires.png"
   },
@@ -6912,13 +6912,13 @@
     "setCode": "xy8",
     "text": [
       "Choose which way this card faces before you play it. Any damage done by attacks from this ↓ player’s Grass, Fire, or Water Pokémon is reduced by 20 (before applying Weakness and Resistance).",
-      "Choose which way this card faces before you play it. This ↓ player can't have more than 3 Benched Pokémon. (When this card comes into play, this ↓ player discards Benched Pokémon until he or she has 3 Pokémon on the Bench.)"
+      "Choose which way this card faces before you play it. This ↓ player can’t have more than 3 Benched Pokémon. (When this card comes into play, this ↓ player discards Benched Pokémon until he or she has 3 Pokémon on the Bench.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/145_hires.png"
   },
   {
     "id": "xy8-146",
-    "name": "Professor's Letter",
+    "name": "Professor’s Letter",
     "imageUrl": "https://images.pokemontcg.io/xy8/146.png",
     "subtype": "Item",
     "supertype": "Trainer",
@@ -7066,7 +7066,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Discard the top 2 cards of your opponent's deck."
+        "text": "Discard the top 2 cards of your opponent’s deck."
       },
       {
         "name": "Grand Flame",
@@ -7166,7 +7166,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Instant Freeze",
@@ -7270,7 +7270,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 30 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 30 (before applying Weakness and Resistance)."
       },
       {
         "name": "Psyburn",
@@ -7337,7 +7337,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Switch all damage counters on this Pokémon with those on your opponent's Active Pokémon."
+        "text": "Switch all damage counters on this Pokémon with those on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -7387,7 +7387,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "150+",
-        "text": "If there is any Stadium card in play, this attack does 50 more damage, and this attack's damage isn't affected by Resistance or any effects on your opponent's Active Pokémon."
+        "text": "If there is any Stadium card in play, this attack does 50 more damage, and this attack’s damage isn’t affected by Resistance or any effects on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -7433,7 +7433,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10+",
-        "text": "This attack does 30 more damage times the amount of Energy attached to both Active Pokémon. This attack's damage isn't affected by Weakness."
+        "text": "This attack does 30 more damage times the amount of Energy attached to both Active Pokémon. This attack’s damage isn’t affected by Weakness."
       }
     ],
     "weaknesses": [
@@ -7464,7 +7464,7 @@
   },
   {
     "id": "xy8-162",
-    "name": "Giovanni's Scheme",
+    "name": "Giovanni’s Scheme",
     "imageUrl": "https://images.pokemontcg.io/xy8/162.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -7475,7 +7475,7 @@
     "set": "BREAKthrough",
     "setCode": "xy8",
     "text": [
-      "Choose 1: •Draw cards until you have 5 cards in your hand. •During this turn, your Pokémon's attacks do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance)."
+      "Choose 1: •Draw cards until you have 5 cards in your hand. •During this turn, your Pokémon’s attacks do 20 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/162_hires.png"
   },
@@ -7511,7 +7511,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 30 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 30 (before applying Weakness and Resistance)."
       },
       {
         "name": "Psyburn",
@@ -7578,7 +7578,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Switch all damage counters on this Pokémon with those on your opponent's Active Pokémon."
+        "text": "Switch all damage counters on this Pokémon with those on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [

--- a/json/cards/BW Black Star Promos.json
+++ b/json/cards/BW Black Star Promos.json
@@ -439,7 +439,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks and use it as this attack."
+        "text": "Choose 1 of the Defending Pokémon’s attacks and use it as this attack."
       }
     ],
     "weaknesses": [
@@ -910,7 +910,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "During your opponent's next turn, damage from the Defending Pokémon attacks is reduced by 20."
+        "text": "During your opponent’s next turn, damage from the Defending Pokémon attacks is reduced by 20."
       }
     ],
     "weaknesses": [
@@ -1270,7 +1270,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "nationalPokedexNumber": 610,
@@ -1344,8 +1344,8 @@
     "set": "BW Black Star Promos",
     "setCode": "bwp",
     "text": [
-      "Once during each player's turn, that player may draw cards until he or she has 7 cards in his or her hand. If he or she does, that player's turn ends.",
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card."
+      "Once during each player’s turn, that player may draw cards until he or she has 7 cards in his or her hand. If he or she does, that player’s turn ends.",
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bwp/BW28_hires.png"
   },
@@ -1408,7 +1408,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Victory Star",
-      "text": "Once during your turn, after you flip any coins for an attack, you may ignore all effects of those coin flips and begin flipping those coins again. You can't use more than 1 Victory Star Ability each turn.",
+      "text": "Once during your turn, after you flip any coins for an attack, you may ignore all effects of those coin flips and begin flipping those coins again. You can’t use more than 1 Victory Star Ability each turn.",
       "type": "Ability"
     },
     "hp": "60",
@@ -1536,7 +1536,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "n/a",
-        "text": "This attack does 40 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 40 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1703,7 +1703,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "This Pokémon can't use Hail Blizzard during your next turn."
+        "text": "This Pokémon can’t use Hail Blizzard during your next turn."
       }
     ],
     "weaknesses": [
@@ -1784,7 +1784,7 @@
     "set": "BW Black Star Promos",
     "setCode": "bwp",
     "text": [
-      "Once during each player's turn, that player may flip a coin. If heads, the player draws a card."
+      "Once during each player’s turn, that player may flip a coin. If heads, the player draws a card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bwp/BW39_hires.png"
   },
@@ -1797,7 +1797,7 @@
     "evolvesFrom": "Larvesta",
     "ability": {
       "name": "Scorching Scales",
-      "text": "Put 4 damage counters instead of 2 on your opponent's Burned Pokémon between turns.",
+      "text": "Put 4 damage counters instead of 2 on your opponent’s Burned Pokémon between turns.",
       "type": "Ability"
     },
     "hp": "110",
@@ -1981,7 +1981,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent’s). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2039,7 +2039,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 30 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2141,7 +2141,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": "Does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2219,7 +2219,7 @@
     "evolvesFrom": "Swablu",
     "ability": {
       "name": "Fight Song",
-      "text": "Your Dragon Pokémon's attacks do 20 more damage to the Active Pokémon (before applying Weakness and Resistance).",
+      "text": "Your Dragon Pokémon’s attacks do 20 more damage to the Active Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "70",
@@ -2326,8 +2326,8 @@
     "set": "BW Black Star Promos",
     "setCode": "bwp",
     "text": [
-      "Once during each player's turn, that player may draw cards until he or she has 7 cards in his or her hand. If he or she does, that player's turn ends.",
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card."
+      "Once during each player’s turn, that player may draw cards until he or she has 7 cards in his or her hand. If he or she does, that player’s turn ends.",
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bwp/BW50_hires.png"
   },
@@ -2433,7 +2433,7 @@
     "evolvesFrom": "Vibrava",
     "ability": {
       "name": "Sand Slammer",
-      "text": "At any time between turns, if this Pokémon is your Active Pokémon, put 1 damage counter on each of your opponent's Pokémon.",
+      "text": "At any time between turns, if this Pokémon is your Active Pokémon, put 1 damage counter on each of your opponent’s Pokémon.",
       "type": "Ability"
     },
     "hp": "140",
@@ -2656,7 +2656,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Dual Chop",
@@ -2812,7 +2812,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, this Pokémon's Aqua Blade attack's base damage is 120."
+        "text": "During your next turn, this Pokémon’s Aqua Blade attack’s base damage is 120."
       },
       {
         "name": "Aqua Blade",
@@ -2927,7 +2927,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "150",
-        "text": "This Pokémon can't attack during your next turn."
+        "text": "This Pokémon can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -3023,7 +3023,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "50x",
-        "text": "Does 50 damage times the number of Special Energy cards in your opponent's discard pile."
+        "text": "Does 50 damage times the number of Special Energy cards in your opponent’s discard pile."
       },
       {
         "name": "Plentiful Placement",
@@ -3033,7 +3033,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Put 4 damage counters on 1 of your opponent's Pokémon."
+        "text": "Put 4 damage counters on 1 of your opponent’s Pokémon."
       }
     ],
     "weaknesses": [
@@ -3096,7 +3096,7 @@
     "evolvesFrom": "Vulpix",
     "ability": {
       "name": "Bright Look",
-      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may switch 1 of your opponent's Benched Pokémon with his or her Active Pokémon.",
+      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may switch 1 of your opponent’s Benched Pokémon with his or her Active Pokémon.",
       "type": "Ability"
     },
     "hp": "90",
@@ -3161,7 +3161,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 30 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Electricannon",
@@ -3292,7 +3292,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Justified",
-      "text": "Each of this Pokémon's attacks does 50 more damage to Darkness Pokémon (before applying Weakness and Resistance).",
+      "text": "Each of this Pokémon’s attacks does 50 more damage to Darkness Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "100",
@@ -3344,7 +3344,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Justified",
-      "text": "Each of this Pokémon's attacks does 50 more damage to Darkness Pokémon (before applying Weakness and Resistance).",
+      "text": "Each of this Pokémon’s attacks does 50 more damage to Darkness Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "130",
@@ -3394,7 +3394,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Justified",
-      "text": "Each of this Pokémon's attacks does 50 more damage to Darkness Pokémon (before applying Weakness and Resistance).",
+      "text": "Each of this Pokémon’s attacks does 50 more damage to Darkness Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "120",
@@ -3542,7 +3542,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "90",
-        "text": "Discard a random card from your opponent's hand."
+        "text": "Discard a random card from your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -3786,7 +3786,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "90",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3832,7 +3832,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with the Defending Pokémon."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon."
       },
       {
         "name": "Boost Claw",
@@ -3843,7 +3843,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "During your next turn, each of this Pokémon's attacks does 30 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, each of this Pokémon’s attacks does 30 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -3916,7 +3916,7 @@
     "level": "ex",
     "ability": {
       "name": "Power Connect",
-      "text": "Your Team Plasma Pokémon's attacks (excluding Deoxys-EX) do 10 more damage to the Active Pokémon (before applying Weakness and Resistance).",
+      "text": "Your Team Plasma Pokémon’s attacks (excluding Deoxys-EX) do 10 more damage to the Active Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "170",
@@ -3963,7 +3963,7 @@
     "level": "ex",
     "ability": {
       "name": "Overflow",
-      "text": "If your opponent's Pokémon is Knocked Out by damage from an attack of this Pokémon, take 1 more Prize card.",
+      "text": "If your opponent’s Pokémon is Knocked Out by damage from an attack of this Pokémon, take 1 more Prize card.",
       "type": "Ability"
     },
     "hp": "180",
@@ -3991,7 +3991,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "Discard a Plasma Energy attached to this Pokémon. If you can't discard a Plasma Energy, this attack does nothing."
+        "text": "Discard a Plasma Energy attached to this Pokémon. If you can’t discard a Plasma Energy, this attack does nothing."
       }
     ],
     "weaknesses": [
@@ -4145,7 +4145,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "During your next turn, this Pokémon's Overdrive Smash attack does 60 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s Overdrive Smash attack does 60 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -4241,7 +4241,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Fire Slash",
@@ -4293,7 +4293,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Spiral Drain",
@@ -4423,7 +4423,7 @@
     "evolvesFrom": "Eevee",
     "ability": {
       "name": "Solar Revelation",
-      "text": "Prevent all effects of your opponent's attacks, except damage, done to each of your Pokémon that has any Energy attached to it.",
+      "text": "Prevent all effects of your opponent’s attacks, except damage, done to each of your Pokémon that has any Energy attached to it.",
       "type": "Ability"
     },
     "hp": "90",
@@ -4502,7 +4502,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "This Pokémon can't use Slashing Strike during your next turn."
+        "text": "This Pokémon can’t use Slashing Strike during your next turn."
       }
     ],
     "weaknesses": [
@@ -4547,7 +4547,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
       },
       {
         "name": "Quick Attack",
@@ -4592,8 +4592,8 @@
     "set": "BW Black Star Promos",
     "setCode": "bwp",
     "text": [
-      "Once during each player's turn, if that player has 6 Pokémon in play, he or she may heal 10 damage from each of his or her Pokémon.",
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card."
+      "Once during each player’s turn, if that player has 6 Pokémon in play, he or she may heal 10 damage from each of his or her Pokémon.",
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bwp/BW95_hires.png"
   },
@@ -4691,7 +4691,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
       },
       {
         "name": "Quick Attack",

--- a/json/cards/Base Set 2.json
+++ b/json/cards/Base Set 2.json
@@ -9,7 +9,7 @@
     "evolvesFrom": "Kadabra",
     "ability": {
       "name": "Damage Swap",
-      "text": "As often as you like during your turn (before your attack), you may move 1 damage counter from 1 of your Pokémon to another as long as you don't Knock Out that Pokémon. This power can't be used if Alakazam is Asleep, Confused, or Paralyzed.",
+      "text": "As often as you like during your turn (before your attack), you may move 1 damage counter from 1 of your Pokémon to another as long as you don’t Knock Out that Pokémon. This power can’t be used if Alakazam is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "80",
@@ -59,7 +59,7 @@
     "evolvesFrom": "Wartortle",
     "ability": {
       "name": "Rain Dance",
-      "text": "As often as you like during your turn (before your attack), you may attach 1 Water Energy Card to 1 of your Water Pokémon. (This doesn't use up your 1 Energy card attachment for the turn.) This power can't be used if Blastoise is Asleep, Confused, or Paralyzed.",
+      "text": "As often as you like during your turn (before your attack), you may attach 1 Water Energy Card to 1 of your Water Pokémon. (This doesn’t use up your 1 Energy card attachment for the turn.) This power can’t be used if Blastoise is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "100",
@@ -87,7 +87,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40+",
-        "text": "Does 40 damage plus 10 more damage for each attached to Blastoise but not used to pay for this attack's Energy cost. Extra Energy after the 2nd doesn't count."
+        "text": "Does 40 damage plus 10 more damage for each attached to Blastoise but not used to pay for this attack’s Energy cost. Extra Energy after the 2nd doesn’t count."
       }
     ],
     "weaknesses": [
@@ -128,7 +128,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to Chansey during your opponent's next turn. (Any other effects of attacks still happen.)"
+        "text": "Flip a coin. If heads, prevent all damage done to Chansey during your opponent’s next turn. (Any other effects of attacks still happen.)"
       },
       {
         "name": "Double-edge",
@@ -243,7 +243,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. Metronome copies that attack except for its Energy costs and anything else required in order to use that attack, such as discarding Energy cards. (No matter what type the Defending Pokémon is, Clefable's type is still Colorless.)"
+        "text": "Choose 1 of the Defending Pokémon’s attacks. Metronome copies that attack except for its Energy costs and anything else required in order to use that attack, such as discarding Energy cards. (No matter what type the Defending Pokémon is, Clefable’s type is still Colorless.)"
       },
       {
         "name": "Minimize",
@@ -253,7 +253,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "All damage done by attacks to Clefable during your opponent's next turn is reduce by 20 (after applying Weakness and Resistance)."
+        "text": "All damage done by attacks to Clefable during your opponent’s next turn is reduce by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -310,7 +310,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of Defending Pokémon's attacks. Metronome copies that attack except for its Energy costs and anything else required in order to use that attack, such as discarding energy cards. (No matter what type the defender is, Clefairy's type is still Colorless.)"
+        "text": "Choose 1 of Defending Pokémon’s attacks. Metronome copies that attack except for its Energy costs and anything else required in order to use that attack, such as discarding energy cards. (No matter what type the defender is, Clefairy’s type is still Colorless.)"
       }
     ],
     "weaknesses": [
@@ -489,7 +489,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "Does 20 damage to each Pokémon on each player's Bench. (Don't apply Weakness and Resistance for Benched Pokémon.) Magneton does 80 damage to itself."
+        "text": "Does 20 damage to each Pokémon on each player’s Bench. (Don’t apply Weakness and Resistance for Benched Pokémon.) Magneton does 80 damage to itself."
       }
     ],
     "weaknesses": [
@@ -545,7 +545,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Discard 1 Energy card attached to Mewtwo in order to use this attack. During your opponent's next turn, prevent all effects of attacks, including damage, done to Mewtwo."
+        "text": "Discard 1 Energy card attached to Mewtwo in order to use this attack. During your opponent’s next turn, prevent all effects of attacks, including damage, done to Mewtwo."
       }
     ],
     "weaknesses": [
@@ -599,7 +599,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "The Defending Pokémon is now Poisoned. It now takes 20 Poison damage instead of 10 after each player's turn (even if it was already Poisoned)."
+        "text": "The Defending Pokémon is now Poisoned. It now takes 20 Poison damage instead of 10 after each player’s turn (even if it was already Poisoned)."
       }
     ],
     "weaknesses": [
@@ -759,7 +759,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Unless this attack Knocks Out the Defending Pokémon, return the Defending Pokémon and all cards attached to it to your opponent's hand."
+        "text": "Unless this attack Knocks Out the Defending Pokémon, return the Defending Pokémon and all cards attached to it to your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -810,7 +810,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
-        "text": "Does 30 damage plus 10 more damage for each Energy attached to Poliwrath but not used to pay for this attack's Energy cost. Extra Energy after the 2nd doesn't count."
+        "text": "Does 30 damage plus 10 more damage for each Energy attached to Poliwrath but not used to pay for this attack’s Energy cost. Extra Energy after the 2nd doesn’t count."
       },
       {
         "name": "Whirlpool",
@@ -865,7 +865,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Raichu."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Raichu."
       },
       {
         "name": "Thunder",
@@ -914,7 +914,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, Scyther's Slash attack's base damage is 60 instead of 30."
+        "text": "During your next turn, Scyther’s Slash attack’s base damage is 60 instead of 30."
       },
       {
         "name": "Slash",
@@ -956,7 +956,7 @@
     "evolvesFrom": "Ivysaur",
     "ability": {
       "name": "Energy Trans",
-      "text": "As often as you like during your turn (before your attack), you may take 1 Grass Energy card attached to 1 of your Pokémon and attach it to a different one. This power can't be used if Venusaur is Asleep, Confused, or Paralyzed.",
+      "text": "As often as you like during your turn (before your attack), you may take 1 Grass Energy card attached to 1 of your Pokémon and attach it to a different one. This power can’t be used if Venusaur is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "100",
@@ -1272,7 +1272,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "70",
-        "text": "Does 10 damage to each of your own Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your own Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1354,7 +1354,7 @@
     "evolvesFrom": "Voltorb",
     "ability": {
       "name": "Buzzap",
-      "text": "At any time during your turn (before your attack) you may Knock Out Electrode and attach it to 1 of your other Pokémon. If you do, chose a type of Energy. is now an Energy card (instead of a Pokémon) that provides 2 energy of that type. This power can't be used if Electrode is Asleep, Confused, or Paralyzed.",
+      "text": "At any time during your turn (before your attack) you may Knock Out Electrode and attach it to 1 of your other Pokémon. If you do, chose a type of Energy. is now an Energy card (instead of a Pokémon) that provides 2 energy of that type. This power can’t be used if Electrode is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "80",
@@ -1461,7 +1461,7 @@
     "evolvesFrom": "Mime Jr.",
     "ability": {
       "name": "Invisible Wall",
-      "text": "Whenever an attack (including your own) does 30 or more damage to Mr. Mime (after applying Weakness and Resistance), prevent that damage. (Any other effects of attacks still happen.) This power can't be used if Mr. Mime is Asleep, Confused, or Paralyzed.",
+      "text": "Whenever an attack (including your own) does 30 or more damage to Mr. Mime (after applying Weakness and Resistance), prevent that damage. (Any other effects of attacks still happen.) This power can’t be used if Mr. Mime is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "40",
@@ -1623,7 +1623,7 @@
     "evolvesFrom": "Munchlax",
     "ability": {
       "name": "Thick Skinned",
-      "text": "Snorlax can't become Asleep, Confused, Paralyzed, or Poisoned. This power can't be used if Snorlax is already Asleep, Confused, or Paralyzed.",
+      "text": "Snorlax can’t become Asleep, Confused, Paralyzed, or Poisoned. This power can’t be used if Snorlax is already Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "90",
@@ -1681,7 +1681,7 @@
     "evolvesFrom": "Venonat",
     "ability": {
       "name": "Shift",
-      "text": "Once during your turn (before your attack), you may change the type of Venomoth to the type of any other Pokémon in play other than Colorless. This power can't be used if Venomoth is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may change the type of Venomoth to the type of any other Pokémon in play other than Colorless. This power can’t be used if Venomoth is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "70",
@@ -1761,7 +1761,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2175,7 +2175,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If tails, this attack does nothing. Either way, use this attack again as long as Farfetch'd stays in play (even putting Farfech'd on the Bench won't let you use it again.)"
+        "text": "Flip a coin. If tails, this attack does nothing. Either way, use this attack again as long as Farfetch'd stays in play (even putting Farfech'd on the Bench won’t let you use it again.)"
       },
       {
         "name": "Pot Smash",
@@ -2232,7 +2232,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Fearow."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Fearow."
       },
       {
         "name": "Drill Peck",
@@ -2345,7 +2345,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "You can't this attack unless the Defending Pokémon is Asleep."
+        "text": "You can’t this attack unless the Defending Pokémon is Asleep."
       }
     ],
     "resistances": [
@@ -2558,7 +2558,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to Kakuna during your opponent's next turn. (Any other effects of attacks still happen.)"
+        "text": "Flip a coin. If heads, prevent all damage done to Kakuna during your opponent’s next turn. (Any other effects of attacks still happen.)"
       },
       {
         "name": "Poisonpowder",
@@ -2851,7 +2851,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Search your deck for a Fighting Basic Pokémon card and put it onto your Bench. Shuffle your deck afterward. (You can't use this attack if your Bench is full.)"
+        "text": "Search your deck for a Fighting Basic Pokémon card and put it onto your Bench. Shuffle your deck afterward. (You can’t use this attack if your Bench is full.)"
       }
     ],
     "weaknesses": [
@@ -3073,7 +3073,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "If the Defending Pokémon attacks Persian during your opponent's next turn, any damage done by the attack is reduce by 10 (after applying Weakness and Resistance). (Benching either Pokémon ends this effect.)"
+        "text": "If the Defending Pokémon attacks Persian during your opponent’s next turn, any damage done by the attack is reduce by 10 (after applying Weakness and Resistance). (Benching either Pokémon ends this effect.)"
       }
     ],
     "weaknesses": [
@@ -3188,7 +3188,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Does damage to the Defending Pokémon equal to half the Defending Pokémon's remaining HP (rounded up to the nearest 10)."
+        "text": "Does damage to the Defending Pokémon equal to half the Defending Pokémon’s remaining HP (rounded up to the nearest 10)."
       }
     ],
     "weaknesses": [
@@ -3455,7 +3455,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to Wartortle during your opponent's next turn. (Any other effects of attacks still happen.)"
+        "text": "Flip a coin. If heads, prevent all damage done to Wartortle during your opponent’s next turn. (Any other effects of attacks still happen.)"
       },
       {
         "name": "Bite",
@@ -3612,7 +3612,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Search your deck for a Basic Pokémon named Bellsprout and put it onto your Bench. Shuffle your deck afterward. (You can't use this attack if your Bench is full.)"
+        "text": "Search your deck for a Basic Pokémon named Bellsprout and put it onto your Bench. Shuffle your deck afterward. (You can’t use this attack if your Bench is full.)"
       }
     ],
     "weaknesses": [
@@ -3795,7 +3795,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the Defending Pokémon attacks Cubone during your opponent's next turn, any damage done by the attack is reduced by 20 (after applying Weakness and Resistance). (Benching either Pokémon ends this effect.)"
+        "text": "If the Defending Pokémon attacks Cubone during your opponent’s next turn, any damage done by the attack is reduced by 20 (after applying Weakness and Resistance). (Benching either Pokémon ends this effect.)"
       },
       {
         "name": "Rage",
@@ -4066,7 +4066,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Discard 1 Energy card attached to Gastly in order to use this attack. If a Pokémon Knocks Out Gastly during your opponent's next turn, Knock Out that Pokémon."
+        "text": "Discard 1 Energy card attached to Gastly in order to use this attack. If a Pokémon Knocks Out Gastly during your opponent’s next turn, Knock Out that Pokémon."
       }
     ],
     "resistances": [
@@ -4261,7 +4261,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Does 10 damage to each Pokémon on each player's Bench. (Don't apply Weakness and Resistance for Benched Pokémon.) Magnemite does 40 damage to itself."
+        "text": "Does 10 damage to each Pokémon on each player’s Bench. (Don’t apply Weakness and Resistance for Benched Pokémon.) Magnemite does 40 damage to itself."
       }
     ],
     "weaknesses": [
@@ -4357,7 +4357,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to Metapod during your opponent's next turn. (Any other effects of attacks still happen.)"
+        "text": "Flip a coin. If heads, prevent all damage done to Metapod during your opponent’s next turn. (Any other effects of attacks still happen.)"
       },
       {
         "name": "Stun Spore",
@@ -4420,7 +4420,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Search your deck for a Basic Pokémon named Nidoran M or Nidoran F and put it onto your Bench. Shuffle your deck afterward. (You can't use this attack if your Bench is full.)"
+        "text": "Search your deck for a Basic Pokémon named Nidoran M or Nidoran F and put it onto your Bench. Shuffle your deck afterward. (You can’t use this attack if your Bench is full.)"
       }
     ],
     "weaknesses": [
@@ -4518,7 +4518,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "During opponent's next turn, whenever 30 or less damage is done to Onix (after applying Weakness and Resistance), prevent that damage. (Any other effects of attacks still happen.)"
+        "text": "During opponent’s next turn, whenever 30 or less damage is done to Onix (after applying Weakness and Resistance), prevent that damage. (Any other effects of attacks still happen.)"
       }
     ],
     "weaknesses": [
@@ -4718,7 +4718,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "Does 10 damage plus 10 damage for each Energy attached to Poliwag but not used to pay for this attack's Energy cost. Extra Energy after the end don't count."
+        "text": "Does 10 damage plus 10 damage for each Energy attached to Poliwag but not used to pay for this attack’s Energy cost. Extra Energy after the end don’t count."
       }
     ],
     "weaknesses": [
@@ -4809,7 +4809,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack Rhyhorn during your opponent's next turn. (Benching either Pokémon ends this effect.)"
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack Rhyhorn during your opponent’s next turn. (Benching either Pokémon ends this effect.)"
       },
       {
         "name": "Horn Attack",
@@ -4869,7 +4869,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -4985,7 +4985,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to Squirtle during your opponent's next turn. (Any other effects of attacks still happen.)"
+        "text": "Flip a coin. If heads, prevent all damage done to Squirtle during your opponent’s next turn. (Any other effects of attacks still happen.)"
       }
     ],
     "weaknesses": [
@@ -5467,7 +5467,7 @@
     "set": "Base Set 2",
     "setCode": "base4",
     "text": [
-      "Discard 1 Energy card attached to 1 of your own Pokémon in order to choose 1 of your opponent's Pokémon and up to 2 Energy cards attached to it. Discard those energy cards."
+      "Discard 1 Energy card attached to 1 of your own Pokémon in order to choose 1 of your opponent’s Pokémon and up to 2 Energy cards attached to it. Discard those energy cards."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/108_hires.png"
   },
@@ -5484,7 +5484,7 @@
     "set": "Base Set 2",
     "setCode": "base4",
     "text": [
-      "Attach Defender to 1 of your Pokémon. At the end of your opponent's next turn, discard Defender. Damage done to that Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance.)"
+      "Attach Defender to 1 of your Pokémon. At the end of your opponent’s next turn, discard Defender. Damage done to that Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/109_hires.png"
   },
@@ -5552,7 +5552,7 @@
     "set": "Base Set 2",
     "setCode": "base4",
     "text": [
-      "Attach PlusPower to your Active Pokémonn. At the end of your turn, discard PlusPower. If this Pokémon's attack does damage to the defending Pokémon (after applying Weakness and Resistance), the attack does 10 more damage to the Defending Pokémon."
+      "Attach PlusPower to your Active Pokémonn. At the end of your turn, discard PlusPower. If this Pokémon’s attack does damage to the defending Pokémon (after applying Weakness and Resistance), the attack does 10 more damage to the Defending Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/113_hires.png"
   },
@@ -5654,7 +5654,7 @@
     "set": "Base Set 2",
     "setCode": "base4",
     "text": [
-      "Choose 1 Energy card attached to 1 of your opponent's Pokémon and discard it."
+      "Choose 1 Energy card attached to 1 of your opponent’s Pokémon and discard it."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/119_hires.png"
   },
@@ -5671,7 +5671,7 @@
     "set": "Base Set 2",
     "setCode": "base4",
     "text": [
-      "Choose 1 of your opponent's Benched Pokémon and switch it with his or her Active Pokémon."
+      "Choose 1 of your opponent’s Benched Pokémon and switch it with his or her Active Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/120_hires.png"
   },
@@ -5739,7 +5739,7 @@
     "set": "Base Set 2",
     "setCode": "base4",
     "text": [
-      "Provides energy. Doesn't count as a basic energy card."
+      "Provides energy. Doesn’t count as a basic energy card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/124_hires.png"
   },

--- a/json/cards/Base.json
+++ b/json/cards/Base.json
@@ -9,7 +9,7 @@
     "evolvesFrom": "Kadabra",
     "ability": {
       "name": "Damage Swap",
-      "text": "As often as you like during your turn (before your attack), you may move 1 damage counter from 1 of your Pokémon to another as long as you don't Knock Out that Pokémon. This power can't be used if Alakazam is Asleep, Confused, or Paralyzed.",
+      "text": "As often as you like during your turn (before your attack), you may move 1 damage counter from 1 of your Pokémon to another as long as you don’t Knock Out that Pokémon. This power can’t be used if Alakazam is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "80",
@@ -59,7 +59,7 @@
     "evolvesFrom": "Wartortle",
     "ability": {
       "name": "Rain Dance",
-      "text": "As often as you like during your turn (before your attack), you may attach 1 Water Energy Card to 1 of your Water Pokémon. (This doesn't use up your 1 Energy card attachment for the turn.) This power can't be used if Blastoise is Asleep, Confused, or Paralyzed.",
+      "text": "As often as you like during your turn (before your attack), you may attach 1 Water Energy Card to 1 of your Water Pokémon. (This doesn’t use up your 1 Energy card attachment for the turn.) This power can’t be used if Blastoise is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "100",
@@ -87,7 +87,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40+",
-        "text": "Does 40 damage plus 10 more damage for each attached to Blastoise but not used to pay for this attack's Energy cost. Extra Energy after the 2nd doesn't count."
+        "text": "Does 40 damage plus 10 more damage for each attached to Blastoise but not used to pay for this attack’s Energy cost. Extra Energy after the 2nd doesn’t count."
       }
     ],
     "weaknesses": [
@@ -128,7 +128,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to Chansey during your opponent's next turn. (Any other effects of attacks still happen.)"
+        "text": "Flip a coin. If heads, prevent all damage done to Chansey during your opponent’s next turn. (Any other effects of attacks still happen.)"
       },
       {
         "name": "Double-edge",
@@ -252,7 +252,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of Defending Pokémon's attacks. Metronome copies that attack except for its Energy costs and anything else required in order to use that attack, such as discarding energy cards. (No matter what type the defender is, Clefairy's type is still Colorless.)"
+        "text": "Choose 1 of Defending Pokémon’s attacks. Metronome copies that attack except for its Energy costs and anything else required in order to use that attack, such as discarding energy cards. (No matter what type the defender is, Clefairy’s type is still Colorless.)"
       }
     ],
     "weaknesses": [
@@ -398,7 +398,7 @@
     "evolvesFrom": "Machoke",
     "ability": {
       "name": "Strikes Back",
-      "text": "Whenever your opponent's attack damages Machamp (even if Machamp is Knoced Out), this power does 10 damage to attacking Pokémon. (Don't apply Weakness and Resistance.) This power can't be used if Machamp is already Asleep, Confused, or Paralyzed when your opponent attacks.",
+      "text": "Whenever your opponent’s attack damages Machamp (even if Machamp is Knoced Out), this power does 10 damage to attacking Pokémon. (Don’t apply Weakness and Resistance.) This power can’t be used if Machamp is already Asleep, Confused, or Paralyzed when your opponent attacks.",
       "type": "Pokémon Power"
     },
     "hp": "100",
@@ -482,7 +482,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "Does 20 damage to each Pokémon on each player's Bench. (Don't apply Weakness and Resistance for Benched Pokémon.) Magneton does 80 damage to itself."
+        "text": "Does 20 damage to each Pokémon on each player’s Bench. (Don’t apply Weakness and Resistance for Benched Pokémon.) Magneton does 80 damage to itself."
       }
     ],
     "weaknesses": [
@@ -538,7 +538,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Discard 1 Energy card attached to Mewtwo in order to use this attack. During your opponent's next turn, prevent all effects of attacks, including damage, done to Mewtwo."
+        "text": "Discard 1 Energy card attached to Mewtwo in order to use this attack. During your opponent’s next turn, prevent all effects of attacks, including damage, done to Mewtwo."
       }
     ],
     "weaknesses": [
@@ -592,7 +592,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "The Defending Pokémon is now Poisoned. It now takes 20 Poison damage instead of 10 after each player's turn (even if it was already Poisoned)."
+        "text": "The Defending Pokémon is now Poisoned. It now takes 20 Poison damage instead of 10 after each player’s turn (even if it was already Poisoned)."
       }
     ],
     "weaknesses": [
@@ -691,7 +691,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
-        "text": "Does 30 damage plus 10 more damage for each Energy attached to Poliwrath but not used to pay for this attack's Energy cost. Extra Energy after the 2nd doesn't count."
+        "text": "Does 30 damage plus 10 more damage for each Energy attached to Poliwrath but not used to pay for this attack’s Energy cost. Extra Energy after the 2nd doesn’t count."
       },
       {
         "name": "Whirlpool",
@@ -746,7 +746,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Raichu."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Raichu."
       },
       {
         "name": "Thunder",
@@ -780,7 +780,7 @@
     "evolvesFrom": "Ivysaur",
     "ability": {
       "name": "Energy Trans",
-      "text": "As often as you like during your turn (before your attack), you may take 1 Grass Energy card attached to 1 of your Pokémon and attach it to a different one. This power can't be used if Venusaur is Asleep, Confused, or Paralyzed.",
+      "text": "As often as you like during your turn (before your attack), you may take 1 Grass Energy card attached to 1 of your Pokémon and attach it to a different one. This power can’t be used if Venusaur is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "100",
@@ -1037,7 +1037,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "70",
-        "text": "Does 10 damage to each of your own Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your own Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1119,7 +1119,7 @@
     "evolvesFrom": "Voltorb",
     "ability": {
       "name": "Buzzap",
-      "text": "At any time during your turn (before your attack) you may Knock Out Electrode and attach it to 1 of your other Pokémon. If you do, chose a type of Energy. is now an Energy card (instead of a Pokémon) that provides 2 energy of that type. This power can't be used if Electrode is Asleep, Confused, or Paralyzed.",
+      "text": "At any time during your turn (before your attack) you may Knock Out Electrode and attach it to 1 of your other Pokémon. If you do, chose a type of Energy. is now an Energy card (instead of a Pokémon) that provides 2 energy of that type. This power can’t be used if Electrode is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "80",
@@ -1461,7 +1461,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If tails, this attack does nothing. Either way, use this attack again as long as Farfetch'd stays in play (even putting Farfech'd on the Bench won't let you use it again.)"
+        "text": "Flip a coin. If tails, this attack does nothing. Either way, use this attack again as long as Farfetch'd stays in play (even putting Farfech'd on the Bench won’t let you use it again.)"
       },
       {
         "name": "Pot Smash",
@@ -1573,7 +1573,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "You can't this attack unless the Defending Pokémon is Asleep."
+        "text": "You can’t this attack unless the Defending Pokémon is Asleep."
       }
     ],
     "resistances": [
@@ -1786,7 +1786,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to Kakuna during your opponent's next turn. (Any other effects of attacks still happen.)"
+        "text": "Flip a coin. If heads, prevent all damage done to Kakuna during your opponent’s next turn. (Any other effects of attacks still happen.)"
       },
       {
         "name": "Poisonpowder",
@@ -2132,7 +2132,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Change Porygon's Resistance to a type of your choice other than Colorless."
+        "text": "Change Porygon’s Resistance to a type of your choice other than Colorless."
       }
     ],
     "weaknesses": [
@@ -2193,7 +2193,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Does damage to the Defending Pokémon equal to half the Defending Pokémon's remaining HP (rounded up to the nearest 10)."
+        "text": "Does damage to the Defending Pokémon equal to half the Defending Pokémon’s remaining HP (rounded up to the nearest 10)."
       }
     ],
     "weaknesses": [
@@ -2284,7 +2284,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to Wartortle during your opponent's next turn. (Any other effects of attacks still happen.)"
+        "text": "Flip a coin. If heads, prevent all damage done to Wartortle during your opponent’s next turn. (Any other effects of attacks still happen.)"
       },
       {
         "name": "Bite",
@@ -2677,7 +2677,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Discard 1 Energy card attached to Gastly in order to use this attack. If a Pokémon Knocks Out Gastly during your opponent's next turn, Knock Out that Pokémon."
+        "text": "Discard 1 Energy card attached to Gastly in order to use this attack. If a Pokémon Knocks Out Gastly during your opponent’s next turn, Knock Out that Pokémon."
       }
     ],
     "resistances": [
@@ -2817,7 +2817,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Does 10 damage to each Pokémon on each player's Bench. (Don't apply Weakness and Resistance for Benched Pokémon.) Magnemite does 40 damage to itself."
+        "text": "Does 10 damage to each Pokémon on each player’s Bench. (Don’t apply Weakness and Resistance for Benched Pokémon.) Magnemite does 40 damage to itself."
       }
     ],
     "weaknesses": [
@@ -2863,7 +2863,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to Metapod during your opponent's next turn. (Any other effects of attacks still happen.)"
+        "text": "Flip a coin. If heads, prevent all damage done to Metapod during your opponent’s next turn. (Any other effects of attacks still happen.)"
       },
       {
         "name": "Stun Spore",
@@ -2971,7 +2971,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "During opponent's next turn, whenever 30 or less damage is done to Onix (after applying Weakness and Resistance), prevent that damage. (Any other effects of attacks still happen.)"
+        "text": "During opponent’s next turn, whenever 30 or less damage is done to Onix (after applying Weakness and Resistance), prevent that damage. (Any other effects of attacks still happen.)"
       }
     ],
     "weaknesses": [
@@ -3117,7 +3117,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "Does 10 damage plus 10 damage for each Energy attached to Poliwag but not used to pay for this attack's Energy cost. Extra Energy after the end don't count."
+        "text": "Does 10 damage plus 10 damage for each Energy attached to Poliwag but not used to pay for this attack’s Energy cost. Extra Energy after the end don’t count."
       }
     ],
     "weaknesses": [
@@ -3260,7 +3260,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -3319,7 +3319,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to Squirtle during your opponent's next turn. (Any other effects of attacks still happen.)"
+        "text": "Flip a coin. If heads, prevent all damage done to Squirtle during your opponent’s next turn. (Any other effects of attacks still happen.)"
       }
     ],
     "weaknesses": [
@@ -3630,7 +3630,7 @@
     "set": "Base",
     "setCode": "base1",
     "text": [
-      "Play Clefairy Doll as if it were a Basic Pokémon. While in play, Clefairy Doll counts as a Pokémon (instead of a Trainer card.) Clefairy Doll has no attacks, can't retreat, and can't be Asleep, Confused, Paralyzed, or Poisoned. If Clefairy Doll is Knocked Out, it doesn't count as a Knock Out Pokémon. At any time during tyour turn before your attack, you may discard Clefairy Doll."
+      "Play Clefairy Doll as if it were a Basic Pokémon. While in play, Clefairy Doll counts as a Pokémon (instead of a Trainer card.) Clefairy Doll has no attacks, can’t retreat, and can’t be Asleep, Confused, Paralyzed, or Poisoned. If Clefairy Doll is Knocked Out, it doesn’t count as a Knock Out Pokémon. At any time during tyour turn before your attack, you may discard Clefairy Doll."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/70_hires.png"
   },
@@ -3783,7 +3783,7 @@
     "set": "Base",
     "setCode": "base1",
     "text": [
-      "Discard 1 Energy card attached to 1 of your own Pokémon in order to choose 1 of your opponent's Pokémon and up to 2 Energy cards attached to it. Discard those energy cards."
+      "Discard 1 Energy card attached to 1 of your own Pokémon in order to choose 1 of your opponent’s Pokémon and up to 2 Energy cards attached to it. Discard those energy cards."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/79_hires.png"
   },
@@ -3800,7 +3800,7 @@
     "set": "Base",
     "setCode": "base1",
     "text": [
-      "Attach Defender to 1 of your Pokémon. At the end of your opponent's next turn, discard Defender. Damage done to that Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance.)"
+      "Attach Defender to 1 of your Pokémon. At the end of your opponent’s next turn, discard Defender. Damage done to that Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/80_hires.png"
   },
@@ -3868,7 +3868,7 @@
     "set": "Base",
     "setCode": "base1",
     "text": [
-      "Attach PlusPower to your Active Pokémonn. At the end of your turn, discard PlusPower. If this Pokémon's attack does damage to the defending Pokémon (after applying Weakness and Resistance), the attack does 10 more damage to the Defending Pokémon."
+      "Attach PlusPower to your Active Pokémonn. At the end of your turn, discard PlusPower. If this Pokémon’s attack does damage to the defending Pokémon (after applying Weakness and Resistance), the attack does 10 more damage to the Defending Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/84_hires.png"
   },
@@ -3902,7 +3902,7 @@
     "set": "Base",
     "setCode": "base1",
     "text": [
-      "Choose 1 Basic Pokémon card from your opponent's discard pile and put it on his or her Bench. (You can't play Pokémon Flute if your opponent's Bench is full.)"
+      "Choose 1 Basic Pokémon card from your opponent’s discard pile and put it on his or her Bench. (You can’t play Pokémon Flute if your opponent’s Bench is full.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/86_hires.png"
   },
@@ -3953,7 +3953,7 @@
     "set": "Base",
     "setCode": "base1",
     "text": [
-      "Put 1 Basic Pokémon card from your discard pile onto your Bench. Put damage counters on that Pokémon equal to half its (rounded down to the nearest 10). (You can't play Revive if your Bench is full.)"
+      "Put 1 Basic Pokémon card from your discard pile onto your Bench. Put damage counters on that Pokémon equal to half its (rounded down to the nearest 10). (You can’t play Revive if your Bench is full.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/89_hires.png"
   },
@@ -4004,7 +4004,7 @@
     "set": "Base",
     "setCode": "base1",
     "text": [
-      "Choose 1 Energy card attached to 1 of your opponent's Pokémon and discard it."
+      "Choose 1 Energy card attached to 1 of your opponent’s Pokémon and discard it."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/92_hires.png"
   },
@@ -4021,7 +4021,7 @@
     "set": "Base",
     "setCode": "base1",
     "text": [
-      "Choose 1 of your opponent's Benched Pokémon and switch it with his or her Active Pokémon."
+      "Choose 1 of your opponent’s Benched Pokémon and switch it with his or her Active Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/93_hires.png"
   },
@@ -4072,7 +4072,7 @@
     "set": "Base",
     "setCode": "base1",
     "text": [
-      "Provides energy. Doesn't count as a basic energy card."
+      "Provides energy. Doesn’t count as a basic energy card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/96_hires.png"
   },

--- a/json/cards/Black & White.json
+++ b/json/cards/Black & White.json
@@ -742,7 +742,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20+",
-        "text": "Does 10 more damage for each Grass Energy attached to both your and your opponent's Pokémon."
+        "text": "Does 10 more damage for each Grass Energy attached to both your and your opponent’s Pokémon."
       },
       {
         "name": "Horn Leech",
@@ -1169,7 +1169,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Does 20 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Fury Swipes",
@@ -1617,7 +1617,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Surf",
@@ -1908,7 +1908,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, each of this Pokémon's attacks does 40 more damage(before applying Weakness and Resistance)."
+        "text": "During your next turn, each of this Pokémon’s attacks does 40 more damage(before applying Weakness and Resistance)."
       },
       {
         "name": "Aqua Ring",
@@ -2218,7 +2218,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "Does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2342,7 +2342,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Leech Life",
@@ -2596,7 +2596,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Heart Stamp",
@@ -2766,7 +2766,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       },
       {
         "name": "Poison Claws",
@@ -3068,7 +3068,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "During your next turn, each of this Pokémon's attacks does 20 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, each of this Pokémon’s attacks does 20 more damage (before applying Weakness and Resistance)."
       },
       {
         "name": "Pound",
@@ -3135,7 +3135,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -3224,7 +3224,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Bite",
@@ -3285,7 +3285,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Bite",
@@ -3348,7 +3348,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Krookoroll",
@@ -3464,7 +3464,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon."
+        "text": "Switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon."
       },
       {
         "name": "Sucker Punch",
@@ -3684,7 +3684,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks and use it as this attack."
+        "text": "Choose 1 of the Defending Pokémon’s attacks and use it as this attack."
       }
     ],
     "weaknesses": [
@@ -3778,7 +3778,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Does 50 damage to 1 of your opponent's Pokémon that has any damage counters on it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 50 damage to 1 of your opponent’s Pokémon that has any damage counters on it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Punishment",
@@ -4318,7 +4318,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "90",
-        "text": "This Pokémon can't attack during your next turn."
+        "text": "This Pokémon can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -4466,7 +4466,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       },
       {
         "name": "Cutting Wind",
@@ -4709,7 +4709,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "If any of your Pokémon were Knocked Out by damage from an opponent's attack during his or her last turn, this attack does 70 more damage."
+        "text": "If any of your Pokémon were Knocked Out by damage from an opponent’s attack during his or her last turn, this attack does 70 more damage."
       },
       {
         "name": "Head Charge",
@@ -4816,7 +4816,7 @@
     "set": "Black & White",
     "setCode": "bw1",
     "text": [
-      "During this turn, your Pokémon's attacks do 10 more damage to the Active Pokémon (before applying Weakness and Resistance)."
+      "During this turn, your Pokémon’s attacks do 10 more damage to the Active Pokémon (before applying Weakness and Resistance)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw1/96_hires.png"
   },

--- a/json/cards/Boundaries Crossed.json
+++ b/json/cards/Boundaries Crossed.json
@@ -128,7 +128,7 @@
     "evolvesFrom": "Gloom",
     "ability": {
       "name": "Allergy Panic",
-      "text": "Apply Weakness for each Pokémon (both yours and your opponent's) as x4 instead.",
+      "text": "Apply Weakness for each Pokémon (both yours and your opponent’s) as x4 instead.",
       "type": "Ability"
     },
     "hp": "140",
@@ -203,7 +203,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "Does 20 more damage for each Colorless in the Defending Pokémon's Retreat Cost."
+        "text": "Does 20 more damage for each Colorless in the Defending Pokémon’s Retreat Cost."
       },
       {
         "name": "Petal Dance",
@@ -323,7 +323,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30x",
-        "text": "Does 30 damage times the amount of Grass Energy attached to this Pokémon. This Pokémon can't use Hundred Furious Lashes during your next turn."
+        "text": "Does 30 damage times the amount of Grass Energy attached to this Pokémon. This Pokémon can’t use Hundred Furious Lashes during your next turn."
       },
       {
         "name": "Mega Drain",
@@ -1066,7 +1066,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 40 damage to 2 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 40 damage to 2 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Scorching Fire",
@@ -1512,7 +1512,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shell Shield",
-      "text": "As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's).",
+      "text": "As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent’s).",
       "type": "Ability"
     },
     "hp": "60",
@@ -1581,7 +1581,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent’s next turn."
       },
       {
         "name": "Waterfall",
@@ -1816,7 +1816,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Aquafall",
@@ -1933,7 +1933,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -2316,7 +2316,7 @@
     "evolvesFrom": "Frillish",
     "ability": {
       "name": "Stickiness",
-      "text": "The Retreat Cost of each of your opponent's Pokémon in play is Colorless more.",
+      "text": "The Retreat Cost of each of your opponent’s Pokémon in play is Colorless more.",
       "type": "Ability"
     },
     "hp": "100",
@@ -2778,7 +2778,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 30 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Shock Wave",
@@ -2790,7 +2790,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -2830,7 +2830,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "This attack does 20 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3146,7 +3146,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose a random card from your opponent's hand. Your opponent reveals that card and shuffles it into his or her deck."
+        "text": "Choose a random card from your opponent’s hand. Your opponent reveals that card and shuffles it into his or her deck."
       },
       {
         "name": "Psyshot",
@@ -3181,7 +3181,7 @@
     "evolvesFrom": "Dusclops",
     "ability": {
       "name": "Sinister Hand",
-      "text": "As often as you like during your turn (before your attack), you may move 1 damage counter from 1 of your opponent's Pokémon to another of your opponent's Pokémon.",
+      "text": "As often as you like during your turn (before your attack), you may move 1 damage counter from 1 of your opponent’s Pokémon to another of your opponent’s Pokémon.",
       "type": "Ability"
     },
     "hp": "130",
@@ -3210,7 +3210,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -3336,7 +3336,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20+",
-        "text": "If any of your Pokémon were Knocked Out by damage from an opponent's attack during his or her last turn, this attack does 70 more damage."
+        "text": "If any of your Pokémon were Knocked Out by damage from an opponent’s attack during his or her last turn, this attack does 70 more damage."
       },
       {
         "name": "Poison Jab",
@@ -3397,7 +3397,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "90",
-        "text": "During your opponent's next turn, this Pokémon has no Weakness."
+        "text": "During your opponent’s next turn, this Pokémon has no Weakness."
       }
     ],
     "weaknesses": [
@@ -3417,7 +3417,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Long-Distance Hypnosis",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, your opponent's Active Pokémon is now Asleep. If tails, your Active Pokémon is now Asleep.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, your opponent’s Active Pokémon is now Asleep. If tails, your Active Pokémon is now Asleep.",
       "type": "Ability"
     },
     "hp": "60",
@@ -3488,7 +3488,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 30 damage to 1 of your opponent's Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "This attack does 30 damage to 1 of your opponent’s Pokémon. This attack’s damage isn’t affected by Weakness or Resistance."
       },
       {
         "name": "Dream Waltz",
@@ -3597,7 +3597,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "For each Psychic Energy attached to this Pokémon, discard the top card of your opponent's deck."
+        "text": "For each Psychic Energy attached to this Pokémon, discard the top card of your opponent’s deck."
       },
       {
         "name": "Acrobatics",
@@ -3633,7 +3633,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Poison Point",
-      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Poisoned.",
+      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Poisoned.",
       "type": "Ability"
     },
     "hp": "70",
@@ -3683,7 +3683,7 @@
     "evolvesFrom": "Venipede",
     "ability": {
       "name": "Poison Point",
-      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Poisoned.",
+      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Poisoned.",
       "type": "Ability"
     },
     "hp": "100",
@@ -3735,7 +3735,7 @@
     "evolvesFrom": "Whirlipede",
     "ability": {
       "name": "Poison Point",
-      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Poisoned.",
+      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Poisoned.",
       "type": "Ability"
     },
     "hp": "150",
@@ -3922,7 +3922,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "During your next turn, this Pokémon's Echoed Voice attack does 50 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s Echoed Voice attack does 50 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -4023,7 +4023,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Earthquake",
@@ -4034,7 +4034,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "Does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4138,7 +4138,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "The Defending Pokémon is now Poisoned. The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon is now Poisoned. The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Night Slash",
@@ -4474,7 +4474,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Discard a random card from your opponent's hand."
+        "text": "Discard a random card from your opponent’s hand."
       },
       {
         "name": "Double Whip",
@@ -4529,10 +4529,10 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
-        "name": "Land's Judgment",
+        "name": "Land’s Judgment",
         "cost": [
           "Fighting",
           "Fighting",
@@ -4585,7 +4585,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, switch 1 of your opponent's Benched Pokémon with the Defending Pokémon."
+        "text": "Flip a coin. If heads, switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -4645,7 +4645,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Flip a coin. If heads, choose 1 of your Benched Pokémon's attacks and use it as this attack."
+        "text": "Flip a coin. If heads, choose 1 of your Benched Pokémon’s attacks and use it as this attack."
       }
     ],
     "weaknesses": [
@@ -4810,7 +4810,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "During your opponent's next turn, prevent all damage done to this Pokémon by attacks from Pokémon-EX."
+        "text": "During your opponent’s next turn, prevent all damage done to this Pokémon by attacks from Pokémon-EX."
       },
       {
         "name": "Slashing Strike",
@@ -4821,7 +4821,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "This Pokémon can't use Slashing Strike during your next turn."
+        "text": "This Pokémon can’t use Slashing Strike during your next turn."
       }
     ],
     "weaknesses": [
@@ -4935,7 +4935,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -5042,7 +5042,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -5066,7 +5066,7 @@
     "evolvesFrom": "Vibrava",
     "ability": {
       "name": "Sand Slammer",
-      "text": "At any time between turns, if this Pokémon is your Active Pokémon, put 1 damage counter on each of your opponent's Pokémon.",
+      "text": "At any time between turns, if this Pokémon is your Active Pokémon, put 1 damage counter on each of your opponent’s Pokémon.",
       "type": "Ability"
     },
     "hp": "140",
@@ -5204,7 +5204,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "150",
-        "text": "This Pokémon can't attack during your next turn."
+        "text": "This Pokémon can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -5670,7 +5670,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -6055,7 +6055,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "During your next turn, this Pokémon's Psych Up attack does 30 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s Psych Up attack does 30 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -6182,7 +6182,7 @@
     "evolvesFrom": "Herdier",
     "ability": {
       "name": "Sentinel",
-      "text": "As long as this Pokémon is your Active Pokémon, your opponent can't play any Supporter cards from his or her hand.",
+      "text": "As long as this Pokémon is your Active Pokémon, your opponent can’t play any Supporter cards from his or her hand.",
       "type": "Ability"
     },
     "hp": "140",
@@ -6414,7 +6414,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -6439,7 +6439,7 @@
     "set": "Boundaries Crossed",
     "setCode": "bw7",
     "text": [
-      "Each Colorless Pokémon in play (both yours and your opponent's) gets +20 HP."
+      "Each Colorless Pokémon in play (both yours and your opponent’s) gets +20 HP."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw7/127_hires.png"
   },
@@ -6541,7 +6541,7 @@
     "set": "Boundaries Crossed",
     "setCode": "bw7",
     "text": [
-      "If the Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent's attack (even if that Pokémon is Knocked Out), put 2 damage counters on the Attacking Pokémon."
+      "If the Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent’s attack (even if that Pokémon is Knocked Out), put 2 damage counters on the Attacking Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw7/133_hires.png"
   },
@@ -6609,7 +6609,7 @@
     "set": "Boundaries Crossed",
     "setCode": "bw7",
     "text": [
-      "Discard 2 cards from your hand. (If you can't discard 2 cards, you can't play this card.) Search your deck for a card and put it into your hand. Shuffle your deck afterward."
+      "Discard 2 cards from your hand. (If you can’t discard 2 cards, you can’t play this card.) Search your deck for a card and put it into your hand. Shuffle your deck afterward."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw7/137_hires.png"
   },
@@ -6807,7 +6807,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "90",
-        "text": "During your opponent's next turn, this Pokémon has no Weakness."
+        "text": "During your opponent’s next turn, this Pokémon has no Weakness."
       }
     ],
     "weaknesses": [
@@ -6851,10 +6851,10 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
-        "name": "Land's Judgment",
+        "name": "Land’s Judgment",
         "cost": [
           "Fighting",
           "Fighting",
@@ -6926,7 +6926,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "150",
-        "text": "This Pokémon can't attack during your next turn."
+        "text": "This Pokémon can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -7080,7 +7080,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Devolve the Defending Pokémon and put the highest Stage Evolution card on it into your opponent's hand."
+        "text": "Devolve the Defending Pokémon and put the highest Stage Evolution card on it into your opponent’s hand."
       },
       {
         "name": "Ghost Hammer",
@@ -7092,7 +7092,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "90",
-        "text": "During your opponent's next turn, this Pokémon has no Weakness."
+        "text": "During your opponent’s next turn, this Pokémon has no Weakness."
       }
     ],
     "weaknesses": [
@@ -7135,7 +7135,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "If any of your Pokémon were Knocked Out by damage from an opponent's attack during his or her last turn, this attack does 60 more damage."
+        "text": "If any of your Pokémon were Knocked Out by damage from an opponent’s attack during his or her last turn, this attack does 60 more damage."
       },
       {
         "name": "Land Crush",
@@ -7167,7 +7167,7 @@
     "evolvesFrom": "Swablu",
     "ability": {
       "name": "Fight Song",
-      "text": "Your Dragon Pokémon's attacks do 20 more damage to the Active Pokémon (before applying Weakness and Resistance).",
+      "text": "Your Dragon Pokémon’s attacks do 20 more damage to the Active Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "70",
@@ -7218,7 +7218,7 @@
     "set": "Boundaries Crossed",
     "setCode": "bw7",
     "text": [
-      "If the Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent's attack (even if that Pokémon is Knocked Out), put 2 damage counters on the Attacking Pokémon."
+      "If the Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent’s attack (even if that Pokémon is Knocked Out), put 2 damage counters on the Attacking Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw7/153_hires.png"
   }

--- a/json/cards/Burning Shadows.json
+++ b/json/cards/Burning Shadows.json
@@ -134,7 +134,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -173,7 +173,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       }
     ],
     "weaknesses": [
@@ -217,7 +217,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       },
       {
         "name": "Razor Leaf",
@@ -252,7 +252,7 @@
     "evolvesFrom": "Gloom",
     "ability": {
       "name": "Disgusting Pollen",
-      "text": "As long as this Pokémon is your Active Pokémon, your opponent's Basic Pokémon can't attack.",
+      "text": "As long as this Pokémon is your Active Pokémon, your opponent’s Basic Pokémon can’t attack.",
       "type": "Ability"
     },
     "hp": "140",
@@ -280,7 +280,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Asleep. If tails, your opponent's Active Pokémon is now Confused."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Asleep. If tails, your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -320,7 +320,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -366,7 +366,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Heal from this Pokémon the same amount of damage you did to your opponent's Active Pokémon."
+        "text": "Heal from this Pokémon the same amount of damage you did to your opponent’s Active Pokémon."
       },
       {
         "name": "Crosswise Whip",
@@ -417,7 +417,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -460,7 +460,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, or any other effects on your opponent's Active Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, or any other effects on your opponent’s Active Pokémon."
       },
       {
         "name": "Comet Punch",
@@ -692,7 +692,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Energy can't be attached to the Defending Pokémon from your opponent's hand during their next turn."
+        "text": "Energy can’t be attached to the Defending Pokémon from your opponent’s hand during their next turn."
       },
       {
         "name": "Sharp Fang",
@@ -811,7 +811,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "During your opponent's next turn, this Pokémon takes 20 less damage from attacks (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, this Pokémon takes 20 less damage from attacks (after applying Weakness and Resistance)."
       },
       {
         "name": "Crossing Cut-GX",
@@ -1001,7 +1001,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Discard the top 10 cards of your opponent's deck. (You can't use more than 1 GX attack in a game.)"
+        "text": "Discard the top 10 cards of your opponent’s deck. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -1047,7 +1047,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 50 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 50 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Phoenix Burn",
@@ -1059,7 +1059,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "180",
-        "text": "This Pokémon can't use Phoenix Burn during your next turn."
+        "text": "This Pokémon can’t use Phoenix Burn during your next turn."
       },
       {
         "name": "Eternal Flame-GX",
@@ -1220,7 +1220,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Your opponent's Active Pokémon is now Burned."
+        "text": "Your opponent’s Active Pokémon is now Burned."
       }
     ],
     "weaknesses": [
@@ -1286,7 +1286,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Discard all Energy from your opponent's Active Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "Discard all Energy from your opponent’s Active Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -1378,7 +1378,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Asleep."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Icy Snow",
@@ -1412,7 +1412,7 @@
     "evolvesFrom": "Alolan Vulpix",
     "ability": {
       "name": "Luminous Barrier",
-      "text": "Prevent all effects of attacks, including damage, done to this Pokémon by your opponent's Pokémon-GX or Pokémon-EX.",
+      "text": "Prevent all effects of attacks, including damage, done to this Pokémon by your opponent’s Pokémon-GX or Pokémon-EX.",
       "type": "Ability"
     },
     "hp": "110",
@@ -1477,7 +1477,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 10 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1520,7 +1520,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 30 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1563,7 +1563,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 90 damage to 1 of your opponent's Pokémon that has any damage counters on it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 90 damage to 1 of your opponent’s Pokémon that has any damage counters on it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Tornado Shot",
@@ -1572,7 +1572,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "90",
-        "text": "Discard a Water Energy from this Pokémon. This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard a Water Energy from this Pokémon. This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1611,7 +1611,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1670,7 +1670,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "160",
-        "text": "This attack does 30 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1709,7 +1709,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Rollout",
@@ -1743,7 +1743,7 @@
     "evolvesFrom": "Marill",
     "ability": {
       "name": "Thick Fat",
-      "text": "This Pokémon takes 30 less damage from the attacks of your opponent's Fire or Water Pokémon (after applying Weakness and Resistance).",
+      "text": "This Pokémon takes 30 less damage from the attacks of your opponent’s Fire or Water Pokémon (after applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "120",
@@ -1902,7 +1902,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       },
       {
         "name": "Synchronoise",
@@ -1913,7 +1913,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "This attack does 20 damage to each of your opponent's Benched Pokémon that shares a type with your opponent's Active Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to each of your opponent’s Benched Pokémon that shares a type with your opponent’s Active Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1967,7 +1967,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Discard 2 Water Energy from this Pokémon. This attack does 120 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard 2 Water Energy from this Pokémon. This attack does 120 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Tapu Storm-GX",
@@ -2018,7 +2018,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -2048,7 +2048,7 @@
     "evolvesFrom": "Pikachu",
     "ability": {
       "name": "Evoshock",
-      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may leave your opponent's Active Pokémon Paralyzed.",
+      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may leave your opponent’s Active Pokémon Paralyzed.",
       "type": "Ability"
     },
     "hp": "110",
@@ -2132,7 +2132,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -2198,7 +2198,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "170",
-        "text": "This Pokémon can't attack during your next turn."
+        "text": "This Pokémon can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -2243,7 +2243,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "If your opponent's Active Pokémon has any Water Energy attached to it, this attack does 30 more damage."
+        "text": "If your opponent’s Active Pokémon has any Water Energy attached to it, this attack does 30 more damage."
       }
     ],
     "weaknesses": [
@@ -2294,7 +2294,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "If your opponent's Active Pokémon’s maximum HP is 100 or more, this attack does nothing."
+        "text": "If your opponent’s Active Pokémon’s maximum HP is 100 or more, this attack does nothing."
       }
     ],
     "weaknesses": [
@@ -2346,7 +2346,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Vacuum Bolt",
@@ -2357,7 +2357,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80+",
-        "text": "You may do 80 more damage. If you do, this attack does 80 damage to 1 of your Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "You may do 80 more damage. If you do, this attack does 80 damage to 1 of your Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2470,7 +2470,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "110",
-        "text": "If you have no cards in your hand, ignore all Energy in this attack's cost."
+        "text": "If you have no cards in your hand, ignore all Energy in this attack’s cost."
       }
     ],
     "weaknesses": [
@@ -2513,7 +2513,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50×",
-        "text": "This attack does 50 damage for each Colorless in your opponent's Active Pokémon's Retreat Cost."
+        "text": "This attack does 50 damage for each Colorless in your opponent’s Active Pokémon’s Retreat Cost."
       }
     ],
     "weaknesses": [
@@ -2533,7 +2533,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "More Poison",
-      "text": "Put 1 more damage counter on your opponent's Poisoned Pokémon between turns.",
+      "text": "Put 1 more damage counter on your opponent’s Poisoned Pokémon between turns.",
       "type": "Ability"
     },
     "hp": "100",
@@ -2560,7 +2560,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       }
     ],
     "weaknesses": [
@@ -2701,7 +2701,7 @@
     "evolvesFrom": "Dusclops",
     "ability": {
       "name": "Dark Invitation",
-      "text": "Once during your turn (before your attack), you may have your opponent reveal their hand. Put a Basic Pokémon you find there onto your opponent's Bench, and put 3 damage counters on that Pokémon.",
+      "text": "Once during your turn (before your attack), you may have your opponent reveal their hand. Put a Basic Pokémon you find there onto your opponent’s Bench, and put 3 damage counters on that Pokémon.",
       "type": "Ability"
     },
     "hp": "150",
@@ -2729,7 +2729,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
-        "text": "This attack does 30 more damage for each of your opponent's Benched Pokémon."
+        "text": "This attack does 30 more damage for each of your opponent’s Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -2829,7 +2829,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       },
       {
         "name": "Poison Boost",
@@ -2890,7 +2890,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "If your opponent's Active Pokémon is Poisoned, this attack does 40 more damage."
+        "text": "If your opponent’s Active Pokémon is Poisoned, this attack does 40 more damage."
       }
     ],
     "weaknesses": [
@@ -2995,7 +2995,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       },
       {
         "name": "Steamroller",
@@ -3007,7 +3007,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "140",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -3194,7 +3194,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Dust Storm",
@@ -3274,7 +3274,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 100 damage to each of your opponent's Pokémon-GX and Pokémon-EX. This damage isn't affected by Weakness or Resistance. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 100 damage to each of your opponent’s Pokémon-GX and Pokémon-EX. This damage isn’t affected by Weakness or Resistance. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -3321,7 +3321,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "60+",
-        "text": "If your opponent's Active Pokémon is an Evolution Pokémon, this attack does 60 more damage."
+        "text": "If your opponent’s Active Pokémon is an Evolution Pokémon, this attack does 60 more damage."
       },
       {
         "name": "Bedrock Breaker",
@@ -3343,7 +3343,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "180",
-        "text": "This attack's damage isn't affected by Resistance. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack’s damage isn’t affected by Resistance. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -3444,7 +3444,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       },
       {
         "name": "Megahorn",
@@ -3480,7 +3480,7 @@
     "evolvesFrom": "Rhydon",
     "ability": {
       "name": "Toppling Wind",
-      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may discard the top 3 cards of your opponent's deck.",
+      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may discard the top 3 cards of your opponent’s deck.",
       "type": "Ability"
     },
     "hp": "160",
@@ -3510,7 +3510,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "170",
-        "text": "This attack's damage isn't affected by Weakness or Resistance. This Pokémon can't attack during your next turn."
+        "text": "This attack’s damage isn’t affected by Weakness or Resistance. This Pokémon can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -3530,7 +3530,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Heal Block",
-      "text": "If you have Solrock in play, Pokémon (both yours and your opponent's) can't be healed.",
+      "text": "If you have Solrock in play, Pokémon (both yours and your opponent’s) can’t be healed.",
       "type": "Ability"
     },
     "hp": "90",
@@ -3743,7 +3743,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Prevent all damage done to this Pokémon by attacks from Basic Pokémon during your opponent's next turn. This Pokémon can't use Quick Guard during your next turn."
+        "text": "Prevent all damage done to this Pokémon by attacks from Basic Pokémon during your opponent’s next turn. This Pokémon can’t use Quick Guard during your next turn."
       },
       {
         "name": "Brick Break",
@@ -3753,7 +3753,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "This attack's damage isn't affected by Resistance or any effects on your opponent's Active Pokémon."
+        "text": "This attack’s damage isn’t affected by Resistance or any effects on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -3892,7 +3892,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30+",
-        "text": "If your opponent's Active Pokémon is a Basic Pokémon, this attack does 30 more damage."
+        "text": "If your opponent’s Active Pokémon is a Basic Pokémon, this attack does 30 more damage."
       },
       {
         "name": "Corner",
@@ -3903,7 +3903,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -4056,7 +4056,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "130",
-        "text": "This Pokémon does 30 damage to itself. This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This Pokémon does 30 damage to itself. This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4106,7 +4106,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "90",
-        "text": "Discard a Pokémon Tool card from your hand. If you don't, this attack does nothing."
+        "text": "Discard a Pokémon Tool card from your hand. If you don’t, this attack does nothing."
       }
     ],
     "weaknesses": [
@@ -4165,7 +4165,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "50×",
-        "text": "This attack does 50 damage times the amount of basic Energy attached to this Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage times the amount of basic Energy attached to this Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -4204,7 +4204,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, this Pokémon's Bite attack's base damage is 60."
+        "text": "During your next turn, this Pokémon’s Bite attack’s base damage is 60."
       },
       {
         "name": "Bite",
@@ -4330,7 +4330,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -4388,7 +4388,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "10+",
-        "text": "This attack does 70 more damage for each Special Condition affecting your opponent's Active Pokémon."
+        "text": "This attack does 70 more damage for each Special Condition affecting your opponent’s Active Pokémon."
       },
       {
         "name": "Crunch",
@@ -4400,7 +4400,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "Discard an Energy from your opponent's Active Pokémon."
+        "text": "Discard an Energy from your opponent’s Active Pokémon."
       },
       {
         "name": "Tri Hazard-GX",
@@ -4409,7 +4409,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. The new Active Pokémon is now Burned, Paralyzed, and Poisoned. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Switch 1 of your opponent’s Benched Pokémon with their Active Pokémon. The new Active Pokémon is now Burned, Paralyzed, and Poisoned. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -4454,7 +4454,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, this Pokémon's Slash attack's base damage is 80."
+        "text": "During your next turn, this Pokémon’s Slash attack’s base damage is 80."
       },
       {
         "name": "Slash",
@@ -4510,7 +4510,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 60 damage to each Pokémon that has an Ability (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 60 damage to each Pokémon that has an Ability (both yours and your opponent’s). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Slash",
@@ -4567,7 +4567,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Dark Raid",
@@ -4635,7 +4635,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "130",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       },
       {
         "name": "Dead End-GX",
@@ -4646,7 +4646,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "If your opponent's Active Pokémon is affected by a Special Condition, that Pokémon is Knocked Out. (You can't use more than 1 GX attack in a game.)"
+        "text": "If your opponent’s Active Pokémon is affected by a Special Condition, that Pokémon is Knocked Out. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -4691,7 +4691,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Tackle",
@@ -4750,7 +4750,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       },
       {
         "name": "Energy Slosh",
@@ -5192,7 +5192,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       }
     ],
     "weaknesses": [
@@ -5240,7 +5240,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "Your opponent can't play any Item cards from their hand during their next turn."
+        "text": "Your opponent can’t play any Item cards from their hand during their next turn."
       },
       {
         "name": "Sonic Volume",
@@ -5251,7 +5251,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "Your opponent can't play any Special Energy cards from their hand during their next turn."
+        "text": "Your opponent can’t play any Special Energy cards from their hand during their next turn."
       },
       {
         "name": "Boomburst-GX",
@@ -5262,7 +5262,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 50 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -5357,7 +5357,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -5535,7 +5535,7 @@
     "evolvesFrom": "Porygon2",
     "ability": {
       "name": "Initialize",
-      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may devolve each of your opponent's evolved Pokémon by putting the highest Stage Evolution card on it into your opponent's hand.",
+      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may devolve each of your opponent’s evolved Pokémon by putting the highest Stage Evolution card on it into your opponent’s hand.",
       "type": "Ability"
     },
     "hp": "130",
@@ -5562,7 +5562,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "This Pokémon can't use Zap Cannon during your next turn."
+        "text": "This Pokémon can’t use Zap Cannon during your next turn."
       }
     ],
     "weaknesses": [
@@ -5660,7 +5660,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Night Raid",
@@ -5718,7 +5718,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "During your opponent's next turn, this Pokémon takes 30 less damage from attacks (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, this Pokémon takes 30 less damage from attacks (after applying Weakness and Resistance)."
       },
       {
         "name": "Knock Over",
@@ -5768,7 +5768,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -5817,7 +5817,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Tackle",
@@ -5872,7 +5872,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, discard the top 3 cards of your opponent's deck."
+        "text": "Flip a coin. If heads, discard the top 3 cards of your opponent’s deck."
       },
       {
         "name": "Tantrum",
@@ -5942,7 +5942,7 @@
     "set": "Burning Shadows",
     "setCode": "sm3",
     "text": [
-      "Each player switches their Active Pokémon with 1 of their Benched Pokémon. Your opponent switches first. (If a player does not have a Benched Pokémon, that player doesn't switch Pokémon.)"
+      "Each player switches their Active Pokémon with 1 of their Benched Pokémon. Your opponent switches first. (If a player does not have a Benched Pokémon, that player doesn’t switch Pokémon.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/114_hires.png"
   },
@@ -6010,7 +6010,7 @@
     "set": "Burning Shadows",
     "setCode": "sm3",
     "text": [
-      "The Retreat Cost of each Basic Pokémon in play (both yours and your opponent's) is Colorless more."
+      "The Retreat Cost of each Basic Pokémon in play (both yours and your opponent’s) is Colorless more."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/118_hires.png"
   },
@@ -6044,7 +6044,7 @@
     "set": "Burning Shadows",
     "setCode": "sm3",
     "text": [
-      "Discard 2 cards from your hand. If you do, discard an Energy from 1 of your opponent's Pokémon."
+      "Discard 2 cards from your hand. If you do, discard an Energy from 1 of your opponent’s Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/120_hires.png"
   },
@@ -6129,7 +6129,7 @@
     "set": "Burning Shadows",
     "setCode": "sm3",
     "text": [
-      "Choose a random card from your opponent's hand. Your opponent reveals that card. If it's a Supporter card, discard it."
+      "Choose a random card from your opponent’s hand. Your opponent reveals that card. If it’s a Supporter card, discard it."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/125_hires.png"
   },
@@ -6180,7 +6180,7 @@
     "set": "Burning Shadows",
     "setCode": "sm3",
     "text": [
-      "If the Pokémon this card is attached to is your Active Pokémon and is Knocked Out by damage from an opponent's attack, move up to 3 basic Energy cards from that Pokémon to 1 of your Benched Pokémon."
+      "If the Pokémon this card is attached to is your Active Pokémon and is Knocked Out by damage from an opponent’s attack, move up to 3 basic Energy cards from that Pokémon to 1 of your Benched Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/128_hires.png"
   },
@@ -6229,7 +6229,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "During your opponent's next turn, this Pokémon takes 20 less damage from attacks (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, this Pokémon takes 20 less damage from attacks (after applying Weakness and Resistance)."
       },
       {
         "name": "Crossing Cut-GX",
@@ -6307,7 +6307,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "150",
-        "text": "Heal all damage from this Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "Heal all damage from this Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/130_hires.png"
@@ -6346,7 +6346,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 50 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 50 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Phoenix Burn",
@@ -6358,7 +6358,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "180",
-        "text": "This Pokémon can't use Phoenix Burn during your next turn."
+        "text": "This Pokémon can’t use Phoenix Burn during your next turn."
       },
       {
         "name": "Eternal Flame-GX",
@@ -6441,7 +6441,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Discard all Energy from your opponent's Active Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "Discard all Energy from your opponent’s Active Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6495,7 +6495,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Discard 2 Water Energy from this Pokémon. This attack does 120 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard 2 Water Energy from this Pokémon. This attack does 120 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Tapu Storm-GX",
@@ -6559,7 +6559,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 100 damage to each of your opponent's Pokémon-GX and Pokémon-EX. This damage isn't affected by Weakness or Resistance. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 100 damage to each of your opponent’s Pokémon-GX and Pokémon-EX. This damage isn’t affected by Weakness or Resistance. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6606,7 +6606,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "60+",
-        "text": "If your opponent's Active Pokémon is an Evolution Pokémon, this attack does 60 more damage."
+        "text": "If your opponent’s Active Pokémon is an Evolution Pokémon, this attack does 60 more damage."
       },
       {
         "name": "Bedrock Breaker",
@@ -6628,7 +6628,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "180",
-        "text": "This attack's damage isn't affected by Resistance. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack’s damage isn’t affected by Resistance. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6673,7 +6673,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Discard an Energy from your opponent's Active Pokémon."
+        "text": "Discard an Energy from your opponent’s Active Pokémon."
       },
       {
         "name": "Accelerock",
@@ -6695,7 +6695,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "200",
-        "text": "Discard 2 Energy from this Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "Discard 2 Energy from this Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6754,7 +6754,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "50×",
-        "text": "This attack does 50 damage times the amount of basic Energy attached to this Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage times the amount of basic Energy attached to this Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6803,7 +6803,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "10+",
-        "text": "This attack does 70 more damage for each Special Condition affecting your opponent's Active Pokémon."
+        "text": "This attack does 70 more damage for each Special Condition affecting your opponent’s Active Pokémon."
       },
       {
         "name": "Crunch",
@@ -6815,7 +6815,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "Discard an Energy from your opponent's Active Pokémon."
+        "text": "Discard an Energy from your opponent’s Active Pokémon."
       },
       {
         "name": "Tri Hazard-GX",
@@ -6824,7 +6824,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. The new Active Pokémon is now Burned, Paralyzed, and Poisoned. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Switch 1 of your opponent’s Benched Pokémon with their Active Pokémon. The new Active Pokémon is now Burned, Paralyzed, and Poisoned. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6881,7 +6881,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "130",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       },
       {
         "name": "Dead End-GX",
@@ -6892,7 +6892,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "If your opponent's Active Pokémon is affected by a Special Condition, that Pokémon is Knocked Out. (You can't use more than 1 GX attack in a game.)"
+        "text": "If your opponent’s Active Pokémon is affected by a Special Condition, that Pokémon is Knocked Out. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7005,7 +7005,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "Your opponent can't play any Item cards from their hand during their next turn."
+        "text": "Your opponent can’t play any Item cards from their hand during their next turn."
       },
       {
         "name": "Sonic Volume",
@@ -7016,7 +7016,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "Your opponent can't play any Special Energy cards from their hand during their next turn."
+        "text": "Your opponent can’t play any Special Energy cards from their hand during their next turn."
       },
       {
         "name": "Boomburst-GX",
@@ -7027,7 +7027,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 50 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7103,7 +7103,7 @@
     "set": "Burning Shadows",
     "setCode": "sm3",
     "text": [
-      "Discard 2 cards from your hand. If you do, discard an Energy from 1 of your opponent's Pokémon."
+      "Discard 2 cards from your hand. If you do, discard an Energy from 1 of your opponent’s Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/145_hires.png"
   },
@@ -7186,7 +7186,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "During your opponent's next turn, this Pokémon takes 20 less damage from attacks (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, this Pokémon takes 20 less damage from attacks (after applying Weakness and Resistance)."
       },
       {
         "name": "Crossing Cut-GX",
@@ -7264,7 +7264,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "150",
-        "text": "Heal all damage from this Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "Heal all damage from this Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/149_hires.png"
@@ -7303,7 +7303,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 50 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 50 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Phoenix Burn",
@@ -7315,7 +7315,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "180",
-        "text": "This Pokémon can't use Phoenix Burn during your next turn."
+        "text": "This Pokémon can’t use Phoenix Burn during your next turn."
       },
       {
         "name": "Eternal Flame-GX",
@@ -7398,7 +7398,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Discard all Energy from your opponent's Active Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "Discard all Energy from your opponent’s Active Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7452,7 +7452,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Discard 2 Water Energy from this Pokémon. This attack does 120 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard 2 Water Energy from this Pokémon. This attack does 120 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Tapu Storm-GX",
@@ -7516,7 +7516,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 100 damage to each of your opponent's Pokémon-GX and Pokémon-EX. This damage isn't affected by Weakness or Resistance. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 100 damage to each of your opponent’s Pokémon-GX and Pokémon-EX. This damage isn’t affected by Weakness or Resistance. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7563,7 +7563,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "60+",
-        "text": "If your opponent's Active Pokémon is an Evolution Pokémon, this attack does 60 more damage."
+        "text": "If your opponent’s Active Pokémon is an Evolution Pokémon, this attack does 60 more damage."
       },
       {
         "name": "Bedrock Breaker",
@@ -7585,7 +7585,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "180",
-        "text": "This attack's damage isn't affected by Resistance. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack’s damage isn’t affected by Resistance. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7630,7 +7630,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Discard an Energy from your opponent's Active Pokémon."
+        "text": "Discard an Energy from your opponent’s Active Pokémon."
       },
       {
         "name": "Accelerock",
@@ -7652,7 +7652,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "200",
-        "text": "Discard 2 Energy from this Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "Discard 2 Energy from this Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7711,7 +7711,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "50×",
-        "text": "This attack does 50 damage times the amount of basic Energy attached to this Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage times the amount of basic Energy attached to this Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7760,7 +7760,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "10+",
-        "text": "This attack does 70 more damage for each Special Condition affecting your opponent's Active Pokémon."
+        "text": "This attack does 70 more damage for each Special Condition affecting your opponent’s Active Pokémon."
       },
       {
         "name": "Crunch",
@@ -7772,7 +7772,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "Discard an Energy from your opponent's Active Pokémon."
+        "text": "Discard an Energy from your opponent’s Active Pokémon."
       },
       {
         "name": "Tri Hazard-GX",
@@ -7781,7 +7781,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. The new Active Pokémon is now Burned, Paralyzed, and Poisoned. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Switch 1 of your opponent’s Benched Pokémon with their Active Pokémon. The new Active Pokémon is now Burned, Paralyzed, and Poisoned. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7838,7 +7838,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "130",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       },
       {
         "name": "Dead End-GX",
@@ -7849,7 +7849,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "If your opponent's Active Pokémon is affected by a Special Condition, that Pokémon is Knocked Out. (You can't use more than 1 GX attack in a game.)"
+        "text": "If your opponent’s Active Pokémon is affected by a Special Condition, that Pokémon is Knocked Out. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7962,7 +7962,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "Your opponent can't play any Item cards from their hand during their next turn."
+        "text": "Your opponent can’t play any Item cards from their hand during their next turn."
       },
       {
         "name": "Sonic Volume",
@@ -7973,7 +7973,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "Your opponent can't play any Special Energy cards from their hand during their next turn."
+        "text": "Your opponent can’t play any Special Energy cards from their hand during their next turn."
       },
       {
         "name": "Boomburst-GX",
@@ -7984,7 +7984,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 50 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -8026,7 +8026,7 @@
     "set": "Burning Shadows",
     "setCode": "sm3",
     "text": [
-      "The attacks of the Pokémon this card is attached to do 30 more damage to your opponent's Active Pokémon-GX or Active Pokémon-EX (before applying Weakness and Resistance)."
+      "The attacks of the Pokémon this card is attached to do 30 more damage to your opponent’s Active Pokémon-GX or Active Pokémon-EX (before applying Weakness and Resistance)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/162_hires.png"
   },
@@ -8043,7 +8043,7 @@
     "set": "Burning Shadows",
     "setCode": "sm3",
     "text": [
-      "Each player switches their Active Pokémon with 1 of their Benched Pokémon. Your opponent switches first. (If a player does not have a Benched Pokémon, that player doesn't switch Pokémon.)"
+      "Each player switches their Active Pokémon with 1 of their Benched Pokémon. Your opponent switches first. (If a player does not have a Benched Pokémon, that player doesn’t switch Pokémon.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/163_hires.png"
   },

--- a/json/cards/Call of Legends.json
+++ b/json/cards/Call of Legends.json
@@ -169,7 +169,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Move up to 4 damage counters from any of your Pokémon to any of your opponent's Pokémon in any way you like."
+        "text": "Move up to 4 damage counters from any of your Pokémon to any of your opponent’s Pokémon in any way you like."
       },
       {
         "name": "Psybeam",
@@ -222,7 +222,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Everyone Explode Now",
@@ -284,7 +284,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "Flip a coin. If heads, discard the top 4 cards of your opponent's deck. If tails, discard the top 4 cards of your deck."
+        "text": "Flip a coin. If heads, discard the top 4 cards of your opponent’s deck. If tails, discard the top 4 cards of your deck."
       }
     ],
     "weaknesses": [
@@ -396,7 +396,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "During your opponent's next turn, any damage done to Hitmontop by attacks is increased by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Hitmontop by attacks is increased by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -558,7 +558,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose a number of your opponent's Stage 1 or Stage 2 Evolved Pokémon up to the amount of Energy attached to Jirachi. Remove the highest Stage Evolution card from each of those Pokémon and put those cards back into your opponent's hand."
+        "text": "Choose a number of your opponent’s Stage 1 or Stage 2 Evolved Pokémon up to the amount of Energy attached to Jirachi. Remove the highest Stage Evolution card from each of those Pokémon and put those cards back into your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -603,7 +603,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Flip a coin. If heads, this attack does 40 damage to each of your opponent's Pokémon. If tails, this attack does 40 damage to each of your Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 40 damage to each of your opponent’s Pokémon. If tails, this attack does 40 damage to each of your Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -710,7 +710,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -753,7 +753,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Hydro Splash",
@@ -848,7 +848,7 @@
     "evolvesFrom": "Vulpix",
     "ability": {
       "name": "Roast Reveal",
-      "text": "Once during your turn (before your attack), you may discard a Fire Energy card from your hand. If you do, draw 3 cards. This power can't be used if Ninetales is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may discard a Fire Energy card from your hand. If you do, draw 3 cards. This power can’t be used if Ninetales is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -1038,7 +1038,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Portrait",
-      "text": "Once during your turn (before your attack), if Smeargle is your Active Pokémon, you may look at your opponent's hand. If you do, choose a Supporter card you find there and use the effect of that card as the effect of this power. This power can't be used if Smeargle is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Smeargle is your Active Pokémon, you may look at your opponent’s hand. If you do, choose a Supporter card you find there and use the effect of that card as the effect of this power. This power can’t be used if Smeargle is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -1103,7 +1103,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "During your opponent's next turn, prevent all effects, including damage, done to Umbreon by attacks from your opponent's Pokémon that has any Poké-Powers or Poké-Bodies."
+        "text": "During your opponent’s next turn, prevent all effects, including damage, done to Umbreon by attacks from your opponent’s Pokémon that has any Poké-Powers or Poké-Bodies."
       },
       {
         "name": "Quick Blow",
@@ -1257,7 +1257,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 20 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Surf",
@@ -1432,7 +1432,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30×",
-        "text": "Look at your opponent's hand. This attack does 30 damage times the number of Trainer, Supporter, and Stadium cards in your opponent's hand."
+        "text": "Look at your opponent’s hand. This attack does 30 damage times the number of Trainer, Supporter, and Stadium cards in your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -1458,7 +1458,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Trick Reveal",
-      "text": "Once during your turn (before your attack), you may have both you and your opponent reveal your hands. This power can't be used if Mr. Mime is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may have both you and your opponent reveal your hands. This power can’t be used if Mr. Mime is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -1521,7 +1521,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "During your opponent's next turn, the attack cost of each of the Defending Pokémon's attacks is ColorlessColorless more."
+        "text": "During your opponent’s next turn, the attack cost of each of the Defending Pokémon’s attacks is ColorlessColorless more."
       },
       {
         "name": "Quick Attack",
@@ -1615,7 +1615,7 @@
     "evolvesFrom": "Slowpoke",
     "ability": {
       "name": "Second Sight",
-      "text": "Once during your turn (before your attack), you may look at the top 3 cards of either player's deck and put them back on top of that player's deck in any order. This power can't be used if Slowking is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may look at the top 3 cards of either player’s deck and put them back on top of that player’s deck in any order. This power can’t be used if Slowking is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -1685,7 +1685,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Remove all damage counters from Snorlax. Snorlax can't use Layabout during your next turn."
+        "text": "Remove all damage counters from Snorlax. Snorlax can’t use Layabout during your next turn."
       },
       {
         "name": "Clomp Clomp Clobber",
@@ -1850,7 +1850,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Weakness or Resistance. Tyrogue is now Asleep."
+        "text": "This attack’s damage isn’t affected by Weakness or Resistance. Tyrogue is now Asleep."
       }
     ],
     "nationalPokedexNumber": 236,
@@ -1953,7 +1953,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "90",
-        "text": "Weezing does 90 damage to itself, and don't apply Weakness to this damage."
+        "text": "Weezing does 90 damage to itself, and don’t apply Weakness to this damage."
       }
     ],
     "weaknesses": [
@@ -1993,7 +1993,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, Zangoose's Lost Claw attack's base damage is 60."
+        "text": "During your next turn, Zangoose’s Lost Claw attack’s base damage is 60."
       },
       {
         "name": "Lost Claw",
@@ -2004,7 +2004,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Choose 1 card from your opponent's hand without looking and put it in the Lost Zone."
+        "text": "Choose 1 card from your opponent’s hand without looking and put it in the Lost Zone."
       }
     ],
     "weaknesses": [
@@ -2118,7 +2118,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2165,7 +2165,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       },
       {
         "name": "Double Spin",
@@ -2223,7 +2223,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Thundershock",
@@ -2331,7 +2331,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to Jolteon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to Jolteon during your opponent’s next turn."
       },
       {
         "name": "Mach Bolt",
@@ -2427,7 +2427,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put the top card of your opponent's deck in the Lost Zone. Mime Jr. is now Asleep."
+        "text": "Put the top card of your opponent’s deck in the Lost Zone. Mime Jr. is now Asleep."
       }
     ],
     "nationalPokedexNumber": 439,
@@ -2576,7 +2576,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Riolu can't attack during your next turn."
+        "text": "Riolu can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -2681,7 +2681,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 2 of your opponent's Pokémon. This attack does 30 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 2 of your opponent’s Pokémon. This attack does 30 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2778,7 +2778,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done to Clefairy by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Clefairy by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Slap",
@@ -2930,7 +2930,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to Hitmonchan during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to Hitmonchan during your opponent’s next turn."
       },
       {
         "name": "Sky Uppercut",
@@ -2940,7 +2940,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -3078,7 +3078,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Suffocating Gas",
@@ -3552,7 +3552,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "During your opponent's next turn, any damage done to Relicanth by attacks is reduced by 30 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Relicanth by attacks is reduced by 30 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -3748,7 +3748,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent can't play any Trainer cards from his or her hand during your opponent's next turn, and any damage done to Teddiursa by attacks is reduced by 30 (after applying weakness and resistance)."
+        "text": "Flip a coin. If heads, your opponent can’t play any Trainer cards from his or her hand during your opponent’s next turn, and any damage done to Teddiursa by attacks is reduced by 30 (after applying weakness and resistance)."
       }
     ],
     "weaknesses": [
@@ -3862,7 +3862,7 @@
   },
   {
     "id": "col1-76",
-    "name": "Cheerleader's Cheer",
+    "name": "Cheerleader’s Cheer",
     "imageUrl": "https://images.pokemontcg.io/col1/76.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -3892,7 +3892,7 @@
     "setCode": "col1",
     "text": [
       "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.",
-      "Shuffle your hand into your deck. Then, draw a number of cards equal to the number of cards in your opponent's hand."
+      "Shuffle your hand into your deck. Then, draw a number of cards equal to the number of cards in your opponent’s hand."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/col1/77_hires.png"
   },
@@ -3915,7 +3915,7 @@
   },
   {
     "id": "col1-79",
-    "name": "Interviewer's Questions",
+    "name": "Interviewer’s Questions",
     "imageUrl": "https://images.pokemontcg.io/col1/79.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -3944,7 +3944,7 @@
     "set": "Call of Legends",
     "setCode": "col1",
     "text": [
-      "Put 1 Special Energy card attached to 1 of your opponent's Pokémon in the Lost Zone."
+      "Put 1 Special Energy card attached to 1 of your opponent’s Pokémon in the Lost Zone."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/col1/80_hires.png"
   },
@@ -3961,14 +3961,14 @@
     "set": "Call of Legends",
     "setCode": "col1",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "Once during each player's turn, if that player's opponent has 6 or more Pokémon in the Lost Zone, the player may choose to win the game."
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
+      "Once during each player’s turn, if that player’s opponent has 6 or more Pokémon in the Lost Zone, the player may choose to win the game."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/col1/81_hires.png"
   },
   {
     "id": "col1-82",
-    "name": "Professor Elm's Training Method",
+    "name": "Professor Elm’s Training Method",
     "imageUrl": "https://images.pokemontcg.io/col1/82.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -3986,7 +3986,7 @@
   },
   {
     "id": "col1-83",
-    "name": "Professor Oak's New Theory",
+    "name": "Professor Oak’s New Theory",
     "imageUrl": "https://images.pokemontcg.io/col1/83.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4021,7 +4021,7 @@
   },
   {
     "id": "col1-85",
-    "name": "Sage's Training",
+    "name": "Sage’s Training",
     "imageUrl": "https://images.pokemontcg.io/col1/85.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4050,7 +4050,7 @@
     "set": "Call of Legends",
     "setCode": "col1",
     "text": [
-      "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect if the Pokémon that Darkness Energy is attached to isn't Darkness. Darkness Energy provides Darkness Energy. (Doesn't count as a basic Energy card.)"
+      "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect if the Pokémon that Darkness Energy is attached to isn’t Darkness. Darkness Energy provides Darkness Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/col1/86_hires.png"
   },
@@ -4067,7 +4067,7 @@
     "set": "Call of Legends",
     "setCode": "col1",
     "text": [
-      "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn't Metal. Metal Energy provides Metal Energy. (Doesn't count as a basic Energy card.)"
+      "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn’t Metal. Metal Energy provides Metal Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/col1/87_hires.png"
   },
@@ -4282,7 +4282,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Extreme Speed",
-      "text": "Entei's Retreat Cost is Colorless less for each Fire Energy attached to Entei.",
+      "text": "Entei’s Retreat Cost is Colorless less for each Fire Energy attached to Entei.",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -4354,7 +4354,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "Flip a coin. If heads, discard the top 4 cards of your opponent's deck. If tails, discard the top 4 cards of your deck."
+        "text": "Flip a coin. If heads, discard the top 4 cards of your opponent’s deck. If tails, discard the top 4 cards of your deck."
       }
     ],
     "weaknesses": [
@@ -4461,7 +4461,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Flip a coin. If heads, this attack does 40 damage to each of your opponent's Pokémon. If tails, this attack does 40 damage to each of your Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 40 damage to each of your opponent’s Pokémon. If tails, this attack does 40 damage to each of your Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4504,7 +4504,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Hydro Splash",
@@ -4587,7 +4587,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Extreme Speed",
-      "text": "Raikou's Retreat Cost is Colorless less for each Lightning Energy attached to Raikou.",
+      "text": "Raikou’s Retreat Cost is Colorless less for each Lightning Energy attached to Raikou.",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -4614,7 +4614,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "Does 20 damage to 1 of your Pokémon, and don't apply Weakness and Resistance to this damage."
+        "text": "Does 20 damage to 1 of your Pokémon, and don’t apply Weakness and Resistance to this damage."
       }
     ],
     "weaknesses": [
@@ -4689,7 +4689,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Extreme Speed",
-      "text": "Suicune's Retreat Cost is Colorless less for each Water Energy attached to Suicune.",
+      "text": "Suicune’s Retreat Cost is Colorless less for each Water Energy attached to Suicune.",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -4716,7 +4716,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 20 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [

--- a/json/cards/Crimson Invasion.json
+++ b/json/cards/Crimson Invasion.json
@@ -26,7 +26,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       }
     ],
     "weaknesses": [
@@ -110,7 +110,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If this Pokémon evolved from Kakuna during this turn, your opponent's Active Pokémon is now Paralyzed and Poisoned."
+        "text": "If this Pokémon evolved from Kakuna during this turn, your opponent’s Active Pokémon is now Paralyzed and Poisoned."
       },
       {
         "name": "Sharp Sting",
@@ -158,7 +158,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Ram",
@@ -253,7 +253,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30+",
-        "text": "If your opponent's Active Pokémon already has any damage counters on it, this attack does 60 more damage."
+        "text": "If your opponent’s Active Pokémon already has any damage counters on it, this attack does 60 more damage."
       },
       {
         "name": "Hunt",
@@ -263,7 +263,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. This attack does 40 damage to the new Active Pokémon."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with their Active Pokémon. This attack does 40 damage to the new Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -471,7 +471,7 @@
     "evolvesFrom": "Skiddo",
     "ability": {
       "name": "Sap Sipper",
-      "text": "This Pokémon's attacks do 80 more damage to your opponent's Grass Pokémon (before applying Weakness and Resistance).",
+      "text": "This Pokémon’s attacks do 80 more damage to your opponent’s Grass Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "120",
@@ -539,7 +539,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "For each Energy attached to your opponent's Pokémon, attach a Fire Energy card from your discard pile to your Pokémon in any way you like."
+        "text": "For each Energy attached to your opponent’s Pokémon, attach a Fire Energy card from your discard pile to your Pokémon in any way you like."
       },
       {
         "name": "Burning Bonemerang",
@@ -550,7 +550,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70×",
-        "text": "Flip 2 coins. This attack does 70 damage for each heads. If either of them is heads, your opponent's Active Pokémon is now Burned."
+        "text": "Flip 2 coins. This attack does 70 damage for each heads. If either of them is heads, your opponent’s Active Pokémon is now Burned."
       }
     ],
     "weaknesses": [
@@ -652,7 +652,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "Your opponent's Active Pokémon is now Burned."
+        "text": "Your opponent’s Active Pokémon is now Burned."
       }
     ],
     "weaknesses": [
@@ -759,7 +759,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Submerge",
-      "text": "As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's).",
+      "text": "As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent’s).",
       "type": "Ability"
     },
     "hp": "30",
@@ -859,7 +859,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Discard an Energy from each of your opponent's Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "Discard an Energy from each of your opponent’s Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -1103,7 +1103,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Special Artillery",
@@ -1201,7 +1201,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "Discard 2 Energy from your opponent's Active Pokémon."
+        "text": "Discard 2 Energy from your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -1240,7 +1240,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1296,7 +1296,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "This attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1316,7 +1316,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Iceberg Shield",
-      "text": "If you have Regirock in play, prevent all effects of attacks, including damage, done to this Pokémon by your opponent's Stage 2 Pokémon.",
+      "text": "If you have Regirock in play, prevent all effects of attacks, including damage, done to this Pokémon by your opponent’s Stage 2 Pokémon.",
       "type": "Ability"
     },
     "hp": "130",
@@ -1501,7 +1501,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70+",
-        "text": "This attack does 20 more damage times the amount of Energy attached to your opponent's Active Pokémon."
+        "text": "This attack does 20 more damage times the amount of Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -1547,7 +1547,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent’s next turn."
       },
       {
         "name": "Tackle",
@@ -1702,7 +1702,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "Your opponent can't play any cards from their hand during their next turn. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Your opponent can’t play any cards from their hand during their next turn. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -1801,7 +1801,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 1 damage counter on 1 of your opponent's Pokémon."
+        "text": "Put 1 damage counter on 1 of your opponent’s Pokémon."
       }
     ],
     "weaknesses": [
@@ -1850,7 +1850,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 2 damage counters on each of your opponent's Pokémon that has any damage counters on it."
+        "text": "Put 2 damage counters on each of your opponent’s Pokémon that has any damage counters on it."
       }
     ],
     "weaknesses": [
@@ -1903,7 +1903,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -1948,7 +1948,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -1997,7 +1997,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Your opponent can't play any Pokémon Tool, Special Energy, or Stadium cards from their hand during their next turn."
+        "text": "Your opponent can’t play any Pokémon Tool, Special Energy, or Stadium cards from their hand during their next turn."
       },
       {
         "name": "Dark Arts",
@@ -2008,7 +2008,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20×",
-        "text": "This attack does 20 damage for each card in your opponent's hand."
+        "text": "This attack does 20 damage for each card in your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -2077,7 +2077,7 @@
     "evolvesFrom": "Spoink",
     "ability": {
       "name": "Own Tempo",
-      "text": "This Pokémon can't be Confused.",
+      "text": "This Pokémon can’t be Confused.",
       "type": "Ability"
     },
     "hp": "120",
@@ -2104,7 +2104,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "During your next turn, this Pokémon's Psych Up attack does 60 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s Psych Up attack does 60 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -2143,7 +2143,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Your opponent can't play any Pokémon that has an Ability from their hand during their next turn."
+        "text": "Your opponent can’t play any Pokémon that has an Ability from their hand during their next turn."
       }
     ],
     "weaknesses": [
@@ -2183,7 +2183,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose a random card from your opponent's hand. Your opponent reveals that card and shuffles it into their deck."
+        "text": "Choose a random card from your opponent’s hand. Your opponent reveals that card and shuffles it into their deck."
       }
     ],
     "weaknesses": [
@@ -2234,7 +2234,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       },
       {
         "name": "Pumpkin Bomb",
@@ -2289,7 +2289,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Burned."
+        "text": "Your opponent’s Active Pokémon is now Burned."
       }
     ],
     "weaknesses": [
@@ -2341,7 +2341,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Poisoned. Put 4 damage counters instead of 1 on that Pokémon between turns."
+        "text": "Your opponent’s Active Pokémon is now Poisoned. Put 4 damage counters instead of 1 on that Pokémon between turns."
       }
     ],
     "weaknesses": [
@@ -2443,7 +2443,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Symbiont-GX",
@@ -2454,7 +2454,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Add the top 2 cards of your opponent's deck to their Prize cards. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Add the top 2 cards of your opponent’s deck to their Prize cards. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -2547,7 +2547,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "90",
-        "text": "During your opponent's next turn, the Defending Pokémon's attacks do 30 more damage (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, the Defending Pokémon’s attacks do 30 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -2587,7 +2587,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Headbutt",
@@ -2620,7 +2620,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Rock Peak Growl",
-      "text": "Your Registeel's attacks do 10 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
+      "text": "Your Registeel’s attacks do 10 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "130",
@@ -2648,7 +2648,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "110",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -2691,7 +2691,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       },
       {
         "name": "Earthquake",
@@ -2702,7 +2702,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2767,7 +2767,7 @@
     "evolvesFrom": "Stufful",
     "ability": {
       "name": "Fluffy",
-      "text": "This Pokémon takes 30 less damage from the attacks of your opponent's non-Fire Pokémon (after applying Weakness and Resistance).",
+      "text": "This Pokémon takes 30 less damage from the attacks of your opponent’s non-Fire Pokémon (after applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "130",
@@ -2795,7 +2795,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "If your opponent's Active Pokémon is an Evolution Pokémon, this attack does 60 more damage."
+        "text": "If your opponent’s Active Pokémon is an Evolution Pokémon, this attack does 60 more damage."
       }
     ],
     "weaknesses": [
@@ -2839,7 +2839,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Knuckle Impact",
@@ -2850,7 +2850,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "160",
-        "text": "This Pokémon can't attack during your next turn."
+        "text": "This Pokémon can’t attack during your next turn."
       },
       {
         "name": "Absorption-GX",
@@ -2861,7 +2861,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40×",
-        "text": "This attack does 40 damage for each of your remaining Prize cards. (You can't use more than 1 GX attack in a game.)"
+        "text": "This attack does 40 damage for each of your remaining Prize cards. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -2960,7 +2960,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Burned."
+        "text": "Your opponent’s Active Pokémon is now Burned."
       },
       {
         "name": "Puncturing Fangs",
@@ -2971,7 +2971,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -3148,7 +3148,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "You may discard an Energy from this Pokémon. If you do, discard an Energy from your opponent's Active Pokémon."
+        "text": "You may discard an Energy from this Pokémon. If you do, discard an Energy from your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -3226,7 +3226,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "100",
-        "text": "If your opponent's Pokémon is Knocked Out by damage from this attack, take 2 more Prize cards. (You can’t use more than 1 GX attack in a game.)"
+        "text": "If your opponent’s Pokémon is Knocked Out by damage from this attack, take 2 more Prize cards. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -3304,7 +3304,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "100",
-        "text": "If your opponent's Pokémon is Knocked Out by damage from this attack, take 2 more Prize cards. (You can’t use more than 1 GX attack in a game.)"
+        "text": "If your opponent’s Pokémon is Knocked Out by damage from this attack, take 2 more Prize cards. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -3359,7 +3359,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, discard an Energy from your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy from your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -3544,7 +3544,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -3687,7 +3687,7 @@
     "level": "GX",
     "ability": {
       "name": "Slice Off",
-      "text": "When you play this Pokémon from your hand onto your Bench during your turn, you may discard a Special Energy from 1 of your opponent's Pokémon.",
+      "text": "When you play this Pokémon from your hand onto your Bench during your turn, you may discard a Special Energy from 1 of your opponent’s Pokémon.",
       "type": "Ability"
     },
     "hp": "170",
@@ -3725,7 +3725,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Take a Prize card. (You can't use more than 1 GX attack in a game.)"
+        "text": "Take a Prize card. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -3831,7 +3831,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Punishing Slap",
@@ -3899,7 +3899,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "130",
-        "text": "This Pokémon can't use Bright Horns during your next turn."
+        "text": "This Pokémon can’t use Bright Horns during your next turn."
       }
     ],
     "weaknesses": [
@@ -3951,7 +3951,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 20 damage times the amount of Energy attached to this Pokémon to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage times the amount of Energy attached to this Pokémon to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Dragon Hammer",
@@ -3963,7 +3963,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       },
       {
         "name": "Tower-Go-Round-GX",
@@ -4133,7 +4133,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "130",
-        "text": "During your opponent's next turn, this Pokémon takes 30 more damage from attacks (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, this Pokémon takes 30 more damage from attacks (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -4277,7 +4277,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "During your opponent's next turn, this Pokémon takes 30 less damage from attacks (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, this Pokémon takes 30 less damage from attacks (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -4442,7 +4442,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Sky Hunting",
@@ -4454,7 +4454,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "If your opponent's Pokémon is Knocked Out by the damage from this attack, switch this Pokémon with 1 of your Benched Pokémon."
+        "text": "If your opponent’s Pokémon is Knocked Out by the damage from this attack, switch this Pokémon with 1 of your Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -4480,7 +4480,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Seal of Antiquity",
-      "text": "This Pokémon can't attack unless Regirock, Regice, and Registeel are on your Bench.",
+      "text": "This Pokémon can’t attack unless Regirock, Regice, and Registeel are on your Bench.",
       "type": "Ability"
     },
     "hp": "180",
@@ -4550,7 +4550,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -4681,7 +4681,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       },
       {
         "name": "Hammer Arm",
@@ -4693,7 +4693,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "90",
-        "text": "Discard the top card of your opponent's deck."
+        "text": "Discard the top card of your opponent’s deck."
       }
     ],
     "weaknesses": [
@@ -4734,7 +4734,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "During your opponent's next turn, this Pokémon takes 30 less damage from attacks (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, this Pokémon takes 30 less damage from attacks (after applying Weakness and Resistance)."
       },
       {
         "name": "Slashing Claw",
@@ -4807,7 +4807,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50×",
-        "text": "This attack does 50 damage for each of your opponent's Benched Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage for each of your opponent’s Benched Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -4832,7 +4832,7 @@
     "set": "Crimson Invasion",
     "setCode": "sm4",
     "text": [
-      "You can play this card only if you have more Prize cards remaining than your opponent. Switch 1 of your opponent's Benched Pokémon with their Active Pokémon."
+      "You can play this card only if you have more Prize cards remaining than your opponent. Switch 1 of your opponent’s Benched Pokémon with their Active Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm4/91_hires.png"
   },
@@ -4866,7 +4866,7 @@
     "set": "Crimson Invasion",
     "setCode": "sm4",
     "text": [
-      "The attacks of Darkness Pokémon and Dragon Pokémon (both yours and your opponent's) do 10 more damage to the opponent's Active Pokémon (before applying Weakness and Resistance)."
+      "The attacks of Darkness Pokémon and Dragon Pokémon (both yours and your opponent’s) do 10 more damage to the opponent’s Active Pokémon (before applying Weakness and Resistance)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm4/93_hires.png"
   },
@@ -4985,7 +4985,7 @@
     "set": "Crimson Invasion",
     "setCode": "sm4",
     "text": [
-      "This card provides Colorless Energy. If you have more Prize cards remaining than your opponent, and if this card is attached to a Pokémon that isn't a Pokémon-GX or Pokémon-EX, this card provides every type of Energy but provides only 2 Energy at a time."
+      "This card provides Colorless Energy. If you have more Prize cards remaining than your opponent, and if this card is attached to a Pokémon that isn’t a Pokémon-GX or Pokémon-EX, this card provides every type of Energy but provides only 2 Energy at a time."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm4/100_hires.png"
   },
@@ -5048,7 +5048,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Discard an Energy from each of your opponent's Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "Discard an Energy from each of your opponent’s Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -5121,7 +5121,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "Your opponent can't play any cards from their hand during their next turn. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Your opponent can’t play any cards from their hand during their next turn. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -5178,7 +5178,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Symbiont-GX",
@@ -5189,7 +5189,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Add the top 2 cards of your opponent's deck to their Prize cards. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Add the top 2 cards of your opponent’s deck to their Prize cards. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -5233,7 +5233,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Knuckle Impact",
@@ -5244,7 +5244,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "160",
-        "text": "This Pokémon can't attack during your next turn."
+        "text": "This Pokémon can’t attack during your next turn."
       },
       {
         "name": "Absorption-GX",
@@ -5255,7 +5255,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40×",
-        "text": "This attack does 40 damage for each of your remaining Prize cards. (You can't use more than 1 GX attack in a game.)"
+        "text": "This attack does 40 damage for each of your remaining Prize cards. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -5327,7 +5327,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "100",
-        "text": "If your opponent's Pokémon is Knocked Out by damage from this attack, take 2 more Prize cards. (You can’t use more than 1 GX attack in a game.)"
+        "text": "If your opponent’s Pokémon is Knocked Out by damage from this attack, take 2 more Prize cards. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -5354,7 +5354,7 @@
     "level": "GX",
     "ability": {
       "name": "Slice Off",
-      "text": "When you play this Pokémon from your hand onto your Bench during your turn, you may discard a Special Energy from 1 of your opponent's Pokémon.",
+      "text": "When you play this Pokémon from your hand onto your Bench during your turn, you may discard a Special Energy from 1 of your opponent’s Pokémon.",
       "type": "Ability"
     },
     "hp": "170",
@@ -5392,7 +5392,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Take a Prize card. (You can't use more than 1 GX attack in a game.)"
+        "text": "Take a Prize card. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -5444,7 +5444,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 20 damage times the amount of Energy attached to this Pokémon to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage times the amount of Energy attached to this Pokémon to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Dragon Hammer",
@@ -5456,7 +5456,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       },
       {
         "name": "Tower-Go-Round-GX",
@@ -5531,7 +5531,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50×",
-        "text": "This attack does 50 damage for each of your opponent's Benched Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage for each of your opponent’s Benched Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -5653,7 +5653,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Discard an Energy from each of your opponent's Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "Discard an Energy from each of your opponent’s Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -5726,7 +5726,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "Your opponent can't play any cards from their hand during their next turn. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Your opponent can’t play any cards from their hand during their next turn. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -5783,7 +5783,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Symbiont-GX",
@@ -5794,7 +5794,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Add the top 2 cards of your opponent's deck to their Prize cards. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Add the top 2 cards of your opponent’s deck to their Prize cards. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -5838,7 +5838,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Knuckle Impact",
@@ -5849,7 +5849,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "160",
-        "text": "This Pokémon can't attack during your next turn."
+        "text": "This Pokémon can’t attack during your next turn."
       },
       {
         "name": "Absorption-GX",
@@ -5860,7 +5860,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40×",
-        "text": "This attack does 40 damage for each of your remaining Prize cards. (You can't use more than 1 GX attack in a game.)"
+        "text": "This attack does 40 damage for each of your remaining Prize cards. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -5932,7 +5932,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "100",
-        "text": "If your opponent's Pokémon is Knocked Out by damage from this attack, take 2 more Prize cards. (You can’t use more than 1 GX attack in a game.)"
+        "text": "If your opponent’s Pokémon is Knocked Out by damage from this attack, take 2 more Prize cards. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -5959,7 +5959,7 @@
     "level": "GX",
     "ability": {
       "name": "Slice Off",
-      "text": "When you play this Pokémon from your hand onto your Bench during your turn, you may discard a Special Energy from 1 of your opponent's Pokémon.",
+      "text": "When you play this Pokémon from your hand onto your Bench during your turn, you may discard a Special Energy from 1 of your opponent’s Pokémon.",
       "type": "Ability"
     },
     "hp": "170",
@@ -5997,7 +5997,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Take a Prize card. (You can't use more than 1 GX attack in a game.)"
+        "text": "Take a Prize card. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6049,7 +6049,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 20 damage times the amount of Energy attached to this Pokémon to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage times the amount of Energy attached to this Pokémon to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Dragon Hammer",
@@ -6061,7 +6061,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       },
       {
         "name": "Tower-Go-Round-GX",
@@ -6136,7 +6136,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50×",
-        "text": "This attack does 50 damage for each of your opponent's Benched Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage for each of your opponent’s Benched Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6161,7 +6161,7 @@
     "set": "Crimson Invasion",
     "setCode": "sm4",
     "text": [
-      "You can play this card only if you have more Prize cards remaining than your opponent. Switch 1 of your opponent's Benched Pokémon with their Active Pokémon."
+      "You can play this card only if you have more Prize cards remaining than your opponent. Switch 1 of your opponent’s Benched Pokémon with their Active Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm4/120_hires.png"
   },
@@ -6178,7 +6178,7 @@
     "set": "Crimson Invasion",
     "setCode": "sm4",
     "text": [
-      "If the Pokémon this card is attached to is your Active Pokémon and is Knocked Out by damage from an opponent's attack, move up to 3 basic Energy cards from that Pokémon to 1 of your Benched Pokémon."
+      "If the Pokémon this card is attached to is your Active Pokémon and is Knocked Out by damage from an opponent’s attack, move up to 3 basic Energy cards from that Pokémon to 1 of your Benched Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm4/121_hires.png"
   },
@@ -6195,7 +6195,7 @@
     "set": "Crimson Invasion",
     "setCode": "sm4",
     "text": [
-      "This card provides Colorless Energy. If you have more Prize cards remaining than your opponent, and if this card is attached to a Pokémon that isn't a Pokémon-GX or Pokémon-EX, this card provides every type of Energy but provides only 2 Energy at a time."
+      "This card provides Colorless Energy. If you have more Prize cards remaining than your opponent, and if this card is attached to a Pokémon that isn’t a Pokémon-GX or Pokémon-EX, this card provides every type of Energy but provides only 2 Energy at a time."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm4/122_hires.png"
   },

--- a/json/cards/Crystal Guardians.json
+++ b/json/cards/Crystal Guardians.json
@@ -8,7 +8,7 @@
     "evolvesFrom": "Shuppet",
     "ability": {
       "name": "Safeguard",
-      "text": "Prevent all effects of attacks, including damage, done to Banette by your opponent's Pokémon-ex.",
+      "text": "Prevent all effects of attacks, including damage, done to Banette by your opponent’s Pokémon-ex.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -91,7 +91,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage for each damage counter on Blastoise to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage for each damage counter on Blastoise to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Skull Bash",
@@ -123,7 +123,7 @@
     "evolvesFrom": "Numel",
     "ability": {
       "name": "Delta Protection",
-      "text": "Any damage done to Camerupt by attacks from your opponent's Pokémon that has δ on its card is reduced by 40 (after applying Weakness and Resistance).",
+      "text": "Any damage done to Camerupt by attacks from your opponent’s Pokémon that has δ on its card is reduced by 40 (after applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -149,7 +149,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Combustion",
@@ -234,7 +234,7 @@
     "evolvesFrom": "Diglett",
     "ability": {
       "name": "Sand Veil",
-      "text": "Prevent all damage done to your Benched Pokémon by your opponent's attacks.",
+      "text": "Prevent all damage done to your Benched Pokémon by your opponent’s attacks.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -259,7 +259,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. This attack’s damage isn’t affected by Weakness or Resistance."
       },
       {
         "name": "Double-edge",
@@ -291,7 +291,7 @@
     "evolvesFrom": "Lombre",
     "ability": {
       "name": "Overzealous",
-      "text": "If your opponent has any Pokémon-ex in play, each of Ludicolo's attacks does 30 more damage to the Defending Pokémon.",
+      "text": "If your opponent has any Pokémon-ex in play, each of Ludicolo’s attacks does 30 more damage to the Defending Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -317,7 +317,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Choose 1 card from your opponent's hand without looking and discard it."
+        "text": "Choose 1 card from your opponent’s hand without looking and discard it."
       },
       {
         "name": "Fire Punch",
@@ -367,7 +367,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Count the number of your opponent's Pokémon. Search your deck for up to that number of Basic Pokémon and put them onto your Bench. Shuffle your deck afterward."
+        "text": "Count the number of your opponent’s Pokémon. Search your deck for up to that number of Basic Pokémon and put them onto your Bench. Shuffle your deck afterward."
       },
       {
         "name": "Stadium Play",
@@ -376,7 +376,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If you have a Stadium card in play, remove 1 damage counter from each of your Pokémon. If your opponent has a Stadium card in play, this attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If you have a Stadium card in play, remove 1 damage counter from each of your Pokémon. If your opponent has a Stadium card in play, this attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -428,7 +428,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "If Manectric has a Pokémon Tool card attached to it, this attack does 20 damage to each of your opponent's Benched Pokémon-ex. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If Manectric has a Pokémon Tool card attached to it, this attack does 20 damage to each of your opponent’s Benched Pokémon-ex. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -509,7 +509,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Excavate",
-      "text": "Once during your turn (before your attack), you may look at the card on top of your deck. Put that card on top of your deck, or discard that card. This power can't be used if Sableye is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may look at the card on top of your deck. Put that card on top of your deck, or discard that card. This power can’t be used if Sableye is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -533,7 +533,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       }
     ],
     "resistances": [
@@ -660,7 +660,7 @@
     "evolvesFrom": "Jigglypuff",
     "ability": {
       "name": "Fluffy Fur",
-      "text": "If Wigglytuff is your Active Pokémon and is damaged by an opponent's attack (even if Wigglytuff is Knocked Out), the Attacking Pokémon is now Asleep.",
+      "text": "If Wigglytuff is your Active Pokémon and is damaged by an opponent’s attack (even if Wigglytuff is Knocked Out), the Attacking Pokémon is now Asleep.",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -716,7 +716,7 @@
     "evolvesFrom": "Wartortle",
     "ability": {
       "name": "Water Pressure",
-      "text": "As long as Blastoise's remaining HP is 40 or less, Blastoise does 40 more damage to the Defending Pokémon (before applying Weakness and Resistance).",
+      "text": "As long as Blastoise’s remaining HP is 40 or less, Blastoise does 40 more damage to the Defending Pokémon (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -743,7 +743,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50+",
-        "text": "Does 50 damage plus 20 more damage for each Water Energy attached to Blastoise but not used to pay for this attack's Energy cost. You can't add more than 40 damage in this way."
+        "text": "Does 50 damage plus 20 more damage for each Water Energy attached to Blastoise but not used to pay for this attack’s Energy cost. You can’t add more than 40 damage in this way."
       }
     ],
     "weaknesses": [
@@ -764,7 +764,7 @@
     "evolvesFrom": "Cacnea",
     "ability": {
       "name": "Spike Storm",
-      "text": "Once during your turn (before your attack), if Cacturne is your Active Pokémon, you may put 1 damage counter on 1 of your opponent's Pokémon that already has any damage counters on it. This power can't be used if Cacturne is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Cacturne is your Active Pokémon, you may put 1 damage counter on 1 of your opponent’s Pokémon that already has any damage counters on it. This power can’t be used if Cacturne is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -788,7 +788,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 3 of your opponent's Pokémon. This attack does 10 damage to each of those Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 3 of your opponent’s Pokémon. This attack does 10 damage to each of those Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Light Punch",
@@ -839,7 +839,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, Combusken's High Jump Kick attack's base damage is 70."
+        "text": "During your next turn, Combusken’s High Jump Kick attack’s base damage is 70."
       },
       {
         "name": "High Jump Kick",
@@ -873,7 +873,7 @@
     "evolvesFrom": "Duskull",
     "ability": {
       "name": "Cursed Glare",
-      "text": "As long as Dusclops is your Active Pokémon, your opponent can't attach any Special Energy cards (except for Darkness and Metal Energy cards) from his or her hand to his or her Active Pokémon.",
+      "text": "As long as Dusclops is your Active Pokémon, your opponent can’t attach any Special Energy cards (except for Darkness and Metal Energy cards) from his or her hand to his or her Active Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -909,7 +909,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Prevent all effects of attacks, including damage, done to Dusclops by your opponent's Pokémon-ex during your opponent's next turn."
+        "text": "Prevent all effects of attacks, including damage, done to Dusclops by your opponent’s Pokémon-ex during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -939,7 +939,7 @@
     "evolvesFrom": "Spearow",
     "ability": {
       "name": "Delta Sign",
-      "text": "Once during your turn (before your attack), you may search your deck for a Pokémon that has δ on its card, show it to your opponent, and put it into your hand. Shuffle your deck afterward. You can't use more than 1 Delta Sign Poké-Power each turn. This power can't be used if Fearow is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may search your deck for a Pokémon that has δ on its card, show it to your opponent, and put it into your hand. Shuffle your deck afterward. You can’t use more than 1 Delta Sign Poké-Power each turn. This power can’t be used if Fearow is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -1022,7 +1022,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Grovyle during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Grovyle during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1079,7 +1079,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "10x",
-        "text": "Does 10 damage times the number of Pokémon in play (both yours and your opponent's), excluding Grumpig."
+        "text": "Does 10 damage times the number of Pokémon in play (both yours and your opponent’s), excluding Grumpig."
       }
     ],
     "weaknesses": [
@@ -1214,7 +1214,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Choose 1 card from your opponent's hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
+        "text": "Choose 1 card from your opponent’s hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
       },
       {
         "name": "Bass Control",
@@ -1225,7 +1225,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 40 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1279,7 +1279,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1339,7 +1339,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -1423,7 +1423,7 @@
     "evolvesFrom": "Marshtomp",
     "ability": {
       "name": "Echo Draw",
-      "text": "Once during your turn (before your attack), you may draw a card. This power can't be used if Swampert is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may draw a card. This power can’t be used if Swampert is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -1450,7 +1450,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -1716,7 +1716,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Grovyle during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Grovyle during your opponent’s next turn."
       },
       {
         "name": "Smash Kick",
@@ -1774,7 +1774,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Sludge Toss",
@@ -1884,7 +1884,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Benched Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Benched Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Sharp Leaf",
@@ -2055,7 +2055,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Mud Shot",
@@ -2236,7 +2236,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
       }
     ],
     "weaknesses": [
@@ -2334,7 +2334,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack during your opponent’s next turn."
       },
       {
         "name": "Bite",
@@ -2704,7 +2704,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3002,7 +3002,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Put 2 damage counters on your opponent's Pokémon in any way you like."
+        "text": "Put 2 damage counters on your opponent’s Pokémon in any way you like."
       }
     ],
     "weaknesses": [
@@ -3025,7 +3025,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Submerge",
-      "text": "As long as Mudkip is on your Bench, prevent all damage done to Mudkip by attacks (both yours and your opponent's).",
+      "text": "As long as Mudkip is on your Bench, prevent all damage done to Mudkip by attacks (both yours and your opponent’s).",
       "type": "Poké-Body"
     },
     "hp": "50",
@@ -3470,7 +3470,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -3703,7 +3703,7 @@
   },
   {
     "id": "ex14-71",
-    "name": "Bill's Maintenance",
+    "name": "Bill’s Maintenance",
     "imageUrl": "https://images.pokemontcg.io/ex14/71.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -3741,7 +3741,7 @@
   },
   {
     "id": "ex14-73",
-    "name": "Celio's Network",
+    "name": "Celio’s Network",
     "imageUrl": "https://images.pokemontcg.io/ex14/73.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -3772,8 +3772,8 @@
     "set": "Crystal Guardians",
     "setCode": "ex14",
     "text": [
-      "Attach Cessation Crystal to 1 of your Pokémon (excluding Pokémon-ex) that doesn't already have a Pokémon Tool attached to it. If the Pokémon Cessation Crystal is attached to is a Pokémon-ex, discard this card.",
-      "As long as Cessation Crystal is attached to an Active Pokémon, each player's Pokémon (both yours and your opponent's) can't use any Poké-Powers or Poké-Bodies."
+      "Attach Cessation Crystal to 1 of your Pokémon (excluding Pokémon-ex) that doesn’t already have a Pokémon Tool attached to it. If the Pokémon Cessation Crystal is attached to is a Pokémon-ex, discard this card.",
+      "As long as Cessation Crystal is attached to an Active Pokémon, each player’s Pokémon (both yours and your opponent’s) can’t use any Poké-Powers or Poké-Bodies."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex14/74_hires.png"
   },
@@ -3791,8 +3791,8 @@
     "set": "Crystal Guardians",
     "setCode": "ex14",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "Each Special Energy card that provides 2 or more Energy (both yours and your opponent's) now provides only 1 Colorless Energy. This isn't affected by any Poké-Powers or Poké-Bodies."
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
+      "Each Special Energy card that provides 2 or more Energy (both yours and your opponent’s) now provides only 1 Colorless Energy. This isn’t affected by any Poké-Powers or Poké-Bodies."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex14/75_hires.png"
   },
@@ -3810,8 +3810,8 @@
     "set": "Crystal Guardians",
     "setCode": "ex14",
     "text": [
-      "Attach Crystal Shard to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
-      "As long as Crystal Shard is attached to a Pokémon, that Pokémon's type is Colorless. If that Pokémon attacks, discard this card at the end of the turn."
+      "Attach Crystal Shard to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
+      "As long as Crystal Shard is attached to a Pokémon, that Pokémon’s type is Colorless. If that Pokémon attacks, discard this card at the end of the turn."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex14/76_hires.png"
   },
@@ -3865,8 +3865,8 @@
     "set": "Crystal Guardians",
     "setCode": "ex14",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "Prevent all effects of an attack, including damage, done by either player's Active Pokémon. If an Active Pokémon uses an attack, that attack ends, and discard this card."
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
+      "Prevent all effects of an attack, including damage, done by either player’s Active Pokémon. If an Active Pokémon uses an attack, that attack ends, and discard this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex14/79_hires.png"
   },
@@ -3884,8 +3884,8 @@
     "set": "Crystal Guardians",
     "setCode": "ex14",
     "text": [
-      "Attach Memory Berry to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
-      "The Pokémon this card is attached to can use any attack from its Basic Pokémon or its Stage 1 Evolution card. (You still have to pay for that attack's Energy cost.) If that Pokémon attacks, discard this card at the end of the turn."
+      "Attach Memory Berry to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
+      "The Pokémon this card is attached to can use any attack from its Basic Pokémon or its Stage 1 Evolution card. (You still have to pay for that attack’s Energy cost.) If that Pokémon attacks, discard this card at the end of the turn."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex14/80_hires.png"
   },
@@ -3903,8 +3903,8 @@
     "set": "Crystal Guardians",
     "setCode": "ex14",
     "text": [
-      "Attach Mysterious Shard to 1 of your Pokémon (excluding Pokémon-ex) that doesn't already have a Pokémon Tool attached to it. If the Pokémon Mysterious Shard is attached to is a Pokémon-ex, discard this card.",
-      "Prevent all effects of attacks, including damage, done to the Pokémon that Mysterious Shard is attached to by your opponent's Pokémon-ex. Discard this card at the end of your opponent's next turn."
+      "Attach Mysterious Shard to 1 of your Pokémon (excluding Pokémon-ex) that doesn’t already have a Pokémon Tool attached to it. If the Pokémon Mysterious Shard is attached to is a Pokémon-ex, discard this card.",
+      "Prevent all effects of attacks, including damage, done to the Pokémon that Mysterious Shard is attached to by your opponent’s Pokémon-ex. Discard this card at the end of your opponent’s next turn."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex14/81_hires.png"
   },
@@ -3976,7 +3976,7 @@
     "set": "Crystal Guardians",
     "setCode": "ex14",
     "text": [
-      "Choose up to 2 in any combination of Pokémon Tool cards and Stadium cards in play (both yours and your opponent's) and discard them."
+      "Choose up to 2 in any combination of Pokémon Tool cards and Stadium cards in play (both yours and your opponent’s) and discard them."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex14/85_hires.png"
   },
@@ -4029,7 +4029,7 @@
     "set": "Crystal Guardians",
     "setCode": "ex14",
     "text": [
-      "Double Rainbow Energy can be attached only to an Evolved Pokémon (excluding Pokémon-ex). While in play, Double Rainbow Energy provides every type of Energy but provides 2 Energy at a time. (Has no effect other than providing Energy.) Damage done to your opponent's Pokémon by the Pokémon Double Rainbow Energy is attached to is reduced by 10 (before applying Weakness and Resistance). When the Pokémon Double Rainbow Energy is attached to is no longer an Evolved Pokémon, discard Double Rainbow Energy."
+      "Double Rainbow Energy can be attached only to an Evolved Pokémon (excluding Pokémon-ex). While in play, Double Rainbow Energy provides every type of Energy but provides 2 Energy at a time. (Has no effect other than providing Energy.) Damage done to your opponent’s Pokémon by the Pokémon Double Rainbow Energy is attached to is reduced by 10 (before applying Weakness and Resistance). When the Pokémon Double Rainbow Energy is attached to is no longer an Evolved Pokémon, discard Double Rainbow Energy."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex14/88_hires.png"
   },
@@ -4043,7 +4043,7 @@
     "evolvesFrom": "Lairon",
     "ability": {
       "name": "Intimidating Armor",
-      "text": "As long as Aggron ex is your Active Pokémon, your opponent's Basic Pokémon can't attack or use any Poké-Powers or Poké-Bodies.",
+      "text": "As long as Aggron ex is your Active Pokémon, your opponent’s Basic Pokémon can’t attack or use any Poké-Powers or Poké-Bodies.",
       "type": "Poké-Body"
     },
     "hp": "150",
@@ -4075,7 +4075,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 2 of your opponent's Pokémon. This attack does 30 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 2 of your opponent’s Pokémon. This attack does 30 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Mega Burn",
@@ -4087,7 +4087,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "During your next turn, Aggron ex can't use Mega Burn."
+        "text": "During your next turn, Aggron ex can’t use Mega Burn."
       }
     ],
     "weaknesses": [
@@ -4139,7 +4139,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Before doing damage, you may choose 1 of your opponent's Benched Pokémon and switch it with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
+        "text": "Before doing damage, you may choose 1 of your opponent’s Benched Pokémon and switch it with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
       },
       {
         "name": "Burn Away",
@@ -4151,7 +4151,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "Before doing damage, count the remaining HP of the Defending Pokémon. If that Pokémon is Knocked Out by this attack, Blaziken ex does damage to itself equal to this attack's damage minus the remaining HP of the Defending Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
+        "text": "Before doing damage, count the remaining HP of the Defending Pokémon. If that Pokémon is Knocked Out by this attack, Blaziken ex does damage to itself equal to this attack’s damage minus the remaining HP of the Defending Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
       }
     ],
     "weaknesses": [
@@ -4173,7 +4173,7 @@
     "evolvesFrom": "Skitty",
     "ability": {
       "name": "Constrain",
-      "text": "Once during your turn (before your attack), you may use this power. Each player discards cards until that player has 6 cards in his or her hand. (You discard first.) This power can't be used if Delcatty ex is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may use this power. Each player discards cards until that player has 6 cards in his or her hand. (You discard first.) This power can’t be used if Delcatty ex is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -4230,7 +4230,7 @@
     "evolvesFrom": "Loudred",
     "ability": {
       "name": "Extra Noise",
-      "text": "As long as Exploud ex is your Active Pokémon, put 1 damage counter on each of your opponent's Pokémon-ex between turns.",
+      "text": "As long as Exploud ex is your Active Pokémon, put 1 damage counter on each of your opponent’s Pokémon-ex between turns.",
       "type": "Poké-Body"
     },
     "hp": "150",
@@ -4292,7 +4292,7 @@
     "level": "ex",
     "ability": {
       "name": "Hard Rock",
-      "text": "As long as Groudon ex has 1 Energy or less attached to it, damage done to any of your Groudon ex in play by attacks is reduced by 20 (after applying Weakness and Resistance). You can't use more than 1 Hard Rock Poké-Body each turn.",
+      "text": "As long as Groudon ex has 1 Energy or less attached to it, damage done to any of your Groudon ex in play by attacks is reduced by 20 (after applying Weakness and Resistance). You can’t use more than 1 Hard Rock Poké-Body each turn.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -4371,7 +4371,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "During your opponent's next turn, your opponent can't use any Poké-Powers on his or her Pokémon."
+        "text": "During your opponent’s next turn, your opponent can’t use any Poké-Powers on his or her Pokémon."
       },
       {
         "name": "Super Psy Bolt",
@@ -4427,7 +4427,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Discard 2 Energy attached to Kyogre ex. Choose 1 of your opponent's Pokémon. This attack does 70 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard 2 Energy attached to Kyogre ex. Choose 1 of your opponent’s Pokémon. This attack does 70 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4449,7 +4449,7 @@
     "evolvesFrom": "Grovyle",
     "ability": {
       "name": "Extra Liquid",
-      "text": "Each player's Pokémon-ex can't use any Poké-Powers and pays Colorless more Energy to use its attacks. Each Pokémon can't be affected by more than 1 Extra Liquid Poké-Body.",
+      "text": "Each player’s Pokémon-ex can’t use any Poké-Powers and pays Colorless more Energy to use its attacks. Each Pokémon can’t be affected by more than 1 Extra Liquid Poké-Body.",
       "type": "Poké-Body"
     },
     "hp": "140",
@@ -4505,7 +4505,7 @@
     "evolvesFrom": "Nuzleaf",
     "ability": {
       "name": "Dark Eyes",
-      "text": "After your opponent's Pokémon uses a Poké-Power, put 2 damage counters on that Pokémon.",
+      "text": "After your opponent’s Pokémon uses a Poké-Power, put 2 damage counters on that Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "140",
@@ -4530,7 +4530,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. If that Pokémon already has any damage counters on it, this attack does 50 damage instead. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. If that Pokémon already has any damage counters on it, this attack does 50 damage instead. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Blade Arms",
@@ -4569,7 +4569,7 @@
     "evolvesFrom": "Marshtomp",
     "ability": {
       "name": "Energy Recycle",
-      "text": "Once during your turn (before your attack), you may search your discard pile for 3 Energy cards and attach them to your Pokémon in any way you like. If you do, your turn ends. This power can't be used if Swampert ex is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may search your discard pile for 3 Energy cards and attach them to your Pokémon in any way you like. If you do, your turn ends. This power can’t be used if Swampert ex is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "150",
@@ -4600,7 +4600,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "You may discard 2 cards from your hand. If you do, this attack does 60 damage plus 20 more damage and does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "You may discard 2 cards from your hand. If you do, this attack does 60 damage plus 20 more damage and does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4629,7 +4629,7 @@
     "set": "Crystal Guardians",
     "setCode": "ex14",
     "text": [
-      "You can't have more than 1 Pokémon Star in your deck."
+      "You can’t have more than 1 Pokémon Star in your deck."
     ],
     "types": [
       "Psychic"
@@ -4653,7 +4653,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Discard a Basic Pokémon or Evolution card from your hand. Choose 1 of that card's attacks. Skill Copy copies that attack. This attack does nothing if Alakazam Star doesn't have the Energy necessary to use that attack. (You must still do anything else required for that attack.) Alakazam Star performs that attack."
+        "text": "Discard a Basic Pokémon or Evolution card from your hand. Choose 1 of that card’s attacks. Skill Copy copies that attack. This attack does nothing if Alakazam Star doesn’t have the Energy necessary to use that attack. (You must still do anything else required for that attack.) Alakazam Star performs that attack."
       }
     ],
     "weaknesses": [
@@ -4673,7 +4673,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Time Travel",
-      "text": "If Celebi Star would be Knocked Out by damage from an opponent's attack, you may flip a coin. If heads, Celebi Star is not Knocked Out, discard all cards attached to Celebi Star, and put Celebi Star on the bottom of your deck.",
+      "text": "If Celebi Star would be Knocked Out by damage from an opponent’s attack, you may flip a coin. If heads, Celebi Star is not Knocked Out, discard all cards attached to Celebi Star, and put Celebi Star on the bottom of your deck.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -4687,7 +4687,7 @@
     "set": "Crystal Guardians",
     "setCode": "ex14",
     "text": [
-      "You can't have more than 1 Pokémon Star in your deck."
+      "You can’t have more than 1 Pokémon Star in your deck."
     ],
     "types": [
       "Grass"
@@ -4700,7 +4700,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Count the amount of Energy attached to Celebi Star. Put that many damage counters on 1 of your opponent's Pokémon."
+        "text": "Count the amount of Energy attached to Celebi Star. Put that many damage counters on 1 of your opponent’s Pokémon."
       }
     ],
     "weaknesses": [

--- a/json/cards/Dark Explorers.json
+++ b/json/cards/Dark Explorers.json
@@ -251,7 +251,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon. The new Defending Pokémon is now Poisoned."
+        "text": "Switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon. The new Defending Pokémon is now Poisoned."
       },
       {
         "name": "Spit Squall",
@@ -432,7 +432,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "Flip a coin. If heads, this attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -617,7 +617,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Fire Slash",
@@ -1107,7 +1107,7 @@
     "evolvesFrom": "Larvesta",
     "ability": {
       "name": "Scorching Scales",
-      "text": "Put 4 damage counters instead of 2 on your opponent's Burned Pokémon between turns.",
+      "text": "Put 4 damage counters instead of 2 on your opponent’s Burned Pokémon between turns.",
       "type": "Ability"
     },
     "hp": "110",
@@ -1211,7 +1211,7 @@
     "evolvesFrom": "Slowpoke",
     "ability": {
       "name": "Airhead",
-      "text": "If you have 2, 4, or 6 Prize cards left, this Pokémon can't attack.",
+      "text": "If you have 2, 4, or 6 Prize cards left, this Pokémon can’t attack.",
       "type": "Ability"
     },
     "hp": "100",
@@ -1279,7 +1279,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Spiral Drain",
@@ -1347,7 +1347,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 50 damage to 2 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 50 damage to 2 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1490,7 +1490,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10x",
-        "text": "Does 10 damage times the number of Pokémon in play (both yours and your opponent's)."
+        "text": "Does 10 damage times the number of Pokémon in play (both yours and your opponent’s)."
       }
     ],
     "weaknesses": [
@@ -1932,7 +1932,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Discard all Lightning Energy attached to this Pokémon. This attack does 100 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard all Lightning Energy attached to this Pokémon. This attack does 100 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2019,7 +2019,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 30 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 30 (before applying Weakness and Resistance)."
       },
       {
         "name": "Electrishower",
@@ -2028,7 +2028,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2253,7 +2253,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2367,7 +2367,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon. This attack does 60 damage to the new Defending Pokémon."
+        "text": "Switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon. This attack does 60 damage to the new Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -2388,7 +2388,7 @@
     "evolvesFrom": "Eevee",
     "ability": {
       "name": "Solar Revelation",
-      "text": "Prevent all effects of your opponent's attacks, except damage, done to each of your Pokémon that has any Energy attached to it.",
+      "text": "Prevent all effects of your opponent’s attacks, except damage, done to each of your Pokémon that has any Energy attached to it.",
       "type": "Ability"
     },
     "hp": "90",
@@ -2563,7 +2563,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, choose a card at random from your opponent's hand. Your opponent reveals that card and shuffles it into his or her deck."
+        "text": "Flip a coin. If heads, choose a card at random from your opponent’s hand. Your opponent reveals that card and shuffles it into his or her deck."
       }
     ],
     "weaknesses": [
@@ -2618,7 +2618,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2638,7 +2638,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Ancient Scream",
-      "text": "Your Pokémon's attacks do 10 more damage to the Active Pokémon (before applying Weakness and Resistance).",
+      "text": "Your Pokémon’s attacks do 10 more damage to the Active Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "90",
@@ -2713,7 +2713,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Giant Claw",
@@ -2822,7 +2822,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Dig Uppercut",
@@ -2895,7 +2895,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "70",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -3062,7 +3062,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "This Pokémon can't use Slashing Strike during your next turn."
+        "text": "This Pokémon can’t use Slashing Strike during your next turn."
       }
     ],
     "weaknesses": [
@@ -3218,7 +3218,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": "Does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3264,7 +3264,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent’s next turn."
       },
       {
         "name": "Corkscrew Punch",
@@ -3392,7 +3392,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Bombast",
@@ -3625,7 +3625,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3851,7 +3851,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "During your opponent's next turn, this Pokémon has no Weakness."
+        "text": "During your opponent’s next turn, this Pokémon has no Weakness."
       }
     ],
     "weaknesses": [
@@ -4624,7 +4624,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 30 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 30 (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -4810,7 +4810,7 @@
     "set": "Dark Explorers",
     "setCode": "bw5",
     "text": [
-      "Discard a Special Energy attached to 1 of your opponent's Pokémon."
+      "Discard a Special Energy attached to 1 of your opponent’s Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw5/94_hires.png"
   },
@@ -4827,7 +4827,7 @@
     "set": "Dark Explorers",
     "setCode": "bw5",
     "text": [
-      "Flip a coin. If heads, choose 3 random cards from your opponent's hand. Your opponent reveals those cards and shuffles them into his or her deck."
+      "Flip a coin. If heads, choose 3 random cards from your opponent’s hand. Your opponent reveals those cards and shuffles them into his or her deck."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw5/95_hires.png"
   },
@@ -4912,7 +4912,7 @@
     "set": "Dark Explorers",
     "setCode": "bw5",
     "text": [
-      "Choose 1 of your Basic Pokémon in play. If you have a Stage 2 card in your hand that evolves from that Pokémon, put that card on the Basic Pokémon. (This counts as evolving that Pokémon.) You can't use this card during your first turn or on a Basic Pokémon that was put into play this turn."
+      "Choose 1 of your Basic Pokémon in play. If you have a Stage 2 card in your hand that evolves from that Pokémon, put that card on the Basic Pokémon. (This counts as evolving that Pokémon.) You can’t use this card during your first turn or on a Basic Pokémon that was put into play this turn."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw5/100_hires.png"
   },
@@ -4929,7 +4929,7 @@
     "set": "Dark Explorers",
     "setCode": "bw5",
     "text": [
-      "Once during each player's turn, that player may flip a coin. If heads, the player searches his or her deck for a Restored Pokémon and puts it onto his or her Bench."
+      "Once during each player’s turn, that player may flip a coin. If heads, the player searches his or her deck for a Restored Pokémon and puts it onto his or her Bench."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw5/101_hires.png"
   },
@@ -4946,7 +4946,7 @@
     "set": "Dark Explorers",
     "setCode": "bw5",
     "text": [
-      "Discard 2 cards from your hand. (If you can't discard 2 cards, you can't play this card.) Search your deck for a Pokémon, reveal it, and put it into your hand. Shuffle your deck afterward."
+      "Discard 2 cards from your hand. (If you can’t discard 2 cards, you can’t play this card.) Search your deck for a Pokémon, reveal it, and put it into your hand. Shuffle your deck afterward."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw5/102_hires.png"
   },
@@ -5051,7 +5051,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 50 damage to 2 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 50 damage to 2 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -5105,7 +5105,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Discard all Lightning Energy attached to this Pokémon. This attack does 100 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard all Lightning Energy attached to this Pokémon. This attack does 100 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -5151,7 +5151,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Giant Claw",
@@ -5218,7 +5218,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": "Does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -5305,7 +5305,7 @@
     "evolvesFrom": "Kirlia",
     "ability": {
       "name": "Psychic Mirage",
-      "text": "Each basic Psychic Energy attached to your Psychic Pokémon provides PsychicPsychic Energy. You can't apply more than 1 Psychic Mirage Ability at a time.",
+      "text": "Each basic Psychic Energy attached to your Psychic Pokémon provides PsychicPsychic Energy. You can’t apply more than 1 Psychic Mirage Ability at a time.",
       "type": "Ability"
     },
     "hp": "110",
@@ -5333,7 +5333,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "This attack's damage isn't affected by Weakness or Resistance."
+        "text": "This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -5354,7 +5354,7 @@
     "evolvesFrom": "Archen",
     "ability": {
       "name": "Ancient Power",
-      "text": "Each player can't play any Pokémon from his or her hand to evolve his or her Pokémon.",
+      "text": "Each player can’t play any Pokémon from his or her hand to evolve his or her Pokémon.",
       "type": "Ability"
     },
     "hp": "130",
@@ -5381,7 +5381,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Does 10 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -5406,7 +5406,7 @@
     "set": "Dark Explorers",
     "setCode": "bw5",
     "text": [
-      "Switch your opponent's Active Pokémon with 1 of his or her Benched Pokémon."
+      "Switch your opponent’s Active Pokémon with 1 of his or her Benched Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw5/111_hires.png"
   }

--- a/json/cards/Delta Species.json
+++ b/json/cards/Delta Species.json
@@ -8,7 +8,7 @@
     "evolvesFrom": "Kakuna",
     "ability": {
       "name": "Final Sting",
-      "text": "Once during your turn (before your attack), you may Knock Out Beedrill. If you do, choose 1 of your opponent's Defending Pokémon. That Pokémon is now Paralyzed and Poisoned. Put 2 damage counters instead of 1 on that Pokémon between turns. This power can't be used if Beedrill is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may Knock Out Beedrill. If you do, choose 1 of your opponent’s Defending Pokémon. That Pokémon is now Paralyzed and Poisoned. Put 2 damage counters instead of 1 on that Pokémon between turns. This power can’t be used if Beedrill is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -77,7 +77,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent can't play any Trainer cards (except for Supporter cards) from his or her hand during your opponent's next turn."
+        "text": "Your opponent can’t play any Trainer cards (except for Supporter cards) from his or her hand during your opponent’s next turn."
       },
       {
         "name": "Target Attack",
@@ -88,7 +88,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. If that Pokémon already has damage counters on it, this attack does 60 damage instead. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 40 damage to that Pokémon. If that Pokémon already has damage counters on it, this attack does 60 damage instead. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -109,7 +109,7 @@
     "evolvesFrom": "Dragonair",
     "ability": {
       "name": "Delta Charge",
-      "text": "Once during your turn (before your attack), you may attach a Lightning Energy card from your discard pile to 1 of your Benched Pokémon. This power can't be used if Dragonite is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may attach a Lightning Energy card from your discard pile to 1 of your Benched Pokémon. This power can’t be used if Dragonite is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -139,7 +139,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Dragonite during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Dragonite during your opponent’s next turn."
       },
       {
         "name": "Heavy Impact",
@@ -182,7 +182,7 @@
     "evolvesFrom": "Eevee",
     "ability": {
       "name": "Delta Heal",
-      "text": "Once during your turn (before your attack), you may remove 1 damage counter from each of your Pokémon that has δ on its card. You can't use more than 1 Delta Heal Poké-Power each turn. This power can't be used if Espeon is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may remove 1 damage counter from each of your Pokémon that has δ on its card. You can’t use more than 1 Delta Heal Poké-Power each turn. This power can’t be used if Espeon is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -285,7 +285,7 @@
     "evolvesFrom": "Kirlia",
     "ability": {
       "name": "Energy Jump",
-      "text": "Once during your turn (before your attack), you may move an Energy card attached to 1 of your Pokémon to another of your Pokémon. This power can't be used if Gardevoir is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may move an Energy card attached to 1 of your Pokémon to another of your Pokémon. This power can’t be used if Gardevoir is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -315,7 +315,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage for each damage counter on Gardevoir to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage for each damage counter on Gardevoir to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Black Magic",
@@ -326,7 +326,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "10+",
-        "text": "Does 10 damage plus 20 more damage times the number of your opponent's Benched Pokémon."
+        "text": "Does 10 damage plus 20 more damage times the number of your opponent’s Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -381,7 +381,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "You may return an Energy card attached to Jolteon to your hand. If you do, this attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "You may return an Energy card attached to Jolteon to your hand. If you do, this attack does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -407,7 +407,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Delta Aura",
-      "text": "If you have Latios or Latios ex in play, the attack cost of Latias's Extra Crush is now Lightning Metal Colorless.",
+      "text": "If you have Latios or Latios ex in play, the attack cost of Latias’s Extra Crush is now Lightning Metal Colorless.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -479,7 +479,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Delta Aura",
-      "text": "If you have Latias or Latias ex in play, the attack cost of Latios's Psychic Force is now Lightning Metal Colorless.",
+      "text": "If you have Latias or Latias ex in play, the attack cost of Latios’s Psychic Force is now Lightning Metal Colorless.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -577,7 +577,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose a number of your opponent's Pokémon up to the amount of Energy attached to Marowak. This attack does 20 damage to each of them."
+        "text": "Choose a number of your opponent’s Pokémon up to the amount of Energy attached to Marowak. This attack does 20 damage to each of them."
       },
       {
         "name": "Metal Crusher",
@@ -588,7 +588,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "If the Defending Pokémon is Metal Pokémon, this attack's base damage is 90."
+        "text": "If the Defending Pokémon is Metal Pokémon, this attack’s base damage is 90."
       }
     ],
     "weaknesses": [
@@ -609,7 +609,7 @@
     "evolvesFrom": "Metang",
     "ability": {
       "name": "Delta Control",
-      "text": "Once during your turn (before your attack), you may look at the top 4 cards of your deck, choose 1 of them, and put it into your hand. Put the 3 other cards on the bottom of your deck in any order. This power can't be used if Metagross is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may look at the top 4 cards of your deck, choose 1 of them, and put it into your hand. Put the 3 other cards on the bottom of your deck in any order. This power can’t be used if Metagross is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -715,7 +715,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Delta Guard",
-      "text": "As long as Rayquaza has any Holon Energy cards attached to it, ignore the effect of Rayquaza's Lightning Storm attack.",
+      "text": "As long as Rayquaza has any Holon Energy cards attached to it, ignore the effect of Rayquaza’s Lightning Storm attack.",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -855,7 +855,7 @@
     "evolvesFrom": "Staryu",
     "ability": {
       "name": "Metal Navigation",
-      "text": "Once during your turn (before your attack), you may search your deck for a Metal Energy card and attach it to Starmie. Shuffle your deck afterward. This power can't be used if Starmie is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may search your deck for a Metal Energy card and attach it to Starmie. Shuffle your deck afterward. This power can’t be used if Starmie is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -910,7 +910,7 @@
     "evolvesFrom": "Pupitar",
     "ability": {
       "name": "Crush Draw",
-      "text": "Once during your turn (before your attack), you may reveal the top card of your deck. If that card is a basic Energy card, attach it to 1 of your Pokémon. If not, put the card back on top of your deck. This power can't be used if Tyranitar is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may reveal the top card of your deck. If that card is a basic Energy card, attach it to 1 of your Pokémon. If not, put the card back on top of your deck. This power can’t be used if Tyranitar is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -962,7 +962,7 @@
     "evolvesFrom": "Eevee",
     "ability": {
       "name": "Delta Moon",
-      "text": "When your opponent attaches a Special Energy card from his or her hand to 1 of his or her Pokémon, put 1 damage counter on that Pokémon. You can't use more than 1 Delta Moon Poké-Body each turn.",
+      "text": "When your opponent attaches a Special Energy card from his or her hand to 1 of his or her Pokémon, put 1 damage counter on that Pokémon. You can’t use more than 1 Delta Moon Poké-Body each turn.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -991,7 +991,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
       }
     ],
     "weaknesses": [
@@ -1052,7 +1052,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "You may return an Energy card attached to Vaporeon to your hand. If you do, choose an Energy card attached to the Defending Pokémon and return it to your opponent's hand."
+        "text": "You may return an Energy card attached to Vaporeon to your hand. If you do, choose an Energy card attached to the Defending Pokémon and return it to your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -1170,11 +1170,11 @@
   },
   {
     "id": "ex11-21",
-    "name": "Holon's Electrode",
+    "name": "Holon’s Electrode",
     "imageUrl": "https://images.pokemontcg.io/ex11/21.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
-    "evolvesFrom": "Holon's Voltorb",
+    "evolvesFrom": "Holon’s Voltorb",
     "hp": "70",
     "number": "21",
     "artist": "Hisao Nakamura",
@@ -1211,11 +1211,11 @@
   },
   {
     "id": "ex11-22",
-    "name": "Holon's Magneton",
+    "name": "Holon’s Magneton",
     "imageUrl": "https://images.pokemontcg.io/ex11/22.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
-    "evolvesFrom": "Holon's Magnemite",
+    "evolvesFrom": "Holon’s Magnemite",
     "hp": "70",
     "retreatCost": [
       "Colorless"
@@ -1271,7 +1271,7 @@
     "evolvesFrom": "Drowzee",
     "ability": {
       "name": "Binding Aura",
-      "text": "Your opponent can't play any Basic Pokémon or Evolution cards from his or her hand to evolve an Asleep Pokémon and can't attach any Energy cards from his or her hand to an Asleep Pokémon.",
+      "text": "Your opponent can’t play any Basic Pokémon or Evolution cards from his or her hand to evolve an Asleep Pokémon and can’t attach any Energy cards from his or her hand to an Asleep Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -1295,7 +1295,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. The new Defending Pokémon is now Asleep."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. The new Defending Pokémon is now Asleep."
       },
       {
         "name": "Psyshot",
@@ -1350,7 +1350,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If the Defending Pokémon is Pokémon-ex, that Pokémon can't attack during your opponent's next turn."
+        "text": "If the Defending Pokémon is Pokémon-ex, that Pokémon can’t attack during your opponent’s next turn."
       },
       {
         "name": "Gang Up",
@@ -1387,7 +1387,7 @@
     "evolvesFrom": "Porygon",
     "ability": {
       "name": "Backup",
-      "text": "Once during your turn (before your attack), if you have less than 6 cards in your hand, you may draw cards until you have 6 cards in your hand. This power can't be used if Porygon2 is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if you have less than 6 cards in your hand, you may draw cards until you have 6 cards in your hand. This power can’t be used if Porygon2 is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -1434,7 +1434,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Temperamental Weather",
-      "text": "Once during your turn (before your attack), you may search your deck for Castform, Sunny Castform, or Snow-cloud Castform and switch it with Rain Castform. (Any cards attached to Rain Castform, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) Shuffle Rain Castform back into your deck. You can't use more than 1 Temperamental Weather Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for Castform, Sunny Castform, or Snow-cloud Castform and switch it with Rain Castform. (Any cards attached to Rain Castform, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) Shuffle Rain Castform back into your deck. You can’t use more than 1 Temperamental Weather Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -1481,7 +1481,7 @@
     "evolvesFrom": "Sandshrew",
     "ability": {
       "name": "Delta Storm",
-      "text": "As long as Sandslash is your Active Pokémon, put 1 damage counter on each of your opponent's Pokémon-ex between turns.",
+      "text": "As long as Sandslash is your Active Pokémon, put 1 damage counter on each of your opponent’s Pokémon-ex between turns.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -1542,7 +1542,7 @@
     "evolvesFrom": "Slowpoke",
     "ability": {
       "name": "Prize Shift",
-      "text": "Once during your turn (before your attack), you may choose a card from your hand and put it as a Prize card face up. If you do, choose 1 of your face-down Prize cards without looking and put it into your hand. This power can't be used if Slowking is affected by a Special Condition or if all of your Prize cards are face up.",
+      "text": "Once during your turn (before your attack), you may choose a card from your hand and put it as a Prize card face up. If you do, choose 1 of your face-down Prize cards without looking and put it into your hand. This power can’t be used if Slowking is affected by a Special Condition or if all of your Prize cards are face up.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -1587,7 +1587,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Temperamental Weather",
-      "text": "Once during your turn (before your attack), you may search your deck for Castform, Rain Castform, or Sunny Castform and switch it with Snow-cloud Castform. (Any cards attached to Snow-cloud Castform, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) Shuffle Snow-cloud Castform back into your deck. You can't use more than 1 Temperamental Weather Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for Castform, Rain Castform, or Sunny Castform and switch it with Snow-cloud Castform. (Any cards attached to Snow-cloud Castform, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) Shuffle Snow-cloud Castform back into your deck. You can’t use more than 1 Temperamental Weather Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -1612,7 +1612,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "If Snow-cloud Castform has any Holon Energy cards attached to it, this attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If Snow-cloud Castform has any Holon Energy cards attached to it, this attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1667,7 +1667,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -1687,7 +1687,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Temperamental Weather",
-      "text": "Once during your turn (before your attack), you may search your deck for Castform, Rain Castform, or Snow-cloud Castform and switch it with Sunny Castform. (Any cards attached to Sunny Castform, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) Shuffle Sunny Castform back into your deck. You can't use more than 1 Temperamental Weather Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for Castform, Rain Castform, or Snow-cloud Castform and switch it with Sunny Castform. (Any cards attached to Sunny Castform, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) Shuffle Sunny Castform back into your deck. You can’t use more than 1 Temperamental Weather Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -1750,7 +1750,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Swellow during your opponent's next turn. If tails, during your next turn, Swellow's Glide attack's base damage is 100."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Swellow during your opponent’s next turn. If tails, during your next turn, Swellow’s Glide attack’s base damage is 100."
       },
       {
         "name": "Glide",
@@ -1788,7 +1788,7 @@
     "evolvesFrom": "Koffing",
     "ability": {
       "name": "Body Odor",
-      "text": "As long as Weezing is the Active Pokémon, put 1 damage counter on each of your opponent's Pokémon that has any Poké-Bodies between turns.",
+      "text": "As long as Weezing is the Active Pokémon, put 1 damage counter on each of your opponent’s Pokémon that has any Poké-Bodies between turns.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -1813,7 +1813,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Sludge Whirlpool",
@@ -1844,7 +1844,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Temperamental Weather",
-      "text": "Once during your turn (before your attack), you may search your deck for Sunny Castform, Rain Castform, or Snow-cloud Castform and switch it with Castform. (Any cards attached to Castform, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) Shuffle Castform back into your deck. You can't use more than 1 Temperamental Weather Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for Sunny Castform, Rain Castform, or Snow-cloud Castform and switch it with Castform. (Any cards attached to Castform, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) Shuffle Castform back into your deck. You can’t use more than 1 Temperamental Weather Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -1888,7 +1888,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Duplicate",
-      "text": "Once during your turn (before your attack), you may search your deck for another Ditto and switch it with Ditto. (Any cards attached to Ditto, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Ditto on top of your deck. Shuffle your deck afterward. You can't use more than 1 Duplicate Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Ditto and switch it with Ditto. (Any cards attached to Ditto, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Ditto on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Duplicate Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -1932,7 +1932,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Duplicate",
-      "text": "Once during your turn (before your attack), you may search your deck for another Ditto and switch it with Ditto. (Any cards attached to Ditto, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Ditto on top of your deck. Shuffle your deck afterward. You can't use more than 1 Duplicate Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Ditto and switch it with Ditto. (Any cards attached to Ditto, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Ditto on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Duplicate Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -1977,7 +1977,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Duplicate",
-      "text": "Once during your turn (before your attack), you may search your deck for another Ditto and switch it with Ditto. (Any cards attached to Ditto, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Ditto on top of your deck. Shuffle your deck afterward. You can't use more than 1 Duplicate Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Ditto and switch it with Ditto. (Any cards attached to Ditto, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Ditto on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Duplicate Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -2022,7 +2022,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Duplicate",
-      "text": "Once during your turn (before your attack), you may search your deck for another Ditto and switch it with Ditto. (Any cards attached to Ditto, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Ditto on top of your deck. Shuffle your deck afterward. You can't use more than 1 Duplicate Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Ditto and switch it with Ditto. (Any cards attached to Ditto, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Ditto on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Duplicate Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -2046,7 +2046,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. Copy copies that attack. This attack does nothing if Ditto doesn't have the Energy necessary to use that attack. (You must still do anything else required for that attack.) Ditto performs that attack."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. Copy copies that attack. This attack does nothing if Ditto doesn’t have the Energy necessary to use that attack. (You must still do anything else required for that attack.) Ditto performs that attack."
       }
     ],
     "weaknesses": [
@@ -2066,7 +2066,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Duplicate",
-      "text": "Once during your turn (before your attack), you may search your deck for another Ditto and switch it with Ditto. (Any cards attached to Ditto, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Ditto on top of your deck. Shuffle your deck afterward. You can't use more than 1 Duplicate Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Ditto and switch it with Ditto. (Any cards attached to Ditto, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Ditto on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Duplicate Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -2111,7 +2111,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Duplicate",
-      "text": "Once during your turn (before your attack), you may search your deck for another Ditto and switch it with Ditto. (Any cards attached to Ditto, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Ditto on top of your deck. Shuffle your deck afterward. You can't use more than 1 Duplicate Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Ditto and switch it with Ditto. (Any cards attached to Ditto, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Ditto on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Duplicate Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -2306,7 +2306,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 2 of your opponent's Pokémon. This attack does 10 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 2 of your opponent’s Pokémon. This attack does 10 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2330,7 +2330,7 @@
     "evolvesFrom": "Makuhita",
     "ability": {
       "name": "Reversal Aura",
-      "text": "As long as you have more Prize cards left than your opponent, each of Hariyama's attacks does 20 more damage to the Active Pokémon (before applying Weakness and Resistance) and damage done by the Active Pokémon to Hariyama is reduced by 20 (after applying Weakness and Resistance).",
+      "text": "As long as you have more Prize cards left than your opponent, each of Hariyama’s attacks does 20 more damage to the Active Pokémon (before applying Weakness and Resistance) and damage done by the Active Pokémon to Hariyama is reduced by 20 (after applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -2365,7 +2365,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "This attack's damage isn't affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -2385,7 +2385,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Beacon Protection",
-      "text": "As long as you have Volbeat in play, prevent all effects, including damage, done to Illumise by attacks from your opponent's Pokémon that has Dark in its name.",
+      "text": "As long as you have Volbeat in play, prevent all effects, including damage, done to Illumise by attacks from your opponent’s Pokémon that has Dark in its name.",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -2697,7 +2697,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2939,7 +2939,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shining Horn",
-      "text": "As long as Skarmory is the only Pokémon you have in play, your opponent's Basic Pokémon can't attack.",
+      "text": "As long as Skarmory is the only Pokémon you have in play, your opponent’s Basic Pokémon can’t attack.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -2970,7 +2970,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "During your opponent's next turn, any damage done to Skarmory by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Skarmory by attacks is reduced by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -2999,7 +2999,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Extra Protection",
-      "text": "As long as you have Illumise in play, prevent all effects, including damage, done to Volbeat by attacks from your opponent's Pokémon-ex.",
+      "text": "As long as you have Illumise in play, prevent all effects, including damage, done to Volbeat by attacks from your opponent’s Pokémon-ex.",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -3024,7 +3024,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -3254,7 +3254,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Duplicate",
-      "text": "Once during your turn (before your attack), you may search your deck for another Ditto and switch it with Ditto. (Any cards attached to Ditto, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Ditto on top of your deck. Shuffle your deck afterward. You can't use more than 1 Duplicate Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Ditto and switch it with Ditto. (Any cards attached to Ditto, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Ditto on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Duplicate Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -3299,7 +3299,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Duplicate",
-      "text": "Once during your turn (before your attack), you may search your deck for another Ditto and switch it with Ditto. (Any cards attached to Ditto, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Ditto on top of your deck. Shuffle your deck afterward. You can't use more than 1 Duplicate Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Ditto and switch it with Ditto. (Any cards attached to Ditto, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Ditto on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Duplicate Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -3324,7 +3324,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3344,7 +3344,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Duplicate",
-      "text": "Once during your turn (before your attack), you may search your deck for another Ditto and switch it with Ditto. (Any cards attached to Ditto, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Ditto on top of your deck. Shuffle your deck afterward. You can't use more than 1 Duplicate Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Ditto and switch it with Ditto. (Any cards attached to Ditto, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Ditto on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Duplicate Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -3389,7 +3389,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Duplicate",
-      "text": "Once during your turn (before your attack), you may search your deck for another Ditto and switch it with Ditto. (Any cards attached to Ditto, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Ditto on top of your deck. Shuffle your deck afterward. You can't use more than 1 Duplicate Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Ditto and switch it with Ditto. (Any cards attached to Ditto, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Ditto on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Duplicate Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -3567,7 +3567,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Headbutt",
@@ -3702,7 +3702,7 @@
   },
   {
     "id": "ex11-70",
-    "name": "Holon's Magnemite",
+    "name": "Holon’s Magnemite",
     "imageUrl": "https://images.pokemontcg.io/ex11/70.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3730,7 +3730,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3753,7 +3753,7 @@
   },
   {
     "id": "ex11-71",
-    "name": "Holon's Voltorb",
+    "name": "Holon’s Voltorb",
     "imageUrl": "https://images.pokemontcg.io/ex11/71.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3983,7 +3983,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -4322,7 +4322,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. This attack’s damage isn’t affected by Weakness or Resistance."
       },
       {
         "name": "Scratch",
@@ -4530,7 +4530,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Does 10 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4702,7 +4702,7 @@
     "setCode": "ex11",
     "text": [
       "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.",
-      "Discard a card from your hand. If you can't discard a card from your hand, you can't play this card.Search your discard pile for 3 basic Energy cards and any combination of 3 Basic Pokémon or Evolution cards, show them to your opponent, and put them on top of your deck. Shuffle your deck afterward."
+      "Discard a card from your hand. If you can’t discard a card from your hand, you can’t play this card.Search your discard pile for 3 basic Energy cards and any combination of 3 Basic Pokémon or Evolution cards, show them to your opponent, and put them on top of your deck. Shuffle your deck afterward."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/91_hires.png"
   },
@@ -4721,7 +4721,7 @@
     "setCode": "ex11",
     "text": [
       "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.",
-      "\"Discard a card from your hand. If you can't discard a card from your hand, you can't play this card.Count the total number of Prize cards left (both yours and your opponent's). Look at that many cards from the top of your deck, choose as many Energy cards as you like, show them to your opponent, and put them into your hand. Put the other cards back on top of your deck. Shuffle your deck afterward.\""
+      "\"Discard a card from your hand. If you can’t discard a card from your hand, you can’t play this card.Count the total number of Prize cards left (both yours and your opponent’s). Look at that many cards from the top of your deck, choose as many Energy cards as you like, show them to your opponent, and put them into your hand. Put the other cards back on top of your deck. Shuffle your deck afterward.\""
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/92_hires.png"
   },
@@ -4740,7 +4740,7 @@
     "setCode": "ex11",
     "text": [
       "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.",
-      "Discard a card from your hand. If you can't discard a card from your hand, you can't play this card.Search your deck for up to 3 Basic Pokémon that each has 100 HP or less, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
+      "Discard a card from your hand. If you can’t discard a card from your hand, you can’t play this card.Search your deck for up to 3 Basic Pokémon that each has 100 HP or less, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/93_hires.png"
   },
@@ -4758,8 +4758,8 @@
     "set": "Delta Species",
     "setCode": "ex11",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "Each player's basic Energy cards attached to Pokémon that has δ on its card are both their usual Energy type and Metal type but provide only 1 Energy at a time. (Has no effect other than providing Energy.)"
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
+      "Each player’s basic Energy cards attached to Pokémon that has δ on its card are both their usual Energy type and Metal type but provide only 1 Energy at a time. (Has no effect other than providing Energy.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/94_hires.png"
   },
@@ -4777,8 +4777,8 @@
     "set": "Delta Species",
     "setCode": "ex11",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "\"Discard a card from your hand. If you can't discard a card from your hand, you can't play this card. Search your deck for a Metal Energy card or a Basic Pokémon (or Evolution card) that has δ on its card, show it to your opponent, and put it into your hand. Shuffle your deck afterward.\""
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
+      "\"Discard a card from your hand. If you can’t discard a card from your hand, you can’t play this card. Search your deck for a Metal Energy card or a Basic Pokémon (or Evolution card) that has δ on its card, show it to your opponent, and put it into your hand. Shuffle your deck afterward.\""
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/95_hires.png"
   },
@@ -4796,7 +4796,7 @@
     "set": "Delta Species",
     "setCode": "ex11",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
       "Each player that has any Pokémon in play that has ݎ on its card may draw a card once during his or her turn. If the player does, he or she discards a card from his or her hand."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/96_hires.png"
@@ -4816,7 +4816,7 @@
     "setCode": "ex11",
     "text": [
       "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.",
-      "Discard a card from your hand. If you can't discard a card from your hand, you can't play this card.If you have less cards in your hand than your opponent, draw cards until you have the same number of cards as your opponent."
+      "Discard a card from your hand. If you can’t discard a card from your hand, you can’t play this card.If you have less cards in your hand than your opponent, draw cards until you have the same number of cards as your opponent."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/97_hires.png"
   },
@@ -4923,7 +4923,7 @@
     "set": "Delta Species",
     "setCode": "ex11",
     "text": [
-      "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect unless the Attacking Pokémon is Darkness or has Dark in its name. Darkness Energy provides Darkness Energy. (Doesn't count as a basic Energy card.)"
+      "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect unless the Attacking Pokémon is Darkness or has Dark in its name. Darkness Energy provides Darkness Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/103_hires.png"
   },
@@ -4940,7 +4940,7 @@
     "set": "Delta Species",
     "setCode": "ex11",
     "text": [
-      "Holon Energy FF provides Colorless Energy. If the Pokémon that Holon Energy FF is attached to also has a basic Fire Energy card attached to it, that Pokémon has no Weakness. If the Pokémon that Holon Energy FF is attached to also has a basic Fighting Energy card attached to it, damage done by that Pokémon's attack isn't affected by Resistance. Ignore these effects if Holon Energy FF is attached to Pokémon-ex."
+      "Holon Energy FF provides Colorless Energy. If the Pokémon that Holon Energy FF is attached to also has a basic Fire Energy card attached to it, that Pokémon has no Weakness. If the Pokémon that Holon Energy FF is attached to also has a basic Fighting Energy card attached to it, damage done by that Pokémon’s attack isn’t affected by Resistance. Ignore these effects if Holon Energy FF is attached to Pokémon-ex."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/104_hires.png"
   },
@@ -4957,7 +4957,7 @@
     "set": "Delta Species",
     "setCode": "ex11",
     "text": [
-      "Holon Energy GL provides Colorless Energy. If the Pokémon that Holon Energy GL is attached to also has a basic Grass Energy card attached to it, that Pokémon can't be affected by any Special Conditions. If the Pokémon that Holon Energy GL is attached to also has a basic Lightning Energy card attached to it, damage done by your opponent's Pokémon-ex is reduced by 10. Ignore these effects if Holon Energy GL is attached to Pokémon-ex."
+      "Holon Energy GL provides Colorless Energy. If the Pokémon that Holon Energy GL is attached to also has a basic Grass Energy card attached to it, that Pokémon can’t be affected by any Special Conditions. If the Pokémon that Holon Energy GL is attached to also has a basic Lightning Energy card attached to it, damage done by your opponent’s Pokémon-ex is reduced by 10. Ignore these effects if Holon Energy GL is attached to Pokémon-ex."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/105_hires.png"
   },
@@ -4974,7 +4974,7 @@
     "set": "Delta Species",
     "setCode": "ex11",
     "text": [
-      "Holon Energy WP provides Colorless Energy. If the Pokémon that Holon Energy WP is attached to also has a basic Water Energy card attached to it, prevent all effects, excluding damage, done to that Pokémon by your opponent's Pokémon. If the Pokémon that Holon Energy WP is attached to also has a basic Psychic Energy card attached to it, that Pokémon's Retreat Cost is 0. Ignore these effects if Holon Energy WP is attached to Pokémon-ex."
+      "Holon Energy WP provides Colorless Energy. If the Pokémon that Holon Energy WP is attached to also has a basic Water Energy card attached to it, prevent all effects, excluding damage, done to that Pokémon by your opponent’s Pokémon. If the Pokémon that Holon Energy WP is attached to also has a basic Psychic Energy card attached to it, that Pokémon’s Retreat Cost is 0. Ignore these effects if Holon Energy WP is attached to Pokémon-ex."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/106_hires.png"
   },
@@ -4991,7 +4991,7 @@
     "set": "Delta Species",
     "setCode": "ex11",
     "text": [
-      "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn't Metal. Metal Energy provides Metal Energy. (Doesn't count as a basic Energy card.)"
+      "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn’t Metal. Metal Energy provides Metal Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/107_hires.png"
   },
@@ -5033,7 +5033,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "During your opponent's next turn, any damage done to Flareon ex by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Flareon ex by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Heat Tackle",
@@ -5066,7 +5066,7 @@
     "evolvesFrom": "Eevee",
     "ability": {
       "name": "Evolutionary Thunder",
-      "text": "Once during your turn, when you play Jolteon ex from your hand to evolve 1 of your Pokémon, you may put 1 damage counter on each of your opponent's Pokémon.",
+      "text": "Once during your turn, when you play Jolteon ex from your hand to evolve 1 of your Pokémon, you may put 1 damage counter on each of your opponent’s Pokémon.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -5158,7 +5158,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "This attack's damage isn't affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       },
       {
         "name": "Hydrosplash",
@@ -5200,7 +5200,7 @@
     "set": "Delta Species",
     "setCode": "ex11",
     "text": [
-      "You can't have more than 1 Pokémon Star in your deck."
+      "You can’t have more than 1 Pokémon Star in your deck."
     ],
     "types": [
       "Fighting"
@@ -5257,7 +5257,7 @@
     "set": "Delta Species",
     "setCode": "ex11",
     "text": [
-      "You can't have more than 1 Pokémon Star in your deck."
+      "You can’t have more than 1 Pokémon Star in your deck."
     ],
     "types": [
       "Water"
@@ -5283,7 +5283,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "60",
-        "text": "Flip a coin. If heads, each Defending Pokémon can't attack during your opponent's next turn."
+        "text": "Flip a coin. If heads, each Defending Pokémon can’t attack during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -5314,7 +5314,7 @@
     "set": "Delta Species",
     "setCode": "ex11",
     "text": [
-      "You can't have more than 1 Pokémon Star in your deck."
+      "You can’t have more than 1 Pokémon Star in your deck."
     ],
     "types": [
       "Metal"

--- a/json/cards/Deoxys.json
+++ b/json/cards/Deoxys.json
@@ -8,7 +8,7 @@
     "evolvesFrom": "Swablu",
     "ability": {
       "name": "Safeguard",
-      "text": "Prevent all effects of attacks, including damage, done to Altaria by your opponent's Pokémon-ex.",
+      "text": "Prevent all effects of attacks, including damage, done to Altaria by your opponent’s Pokémon-ex.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -70,7 +70,7 @@
     "evolvesFrom": "Silcoon",
     "ability": {
       "name": "Hunch",
-      "text": "As long as Beautifly's remaining HP is 40 or less, Beautifly does 40 more damage to the Defending Pokémon (before applying Weakness and Resistance).",
+      "text": "As long as Beautifly’s remaining HP is 40 or less, Beautifly does 40 more damage to the Defending Pokémon (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -94,7 +94,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Before doing damage, you may choose 1 of your opponent's Benched Pokémon and switch it with 1 of the Defending Pokémon. If you do, this attack does 20 damage to the new Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
+        "text": "Before doing damage, you may choose 1 of your opponent’s Benched Pokémon and switch it with 1 of the Defending Pokémon. If you do, this attack does 20 damage to the new Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
       },
       {
         "name": "Cutting Wind",
@@ -156,7 +156,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70-",
-        "text": "During your next turn, Hustle Punch attack's base damage is 50 instead of 70."
+        "text": "During your next turn, Hustle Punch attack’s base damage is 50 instead of 70."
       }
     ],
     "weaknesses": [
@@ -208,7 +208,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 2 of your opponent's Pokémon. This attack does 30 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 2 of your opponent’s Pokémon. This attack does 30 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -229,7 +229,7 @@
     "evolvesFrom": "Baltoy",
     "ability": {
       "name": "Psychic Trace",
-      "text": "Once during your turn (before your attack), if Claydol is your Active Pokémon, you may shuffle your hand into your deck. Then, draw a number of cards equal to the number of cards in your opponent's hand. This power can't be used if Claydol is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Claydol is your Active Pokémon, you may shuffle your hand into your deck. Then, draw a number of cards equal to the number of cards in your opponent’s hand. This power can’t be used if Claydol is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -275,7 +275,7 @@
     "evolvesFrom": "Corphish",
     "ability": {
       "name": "Dark Protection",
-      "text": "Any damage done to Crawdaunt by your opponent's attacks is reduced by 10 for each Darkness Energy attached to Crawdaunt (after applying Weakness and Resistance). You can't reduce more than 20 damage in this way.",
+      "text": "Any damage done to Crawdaunt by your opponent’s attacks is reduced by 10 for each Darkness Energy attached to Crawdaunt (after applying Weakness and Resistance). You can’t reduce more than 20 damage in this way.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -368,7 +368,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Count the number of cards in your hand. Put that many damage counters on the Defending Pokémon. You can't put more than 7 damage counters in this way."
+        "text": "Count the number of cards in your hand. Put that many damage counters on the Defending Pokémon. You can’t put more than 7 damage counters in this way."
       }
     ],
     "weaknesses": [
@@ -418,7 +418,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Full Retaliation",
@@ -460,7 +460,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Wishing Star",
-      "text": "Once during your turn (before your attack), if Jirachi is your Active Pokémon, you may look at the top 5 cards of your deck, choose 1 of them, and put it into your hand. Shuffle your deck afterward. Jirachi and your other Active Pokémon, if any, are now Asleep. This power can't be used if Jirachi is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Jirachi is your Active Pokémon, you may look at the top 5 cards of your deck, choose 1 of them, and put it into your hand. Shuffle your deck afterward. Jirachi and your other Active Pokémon, if any, are now Asleep. This power can’t be used if Jirachi is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -512,7 +512,7 @@
     "evolvesFrom": "Lombre",
     "ability": {
       "name": "Swing Dance",
-      "text": "Once during your turn (before your attack), you may draw a card. This power can't be used if Ludicolo is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may draw a card. This power can’t be used if Ludicolo is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -548,7 +548,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "10x",
-        "text": "Does 10 damage times the number of Pokémon in play (both yours and your opponent's), excluding Ludicolo."
+        "text": "Does 10 damage times the number of Pokémon in play (both yours and your opponent’s), excluding Ludicolo."
       }
     ],
     "weaknesses": [
@@ -569,7 +569,7 @@
     "evolvesFrom": "Metang",
     "ability": {
       "name": "Super Connectivity",
-      "text": "Once during your turn (before your attack), you may search your discard pile for a Psychic or Metal Energy card and attach it to your Active Pokémon. Then, put 1 damage counter on that Pokémon. This power can't be used if Metagross is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may search your discard pile for a Psychic or Metal Energy card and attach it to your Active Pokémon. Then, put 1 damage counter on that Pokémon. This power can’t be used if Metagross is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -595,7 +595,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "70",
-        "text": "If Metagross and the Defending Pokémon have a different amount of Energy attached to them, this attack's base damage is 40 instead of 70."
+        "text": "If Metagross and the Defending Pokémon have a different amount of Energy attached to them, this attack’s base damage is 40 instead of 70."
       }
     ],
     "weaknesses": [
@@ -669,7 +669,7 @@
     "evolvesFrom": "Nincada",
     "ability": {
       "name": "Fast Protection",
-      "text": "Prevent all effects, including damage, done to Ninjask by your opponent's attacks from his or her Basic Pokémon.",
+      "text": "Prevent all effects, including damage, done to Ninjask by your opponent’s attacks from his or her Basic Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -690,7 +690,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, Ninjask's Slash attack's base damage is 80."
+        "text": "During your next turn, Ninjask’s Slash attack’s base damage is 80."
       },
       {
         "name": "Slash",
@@ -723,7 +723,7 @@
     "evolvesFrom": "Nincada",
     "ability": {
       "name": "Empty Shell",
-      "text": "When Shedinja is Knocked Out, your opponent doesn't take any Prize cards.",
+      "text": "When Shedinja is Knocked Out, your opponent doesn’t take any Prize cards.",
       "type": "Poké-Body"
     },
     "hp": "50",
@@ -759,7 +759,7 @@
     "evolvesFrom": "Vigoroth",
     "ability": {
       "name": "Lazy Aura",
-      "text": "As long as Slaking is your Active Pokémon, any damage done by attacks from your opponent's Pokémon-ex is reduced by 30 (before applying Weakness and Resistance).",
+      "text": "As long as Slaking is your Active Pokémon, any damage done by attacks from your opponent’s Pokémon-ex is reduced by 30 (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -786,7 +786,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Lazy Headbutt",
@@ -818,7 +818,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Form Change",
-      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys and switch it with Deoxys. (Any cards attached to Deoxys, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys on top of your deck. Shuffle your deck afterward. You can't use more than 1 Form Change Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys and switch it with Deoxys. (Any cards attached to Deoxys, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Form Change Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -843,7 +843,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "If Deoxys and the Defending Pokémon have a different amount of Energy attached to them, this attack's base damage is 20 instead of 40."
+        "text": "If Deoxys and the Defending Pokémon have a different amount of Energy attached to them, this attack’s base damage is 20 instead of 40."
       }
     ],
     "weaknesses": [
@@ -863,7 +863,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Form Change",
-      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys and switch it with Deoxys. (Any cards attached to Deoxys, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys on top of your deck. Shuffle your deck afterward. You can't use more than 1 Form Change Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys and switch it with Deoxys. (Any cards attached to Deoxys, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Form Change Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -889,7 +889,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "10+",
-        "text": "Does 10 damage plus 10 more damage for each Energy attached to all of your opponent's Pokémon."
+        "text": "Does 10 damage plus 10 more damage for each Energy attached to all of your opponent’s Pokémon."
       }
     ],
     "weaknesses": [
@@ -909,7 +909,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Form Change",
-      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys and switch it with Deoxys. (Any cards attached to Deoxys, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys on top of your deck. Shuffle your deck afterward. You can't use more than 1 Form Change Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys and switch it with Deoxys. (Any cards attached to Deoxys, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Form Change Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -934,7 +934,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "During your opponent's next turn, any damage done to Deoxys by attacks is reduced by 30 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Deoxys by attacks is reduced by 30 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -955,7 +955,7 @@
     "evolvesFrom": "Lombre",
     "ability": {
       "name": "Happy Dance",
-      "text": "Once during your turn (before your attack), you may remove 1 damage counter from each of your Pokémon. You can't use more than 1 Happy Dance Poké-Power each turn. This power can't be used if Ludicolo is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may remove 1 damage counter from each of your Pokémon. You can’t use more than 1 Happy Dance Poké-Power each turn. This power can’t be used if Ludicolo is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -1003,7 +1003,7 @@
     "evolvesFrom": "Slugma",
     "ability": {
       "name": "Smooth Over",
-      "text": "Once during your turn (before your attack), you may search your deck for a card. Shuffle your deck, then put that card on top of your deck. This power can't be used if Magcargo is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may search your deck for a card. Shuffle your deck, then put that card on top of your deck. This power can’t be used if Magcargo is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -1091,7 +1091,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "This attack's damage is not affected by Resistance."
+        "text": "This attack’s damage is not affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -1117,7 +1117,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Dragon Aura",
-      "text": "As long as Rayquaza has any basic Fire Energy cards and any basic Lightning Energy cards attached to it, prevent all effects, except damage, by an opponent's attack done to Rayquaza.",
+      "text": "As long as Rayquaza has any basic Fire Energy cards and any basic Lightning Energy cards attached to it, prevent all effects, except damage, by an opponent’s attack done to Rayquaza.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -1162,7 +1162,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Night Vision",
-      "text": "Once during your turn (before your attack), if Sableye is your Active Pokémon, you may look at your opponent's hand. This power can't be used if Sableye is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Sableye is your Active Pokémon, you may look at your opponent’s hand. This power can’t be used if Sableye is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -1195,7 +1195,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent can't play any Supporter cards from his or her hand during your opponent's next turn."
+        "text": "Your opponent can’t play any Supporter cards from his or her hand during your opponent’s next turn."
       }
     ],
     "resistances": [
@@ -1232,7 +1232,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 3 of your opponent's Pokémon. This attack does 10 damage to each of those Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 3 of your opponent’s Pokémon. This attack does 10 damage to each of those Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Rend",
@@ -1263,7 +1263,7 @@
     "evolvesFrom": "Nuzleaf",
     "ability": {
       "name": "Fan Action",
-      "text": "Once during your turn (before your attack), you may switch 1 of the Defending Pokémon with 1 of your opponent's Benched Pokémon. Your opponent chooses the Benched Pokémon to switch. This power can't be used if Shiftry is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may switch 1 of the Defending Pokémon with 1 of your opponent’s Benched Pokémon. Your opponent chooses the Benched Pokémon to switch. This power can’t be used if Shiftry is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -1369,7 +1369,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Tropical Motion",
-      "text": "As long as Tropius is your Active Pokémon, your opponent's Pokémon have no Resistance.",
+      "text": "As long as Tropius is your Active Pokémon, your opponent’s Pokémon have no Resistance.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -1478,7 +1478,7 @@
     "evolvesFrom": "Natu",
     "ability": {
       "name": "Mirror Coat",
-      "text": "If Xatu is Burned or Poisoned by an opponent's attack (even if Xatu is Knocked Out), the Attacking Pokémon is now affected by the same Special Conditions (1 if there is only 1).",
+      "text": "If Xatu is Burned or Poisoned by an opponent’s attack (even if Xatu is Knocked Out), the Attacking Pokémon is now affected by the same Special Conditions (1 if there is only 1).",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -1555,7 +1555,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Rock Hurl",
@@ -1566,7 +1566,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "This attack's damage is not affected by Resistance."
+        "text": "This attack’s damage is not affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -1587,7 +1587,7 @@
     "evolvesFrom": "Zubat",
     "ability": {
       "name": "Self-control",
-      "text": "Golbat can't be Paralyzed.",
+      "text": "Golbat can’t be Paralyzed.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -1633,7 +1633,7 @@
     "evolvesFrom": "Spoink",
     "ability": {
       "name": "Carefree",
-      "text": "Grumpig can't be Confused.",
+      "text": "Grumpig can’t be Confused.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -1806,7 +1806,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Choose 1 card from your opponent's hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
+        "text": "Choose 1 card from your opponent’s hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
       }
     ],
     "weaknesses": [
@@ -1853,7 +1853,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at the top 5 cards of either player's deck and put them back on top of that player's deck in any order."
+        "text": "Look at the top 5 cards of either player’s deck and put them back on top of that player’s deck in any order."
       },
       {
         "name": "Target Beam",
@@ -1955,7 +1955,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Magnetic Tackle",
@@ -1993,7 +1993,7 @@
     "evolvesFrom": "Surskit",
     "ability": {
       "name": "Intimidating Pattern",
-      "text": "As long as Masquerain is your Active Pokémon, any damage done by an opponent's attack is reduced by 20 (before applying Weakness and Resistance). You can't use more than 1 Intimidating Pattern Poké-Body each turn.",
+      "text": "As long as Masquerain is your Active Pokémon, any damage done by an opponent’s attack is reduced by 20 (before applying Weakness and Resistance). You can’t use more than 1 Intimidating Pattern Poké-Body each turn.",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -2124,7 +2124,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Does 20 damage to each of your opponent's Pokémon that has any Poké-Bodies. Don't apply Weakness and Resistance."
+        "text": "Does 20 damage to each of your opponent’s Pokémon that has any Poké-Bodies. Don’t apply Weakness and Resistance."
       }
     ],
     "weaknesses": [
@@ -2144,7 +2144,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Magnetic Reversal",
-      "text": "Once during your turn (before your attack), if Nosepass is your Active Pokémon, you may flip a coin. If heads, switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. This power can't be used if Nosepass is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Nosepass is your Active Pokémon, you may flip a coin. If heads, switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. This power can’t be used if Nosepass is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -2273,7 +2273,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Does 20 damage to each of your opponent's Pokémon that has any Poké-Powers. Don't apply Weakness and Resistance."
+        "text": "Does 20 damage to each of your opponent’s Pokémon that has any Poké-Powers. Don’t apply Weakness and Resistance."
       }
     ],
     "weaknesses": [
@@ -2384,7 +2384,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "During your opponent's next turn, prevent all effects of attacks, including damage, done to Silcoon by your opponent's Evolved Pokémon."
+        "text": "During your opponent’s next turn, prevent all effects of attacks, including damage, done to Silcoon by your opponent’s Evolved Pokémon."
       }
     ],
     "weaknesses": [
@@ -2441,7 +2441,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Benched Pokémon. This attack does 10 damage to that Pokémon for each Lunatone you have in play. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Benched Pokémon. This attack does 10 damage to that Pokémon for each Lunatone you have in play. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2486,7 +2486,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Benched Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) You may move an Energy attached to that Pokémon to another of your opponent's Pokémon."
+        "text": "Choose 1 of your opponent’s Benched Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) You may move an Energy attached to that Pokémon to another of your opponent’s Pokémon."
       },
       {
         "name": "Psychic Boom",
@@ -2533,7 +2533,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Flip a coin. If heads, your opponent discards 1 Energy card, if any, attached to that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) Flip a coin. If heads, your opponent discards 1 Energy card, if any, attached to that Pokémon."
       },
       {
         "name": "Nosedive",
@@ -2570,7 +2570,7 @@
     "evolvesFrom": "Slakoth",
     "ability": {
       "name": "Vigorous Aura",
-      "text": "As long as Vigoroth is your Active Pokémon, attacks by each player's Active Pokémon (both if there are 2) do 10 more damage to any Active Pokémon (before applying Weakness and Resistance).",
+      "text": "As long as Vigoroth is your Active Pokémon, attacks by each player’s Active Pokémon (both if there are 2) do 10 more damage to any Active Pokémon (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -2649,7 +2649,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "The Defending Pokémon is now Poisoned. If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "The Defending Pokémon is now Poisoned. If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -2759,7 +2759,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.) Baltoy does 50 damage to itself."
+        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent’s). (Don’t apply Weakness and Resistance for Benched Pokémon.) Baltoy does 50 damage to itself."
       }
     ],
     "weaknesses": [
@@ -2801,7 +2801,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Tackle",
@@ -2853,7 +2853,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Beldum does 10 damage to itself, and don't apply Weakness and Resistance to this damage."
+        "text": "Beldum does 10 damage to itself, and don’t apply Weakness and Resistance to this damage."
       }
     ],
     "weaknesses": [
@@ -3058,7 +3058,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent can't play Trainer cards from his or her hand during his or her next turn."
+        "text": "Flip a coin. If heads, your opponent can’t play Trainer cards from his or her hand during his or her next turn."
       },
       {
         "name": "Gnaw",
@@ -3398,7 +3398,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Mirror Coat",
-      "text": "If Natu is Burned or Poisoned by an opponent's attack (even if Natu is Knocked Out), the Attacking Pokémon is now affected by the same Special Conditions (1 if there is only 1).",
+      "text": "If Natu is Burned or Poisoned by an opponent’s attack (even if Natu is Knocked Out), the Attacking Pokémon is now affected by the same Special Conditions (1 if there is only 1).",
       "type": "Poké-Body"
     },
     "hp": "50",
@@ -3464,7 +3464,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. This attack’s damage isn’t affected by Weakness or Resistance."
       },
       {
         "name": "Scratch",
@@ -3497,7 +3497,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Dense",
-      "text": "Any damage done to Numel by attacks from Evolved Pokémon (both yours and your opponent's) is reduced by 20 (after applying Weakness and Resistance).",
+      "text": "Any damage done to Numel by attacks from Evolved Pokémon (both yours and your opponent’s) is reduced by 20 (after applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "40",
@@ -3615,7 +3615,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 card from your opponent's hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
+        "text": "Choose 1 card from your opponent’s hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
       },
       {
         "name": "Sharp Fang",
@@ -3885,7 +3885,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Flare",
@@ -4031,7 +4031,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Surskit during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Surskit during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -4054,7 +4054,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Fluff",
-      "text": "Whenever Swablu would be damaged or affected by an opponent's attack and already has at least 1 damage counter on it, flip a coin. If heads, prevent all effects of that attack, including damage, done to Swablu.",
+      "text": "Whenever Swablu would be damaged or affected by an opponent’s attack and already has at least 1 damage counter on it, flip a coin. If heads, prevent all effects of that attack, including damage, done to Swablu.",
       "type": "Poké-Body"
     },
     "hp": "40",
@@ -4126,7 +4126,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of an attack, including damage, done to Taillow during your opponent's next turn."
+        "text": "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of an attack, including damage, done to Taillow during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -4256,7 +4256,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Self-control",
-      "text": "Zubat can't be Paralyzed.",
+      "text": "Zubat can’t be Paralyzed.",
       "type": "Poké-Body"
     },
     "hp": "50",
@@ -4309,8 +4309,8 @@
     "set": "Deoxys",
     "setCode": "ex8",
     "text": [
-      "As long as Balloon Berry is attached to a Pokémon, that Pokémon's Retreat Cost is 0. When this Pokémon retreats, discard Balloon Berry.",
-      "Attach Balloon Berry to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card."
+      "As long as Balloon Berry is attached to a Pokémon, that Pokémon’s Retreat Cost is 0. When this Pokémon retreats, discard Balloon Berry.",
+      "Attach Balloon Berry to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex8/84_hires.png"
   },
@@ -4328,8 +4328,8 @@
     "set": "Deoxys",
     "setCode": "ex8",
     "text": [
-      "As long as this card is attached to a Pokémon, that Pokémon's type is Colorless. If that Pokémon attacks, discard this card at the end of the turn.",
-      "Attach Crystal Shard to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card."
+      "As long as this card is attached to a Pokémon, that Pokémon’s type is Colorless. If that Pokémon attacks, discard this card at the end of the turn.",
+      "Attach Crystal Shard to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex8/85_hires.png"
   },
@@ -4401,14 +4401,14 @@
     "set": "Deoxys",
     "setCode": "ex8",
     "text": [
-      "Each player's Active Evolved Pokémon (excluding Pokémon-ex) can use any attack from its Basic Pokémon or its Stage 1 Evolution card. (You still have to pay for that attack's Energy cost.)",
+      "Each player’s Active Evolved Pokémon (excluding Pokémon-ex) can use any attack from its Basic Pokémon or its Stage 1 Evolution card. (You still have to pay for that attack’s Energy cost.)",
       "This card stays in play when you play it. Discard this card if another Stadium card comes into play."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex8/89_hires.png"
   },
   {
     "id": "ex8-90",
-    "name": "Professor Cozmo's Discovery",
+    "name": "Professor Cozmo’s Discovery",
     "imageUrl": "https://images.pokemontcg.io/ex8/90.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4439,7 +4439,7 @@
     "set": "Deoxys",
     "setCode": "ex8",
     "text": [
-      "Ignore Poké-Bodies for all Basic Pokémon in play (both yours and your opponent's) (excluding Pokémon-ex and Pokémon that has an owner in its name).",
+      "Ignore Poké-Bodies for all Basic Pokémon in play (both yours and your opponent’s) (excluding Pokémon-ex and Pokémon that has an owner in its name).",
       "This card stays in play when you play it. Discard this card if another Stadium card comes into play."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex8/91_hires.png"
@@ -4459,7 +4459,7 @@
     "setCode": "ex8",
     "text": [
       "Whenever an attack from the Pokémon that Strength Charm is attached to does damage to the Active Pokémon, the attack does 10 more damage (before applying Weakness and Resistance). Discard Strength Charm at the end of the turn in which this Pokémon attacks.",
-      "Attach Strength Charm to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card."
+      "Attach Strength Charm to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex8/92_hires.png"
   },
@@ -4476,7 +4476,7 @@
     "set": "Deoxys",
     "setCode": "ex8",
     "text": [
-      "Boost Energy can be attached only to an Evolved Pokémon. Discard Boost Energy at the end of the turn it was attached. Boost Energy provides ColorlessColorlessColorless Energy. The Pokémon Boost Energy is attached to can't retreat. If the Pokémon Boost Energy is attached to isn't an Evolved Pokémon, discard Boost Energy."
+      "Boost Energy can be attached only to an Evolved Pokémon. Discard Boost Energy at the end of the turn it was attached. Boost Energy provides ColorlessColorlessColorless Energy. The Pokémon Boost Energy is attached to can’t retreat. If the Pokémon Boost Energy is attached to isn’t an Evolved Pokémon, discard Boost Energy."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex8/93_hires.png"
   },
@@ -4493,7 +4493,7 @@
     "set": "Deoxys",
     "setCode": "ex8",
     "text": [
-      "Scramble Energy can be attached only to an Evolved Pokémon (excluding Pokémon-ex). Scramble Energy provides Colorless Energy. While in play, if you have more Prize cards left than your opponent, Scramble Energy provides every type of Energy but provides only 3 in any combination at a time. If the Pokémon Scramble Energy is attached to isn't an Evolved Pokémon (or evolves into Pokémon-ex), discard Scramble Energy."
+      "Scramble Energy can be attached only to an Evolved Pokémon (excluding Pokémon-ex). Scramble Energy provides Colorless Energy. While in play, if you have more Prize cards left than your opponent, Scramble Energy provides every type of Energy but provides only 3 in any combination at a time. If the Pokémon Scramble Energy is attached to isn’t an Evolved Pokémon (or evolves into Pokémon-ex), discard Scramble Energy."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex8/94_hires.png"
   },
@@ -4510,7 +4510,7 @@
     "set": "Deoxys",
     "setCode": "ex8",
     "text": [
-      "Scramble Energy can be attached only to an Evolved Pokémon (excluding Pokémon-ex). Scramble Energy provides Colorless Energy. While in play, if you have more Prize cards left than your opponent, Scramble Energy provides every type of Energy but provides only 3 in any combination at a time. If the Pokémon Scramble Energy is attached to isn't an Evolved Pokémon (or evolves into Pokémon-ex), discard Scramble Energy."
+      "Scramble Energy can be attached only to an Evolved Pokémon (excluding Pokémon-ex). Scramble Energy provides Colorless Energy. While in play, if you have more Prize cards left than your opponent, Scramble Energy provides every type of Energy but provides only 3 in any combination at a time. If the Pokémon Scramble Energy is attached to isn’t an Evolved Pokémon (or evolves into Pokémon-ex), discard Scramble Energy."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex8/95_hires.png"
   },
@@ -4524,7 +4524,7 @@
     "evolvesFrom": "Golbat",
     "ability": {
       "name": "Distortion",
-      "text": "Once during your turn (before your attack), if Crobat ex is your Active Pokémon, you may put 1 damage counter on 1 of your opponent's Pokémon. This power can't be used if Crobat ex is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Crobat ex is your Active Pokémon, you may put 1 damage counter on 1 of your opponent’s Pokémon. This power can’t be used if Crobat ex is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "130",
@@ -4587,7 +4587,7 @@
     "level": "ex",
     "ability": {
       "name": "Form Change",
-      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys ex and switch it with Deoxys ex. (Any cards attached to Deoxys ex, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys ex on top of your deck. Shuffle your deck afterward. You can't use more than 1 Form Change Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys ex and switch it with Deoxys ex. (Any cards attached to Deoxys ex, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys ex on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Form Change Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -4636,7 +4636,7 @@
     "level": "ex",
     "ability": {
       "name": "Form Change",
-      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys ex and switch it with Deoxys ex. (Any cards attached to Deoxys ex, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys ex on top of your deck. Shuffle your deck afterward. You can't use more than 1 Form Change Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys ex and switch it with Deoxys ex. (Any cards attached to Deoxys ex, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys ex on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Form Change Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -4687,7 +4687,7 @@
     "level": "ex",
     "ability": {
       "name": "Form Change",
-      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys ex and switch it with Deoxys ex. (Any cards attached to Deoxys ex, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys ex on top of your deck. Shuffle your deck afterward. You can't use more than 1 Form Change Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys ex and switch it with Deoxys ex. (Any cards attached to Deoxys ex, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys ex on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Form Change Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -4717,7 +4717,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Prevent all effects of attacks, including damage, done to Deoxys ex by your opponent's Pokémon-ex during your opponent's next turn."
+        "text": "Prevent all effects of attacks, including damage, done to Deoxys ex by your opponent’s Pokémon-ex during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -4739,7 +4739,7 @@
     "evolvesFrom": "Makuhita",
     "ability": {
       "name": "Commanding Aura",
-      "text": "As long as Hariyama ex is your Active Pokémon, your opponent can't play any Stadium cards from his or her hand.",
+      "text": "As long as Hariyama ex is your Active Pokémon, your opponent can’t play any Stadium cards from his or her hand.",
       "type": "Poké-Body"
     },
     "hp": "110",
@@ -4768,7 +4768,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Choose 1 card from your opponent's hand without looking and discard it."
+        "text": "Choose 1 card from your opponent’s hand without looking and discard it."
       },
       {
         "name": "Pivot Throw",
@@ -4779,7 +4779,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "During your opponent's next turn, any damage done to Hariyama ex by attacks is increased by 10 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Hariyama ex by attacks is increased by 10 (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -4824,7 +4824,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Your opponent can't play any Trainer cards (except for Supporter cards) from his or her hand during your opponent's next turn."
+        "text": "Your opponent can’t play any Trainer cards (except for Supporter cards) from his or her hand during your opponent’s next turn."
       },
       {
         "name": "Mega Shot",
@@ -4835,7 +4835,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Discard all Lightning Energy attached to Manectric ex and then choose 1 of your opponent's Pokémon. This attack does 80 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard all Lightning Energy attached to Manectric ex and then choose 1 of your opponent’s Pokémon. This attack does 80 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4952,7 +4952,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 40 damage to that Pokémon. This attack’s damage isn’t affected by Weakness or Resistance."
       },
       {
         "name": "Bright Flame",
@@ -5016,7 +5016,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Before doing damage, you may switch 1 of your opponent's Benched Pokémon with the Defending Pokémon. If you do, this attack does 20 damage to the new Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
+        "text": "Before doing damage, you may switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon. If you do, this attack does 20 damage to the new Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
       },
       {
         "name": "Darkness Blast",
@@ -5062,7 +5062,7 @@
     "set": "Deoxys",
     "setCode": "ex8",
     "text": [
-      "You can't have more than 1 Pokémon Star in your deck."
+      "You can’t have more than 1 Pokémon Star in your deck."
     ],
     "types": [
       "Colorless"
@@ -5125,7 +5125,7 @@
     "set": "Deoxys",
     "setCode": "ex8",
     "text": [
-      "You can't have more than 1 Pokémon Star in your deck."
+      "You can’t have more than 1 Pokémon Star in your deck."
     ],
     "types": [
       "Colorless"
@@ -5189,7 +5189,7 @@
     "set": "Deoxys",
     "setCode": "ex8",
     "text": [
-      "You can't have more than 1 Pokémon Star in your deck."
+      "You can’t have more than 1 Pokémon Star in your deck."
     ],
     "types": [
       "Colorless"
@@ -5215,7 +5215,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Discard all Energy cards attached to Rayquaza Star. This attack does 100 damage to each of your opponent's Pokémon-ex. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard all Energy cards attached to Rayquaza Star. This attack does 100 damage to each of your opponent’s Pokémon-ex. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [

--- a/json/cards/Diamond & Pearl.json
+++ b/json/cards/Diamond & Pearl.json
@@ -39,7 +39,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "You may return all Energy cards attached to Dialga to your hand. If you do, remove the highest Stage Evolution card from the Defending Pokémon and shuffle that card into your opponent's deck."
+        "text": "You may return all Energy cards attached to Dialga to your hand. If you do, remove the highest Stage Evolution card from the Defending Pokémon and shuffle that card into your opponent’s deck."
       }
     ],
     "weaknesses": [
@@ -67,7 +67,7 @@
     "evolvesFrom": "Dusclops",
     "ability": {
       "name": "Dark Palm",
-      "text": "Once during your turn (before your attack), if your opponent has 4 or more Benched Pokémon, you may choose 1 of them and shuffle that Pokémon and all cards attached to it into his or her deck. This power can't be used if Dusknoir is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if your opponent has 4 or more Benched Pokémon, you may choose 1 of them and shuffle that Pokémon and all cards attached to it into his or her deck. This power can’t be used if Dusknoir is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -123,7 +123,7 @@
     "evolvesFrom": "Electabuzz",
     "ability": {
       "name": "Intense Voltage",
-      "text": "As often as you like during your turn (before your attack), if Elekid is anywhere under Electivire, you may move a Lightning Energy attached to 1 of your Pokémon to Electivire. This power can't be used if Electivire is affected by a Special Condition.",
+      "text": "As often as you like during your turn (before your attack), if Elekid is anywhere under Electivire, you may move a Lightning Energy attached to 1 of your Pokémon to Electivire. This power can’t be used if Electivire is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -152,7 +152,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "You may discard all  Lightning Energy attached to Electivire. If you do, this attack's base damage is 120 instead of 60."
+        "text": "You may discard all  Lightning Energy attached to Electivire. If you do, this attack’s base damage is 120 instead of 60."
       }
     ],
     "weaknesses": [
@@ -201,7 +201,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 40 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Aqua Jet",
@@ -212,7 +212,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "Flip a coin. If heads, this attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -301,7 +301,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       },
       {
         "name": "Aura Sphere",
@@ -311,7 +311,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -333,7 +333,7 @@
     "evolvesFrom": "Luxio",
     "ability": {
       "name": "Sharp Eye",
-      "text": "Once during your turn, when you play Luxray from your hand to evolve 1 of your Pokémon, you may look at your opponent's hand. If your opponent's Bench isn't full, choose 1 Basic Pokémon from your opponent's hand, and put it onto his or her Bench. Then, switch it with the Defending Pokémon.",
+      "text": "Once during your turn, when you play Luxray from your hand to evolve 1 of your Pokémon, you may look at your opponent’s hand. If your opponent’s Bench isn’t full, choose 1 Basic Pokémon from your opponent’s hand, and put it onto his or her Bench. Then, switch it with the Defending Pokémon.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -360,7 +360,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "Move all Lightning Energy attached to Luxray to 1 of your Benched Pokémon. (Ignore this effect if you don't have any Benched Pokémon.)"
+        "text": "Move all Lightning Energy attached to Luxray to 1 of your Benched Pokémon. (Ignore this effect if you don’t have any Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -583,7 +583,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "You may flip a coin. If heads, discard all Energy attached to Palkia and put the Defending Pokémon and all cards attached to it on top of your opponent's deck. Your opponent shuffles his or her deck afterward."
+        "text": "You may flip a coin. If heads, discard all Energy attached to Palkia and put the Defending Pokémon and all cards attached to it on top of your opponent’s deck. Your opponent shuffles his or her deck afterward."
       }
     ],
     "weaknesses": [
@@ -605,7 +605,7 @@
     "evolvesFrom": "Rhydon",
     "ability": {
       "name": "Earth Fissure",
-      "text": "Once during your turn, when you play Rhyperior from your hand to evolve 1 of your Pokémon, you may discard the top 3 cards from your opponent's deck.",
+      "text": "Once during your turn, when you play Rhyperior from your hand to evolve 1 of your Pokémon, you may discard the top 3 cards from your opponent’s deck.",
       "type": "Poké-Power"
     },
     "hp": "140",
@@ -634,7 +634,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "This attack's damage isn't affected by Weakness or Resistance. Rhyperior can't attack during your next turn."
+        "text": "This attack’s damage isn’t affected by Weakness or Resistance. Rhyperior can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -693,7 +693,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "If Budew is anywhere under Roserade, choose 1 of your opponent's Benched Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If Budew is anywhere under Roserade, choose 1 of your opponent’s Benched Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -715,7 +715,7 @@
     "evolvesFrom": "Nuzleaf",
     "ability": {
       "name": "Darkness Fan",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, choose 1 Evolved Pokémon on your opponent's Bench, remove the highest Stage Evolution card from that Pokémon, and put it back into his or her hand. This power can't be used if Shiftry is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, choose 1 Evolved Pokémon on your opponent’s Bench, remove the highest Stage Evolution card from that Pokémon, and put it back into his or her hand. This power can’t be used if Shiftry is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -790,7 +790,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon that doesn't have any damage counters on it. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon that doesn’t have any damage counters on it. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Toxic Cloud",
@@ -845,7 +845,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Flip a coin. If tails, this attack does nothing. If heads, prevent all damage done to Staraptor by attacks (both yours and your opponent's) until the end of your next turn."
+        "text": "Flip a coin. If tails, this attack does nothing. If heads, prevent all damage done to Staraptor by attacks (both yours and your opponent’s) until the end of your next turn."
       },
       {
         "name": "Brave Heart",
@@ -963,7 +963,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to Azumarill during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all damage done to Azumarill during your opponent’s next turn."
       },
       {
         "name": "Bubble Pump",
@@ -1127,7 +1127,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Before doing damage, count the remaining HP of the Defending Pokémon and Carnivine. If the Defending Pokémon has fewer remaining HP than Carnivine's, this attack does 60 damage instead."
+        "text": "Before doing damage, count the remaining HP of the Defending Pokémon and Carnivine. If the Defending Pokémon has fewer remaining HP than Carnivine’s, this attack does 60 damage instead."
       },
       {
         "name": "Wring Out",
@@ -1197,7 +1197,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. Metronome copies that attack except for its Energy cost. (You must still do anything else in order to use that attack.) Clefable performs that attack."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. Metronome copies that attack except for its Energy cost. (You must still do anything else in order to use that attack.) Clefable performs that attack."
       }
     ],
     "weaknesses": [
@@ -1301,7 +1301,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent’s). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1414,7 +1414,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40+",
-        "text": "Does 40 damage plus 20 more damage for each Water Energy attached to Floatzel but not used to pay for this attack's Energy cost. You can't add more than 40 damage in this way."
+        "text": "Does 40 damage plus 20 more damage for each Water Energy attached to Floatzel but not used to pay for this attack’s Energy cost. You can’t add more than 40 damage in this way."
       }
     ],
     "weaknesses": [
@@ -1466,7 +1466,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Put 4 damage counters on your opponent's Pokémon in any way you like. Then, switch Gengar with 1 of your Benched Pokémon."
+        "text": "Put 4 damage counters on your opponent’s Pokémon in any way you like. Then, switch Gengar with 1 of your Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -1568,7 +1568,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Sand Eject",
@@ -1638,7 +1638,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) You may switch Lopunny with 1 of your Benched Pokémon."
+        "text": "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) You may switch Lopunny with 1 of your Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -1681,7 +1681,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20+",
-        "text": "If any of your Pokémon were Knocked Out by damage from an opponent's attack during his or her last turn, this attack does 20 damage plus 50 more damage."
+        "text": "If any of your Pokémon were Knocked Out by damage from an opponent’s attack during his or her last turn, this attack does 20 damage plus 50 more damage."
       },
       {
         "name": "Dynamic Punch",
@@ -1734,7 +1734,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Count the number of damage counters on Medicham. Put that many damage counters on 1 of your opponent's Pokémon."
+        "text": "Count the number of damage counters on Medicham. Put that many damage counters on 1 of your opponent’s Pokémon."
       },
       {
         "name": "Spinning Kick",
@@ -1791,7 +1791,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30x",
-        "text": "Discard 2 cards from your hand. (If you can't discard 2 cards, this attack does nothing.) Flip 2 coins. This attack does 30 damage times the number of heads."
+        "text": "Discard 2 cards from your hand. (If you can’t discard 2 cards, this attack does nothing.) Flip 2 coins. This attack does 30 damage times the number of heads."
       }
     ],
     "weaknesses": [
@@ -1948,7 +1948,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 card from your opponent's hand without looking and discard it."
+        "text": "Choose 1 card from your opponent’s hand without looking and discard it."
       },
       {
         "name": "Body Slam",
@@ -2003,7 +2003,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Ease Up",
@@ -2071,7 +2071,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "Steelix can't attack during your next turn."
+        "text": "Steelix can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -2131,7 +2131,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "10x",
-        "text": "Does 10 damage times the number of Grass Pokémon in play (both yours and your opponent's)."
+        "text": "Does 10 damage times the number of Grass Pokémon in play (both yours and your opponent’s)."
       }
     ],
     "weaknesses": [
@@ -2283,7 +2283,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 card from your opponent's hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
+        "text": "Choose 1 card from your opponent’s hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
       }
     ],
     "weaknesses": [
@@ -2377,7 +2377,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, if Cascoon would be damaged by an attack, prevent that attack's damage done to Cascoon if that damage is 30 or less."
+        "text": "During your opponent’s next turn, if Cascoon would be damaged by an attack, prevent that attack’s damage done to Cascoon if that damage is 30 or less."
       },
       {
         "name": "Gooey Thread",
@@ -2387,7 +2387,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2498,7 +2498,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Flip a coin. If heads, the Defending Pokémon is now Confused and can't retreat during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon is now Confused and can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2550,7 +2550,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, put 2 damage counters on each of your opponent's Pokémon. If tails, put 2 damage counters on 1 of your Pokémon."
+        "text": "Flip a coin. If heads, put 2 damage counters on each of your opponent’s Pokémon. If tails, put 2 damage counters on 1 of your Pokémon."
       },
       {
         "name": "Gravity Wave",
@@ -2560,7 +2560,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Does 10 damage to each of your opponent's Benched Pokémon that doesn't have a Retreat Cost. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Benched Pokémon that doesn’t have a Retreat Cost. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2793,7 +2793,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -2970,7 +2970,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Before doing damage, you may choose 1 of your opponent's Benched Pokémon that has any Energy attached to it and switch that Pokémon with 1 of the Defending Pokémon."
+        "text": "Before doing damage, you may choose 1 of your opponent’s Benched Pokémon that has any Energy attached to it and switch that Pokémon with 1 of the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -3185,7 +3185,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Brine",
@@ -3195,7 +3195,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon that has any damage counters on it. This attack does 40 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon that has any damage counters on it. This attack does 40 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3237,7 +3237,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Blaze Up",
@@ -3248,7 +3248,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Flip a coin. If tails, discard a Fire Energy attached to Rapidash and this attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If tails, discard a Fire Energy attached to Rapidash and this attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3449,7 +3449,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, if Silcoon would be damaged by an attack, prevent that attack's damage done to Silcoon if that damage is 30 or less."
+        "text": "During your opponent’s next turn, if Silcoon would be damaged by an attack, prevent that attack’s damage done to Silcoon if that damage is 30 or less."
       },
       {
         "name": "Entangling String",
@@ -3459,7 +3459,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3511,7 +3511,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3788,7 +3788,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Scavenge",
@@ -3845,7 +3845,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent can't play any Trainer cards from his or her hand during your opponent's next turn, and any damage done to Bonsly by attacks is reduced by 30 (after applying Weakness and Resistance)."
+        "text": "Flip a coin. If heads, your opponent can’t play any Trainer cards from his or her hand during your opponent’s next turn, and any damage done to Bonsly by attacks is reduced by 30 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -3941,7 +3941,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4252,7 +4252,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. The new Defending Pokémon is now Asleep."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon. The new Defending Pokémon is now Asleep."
       },
       {
         "name": "Gust",
@@ -4311,7 +4311,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Flip a coin. If heads, choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Night Shade",
@@ -4321,7 +4321,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4382,7 +4382,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, the Defending Pokémon is now Paralyzed. If Electabuzz is evolved from Elekid, this attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, the Defending Pokémon is now Paralyzed. If Electabuzz is evolved from Elekid, this attack does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4431,7 +4431,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Move 1 damage counter from Gastly to 1 of your opponent's Pokémon."
+        "text": "Move 1 damage counter from Gastly to 1 of your opponent’s Pokémon."
       }
     ],
     "weaknesses": [
@@ -4480,7 +4480,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
       },
       {
         "name": "Pose",
@@ -4801,7 +4801,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Meditite during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Meditite during your opponent’s next turn."
       },
       {
         "name": "Meditate",
@@ -4859,7 +4859,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Shuffle your hand into your deck. Then, draw a number of cards equal to the number of cards in your opponent's hand."
+        "text": "Shuffle your hand into your deck. Then, draw a number of cards equal to the number of cards in your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -4899,7 +4899,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 card from your opponent's hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
+        "text": "Choose 1 card from your opponent’s hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
       },
       {
         "name": "Confuse Ray",
@@ -4960,7 +4960,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose up to 2 of your opponent's Benched Pokémon. This attack does 10 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.) Onix can't attack during your next turn."
+        "text": "Choose up to 2 of your opponent’s Benched Pokémon. This attack does 10 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.) Onix can’t attack during your next turn."
       },
       {
         "name": "Headbutt",
@@ -5232,7 +5232,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, during your opponent's next turn, if Seedot would be Knocked Out by damage from an attack, Seedot is not Knocked Out and its remaining HP becomes 10 instead."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, if Seedot would be Knocked Out by damage from an attack, Seedot is not Knocked Out and its remaining HP becomes 10 instead."
       },
       {
         "name": "Rollout",
@@ -5291,7 +5291,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -5404,7 +5404,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
       }
     ],
     "weaknesses": [
@@ -5687,7 +5687,7 @@
     "set": "Diamond & Pearl",
     "setCode": "dp1",
     "text": [
-      "Flip 3 coins. For each heads, put a basic Energy card from your discard pile into your hand. If you don't have that many basic Energy cards in your discard pile, put all of them into your hand."
+      "Flip 3 coins. For each heads, put a basic Energy card from your discard pile into your hand. If you don’t have that many basic Energy cards in your discard pile, put all of them into your hand."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp1/106_hires.png"
   },
@@ -5796,7 +5796,7 @@
     "setCode": "dp1",
     "text": [
       "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.",
-      "Choose 1 card in your hand and shuffle the rest of your cards into your deck. Then, draw 4 cards. (If this is the only card in your hand, you can't play this card.)"
+      "Choose 1 card in your hand and shuffle the rest of your cards into your deck. Then, draw 4 cards. (If this is the only card in your hand, you can’t play this card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp1/112_hires.png"
   },
@@ -5832,8 +5832,8 @@
     "set": "Diamond & Pearl",
     "setCode": "dp1",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "Once during each player's turn, the player may flip a coin until he or she gets tails. For each heads, that player draws a card."
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
+      "Once during each player’s turn, the player may flip a coin until he or she gets tails. For each heads, that player draws a card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp1/114_hires.png"
   },
@@ -5936,7 +5936,7 @@
     "level": "X",
     "ability": {
       "name": "Supreme Command",
-      "text": "Once during your turn (before your attack), you may choose up to 2 cards from your opponent's hand without looking and put them face down next to the Defending Pokémon. (These cards are not in play or in your opponent's hand.) At the end of your opponent's next turn, return those cards to your opponent's hand. This power can't be used if Empoleon is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may choose up to 2 cards from your opponent’s hand without looking and put them face down next to the Defending Pokémon. (These cards are not in play or in your opponent’s hand.) At the end of your opponent’s next turn, return those cards to your opponent’s hand. This power can’t be used if Empoleon is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "140",
@@ -5966,7 +5966,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 80 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Empoleon can't attack during your next turn."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 80 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) Empoleon can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -5987,7 +5987,7 @@
     "level": "X",
     "ability": {
       "name": "Burning Head",
-      "text": "Once during your turn (before your attack), you may look at the top 3 cards of your deck, choose 1 of them, and put it into your hand. Discard the other 2 cards. This power can't be used if Infernape is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may look at the top 3 cards of your deck, choose 1 of them, and put it into your hand. Discard the other 2 cards. This power can’t be used if Infernape is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -6012,7 +6012,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "150",
-        "text": "Search your discard pile for 8 Fire Energy cards, show them to your opponent, and shuffle them into your deck. (This attack does nothing if you don't have 8 Fire Energy cards in your discard pile.)"
+        "text": "Search your discard pile for 8 Fire Energy cards, show them to your opponent, and shuffle them into your deck. (This attack does nothing if you don’t have 8 Fire Energy cards in your discard pile.)"
       }
     ],
     "weaknesses": [
@@ -6033,7 +6033,7 @@
     "level": "X",
     "ability": {
       "name": "Forest Murmurs",
-      "text": "Once during your turn (before your attack), if you have more Prize cards left than your opponent, you may choose 1 of your opponent's Benched Pokémon and switch it with 1 of the Defending Pokémon. This power can't be used if Torterra is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if you have more Prize cards left than your opponent, you may choose 1 of your opponent’s Benched Pokémon and switch it with 1 of the Defending Pokémon. This power can’t be used if Torterra is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "160",
@@ -6066,7 +6066,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "Does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Torterra does 30 damage to itself."
+        "text": "Does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) Torterra does 30 damage to itself."
       }
     ],
     "weaknesses": [

--- a/json/cards/Double Crisis.json
+++ b/json/cards/Double Crisis.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "dc1-1",
-    "name": "Team Magma's Numel",
+    "name": "Team Magma’s Numel",
     "imageUrl": "https://images.pokemontcg.io/dc1/1.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -45,11 +45,11 @@
   },
   {
     "id": "dc1-2",
-    "name": "Team Magma's Camerupt",
+    "name": "Team Magma’s Camerupt",
     "imageUrl": "https://images.pokemontcg.io/dc1/2.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
-    "evolvesFrom": "Team Magma's Numel",
+    "evolvesFrom": "Team Magma’s Numel",
     "ability": {
       "name": "Burning Draft",
       "text": "Once during your turn (before your attack), you may attach a Fighting or Fire Energy card from your discard pile to this Pokémon.",
@@ -94,7 +94,7 @@
   },
   {
     "id": "dc1-3",
-    "name": "Team Aqua's Spheal",
+    "name": "Team Aqua’s Spheal",
     "imageUrl": "https://images.pokemontcg.io/dc1/3.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -137,11 +137,11 @@
   },
   {
     "id": "dc1-4",
-    "name": "Team Aqua's Sealeo",
+    "name": "Team Aqua’s Sealeo",
     "imageUrl": "https://images.pokemontcg.io/dc1/4.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
-    "evolvesFrom": "Team Aqua's Spheal",
+    "evolvesFrom": "Team Aqua’s Spheal",
     "hp": "90",
     "retreatCost": [
       "Colorless",
@@ -166,7 +166,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "This attack does 20 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Hail Storm",
@@ -177,7 +177,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60＋",
-        "text": "If your opponent's Active Pokémon is a Team Magma Pokémon, this attack does 60 more damage."
+        "text": "If your opponent’s Active Pokémon is a Team Magma Pokémon, this attack does 60 more damage."
       }
     ],
     "weaknesses": [
@@ -194,11 +194,11 @@
   },
   {
     "id": "dc1-5",
-    "name": "Team Aqua's Walrein",
+    "name": "Team Aqua’s Walrein",
     "imageUrl": "https://images.pokemontcg.io/dc1/5.png",
     "subtype": "Stage 2",
     "supertype": "Pokémon",
-    "evolvesFrom": "Team Aqua's Sealeo",
+    "evolvesFrom": "Team Aqua’s Sealeo",
     "hp": "140",
     "retreatCost": [
       "Colorless",
@@ -235,7 +235,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Discard 2 Water Energy attached to this Pokémon. This attack does 80 damage to 2 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard 2 Water Energy attached to this Pokémon. This attack does 80 damage to 2 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -249,14 +249,14 @@
   },
   {
     "id": "dc1-6",
-    "name": "Team Aqua's Kyogre-ex",
+    "name": "Team Aqua’s Kyogre-ex",
     "imageUrl": "https://images.pokemontcg.io/dc1/6.png",
     "subtype": "EX",
     "supertype": "Pokémon",
     "level": "ex",
     "ability": {
       "name": "Power Saver",
-      "text": "If there are 4 or fewer Team Aqua Pokémon in play, this Pokémon can't attack.",
+      "text": "If there are 4 or fewer Team Aqua Pokémon in play, this Pokémon can’t attack.",
       "type": "Ability"
     },
     "hp": "190",
@@ -286,7 +286,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80＋",
-        "text": "This attack does 20 more damage for each Colorless in your opponent's Active Pokémon's Retreat Cost."
+        "text": "This attack does 20 more damage for each Colorless in your opponent’s Active Pokémon’s Retreat Cost."
       }
     ],
     "weaknesses": [
@@ -300,7 +300,7 @@
   },
   {
     "id": "dc1-7",
-    "name": "Team Aqua's Grimer",
+    "name": "Team Aqua’s Grimer",
     "imageUrl": "https://images.pokemontcg.io/dc1/7.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -354,11 +354,11 @@
   },
   {
     "id": "dc1-8",
-    "name": "Team Aqua's Muk",
+    "name": "Team Aqua’s Muk",
     "imageUrl": "https://images.pokemontcg.io/dc1/8.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
-    "evolvesFrom": "Team Aqua's Grimer",
+    "evolvesFrom": "Team Aqua’s Grimer",
     "ability": {
       "name": "Sludge Festival",
       "text": "The Retreat Cost of each Pokémon in play (except for Team Aqua Pokémon) is Colorless more.",
@@ -389,7 +389,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60＋",
-        "text": "If your opponent's Active Pokémon is affected by a Special Condition, this attack does 60 more damage."
+        "text": "If your opponent’s Active Pokémon is affected by a Special Condition, this attack does 60 more damage."
       }
     ],
     "weaknesses": [
@@ -403,7 +403,7 @@
   },
   {
     "id": "dc1-9",
-    "name": "Team Aqua's Seviper",
+    "name": "Team Aqua’s Seviper",
     "imageUrl": "https://images.pokemontcg.io/dc1/9.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -428,7 +428,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Poisoned."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Poisoned."
       },
       {
         "name": "Venom Tail",
@@ -438,7 +438,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "If your opponent's Active Pokémon is affected by a Special Condition, discard an Energy attached to that Pokémon."
+        "text": "If your opponent’s Active Pokémon is affected by a Special Condition, discard an Energy attached to that Pokémon."
       }
     ],
     "weaknesses": [
@@ -452,7 +452,7 @@
   },
   {
     "id": "dc1-10",
-    "name": "Team Magma's Baltoy",
+    "name": "Team Magma’s Baltoy",
     "imageUrl": "https://images.pokemontcg.io/dc1/10.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -478,7 +478,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "This attack does 20 damage to 1 of your opponent's Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "This attack does 20 damage to 1 of your opponent’s Pokémon. This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -495,11 +495,11 @@
   },
   {
     "id": "dc1-11",
-    "name": "Team Magma's Claydol",
+    "name": "Team Magma’s Claydol",
     "imageUrl": "https://images.pokemontcg.io/dc1/11.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
-    "evolvesFrom": "Team Magma's Baltoy",
+    "evolvesFrom": "Team Magma’s Baltoy",
     "ability": {
       "name": "Magma Switch",
       "text": "Once during your turn (before your attack), you may move a basic Energy from 1 of your Pokémon to 1 of your Team Magma Pokémon.",
@@ -543,7 +543,7 @@
   },
   {
     "id": "dc1-12",
-    "name": "Team Magma's Aron",
+    "name": "Team Magma’s Aron",
     "imageUrl": "https://images.pokemontcg.io/dc1/12.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -586,11 +586,11 @@
   },
   {
     "id": "dc1-13",
-    "name": "Team Magma's Lairon",
+    "name": "Team Magma’s Lairon",
     "imageUrl": "https://images.pokemontcg.io/dc1/13.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
-    "evolvesFrom": "Team Magma's Aron",
+    "evolvesFrom": "Team Magma’s Aron",
     "hp": "90",
     "retreatCost": [
       "Colorless",
@@ -643,11 +643,11 @@
   },
   {
     "id": "dc1-14",
-    "name": "Team Magma's Aggron",
+    "name": "Team Magma’s Aggron",
     "imageUrl": "https://images.pokemontcg.io/dc1/14.png",
     "subtype": "Stage 2",
     "supertype": "Pokémon",
-    "evolvesFrom": "Team Magma's Lairon",
+    "evolvesFrom": "Team Magma’s Lairon",
     "hp": "140",
     "retreatCost": [
       "Colorless",
@@ -685,7 +685,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "This attack does 20 damage to each of your opponent's Benched Pokémon that has any damage counters on it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to each of your opponent’s Benched Pokémon that has any damage counters on it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -699,14 +699,14 @@
   },
   {
     "id": "dc1-15",
-    "name": "Team Magma's Groudon-ex",
+    "name": "Team Magma’s Groudon-ex",
     "imageUrl": "https://images.pokemontcg.io/dc1/15.png",
     "subtype": "EX",
     "supertype": "Pokémon",
     "level": "ex",
     "ability": {
       "name": "Power Saver",
-      "text": "If there are 4 or fewer Team Magma Pokémon in play, this Pokémon can't attack.",
+      "text": "If there are 4 or fewer Team Magma Pokémon in play, this Pokémon can’t attack.",
       "type": "Ability"
     },
     "hp": "190",
@@ -736,7 +736,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80＋",
-        "text": "If your opponent's Active Pokémon already has any damage counters on it, this attack does 80 more damage."
+        "text": "If your opponent’s Active Pokémon already has any damage counters on it, this attack does 80 more damage."
       }
     ],
     "weaknesses": [
@@ -750,7 +750,7 @@
   },
   {
     "id": "dc1-16",
-    "name": "Team Aqua's Poochyena",
+    "name": "Team Aqua’s Poochyena",
     "imageUrl": "https://images.pokemontcg.io/dc1/16.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -808,7 +808,7 @@
   },
   {
     "id": "dc1-17",
-    "name": "Team Magma's Poochyena",
+    "name": "Team Magma’s Poochyena",
     "imageUrl": "https://images.pokemontcg.io/dc1/17.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -866,11 +866,11 @@
   },
   {
     "id": "dc1-18",
-    "name": "Team Aqua's Mightyena",
+    "name": "Team Aqua’s Mightyena",
     "imageUrl": "https://images.pokemontcg.io/dc1/18.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
-    "evolvesFrom": "Team Aqua's Poochyena",
+    "evolvesFrom": "Team Aqua’s Poochyena",
     "hp": "100",
     "retreatCost": [
       "Colorless"
@@ -904,7 +904,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -924,11 +924,11 @@
   },
   {
     "id": "dc1-19",
-    "name": "Team Magma's Mightyena",
+    "name": "Team Magma’s Mightyena",
     "imageUrl": "https://images.pokemontcg.io/dc1/19.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
-    "evolvesFrom": "Team Magma's Poochyena",
+    "evolvesFrom": "Team Magma’s Poochyena",
     "hp": "100",
     "retreatCost": [
       "Colorless"
@@ -962,7 +962,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80＋",
-        "text": "If your opponent's Active Pokémon is a Team Aqua Pokémon, this attack does 40 more damage."
+        "text": "If your opponent’s Active Pokémon is a Team Aqua Pokémon, this attack does 40 more damage."
       }
     ],
     "weaknesses": [
@@ -982,7 +982,7 @@
   },
   {
     "id": "dc1-20",
-    "name": "Team Aqua's Carvanha",
+    "name": "Team Aqua’s Carvanha",
     "imageUrl": "https://images.pokemontcg.io/dc1/20.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -1024,11 +1024,11 @@
   },
   {
     "id": "dc1-21",
-    "name": "Team Aqua's Sharpedo",
+    "name": "Team Aqua’s Sharpedo",
     "imageUrl": "https://images.pokemontcg.io/dc1/21.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
-    "evolvesFrom": "Team Aqua's Carvanha",
+    "evolvesFrom": "Team Aqua’s Carvanha",
     "ability": {
       "name": "Aqua Search",
       "text": "Once during your turn (before your attack), you may search your deck for a Team Aqua Pokémon, reveal it, and put it into your hand. Shuffle your deck afterward.",
@@ -1068,7 +1068,7 @@
   },
   {
     "id": "dc1-22",
-    "name": "Team Magma's Zangoose",
+    "name": "Team Magma’s Zangoose",
     "imageUrl": "https://images.pokemontcg.io/dc1/22.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -1180,13 +1180,13 @@
     "set": "Double Crisis",
     "setCode": "dc1",
     "text": [
-      "Discard a card from your hand. (If you can't discard a card, you can't play this card.) Draw 3 cards. If you discarded a Team Aqua Pokémon, draw 1 more card."
+      "Discard a card from your hand. (If you can’t discard a card, you can’t play this card.) Draw 3 cards. If you discarded a Team Aqua Pokémon, draw 1 more card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dc1/26_hires.png"
   },
   {
     "id": "dc1-27",
-    "name": "Team Aqua's Great Ball",
+    "name": "Team Aqua’s Great Ball",
     "imageUrl": "https://images.pokemontcg.io/dc1/27.png",
     "subtype": "Item",
     "supertype": "Trainer",
@@ -1203,7 +1203,7 @@
   },
   {
     "id": "dc1-28",
-    "name": "Team Aqua's Secret Base",
+    "name": "Team Aqua’s Secret Base",
     "imageUrl": "https://images.pokemontcg.io/dc1/28.png",
     "subtype": "Stadium",
     "supertype": "Trainer",
@@ -1248,13 +1248,13 @@
     "set": "Double Crisis",
     "setCode": "dc1",
     "text": [
-      "Discard a card from your hand. (If you can't discard a card, you can't play this card.) Draw 3 cards. If you discarded a Team Magma Pokémon, draw 1 more card."
+      "Discard a card from your hand. (If you can’t discard a card, you can’t play this card.) Draw 3 cards. If you discarded a Team Magma Pokémon, draw 1 more card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dc1/30_hires.png"
   },
   {
     "id": "dc1-31",
-    "name": "Team Magma's Great Ball",
+    "name": "Team Magma’s Great Ball",
     "imageUrl": "https://images.pokemontcg.io/dc1/31.png",
     "subtype": "Item",
     "supertype": "Trainer",
@@ -1271,7 +1271,7 @@
   },
   {
     "id": "dc1-32",
-    "name": "Team Magma's Secret Base",
+    "name": "Team Magma’s Secret Base",
     "imageUrl": "https://images.pokemontcg.io/dc1/32.png",
     "subtype": "Stadium",
     "supertype": "Trainer",

--- a/json/cards/Dragon Frontiers.json
+++ b/json/cards/Dragon Frontiers.json
@@ -82,7 +82,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Before doing damage, you may choose 1 of your opponent's Benched Pokémon and switch it with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
+        "text": "Before doing damage, you may choose 1 of your opponent’s Benched Pokémon and switch it with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
       },
       {
         "name": "Sharp Fang",
@@ -113,7 +113,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shining Horn",
-      "text": "As long as Heracross is the only Pokémon you have in play, your opponent's Basic Pokémon can't attack.",
+      "text": "As long as Heracross is the only Pokémon you have in play, your opponent’s Basic Pokémon can’t attack.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -194,7 +194,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 30 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 30 (before applying Weakness and Resistance)."
       },
       {
         "name": "Mega Impact",
@@ -232,7 +232,7 @@
     "evolvesFrom": "Feebas",
     "ability": {
       "name": "Sharing",
-      "text": "Once during your turn (before your attack), you may look at your opponent's hand. You may use the effect of a Supporter card you find there as the effect of this power. (The Supporter card remains in your opponent's hand.) You can't use more than 1 Sharing Poké-Power each turn. This power can't be used if Milotic is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may look at your opponent’s hand. You may use the effect of a Supporter card you find there as the effect of this power. (The Supporter card remains in your opponent’s hand.) You can’t use more than 1 Sharing Poké-Power each turn. This power can’t be used if Milotic is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -302,7 +302,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Dark Horn",
@@ -313,7 +313,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "You may discard a Basic Pokémon or Evolution card from your hand. If you do, choose 1 of your opponent's Benched Pokémon and do 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "You may discard a Basic Pokémon or Evolution card from your hand. If you do, choose 1 of your opponent’s Benched Pokémon and do 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -334,7 +334,7 @@
     "evolvesFrom": "Nidorina",
     "ability": {
       "name": "Invitation",
-      "text": "Once during your turn (before your attack), you may search your deck for a Basic Pokémon or Evolution card, show it to your opponent, and put it into your hand. Shuffle your deck afterward. This power can't be used if Nidoqueen is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may search your deck for a Basic Pokémon or Evolution card, show it to your opponent, and put it into your hand. Shuffle your deck afterward. This power can’t be used if Nidoqueen is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -361,7 +361,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
-        "text": "Does 30 damage plus 10 more damage for each Basic Pokémon and each Evolution card in your discard pile. You can't add more than 60 damage in this way."
+        "text": "Does 30 damage plus 10 more damage for each Basic Pokémon and each Evolution card in your discard pile. You can’t add more than 60 damage in this way."
       }
     ],
     "weaknesses": [
@@ -532,7 +532,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose an attack on 1 of your opponent's Pokémon in play that has δ on its card. Delta Copy copies that attack except for its Energy cost. (You must still do anything else required for that attack.) Togetic performs that attack."
+        "text": "Choose an attack on 1 of your opponent’s Pokémon in play that has δ on its card. Delta Copy copies that attack except for its Energy cost. (You must still do anything else required for that attack.) Togetic performs that attack."
       },
       {
         "name": "Wave Splash",
@@ -572,7 +572,7 @@
     "evolvesFrom": "Quilava",
     "ability": {
       "name": "Shady Move",
-      "text": "Once during your turn (before your attack), if Typhlosion is your Active Pokémon, you may move 1 damage counter from either player's Pokémon to another Pokémon (yours or your opponent's). This power can't be used if Typhlosion is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Typhlosion is your Active Pokémon, you may move 1 damage counter from either player’s Pokémon to another Pokémon (yours or your opponent’s). This power can’t be used if Typhlosion is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -670,7 +670,7 @@
     "evolvesFrom": "Shellder",
     "ability": {
       "name": "Solid Shell",
-      "text": "Prevent all of effects of attacks, including damage, done by your opponent's Pokémon to each of your Benched Pokémon that has δ on its card.",
+      "text": "Prevent all of effects of attacks, including damage, done by your opponent’s Pokémon to each of your Benched Pokémon that has δ on its card.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -715,7 +715,7 @@
     "evolvesFrom": "Seel",
     "ability": {
       "name": "Delta Protection",
-      "text": "Any damage done to Dewgong by attacks from your opponent's Pokémon that has δ on its card is reduced by 40 (after applying Weakness and Resistance).",
+      "text": "Any damage done to Dewgong by attacks from your opponent’s Pokémon that has δ on its card is reduced by 40 (after applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -939,7 +939,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 1 damage counter on 1 of your opponent's Pokémon. If that Pokémon has δ on its card, put 3 damage counters instead."
+        "text": "Put 1 damage counter on 1 of your opponent’s Pokémon. If that Pokémon has δ on its card, put 3 damage counters instead."
       }
     ],
     "weaknesses": [
@@ -962,7 +962,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Power Circulation",
-      "text": "Once during your turn (before your attack), you may search your discard pile for a basic Energy card, show it to your opponent, and put it on top of your deck. If you do, put 1 damage counter on Mantine. This power can't be used if Mantine is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may search your discard pile for a basic Energy card, show it to your opponent, and put it on top of your deck. If you do, put 1 damage counter on Mantine. This power can’t be used if Mantine is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "50",
@@ -1074,7 +1074,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Razor Wing",
@@ -1328,7 +1328,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack or retreat during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack or retreat during your opponent’s next turn."
       },
       {
         "name": "Slash",
@@ -1411,7 +1411,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Power of Evolution",
-      "text": "Once during your turn (before your attack), if Electabuzz is an Evolved Pokémon, you may draw a card from the bottom of your deck. This power can't be used if Electabuzz is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Electabuzz is an Evolved Pokémon, you may draw a card from the bottom of your deck. This power can’t be used if Electabuzz is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -1436,7 +1436,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -1587,7 +1587,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "If Kirlia and the Defending Pokémon have a different amount of Energy attached to them, this attack's base damage is 30 instead of 60."
+        "text": "If Kirlia and the Defending Pokémon have a different amount of Energy attached to them, this attack’s base damage is 30 instead of 60."
       }
     ],
     "weaknesses": [
@@ -2008,7 +2008,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Swellow during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Swellow during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2053,7 +2053,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -2142,7 +2142,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "During your opponent's next turn, any damage done to Bagon by attacks is reduced by 10 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Bagon by attacks is reduced by 10 (after applying Weakness and Resistance)."
       }
     ],
     "nationalPokedexNumber": 371,
@@ -2237,7 +2237,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
       }
     ],
     "weaknesses": [
@@ -2372,7 +2372,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2737,7 +2737,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack during your opponent’s next turn."
       },
       {
         "name": "Scratch",
@@ -3370,7 +3370,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
       }
     ],
     "weaknesses": [
@@ -3464,7 +3464,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Tail Slap",
@@ -3503,8 +3503,8 @@
     "set": "Dragon Frontiers",
     "setCode": "ex15",
     "text": [
-      "Attach Buffer Piece to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
-      "Damage done to the Pokémon Buffer Piece is attached to by an opponent's attack is reduced by 20 (after applying Weakness and Resistance). At the end of your opponent's turn after you played Buffer Piece, discard Buffer Piece."
+      "Attach Buffer Piece to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
+      "Damage done to the Pokémon Buffer Piece is attached to by an opponent’s attack is reduced by 20 (after applying Weakness and Resistance). At the end of your opponent’s turn after you played Buffer Piece, discard Buffer Piece."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/72_hires.png"
   },
@@ -3523,7 +3523,7 @@
     "setCode": "ex15",
     "text": [
       "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.",
-      "Shuffle your hand into your deck. Then, count the number of cards in your opponent's hand and draw that many cards."
+      "Shuffle your hand into your deck. Then, count the number of cards in your opponent’s hand and draw that many cards."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/73_hires.png"
   },
@@ -3541,8 +3541,8 @@
     "set": "Dragon Frontiers",
     "setCode": "ex15",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "Each Pokémon in play that has δ on its card in play (both yours and your opponent's) has no Weakness and can't use any Poké-Powers."
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
+      "Each Pokémon in play that has δ on its card in play (both yours and your opponent’s) has no Weakness and can’t use any Poké-Powers."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/74_hires.png"
   },
@@ -3561,7 +3561,7 @@
     "setCode": "ex15",
     "text": [
       "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.",
-      "Discard a card from your hand. If you can't discard a card from your hand, you can't play this card. Search your deck for up to 3 Basic Pokémon that each has 100 HP or less, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
+      "Discard a card from your hand. If you can’t discard a card from your hand, you can’t play this card. Search your deck for up to 3 Basic Pokémon that each has 100 HP or less, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/75_hires.png"
   },
@@ -3586,7 +3586,7 @@
   },
   {
     "id": "ex15-77",
-    "name": "Mr. Stone's Project",
+    "name": "Mr. Stone’s Project",
     "imageUrl": "https://images.pokemontcg.io/ex15/77.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -3623,7 +3623,7 @@
   },
   {
     "id": "ex15-79",
-    "name": "Professor Elm's Training Method",
+    "name": "Professor Elm’s Training Method",
     "imageUrl": "https://images.pokemontcg.io/ex15/79.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -3642,7 +3642,7 @@
   },
   {
     "id": "ex15-80",
-    "name": "Professor Oak's Research",
+    "name": "Professor Oak’s Research",
     "imageUrl": "https://images.pokemontcg.io/ex15/80.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -3673,7 +3673,7 @@
     "set": "Dragon Frontiers",
     "setCode": "ex15",
     "text": [
-      "Attach Strength Charm to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
+      "Attach Strength Charm to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
       "Whenever an attack from the Pokémon that Strength Charm is attached to does damage to the Active Pokémon, the attack does 10 more damage (before applying Weakness and Resistance). Discard Strength Charm at the end of the turn in which this Pokémon attacks."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/81_hires.png"
@@ -3728,7 +3728,7 @@
     "set": "Dragon Frontiers",
     "setCode": "ex15",
     "text": [
-      "Holon Energy FF provides Colorless Energy. If the Pokémon that Holon Energy FF is attached to also has a basic Fire Energy card attached to it, that Pokémon has no Weakness. If the Pokémon that Holon Energy FF is attached to also has a basic Fighting Energy card attached to it, damage done by that Pokémon's attack isn't affected by Resistance. Ignore these effects if Holon Energy FF is attached to Pokémon-ex."
+      "Holon Energy FF provides Colorless Energy. If the Pokémon that Holon Energy FF is attached to also has a basic Fire Energy card attached to it, that Pokémon has no Weakness. If the Pokémon that Holon Energy FF is attached to also has a basic Fighting Energy card attached to it, damage done by that Pokémon’s attack isn’t affected by Resistance. Ignore these effects if Holon Energy FF is attached to Pokémon-ex."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/84_hires.png"
   },
@@ -3745,7 +3745,7 @@
     "set": "Dragon Frontiers",
     "setCode": "ex15",
     "text": [
-      "Holon Energy GL provides Colorless Energy. If the Pokémon that Holon Energy GL is attached to also has a basic Grass Energy card attached to it, that Pokémon can't be affected by any Special Conditions. If the Pokémon that Holon Energy GL is attached to also has a basic Lightning Energy card attached to it, damage done by your opponent's Pokémon-ex is reduced by 10. Ignore these effects if Holon Energy GL is attached to Pokémon-ex."
+      "Holon Energy GL provides Colorless Energy. If the Pokémon that Holon Energy GL is attached to also has a basic Grass Energy card attached to it, that Pokémon can’t be affected by any Special Conditions. If the Pokémon that Holon Energy GL is attached to also has a basic Lightning Energy card attached to it, damage done by your opponent’s Pokémon-ex is reduced by 10. Ignore these effects if Holon Energy GL is attached to Pokémon-ex."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/85_hires.png"
   },
@@ -3762,7 +3762,7 @@
     "set": "Dragon Frontiers",
     "setCode": "ex15",
     "text": [
-      "Holon Energy WP provides Colorless Energy. If the Pokémon that Holon Energy WP is attached to also has a basic Water Energy card attached to it, prevent all effects of attacks, excluding damage, done to that Pokémon by your opponent's Pokémon. If the Pokémon that Holon Energy WP is attached to also has a basic Psychic Energy card attached to it, that Pokémon's Retreat Cost is 0. Ignore these effects if Holon Energy WP is attached to Pokémon-ex."
+      "Holon Energy WP provides Colorless Energy. If the Pokémon that Holon Energy WP is attached to also has a basic Water Energy card attached to it, prevent all effects of attacks, excluding damage, done to that Pokémon by your opponent’s Pokémon. If the Pokémon that Holon Energy WP is attached to also has a basic Psychic Energy card attached to it, that Pokémon’s Retreat Cost is 0. Ignore these effects if Holon Energy WP is attached to Pokémon-ex."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/86_hires.png"
   },
@@ -3779,7 +3779,7 @@
     "set": "Dragon Frontiers",
     "setCode": "ex15",
     "text": [
-      "Boost Energy can be attached only to an Evolved Pokémon. Discard Boost Energy at the end of the turn it was attached. Boost Energy provides Colorless Colorless Colorless Energy. The Pokémon Boost Energy is attached to can't retreat. If the Pokémon Boost Energy is attached to isn't an Evolved Pokémon, discard Boost Energy."
+      "Boost Energy can be attached only to an Evolved Pokémon. Discard Boost Energy at the end of the turn it was attached. Boost Energy provides Colorless Colorless Colorless Energy. The Pokémon Boost Energy is attached to can’t retreat. If the Pokémon Boost Energy is attached to isn’t an Evolved Pokémon, discard Boost Energy."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/87_hires.png"
   },
@@ -3813,7 +3813,7 @@
     "set": "Dragon Frontiers",
     "setCode": "ex15",
     "text": [
-      "Scramble Energy can be attached only to an Evolved Pokémon (excluding Pokémon-ex). Scramble Energy provides Colorless Energy. While in play, if you have more Prize cards left than your opponent, Scramble Energy provides every type of Energy but provides only 3 in any combination at a time. If the Pokémon Scramble Energy is attached to isn't an Evolved Pokémon (or evolves into Pokémon-ex), discard Scramble Energy."
+      "Scramble Energy can be attached only to an Evolved Pokémon (excluding Pokémon-ex). Scramble Energy provides Colorless Energy. While in play, if you have more Prize cards left than your opponent, Scramble Energy provides every type of Energy but provides only 3 in any combination at a time. If the Pokémon Scramble Energy is attached to isn’t an Evolved Pokémon (or evolves into Pokémon-ex), discard Scramble Energy."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/89_hires.png"
   },
@@ -3827,7 +3827,7 @@
     "evolvesFrom": "Swablu",
     "ability": {
       "name": "Extra Boost",
-      "text": "Once during your turn (before your attack), you may attach a basic Energy card from your hand to 1 of your Stage 2 Pokémon-ex. This power can't be used if Altaria ex is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may attach a basic Energy card from your hand to 1 of your Stage 2 Pokémon-ex. This power can’t be used if Altaria ex is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -3912,7 +3912,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Your opponent can't play any Trainer cards (except for Supporter cards) from his or her hand during your opponent's next turn."
+        "text": "Your opponent can’t play any Trainer cards (except for Supporter cards) from his or her hand during your opponent’s next turn."
       },
       {
         "name": "Dragon Roar",
@@ -3924,7 +3924,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Put 8 damage counters on the Defending Pokémon. If that Pokémon would be Knocked Out by this attack, you may put any damage counters not necessary to Knocked Out the Defending Pokémon on your opponent's Benched Pokémon in any way you like."
+        "text": "Put 8 damage counters on the Defending Pokémon. If that Pokémon would be Knocked Out by this attack, you may put any damage counters not necessary to Knocked Out the Defending Pokémon on your opponent’s Benched Pokémon in any way you like."
       }
     ],
     "nationalPokedexNumber": 149,
@@ -3940,7 +3940,7 @@
     "evolvesFrom": "Vibrava",
     "ability": {
       "name": "Sand Damage",
-      "text": "As long as Flygon ex is your Active Pokémon, put 1 damage counter on each of your opponent's Benched Basic Pokémon between turns. You can't use more than 1 Sand Damage Poké-Body between turns.",
+      "text": "As long as Flygon ex is your Active Pokémon, put 1 damage counter on each of your opponent’s Benched Basic Pokémon between turns. You can’t use more than 1 Sand Damage Poké-Body between turns.",
       "type": "Poké-Body"
     },
     "hp": "150",
@@ -3970,7 +3970,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "Does 10 damage to each of your opponent's Benched Pokémon that has any damage counters on it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Benched Pokémon that has any damage counters on it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "nationalPokedexNumber": 330,
@@ -3986,7 +3986,7 @@
     "evolvesFrom": "Kirlia",
     "ability": {
       "name": "Imprison",
-      "text": "Once during your turn (before your attack), if Gardevoir ex is your Active Pokémon, you may put an Imprison marker on 1 of your opponent's Pokémon. Any Pokémon that has any Imprison markers on it can't use any Poké-Powers or Poké-Bodies. This power can't be used if Gardevoir ex is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Gardevoir ex is your Active Pokémon, you may put an Imprison marker on 1 of your opponent’s Pokémon. Any Pokémon that has any Imprison markers on it can’t use any Poké-Powers or Poké-Bodies. This power can’t be used if Gardevoir ex is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "150",
@@ -4038,7 +4038,7 @@
     "evolvesFrom": "Seadra",
     "ability": {
       "name": "Extra Smoke",
-      "text": "Any damage done to your Stage 2 Pokémon-ex by your opponent's attacks is reduced by 10 (before applying Weakness and Resistance).",
+      "text": "Any damage done to your Stage 2 Pokémon-ex by your opponent’s attacks is reduced by 10 (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "140",
@@ -4077,7 +4077,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "Kingdra ex has no Weakness during your opponent's next turn."
+        "text": "Kingdra ex has no Weakness during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -4098,7 +4098,7 @@
     "level": "ex",
     "ability": {
       "name": "Fellow Boost",
-      "text": "Once during your turn (before your attack), you may attach a basic Energy card from your hand to your Latias, Latias ex, Latios or Latios ex. If you do, your turn ends. This power can't be used if Latias ex is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may attach a basic Energy card from your hand to your Latias, Latias ex, Latios or Latios ex. If you do, your turn ends. This power can’t be used if Latias ex is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -4178,7 +4178,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Prevent all effects of an attack, including damage, done to Latios ex by your opponent's Pokémon-ex during your opponent's next turn."
+        "text": "Prevent all effects of an attack, including damage, done to Latios ex by your opponent’s Pokémon-ex during your opponent’s next turn."
       },
       {
         "name": "Hydro Splash",
@@ -4210,7 +4210,7 @@
     "level": "ex",
     "ability": {
       "name": "Rage Aura",
-      "text": "If you have more Prize cards left than your opponent, the attack cost of Rayquaza ex's Special Circuit is now Lightning and Rayquaza ex's Sky-high Claws is now Lightning Lightning.",
+      "text": "If you have more Prize cards left than your opponent, the attack cost of Rayquaza ex’s Special Circuit is now Lightning and Rayquaza ex’s Sky-high Claws is now Lightning Lightning.",
       "type": "Poké-Body"
     },
     "hp": "110",
@@ -4239,7 +4239,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. If you choose a Pokémon that has any Poké-Powers or Poké-Bodies, this attack does 50 damage instead. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. If you choose a Pokémon that has any Poké-Powers or Poké-Bodies, this attack does 50 damage instead. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Sky-high Claws",
@@ -4267,7 +4267,7 @@
     "evolvesFrom": "Shelgon",
     "ability": {
       "name": "Type Shift",
-      "text": "Once during your turn (before your attack), you may use this power. Salamence ex's type is Fire until the end of your turn.",
+      "text": "Once during your turn (before your attack), you may use this power. Salamence ex’s type is Fire until the end of your turn.",
       "type": "Poké-Power"
     },
     "hp": "160",
@@ -4309,7 +4309,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "You may do 40 damage instead of 80 to the Defending Pokémon. If you do, this attack does 40 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "You may do 40 damage instead of 80 to the Defending Pokémon. If you do, this attack does 40 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4366,7 +4366,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Put a Shock-wave marker on 1 of your opponent's Pokémon."
+        "text": "Put a Shock-wave marker on 1 of your opponent’s Pokémon."
       },
       {
         "name": "Hyper Claws",
@@ -4388,7 +4388,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon that has any Shock-wave markers on it. That Pokémon is Knocked Out."
+        "text": "Choose 1 of your opponent’s Pokémon that has any Shock-wave markers on it. That Pokémon is Knocked Out."
       }
     ],
     "weaknesses": [
@@ -4419,7 +4419,7 @@
     "set": "Dragon Frontiers",
     "setCode": "ex15",
     "text": [
-      "You can't have more than 1 Pokémon Star in your deck."
+      "You can’t have more than 1 Pokémon Star in your deck."
     ],
     "types": [
       "Darkness"
@@ -4446,7 +4446,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "150",
-        "text": "Discard all Energy cards attached to Charizard Star and discard the top 3 cards from your opponent's deck."
+        "text": "Discard all Energy cards attached to Charizard Star and discard the top 3 cards from your opponent’s deck."
       }
     ],
     "weaknesses": [
@@ -4475,7 +4475,7 @@
     "set": "Dragon Frontiers",
     "setCode": "ex15",
     "text": [
-      "You can't have more than 1 Pokémon Star in your deck."
+      "You can’t have more than 1 Pokémon Star in your deck."
     ],
     "types": [
       "Water"
@@ -4488,7 +4488,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose an attack on 1 of your opponent's Pokémon in play. Mimicry copies that attack. This attack does nothing if Mew Star doesn't have the Energy necessary to use that attack. (You must still do anything else required for that attack.) Mew Star performs that attack."
+        "text": "Choose an attack on 1 of your opponent’s Pokémon in play. Mimicry copies that attack. This attack does nothing if Mew Star doesn’t have the Energy necessary to use that attack. (You must still do anything else required for that attack.) Mew Star performs that attack."
       },
       {
         "name": "Rainbow Wave",
@@ -4497,7 +4497,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 basic Energy card attached to Mew Star. This attack does 20 damage to each of your opponent's Pokémon that is the same type as the basic Energy card that you chose. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 basic Energy card attached to Mew Star. This attack does 20 damage to each of your opponent’s Pokémon that is the same type as the basic Energy card that you chose. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [

--- a/json/cards/Dragon Vault.json
+++ b/json/cards/Dragon Vault.json
@@ -404,7 +404,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "90",
-        "text": "This attack's damage isn't affected by any effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by any effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -556,7 +556,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": "This attack's damage isn't affected by any effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by any effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -887,7 +887,7 @@
     "set": "Dragon Vault",
     "setCode": "dv1",
     "text": [
-      "When your Active Pokémon is Knocked Out by damage from an opponent's attack, you may move 1 basic Energy card that was attached to that Pokémon to the Pokémon this card is attached to."
+      "When your Active Pokémon is Knocked Out by damage from an opponent’s attack, you may move 1 basic Energy card that was attached to that Pokémon to the Pokémon this card is attached to."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dv1/18_hires.png"
   },
@@ -904,7 +904,7 @@
     "set": "Dragon Vault",
     "setCode": "dv1",
     "text": [
-      "Before you flip a coin to decide who goes first in a game, you may play this card. Don't flip that coin, and you go first. If both players play First Ticket, flip the coin as normal. (You may play only 1 First Ticket before you flip that coin.)"
+      "Before you flip a coin to decide who goes first in a game, you may play this card. Don’t flip that coin, and you go first. If both players play First Ticket, flip the coin as normal. (You may play only 1 First Ticket before you flip that coin.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dv1/19_hires.png"
   },

--- a/json/cards/Dragon.json
+++ b/json/cards/Dragon.json
@@ -26,7 +26,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the number of cards in your opponent's hand is at least 6, choose a number of cards there, without looking, until your opponent has 5 cards left. Have your opponent discard the cards you chose."
+        "text": "If the number of cards in your opponent’s hand is at least 6, choose a number of cards there, without looking, until your opponent has 5 cards left. Have your opponent discard the cards you chose."
       },
       {
         "name": "Prize Count",
@@ -271,7 +271,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "60",
-        "text": "Does 20 damage to 2 of your opponent's Benched Pokémon (1 if there is only 1). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 2 of your opponent’s Benched Pokémon (1 if there is only 1). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -343,7 +343,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Chain of Events",
-      "text": "As long as Minun is your Active Pokémon, whenever your other Active Pokémon, if any, attacks, you may use Cheer On after the first attack (you still need the necessary Energy to use Cheer On). You can't use Cheer On more than once in this way even if your other Active Pokémon has the Chain of Events Poké-Body.",
+      "text": "As long as Minun is your Active Pokémon, whenever your other Active Pokémon, if any, attacks, you may use Cheer On after the first attack (you still need the necessary Energy to use Cheer On). You can’t use Cheer On more than once in this way even if your other Active Pokémon has the Chain of Events Poké-Body.",
       "type": "Poké-Body"
     },
     "hp": "50",
@@ -377,7 +377,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. If you choose Pokémon that has a Poké-Power or Poké-Body, this attack does 40 damage instead. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. If you choose Pokémon that has a Poké-Power or Poké-Body, this attack does 40 damage instead. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -403,7 +403,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Chain of Events",
-      "text": "As long as Plusle is your Active Pokémon, whenever your other Active Pokémon, if any, attacks, you may use Cheer On after the first attack (you still need the necessary Energy to use Cheer On). You can't use Cheer On more than once in this way even if your other Active Pokémon has the Chain of Events Poké-Body.",
+      "text": "As long as Plusle is your Active Pokémon, whenever your other Active Pokémon, if any, attacks, you may use Cheer On after the first attack (you still need the necessary Energy to use Cheer On). You can’t use Cheer On more than once in this way even if your other Active Pokémon has the Chain of Events Poké-Body.",
       "type": "Poké-Body"
     },
     "hp": "50",
@@ -437,7 +437,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. If you choose Pokémon-ex, this attack does 40 damage instead. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. If you choose Pokémon-ex, this attack does 40 damage instead. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -463,7 +463,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Thick Skin",
-      "text": "Roselia can't be affected by any Special Conditions.",
+      "text": "Roselia can’t be affected by any Special Conditions.",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -520,7 +520,7 @@
     "evolvesFrom": "Shelgon",
     "ability": {
       "name": "Dragon Wind",
-      "text": "Once during your turn (before your attack), if Salamence is your Active Pokémon, you may switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. This power can't be used if Salamence is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Salamence is your Active Pokémon, you may switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. This power can’t be used if Salamence is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -546,7 +546,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Salamence during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Salamence during your opponent’s next turn."
       },
       {
         "name": "Dragon Claw",
@@ -589,7 +589,7 @@
     "evolvesFrom": "Nincada",
     "ability": {
       "name": "Wonder Guard",
-      "text": "Prevent all effects of attacks, including damage, done to Shedinja by your opponent's Evolved Pokémon and Pokémon-ex.",
+      "text": "Prevent all effects of attacks, including damage, done to Shedinja by your opponent’s Evolved Pokémon and Pokémon-ex.",
       "type": "Poké-Body"
     },
     "hp": "30",
@@ -795,7 +795,7 @@
     "evolvesFrom": "Vibrava",
     "ability": {
       "name": "Sand Guard",
-      "text": "Whenever Flygon would be damaged by your opponent's attack (after applying Weakness and Resistance), flip a coin. If heads, reduce that damage by 20.",
+      "text": "Whenever Flygon would be damaged by your opponent’s attack (after applying Weakness and Resistance), flip a coin. If heads, reduce that damage by 20.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -865,7 +865,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage for each Colorless Energy in that Pokémon's Retreat Cost to that Pokémon (after applying effects to the Retreat Cost). (Don't apply Weakness and Resistance for Benched Pokémon.)\""
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage for each Colorless Energy in that Pokémon’s Retreat Cost to that Pokémon (after applying effects to the Retreat Cost). (Don’t apply Weakness and Resistance for Benched Pokémon.)\""
       }
     ],
     "weaknesses": [
@@ -886,7 +886,7 @@
     "evolvesFrom": "Magnemite",
     "ability": {
       "name": "Magnetic Field",
-      "text": "Once during your turn (before your attack), if you have basic Energy cards in your discard pile, you may discard any 1 card from your hand. Then search up to 2 basic Energy cards from your discard pile, show them to your opponent, and put them into your hand. You can't return the card you first discarded to your hand in this way. This power can't be used if Magneton is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if you have basic Energy cards in your discard pile, you may discard any 1 card from your hand. Then search up to 2 basic Energy cards from your discard pile, show them to your opponent, and put them into your hand. You can’t return the card you first discarded to your hand in this way. This power can’t be used if Magneton is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -987,7 +987,7 @@
     "evolvesFrom": "Shelgon",
     "ability": {
       "name": "Intimidating Fang",
-      "text": "As long as Salamence is your Active Pokémon, any damage done to your Pokémon by an opponent's attack is reduced by 10 (before applying Weakness and Resistance).",
+      "text": "As long as Salamence is your Active Pokémon, any damage done to your Pokémon by an opponent’s attack is reduced by 10 (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -1049,7 +1049,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to Shelgon during your opponent's next turn. (Any other effects of attacks still happen.)"
+        "text": "Flip a coin. If heads, prevent all damage done to Shelgon during your opponent’s next turn. (Any other effects of attacks still happen.)"
       },
       {
         "name": "Rolling Attack",
@@ -1112,7 +1112,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the number of cards in your opponent's hand is at least 6, look at his or her hand. Choose a number of cards there until your opponent has 5 cards left in his or her hand and have your opponent shuffle the cards you chose into his or her deck."
+        "text": "If the number of cards in your opponent’s hand is at least 6, look at his or her hand. Choose a number of cards there until your opponent has 5 cards left in his or her hand and have your opponent shuffle the cards you chose into his or her deck."
       },
       {
         "name": "Power Count",
@@ -1122,7 +1122,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "Count the amount of Energy attached to all of your Pokémon and all of your opponent's Pokémon. If your Pokémon have less Energy than your opponent's, this attack does 20 damage plus 30 more damage."
+        "text": "Count the amount of Energy attached to all of your Pokémon and all of your opponent’s Pokémon. If your Pokémon have less Energy than your opponent’s, this attack does 20 damage plus 30 more damage."
       }
     ],
     "weaknesses": [
@@ -1178,7 +1178,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, this attack does 20 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance to Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 20 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance to Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1594,7 +1594,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Does 80 damage to each Active Pokémon (both yours and your opponent's)."
+        "text": "Does 80 damage to each Active Pokémon (both yours and your opponent’s)."
       }
     ],
     "weaknesses": [
@@ -1640,7 +1640,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent’s). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Rollout",
@@ -1758,7 +1758,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "80",
-        "text": "This attack's damage is not affected by Resistance."
+        "text": "This attack’s damage is not affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -1806,7 +1806,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -1850,7 +1850,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
       },
       {
         "name": "Flamethrower",
@@ -1963,7 +1963,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2066,7 +2066,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "This attack's damage is not affected by Resistance."
+        "text": "This attack’s damage is not affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -2109,7 +2109,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20+",
-        "text": "Does 20 damage plus 10 more damage for each Energy attached to Seadra but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "Does 20 damage plus 10 more damage for each Energy attached to Seadra but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       },
       {
         "name": "Water Arrow",
@@ -2120,7 +2120,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2164,7 +2164,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Seadra during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Seadra during your opponent’s next turn."
       },
       {
         "name": "Waterfall",
@@ -2199,7 +2199,7 @@
     "evolvesFrom": "Bagon",
     "ability": {
       "name": "Energy Guard",
-      "text": "As long as Shelgon has any basic Energy cards attached to it, damage done to Shelgon by an opponent's attack is reduced by 10 (after applying Weakness and Resistance).",
+      "text": "As long as Shelgon has any basic Energy cards attached to it, damage done to Shelgon by an opponent’s attack is reduced by 10 (after applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -2264,7 +2264,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Damage done to Shelgon by an opponent's attack is reduced by 10 (after applying Weakness and Resistance) during your opponent's next turn."
+        "text": "Damage done to Shelgon by an opponent’s attack is reduced by 10 (after applying Weakness and Resistance) during your opponent’s next turn."
       },
       {
         "name": "Flare",
@@ -2320,7 +2320,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 1 damage counter on 1 of your opponent's Pokémon."
+        "text": "Put 1 damage counter on 1 of your opponent’s Pokémon."
       }
     ],
     "weaknesses": [
@@ -2409,7 +2409,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "The Defending Pokémon can't retreat until the end of your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat until the end of your opponent’s next turn."
       },
       {
         "name": "Quick Dive",
@@ -2419,7 +2419,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, choose 1 of your opponent's Pokémon. This attack does 50 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Flip a coin. If heads, choose 1 of your opponent’s Pokémon. This attack does 50 damage to that Pokémon. This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -2446,7 +2446,7 @@
     "evolvesFrom": "Trapinch",
     "ability": {
       "name": "Levitate",
-      "text": "If Vibrava has any basic Energy cards attached to it, Vibrava's Retreat Cost is 0.",
+      "text": "If Vibrava has any basic Energy cards attached to it, Vibrava’s Retreat Cost is 0.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -2538,7 +2538,7 @@
     "evolvesFrom": "Barboach",
     "ability": {
       "name": "Submerge",
-      "text": "As long as Whiscash is on your Bench, prevent all damage done to Whiscash by opponent's attacks.",
+      "text": "As long as Whiscash is on your Bench, prevent all damage done to Whiscash by opponent’s attacks.",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -2576,7 +2576,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent’s). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2923,7 +2923,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Benched Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Benched Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3278,7 +3278,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3416,7 +3416,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "Does 10 damage plus 10 more damage for each Water Energy attached to Mudkip but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "Does 10 damage plus 10 more damage for each Water Energy attached to Mudkip but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       }
     ],
     "weaknesses": [
@@ -3753,7 +3753,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. The new Defending Pokémon is now Burned."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. The new Defending Pokémon is now Burned."
       }
     ],
     "weaknesses": [
@@ -4223,7 +4223,7 @@
     "setCode": "ex3",
     "text": [
       "When the Pokémon Balloon Berry is attached to retreats, discard Balloon Berry instead of discarding Energy cards.",
-      "Attach Balloon Berry to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card."
+      "Attach Balloon Berry to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex3/82_hires.png"
   },
@@ -4241,8 +4241,8 @@
     "set": "Dragon",
     "setCode": "ex3",
     "text": [
-      "Attach Buffer Piece to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
-      "Damage done to the Pokémon Buffer Piece is attached to by an opponent's attack is reduced by 20 (after applying Weakness and Resistance). At the end of your opponent's turn after you played Buffer Piece, discard Buffer Piece."
+      "Attach Buffer Piece to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
+      "Damage done to the Pokémon Buffer Piece is attached to by an opponent’s attack is reduced by 20 (after applying Weakness and Resistance). At the end of your opponent’s turn after you played Buffer Piece, discard Buffer Piece."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex3/83_hires.png"
   },
@@ -4298,13 +4298,13 @@
     "setCode": "ex3",
     "text": [
       "This card stays in play when you play it. Discard this card if another Stadium card comes into play.",
-      "Each Grass and Lightning Pokémon in play (both yours and your opponent's) gets +10 HP.\""
+      "Each Grass and Lightning Pokémon in play (both yours and your opponent’s) gets +10 HP.\""
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex3/86_hires.png"
   },
   {
     "id": "ex3-87",
-    "name": "Mr. Briney's Compassion",
+    "name": "Mr. Briney’s Compassion",
     "imageUrl": "https://images.pokemontcg.io/ex3/87.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4350,7 +4350,7 @@
     "evolvesFrom": "Flaaffy",
     "ability": {
       "name": "Conductivity",
-      "text": "As long as Ampharos ex is in play, whenever your opponent attaches an Energy card to his or her Pokémon from hand, put 1 damage counter on that Pokémon. You can't put more than 1 damage counter even if there is more than 1 Ampharos ex in play.",
+      "text": "As long as Ampharos ex is in play, whenever your opponent attaches an Energy card to his or her Pokémon from hand, put 1 damage counter on that Pokémon. You can’t put more than 1 damage counter even if there is more than 1 Ampharos ex in play.",
       "type": "Poké-Body"
     },
     "hp": "150",
@@ -4409,7 +4409,7 @@
     "evolvesFrom": "Dragonair",
     "ability": {
       "name": "Call for Power",
-      "text": "As often as you like during your turn, you may move an Energy card attached to 1 of your Pokémon to Dragonite ex. This power can't be used if Dragonite ex is affected by a Special Condition.",
+      "text": "As often as you like during your turn, you may move an Energy card attached to 1 of your Pokémon to Dragonite ex. This power can’t be used if Dragonite ex is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "150",
@@ -4510,7 +4510,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent’s). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Double-edge",
@@ -4573,7 +4573,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Use any attack from Kingdra ex's Basic Pokémon card or Stage 1 Evolution card. (Kingdra ex doesn't have to pay for that attack's Energy cost.)"
+        "text": "Use any attack from Kingdra ex’s Basic Pokémon card or Stage 1 Evolution card. (Kingdra ex doesn’t have to pay for that attack’s Energy cost.)"
       },
       {
         "name": "Hydrocannon",
@@ -4584,7 +4584,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50+",
-        "text": "Does 50 damage plus 20 more damage for each Water Energy attached to Kingdra ex but not used to pay for this attack's Energy cost. You can't add more than 40 damage in this way."
+        "text": "Does 50 damage plus 20 more damage for each Water Energy attached to Kingdra ex but not used to pay for this attack’s Energy cost. You can’t add more than 40 damage in this way."
       }
     ],
     "weaknesses": [
@@ -4836,7 +4836,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40+",
-        "text": "Does 40 damage plus 10 more damage for each Colorless Energy in the Defending Pokémon's Retreat Cost (after applying effects to the Retreat Cost)."
+        "text": "Does 40 damage plus 10 more damage for each Colorless Energy in the Defending Pokémon’s Retreat Cost (after applying effects to the Retreat Cost)."
       }
     ],
     "weaknesses": [

--- a/json/cards/Dragons Exalted.json
+++ b/json/cards/Dragons Exalted.json
@@ -216,7 +216,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       },
       {
         "name": "Cutting Wind",
@@ -318,7 +318,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, if this Pokémon would be damaged by an attack, prevent that attack's damage done to this Pokémon if that damage is 60 or less."
+        "text": "During your opponent’s next turn, if this Pokémon would be damaged by an attack, prevent that attack’s damage done to this Pokémon if that damage is 60 or less."
       },
       {
         "name": "Bug Bite",
@@ -425,7 +425,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with the Defending Pokémon."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon."
       },
       {
         "name": "Spiral Drain",
@@ -477,7 +477,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -913,7 +913,7 @@
     "evolvesFrom": "Vulpix",
     "ability": {
       "name": "Bright Look",
-      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may switch 1 of your opponent's Benched Pokémon with his or her Active Pokémon.",
+      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may switch 1 of your opponent’s Benched Pokémon with his or her Active Pokémon.",
       "type": "Ability"
     },
     "hp": "90",
@@ -1033,7 +1033,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "40",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Flamethrower",
@@ -1308,7 +1308,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "This Pokémon can't use Giant Wave during your next turn."
+        "text": "This Pokémon can’t use Giant Wave during your next turn."
       }
     ],
     "weaknesses": [
@@ -1559,7 +1559,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "The Defending Pokémon is now Paralyzed. This Pokémon can't use Ice Entomb during your next turn."
+        "text": "The Defending Pokémon is now Paralyzed. This Pokémon can’t use Ice Entomb during your next turn."
       }
     ],
     "weaknesses": [
@@ -1790,7 +1790,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "During your next turn, this Pokémon's Echoed Voice attack does 50 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s Echoed Voice attack does 50 more damage (before applying Weakness and Resistance)."
       },
       {
         "name": "Drain Punch",
@@ -1893,7 +1893,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Thunder Jolt",
@@ -1946,7 +1946,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Power Gem",
@@ -2008,7 +2008,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2140,7 +2140,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20x",
-        "text": "Does 20 damage times the amount of Energy attached to all of your opponent's Pokémon."
+        "text": "Does 20 damage times the amount of Energy attached to all of your opponent’s Pokémon."
       },
       {
         "name": "Flash Impact",
@@ -2151,7 +2151,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "Does 20 damage to 1 of your Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2272,7 +2272,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Versatile",
-      "text": "This Pokémon can use the attacks of any Pokémon in play (both yours and your opponent's). (You still need the necessary Energy to use each attack.)",
+      "text": "This Pokémon can use the attacks of any Pokémon in play (both yours and your opponent’s). (You still need the necessary Energy to use each attack.)",
       "type": "Ability"
     },
     "hp": "120",
@@ -2371,7 +2371,7 @@
     "evolvesFrom": "Nincada",
     "ability": {
       "name": "Empty Shell",
-      "text": "If this Pokémon is Knocked Out, your opponent can't take any Prize cards for it.",
+      "text": "If this Pokémon is Knocked Out, your opponent can’t take any Prize cards for it.",
       "type": "Ability"
     },
     "hp": "60",
@@ -2392,7 +2392,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 3 damage counters on your opponent's Pokémon in any way you like."
+        "text": "Put 3 damage counters on your opponent’s Pokémon in any way you like."
       }
     ],
     "nationalPokedexNumber": 292,
@@ -2425,7 +2425,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 1 damage counter on 1 of your opponent's Pokémon."
+        "text": "Put 1 damage counter on 1 of your opponent’s Pokémon."
       }
     ],
     "weaknesses": [
@@ -2520,7 +2520,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "50x",
-        "text": "Does 50 damage times the number of Special Energy cards in your opponent's discard pile."
+        "text": "Does 50 damage times the number of Special Energy cards in your opponent’s discard pile."
       },
       {
         "name": "Plentiful Placement",
@@ -2530,7 +2530,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Put 4 damage counters on 1 of your opponent's Pokémon."
+        "text": "Put 4 damage counters on 1 of your opponent’s Pokémon."
       }
     ],
     "weaknesses": [
@@ -2652,7 +2652,7 @@
     "evolvesFrom": "Trubbish",
     "ability": {
       "name": "Garbotoxin",
-      "text": "If this Pokémon has a Pokémon Tool card attached to it, each Pokémon in play, in each player's hand, and in each player's discard pile has no Abilities (except for Garbotoxin).",
+      "text": "If this Pokémon has a Pokémon Tool card attached to it, each Pokémon in play, in each player’s hand, and in each player’s discard pile has no Abilities (except for Garbotoxin).",
       "type": "Ability"
     },
     "hp": "100",
@@ -2773,7 +2773,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "This attack's damage isn't affected by Weakness or Resistance."
+        "text": "This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -2829,7 +2829,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40+",
-        "text": "Does 20 more damage for each of your opponent's Benched Pokémon."
+        "text": "Does 20 more damage for each of your opponent’s Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -2930,7 +2930,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Devolve the Defending Pokémon and put the highest Stage Evolution card on it into your opponent's hand."
+        "text": "Devolve the Defending Pokémon and put the highest Stage Evolution card on it into your opponent’s hand."
       },
       {
         "name": "Ghost Hammer",
@@ -2942,7 +2942,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "90",
-        "text": "During your opponent's next turn, this Pokémon has no Weakness."
+        "text": "During your opponent’s next turn, this Pokémon has no Weakness."
       }
     ],
     "weaknesses": [
@@ -3040,7 +3040,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Vortex Chop",
@@ -3316,7 +3316,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3522,7 +3522,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Rumble",
@@ -3532,7 +3532,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3583,7 +3583,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       },
       {
         "name": "Pump-up Smash",
@@ -3705,7 +3705,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "Discard a random card from your opponent's hand."
+        "text": "Discard a random card from your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -3915,7 +3915,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "The Defending Pokémon is now Poisoned. If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "The Defending Pokémon is now Poisoned. If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Hammer In",
@@ -4036,7 +4036,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Flip a coin until you get tails. For each heads, discard the top card of your opponent's deck."
+        "text": "Flip a coin until you get tails. For each heads, discard the top card of your opponent’s deck."
       }
     ],
     "weaknesses": [
@@ -4066,7 +4066,7 @@
     "evolvesFrom": "Lairon",
     "ability": {
       "name": "Toppling Wind",
-      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may discard the top 3 cards of your opponent's deck.",
+      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may discard the top 3 cards of your opponent’s deck.",
       "type": "Ability"
     },
     "hp": "140",
@@ -4148,7 +4148,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 30 damage to 3 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 3 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Protect Charge",
@@ -4160,7 +4160,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -4210,7 +4210,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "You may move an Energy attached to the Defending Pokémon to 1 of your opponent's Benched Pokémon."
+        "text": "You may move an Energy attached to the Defending Pokémon to 1 of your opponent’s Benched Pokémon."
       },
       {
         "name": "Heavy Nose",
@@ -4303,7 +4303,7 @@
     "evolvesFrom": "Swablu",
     "ability": {
       "name": "Fight Song",
-      "text": "Your Dragon Pokémon's attacks do 20 more damage to the Active Pokémon (before applying Weakness and Resistance).",
+      "text": "Your Dragon Pokémon’s attacks do 20 more damage to the Active Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "70",
@@ -4473,7 +4473,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Knock Away",
@@ -4536,7 +4536,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "This attack's damage isn't affected by any effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by any effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -4686,7 +4686,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -4732,7 +4732,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": "This attack's damage isn't affected by any effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by any effects on the Defending Pokémon."
       },
       {
         "name": "Dragon Pulse",
@@ -4837,7 +4837,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 10 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 10 (after applying Weakness and Resistance)."
       },
       {
         "name": "Headbutt",
@@ -5269,7 +5269,7 @@
     "evolvesFrom": "Vigoroth",
     "ability": {
       "name": "Unobservant",
-      "text": "If your opponent's Active Pokémon is a Basic Pokémon, this Pokémon can't attack.",
+      "text": "If your opponent’s Active Pokémon is a Basic Pokémon, this Pokémon can’t attack.",
       "type": "Ability"
     },
     "hp": "150",
@@ -5492,7 +5492,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Tumbling Tackle",
@@ -5792,7 +5792,7 @@
     "set": "Dragons Exalted",
     "setCode": "bw6",
     "text": [
-      "Devolve 1 of your evolved Pokémon and put the highest Stage Evolution card on it into your hand. (That Pokémon can't evolve this turn.)"
+      "Devolve 1 of your evolved Pokémon and put the highest Stage Evolution card on it into your hand. (That Pokémon can’t evolve this turn.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw6/113_hires.png"
   },
@@ -5843,7 +5843,7 @@
     "set": "Dragons Exalted",
     "setCode": "bw6",
     "text": [
-      "Choose up to 2 Pokémon Tool cards attached to Pokémon in play (yours or your opponent's) and discard them."
+      "Choose up to 2 Pokémon Tool cards attached to Pokémon in play (yours or your opponent’s) and discard them."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw6/116_hires.png"
   },
@@ -5945,7 +5945,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Versatile",
-      "text": "This Pokémon can use the attacks of any Pokémon in play (both yours and your opponent's). (You still need the necessary Energy to use each attack.)",
+      "text": "This Pokémon can use the attacks of any Pokémon in play (both yours and your opponent’s). (You still need the necessary Energy to use each attack.)",
       "type": "Ability"
     },
     "hp": "120",
@@ -6017,7 +6017,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       },
       {
         "name": "Pump-up Smash",
@@ -6075,7 +6075,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 30 damage to 3 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 3 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Protect Charge",
@@ -6087,7 +6087,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -6192,7 +6192,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": "This attack's damage isn't affected by any effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by any effects on the Defending Pokémon."
       },
       {
         "name": "Dragon Pulse",
@@ -6348,7 +6348,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Bombast",
@@ -6418,7 +6418,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": "This attack's damage isn't affected by any effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by any effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [

--- a/json/cards/Emerald.json
+++ b/json/cards/Emerald.json
@@ -8,7 +8,7 @@
     "evolvesFrom": "Combusken",
     "ability": {
       "name": "Blaze",
-      "text": "As long as Blaziken's remaining HP is 40 or less, Blaziken does 40 more damage to the Defending Pokémon (before applying Weakness and Resistance).",
+      "text": "As long as Blaziken’s remaining HP is 40 or less, Blaziken does 40 more damage to the Defending Pokémon (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "110",
@@ -62,7 +62,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Form Change",
-      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys and switch it with Deoxys. (Any cards attached to Deoxys, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys on top of your deck. Shuffle your deck afterward. You can't use more than 1 Form Change Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys and switch it with Deoxys. (Any cards attached to Deoxys, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Form Change Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -87,7 +87,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -183,7 +183,7 @@
     "evolvesFrom": "Kirlia",
     "ability": {
       "name": "Heal Dance",
-      "text": "Once during your turn (before your attack), you may remove 2 damage counters from 1 of your Pokémon. You can't use more than 1 Heal Dance Poké-Power each turn. This power can't be used if Gardevoir is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may remove 2 damage counters from 1 of your Pokémon. You can’t use more than 1 Heal Dance Poké-Power each turn. This power can’t be used if Gardevoir is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -221,7 +221,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "This attack's damage isn't affected by Weakness or Resistance."
+        "text": "This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -271,7 +271,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -322,7 +322,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -363,7 +363,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       },
       {
         "name": "Tail Shock",
@@ -374,7 +374,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -505,7 +505,7 @@
     "evolvesFrom": "Grovyle",
     "ability": {
       "name": "Green Essence",
-      "text": "As long as Sceptile is in play, each of your Active Pokémon that has Grass Energy attached to it can't be affected by any Special Conditions.",
+      "text": "As long as Sceptile is in play, each of your Active Pokémon that has Grass Energy attached to it can’t be affected by any Special Conditions.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -542,7 +542,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -569,7 +569,7 @@
     "evolvesFrom": "Marshtomp",
     "ability": {
       "name": "Water Cyclone",
-      "text": "As often as you like during your turn (before your attack), you may move a Water Energy attached to 1 of your Active Pokémon to 1 of your Benched Pokémon. This power can't be used if Swampert is affected by a Special Condition.",
+      "text": "As often as you like during your turn (before your attack), you may move a Water Energy attached to 1 of your Active Pokémon to 1 of your Benched Pokémon. This power can’t be used if Swampert is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -594,7 +594,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Aqua Sonic",
@@ -605,7 +605,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -694,7 +694,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Super Slash",
@@ -798,7 +798,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack or retreat during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack or retreat during your opponent’s next turn."
       },
       {
         "name": "Hydro Pump",
@@ -809,7 +809,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Does 40 damage plus 10 more damage for each Water Energy attached to Kyogre but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "Does 40 damage plus 10 more damage for each Water Energy attached to Kyogre but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       }
     ],
     "weaknesses": [
@@ -914,7 +914,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1019,7 +1019,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -1313,7 +1313,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Sharp Claws",
@@ -1588,7 +1588,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Psypunch",
@@ -1751,7 +1751,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "This attack's damage isn't affected by Weakness or Resistance."
+        "text": "This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -2171,7 +2171,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "0",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 40 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2543,7 +2543,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Submerge",
-      "text": "As long as Feebas is on your Bench, prevent all damage done to Feebas by attacks (both yours and your opponent's).",
+      "text": "As long as Feebas is on your Bench, prevent all damage done to Feebas by attacks (both yours and your opponent’s).",
       "type": "Poké-Body"
     },
     "hp": "30",
@@ -2610,7 +2610,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "0",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2705,7 +2705,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "0",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -3395,7 +3395,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Feathery",
-      "text": "As long as Swablu is on your Bench, prevent all damage done to Swablu by opponent's attacks.",
+      "text": "As long as Swablu is on your Bench, prevent all damage done to Swablu by opponent’s attacks.",
       "type": "Poké-Body"
     },
     "hp": "40",
@@ -3801,7 +3801,7 @@
     "set": "Emerald",
     "setCode": "ex9",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. Each player's Colorless Evolved Pokémon, Darkness Evolved Pokémon, and Metal Evolved Pokémon can't use any Poké-Powers or Poké-Bodies."
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. Each player’s Colorless Evolved Pokémon, Darkness Evolved Pokémon, and Metal Evolved Pokémon can’t use any Poké-Powers or Poké-Bodies."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex9/75_hires.png"
   },
@@ -3825,7 +3825,7 @@
   },
   {
     "id": "ex9-77",
-    "name": "Lanette's Net Search",
+    "name": "Lanette’s Net Search",
     "imageUrl": "https://images.pokemontcg.io/ex9/77.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -3856,14 +3856,14 @@
     "set": "Emerald",
     "setCode": "ex9",
     "text": [
-      "Attach Lum Berry to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
+      "Attach Lum Berry to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
       "At any time between turns, if the Pokémon this card is attached to is affected by any Special Conditions, remove all of them. Then, discard Lum Berry."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex9/78_hires.png"
   },
   {
     "id": "ex9-79",
-    "name": "Mr. Stone's Project",
+    "name": "Mr. Stone’s Project",
     "imageUrl": "https://images.pokemontcg.io/ex9/79.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -3894,7 +3894,7 @@
     "set": "Emerald",
     "setCode": "ex9",
     "text": [
-      "Attach Oran Berry to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
+      "Attach Oran Berry to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
       "At any time between turns, if the Pokémon this card is attached to has at least 2 damage counters on it, remove 2 damage counters from it. Then, discard Oran Berry."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex9/80_hires.png"
@@ -3975,7 +3975,7 @@
   },
   {
     "id": "ex9-85",
-    "name": "Wally's Training",
+    "name": "Wally’s Training",
     "imageUrl": "https://images.pokemontcg.io/ex9/85.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4005,7 +4005,7 @@
     "set": "Emerald",
     "setCode": "ex9",
     "text": [
-      "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect unless the Attacking Pokémon is Darkness or has Dark in its name. Darkness Energy provides Darkness Energy. (Doesn't count as a basic Energy card.)"
+      "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect unless the Attacking Pokémon is Darkness or has Dark in its name. Darkness Energy provides Darkness Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex9/86_hires.png"
   },
@@ -4022,7 +4022,7 @@
     "set": "Emerald",
     "setCode": "ex9",
     "text": [
-      "Double Rainbow Energy can be attached only to an Evolved Pokémon (excluding Pokémon-ex). While in play, Double Rainbow Energy provides every type of Energy but provides 2 Energy at a time. (Has no effect other than providing Energy.) Damage done to your opponent's Pokémon by the Pokémon Double Rainbow Energy is attached to is reduced by 10 (before applying Weakness and Resistance). When the Pokémon Double Rainbow Energy is attached to is no longer an Evolved Pokémon, discard Double Rainbow Energy."
+      "Double Rainbow Energy can be attached only to an Evolved Pokémon (excluding Pokémon-ex). While in play, Double Rainbow Energy provides every type of Energy but provides 2 Energy at a time. (Has no effect other than providing Energy.) Damage done to your opponent’s Pokémon by the Pokémon Double Rainbow Energy is attached to is reduced by 10 (before applying Weakness and Resistance). When the Pokémon Double Rainbow Energy is attached to is no longer an Evolved Pokémon, discard Double Rainbow Energy."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex9/87_hires.png"
   },
@@ -4039,7 +4039,7 @@
     "set": "Emerald",
     "setCode": "ex9",
     "text": [
-      "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn't Metal. Metal Energy provides Metal Energy. (Doesn't count as a basic Energy card.)"
+      "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn’t Metal. Metal Energy provides Metal Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex9/88_hires.png"
   },
@@ -4070,7 +4070,7 @@
     "evolvesFrom": "Swablu",
     "ability": {
       "name": "Mist",
-      "text": "Any damage done to Altaria ex by attacks from Stage 2 Evolved Pokémon (both yours and your opponent's) is reduced by 30 (after applying Weakness and Resistance).",
+      "text": "Any damage done to Altaria ex by attacks from Stage 2 Evolved Pokémon (both yours and your opponent’s) is reduced by 30 (after applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -4108,7 +4108,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "This attack's damage isn't affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "nationalPokedexNumber": 334,
@@ -4124,7 +4124,7 @@
     "evolvesFrom": "Cacnea",
     "ability": {
       "name": "Cursed Glare",
-      "text": "As long as Cacturne ex is your Active Pokémon, your opponent can't attach any Special Energy cards (except for Darkness and Metal Energy cards) from his or her hand to his or her Active Pokémon.",
+      "text": "As long as Cacturne ex is your Active Pokémon, your opponent can’t attach any Special Energy cards (except for Darkness and Metal Energy cards) from his or her hand to his or her Active Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "110",
@@ -4184,7 +4184,7 @@
     "evolvesFrom": "Numel",
     "ability": {
       "name": "Magma Armor",
-      "text": "Camerupt ex can't be Asleep or Paralyzed.",
+      "text": "Camerupt ex can’t be Asleep or Paralyzed.",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -4245,7 +4245,7 @@
     "level": "ex",
     "ability": {
       "name": "Form Change",
-      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys ex and switch it with Deoxys ex. (Any cards attached to Deoxys ex, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys ex on top of your deck. Shuffle your deck afterward. You can't use more than 1 Form Change Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys ex and switch it with Deoxys ex. (Any cards attached to Deoxys ex, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys ex on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Form Change Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -4274,7 +4274,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "This attack's damage isn't affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -4296,7 +4296,7 @@
     "evolvesFrom": "Duskull",
     "ability": {
       "name": "Dark Hole",
-      "text": "As long as Dusclops ex is on your Bench, don't apply Darkness Weakness for all of your Pokémon in play.",
+      "text": "As long as Dusclops ex is on your Bench, don’t apply Darkness Weakness for all of your Pokémon in play.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -4359,7 +4359,7 @@
     "evolvesFrom": "Meditite",
     "ability": {
       "name": "Wise Aura",
-      "text": "As long as Medicham ex is your Active Pokémon, each Pokémon (excluding Pokémon-ex) (both yours and your opponent's) can't use any Poké-Powers.",
+      "text": "As long as Medicham ex is your Active Pokémon, each Pokémon (excluding Pokémon-ex) (both yours and your opponent’s) can’t use any Poké-Powers.",
       "type": "Poké-Body"
     },
     "hp": "110",
@@ -4387,7 +4387,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Put 3 damage counters on your opponent's Pokémon in any way you like."
+        "text": "Put 3 damage counters on your opponent’s Pokémon in any way you like."
       },
       {
         "name": "Sky Kick",
@@ -4420,7 +4420,7 @@
     "evolvesFrom": "Feebas",
     "ability": {
       "name": "Mystic Scale",
-      "text": "As long as Milotic ex is in play, each player can't play any Technical Machine cards from his or her hand. Discard all Technical Machine cards in play (both yours and your opponent's).",
+      "text": "As long as Milotic ex is in play, each player can’t play any Technical Machine cards from his or her hand. Discard all Technical Machine cards in play (both yours and your opponent’s).",
       "type": "Poké-Body"
     },
     "hp": "130",
@@ -4448,7 +4448,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Reflect Energy",
@@ -4481,7 +4481,7 @@
     "evolvesFrom": "Pikachu",
     "ability": {
       "name": "Rai-shield",
-      "text": "Damage done to any of your Raichu ex in play by attacks from your opponent's Pokémon-ex is reduced by 30 (after applying Weakness and Resistance). You can't use more than 1 Rai-shield Poké-Body each turn.",
+      "text": "Damage done to any of your Raichu ex in play by attacks from your opponent’s Pokémon-ex is reduced by 30 (after applying Weakness and Resistance). You can’t use more than 1 Rai-shield Poké-Body each turn.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -4506,7 +4506,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) If that Pokémon has Poké-Powers, this attack does 30 damage plus 20 more damage."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) If that Pokémon has Poké-Powers, this attack does 30 damage plus 20 more damage."
       },
       {
         "name": "Pika Bolt",
@@ -4685,7 +4685,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Does 20 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [

--- a/json/cards/Emerging Powers.json
+++ b/json/cards/Emerging Powers.json
@@ -80,7 +80,7 @@
     ],
     "attacks": [
       {
-        "name": "Fire's Power",
+        "name": "Fire’s Power",
         "cost": [
           "Colorless",
           "Colorless"
@@ -503,7 +503,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 10 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 10 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -558,7 +558,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 30 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 30 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -604,7 +604,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Choose 1 of the Defending Pokémon's attacks. During your opponent's next turn, that Pokémon can use only that attack."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. During your opponent’s next turn, that Pokémon can use only that attack."
       },
       {
         "name": "U-turn",
@@ -902,7 +902,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "This Pokémon can't use Sacred Sword during your next turn."
+        "text": "This Pokémon can’t use Sacred Sword during your next turn."
       }
     ],
     "weaknesses": [
@@ -994,7 +994,7 @@
     ],
     "attacks": [
       {
-        "name": "Water's Power",
+        "name": "Water’s Power",
         "cost": [
           "Colorless",
           "Colorless"
@@ -1225,7 +1225,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Move an Energy attached to the Defending Pokémon to 1 of your opponent's Benched Pokémon."
+        "text": "Move an Energy attached to the Defending Pokémon to 1 of your opponent’s Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -1324,7 +1324,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Does 30 damage to one of your oppoent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 30 damage to one of your oppoent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1363,7 +1363,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Heal 40 damage from this Pokémon. This Pokémon can't retreat during your next turn."
+        "text": "Heal 40 damage from this Pokémon. This Pokémon can’t retreat during your next turn."
       },
       {
         "name": "Rain Splash",
@@ -1423,7 +1423,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       },
       {
         "name": "Air Slash",
@@ -1581,7 +1581,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "The Defending Pokémon can't attack during your opponent's next turn."
+        "text": "The Defending Pokémon can’t attack during your opponent’s next turn."
       },
       {
         "name": "Icicle Crash",
@@ -1593,7 +1593,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -1923,7 +1923,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip 3 coins. This attack does 10 damage times the number of heads to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip 3 coins. This attack does 10 damage times the number of heads to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2035,7 +2035,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -2130,7 +2130,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 40 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 40 (after applying Weakness and Resistance)."
       },
       {
         "name": "Telekinesis",
@@ -2141,7 +2141,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Does 50 damage to 1 of your opponent's Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Does 50 damage to 1 of your opponent’s Pokémon. This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -2391,7 +2391,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, discard an Energy attached to 1 of your opponent's Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to 1 of your opponent’s Pokémon."
       },
       {
         "name": "Super Psy Bolt",
@@ -2426,7 +2426,7 @@
     "evolvesFrom": "Gothorita",
     "ability": {
       "name": "Magic Room",
-      "text": "As long as this Pokémon is your Active Pokémon, your opponent can't play any Item cards from his or her hand.",
+      "text": "As long as this Pokémon is your Active Pokémon, your opponent can’t play any Item cards from his or her hand.",
       "type": "Ability"
     },
     "hp": "130",
@@ -2544,7 +2544,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, if this Pokémon would be damaged by an attack, prevent that attack's damage done to this Pokémon if that damage is 40 or less."
+        "text": "During your opponent’s next turn, if this Pokémon would be damaged by an attack, prevent that attack’s damage done to this Pokémon if that damage is 40 or less."
       },
       {
         "name": "Headbutt",
@@ -2821,7 +2821,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, each of this Pokémon's attacks does 30 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, each of this Pokémon’s attacks does 30 more damage (before applying Weakness and Resistance)."
       },
       {
         "name": "Scratch",
@@ -2989,7 +2989,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       },
       {
         "name": "Earthquake",
@@ -3000,7 +3000,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "Does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3047,7 +3047,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3087,7 +3087,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20×",
-        "text": "Flip 5 coins. This attack does 20 damage times the number of heads. This Pokémon can't attack during your next turn."
+        "text": "Flip 5 coins. This attack does 20 damage times the number of heads. This Pokémon can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -3207,7 +3207,7 @@
     "evolvesFrom": "Krokorok",
     "ability": {
       "name": "Black Eyes",
-      "text": "Once during your turn (before your attack), if this Pokémon is your Active Pokémon, you may flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon.",
+      "text": "Once during your turn (before your attack), if this Pokémon is your Active Pokémon, you may flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon.",
       "type": "Ability"
     },
     "hp": "140",
@@ -3295,7 +3295,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "This Pokémon can't use Sacred Sword during your next turn."
+        "text": "This Pokémon can’t use Sacred Sword during your next turn."
       }
     ],
     "weaknesses": [
@@ -3335,7 +3335,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, discard a random card from your opponent's hand."
+        "text": "Flip a coin. If heads, discard a random card from your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -3384,7 +3384,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Does 30 damage to 1 of your opponent's Pokémon. This attack's damage isn't affected by Weakness, Resistance, or any other effects on that Pokémon."
+        "text": "Does 30 damage to 1 of your opponent’s Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, or any other effects on that Pokémon."
       },
       {
         "name": "Claw Rend",
@@ -3556,7 +3556,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 30 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 30 (after applying Weakness and Resistance)."
       },
       {
         "name": "Gust",
@@ -3831,7 +3831,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       },
       {
         "name": "Power Whip",
@@ -3841,7 +3841,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Does 10 damage for each Energy attached to this Pokémon to one of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage for each Energy attached to this Pokémon to one of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3957,7 +3957,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -4020,7 +4020,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "Flip a coin. If tails, this Pokémon can't use Zap Cannon during your next turn."
+        "text": "Flip a coin. If tails, this Pokémon can’t use Zap Cannon during your next turn."
       }
     ],
     "weaknesses": [
@@ -4078,7 +4078,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "This Pokémon can't use Sacred Sword during your next turn."
+        "text": "This Pokémon can’t use Sacred Sword during your next turn."
       }
     ],
     "weaknesses": [
@@ -4166,7 +4166,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at the top 5 cards of your opponent's deck and put them back on top of his or her deck in any order."
+        "text": "Look at the top 5 cards of your opponent’s deck and put them back on top of his or her deck in any order."
       },
       {
         "name": "Quick Tail Smash",
@@ -4472,7 +4472,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon."
+        "text": "Switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon."
       },
       {
         "name": "Fluffy Tail",
@@ -4771,7 +4771,7 @@
     "set": "Emerging Powers",
     "setCode": "bw2",
     "text": [
-      "Flip a coin. If heads, discard an Energy attached to 1 of your opponent's Pokémon."
+      "Flip a coin. If heads, discard an Energy attached to 1 of your opponent’s Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw2/92_hires.png"
   },
@@ -4822,7 +4822,7 @@
     "set": "Emerging Powers",
     "setCode": "bw2",
     "text": [
-      "Switch your opponent's Active Pokémon with 1 of his or her Benched Pokémon."
+      "Switch your opponent’s Active Pokémon with 1 of his or her Benched Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw2/95_hires.png"
   },

--- a/json/cards/Evolutions.json
+++ b/json/cards/Evolutions.json
@@ -34,7 +34,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       },
       {
         "name": "Jungle Hammer",
@@ -97,7 +97,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "Your opponent's Active Pokémon is now Paralyzed and Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Paralyzed and Poisoned."
       }
     ],
     "weaknesses": [
@@ -136,7 +136,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -181,7 +181,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 40 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 40 (after applying Weakness and Resistance)."
       },
       {
         "name": "Stun Spore",
@@ -191,7 +191,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -233,7 +233,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Poisoned."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Poisoned."
       }
     ],
     "weaknesses": [
@@ -278,7 +278,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 40 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 40 (after applying Weakness and Resistance)."
       },
       {
         "name": "Poison Powder",
@@ -288,7 +288,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Poisoned."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Poisoned."
       }
     ],
     "weaknesses": [
@@ -328,7 +328,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       },
       {
         "name": "Swarming Sting",
@@ -338,7 +338,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "This attack does 40 damage times the number of Beedrill you have in play to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 40 damage times the number of Beedrill you have in play to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -379,7 +379,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Poison Powder",
@@ -390,7 +390,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       }
     ],
     "weaknesses": [
@@ -614,7 +614,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "150",
-        "text": "This Pokémon can't use Combustion Blast during your next turn."
+        "text": "This Pokémon can’t use Combustion Blast during your next turn."
       }
     ],
     "weaknesses": [
@@ -703,7 +703,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Confused."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -746,7 +746,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with his or her Active Pokémon. The new Active Pokémon can't retreat during your opponent's next turn."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with his or her Active Pokémon. The new Active Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Fire Blast",
@@ -894,7 +894,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "150",
-        "text": "This Pokémon can't attack during your next turn."
+        "text": "This Pokémon can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -1107,7 +1107,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "This attack does 30 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1191,7 +1191,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Choose 1 of your opponent's Active Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of your opponent’s Active Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Double Slap",
@@ -1258,7 +1258,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "Discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -1303,7 +1303,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Heal 60 damage from this Pokémon. This Pokémon can't attack during your next turn."
+        "text": "Heal 60 damage from this Pokémon. This Pokémon can’t attack during your next turn."
       },
       {
         "name": "Flash Splash",
@@ -1363,7 +1363,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100+",
-        "text": "This Pokémon is now Confused. During your next turn, this Pokémon's Loll Roll Spin attack does 100 more damage (before applying Weakness and Resistance)."
+        "text": "This Pokémon is now Confused. During your next turn, this Pokémon’s Loll Roll Spin attack does 100 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -1403,7 +1403,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
       },
       {
         "name": "Headbutt",
@@ -1532,7 +1532,7 @@
     "evolvesFrom": "Staryu",
     "ability": {
       "name": "Space Beacon",
-      "text": "Once during your turn (before your attack), you may discard a card from your hand. If you do, put 2 basic Energy cards from your discard pile into your hand. (You can't choose a card you discarded with the effect of this Ability.)",
+      "text": "Once during your turn (before your attack), you may discard a card from your hand. If you do, put 2 basic Energy cards from your discard pile into your hand. (You can’t choose a card you discarded with the effect of this Ability.)",
       "type": "Ability"
     },
     "hp": "90",
@@ -1557,7 +1557,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -1597,7 +1597,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 100 damage to each of your opponent's Pokémon BREAK. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 100 damage to each of your opponent’s Pokémon BREAK. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "nationalPokedexNumber": 121,
@@ -1677,7 +1677,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Dragon Rage",
@@ -1843,7 +1843,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Self-Destruct",
@@ -1903,7 +1903,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Self-Destruct",
@@ -2064,7 +2064,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Thunder Punch",
@@ -2278,7 +2278,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Tail Swing",
@@ -2289,7 +2289,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "This attack does 20 damage to each of your opponent's Benched Basic Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to each of your opponent’s Benched Basic Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2331,7 +2331,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "Your opponent's Active Pokémon is now Poisoned. Put 2 damage counters instead of 1 on that Pokémon between turns."
+        "text": "Your opponent’s Active Pokémon is now Poisoned. Put 2 damage counters instead of 1 on that Pokémon between turns."
       }
     ],
     "nationalPokedexNumber": 34,
@@ -2364,7 +2364,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, if this Pokémon is Knocked Out by damage from an attack, discard an Energy attached to the Attacking Pokémon."
+        "text": "During your opponent’s next turn, if this Pokémon is Knocked Out by damage from an attack, discard an Energy attached to the Attacking Pokémon."
       },
       {
         "name": "Nightmare",
@@ -2374,7 +2374,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Asleep."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Asleep."
       }
     ],
     "weaknesses": [
@@ -2423,7 +2423,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Dream Eater",
@@ -2433,7 +2433,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "80",
-        "text": "If your opponent's Active Pokémon is not Asleep, this attack does nothing."
+        "text": "If your opponent’s Active Pokémon is not Asleep, this attack does nothing."
       }
     ],
     "weaknesses": [
@@ -2491,7 +2491,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -2534,7 +2534,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Poisoned. If tails, your opponent's Active Pokémon is now Confused."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Poisoned. If tails, your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -2578,7 +2578,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "This attack does 20 more damage for each Energy attached to your opponent's Active Pokémon."
+        "text": "This attack does 20 more damage for each Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Barrier",
@@ -2588,7 +2588,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "During your opponent's next turn, prevent all effects of attacks, including damage, done to this Pokémon. If 1 of your Pokémon used Barrier during your last turn, this attack can't be used."
+        "text": "During your opponent’s next turn, prevent all effects of attacks, including damage, done to this Pokémon. If 1 of your Pokémon used Barrier during your last turn, this attack can’t be used."
       }
     ],
     "weaknesses": [
@@ -2673,7 +2673,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Neutral Shield",
-      "text": "Prevent all effects of attacks, including damage, done to this Pokémon by your opponent's Evolution Pokémon.",
+      "text": "Prevent all effects of attacks, including damage, done to this Pokémon by your opponent’s Evolution Pokémon.",
       "type": "Ability"
     },
     "hp": "40",
@@ -2698,7 +2698,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -2737,7 +2737,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -2760,7 +2760,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Submerge",
-      "text": "As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's).",
+      "text": "As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent’s).",
       "type": "Ability"
     },
     "hp": "40",
@@ -2785,7 +2785,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2840,7 +2840,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "130",
-        "text": "This attack does 20 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2961,7 +2961,7 @@
     "evolvesFrom": "Machoke",
     "ability": {
       "name": "Counterattack",
-      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), put 3 damage counters on the Attacking Pokémon.",
+      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack (even if this Pokémon is Knocked Out), put 3 damage counters on the Attacking Pokémon.",
       "type": "Ability"
     },
     "hp": "160",
@@ -3030,7 +3030,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "During your next turn, this Pokémon's attacks do 100 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s attacks do 100 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance)."
       }
     ],
     "nationalPokedexNumber": 68,
@@ -3065,7 +3065,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, if this Pokémon would be damaged by an attack, prevent that attack's damage done to this Pokémon if that damage is 60 or less."
+        "text": "During your opponent’s next turn, if this Pokémon would be damaged by an attack, prevent that attack’s damage done to this Pokémon if that damage is 60 or less."
       },
       {
         "name": "Rock Throw",
@@ -3168,7 +3168,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Asleep."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Metronome",
@@ -3179,7 +3179,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Active Pokémon's attacks and use it as this attack."
+        "text": "Choose 1 of your opponent’s Active Pokémon’s attacks and use it as this attack."
       }
     ],
     "weaknesses": [
@@ -3230,7 +3230,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If this Pokémon was damaged by an attack during your opponent's last turn, this attack does the same amount of damage to your opponent's Active Pokémon."
+        "text": "If this Pokémon was damaged by an attack during your opponent’s last turn, this attack does the same amount of damage to your opponent’s Active Pokémon."
       },
       {
         "name": "Feather Lance",
@@ -3241,7 +3241,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "This attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3317,7 +3317,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Mischievous Fang",
-      "text": "When you play this Pokémon from your hand onto your Bench, you may discard all Pokémon Tool cards attached to your opponent's Active Pokémon.",
+      "text": "When you play this Pokémon from your hand onto your Bench, you may discard all Pokémon Tool cards attached to your opponent’s Active Pokémon.",
       "type": "Ability"
     },
     "hp": "40",
@@ -3384,7 +3384,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Discard an Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Shadowy Bite",
@@ -3393,7 +3393,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "60×",
-        "text": "This attack does 60 damage times the number of Special Energy cards in your opponent's discard pile."
+        "text": "This attack does 60 damage times the number of Special Energy cards in your opponent’s discard pile."
       }
     ],
     "weaknesses": [
@@ -3432,7 +3432,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "50",
-        "text": "This Pokémon can't use Leek Slap during your next turn."
+        "text": "This Pokémon can’t use Leek Slap during your next turn."
       },
       {
         "name": "Pot Smash",
@@ -3539,7 +3539,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent’s next turn."
       },
       {
         "name": "Double-Edge",
@@ -3648,7 +3648,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "130",
-        "text": "Discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -3685,7 +3685,7 @@
   },
   {
     "id": "xy12-74",
-    "name": "Brock's Grit",
+    "name": "Brock’s Grit",
     "imageUrl": "https://images.pokemontcg.io/xy12/74.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -3730,7 +3730,7 @@
     "set": "Evolutions",
     "setCode": "xy12",
     "text": [
-      "Devolve 1 of your evolved Pokémon and put the highest Stage Evolution card on it into your hand. (That Pokémon can't evolve this turn.)"
+      "Devolve 1 of your evolved Pokémon and put the highest Stage Evolution card on it into your hand. (That Pokémon can’t evolve this turn.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/76_hires.png"
   },
@@ -3781,13 +3781,13 @@
     "set": "Evolutions",
     "setCode": "xy12",
     "text": [
-      "Shuffle 2 cards from your hand into your deck. (If you can't shuffle 2 cards into your deck, you can't play this card.) Then, draw a card."
+      "Shuffle 2 cards from your hand into your deck. (If you can’t shuffle 2 cards into your deck, you can’t play this card.) Then, draw a card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/79_hires.png"
   },
   {
     "id": "xy12-80",
-    "name": "Misty's Determination",
+    "name": "Misty’s Determination",
     "imageUrl": "https://images.pokemontcg.io/xy12/80.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -3855,7 +3855,7 @@
   },
   {
     "id": "xy12-84",
-    "name": "Professor Oak's Hint",
+    "name": "Professor Oak’s Hint",
     "imageUrl": "https://images.pokemontcg.io/xy12/84.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4136,7 +4136,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "Your opponent's Active Pokémon is now Paralyzed and Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Paralyzed and Poisoned."
       }
     ],
     "weaknesses": [
@@ -4232,7 +4232,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "This attack does 30 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4339,7 +4339,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If this Pokémon was damaged by an attack during your opponent's last turn, this attack does the same amount of damage to your opponent's Active Pokémon."
+        "text": "If this Pokémon was damaged by an attack during your opponent’s last turn, this attack does the same amount of damage to your opponent’s Active Pokémon."
       },
       {
         "name": "Feather Lance",
@@ -4350,7 +4350,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "This attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4458,7 +4458,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "130",
-        "text": "Discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -4478,7 +4478,7 @@
   },
   {
     "id": "xy12-107",
-    "name": "Brock's Grit",
+    "name": "Brock’s Grit",
     "imageUrl": "https://images.pokemontcg.io/xy12/107.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4495,7 +4495,7 @@
   },
   {
     "id": "xy12-108",
-    "name": "Misty's Determination",
+    "name": "Misty’s Determination",
     "imageUrl": "https://images.pokemontcg.io/xy12/108.png",
     "subtype": "Supporter",
     "supertype": "Trainer",

--- a/json/cards/Expedition Base Set.json
+++ b/json/cards/Expedition Base Set.json
@@ -8,7 +8,7 @@
     "evolvesFrom": "Kadabra",
     "ability": {
       "name": "Psymimic",
-      "text": "Once during your turn, instead of Alakazam's normal attack, you may choose 1 of your opponent's Pokémon's attack. Alakazam copies that attack including its Energy costs and anything else required in order to use that attack, such as discarding Energy cards. (No matter what type that Pokémon is, Alakazam's type is still Psychic.) This power can't be used if Alakazam is affected by a Special Condition.",
+      "text": "Once during your turn, instead of Alakazam’s normal attack, you may choose 1 of your opponent’s Pokémon’s attack. Alakazam copies that attack including its Energy costs and anything else required in order to use that attack, such as discarding Energy cards. (No matter what type that Pokémon is, Alakazam’s type is still Psychic.) This power can’t be used if Alakazam is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -35,7 +35,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "If Alakazam and the Defending Pokémon don't have the same number of Energy cards on them, this attack's base damage is 20 instead of 80."
+        "text": "If Alakazam and the Defending Pokémon don’t have the same number of Energy cards on them, this attack’s base damage is 20 instead of 80."
       }
     ],
     "weaknesses": [
@@ -56,7 +56,7 @@
     "evolvesFrom": "Flaaffy",
     "ability": {
       "name": "Energy Connect",
-      "text": "Once during your turn (before you attack), you make take one basic Energy cards attached to one of your Benched Pokémon and attach it to your Active Pokémon. This power can't be used if Ampharos is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack), you make take one basic Energy cards attached to one of your Benched Pokémon and attach it to your Active Pokémon. This power can’t be used if Ampharos is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -84,7 +84,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "You may discard all Energy cards attached to Ampharos. If you do, this attack's base damage is 80 instead of 40."
+        "text": "You may discard all Energy cards attached to Ampharos. If you do, this attack’s base damage is 80 instead of 40."
       }
     ],
     "weaknesses": [
@@ -155,7 +155,7 @@
     "evolvesFrom": "Wartortle",
     "ability": {
       "name": "Jet Stream",
-      "text": "Once during your turn (before you attack), if Blastoise is your Active Pokémon, you may flip a coin. If heads, discard an Energy card attached to Blastoise, if any. Then, if there are any Energy cards attached to the Defending Pokémon, choose one of them and discard it. This power can't be used if Blastoise is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack), if Blastoise is your Active Pokémon, you may flip a coin. If heads, discard an Energy card attached to Blastoise, if any. Then, if there are any Energy cards attached to the Defending Pokémon, choose one of them and discard it. This power can’t be used if Blastoise is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -182,7 +182,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40+",
-        "text": "(40+) Does 40 damage plus 10 more damage for each Energy attached to Blastoise but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "(40+) Does 40 damage plus 10 more damage for each Energy attached to Blastoise but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       }
     ],
     "weaknesses": [
@@ -203,7 +203,7 @@
     "evolvesFrom": "Metapod",
     "ability": {
       "name": "Miraculous Powder",
-      "text": "Once during your turn (before you attack), you may remove all Special Conditions from your Active Pokémon. This power can't be used if Butterfree is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack), you may remove all Special Conditions from your Active Pokémon. This power can’t be used if Butterfree is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -247,7 +247,7 @@
     "evolvesFrom": "Charmeleon",
     "ability": {
       "name": "Burning Energy",
-      "text": "Once during your turn (before you attack), you may turn all basic Energy attached to all of your Pokémon into R Energy for the rest of the turn. This power can't be used if Charizard is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack), you may turn all basic Energy attached to all of your Pokémon into R Energy for the rest of the turn. This power can’t be used if Charizard is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -297,7 +297,7 @@
     "evolvesFrom": "Clefairy",
     "ability": {
       "name": "Moonlight",
-      "text": "Once during your turn (before you attack), you may put a card from your hand back on your deck. If you do so, search your deck for a basic Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward. This power can't be used if Clefable is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack), you may put a card from your hand back on your deck. If you do so, search your deck for a basic Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward. This power can’t be used if Clefable is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -396,7 +396,7 @@
     "evolvesFrom": "Dragonair",
     "ability": {
       "name": "Tailwind",
-      "text": "Once during your turn (before you attack), if Dragonite is on your Bench, you may reduce your Active Pokémon's Retreat cost to 0.",
+      "text": "Once during your turn (before you attack), if Dragonite is on your Bench, you may reduce your Active Pokémon’s Retreat cost to 0.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -468,7 +468,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Does 10 damage to each Benched Pokémon (yours and your opponent's). (Don't apply Weakness and resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each Benched Pokémon (yours and your opponent’s). (Don’t apply Weakness and resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -512,7 +512,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during you opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during you opponent’s next turn."
       },
       {
         "name": "Supersonic Flight",
@@ -550,7 +550,7 @@
     "evolvesFrom": "Croconaw",
     "ability": {
       "name": "Major Tsunami",
-      "text": "Once during your turn (before you attack), if Feraligatr is your Active Pokémon and if your opponent has any Benched Pokémon, your opponent switches his or her Active Pokémon with 1 of his or her Benched Pokémon. Either way, if you have any Benched Pokémon, switch Feraligatr with 1 of them. This power can't be used if Feraligatr is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack), if Feraligatr is your Active Pokémon and if your opponent has any Benched Pokémon, your opponent switches his or her Active Pokémon with 1 of his or her Benched Pokémon. Either way, if you have any Benched Pokémon, switch Feraligatr with 1 of them. This power can’t be used if Feraligatr is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -579,7 +579,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "If there are no damage counters on the Defending Pokémon, this attack's base damage is 40 instead of 70."
+        "text": "If there are no damage counters on the Defending Pokémon, this attack’s base damage is 40 instead of 70."
       }
     ],
     "weaknesses": [
@@ -600,7 +600,7 @@
     "evolvesFrom": "Haunter",
     "ability": {
       "name": "Chaos Move",
-      "text": "Once during your turn (before you attack), if your opponent has 3 or fewer Prizes, you may move 1 damage counter from 1 Pokémon (yours or your opponent's) to another (even if it would Knock Out the other Pokémon). This power can't be used if Gengar is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack), if your opponent has 3 or fewer Prizes, you may move 1 damage counter from 1 Pokémon (yours or your opponent’s) to another (even if it would Knock Out the other Pokémon). This power can’t be used if Gengar is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -683,7 +683,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "Don't apply Resistance."
+        "text": "Don’t apply Resistance."
       }
     ],
     "weaknesses": [
@@ -756,7 +756,7 @@
     "evolvesFrom": "Machoke",
     "ability": {
       "name": "Terraforming",
-      "text": "Once during your turn (before you attack), you may look at the top 4 cards of your deck and rearrange them as you like. This power can't be used if Machamp is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack), you may look at the top 4 cards of your deck and rearrange them as you like. This power can’t be used if Machamp is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -827,7 +827,7 @@
       }
     ],
     "text": [
-      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent's turn ends without an attack."
+      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent’s turn ends without an attack."
     ],
     "nationalPokedexNumber": 240,
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/17_hires.png",
@@ -844,7 +844,7 @@
     "evolvesFrom": "Bayleef",
     "ability": {
       "name": "Soothing Aroma",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, remove 1 damage counter from each of your Pokémon that has any. This power can't be used if Meganium is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, remove 1 damage counter from each of your Pokémon that has any. This power can’t be used if Meganium is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -918,7 +918,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose one of you opponent's Pokémon. Count the number of Energy cards attached to that Pokémon. Put that many damage counters on the Pokémon."
+        "text": "Choose one of you opponent’s Pokémon. Count the number of Energy cards attached to that Pokémon. Put that many damage counters on the Pokémon."
       }
     ],
     "weaknesses": [
@@ -1064,7 +1064,7 @@
       }
     ],
     "text": [
-      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent's turn ends without an attack."
+      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent’s turn ends without an attack."
     ],
     "nationalPokedexNumber": 172,
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/22_hires.png",
@@ -1081,7 +1081,7 @@
     "evolvesFrom": "Pidgeotto",
     "ability": {
       "name": "Beating Wings",
-      "text": "Once during your turn (before you attack), If Pidgeot is your Active Pokémon, you may shuffle 1 of your Benched Pokémon and all cards attached to it in your deck. This power can't be used if Pidgeot is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack), If Pidgeot is your Active Pokémon, you may shuffle 1 of your Benched Pokémon and all cards attached to it in your deck. This power can’t be used if Pidgeot is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -1248,7 +1248,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If your opponent has any Benched Pokémon, flip a coin. If heads, choose 1 of them and this attack does 10 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, flip a coin. If heads, choose 1 of them and this attack does 10 damage to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Flame Tail",
@@ -1338,7 +1338,7 @@
     "evolvesFrom": "Quilava",
     "ability": {
       "name": "Heat Up",
-      "text": "Once during your turn (before you attack), You may count the total number of Energy cards attached to all of your Pokémon and all of your opponent's Pokémon. If your opponent has more total energy cards attached, you may search your deck for 1 Fire Energy card and attach it to one of your Benched Pokémon, if any. Shuffle your deck afterward. This power can't be used if Typhlosion is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack), You may count the total number of Energy cards attached to all of your Pokémon and all of your opponent’s Pokémon. If your opponent has more total energy cards attached, you may search your deck for 1 Fire Energy card and attach it to one of your Benched Pokémon, if any. Shuffle your deck afterward. This power can’t be used if Typhlosion is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -1417,7 +1417,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "50+",
-        "text": "Flip a coin. If heads, this attack does 50 damage plus 10 more damage and does 10 damage to each of your opponent's Benched Pokémon, if any. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 50 damage plus 10 more damage and does 10 damage to each of your opponent’s Benched Pokémon, if any. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1444,7 +1444,7 @@
     "evolvesFrom": "Ivysaur",
     "ability": {
       "name": "Harvest Bounty",
-      "text": "Once during your turn (before you attack), If you attach an Energy card from your hand to your Active Pokémon as part of your turn, you may attach an additional Energy card to that Pokémon at the same time. This power can't be used if Venusaur is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack), If you attach an Energy card from your hand to your Active Pokémon as part of your turn, you may attach an additional Energy card to that Pokémon at the same time. This power can’t be used if Venusaur is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -1493,7 +1493,7 @@
     "evolvesFrom": "Gloom",
     "ability": {
       "name": "Poison Pollen",
-      "text": "Once during your turn (before you attack), you may flip a coin. If heads, the Defending Pokémon is now Poisoned. This power can't be used if Vileplume is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack), you may flip a coin. If heads, the Defending Pokémon is now Poisoned. This power can’t be used if Vileplume is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -1593,7 +1593,7 @@
     "evolvesFrom": "Kadabra",
     "ability": {
       "name": "Psymimic",
-      "text": "Once during your turn, instead of Alakazam's normal attack, you may choose 1 of your opponent's Pokémon's attack. Alakazam copies that attack including its Energy costs and anything else required in order to use that attack, such as discarding Energy cards. (No matter what type that Pokémon is, Alakazam's type is still Psychic.) This power can't be used if Alakazam is affected by a Special Condition.",
+      "text": "Once during your turn, instead of Alakazam’s normal attack, you may choose 1 of your opponent’s Pokémon’s attack. Alakazam copies that attack including its Energy costs and anything else required in order to use that attack, such as discarding Energy cards. (No matter what type that Pokémon is, Alakazam’s type is still Psychic.) This power can’t be used if Alakazam is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -1620,7 +1620,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "If Alakazam and the Defending Pokémon don't have the same number of Energy cards on them, this attack's base damage is 20 instead of 80."
+        "text": "If Alakazam and the Defending Pokémon don’t have the same number of Energy cards on them, this attack’s base damage is 20 instead of 80."
       }
     ],
     "weaknesses": [
@@ -1641,7 +1641,7 @@
     "evolvesFrom": "Flaaffy",
     "ability": {
       "name": "Energy Connect",
-      "text": "Once during your turn (before you attack), you make take one basic Energy cards attached to one of your Benched Pokémon and attach it to your Active Pokémon. This power can't be used if Ampharos is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack), you make take one basic Energy cards attached to one of your Benched Pokémon and attach it to your Active Pokémon. This power can’t be used if Ampharos is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -1669,7 +1669,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "You may discard all Energy cards attached to Ampharos. If you do, this attack's base damage is 80 instead of 40."
+        "text": "You may discard all Energy cards attached to Ampharos. If you do, this attack’s base damage is 80 instead of 40."
       }
     ],
     "weaknesses": [
@@ -1790,7 +1790,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Jet Stream",
-      "text": "Once during your turn (before you attack), if Blastoise is your Active Pokémon, you may flip a coin. If heads, discard an Energy card attached to Blastoise, if any. Then, if there are any Energy cards attached to the Defending Pokémon, choose one of them and discard it. This power can't be used if Blastoise is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack), if Blastoise is your Active Pokémon, you may flip a coin. If heads, discard an Energy card attached to Blastoise, if any. Then, if there are any Energy cards attached to the Defending Pokémon, choose one of them and discard it. This power can’t be used if Blastoise is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -1817,7 +1817,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40+",
-        "text": "(40+) Does 40 damage plus 10 more damage for each Energy attached to Blastoise but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "(40+) Does 40 damage plus 10 more damage for each Energy attached to Blastoise but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       }
     ],
     "weaknesses": [
@@ -1838,7 +1838,7 @@
     "evolvesFrom": "Metapod",
     "ability": {
       "name": "Miraculous Powder",
-      "text": "Once during your turn (before you attack), you may remove all Special Conditions from your Active Pokémon. This power can't be used if Butterfree is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack), you may remove all Special Conditions from your Active Pokémon. This power can’t be used if Butterfree is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -1934,7 +1934,7 @@
     "evolvesFrom": "Charmeleon",
     "ability": {
       "name": "Burning Energy",
-      "text": "Once during your turn (before you attack), you may turn all basic Energy attached to all of your Pokémon into Fire Energy for the rest of the turn. This power can't be used if Charizard is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack), you may turn all basic Energy attached to all of your Pokémon into Fire Energy for the rest of the turn. This power can’t be used if Charizard is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -1984,7 +1984,7 @@
     "evolvesFrom": "Clefairy",
     "ability": {
       "name": "Moonlight",
-      "text": "Once during your turn (before you attack), you may put a card from your hand back on your deck. If you do so, search your deck for a basic Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward. This power can't be used if Clefable is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack), you may put a card from your hand back on your deck. If you do so, search your deck for a basic Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward. This power can’t be used if Clefable is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -2083,7 +2083,7 @@
     "evolvesFrom": "Dragonair",
     "ability": {
       "name": "Tailwind",
-      "text": "Once during your turn (before you attack), if Dragonite is on your Bench, you may reduce your Active Pokémon's Retreat cost to 0.",
+      "text": "Once during your turn (before you attack), if Dragonite is on your Bench, you may reduce your Active Pokémon’s Retreat cost to 0.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -2155,7 +2155,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Does 10 damage to each Benched Pokémon (yours and your opponent's). (Don't apply Weakness and resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each Benched Pokémon (yours and your opponent’s). (Don’t apply Weakness and resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2199,7 +2199,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during you opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during you opponent’s next turn."
       },
       {
         "name": "Supersonic Flight",
@@ -2289,7 +2289,7 @@
     "evolvesFrom": "Croconaw",
     "ability": {
       "name": "Major Tsunami",
-      "text": "Once during your turn (before you attack), if Feraligatr is your Active Pokémon and if your opponent has any Benched Pokémon, your opponent switches his or her Active Pokémon with 1 of his or her Benched Pokémon. Either way, if you have any Benched Pokémon, switch Feraligatr with 1 of them. This power can't be used if Feraligatr is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack), if Feraligatr is your Active Pokémon and if your opponent has any Benched Pokémon, your opponent switches his or her Active Pokémon with 1 of his or her Benched Pokémon. Either way, if you have any Benched Pokémon, switch Feraligatr with 1 of them. This power can’t be used if Feraligatr is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -2318,7 +2318,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "If there are no damage counters on the Defending Pokémon, this attack's base damage is 40 instead of 70."
+        "text": "If there are no damage counters on the Defending Pokémon, this attack’s base damage is 40 instead of 70."
       }
     ],
     "weaknesses": [
@@ -2339,7 +2339,7 @@
     "evolvesFrom": "Haunter",
     "ability": {
       "name": "Chaos Move",
-      "text": "Once during your turn (before you attack), if your opponent has 3 or fewer Prizes, you may move 1 damage counter from 1 Pokémon (yours or your opponent's) to another (even if it would Knock Out the other Pokémon). This power can't be used if Gengar is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack), if your opponent has 3 or fewer Prizes, you may move 1 damage counter from 1 Pokémon (yours or your opponent’s) to another (even if it would Knock Out the other Pokémon). This power can’t be used if Gengar is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -2422,7 +2422,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "Don't apply Resistance."
+        "text": "Don’t apply Resistance."
       }
     ],
     "weaknesses": [
@@ -2495,7 +2495,7 @@
     "evolvesFrom": "Machoke",
     "ability": {
       "name": "Terraforming",
-      "text": "Once during your turn (before you attack), you may look at the top 4 cards of your deck and rearrange them as you like. This power can't be used if Machamp is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack), you may look at the top 4 cards of your deck and rearrange them as you like. This power can’t be used if Machamp is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -2566,7 +2566,7 @@
       }
     ],
     "text": [
-      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent's turn ends without an attack."
+      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent’s turn ends without an attack."
     ],
     "nationalPokedexNumber": 240,
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/52_hires.png",
@@ -2642,7 +2642,7 @@
     "evolvesFrom": "Bayleef",
     "ability": {
       "name": "Soothing Aroma",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, remove 1 damage counter from each of your Pokémon that has any. This power can't be used if Meganium is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, remove 1 damage counter from each of your Pokémon that has any. This power can’t be used if Meganium is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -2716,7 +2716,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose one of you opponent's Pokémon. Count the number of Energy cards attached to that Pokémon. Put that many damage counters on the Pokémon."
+        "text": "Choose one of you opponent’s Pokémon. Count the number of Energy cards attached to that Pokémon. Put that many damage counters on the Pokémon."
       }
     ],
     "weaknesses": [
@@ -2862,7 +2862,7 @@
       }
     ],
     "text": [
-      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent's turn ends without an attack."
+      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent’s turn ends without an attack."
     ],
     "nationalPokedexNumber": 172,
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/58_hires.png",
@@ -2879,7 +2879,7 @@
     "evolvesFrom": "Pidgeotto",
     "ability": {
       "name": "Beating Wings",
-      "text": "Once during your turn (before you attack), If Pidgeot is your Active Pokémon, you may shuffle 1 of your Benched Pokémon and all cards attached to it in your deck. This power can't be used if Pidgeot is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack), If Pidgeot is your Active Pokémon, you may shuffle 1 of your Benched Pokémon and all cards attached to it in your deck. This power can’t be used if Pidgeot is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -3046,7 +3046,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If your opponent has any Benched Pokémon, flip a coin. If heads, choose 1 of them and this attack does 10 damage to it. (don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, flip a coin. If heads, choose 1 of them and this attack does 10 damage to it. (don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Flame Tail",
@@ -3167,7 +3167,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Benched Pokémon, if any. (Don't apply Weakness and Resistance for Benched Pokémon."
+        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent’s Benched Pokémon, if any. (Don’t apply Weakness and Resistance for Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -3188,7 +3188,7 @@
     "evolvesFrom": "Quilava",
     "ability": {
       "name": "Heat Up",
-      "text": "Once during your turn (before you attack), You may count the total number of Energy cards attached to all of your Pokémon and all of your opponent's Pokémon. If your opponent has more total energy cards attached, you may search your deck for 1 Fire Energy card and attach it to one of your Benched Pokémon, if any. Shuffle your deck afterward. This power can't be used if Typhlosion is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack), You may count the total number of Energy cards attached to all of your Pokémon and all of your opponent’s Pokémon. If your opponent has more total energy cards attached, you may search your deck for 1 Fire Energy card and attach it to one of your Benched Pokémon, if any. Shuffle your deck afterward. This power can’t be used if Typhlosion is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -3267,7 +3267,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "50+",
-        "text": "(50+) Flip a coin. If heads, this attack does 50 damage plus 10 more damage and does 10 damage to each of your opponent's Benched Pokémon, if any. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "(50+) Flip a coin. If heads, this attack does 50 damage plus 10 more damage and does 10 damage to each of your opponent’s Benched Pokémon, if any. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3346,7 +3346,7 @@
     "evolvesFrom": "Ivysaur",
     "ability": {
       "name": "Harvest Bounty",
-      "text": "Once during your turn (before you attack), If you attach an Energy card from your hand to your Active Pokémon as part of your turn, you may attach an additional Energy card to that Pokémon at the same time. This power can't be used if Venusaur is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack), If you attach an Energy card from your hand to your Active Pokémon as part of your turn, you may attach an additional Energy card to that Pokémon at the same time. This power can’t be used if Venusaur is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -3395,7 +3395,7 @@
     "evolvesFrom": "Gloom",
     "ability": {
       "name": "Poison Pollen",
-      "text": "Once during your turn (before you attack), you may flip a coin. If heads, the Defending Pokémon is now Poisoned. This power can't be used if Vileplume is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack), you may flip a coin. If heads, the Defending Pokémon is now Poisoned. This power can’t be used if Vileplume is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -3944,7 +3944,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Don't apply Resistance."
+        "text": "Don’t apply Resistance."
       },
       {
         "name": "Rock Slide",
@@ -3955,7 +3955,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Chose 2 of your opponent's Pokémon (1 if he or she has only 1). This attack does 10 damage to each of those Pokémon. (Don't apply Weakness and Resistance for those Pokémon."
+        "text": "Chose 2 of your opponent’s Pokémon (1 if he or she has only 1). This attack does 10 damage to each of those Pokémon. (Don’t apply Weakness and Resistance for those Pokémon."
       }
     ],
     "weaknesses": [
@@ -4009,7 +4009,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "If the Defending Pokémon isn't Asleep, this attack does nothing."
+        "text": "If the Defending Pokémon isn’t Asleep, this attack does nothing."
       }
     ],
     "weaknesses": [
@@ -4069,7 +4069,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "If your opponent has any Benched Pokémon, chose 1 of them and this attack does 30 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon."
+        "text": "If your opponent has any Benched Pokémon, chose 1 of them and this attack does 30 damage to it. (Don’t apply Weakness and Resistance for Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -4637,7 +4637,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Wartortle can't attack during your next turn."
+        "text": "Wartortle can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -5543,7 +5543,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Don't apply Resistance."
+        "text": "Don’t apply Resistance."
       }
     ],
     "weaknesses": [
@@ -6844,7 +6844,7 @@
   },
   {
     "id": "ecard1-137",
-    "name": "Bill's Maintenance",
+    "name": "Bill’s Maintenance",
     "imageUrl": "https://images.pokemontcg.io/ecard1/137.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -6872,7 +6872,7 @@
     "set": "Expedition Base Set",
     "setCode": "ecard1",
     "text": [
-      "Shuffle your hand into your deck. Then, count the number of cards in your opponent's hand and draw that many cards."
+      "Shuffle your hand into your deck. Then, count the number of cards in your opponent’s hand and draw that many cards."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/138_hires.png"
   },
@@ -6906,7 +6906,7 @@
     "set": "Expedition Base Set",
     "setCode": "ecard1",
     "text": [
-      "Flip a coin. If heads, choose 1 Energy card attached to 1 of your opponent's Pokémon and discard it."
+      "Flip a coin. If heads, choose 1 Energy card attached to 1 of your opponent’s Pokémon and discard it."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/140_hires.png"
   },
@@ -6923,13 +6923,13 @@
     "set": "Expedition Base Set",
     "setCode": "ecard1",
     "text": [
-      "Flip 3 coins. For each heads, put a basic Energy card from your discard pile into your hand. If you don't have that many basic Energy cards in your discard pile, put all of them into your hand."
+      "Flip 3 coins. For each heads, put a basic Energy card from your discard pile into your hand. If you don’t have that many basic Energy cards in your discard pile, put all of them into your hand."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/141_hires.png"
   },
   {
     "id": "ecard1-142",
-    "name": "Mary's Impulse",
+    "name": "Mary’s Impulse",
     "imageUrl": "https://images.pokemontcg.io/ecard1/142.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -7008,7 +7008,7 @@
     "set": "Expedition Base Set",
     "setCode": "ecard1",
     "text": [
-      "Choose one of your opponent's Benched Pokémon. Flip a coin. If heads, switch that Pokémon with the Defending Pokémon."
+      "Choose one of your opponent’s Benched Pokémon. Flip a coin. If heads, switch that Pokémon with the Defending Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/146_hires.png"
   },
@@ -7031,7 +7031,7 @@
   },
   {
     "id": "ecard1-148",
-    "name": "Professor Elm's Training Method",
+    "name": "Professor Elm’s Training Method",
     "imageUrl": "https://images.pokemontcg.io/ecard1/148.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -7048,7 +7048,7 @@
   },
   {
     "id": "ecard1-149",
-    "name": "Professor Oak's Research",
+    "name": "Professor Oak’s Research",
     "imageUrl": "https://images.pokemontcg.io/ecard1/149.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -7212,7 +7212,7 @@
     "set": "Expedition Base Set",
     "setCode": "ecard1",
     "text": [
-      "If the Pokémon Darkness Energy is attached to does damage with an attack (after applying Weakness and Resistance), the attack does 10 more damage. At the end of every turn, put 1 damage counter on the Pokémon Darkness Energy is attached to, unless it's D or has Dark in its name. Darkness Energy provides D Energy. (Doesn't count as a basic Energy card.)"
+      "If the Pokémon Darkness Energy is attached to does damage with an attack (after applying Weakness and Resistance), the attack does 10 more damage. At the end of every turn, put 1 damage counter on the Pokémon Darkness Energy is attached to, unless it’s D or has Dark in its name. Darkness Energy provides D Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/158_hires.png"
   },
@@ -7229,7 +7229,7 @@
     "set": "Expedition Base Set",
     "setCode": "ecard1",
     "text": [
-      "Damage done by attacks to the Pokémon Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). If the Pokémon Metal Energy is attached to isn't M, whenever it damages a Pokémon by an attack, reduce that damage by 10 (after applying Weakness and Resistance). Metal Energy provides M Energy. (Doesn't count as a basic Energy card.)"
+      "Damage done by attacks to the Pokémon Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). If the Pokémon Metal Energy is attached to isn’t M, whenever it damages a Pokémon by an attack, reduce that damage by 10 (after applying Weakness and Resistance). Metal Energy provides M Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/159_hires.png"
   },

--- a/json/cards/Fates Collide.json
+++ b/json/cards/Fates Collide.json
@@ -36,7 +36,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -249,7 +249,7 @@
     "evolvesFrom": "Snivy",
     "ability": {
       "name": "Serpentine Strangle",
-      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.",
+      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed.",
       "type": "Ability"
     },
     "hp": "70",
@@ -317,7 +317,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "40",
-        "text": "During your next turn, this Pokémon's attacks do 60 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s attacks do 60 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance)."
       },
       {
         "name": "Slashing Strike",
@@ -326,7 +326,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "80",
-        "text": "This Pokémon can't use Slashing Strike during your next turn."
+        "text": "This Pokémon can’t use Slashing Strike during your next turn."
       }
     ],
     "weaknesses": [
@@ -474,7 +474,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -516,7 +516,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, switch 1 of your opponent's Benched Pokémon with his or her Active Pokémon."
+        "text": "Flip a coin. If heads, switch 1 of your opponent’s Benched Pokémon with his or her Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -559,7 +559,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Crackling Ribbon",
@@ -613,7 +613,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "40",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Psystorm",
@@ -737,7 +737,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed. If tails, your opponent's Active Pokémon is now Asleep."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed. If tails, your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Aurora Beam",
@@ -863,7 +863,7 @@
     "evolvesFrom": "Omastar",
     "ability": {
       "name": "Dangerous Tentacle",
-      "text": "Once during your turn (before your attack), you may switch 1 of your opponent's Benched Pokémon-EX with his or her Active Pokémon.",
+      "text": "Once during your turn (before your attack), you may switch 1 of your opponent’s Benched Pokémon-EX with his or her Active Pokémon.",
       "type": "Ability"
     },
     "hp": "140",
@@ -914,7 +914,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "This attack does 10 more damage for each damage counter on your opponent's Active Pokémon."
+        "text": "This attack does 10 more damage for each damage counter on your opponent’s Active Pokémon."
       },
       {
         "name": "Crystal Ray",
@@ -925,7 +925,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "During your opponent's next turn, prevent all damage done to this Pokémon by attacks from Evolution Pokémon."
+        "text": "During your opponent’s next turn, prevent all damage done to this Pokémon by attacks from Evolution Pokémon."
       }
     ],
     "weaknesses": [
@@ -967,7 +967,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "If this Pokémon has any Fire Energy attached to it, this attack does 20 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If this Pokémon has any Fire Energy attached to it, this attack does 20 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Blizzard Burn",
@@ -978,7 +978,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "130",
-        "text": "This Pokémon can't attack during your next turn."
+        "text": "This Pokémon can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -1043,7 +1043,7 @@
     "evolvesFrom": "Binacle",
     "ability": {
       "name": "Hand Block",
-      "text": "If you have a Stadium card in play, your opponent can't attach any Special Energy cards from his or her hand to his or her Pokémon.",
+      "text": "If you have a Stadium card in play, your opponent can’t attach any Special Energy cards from his or her hand to his or her Pokémon.",
       "type": "Ability"
     },
     "hp": "100",
@@ -1120,7 +1120,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Move 2 damage counters from each of your Pokémon to your opponent's Active Pokémon."
+        "text": "Move 2 damage counters from each of your Pokémon to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -1146,7 +1146,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Kinesis",
-      "text": "When you play M Alakazam-EX from your hand to evolve this Pokémon, before it evolves, you may put 2 damage counters on your opponent's Active Pokémon and 3 damage counters on 1 of your opponent's Benched Pokémon.",
+      "text": "When you play M Alakazam-EX from your hand to evolve this Pokémon, before it evolves, you may put 2 damage counters on your opponent’s Active Pokémon and 3 damage counters on 1 of your opponent’s Benched Pokémon.",
       "type": "Ability"
     },
     "hp": "160",
@@ -1175,7 +1175,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Put 3 damage counters on each of your opponent's Pokémon that has any Energy attached to it."
+        "text": "Put 3 damage counters on each of your opponent’s Pokémon that has any Energy attached to it."
       }
     ],
     "weaknesses": [
@@ -1221,7 +1221,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10+",
-        "text": "This attack does 30 more damage for each damage counter on your opponent's Active Pokémon."
+        "text": "This attack does 30 more damage for each damage counter on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -1307,7 +1307,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip 2 coins. For each heads, discard 2 cards from the top of your opponent's deck."
+        "text": "Flip 2 coins. For each heads, discard 2 cards from the top of your opponent’s deck."
       },
       {
         "name": "Thick Liquid",
@@ -1442,7 +1442,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put a Basic Pokémon from your opponent's discard pile onto his or her Bench. Then, put 3 damage counters on that Pokémon."
+        "text": "Put a Basic Pokémon from your opponent’s discard pile onto his or her Bench. Then, put 3 damage counters on that Pokémon."
       },
       {
         "name": "Knock Back",
@@ -1492,7 +1492,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -1683,7 +1683,7 @@
     "evolvesFrom": "Cubone",
     "ability": {
       "name": "Bodyguard",
-      "text": "Prevent all effects of attacks done to you or your hand by your opponent's Pokémon. Remove any existing effects.",
+      "text": "Prevent all effects of attacks done to you or your hand by your opponent’s Pokémon. Remove any existing effects.",
       "type": "Ability"
     },
     "hp": "100",
@@ -1796,7 +1796,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "Heal from this Pokémon the same amount of damage you did to your opponent's Active Pokémon."
+        "text": "Heal from this Pokémon the same amount of damage you did to your opponent’s Active Pokémon."
       },
       {
         "name": "X-Scissor",
@@ -1888,7 +1888,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Discard the top card of your opponent's deck."
+        "text": "Discard the top card of your opponent’s deck."
       },
       {
         "name": "Corkscrew Punch",
@@ -1964,7 +1964,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Regi Power",
-      "text": "The attacks of your Fighting Pokémon (excluding Regirock-EX) do 10 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
+      "text": "The attacks of your Fighting Pokémon (excluding Regirock-EX) do 10 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "180",
@@ -1995,7 +1995,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -2015,7 +2015,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Regi Power",
-      "text": "The attacks of your Fighting Pokémon (excluding Regirock-EX) do 10 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
+      "text": "The attacks of your Fighting Pokémon (excluding Regirock-EX) do 10 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "180",
@@ -2046,7 +2046,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -2285,7 +2285,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -2311,7 +2311,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Energy Keeper",
-      "text": "Basic Energy attached to your Basic Pokémon can't be discarded by effects of your opponent's attacks, Abilities, or Trainer cards.",
+      "text": "Basic Energy attached to your Basic Pokémon can’t be discarded by effects of your opponent’s attacks, Abilities, or Trainer cards.",
       "type": "Ability"
     },
     "hp": "80",
@@ -2357,7 +2357,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Safeguard",
-      "text": "Prevent all effects of attacks, including damage, done to this Pokémon by your opponent's Pokémon-EX.",
+      "text": "Prevent all effects of attacks, including damage, done to this Pokémon by your opponent’s Pokémon-EX.",
       "type": "Ability"
     },
     "hp": "90",
@@ -2455,7 +2455,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with his or her Active Pokémon."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with his or her Active Pokémon."
       },
       {
         "name": "Aura Break",
@@ -2466,7 +2466,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "If the Defending Pokémon is a Darkness or Fairy Pokémon, it can't attack during your opponent's next turn."
+        "text": "If the Defending Pokémon is a Darkness or Fairy Pokémon, it can’t attack during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2507,7 +2507,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Geostrike",
@@ -2518,7 +2518,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2556,7 +2556,7 @@
     ],
     "attacks": [
       {
-        "name": "Land's Pulse",
+        "name": "Land’s Pulse",
         "cost": [
           "Fighting"
         ],
@@ -2575,7 +2575,7 @@
         "text": "Heal 30 damage from this Pokémon."
       },
       {
-        "name": "Land's Wrath",
+        "name": "Land’s Wrath",
         "cost": [
           "Fighting",
           "Fighting",
@@ -2621,7 +2621,7 @@
     ],
     "attacks": [
       {
-        "name": "Land's Pulse",
+        "name": "Land’s Pulse",
         "cost": [
           "Fighting"
         ],
@@ -2640,7 +2640,7 @@
         "text": "Heal 30 damage from this Pokémon."
       },
       {
-        "name": "Land's Wrath",
+        "name": "Land’s Wrath",
         "cost": [
           "Fighting",
           "Fighting",
@@ -2701,7 +2701,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "If your opponent's Mega Evolution Pokémon is Knocked Out by damage from this attack, take 2 more Prize cards."
+        "text": "If your opponent’s Mega Evolution Pokémon is Knocked Out by damage from this attack, take 2 more Prize cards."
       }
     ],
     "weaknesses": [
@@ -2804,7 +2804,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Cutting Wind",
@@ -2864,7 +2864,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 60 damage to 1 of your opponent's Pokémon that has an Ability. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 60 damage to 1 of your opponent’s Pokémon that has an Ability. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Cutting Wind",
@@ -2982,7 +2982,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       },
       {
         "name": "Hammer In",
@@ -3022,7 +3022,7 @@
     "evolvesFrom": "Bronzor",
     "ability": {
       "name": "Metal Fortress",
-      "text": "Prevent all effects of your opponent's attacks, including damage, done to your Benched Pokémon.",
+      "text": "Prevent all effects of your opponent’s attacks, including damage, done to your Benched Pokémon.",
       "type": "Ability"
     },
     "hp": "100",
@@ -3050,7 +3050,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -3097,7 +3097,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Discard as many Metal Energy attached to this Pokémon as you like. For each Energy card discarded in this way, choose 1 of your opponent's Pokémon and do 30 damage to it. Don't apply Weakness and Resistance. (You may choose the same Pokémon more than once.)"
+        "text": "Discard as many Metal Energy attached to this Pokémon as you like. For each Energy card discarded in this way, choose 1 of your opponent’s Pokémon and do 30 damage to it. Don’t apply Weakness and Resistance. (You may choose the same Pokémon more than once.)"
       }
     ],
     "nationalPokedexNumber": 437,
@@ -3132,7 +3132,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "50",
-        "text": "This attack's damage isn't affected by Weakness or Resistance."
+        "text": "This attack’s damage isn’t affected by Weakness or Resistance."
       },
       {
         "name": "Fight Alone",
@@ -3305,7 +3305,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 30 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 30 (after applying Weakness and Resistance)."
       },
       {
         "name": "Double Slap",
@@ -3361,7 +3361,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Shuffle your hand into your deck. Then, draw a number of cards equal to the number of cards in your opponent's hand."
+        "text": "Shuffle your hand into your deck. Then, draw a number of cards equal to the number of cards in your opponent’s hand."
       },
       {
         "name": "Juggling",
@@ -3591,7 +3591,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Sparkle Veil",
-      "text": "As long as this Pokémon is your Active Pokémon, any damage done to your Pokémon by an opponent's attack is reduced by 30 (after applying Weakness and Resistance).",
+      "text": "As long as this Pokémon is your Active Pokémon, any damage done to your Pokémon by an opponent’s attack is reduced by 30 (after applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "150",
@@ -3722,7 +3722,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "This attack does 50 damage to 1 of your opponent's Pokémon that has any damage counters on it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 50 damage to 1 of your opponent’s Pokémon that has any damage counters on it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3828,7 +3828,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "120",
-        "text": "Discard a Special Energy attached to your opponent's Active Pokémon."
+        "text": "Discard a Special Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -3890,7 +3890,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
-        "text": "Heal from this Pokémon the same amount of damage you did to your opponent's Active Pokémon."
+        "text": "Heal from this Pokémon the same amount of damage you did to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -3910,7 +3910,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Pressure",
-      "text": "As long as this Pokémon is your Active Pokémon, any damage done by attacks from your opponent's Active Pokémon is reduced by 20 (before applying Weakness and Resistance).",
+      "text": "As long as this Pokémon is your Active Pokémon, any damage done by attacks from your opponent’s Active Pokémon is reduced by 20 (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "120",
@@ -3937,7 +3937,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "If your opponent's Active Pokémon is a Pokémon-EX, this attack does 60 more damage."
+        "text": "If your opponent’s Active Pokémon is a Pokémon-EX, this attack does 60 more damage."
       }
     ],
     "weaknesses": [
@@ -4143,7 +4143,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "At the end of your opponent's next turn, discard the Defending Pokémon and all cards attached to it."
+        "text": "At the end of your opponent’s next turn, discard the Defending Pokémon and all cards attached to it."
       }
     ],
     "weaknesses": [
@@ -4197,7 +4197,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "During your opponent's next turn, this Pokémon has no Weakness."
+        "text": "During your opponent’s next turn, this Pokémon has no Weakness."
       }
     ],
     "weaknesses": [
@@ -4308,7 +4308,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "110",
-        "text": "If you played a Supporter card from your hand during this turn, this attack does 50 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If you played a Supporter card from your hand during this turn, this attack does 50 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4347,7 +4347,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Discard a Pokémon Tool card attached to 1 of your opponent's Pokémon."
+        "text": "Discard a Pokémon Tool card attached to 1 of your opponent’s Pokémon."
       }
     ],
     "weaknesses": [
@@ -4432,7 +4432,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent reveals his or her hand. Choose a card you find there and put it on the bottom of your opponent's deck."
+        "text": "Your opponent reveals his or her hand. Choose a card you find there and put it on the bottom of your opponent’s deck."
       },
       {
         "name": "Last Resort",
@@ -4567,7 +4567,7 @@
     "set": "Fates Collide",
     "setCode": "xy10",
     "text": [
-      "Prevent all effects of your opponent's attacks, except damage, done to the Pokémon this card is attached to. (Existing effects are not removed.)"
+      "Prevent all effects of your opponent’s attacks, except damage, done to the Pokémon this card is attached to. (Existing effects are not removed.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/93_hires.png"
   },
@@ -4584,8 +4584,8 @@
     "set": "Fates Collide",
     "setCode": "xy10",
     "text": [
-      "Choose which way this card faces before you play it. This ↓ player's Pokémon can't be Confused or Poisoned. (If those Pokémon are already Confused or Poisoned, remove those Special Conditions.)",
-      "Choose which way this card faces before you play it. This ↓ player's Pokémon can't be Asleep or Paralyzed. (If those Pokémon are already Asleep or Paralyzed, remove those Special Conditions.)"
+      "Choose which way this card faces before you play it. This ↓ player’s Pokémon can’t be Confused or Poisoned. (If those Pokémon are already Confused or Poisoned, remove those Special Conditions.)",
+      "Choose which way this card faces before you play it. This ↓ player’s Pokémon can’t be Asleep or Paralyzed. (If those Pokémon are already Asleep or Paralyzed, remove those Special Conditions.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/94_hires.png"
   },
@@ -4602,7 +4602,7 @@
     "set": "Fates Collide",
     "setCode": "xy10",
     "text": [
-      "Devolve 1 of your evolved Pokémon and put the highest Stage Evolution card on it into your hand. (That Pokémon can't evolve this turn.)"
+      "Devolve 1 of your evolved Pokémon and put the highest Stage Evolution card on it into your hand. (That Pokémon can’t evolve this turn.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/95_hires.png"
   },
@@ -4636,7 +4636,7 @@
     "set": "Fates Collide",
     "setCode": "xy10",
     "text": [
-      "If the Pokémon this card is attached to is Knocked Out by damage from an opponent's attack, put all basic Energy attached to that Pokémon into your hand."
+      "If the Pokémon this card is attached to is Knocked Out by damage from an opponent’s attack, put all basic Energy attached to that Pokémon into your hand."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/97_hires.png"
   },
@@ -4687,7 +4687,7 @@
     "set": "Fates Collide",
     "setCode": "xy10",
     "text": [
-      "Each Pokémon that has any Fairy Energy attached to it (both yours and your opponent's) has no Retreat Cost."
+      "Each Pokémon that has any Fairy Energy attached to it (both yours and your opponent’s) has no Retreat Cost."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/100_hires.png"
   },
@@ -4727,7 +4727,7 @@
   },
   {
     "id": "xy10-103",
-    "name": "Lass's Special",
+    "name": "Lass’s Special",
     "imageUrl": "https://images.pokemontcg.io/xy10/103.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4738,7 +4738,7 @@
     "set": "Fates Collide",
     "setCode": "xy10",
     "text": [
-      "Draw a card for each of your opponent's Benched Basic Pokémon."
+      "Draw a card for each of your opponent’s Benched Basic Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/103_hires.png"
   },
@@ -4755,7 +4755,7 @@
     "set": "Fates Collide",
     "setCode": "xy10",
     "text": [
-      "Switch 1 of your opponent's Benched Mega Evolution Pokémon with his or her Active Pokémon."
+      "Switch 1 of your opponent’s Benched Mega Evolution Pokémon with his or her Active Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/104_hires.png"
   },
@@ -4874,7 +4874,7 @@
     "set": "Fates Collide",
     "setCode": "xy10",
     "text": [
-      "Once during each player's turn, that player may discard a Fire or Fighting Energy card from his or her hand. If that player does so, he or she draws 2 cards."
+      "Once during each player’s turn, that player may discard a Fire or Fighting Energy card from his or her hand. If that player does so, he or she draws 2 cards."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/110_hires.png"
   },
@@ -4914,7 +4914,7 @@
   },
   {
     "id": "xy10-112",
-    "name": "Team Rocket's Handiwork",
+    "name": "Team Rocket’s Handiwork",
     "imageUrl": "https://images.pokemontcg.io/xy10/112.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4925,7 +4925,7 @@
     "set": "Fates Collide",
     "setCode": "xy10",
     "text": [
-      "Flip 2 coins. For each heads, discard 2 cards from the top of your opponent's deck."
+      "Flip 2 coins. For each heads, discard 2 cards from the top of your opponent’s deck."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/112_hires.png"
   },
@@ -4942,7 +4942,7 @@
     "set": "Fates Collide",
     "setCode": "xy10",
     "text": [
-      "Discard 2 cards from your hand. (If you can't discard 2 cards, you can't play this card.) Search your deck for a Pokémon, reveal it, and put it into your hand. Shuffle your deck afterward."
+      "Discard 2 cards from your hand. (If you can’t discard 2 cards, you can’t play this card.) Search your deck for a Pokémon, reveal it, and put it into your hand. Shuffle your deck afterward."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/113_hires.png"
   },
@@ -4976,7 +4976,7 @@
     "set": "Fates Collide",
     "setCode": "xy10",
     "text": [
-      "This card can only be attached to Fighting Pokémon. This card provides Fighting Energy only while this card is attached to a Fighting Pokémon. The attacks of the Fighting Pokémon this card is attached to do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance). (If this card is attached to anything other than a Fighting Pokémon, discard this card.)"
+      "This card can only be attached to Fighting Pokémon. This card provides Fighting Energy only while this card is attached to a Fighting Pokémon. The attacks of the Fighting Pokémon this card is attached to do 20 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance). (If this card is attached to anything other than a Fighting Pokémon, discard this card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/115_hires.png"
   },
@@ -5012,7 +5012,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "This attack does 10 more damage for each damage counter on your opponent's Active Pokémon."
+        "text": "This attack does 10 more damage for each damage counter on your opponent’s Active Pokémon."
       },
       {
         "name": "Crystal Ray",
@@ -5023,7 +5023,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "During your opponent's next turn, prevent all damage done to this Pokémon by attacks from Evolution Pokémon."
+        "text": "During your opponent’s next turn, prevent all damage done to this Pokémon by attacks from Evolution Pokémon."
       }
     ],
     "weaknesses": [
@@ -5043,7 +5043,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Kinesis",
-      "text": "When you play M Alakazam-EX from your hand to evolve this Pokémon, before it evolves, you may put 2 damage counters on your opponent's Active Pokémon and 3 damage counters on 1 of your opponent's Benched Pokémon.",
+      "text": "When you play M Alakazam-EX from your hand to evolve this Pokémon, before it evolves, you may put 2 damage counters on your opponent’s Active Pokémon and 3 damage counters on 1 of your opponent’s Benched Pokémon.",
       "type": "Ability"
     },
     "hp": "160",
@@ -5072,7 +5072,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Put 3 damage counters on each of your opponent's Pokémon that has any Energy attached to it."
+        "text": "Put 3 damage counters on each of your opponent’s Pokémon that has any Energy attached to it."
       }
     ],
     "weaknesses": [
@@ -5118,7 +5118,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10+",
-        "text": "This attack does 30 more damage for each damage counter on your opponent's Active Pokémon."
+        "text": "This attack does 30 more damage for each damage counter on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -5171,7 +5171,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "If your opponent's Mega Evolution Pokémon is Knocked Out by damage from this attack, take 2 more Prize cards."
+        "text": "If your opponent’s Mega Evolution Pokémon is Knocked Out by damage from this attack, take 2 more Prize cards."
       }
     ],
     "weaknesses": [
@@ -5394,7 +5394,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "During your opponent's next turn, this Pokémon has no Weakness."
+        "text": "During your opponent’s next turn, this Pokémon has no Weakness."
       }
     ],
     "weaknesses": [
@@ -5415,7 +5415,7 @@
   },
   {
     "id": "xy10-124",
-    "name": "Team Rocket's Handiwork",
+    "name": "Team Rocket’s Handiwork",
     "imageUrl": "https://images.pokemontcg.io/xy10/124.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -5426,7 +5426,7 @@
     "set": "Fates Collide",
     "setCode": "xy10",
     "text": [
-      "Flip 2 coins. For each heads, discard 2 cards from the top of your opponent's deck."
+      "Flip 2 coins. For each heads, discard 2 cards from the top of your opponent’s deck."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/124_hires.png"
   },
@@ -5438,7 +5438,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Kinesis",
-      "text": "When you play M Alakazam-EX from your hand to evolve this Pokémon, before it evolves, you may put 2 damage counters on your opponent's Active Pokémon and 3 damage counters on 1 of your opponent's Benched Pokémon.",
+      "text": "When you play M Alakazam-EX from your hand to evolve this Pokémon, before it evolves, you may put 2 damage counters on your opponent’s Active Pokémon and 3 damage counters on 1 of your opponent’s Benched Pokémon.",
       "type": "Ability"
     },
     "hp": "160",
@@ -5467,7 +5467,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Put 3 damage counters on each of your opponent's Pokémon that has any Energy attached to it."
+        "text": "Put 3 damage counters on each of your opponent’s Pokémon that has any Energy attached to it."
       }
     ],
     "weaknesses": [

--- a/json/cards/FireRed & LeafGreen.json
+++ b/json/cards/FireRed & LeafGreen.json
@@ -116,7 +116,7 @@
     "evolvesFrom": "Seel",
     "ability": {
       "name": "Safeguard",
-      "text": "Prevent all effects of attacks, including damage, done to Dewgong by your opponent's Pokémon-ex.",
+      "text": "Prevent all effects of attacks, including damage, done to Dewgong by your opponent’s Pokémon-ex.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -196,7 +196,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "Does 10 damage plus 10 more damage for each Energy attached to Ditto but not used to pay for this attack's Energy cost. You can't add more then 20 damage in this way."
+        "text": "Does 10 damage plus 10 more damage for each Energy attached to Ditto but not used to pay for this attack’s Energy cost. You can’t add more then 20 damage in this way."
       }
     ],
     "weaknesses": [
@@ -349,7 +349,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Vengeance",
@@ -360,7 +360,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
-        "text": "Does 30 damage plus 10 more damage for each Basic Pokémon and each Evolution card in your discard pile. You can't add more than 60 damage in this way."
+        "text": "Does 30 damage plus 10 more damage for each Basic Pokémon and each Evolution card in your discard pile. You can’t add more than 60 damage in this way."
       }
     ],
     "weaknesses": [
@@ -420,7 +420,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 60 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Nidoking can't use Bound Crush during your next turn."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 60 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) Nidoking can’t use Bound Crush during your next turn."
       }
     ],
     "weaknesses": [
@@ -498,7 +498,7 @@
     "evolvesFrom": "Pidgeotto",
     "ability": {
       "name": "Quick Search",
-      "text": "Once during your turn (before your attack), you may choose any 1 card from your deck and put it into your hand. Shuffle your deck afterward. You can't use more than 1 Quick Search Poké-Power each turn. This power can't be used if Pidgeot is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may choose any 1 card from your deck and put it into your hand. Shuffle your deck afterward. You can’t use more than 1 Quick Search Poké-Power each turn. This power can’t be used if Pidgeot is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -520,7 +520,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "The Defending Pokémon can't retreat until the end of your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat until the end of your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -547,7 +547,7 @@
     "evolvesFrom": "Poliwhirl",
     "ability": {
       "name": "Spiral",
-      "text": "As long as Poliwrath is your Active Pokémon, your opponent's Confused Pokémon can't retreat.",
+      "text": "As long as Poliwrath is your Active Pokémon, your opponent’s Confused Pokémon can’t retreat.",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -713,7 +713,7 @@
     "evolvesFrom": "Slowpoke",
     "ability": {
       "name": "Strange Behavior",
-      "text": "As often as you like during your turn (before your attack), you may move 1 damage counter from 1 of your Pokémon to Slowbro as long as you don't Knock Out Slowbro. This power can't be used if Slowbro is affected by a Special Condition.",
+      "text": "As often as you like during your turn (before your attack), you may move 1 damage counter from 1 of your Pokémon to Slowbro as long as you don’t Knock Out Slowbro. This power can’t be used if Slowbro is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -893,7 +893,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "The Defending Pokémon can't retreat until the end of your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat until the end of your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1150,7 +1150,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Weakness or Resistance."
+        "text": "This attack’s damage isn’t affected by Weakness or Resistance."
       },
       {
         "name": "Rumble",
@@ -1161,7 +1161,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "The Defending Pokémon can't retreat until the end of your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat until the end of your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1236,7 +1236,7 @@
     "evolvesFrom": "Spearow",
     "ability": {
       "name": "Free Flight",
-      "text": "If Fearow has no Energy attached to it, Fearow's Retreat Cost is 0.",
+      "text": "If Fearow has no Energy attached to it, Fearow’s Retreat Cost is 0.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -1261,7 +1261,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Drill Peck",
@@ -1375,7 +1375,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "Does 30 damage plus 20 more damage for each basic Energy attached to Kingler but not used to pay for this attack's Energy cost. You can't add more than 40 damage in this way."
+        "text": "Does 30 damage plus 20 more damage for each basic Energy attached to Kingler but not used to pay for this attack’s Energy cost. You can’t add more than 40 damage in this way."
       }
     ],
     "weaknesses": [
@@ -1427,7 +1427,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 40 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
       }
     ],
     "weaknesses": [
@@ -1504,7 +1504,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Leaf Ride",
-      "text": "If Scyther has any Energy attached to it, Scyther's Retreat Cost is 0.",
+      "text": "If Scyther has any Energy attached to it, Scyther’s Retreat Cost is 0.",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -1877,7 +1877,7 @@
     "evolvesFrom": "Weedle",
     "ability": {
       "name": "Poison Payback",
-      "text": "If Kakuna is your Active Pokémon and is damaged by an opponent's attack (even if Kakuna is Knocked Out), the Attacking Pokémon is now Poisoned.",
+      "text": "If Kakuna is your Active Pokémon and is damaged by an opponent’s attack (even if Kakuna is Knocked Out), the Attacking Pokémon is now Poisoned.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -1955,7 +1955,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1997,7 +1997,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Shuffle your opponent's deck."
+        "text": "Shuffle your opponent’s deck."
       },
       {
         "name": "Light Punch",
@@ -2031,7 +2031,7 @@
     "evolvesFrom": "Caterpie",
     "ability": {
       "name": "Energy Protection",
-      "text": "Any damage done to Metapod by attacks is reduced by 10 for each Energy card attached to Metapod. You can't reduce more than 30 damage in this way.",
+      "text": "Any damage done to Metapod by attacks is reduced by 10 for each Energy card attached to Metapod. You can’t reduce more than 30 damage in this way.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -2218,7 +2218,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose up to 2 of your opponent's Benched Pokémon. This attack does 10 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.) Onix can't attack during your next turn."
+        "text": "Choose up to 2 of your opponent’s Benched Pokémon. This attack does 10 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.) Onix can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -2292,7 +2292,7 @@
     "evolvesFrom": "Meowth",
     "ability": {
       "name": "Thick Skin",
-      "text": "Persian can't be affected by any Special Conditions.",
+      "text": "Persian can’t be affected by any Special Conditions.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -2363,7 +2363,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "The Defending Pokémon can't retreat until the end of your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat until the end of your opponent’s next turn."
       },
       {
         "name": "Cutting Wind",
@@ -2509,7 +2509,7 @@
     "evolvesFrom": "Rattata",
     "ability": {
       "name": "Thick Skin",
-      "text": "Raticate can't be affected by any Special Conditions.",
+      "text": "Raticate can’t be affected by any Special Conditions.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -2632,7 +2632,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20+",
-        "text": "Does 20 damage plus 10 more damage for each Water Energy attached to Wartortle but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "Does 20 damage plus 10 more damage for each Water Energy attached to Wartortle but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       },
       {
         "name": "Smash Turn",
@@ -2745,7 +2745,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "During your opponent's next turn, any damage done to Wigglytuff by attacks is reduced by 10 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Wigglytuff by attacks is reduced by 10 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -3075,7 +3075,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Benched Pokémon and switch it with the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
+        "text": "Choose 1 of your opponent’s Benched Pokémon and switch it with the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
       },
       {
         "name": "Moon Kick",
@@ -3137,7 +3137,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3179,7 +3179,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -3279,7 +3279,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "At the end of your opponent's next turn, the Defending Pokémon is now Confused."
+        "text": "At the end of your opponent’s next turn, the Defending Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -3381,7 +3381,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. The new Defending Pokémon is now Asleep."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. The new Defending Pokémon is now Asleep."
       },
       {
         "name": "Quick Blow",
@@ -3647,7 +3647,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Reveal cards from your deck until you reveal a Basic Pokémon. Show that card to your opponent and put it into your hand. Shuffle the other revealed cards into your deck. (If you don't reveal a Basic Pokémon, shuffle all the revealed cards back into your deck.)"
+        "text": "Reveal cards from your deck until you reveal a Basic Pokémon. Show that card to your opponent and put it into your hand. Shuffle the other revealed cards into your deck. (If you don’t reveal a Basic Pokémon, shuffle all the revealed cards back into your deck.)"
       },
       {
         "name": "Bite",
@@ -3801,7 +3801,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "The Defending Pokémon can't retreat until the end of your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat until the end of your opponent’s next turn."
       },
       {
         "name": "Gust",
@@ -4089,7 +4089,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done to Shellder by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Shellder by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Wave Splash",
@@ -4367,7 +4367,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Floating Electrons",
-      "text": "As long as Voltorb has any Energy attached to it, Voltorb's Retreat Cost is 0.",
+      "text": "As long as Voltorb has any Energy attached to it, Voltorb’s Retreat Cost is 0.",
       "type": "Poké-Body"
     },
     "hp": "50",
@@ -4460,7 +4460,7 @@
   },
   {
     "id": "ex6-87",
-    "name": "Bill's Maintenance",
+    "name": "Bill’s Maintenance",
     "imageUrl": "https://images.pokemontcg.io/ex6/87.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4479,7 +4479,7 @@
   },
   {
     "id": "ex6-88",
-    "name": "Celio's Network",
+    "name": "Celio’s Network",
     "imageUrl": "https://images.pokemontcg.io/ex6/88.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4510,7 +4510,7 @@
     "set": "FireRed & LeafGreen",
     "setCode": "ex6",
     "text": [
-      "Flip a coin. If heads, choose 1 Energy card attached to 1 of your opponent's Pokémon and discard it."
+      "Flip a coin. If heads, choose 1 Energy card attached to 1 of your opponent’s Pokémon and discard it."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex6/89_hires.png"
   },
@@ -4546,8 +4546,8 @@
     "set": "FireRed & LeafGreen",
     "setCode": "ex6",
     "text": [
-      "During your opponent's turn, if 1 of your Active Pokémon is Knocked Out by your opponent's attack, you may take 1 basic Energy card attached to that Knocked Out Pokémon and attach it to the Pokémon with EXP.ALL attached to it. If you do, discard EXP.ALL.",
-      "Attach EXP. ALL to 1 of your Pokémon (excluding Pokémon-ex and Pokémon that has an owner in its name) that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card."
+      "During your opponent’s turn, if 1 of your Active Pokémon is Knocked Out by your opponent’s attack, you may take 1 basic Energy card attached to that Knocked Out Pokémon and attach it to the Pokémon with EXP.ALL attached to it. If you do, discard EXP.ALL.",
+      "Attach EXP. ALL to 1 of your Pokémon (excluding Pokémon-ex and Pokémon that has an owner in its name) that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex6/91_hires.png"
   },
@@ -4601,7 +4601,7 @@
     "set": "FireRed & LeafGreen",
     "setCode": "ex6",
     "text": [
-      "Any Pokémon (both yours and your opponent's) with maximum HP less than 70 can't use any Poké-Powers.",
+      "Any Pokémon (both yours and your opponent’s) with maximum HP less than 70 can’t use any Poké-Powers.",
       "This card stays in play when you play it. Discard this card if another Stadium card comes into play."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex6/94_hires.png"
@@ -4656,13 +4656,13 @@
     "set": "FireRed & LeafGreen",
     "setCode": "ex6",
     "text": [
-      "Flip a coin. If heads, choose 1 of your opponent's Benched Pokémon and switch it with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
+      "Flip a coin. If heads, choose 1 of your opponent’s Benched Pokémon and switch it with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex6/97_hires.png"
   },
   {
     "id": "ex6-98",
-    "name": "Prof. Oak's Research",
+    "name": "Prof. Oak’s Research",
     "imageUrl": "https://images.pokemontcg.io/ex6/98.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4765,7 +4765,7 @@
     "set": "FireRed & LeafGreen",
     "setCode": "ex6",
     "text": [
-      "Attach Multi Energy to 1 of your Pokémon. While in play, Multi Energy provides every type of Energy but provides only 1 Energy at a time. (Doesn't count as a basic Energy card when not in play.) Multi Energy provides Colorless Energy when attached to a Pokémon that already has Special Energy cards attached to it.\""
+      "Attach Multi Energy to 1 of your Pokémon. While in play, Multi Energy provides every type of Energy but provides only 1 Energy at a time. (Doesn’t count as a basic Energy card when not in play.) Multi Energy provides Colorless Energy when attached to a Pokémon that already has Special Energy cards attached to it.\""
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex6/103_hires.png"
   },
@@ -4779,7 +4779,7 @@
     "evolvesFrom": "Wartortle",
     "ability": {
       "name": "Energy Rain",
-      "text": "As often as you like during your turn (before your attack), you may attach a Water Energy card from your hand to 1 of your Pokémon. Put 1 damage counter on that Pokémon. This power can't be used if Blastoise ex is affected by a Special Condition.",
+      "text": "As often as you like during your turn (before your attack), you may attach a Water Energy card from your hand to 1 of your Pokémon. Put 1 damage counter on that Pokémon. This power can’t be used if Blastoise ex is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "150",
@@ -4870,7 +4870,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "200",
-        "text": "Discard 5 Fire Energy attached to Charizard ex. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, and any other effects on the Defending Pokémon."
+        "text": "Discard 5 Fire Energy attached to Charizard ex. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, and any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -4917,7 +4917,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. Metronome copies that attack except for its Energy cost. (You must still do anything else in order to use that attack.) (No matter what type that Pokémon is, Clefable ex's type is still Colorless.) Clefable ex performs that attack. \""
+        "text": "Choose 1 of the Defending Pokémon’s attacks. Metronome copies that attack except for its Energy cost. (You must still do anything else in order to use that attack.) (No matter what type that Pokémon is, Clefable ex’s type is still Colorless.) Clefable ex performs that attack. \""
       },
       {
         "name": "Moon Impact",
@@ -4949,7 +4949,7 @@
     "evolvesFrom": "Voltorb",
     "ability": {
       "name": "Extra Energy Bomb",
-      "text": "Once during your turn (before your attack), you may discard Electrode ex and all the cards attached to it (this counts as Knocking Out Electrode ex). If you do, search your discard pile for 5 Energy cards and attach them to any of your Pokémon (excluding Pokémon-ex) in any way you like. This power can't be used if Electrode ex is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may discard Electrode ex and all the cards attached to it (this counts as Knocking Out Electrode ex). If you do, search your discard pile for 5 Energy cards and attach them to any of your Pokémon (excluding Pokémon-ex) in any way you like. This power can’t be used if Electrode ex is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -5017,7 +5017,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40+",
-        "text": "Look at your opponent's hand. This attack does 40 damage plus 10 more damage for each Trainer card in your opponent's hand."
+        "text": "Look at your opponent’s hand. This attack does 40 damage plus 10 more damage for each Trainer card in your opponent’s hand."
       },
       {
         "name": "Prize Count",
@@ -5120,7 +5120,7 @@
     "level": "ex",
     "ability": {
       "name": "Magic Odds",
-      "text": "If Mr. Mime ex would be damaged by an attack, prevent that attack's damage done to Mr. Mime ex if that damage is 10, 30, 50, 70, 90, 110, 130, 150, or 170.",
+      "text": "If Mr. Mime ex would be damaged by an attack, prevent that attack’s damage done to Mr. Mime ex if that damage is 10, 30, 50, 70, 90, 110, 130, 150, or 170.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -5145,7 +5145,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Count the number of cards in your opponent's hand. Put that many damage counters on the Defending Pokémon."
+        "text": "Count the number of cards in your opponent’s hand. Put that many damage counters on the Defending Pokémon."
       }
     ],
     "nationalPokedexNumber": 122,
@@ -5160,7 +5160,7 @@
     "level": "ex",
     "ability": {
       "name": "Magic Evens",
-      "text": "If Mr. Mime ex would be damaged by an attack, prevent that attack's damage done to Mr. Mime ex if that damage is 20, 40, 60, 80, 100, 120, 140, 160, or 180.",
+      "text": "If Mr. Mime ex would be damaged by an attack, prevent that attack’s damage done to Mr. Mime ex if that damage is 20, 40, 60, 80, 100, 120, 140, 160, or 180.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -5185,7 +5185,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Count the number of cards in your opponent's hand. Put that many damage counters on the Defending Pokémon."
+        "text": "Count the number of cards in your opponent’s hand. Put that many damage counters on the Defending Pokémon."
       }
     ],
     "nationalPokedexNumber": 122,
@@ -5201,7 +5201,7 @@
     "evolvesFrom": "Ivysaur",
     "ability": {
       "name": "Energy Trans",
-      "text": "As often as you like during your turn (before your attack), move a Grass Energy card attached to 1 of your Pokémon to another of your Pokémon. This power can't be used if Venusaur ex is affected by a Special Condition.",
+      "text": "As often as you like during your turn (before your attack), move a Grass Energy card attached to 1 of your Pokémon to another of your Pokémon. This power can’t be used if Venusaur ex is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "150",

--- a/json/cards/Flashfire.json
+++ b/json/cards/Flashfire.json
@@ -81,7 +81,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "During your opponent's next turn, if this Pokémon would be damaged by an attack, prevent that attack's damage done to this Pokémon if that damage is 60 or less."
+        "text": "During your opponent’s next turn, if this Pokémon would be damaged by an attack, prevent that attack’s damage done to this Pokémon if that damage is 60 or less."
       }
     ],
     "weaknesses": [
@@ -329,7 +329,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20x",
-        "text": "This attack does 20 damage times the number of Benched Pokémon (both yours and your opponent's)."
+        "text": "This attack does 20 damage times the number of Benched Pokémon (both yours and your opponent’s)."
       }
     ],
     "weaknesses": [
@@ -368,7 +368,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Asleep."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Cut",
@@ -421,7 +421,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin until you get tails. For each heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin until you get tails. For each heads, discard an Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Mega Drain",
@@ -471,7 +471,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, flip 6 coins instead of 2 for this Pokémon's Prickly Needles attack."
+        "text": "During your next turn, flip 6 coins instead of 2 for this Pokémon’s Prickly Needles attack."
       },
       {
         "name": "Prickly Needles",
@@ -594,7 +594,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "150",
-        "text": "This Pokémon can't use Combustion Blast during your next turn."
+        "text": "This Pokémon can’t use Combustion Blast during your next turn."
       }
     ],
     "weaknesses": [
@@ -682,7 +682,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       },
       {
         "name": "Flame Tail",
@@ -732,7 +732,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       },
       {
         "name": "Overrun",
@@ -742,7 +742,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "This attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -952,7 +952,7 @@
     "evolvesFrom": "Litleo",
     "ability": {
       "name": "Intimidating Mane",
-      "text": "Prevent all damage done to this Pokémon by attacks from your opponent's Basic Pokémon.",
+      "text": "Prevent all damage done to this Pokémon by attacks from your opponent’s Basic Pokémon.",
       "type": "Ability"
     },
     "hp": "110",
@@ -999,7 +999,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Counterattack Quills",
-      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), put 2 damage counters on the Attacking Pokémon.",
+      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack (even if this Pokémon is Knocked Out), put 2 damage counters on the Attacking Pokémon.",
       "type": "Ability"
     },
     "hp": "80",
@@ -1024,7 +1024,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       }
     ],
     "weaknesses": [
@@ -1260,7 +1260,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Big Tusk",
@@ -1311,7 +1311,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent can't draw a card at the beginning of his or her next turn."
+        "text": "Flip a coin. If heads, your opponent can’t draw a card at the beginning of his or her next turn."
       },
       {
         "name": "Spike Draw",
@@ -1423,7 +1423,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -1463,7 +1463,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Discard the top card of your opponent's deck."
+        "text": "Discard the top card of your opponent’s deck."
       },
       {
         "name": "Tackle",
@@ -1522,7 +1522,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Shatter",
@@ -1573,7 +1573,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Static Shock",
@@ -1766,7 +1766,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 50 damage to 2 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 50 damage to 2 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1821,7 +1821,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -1926,7 +1926,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put a Basic Pokémon from your opponent's discard pile onto his or her Bench."
+        "text": "Put a Basic Pokémon from your opponent’s discard pile onto his or her Bench."
       },
       {
         "name": "Sneaky Placement",
@@ -1935,7 +1935,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 1 damage counter on your opponent's Active Pokémon."
+        "text": "Put 1 damage counter on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -1985,7 +1985,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       },
       {
         "name": "Cursed Drop",
@@ -1996,7 +1996,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Put 4 damage counters on your opponent's Pokémon in any way you like."
+        "text": "Put 4 damage counters on your opponent’s Pokémon in any way you like."
       }
     ],
     "weaknesses": [
@@ -2054,7 +2054,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Put damage counters on 1 of your opponent's Pokémon equal to the number of damage counters on this Pokémon."
+        "text": "Put damage counters on 1 of your opponent’s Pokémon equal to the number of damage counters on this Pokémon."
       }
     ],
     "weaknesses": [
@@ -2103,7 +2103,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Poisoned. Put 3 damage counters instead of 1 on that Pokémon between turns."
+        "text": "Your opponent’s Active Pokémon is now Poisoned. Put 3 damage counters instead of 1 on that Pokémon between turns."
       },
       {
         "name": "Smash Uppercut",
@@ -2114,7 +2114,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -2163,7 +2163,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -2206,7 +2206,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Move as many damage counters on your opponent's Pokémon as you like to any of your opponent's other Pokémon in any way you like."
+        "text": "Move as many damage counters on your opponent’s Pokémon as you like to any of your opponent’s other Pokémon in any way you like."
       },
       {
         "name": "Psychic",
@@ -2217,7 +2217,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "This attack does 10 more damage for each Energy attached to your opponent's Active Pokémon."
+        "text": "This attack does 10 more damage for each Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -2256,7 +2256,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Poisoned."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Poisoned."
       }
     ],
     "weaknesses": [
@@ -2622,7 +2622,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Scratch",
@@ -2692,7 +2692,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "If your opponent's Active Pokémon already has any damage counters on it, this attack does 30 more damage."
+        "text": "If your opponent’s Active Pokémon already has any damage counters on it, this attack does 30 more damage."
       }
     ],
     "weaknesses": [
@@ -2737,7 +2737,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Slash",
@@ -2868,7 +2868,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -2965,7 +2965,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Double Swing",
@@ -3077,7 +3077,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Jet Headbutt",
@@ -3115,7 +3115,7 @@
     "evolvesFrom": "Pineco",
     "ability": {
       "name": "Thorn Tempest",
-      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may put 1 damage counter on each of your opponent's Pokémon.",
+      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may put 1 damage counter on each of your opponent’s Pokémon.",
       "type": "Ability"
     },
     "hp": "100",
@@ -3142,7 +3142,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "This attack does 20 more damage for each Colorless in your opponent's Active Pokémon's Retreat Cost."
+        "text": "This attack does 20 more damage for each Colorless in your opponent’s Active Pokémon’s Retreat Cost."
       }
     ],
     "weaknesses": [
@@ -3187,7 +3187,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Discard cards from your opponent's hand at random until he or she has 4 cards in his or her hand."
+        "text": "Discard cards from your opponent’s hand at random until he or she has 4 cards in his or her hand."
       },
       {
         "name": "X-Scissor",
@@ -3393,7 +3393,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Razor Leaf",
@@ -3461,7 +3461,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 20 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3565,7 +3565,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       },
       {
         "name": "Wonder Blast",
@@ -3673,7 +3673,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "If any of your Pokémon were Knocked Out by damage from an opponent's attack during his or her last turn, this attack does 70 more damage."
+        "text": "If any of your Pokémon were Knocked Out by damage from an opponent’s attack during his or her last turn, this attack does 70 more damage."
       },
       {
         "name": "Dragon Claw",
@@ -3706,7 +3706,7 @@
     "evolvesFrom": "Skrelp",
     "ability": {
       "name": "Poison Barrier",
-      "text": "Your opponent's Poisoned Pokémon can't retreat.",
+      "text": "Your opponent’s Poisoned Pokémon can’t retreat.",
       "type": "Ability"
     },
     "hp": "100",
@@ -3732,7 +3732,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Poisoned."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Poisoned."
       }
     ],
     "weaknesses": [
@@ -3929,7 +3929,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Before doing damage, discard all Pokémon Tool cards attached to your opponent's Active Pokémon."
+        "text": "Before doing damage, discard all Pokémon Tool cards attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -3978,7 +3978,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Ambush",
@@ -4038,7 +4038,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Strong Gust",
@@ -4049,7 +4049,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "During your next turn, this Pokémon's Strong Gust attack does 60 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s Strong Gust attack does 60 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -4452,7 +4452,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "Flip a coin. If tails, this Pokémon can't attack during your next turn."
+        "text": "Flip a coin. If tails, this Pokémon can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -4540,7 +4540,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Sharp Fang",
@@ -4610,7 +4610,7 @@
     "set": "Flashfire",
     "setCode": "xy2",
     "text": [
-      "Discard a Fire Energy card from your hand. (If you can't discard a Fire Energy card, you can't play this card.) Draw 2 cards."
+      "Discard a Fire Energy card from your hand. (If you can’t discard a Fire Energy card, you can’t play this card.) Draw 2 cards."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy2/89_hires.png"
   },
@@ -4627,7 +4627,7 @@
     "set": "Flashfire",
     "setCode": "xy2",
     "text": [
-      "Switch 1 of your opponent's Benched Pokémon with his or her Active Pokémon."
+      "Switch 1 of your opponent’s Benched Pokémon with his or her Active Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy2/90_hires.png"
   },
@@ -4746,7 +4746,7 @@
     "set": "Flashfire",
     "setCode": "xy2",
     "text": [
-      "Discard all Pokémon Tool cards attached to each of your opponent's Pokémon."
+      "Discard all Pokémon Tool cards attached to each of your opponent’s Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy2/97_hires.png"
   },
@@ -4763,7 +4763,7 @@
     "set": "Flashfire",
     "setCode": "xy2",
     "text": [
-      "Look at the top card of either player's deck. You may discard that card or return it to the top of the deck."
+      "Look at the top card of either player’s deck. You may discard that card or return it to the top of the deck."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy2/98_hires.png"
   },
@@ -4780,7 +4780,7 @@
     "set": "Flashfire",
     "setCode": "xy2",
     "text": [
-      "Discard 2 cards from your hand. (If you can't discard 2 cards, you can't play this card.) Search your deck for a Pokémon, reveal it, and put it into your hand. Shuffle your deck afterward."
+      "Discard 2 cards from your hand. (If you can’t discard 2 cards, you can’t play this card.) Search your deck for a Pokémon, reveal it, and put it into your hand. Shuffle your deck afterward."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy2/99_hires.png"
   },
@@ -4884,7 +4884,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 50 damage to 2 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 50 damage to 2 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4933,7 +4933,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Poisoned. Put 3 damage counters instead of 1 on that Pokémon between turns."
+        "text": "Your opponent’s Active Pokémon is now Poisoned. Put 3 damage counters instead of 1 on that Pokémon between turns."
       },
       {
         "name": "Smash Uppercut",
@@ -4944,7 +4944,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -5025,7 +5025,7 @@
     "set": "Flashfire",
     "setCode": "xy2",
     "text": [
-      "Switch 1 of your opponent's Benched Pokémon with his or her Active Pokémon."
+      "Switch 1 of your opponent’s Benched Pokémon with his or her Active Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy2/104_hires.png"
   },

--- a/json/cards/Fossil.json
+++ b/json/cards/Fossil.json
@@ -96,7 +96,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
-        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Benched Pokémon. If tails, this attack does 10 damage to each of your own Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent’s Benched Pokémon. If tails, this attack does 10 damage to each of your own Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "resistances": [
@@ -117,7 +117,7 @@
     "level": "20",
     "ability": {
       "name": "Transform",
-      "text": "If Ditto is your Active Pokémon, treat it as if it were the same card as the Defending Pokémon, including type, Hit Points, Weakness, and so on, except Ditto can't evolve, always has this Pokémon Power, and you may treat any Energy attached to Ditto as Energy of any type. Ditto isn't a copy of any other Pokémon while Ditto is Asleep, Confused, or Paralyzed.",
+      "text": "If Ditto is your Active Pokémon, treat it as if it were the same card as the Defending Pokémon, including type, Hit Points, Weakness, and so on, except Ditto can’t evolve, always has this Pokémon Power, and you may treat any Energy attached to Ditto as Energy of any type. Ditto isn’t a copy of any other Pokémon while Ditto is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "50",
@@ -207,7 +207,7 @@
     "evolvesFrom": "Haunter",
     "ability": {
       "name": "Curse",
-      "text": "Once during your turn (before your attack), you may move 1 damage counter from 1 of your opponent's Pokémon to another (even if it would Knock Out the other Pokémon). This power can't be used if Gengar is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may move 1 damage counter from 1 of your opponent’s Pokémon to another (even if it would Knock Out the other Pokémon). This power can’t be used if Gengar is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "80",
@@ -233,7 +233,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "resistances": [
@@ -321,7 +321,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 20 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 20 damage to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "High Jump Kick",
@@ -374,7 +374,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at up to 3 cards from the top of either player's deck and rearrange them as you like."
+        "text": "Look at up to 3 cards from the top of either player’s deck and rearrange them as you like."
       },
       {
         "name": "Dark Mind",
@@ -385,7 +385,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -479,7 +479,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "Does 10 damage plus 10 more damage for each Energy attached to Lapras but not used to pay for this attack's Energy cost. You can't add more than 20 damage this way."
+        "text": "Does 10 damage plus 10 more damage for each Energy attached to Lapras but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage this way."
       },
       {
         "name": "Confuse Ray",
@@ -532,7 +532,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Don't apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
+        "text": "Don’t apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
       },
       {
         "name": "Selfdestruct",
@@ -544,7 +544,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "Does 20 damage to each Pokémon on each player's Bench. (Don't apply Weakness and Resistance for Benched Pokémon.) Magneton does 100 damage to itself."
+        "text": "Does 20 damage to each Pokémon on each player’s Bench. (Don’t apply Weakness and Resistance for Benched Pokémon.) Magneton does 100 damage to itself."
       }
     ],
     "weaknesses": [
@@ -588,7 +588,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "You may discard any number of Energy cards attached to Moltres when you use this attack. If you do, discard that many cards from the top of your opponent's deck."
+        "text": "You may discard any number of Energy cards attached to Moltres when you use this attack. If you do, discard that many cards from the top of your opponent’s deck."
       },
       {
         "name": "Dive Bomb",
@@ -693,7 +693,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "30",
-        "text": "Choose 3 of your opponent's Benched Pokémon and this attack does 10 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.) If your opponent has fewer than 3 Benched Pokémon, do the damage to each of them."
+        "text": "Choose 3 of your opponent’s Benched Pokémon and this attack does 10 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.) If your opponent has fewer than 3 Benched Pokémon, do the damage to each of them."
       }
     ],
     "weaknesses": [
@@ -737,7 +737,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "40",
-        "text": "For each of your opponent's Benched Pokémon, flip a coin. If heads, this attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Then, Zapdos does 10 damage times the number of tails to itself."
+        "text": "For each of your opponent’s Benched Pokémon, flip a coin. If heads, this attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) Then, Zapdos does 10 damage times the number of tails to itself."
       }
     ],
     "resistances": [
@@ -846,7 +846,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
-        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Benched Pokémon. If tails, this attack does 10 damage to each of your own Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent’s Benched Pokémon. If tails, this attack does 10 damage to each of your own Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "resistances": [
@@ -867,7 +867,7 @@
     "level": "20",
     "ability": {
       "name": "Transform",
-      "text": "If Ditto is your Active Pokémon, treat it as if it were the same card as the Defending Pokémon, including type, Hit Points, Weakness, and so on, except Ditto can't evolve, always has this Pokémon Power, and you may treat any Energy attached to Ditto as Energy of any type. Ditto isn't a copy of any other Pokémon while Ditto is Asleep, Confused, or Paralyzed.",
+      "text": "If Ditto is your Active Pokémon, treat it as if it were the same card as the Defending Pokémon, including type, Hit Points, Weakness, and so on, except Ditto can’t evolve, always has this Pokémon Power, and you may treat any Energy attached to Ditto as Energy of any type. Ditto isn’t a copy of any other Pokémon while Ditto is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "50",
@@ -957,7 +957,7 @@
     "evolvesFrom": "Haunter",
     "ability": {
       "name": "Curse",
-      "text": "Once during your turn (before your attack), you may move 1 damage counter from 1 of your opponent's Pokémon to another (even if it would Knock Out the other Pokémon). This power can't be used if Gengar is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may move 1 damage counter from 1 of your opponent’s Pokémon to another (even if it would Knock Out the other Pokémon). This power can’t be used if Gengar is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "80",
@@ -983,7 +983,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "resistances": [
@@ -1071,7 +1071,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 20 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 20 damage to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "High Jump Kick",
@@ -1124,7 +1124,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at up to 3 cards from the top of either player's deck and rearrange them as you like."
+        "text": "Look at up to 3 cards from the top of either player’s deck and rearrange them as you like."
       },
       {
         "name": "Dark Mind",
@@ -1135,7 +1135,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1230,7 +1230,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "Does 10 damage plus 10 more damage for each Energy attached to Lapras but not used to pay for this attack's Energy cost. You can't add more than 20 damage this way."
+        "text": "Does 10 damage plus 10 more damage for each Energy attached to Lapras but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage this way."
       },
       {
         "name": "Confuse Ray",
@@ -1283,7 +1283,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Don't apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
+        "text": "Don’t apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
       },
       {
         "name": "Selfdestruct",
@@ -1295,7 +1295,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "Does 20 damage to each Pokémon on each player's Bench. (Don't apply Weakness and Resistance for Benched Pokémon.) Magneton does 100 damage to itself."
+        "text": "Does 20 damage to each Pokémon on each player’s Bench. (Don’t apply Weakness and Resistance for Benched Pokémon.) Magneton does 100 damage to itself."
       }
     ],
     "weaknesses": [
@@ -1339,7 +1339,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "You may discard any number of Energy cards attached to Moltres when you use this attack. If you do, discard that many cards from the top of your opponent's deck."
+        "text": "You may discard any number of Energy cards attached to Moltres when you use this attack. If you do, discard that many cards from the top of your opponent’s deck."
       },
       {
         "name": "Dive Bomb",
@@ -1444,7 +1444,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "30",
-        "text": "Choose 3 of your opponent's Benched Pokémon and this attack does 10 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.) If your opponent has fewer than 3 Benched Pokémon, do the damage to each of them."
+        "text": "Choose 3 of your opponent’s Benched Pokémon and this attack does 10 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.) If your opponent has fewer than 3 Benched Pokémon, do the damage to each of them."
       }
     ],
     "weaknesses": [
@@ -1488,7 +1488,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "40",
-        "text": "For each of your opponent's Benched Pokémon, flip a coin. If heads, this attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Then, Zapdos does 10 damage times the number of tails to itself."
+        "text": "For each of your opponent’s Benched Pokémon, flip a coin. If heads, this attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) Then, Zapdos does 10 damage times the number of tails to itself."
       }
     ],
     "resistances": [
@@ -1815,7 +1815,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "Does 20 damage to each Pokémon on each player's Bench. (Don't apply Weakness and Resistance for Benched Pokémon.) Golem does 100 damage to itself."
+        "text": "Does 20 damage to each Pokémon on each player’s Bench. (Don’t apply Weakness and Resistance for Benched Pokémon.) Golem does 100 damage to itself."
       }
     ],
     "weaknesses": [
@@ -1858,7 +1858,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "During your opponent's next turn, whenever 30 or less damage is done to Graveler (after applying Weakness and Resistance), prevent that damage. (Any other effects of attacks still happen.)"
+        "text": "During your opponent’s next turn, whenever 30 or less damage is done to Graveler (after applying Weakness and Resistance), prevent that damage. (Any other effects of attacks still happen.)"
       },
       {
         "name": "Rock Throw",
@@ -1967,7 +1967,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Smog",
@@ -2022,7 +2022,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "Does 20 damage plus 10 more damage for each Energy attached to Omastar but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "Does 20 damage plus 10 more damage for each Energy attached to Omastar but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       },
       {
         "name": "Spike Cannon",
@@ -2132,7 +2132,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "Does 20 damage plus 10 more damage for each Energy attached to Seadra but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "Does 20 damage plus 10 more damage for each Energy attached to Seadra but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       },
       {
         "name": "Agility",
@@ -2143,7 +2143,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Seadra."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Seadra."
       }
     ],
     "weaknesses": [
@@ -2168,7 +2168,7 @@
     "evolvesFrom": "Slowpoke",
     "ability": {
       "name": "Strange Behavior",
-      "text": "As often as you like during your turn (before your attack), you may move 1 damage counter from 1 of your Pokémon to Slowbro as long as you don't Knock Out Slowbro. This power can't be used if Slowbro is Asleep, Confused, or Paralyzed.",
+      "text": "As often as you like during your turn (before your attack), you may move 1 damage counter from 1 of your Pokémon to Slowbro as long as you don’t Knock Out Slowbro. This power can’t be used if Slowbro is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "60",
@@ -2294,7 +2294,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Does 10 damage to each Pokémon on each player's Bench. (Don't apply Weakness and Resistance for Benched Pokémon.) Weezing does 60 damage to itself."
+        "text": "Does 10 damage to each Pokémon on each player’s Bench. (Don’t apply Weakness and Resistance for Benched Pokémon.) Weezing does 60 damage to itself."
       }
     ],
     "weaknesses": [
@@ -2440,7 +2440,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "All damage done by attacks to Grimer during your opponent's next turn is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "All damage done by attacks to Grimer during your opponent’s next turn is reduced by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -2480,7 +2480,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -2572,7 +2572,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Search your deck for a Basic Pokémon named Krabby and put it onto your Bench. Shuffle your deck afterward. (You can't use this attack if your Bench is full.)"
+        "text": "Search your deck for a Basic Pokémon named Krabby and put it onto your Bench. Shuffle your deck afterward. (You can’t use this attack if your Bench is full.)"
       },
       {
         "name": "Irongrip",
@@ -2630,7 +2630,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "Does 10 damage plus 10 more damage for each Energy attached to Omanyte but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "Does 10 damage plus 10 more damage for each Energy attached to Omanyte but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       }
     ],
     "weaknesses": [
@@ -2673,7 +2673,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent can't play Trainer cards during his or her next turn."
+        "text": "Your opponent can’t play Trainer cards during his or her next turn."
       },
       {
         "name": "Fury Swipes",
@@ -2734,7 +2734,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to Shellder during your opponent's next turn. (Any other effects of attacks still happen.)"
+        "text": "Flip a coin. If heads, prevent all damage done to Shellder during your opponent’s next turn. (Any other effects of attacks still happen.)"
       }
     ],
     "weaknesses": [
@@ -2777,7 +2777,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, remove a damage counter from Slowpoke. This attack can't be used if Slowpoke has no damage counters on it."
+        "text": "Flip a coin. If heads, remove a damage counter from Slowpoke. This attack can’t be used if Slowpoke has no damage counters on it."
       },
       {
         "name": "Scavenge",
@@ -2812,7 +2812,7 @@
     "level": "10",
     "ability": {
       "name": "Cowardice",
-      "text": "At any time during your turn (before your attack), you may return Tentacool to your hand. (Discard all cards attached to Tentacool.) This power can't be used the turn you put Tentacool into play or if Tentacool is Asleep, Confused, or Paralyzed.",
+      "text": "At any time during your turn (before your attack), you may return Tentacool to your hand. (Discard all cards attached to Tentacool.) This power can’t be used the turn you put Tentacool into play or if Tentacool is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "30",
@@ -2987,7 +2987,7 @@
     "set": "Fossil",
     "setCode": "base3",
     "text": [
-      "Play Mysterious Fossil as if it were a Basic Pokémon. While in play, Mysterious Fossil counts as a Pokémon (instead of a Trainer card). Mysterious Fossil has no attacks, can't retreat, and can't be Asleep, Confused, Paralyzed, or Poisoned. If Mysterious Fossil is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Mysterious Fossil from play. (Major text change in Legend Maker. Requires reference.)"
+      "Play Mysterious Fossil as if it were a Basic Pokémon. While in play, Mysterious Fossil counts as a Pokémon (instead of a Trainer card). Mysterious Fossil has no attacks, can’t retreat, and can’t be Asleep, Confused, Paralyzed, or Poisoned. If Mysterious Fossil is Knocked Out, it doesn’t count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Mysterious Fossil from play. (Major text change in Legend Maker. Requires reference.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base3/62_hires.png"
   }

--- a/json/cards/Furious Fists.json
+++ b/json/cards/Furious Fists.json
@@ -36,7 +36,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Discard a random card from your opponent's hand."
+        "text": "Discard a random card from your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -92,7 +92,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       }
     ],
     "weaknesses": [
@@ -116,7 +116,7 @@
     "evolvesFrom": "Weepinbell",
     "ability": {
       "name": "Wafting Scent",
-      "text": "Once during your turn (before your attack), you may discard a Grass Energy attached to this Pokémon. If you do, your opponent's Active Pokémon is now Confused and Poisoned.",
+      "text": "Once during your turn (before your attack), you may discard a Grass Energy attached to this Pokémon. If you do, your opponent’s Active Pokémon is now Confused and Poisoned.",
       "type": "Ability"
     },
     "hp": "130",
@@ -188,7 +188,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Giga Power",
@@ -330,7 +330,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Magical Leaf",
@@ -432,7 +432,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "If any damage is done to this Pokémon by attacks during your opponent's next turn, flip a coin. If heads, prevent that damage."
+        "text": "If any damage is done to this Pokémon by attacks during your opponent’s next turn, flip a coin. If heads, prevent that damage."
       }
     ],
     "weaknesses": [
@@ -679,7 +679,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Burning Shot",
@@ -691,7 +691,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Discard 2 Energy attached to this Pokémon. This attack does 150 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard 2 Energy attached to this Pokémon. This attack does 150 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -741,7 +741,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "Your opponent's Active Pokémon is now Confused. That Pokémon can't retreat during your opponent's next turn."
+        "text": "Your opponent’s Active Pokémon is now Confused. That Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -795,7 +795,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50+",
-        "text": "If your opponent's Active Pokémon already has any damage counters on it, this attack does 50 more damage."
+        "text": "If your opponent’s Active Pokémon already has any damage counters on it, this attack does 50 more damage."
       }
     ],
     "weaknesses": [
@@ -843,7 +843,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Submission",
@@ -875,8 +875,8 @@
     "supertype": "Pokémon",
     "evolvesFrom": "Poliwhirl",
     "ability": {
-      "name": "King's Song",
-      "text": "Ignore all Colorless Energy in the attack cost of each of your Poliwag, Poliwhirl, and Poliwrath's attacks.",
+      "name": "King’s Song",
+      "text": "Ignore all Colorless Energy in the attack cost of each of your Poliwag, Poliwhirl, and Poliwrath’s attacks.",
       "type": "Ability"
     },
     "hp": "130",
@@ -942,7 +942,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "This attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Ice Edge",
@@ -998,7 +998,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent can't play any Item cards from his or her hand during his or her next turn."
+        "text": "Your opponent can’t play any Item cards from his or her hand during his or her next turn."
       },
       {
         "name": "Grenade Hammer",
@@ -1009,7 +1009,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "130",
-        "text": "This attack does 30 damage to 2 of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 2 of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1107,7 +1107,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "This attack does 20 more damage for each Colorless in your opponent's Active Pokémon's Retreat Cost."
+        "text": "This attack does 20 more damage for each Colorless in your opponent’s Active Pokémon’s Retreat Cost."
       },
       {
         "name": "Mountain Drop",
@@ -1158,7 +1158,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Crabhammer",
@@ -1303,7 +1303,7 @@
     "evolvesFrom": "Amaura",
     "ability": {
       "name": "Ice Shield",
-      "text": "Any damage done by an opponent's attack to each of your Water Pokémon that has any Water Energy attached to it is reduced by 20 (after applying Weakness and Resistance).",
+      "text": "Any damage done by an opponent’s attack to each of your Water Pokémon that has any Water Energy attached to it is reduced by 20 (after applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "130",
@@ -1332,7 +1332,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "70",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       }
     ],
     "weaknesses": [
@@ -1372,7 +1372,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -1422,7 +1422,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Electro Ball",
@@ -1551,7 +1551,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "Flip a coin. If heads, this attack does 30 more damage. If tails, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, this attack does 30 more damage. If tails, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -1606,7 +1606,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -1706,7 +1706,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "If your opponent's Active Pokémon has a Pokémon Tool card attached to it, this attack does 30 more damage."
+        "text": "If your opponent’s Active Pokémon has a Pokémon Tool card attached to it, this attack does 30 more damage."
       },
       {
         "name": "Lightning Slam",
@@ -1717,7 +1717,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "This Pokémon can't use Lightning Slam during your next turn."
+        "text": "This Pokémon can’t use Lightning Slam during your next turn."
       }
     ],
     "weaknesses": [
@@ -1771,7 +1771,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20x",
-        "text": "This attack does 20 damage times the amount of Energy attached to your opponent's Active Pokémon."
+        "text": "This attack does 20 damage times the amount of Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -1882,7 +1882,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       }
     ],
     "weaknesses": [
@@ -1928,7 +1928,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1968,7 +1968,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Poisoned."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Poisoned."
       },
       {
         "name": "Pierce",
@@ -2031,7 +2031,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -2074,7 +2074,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at the top 5 cards of your opponent's deck and put them back on top of his or her deck in any order."
+        "text": "Look at the top 5 cards of your opponent’s deck and put them back on top of his or her deck in any order."
       },
       {
         "name": "Smack",
@@ -2369,7 +2369,7 @@
     "evolvesFrom": "Machoke",
     "ability": {
       "name": "Fighting Fury",
-      "text": "Each of your Fighting Pokémon's attacks do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
+      "text": "Each of your Fighting Pokémon’s attacks do 20 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "150",
@@ -2396,7 +2396,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 40 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 40 (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -2435,7 +2435,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Spiral Kick",
@@ -2588,7 +2588,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Heal from this Pokémon the same amount of damage you did to your opponent's Active Pokémon."
+        "text": "Heal from this Pokémon the same amount of damage you did to your opponent’s Active Pokémon."
       },
       {
         "name": "Sky Uppercut",
@@ -2599,7 +2599,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -2675,7 +2675,7 @@
     "evolvesFrom": "Makuhita",
     "ability": {
       "name": "Thick Fat",
-      "text": "Any damage done to this Pokémon by attacks from your opponent's Fire or Water Pokémon is reduced by 30 (after applying Weakness and Resistance).",
+      "text": "Any damage done to this Pokémon by attacks from your opponent’s Fire or Water Pokémon is reduced by 30 (after applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "120",
@@ -2743,7 +2743,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Discard the top card of your opponent's deck."
+        "text": "Discard the top card of your opponent’s deck."
       },
       {
         "name": "Mud-Slap",
@@ -2799,7 +2799,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       },
       {
         "name": "Corkscrew Smash",
@@ -2867,7 +2867,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "140",
-        "text": "Discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -2913,7 +2913,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "140",
-        "text": "Discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -3217,7 +3217,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -3264,7 +3264,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "If your opponent's Active Pokémon has any Special Energy attached to it, this attack does 90 more damage."
+        "text": "If your opponent’s Active Pokémon has any Special Energy attached to it, this attack does 90 more damage."
       },
       {
         "name": "Giga Impact",
@@ -3276,7 +3276,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "150",
-        "text": "This Pokémon can't attack during your next turn."
+        "text": "This Pokémon can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -3296,7 +3296,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shining Spirit",
-      "text": "Damage from this Pokémon's attacks isn't affected by Weakness or Resistance.",
+      "text": "Damage from this Pokémon’s attacks isn’t affected by Weakness or Resistance.",
       "type": "Ability"
     },
     "hp": "70",
@@ -3317,7 +3317,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "60",
-        "text": "If your opponent's Active Pokémon isn't a Pokémon-EX, this attack does nothing."
+        "text": "If your opponent’s Active Pokémon isn’t a Pokémon-EX, this attack does nothing."
       }
     ],
     "weaknesses": [
@@ -3343,7 +3343,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Counterattack",
-      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), put 2 damage counters on the Attacking Pokémon.",
+      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack (even if this Pokémon is Knocked Out), put 2 damage counters on the Attacking Pokémon.",
       "type": "Ability"
     },
     "hp": "130",
@@ -3420,7 +3420,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20+",
-        "text": "If your opponent's Active Pokémon is Poisoned, this attack does 40 more damage."
+        "text": "If your opponent’s Active Pokémon is Poisoned, this attack does 40 more damage."
       },
       {
         "name": "Venomous Fang",
@@ -3432,7 +3432,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       }
     ],
     "weaknesses": [
@@ -3600,7 +3600,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "Discard the top card of your opponent's deck."
+        "text": "Discard the top card of your opponent’s deck."
       }
     ],
     "weaknesses": [
@@ -3703,7 +3703,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 10 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 10 (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -3753,7 +3753,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with your opponent's Active Pokémon."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with your opponent’s Active Pokémon."
       },
       {
         "name": "Moonblast",
@@ -3763,7 +3763,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 30 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 30 (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -3809,7 +3809,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Move an Energy attached to your opponent's Active Pokémon to 1 of his or her Benched Pokémon."
+        "text": "Move an Energy attached to your opponent’s Active Pokémon to 1 of his or her Benched Pokémon."
       },
       {
         "name": "Echoed Voice",
@@ -3820,7 +3820,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "During your next turn, this Pokémon's Echoed Voice attack does 50 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s Echoed Voice attack does 50 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -3846,7 +3846,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Secret Key",
-      "text": "Each of your Fairy Pokémon's Resistance is now -40.",
+      "text": "Each of your Fairy Pokémon’s Resistance is now -40.",
       "type": "Ability"
     },
     "hp": "60",
@@ -3871,7 +3871,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -4079,7 +4079,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 30 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4170,7 +4170,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Discard a random card from your opponent's hand."
+        "text": "Discard a random card from your opponent’s hand."
       },
       {
         "name": "Lickichop",
@@ -4382,7 +4382,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Choose 1 of your opponent's Active Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of your opponent’s Active Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Knuckle Sandwich",
@@ -4486,7 +4486,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip 2 coins. For each heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip 2 coins. For each heads, discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -4660,7 +4660,7 @@
     "set": "Furious Fists",
     "setCode": "xy3",
     "text": [
-      "The attacks of each Fighting Pokémon in play (both yours and your opponent's) do 20 more damage to the Defending Pokémon-EX (before applying Weakness and Resistance)."
+      "The attacks of each Fighting Pokémon in play (both yours and your opponent’s) do 20 more damage to the Defending Pokémon-EX (before applying Weakness and Resistance)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy3/90_hires.png"
   },
@@ -4677,7 +4677,7 @@
     "set": "Furious Fists",
     "setCode": "xy3",
     "text": [
-      "If the Fighting Pokémon this card is attached to has full HP and would be Knocked Out by damage from an opponent's attack, that Pokémon is not Knocked Out and its remaining HP becomes 10 instead. Then, discard this card."
+      "If the Fighting Pokémon this card is attached to has full HP and would be Knocked Out by damage from an opponent’s attack, that Pokémon is not Knocked Out and its remaining HP becomes 10 instead. Then, discard this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy3/91_hires.png"
   },
@@ -4762,7 +4762,7 @@
     "set": "Furious Fists",
     "setCode": "xy3",
     "text": [
-      "Shuffle 2 cards from your hand into your deck. (If you can't shuffle 2 cards into your deck, you can't play this card.) Then, draw a card."
+      "Shuffle 2 cards from your hand into your deck. (If you can’t shuffle 2 cards into your deck, you can’t play this card.) Then, draw a card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy3/96_hires.png"
   },
@@ -4779,7 +4779,7 @@
     "set": "Furious Fists",
     "setCode": "xy3",
     "text": [
-      "Prevent all damage done to Benched Pokémon by attacks (both yours and your opponent's)."
+      "Prevent all damage done to Benched Pokémon by attacks (both yours and your opponent’s)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy3/97_hires.png"
   },
@@ -4813,7 +4813,7 @@
     "set": "Furious Fists",
     "setCode": "xy3",
     "text": [
-      "The Pokémon this card is attached to can't be affected by any Special Conditions. (Remove any Special Conditions affecting that Pokémon.)"
+      "The Pokémon this card is attached to can’t be affected by any Special Conditions. (Remove any Special Conditions affecting that Pokémon.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy3/99_hires.png"
   },
@@ -4864,7 +4864,7 @@
     "set": "Furious Fists",
     "setCode": "xy3",
     "text": [
-      "Each Stage 1 and Stage 2 Pokémon in play (both yours and your opponent's) gets +30 HP."
+      "Each Stage 1 and Stage 2 Pokémon in play (both yours and your opponent’s) gets +30 HP."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy3/102_hires.png"
   },
@@ -4898,7 +4898,7 @@
     "set": "Furious Fists",
     "setCode": "xy3",
     "text": [
-      "This card can only be attached to Fighting Pokémon. This card provides Fighting Energy only while this card is attached to a Fighting Pokémon. The attacks of the Fighting Pokémon this card is attached to do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance). (If this card is attached to anything other than a Fighting Pokémon, discard this card.)"
+      "This card can only be attached to Fighting Pokémon. This card provides Fighting Energy only while this card is attached to a Fighting Pokémon. The attacks of the Fighting Pokémon this card is attached to do 20 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance). (If this card is attached to anything other than a Fighting Pokémon, discard this card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy3/104_hires.png"
   },
@@ -4935,7 +4935,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Giga Power",
@@ -4992,7 +4992,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent can't play any Item cards from his or her hand during his or her next turn."
+        "text": "Your opponent can’t play any Item cards from his or her hand during his or her next turn."
       },
       {
         "name": "Grenade Hammer",
@@ -5003,7 +5003,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "130",
-        "text": "This attack does 30 damage to 2 of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 2 of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -5046,7 +5046,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       },
       {
         "name": "Corkscrew Smash",
@@ -5264,7 +5264,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "140",
-        "text": "Discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [

--- a/json/cards/Generations.json
+++ b/json/cards/Generations.json
@@ -46,7 +46,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "Your opponent's Active Pokémon is now Asleep and Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Asleep and Poisoned."
       }
     ],
     "weaknesses": [
@@ -97,7 +97,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "130",
-        "text": "Flip a coin. If heads, this attack does 30 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 30 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -191,7 +191,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "During your opponent's next turn, if this Pokémon would be damaged by an attack, prevent that attack's damage done to this Pokémon if that damage is 60 or less."
+        "text": "During your opponent’s next turn, if this Pokémon would be damaged by an attack, prevent that attack’s damage done to this Pokémon if that damage is 60 or less."
       }
     ],
     "weaknesses": [
@@ -439,7 +439,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "This attack does 20 damage to 1 of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 1 of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Heavy Suplex",
@@ -450,7 +450,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40+",
-        "text": "This attack does 20 more damage for each Colorless in your opponent's Active Pokémon's Retreat Cost."
+        "text": "This attack does 20 more damage for each Colorless in your opponent’s Active Pokémon’s Retreat Cost."
       }
     ],
     "weaknesses": [
@@ -497,7 +497,7 @@
         "text": "Flip a coin. If heads, this attack does 30 more damage."
       },
       {
-        "name": "Nature's Breath",
+        "name": "Nature’s Breath",
         "cost": [
           "Grass",
           "Grass",
@@ -704,7 +704,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       },
       {
         "name": "Flame Tail",
@@ -754,7 +754,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       },
       {
         "name": "Overrun",
@@ -764,7 +764,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "This attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -863,7 +863,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Hydro Press",
@@ -875,7 +875,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "This attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1011,7 +1011,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed and discard an Energy attached to that Pokémon."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed and discard an Energy attached to that Pokémon."
       },
       {
         "name": "Spike Cannon",
@@ -1158,7 +1158,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "This attack does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each Benched Pokémon (both yours and your opponent’s). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Aqua Tail",
@@ -1322,7 +1322,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Quick Attack",
@@ -1435,7 +1435,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, or any other effects on your opponent's Active Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, or any other effects on your opponent’s Active Pokémon."
       },
       {
         "name": "Flash Ray",
@@ -1446,7 +1446,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "During your opponent's next turn, prevent all damage done to this Pokémon by attacks from Basic Pokémon."
+        "text": "During your opponent’s next turn, prevent all damage done to this Pokémon by attacks from Basic Pokémon."
       }
     ],
     "weaknesses": [
@@ -1464,7 +1464,6 @@
     "nationalPokedexNumber": 135,
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/28_hires.png"
   },
-
   {
     "id": "g1-28a",
     "name": "Jolteon-EX",
@@ -1492,7 +1491,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, or any other effects on your opponent's Active Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, or any other effects on your opponent’s Active Pokémon."
       },
       {
         "name": "Flash Ray",
@@ -1503,7 +1502,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "During your opponent's next turn, prevent all damage done to this Pokémon by attacks from Basic Pokémon."
+        "text": "During your opponent’s next turn, prevent all damage done to this Pokémon by attacks from Basic Pokémon."
       }
     ],
     "weaknesses": [
@@ -1560,7 +1559,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "This attack does 40 damage to 1 of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 40 damage to 1 of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1605,7 +1604,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 10 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1635,7 +1634,7 @@
     "evolvesFrom": "Zubat",
     "ability": {
       "name": "Sneaky Bite",
-      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may put 2 damage counters on 1 of your opponent's Pokémon.",
+      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may put 2 damage counters on 1 of your opponent’s Pokémon.",
       "type": "Ability"
     },
     "hp": "70",
@@ -1656,7 +1655,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1757,7 +1756,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Asleep and Poisoned."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Asleep and Poisoned."
       }
     ],
     "weaknesses": [
@@ -1812,7 +1811,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Poisoned. That Pokémon can't retreat during your opponent's next turn."
+        "text": "Your opponent’s Active Pokémon is now Poisoned. That Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1858,7 +1857,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Poisoned. Put 1 damage counter on each of your opponent's Benched Pokémon."
+        "text": "Your opponent’s Active Pokémon is now Poisoned. Put 1 damage counter on each of your opponent’s Benched Pokémon."
       },
       {
         "name": "Creep Show",
@@ -1868,7 +1867,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "If your opponent's Active Pokémon has 3 or more damage counters on it, that Pokémon is Knocked Out."
+        "text": "If your opponent’s Active Pokémon has 3 or more damage counters on it, that Pokémon is Knocked Out."
       }
     ],
     "weaknesses": [
@@ -1920,7 +1919,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1940,7 +1939,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shadow Ear",
-      "text": "Once during your turn (before your attack), if this Pokémon is your Active Pokémon, you may move 1 damage counter from 1 of your Pokémon to 1 of your opponent's Pokémon.",
+      "text": "Once during your turn (before your attack), if this Pokémon is your Active Pokémon, you may move 1 damage counter from 1 of your Pokémon to 1 of your opponent’s Pokémon.",
       "type": "Ability"
     },
     "hp": "160",
@@ -1968,7 +1967,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "60",
-        "text": "This attack's damage isn't affected by Weakness or Resistance."
+        "text": "This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -2007,7 +2006,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at the top card of your opponent's deck. Then, you may have your opponent shuffle his or her deck."
+        "text": "Look at the top card of your opponent’s deck. Then, you may have your opponent shuffle his or her deck."
       },
       {
         "name": "Mud-Slap",
@@ -2060,7 +2059,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "60",
-        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Rock Tumble",
@@ -2071,7 +2070,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -2180,7 +2179,7 @@
     "evolvesFrom": "Machoke",
     "ability": {
       "name": "Fighting Fury",
-      "text": "Each of your Fighting Pokémon's attacks do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
+      "text": "Each of your Fighting Pokémon’s attacks do 20 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "150",
@@ -2207,7 +2206,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 40 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 40 (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -2473,7 +2472,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Spiral Kick",
@@ -2678,7 +2677,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with his or her Active Pokémon."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with his or her Active Pokémon."
       },
       {
         "name": "Moonblast",
@@ -2688,7 +2687,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 30 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 30 (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -2784,7 +2783,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, this attack does 30 damage to your opponent's Active Pokémon. If tails, this Pokémon does 30 damage to itself."
+        "text": "Flip a coin. If heads, this attack does 30 damage to your opponent’s Active Pokémon. If tails, this Pokémon does 30 damage to itself."
       }
     ],
     "weaknesses": [
@@ -2827,7 +2826,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Ambush",
@@ -2916,7 +2915,7 @@
     "evolvesFrom": "Doduo",
     "ability": {
       "name": "Retreat Aid",
-      "text": "As long as this Pokémon is on your Bench, your Active Pokémon's Retreat Cost is ColorlessColorless less.",
+      "text": "As long as this Pokémon is on your Bench, your Active Pokémon’s Retreat Cost is ColorlessColorless less.",
       "type": "Ability"
     },
     "hp": "90",
@@ -3091,7 +3090,7 @@
     "set": "Generations",
     "setCode": "g1",
     "text": [
-      "Flip a coin. If heads, discard an Energy attached to 1 of your opponent's Pokémon."
+      "Flip a coin. If heads, discard an Energy attached to 1 of your opponent’s Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/60_hires.png"
   },
@@ -3125,7 +3124,7 @@
     "set": "Generations",
     "setCode": "g1",
     "text": [
-      "Search your deck for a card that evolves from 1 of your Pokémon and put it onto that Pokémon. (This counts as evolving that Pokémon.) Shuffle your deck afterward. You can't use this card during your first turn or on a Pokémon that was put into play this turn."
+      "Search your deck for a card that evolves from 1 of your Pokémon and put it onto that Pokémon. (This counts as evolving that Pokémon.) Shuffle your deck afterward. You can’t use this card during your first turn or on a Pokémon that was put into play this turn."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/62_hires.png"
   },
@@ -3159,7 +3158,7 @@
     "set": "Generations",
     "setCode": "g1",
     "text": [
-      "Shuffle 2 cards from your hand into your deck. (If you can't shuffle 2 cards into your deck, you can't play this card.) Then, draw a card."
+      "Shuffle 2 cards from your hand into your deck. (If you can’t shuffle 2 cards into your deck, you can’t play this card.) Then, draw a card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/64_hires.png"
   },
@@ -3312,7 +3311,7 @@
     "set": "Generations",
     "setCode": "g1",
     "text": [
-      "Discard an Energy attached to your opponent's Active Pokémon."
+      "Discard an Energy attached to your opponent’s Active Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/73_hires.png"
   },
@@ -3329,7 +3328,7 @@
     "set": "Generations",
     "setCode": "g1",
     "text": [
-      "Discard an Energy attached to your opponent's Active Pokémon."
+      "Discard an Energy attached to your opponent’s Active Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/73a_hires.png"
   },
@@ -3556,7 +3555,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Confused."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -3700,7 +3699,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of this Pokémon's attacks from its previous Evolutions and use it as this attack."
+        "text": "Choose 1 of this Pokémon’s attacks from its previous Evolutions and use it as this attack."
       },
       {
         "name": "Combustion Blast",
@@ -3712,7 +3711,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "130",
-        "text": "This Pokémon can't use Combustion Blast during your next turn."
+        "text": "This Pokémon can’t use Combustion Blast during your next turn."
       }
     ],
     "weaknesses": [
@@ -3826,7 +3825,7 @@
     "evolvesFrom": "Snorunt",
     "ability": {
       "name": "Drag Along",
-      "text": "If this Pokémon is your Active Pokémon and is Knocked Out by damage from an opponent's attack, flip a coin. If heads, the Attacking Pokémon is Knocked Out.",
+      "text": "If this Pokémon is your Active Pokémon and is Knocked Out by damage from an opponent’s attack, flip a coin. If heads, the Attacking Pokémon is Knocked Out.",
       "type": "Ability"
     },
     "hp": "90",
@@ -3853,7 +3852,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Put 4 damage counters on your opponent's Pokémon in any way you like."
+        "text": "Put 4 damage counters on your opponent’s Pokémon in any way you like."
       }
     ],
     "weaknesses": [
@@ -3982,7 +3981,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Bide Barricade",
-      "text": "As long as this Pokémon is your Active Pokémon, each Pokémon in play, in each player's hand, and in each player's discard pile has no Abilities (except for Psychic Pokémon).",
+      "text": "As long as this Pokémon is your Active Pokémon, each Pokémon in play, in each player’s hand, and in each player’s discard pile has no Abilities (except for Psychic Pokémon).",
       "type": "Ability"
     },
     "hp": "110",
@@ -4008,7 +4007,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10+",
-        "text": "This attack does 10 more damage for each damage counter on your opponent's Active Pokémon."
+        "text": "This attack does 10 more damage for each damage counter on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -4141,7 +4140,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       }
     ],
     "weaknesses": [
@@ -4184,7 +4183,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Move as many damage counters on your opponent's Pokémon as you like to any of your opponent's other Pokémon in any way you like."
+        "text": "Move as many damage counters on your opponent’s Pokémon as you like to any of your opponent’s other Pokémon in any way you like."
       },
       {
         "name": "Psychic",
@@ -4195,7 +4194,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "This attack does 10 more damage for each Energy attached to your opponent's Active Pokémon."
+        "text": "This attack does 10 more damage for each Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -4246,7 +4245,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "Flip a coin. If tails, this Pokémon can't attack during your next turn."
+        "text": "Flip a coin. If tails, this Pokémon can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -4340,7 +4339,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Razor Leaf",
@@ -4575,7 +4574,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Diamond Storm",
@@ -4769,7 +4768,7 @@
     "set": "Generations",
     "setCode": "g1",
     "text": [
-      "At the end of your opponent's turn, heal 20 damage from the Basic Pokémon this card is attached to."
+      "At the end of your opponent’s turn, heal 20 damage from the Basic Pokémon this card is attached to."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/RC26_hires.png"
   },
@@ -4867,7 +4866,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Quick Attack",
@@ -4929,7 +4928,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Heal from this Pokémon the same amount of damage you did to your opponent's Active Pokémon."
+        "text": "Heal from this Pokémon the same amount of damage you did to your opponent’s Active Pokémon."
       },
       {
         "name": "Shining Wind",
@@ -4940,7 +4939,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "During your opponent's next turn, this Pokémon has no Weakness."
+        "text": "During your opponent’s next turn, this Pokémon has no Weakness."
       }
     ],
     "weaknesses": [

--- a/json/cards/Great Encounters.json
+++ b/json/cards/Great Encounters.json
@@ -39,7 +39,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Discard 2 Fire Energy attached to Blaziken. This attack does 80 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard 2 Fire Energy attached to Blaziken. This attack does 80 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -141,7 +141,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "If the Defending Pokémon is Cresselia, this attack's base damage is 100."
+        "text": "If the Defending Pokémon is Cresselia, this attack’s base damage is 100."
       }
     ],
     "weaknesses": [
@@ -253,7 +253,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "If the Defending Pokémon has a Pokémon Tool card attached to it, this attack does 10 damage plus 30 more damage. Discard that Pokémon Tool card, look at your opponent's hand, and discard any Pokémon Tool cards of the same name you find there."
+        "text": "If the Defending Pokémon has a Pokémon Tool card attached to it, this attack does 10 damage plus 30 more damage. Discard that Pokémon Tool card, look at your opponent’s hand, and discard any Pokémon Tool cards of the same name you find there."
       }
     ],
     "weaknesses": [
@@ -281,7 +281,7 @@
     "evolvesFrom": "Porygon2",
     "ability": {
       "name": "Conversion",
-      "text": "Once during your turn (before your attack), you may discard a basic Energy card from your hand. Porygon-Z is the same type as that Energy card until the end of your turn. This power can't be used if Porygon-Z is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may discard a basic Energy card from your hand. Porygon-Z is the same type as that Energy card until the end of your turn. This power can’t be used if Porygon-Z is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -348,7 +348,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Choose 1 card from your opponent's hand without looking. Look at that card you chose, then have your opponent shuffle that card into his or her deck."
+        "text": "Choose 1 card from your opponent’s hand without looking. Look at that card you chose, then have your opponent shuffle that card into his or her deck."
       },
       {
         "name": "Telebeam",
@@ -386,7 +386,7 @@
     "evolvesFrom": "Grovyle",
     "ability": {
       "name": "Wild Growth",
-      "text": "Each basic Grass Energy card attached to your Grass Pokémon provides Grass Grass Energy instead. You can't use more than 1 Wild Growth Poké-Body each turn.",
+      "text": "Each basic Grass Energy card attached to your Grass Pokémon provides Grass Grass Energy instead. You can’t use more than 1 Wild Growth Poké-Body each turn.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -443,7 +443,7 @@
     "evolvesFrom": "Marshtomp",
     "ability": {
       "name": "Wash Out",
-      "text": "As often as you like during your turn (before your attack), you may move a Water or Fighting Energy attached to 1 of your Benched Pokémon to your Active Pokémon. This power can't be used if Swampert is affected by a Special Condition.",
+      "text": "As often as you like during your turn (before your attack), you may move a Water or Fighting Energy attached to 1 of your Benched Pokémon to your Active Pokémon. This power can’t be used if Swampert is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "130",
@@ -471,7 +471,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "Discard the top card from your opponent's deck."
+        "text": "Discard the top card from your opponent’s deck."
       }
     ],
     "weaknesses": [
@@ -513,7 +513,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage for each basic Energy card attached to Tangrowth to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage for each basic Energy card attached to Tangrowth to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Stick and Absorb",
@@ -525,7 +525,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "Remove 3 damage counters from Tangrowth. The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "Remove 3 damage counters from Tangrowth. The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -637,7 +637,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "During your opponent's next turn, any damage done to Altaria by attacks from your opponent's Evolved Pokémon is reduced by 30 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Altaria by attacks from your opponent’s Evolved Pokémon is reduced by 30 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -763,7 +763,7 @@
     "evolvesFrom": "Baltoy",
     "ability": {
       "name": "Cosmic Power",
-      "text": "Once during your turn (before your attack), you may choose up to 2 cards from your hand and put them on the bottom of your deck in any order. If you do, draw cards until you have 6 cards in your hand. This power can't be used if Claydol is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may choose up to 2 cards from your hand and put them on the bottom of your deck in any order. If you do, draw cards until you have 6 cards in your hand. This power can’t be used if Claydol is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -841,7 +841,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "You may return all Energy cards attached to Dialga to your hand. If you do, remove the highest Stage Evolution card from the Defending Pokémon and shuffle that card into your opponent's deck."
+        "text": "You may return all Energy cards attached to Dialga to your hand. If you do, remove the highest Stage Evolution card from the Defending Pokémon and shuffle that card into your opponent’s deck."
       }
     ],
     "weaknesses": [
@@ -891,7 +891,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip 2 coins. If the first coin is heads, this attack does 50 damage to the Defending Pokémon. If the first coin is tails, this attack does 20 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) If the second coin is heads, the Defending Pokémon is now Confused. If the second coin is tails, your opponent can't play any Trainer, Supporter, or Stadium cards from his or her hand during your opponent's next turn."
+        "text": "Flip 2 coins. If the first coin is heads, this attack does 50 damage to the Defending Pokémon. If the first coin is tails, this attack does 20 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) If the second coin is heads, the Defending Pokémon is now Confused. If the second coin is tails, your opponent can’t play any Trainer, Supporter, or Stadium cards from his or her hand during your opponent’s next turn."
       },
       {
         "name": "Hyper Voice",
@@ -944,7 +944,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Choose 1 card from your opponent's hand without looking and discard it."
+        "text": "Choose 1 card from your opponent’s hand without looking and discard it."
       },
       {
         "name": "Black Fire",
@@ -1275,7 +1275,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 face-down Prize card (yours or your opponent's) and put it face up. If that card is a Supporter card, use the effect of that card as the effect of this attack. (That card remains face up for the rest of the game.)"
+        "text": "Choose 1 face-down Prize card (yours or your opponent’s) and put it face up. If that card is a Supporter card, use the effect of that card as the effect of this attack. (That card remains face up for the rest of the game.)"
       },
       {
         "name": "Jaw Bite",
@@ -1313,7 +1313,7 @@
     "evolvesFrom": "Feebas",
     "ability": {
       "name": "Marvel Scale",
-      "text": "Prevent all effects of attacks, including damage, done to Milotic by your opponent's Pokémon LV.X.",
+      "text": "Prevent all effects of attacks, including damage, done to Milotic by your opponent’s Pokémon LV.X.",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -1392,7 +1392,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "You may flip a coin. If heads, discard all Energy attached to Palkia and put the Defending Pokémon and all cards attached to it on top of your opponent's deck. Your opponent shuffles his or her deck afterward."
+        "text": "You may flip a coin. If heads, discard all Energy attached to Palkia and put the Defending Pokémon and all cards attached to it on top of your opponent’s deck. Your opponent shuffles his or her deck afterward."
       }
     ],
     "weaknesses": [
@@ -1414,7 +1414,7 @@
     "evolvesFrom": "Mankey",
     "ability": {
       "name": "Anger Point",
-      "text": "If Primeape has any damage counters on it, Primeape's attacks do 40 more damage to the Active Pokémon (before applying Weakness and Resistance).",
+      "text": "If Primeape has any damage counters on it, Primeape’s attacks do 40 more damage to the Active Pokémon (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -1440,7 +1440,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Primeape is now Confused. Flip a coin. If heads, the Defending Pokémon can't attack during your opponent's next turn."
+        "text": "Primeape is now Confused. Flip a coin. If heads, the Defending Pokémon can’t attack during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1462,7 +1462,7 @@
     "evolvesFrom": "Slowpoke",
     "ability": {
       "name": "Trump Card",
-      "text": "Once during your turn (before your attack), if any of your Pokémon were Knocked Out during your opponent's last turn, search your deck for any 1 card and put it into your hand. Shuffle your deck afterward. This power can't be used if Slowking is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if any of your Pokémon were Knocked Out during your opponent’s last turn, search your deck for any 1 card and put it into your hand. Shuffle your deck afterward. This power can’t be used if Slowking is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -1488,7 +1488,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "During your next turn, Slowking's Psych Up attack's base damage is 60."
+        "text": "During your next turn, Slowking’s Psych Up attack’s base damage is 60."
       }
     ],
     "weaknesses": [
@@ -1533,7 +1533,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Discard a card from your hand. (If you can't discard a card from your hand, this attack does nothing.)"
+        "text": "Discard a card from your hand. (If you can’t discard a card from your hand, this attack does nothing.)"
       }
     ],
     "weaknesses": [
@@ -1655,7 +1655,7 @@
     "evolvesFrom": "Jigglypuff",
     "ability": {
       "name": "Good Night Melody",
-      "text": "Once during your turn (before your attack), you may use this power. Each Active Pokémon (both yours and your opponent's) is now Asleep. This power can't be used if Wigglytuff is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may use this power. Each Active Pokémon (both yours and your opponent’s) is now Asleep. This power can’t be used if Wigglytuff is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -1833,7 +1833,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "During your next turn, each of Combusken's attacks does 30 more damage to the Defending Pokémon (before applying Weakness and Resistance)."
+        "text": "During your next turn, each of Combusken’s attacks does 30 more damage to the Defending Pokémon (before applying Weakness and Resistance)."
       },
       {
         "name": "Double Kick",
@@ -1938,7 +1938,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Floatzel during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Floatzel during your opponent’s next turn."
       },
       {
         "name": "Aqua Jet",
@@ -1949,7 +1949,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Flip a coin. If heads, this attack does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1987,7 +1987,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. This attack does 10 damage to the new Defending Pokémon."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon. This attack does 10 damage to the new Defending Pokémon."
       },
       {
         "name": "Psychic Snap",
@@ -2040,7 +2040,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
       },
       {
         "name": "Rage",
@@ -2167,7 +2167,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "If Hariyama has fewer remaining HP than the Defending Pokémon, this attack's base damage is 80."
+        "text": "If Hariyama has fewer remaining HP than the Defending Pokémon, this attack’s base damage is 80."
       }
     ],
     "weaknesses": [
@@ -2208,7 +2208,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack or retreat during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack or retreat during your opponent’s next turn."
       },
       {
         "name": "Threaten and Drop",
@@ -2256,7 +2256,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Move a Pokémon Tool card attached to 1 of your opponent's Pokémon to another of your opponent's Pokémon (excluding Pokémon that already has a Pokémon Tool attached to it). (If an effect of this attack is prevented, this attack does nothing.)"
+        "text": "Move a Pokémon Tool card attached to 1 of your opponent’s Pokémon to another of your opponent’s Pokémon (excluding Pokémon that already has a Pokémon Tool attached to it). (If an effect of this attack is prevented, this attack does nothing.)"
       },
       {
         "name": "Overrun",
@@ -2267,7 +2267,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2310,7 +2310,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Stomp",
@@ -2346,7 +2346,7 @@
     "evolvesFrom": "Slugma",
     "ability": {
       "name": "Magma Armor",
-      "text": "Magcargo can't be Asleep or Paralyzed.",
+      "text": "Magcargo can’t be Asleep or Paralyzed.",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -2428,7 +2428,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon and 10 damage to each of your opponent's other Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon and 10 damage to each of your opponent’s other Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2453,7 +2453,7 @@
     "evolvesFrom": "Caterpie",
     "ability": {
       "name": "Emerge",
-      "text": "Once during your turn (before your attack), if Metapod is your Active Pokémon, you may flip a coin. If heads, search your deck for a card that evolves from Metapod and put it onto Metapod. (This counts as evolving Metapod.) Shuffle your deck afterward. This power can't be used if Metapod is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Metapod is your Active Pokémon, you may flip a coin. If heads, search your deck for a card that evolves from Metapod and put it onto Metapod. (This counts as evolving Metapod.) Shuffle your deck afterward. This power can’t be used if Metapod is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -2562,7 +2562,7 @@
     "evolvesFrom": "Porygon",
     "ability": {
       "name": "Download",
-      "text": "Once during your turn (before your attack), you may discard a Supporter card from your hand and use the effect of that card as the effect of this power. This power can't be used if Porygon2 is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may discard a Supporter card from your hand and use the effect of that card as the effect of this power. This power can’t be used if Porygon2 is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -2736,7 +2736,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent can't play any Trainer cards from his or her hand during your opponent's next turn."
+        "text": "Flip a coin. If heads, your opponent can’t play any Trainer cards from his or her hand during your opponent’s next turn."
       },
       {
         "name": "Poison Tail",
@@ -2798,7 +2798,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "During your opponent's next turn, any damage done to Skarmory by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Skarmory by attacks is reduced by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -2847,7 +2847,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Zen Headbutt",
@@ -2965,7 +2965,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "You may flip a coin. If tails, this attack does nothing. If heads, this attack's base damage is 30."
+        "text": "You may flip a coin. If tails, this attack does nothing. If heads, this attack’s base damage is 30."
       }
     ],
     "weaknesses": [
@@ -3011,7 +3011,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "If Unown G has any damage counters on it, this attack's base damage is 10."
+        "text": "If Unown G has any damage counters on it, this attack’s base damage is 10."
       }
     ],
     "weaknesses": [
@@ -3054,7 +3054,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Ram",
@@ -3265,7 +3265,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Poison Sting",
@@ -3305,7 +3305,7 @@
     "level": "6",
     "ability": {
       "name": "Pupate",
-      "text": "Once during your turn (before your attack), if Caterpie is your Active Pokémon, you may flip a coin. If heads, search your deck for a card that evolves from Caterpie and put it onto Caterpie. (This counts as evolving Caterpie.) Shuffle your deck afterward. This power can't be used if Caterpie is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Caterpie is your Active Pokémon, you may flip a coin. If heads, search your deck for a card that evolves from Caterpie and put it onto Caterpie. (This counts as evolving Caterpie.) Shuffle your deck afterward. This power can’t be used if Caterpie is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "40",
@@ -3584,7 +3584,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon."
       },
       {
         "name": "Slash",
@@ -3695,7 +3695,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Draw a card. If you didn't play any Supporter card from your hand during this turn, draw 2 more cards."
+        "text": "Draw a card. If you didn’t play any Supporter card from your hand during this turn, draw 2 more cards."
       }
     ],
     "weaknesses": [
@@ -3719,7 +3719,7 @@
     "level": "29",
     "ability": {
       "name": "Scent Conduct",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, search your deck for a Grass Basic Pokémon and put it onto your Bench. Shuffle your deck afterward. This power can't be used if Illumise is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, search your deck for a Grass Basic Pokémon and put it onto your Bench. Shuffle your deck afterward. This power can’t be used if Illumise is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -3794,7 +3794,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "During your opponent's next turn, any damage done to Jigglypuff by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Jigglypuff by attacks is reduced by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -3839,7 +3839,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done to Kakuna by attacks is reduced by 30 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Kakuna by attacks is reduced by 30 (after applying Weakness and Resistance)."
       },
       {
         "name": "Spit Poison",
@@ -3902,7 +3902,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "The Defending Pokémon is now Poisoned. If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "The Defending Pokémon is now Poisoned. If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -3980,7 +3980,7 @@
     "level": "31",
     "ability": {
       "name": "Gravity Change",
-      "text": "Once during your turn (before your attack), you may discard a card from your hand. Then, if you have Solrock in play, draw a card. This power can't be used if Lunatone is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may discard a card from your hand. Then, if you have Solrock in play, draw a card. This power can’t be used if Lunatone is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -4317,7 +4317,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Slowpoke can't attack during your next turn."
+        "text": "Slowpoke can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -4450,7 +4450,7 @@
     "level": "29",
     "ability": {
       "name": "Sunlight",
-      "text": "If you have Lunatone in play, damage done to your opponent's Pokémon by your Psychic or Fighting Pokémon isn't affected by Resistance.",
+      "text": "If you have Lunatone in play, damage done to your opponent’s Pokémon by your Psychic or Fighting Pokémon isn’t affected by Resistance.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -4514,7 +4514,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Swablu during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Swablu during your opponent’s next turn."
       },
       {
         "name": "Shoot Through",
@@ -4524,7 +4524,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4574,7 +4574,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon."
       },
       {
         "name": "Grass Knot",
@@ -4584,7 +4584,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "Does 20 damage plus 10 more damage for each Colorless Energy in the Defending Pokémon's Retreat Cost (after applying effects to the Retreat Cost)."
+        "text": "Does 20 damage plus 10 more damage for each Colorless Energy in the Defending Pokémon’s Retreat Cost (after applying effects to the Retreat Cost)."
       }
     ],
     "weaknesses": [
@@ -4731,7 +4731,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "Does 10 damage plus 10 more damage for each Energy attached to Treecko but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "Does 10 damage plus 10 more damage for each Energy attached to Treecko but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       },
       {
         "name": "Absorb",
@@ -4771,7 +4771,7 @@
     "level": "18",
     "ability": {
       "name": "LINK",
-      "text": "Unown L can use any attack from any Unown in play (both yours and your opponent's). (You still have to pay for that attack's Energy cost.)",
+      "text": "Unown L can use any attack from any Unown in play (both yours and your opponent’s). (You still have to pay for that attack’s Energy cost.)",
       "type": "Poké-Body"
     },
     "hp": "50",
@@ -4796,7 +4796,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Search either player's discard pile for up to any 2 cards, show them to your opponent, and put them on top of that player's deck in any order you like."
+        "text": "Search either player’s discard pile for up to any 2 cards, show them to your opponent, and put them on top of that player’s deck in any order you like."
       }
     ],
     "weaknesses": [
@@ -4817,7 +4817,7 @@
     "level": "34",
     "ability": {
       "name": "Light Conduct",
-      "text": "Once during your turn (before your attack), if you have Illumise in play, you may search your discard pile for a Supporter card, show it to your opponent, and put it on top of your deck. This power can't be used if Volbeat is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if you have Illumise in play, you may search your discard pile for a Supporter card, show it to your opponent, and put it on top of your deck. This power can’t be used if Volbeat is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -4943,7 +4943,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -5083,14 +5083,14 @@
     "set": "Great Encounters",
     "setCode": "dp4",
     "text": [
-      "Attach Amulet Coin to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
+      "Attach Amulet Coin to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
       "If the Pokémon Amulet Coin is attached to is your Active Pokémon at the end of your turn, draw a card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp4/97_hires.png"
   },
   {
     "id": "dp4-98",
-    "name": "Felicity's Drawing",
+    "name": "Felicity’s Drawing",
     "imageUrl": "https://images.pokemontcg.io/dp4/98.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -5121,7 +5121,7 @@
     "set": "Great Encounters",
     "setCode": "dp4",
     "text": [
-      "Attach Leftovers to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
+      "Attach Leftovers to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
       "If the Pokémon Leftovers is attached to is your Active Pokémon at the end of your turn, remove 1 damage counter from that Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp4/99_hires.png"
@@ -5139,8 +5139,8 @@
     "set": "Great Encounters",
     "setCode": "dp4",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "The Retreat Cost for each Psychic and Darkness Pokémon (both yours and your opponent's) is 0."
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
+      "The Retreat Cost for each Psychic and Darkness Pokémon (both yours and your opponent’s) is 0."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp4/100_hires.png"
   },
@@ -5189,7 +5189,7 @@
     "level": "X",
     "ability": {
       "name": "Full Moon Dance",
-      "text": "Once during your turn (before your attack), you may move 1 damage counter from either player's Pokémon to another Pokémon (yours or your opponent's). This power can't be used if Cresselia is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may move 1 damage counter from either player’s Pokémon to another Pokémon (yours or your opponent’s). This power can’t be used if Cresselia is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -5239,7 +5239,7 @@
     "level": "X",
     "ability": {
       "name": "Dark Shadow",
-      "text": "Each basic Darkness Energy card attached to your Darkness Pokémon now has the effect \"If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance).\" You can't use more than 1 Dark Shadow Poké-Body each turn.",
+      "text": "Each basic Darkness Energy card attached to your Darkness Pokémon now has the effect \"If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance).\" You can’t use more than 1 Dark Shadow Poké-Body each turn.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -5295,7 +5295,7 @@
     "level": "X",
     "ability": {
       "name": "Time Skip",
-      "text": "Once during your turn (before your attack), you may have your opponent flip 2 coins. If both of them are heads, your turn ends. If both of them are tails, after your opponent draws a card at the beginning of his or her next turn, his or her turn ends. This power can't be used if Dialga is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may have your opponent flip 2 coins. If both of them are heads, your turn ends. If both of them are tails, after your opponent draws a card at the beginning of his or her next turn, his or her turn ends. This power can’t be used if Dialga is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -5326,7 +5326,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "During your next turn, Dialga can't use Metal Flash."
+        "text": "During your next turn, Dialga can’t use Metal Flash."
       }
     ],
     "weaknesses": [
@@ -5353,7 +5353,7 @@
     "level": "X",
     "ability": {
       "name": "Restructure",
-      "text": "Once during your turn (before your attack), you may have your opponent switch 1 of your Active Pokémon with 1 of your Benched Pokémon. Then, you switch 1 of the Defending Pokémon with 1 of your opponent's Benched Pokémon. This power can't be used if Palkia is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may have your opponent switch 1 of your Active Pokémon with 1 of your Benched Pokémon. Then, you switch 1 of the Defending Pokémon with 1 of your opponent’s Benched Pokémon. This power can’t be used if Palkia is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -5384,7 +5384,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "You may move all Energy cards attached to Palkia to your Benched Pokémon in any way you like. (Ignore this effect if you don't have any Benched Pokémon.)"
+        "text": "You may move all Energy cards attached to Palkia to your Benched Pokémon in any way you like. (Ignore this effect if you don’t have any Benched Pokémon.)"
       }
     ],
     "weaknesses": [

--- a/json/cards/Guardians Rising.json
+++ b/json/cards/Guardians Rising.json
@@ -72,7 +72,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Flip a coin. If heads, discard an Energy from your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy from your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -116,7 +116,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Your opponent's Active Pokémon is now Burned, Confused, and Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Burned, Confused, and Poisoned."
       },
       {
         "name": "Stick and Absorb",
@@ -127,7 +127,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "Heal 20 damage from this Pokémon. The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "Heal 20 damage from this Pokémon. The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -209,7 +209,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Petal Dance",
@@ -269,7 +269,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -425,7 +425,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80+",
-        "text": "If your opponent's Active Pokémon is a Pokémon-GX or a Pokémon-EX, this attack does 70 more damage (before applying Weakness and Resistance)."
+        "text": "If your opponent’s Active Pokémon is a Pokémon-GX or a Pokémon-EX, this attack does 70 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -445,7 +445,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Victory Star",
-      "text": "Once during your turn, after you flip any coins for an attack, you may ignore all results of those coin flips and begin flipping those coins again. You can't use more than 1 Victory Star Ability each turn.",
+      "text": "Once during your turn, after you flip any coins for an attack, you may ignore all results of those coin flips and begin flipping those coins again. You can’t use more than 1 Victory Star Ability each turn.",
       "type": "Ability"
     },
     "hp": "70",
@@ -509,7 +509,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       }
     ],
     "weaknesses": [
@@ -600,7 +600,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "50",
-        "text": "Your opponent's Active Pokémon is now Burned."
+        "text": "Your opponent’s Active Pokémon is now Burned."
       }
     ],
     "weaknesses": [
@@ -649,7 +649,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Discard an Energy from this Pokémon. If you do, discard an Energy from your opponent's Active Pokémon."
+        "text": "Discard an Energy from this Pokémon. If you do, discard an Energy from your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -698,7 +698,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "If your opponent's Active Pokémon is Poisoned, this attack does 40 more damage."
+        "text": "If your opponent’s Active Pokémon is Poisoned, this attack does 40 more damage."
       }
     ],
     "weaknesses": [
@@ -722,7 +722,7 @@
     "evolvesFrom": "Salandit",
     "ability": {
       "name": "Hot Poison",
-      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may leave your opponent's Active Pokémon Burned and Poisoned.",
+      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may leave your opponent’s Active Pokémon Burned and Poisoned.",
       "type": "Ability"
     },
     "hp": "110",
@@ -790,7 +790,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Heat Blast",
@@ -847,7 +847,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "During your opponent's next turn, if this Pokémon is damaged by an attack (even if this Pokémon is Knocked Out), put 8 damage counters on the Attacking Pokémon."
+        "text": "During your opponent’s next turn, if this Pokémon is damaged by an attack (even if this Pokémon is Knocked Out), put 8 damage counters on the Attacking Pokémon."
       },
       {
         "name": "Bright Flame",
@@ -906,7 +906,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent’s next turn."
       },
       {
         "name": "Ice Ball",
@@ -1065,7 +1065,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "This attack does 50 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 50 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Blizzard Edge",
@@ -1086,7 +1086,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Move all damage counters from this Pokémon to your opponent's Active Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Move all damage counters from this Pokémon to your opponent’s Active Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -1125,7 +1125,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "The Defending Pokémon can’t be healed during your opponent's next turn."
+        "text": "The Defending Pokémon can’t be healed during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1170,7 +1170,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       },
       {
         "name": "Seething Tentacles",
@@ -1181,7 +1181,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40+",
-        "text": "Flip a coin. If heads, this attack does 40 more damage. If tails, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, this attack does 40 more damage. If tails, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -1462,7 +1462,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       },
       {
         "name": "Open Sea",
@@ -1571,7 +1571,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Flip a coin. If heads, discard an Energy from your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy from your opponent’s Active Pokémon."
       },
       {
         "name": "Raging Floe",
@@ -1665,7 +1665,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30+",
-        "text": "If your opponent's Active Pokémon is a Fighting Pokémon, this attack does 30 more damage."
+        "text": "If your opponent’s Active Pokémon is a Fighting Pokémon, this attack does 30 more damage."
       }
     ],
     "weaknesses": [
@@ -1709,7 +1709,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 20 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Frozen Breath",
@@ -1720,7 +1720,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "You may discard 2 Water Energy from this Pokémon. If you do, your opponent's Active Pokémon is now Paralyzed."
+        "text": "You may discard 2 Water Energy from this Pokémon. If you do, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -1812,7 +1812,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 10 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1870,7 +1870,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "120",
-        "text": "Discard a Special Energy from your opponent's Active Pokémon."
+        "text": "Discard a Special Energy from your opponent’s Active Pokémon."
       },
       {
         "name": "Blue Surge-GX",
@@ -2051,7 +2051,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "This attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2117,7 +2117,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "200-",
-        "text": "This attack does 30 less damage for each Colorless in your opponent's Active Pokémon's Retreat Cost."
+        "text": "This attack does 30 less damage for each Colorless in your opponent’s Active Pokémon’s Retreat Cost."
       }
     ],
     "weaknesses": [
@@ -2162,7 +2162,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -2222,7 +2222,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "This attack does 30 damage to 1 of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2296,7 +2296,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "This attack does 60 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 60 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -2341,7 +2341,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, this Pokémon's Pom-Pom Punch attack's base damage is 100."
+        "text": "During your next turn, this Pokémon’s Pom-Pom Punch attack’s base damage is 100."
       },
       {
         "name": "Pom-Pom Punch",
@@ -2418,7 +2418,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50×",
-        "text": "This attack does 50 damage times the amount of Energy attached to all of your opponent's Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage times the amount of Energy attached to all of your opponent’s Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/47_hires.png"
@@ -2509,7 +2509,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Choose 1 of your opponent's Active Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of your opponent’s Active Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Facade",
@@ -2560,7 +2560,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Discard the top card of your opponent's deck."
+        "text": "Discard the top card of your opponent’s deck."
       },
       {
         "name": "Drool",
@@ -2616,7 +2616,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20×",
-        "text": "This attack does 20 damage for each Item card in your opponent's discard pile."
+        "text": "This attack does 20 damage for each Item card in your opponent’s discard pile."
       },
       {
         "name": "Acid Spray",
@@ -2627,7 +2627,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "Flip a coin. If heads, discard an Energy from your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy from your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -2666,7 +2666,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 1 damage counter on 1 of your opponent's Pokémon."
+        "text": "Put 1 damage counter on 1 of your opponent’s Pokémon."
       }
     ],
     "weaknesses": [
@@ -2720,7 +2720,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -2764,7 +2764,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. This attack does 30 damage to the new Active Pokémon."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with their Active Pokémon. This attack does 30 damage to the new Active Pokémon."
       },
       {
         "name": "Link Blast",
@@ -2774,7 +2774,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50+",
-        "text": "If this Pokémon and your opponent's Active Pokémon have the same amount of Energy attached to them, this attack does 80 more damage."
+        "text": "If this Pokémon and your opponent’s Active Pokémon have the same amount of Energy attached to them, this attack does 80 more damage."
       }
     ],
     "weaknesses": [
@@ -2858,7 +2858,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "For each Pokémon in your opponent’s discard pile, put 1 damage counter on your opponent's Pokémon in any way you like."
+        "text": "For each Pokémon in your opponent’s discard pile, put 1 damage counter on your opponent’s Pokémon in any way you like."
       },
       {
         "name": "Revelation Dance",
@@ -2930,7 +2930,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Poisoned. Put 10 damage counters instead of 1 on that Pokémon between turns."
+        "text": "Your opponent’s Active Pokémon is now Poisoned. Put 10 damage counters instead of 1 on that Pokémon between turns."
       },
       {
         "name": "Total Shelter-GX",
@@ -2941,7 +2941,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "150",
-        "text": "Prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -2990,7 +2990,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "If your opponent's Pokémon used an attack that isn't a GX attack during their last turn, use it as this attack."
+        "text": "If your opponent’s Pokémon used an attack that isn’t a GX attack during their last turn, use it as this attack."
       }
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/58_hires.png",
@@ -3004,7 +3004,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Steelworker",
-      "text": "Your Metal Pokémon's attacks do 10 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
+      "text": "Your Metal Pokémon’s attacks do 10 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "120",
@@ -3031,7 +3031,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3086,7 +3086,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20×",
-        "text": "This attack does 20 damage times the amount of Energy attached to both Active Pokémon. This damage isn't affected by Weakness or Resistance."
+        "text": "This attack does 20 damage times the amount of Energy attached to both Active Pokémon. This damage isn’t affected by Weakness or Resistance."
       },
       {
         "name": "Tapu Cure-GX",
@@ -3255,7 +3255,7 @@
     "evolvesFrom": "Machop",
     "ability": {
       "name": "Daunting Pose",
-      "text": "Prevent all damage done to your Benched Pokémon by your opponent's attacks. Your opponent’s attacks and Abilities can't put damage counters on your Benched Pokémon.",
+      "text": "Prevent all damage done to your Benched Pokémon by your opponent’s attacks. Your opponent’s attacks and Abilities can’t put damage counters on your Benched Pokémon.",
       "type": "Ability"
     },
     "hp": "100",
@@ -3424,7 +3424,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 10 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3467,7 +3467,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "70",
-        "text": "If your opponent's Active Pokémon has no damage counters on it before this attack does damage, this attack does nothing."
+        "text": "If your opponent’s Active Pokémon has no damage counters on it before this attack does damage, this attack does nothing."
       },
       {
         "name": "Guillotine",
@@ -3631,7 +3631,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Landslip",
@@ -3726,7 +3726,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Wild Kick",
@@ -3761,7 +3761,7 @@
     "evolvesFrom": "Rockruff",
     "ability": {
       "name": "Bloodthirsty Eyes",
-      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may switch 1 of your opponent's Benched Pokémon with their Active Pokémon.",
+      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may switch 1 of your opponent’s Benched Pokémon with their Active Pokémon.",
       "type": "Ability"
     },
     "hp": "200",
@@ -3801,7 +3801,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50×",
-        "text": "This attack does 50 damage for each of your opponent's Benched Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage for each of your opponent’s Benched Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -3941,7 +3941,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, or any other effects on your opponent's Active Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, or any other effects on your opponent’s Active Pokémon."
       },
       {
         "name": "Cosmicsplosion",
@@ -4046,17 +4046,17 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 30 damage to 1 of your opponent's Pokémon. This damage isn't affected by Weakness, Resistance, or any other effects on that Pokémon."
+        "text": "This attack does 30 damage to 1 of your opponent’s Pokémon. This damage isn’t affected by Weakness, Resistance, or any other effects on that Pokémon."
       },
       {
-        "name": "Raven's Claw",
+        "name": "Raven’s Claw",
         "cost": [
           "Colorless",
           "Colorless"
         ],
         "convertedEnergyCost": 2,
         "damage": "10+",
-        "text": "This attack does 10 more damage for each damage counter on all of your opponent's Pokémon."
+        "text": "This attack does 10 more damage for each damage counter on all of your opponent’s Pokémon."
       }
     ],
     "weaknesses": [
@@ -4101,7 +4101,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent can't play any Supporter cards from their hand during their next turn."
+        "text": "Your opponent can’t play any Supporter cards from their hand during their next turn."
       },
       {
         "name": "Scratch",
@@ -4143,7 +4143,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at the top 4 cards of either player's deck and put them back in any order."
+        "text": "Look at the top 4 cards of either player’s deck and put them back in any order."
       },
       {
         "name": "Doom News",
@@ -4153,7 +4153,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Put all Energy attached to this Pokémon into your hand. At the end of your opponent's next turn, the Defending Pokémon will be Knocked Out."
+        "text": "Put all Energy attached to this Pokémon into your hand. At the end of your opponent’s next turn, the Defending Pokémon will be Knocked Out."
       }
     ],
     "weaknesses": [
@@ -4203,7 +4203,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       },
       {
         "name": "Magnum Punch",
@@ -4384,7 +4384,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "150",
-        "text": "This Pokémon can't use Giga Hammer during your next turn."
+        "text": "This Pokémon can’t use Giga Hammer during your next turn."
       },
       {
         "name": "Algorithm-GX",
@@ -4503,7 +4503,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "This attack does 50 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 50 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Fangs of the Sunne",
@@ -4514,7 +4514,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "170",
-        "text": "This Pokémon can't use Fangs of the Sunne during your next turn."
+        "text": "This Pokémon can’t use Fangs of the Sunne during your next turn."
       }
     ],
     "weaknesses": [
@@ -4569,7 +4569,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with their Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -4618,7 +4618,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Meteor Mash",
@@ -4629,7 +4629,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "During your next turn, this Pokémon's Meteor Mash attack does 60 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s Meteor Mash attack does 60 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -4802,7 +4802,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Put 2 of your opponent's Benched Pokémon and all cards attached to them into your opponent’s hand. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Put 2 of your opponent’s Benched Pokémon and all cards attached to them into your opponent’s hand. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -4828,7 +4828,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Flower Shield",
-      "text": "Each of your Pokémon that has any Fairy Energy attached to it can't be affected by any Special Conditions. Remove any Special Conditions affecting those Pokémon.",
+      "text": "Each of your Pokémon that has any Fairy Energy attached to it can’t be affected by any Special Conditions. Remove any Special Conditions affecting those Pokémon.",
       "type": "Ability"
     },
     "hp": "70",
@@ -4898,7 +4898,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Tackle",
@@ -5008,7 +5008,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 20 damage times the amount of Energy attached to this Pokémon to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage times the amount of Energy attached to this Pokémon to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Beat Slider",
@@ -5219,7 +5219,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "During your opponent's next turn, this Pokémon takes 30 less damage from attacks (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, this Pokémon takes 30 less damage from attacks (after applying Weakness and Resistance)."
       },
       {
         "name": "Shred",
@@ -5231,7 +5231,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "130",
-        "text": "This attack's damage isn't affected by any effects on your opponent's Active Pokémon."
+        "text": "This attack’s damage isn’t affected by any effects on your opponent’s Active Pokémon."
       },
       {
         "name": "Ultra Uppercut-GX",
@@ -5438,7 +5438,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       },
       {
         "name": "Swallow Dive",
@@ -5502,7 +5502,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       }
     ],
     "weaknesses": [
@@ -5598,7 +5598,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at the top card of your opponent's deck."
+        "text": "Look at the top card of your opponent’s deck."
       },
       {
         "name": "Tackle",
@@ -5651,7 +5651,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at the top 2 cards of your opponent's deck, discard 1 of them, and put the other card back."
+        "text": "Look at the top 2 cards of your opponent’s deck, discard 1 of them, and put the other card back."
       },
       {
         "name": "Slam",
@@ -5701,7 +5701,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, the Defending Pokémon's attacks do 20 less damage (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, the Defending Pokémon’s attacks do 20 less damage (before applying Weakness and Resistance)."
       },
       {
         "name": "Flap",
@@ -5934,7 +5934,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "If your opponent's Active Pokémon is a Basic Pokémon, this attack does 60 more damage."
+        "text": "If your opponent’s Active Pokémon is a Basic Pokémon, this attack does 60 more damage."
       }
     ],
     "weaknesses": [
@@ -6025,7 +6025,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Discard a Special Energy from your opponent's Active Pokémon."
+        "text": "Discard a Special Energy from your opponent’s Active Pokémon."
       },
       {
         "name": "Berserk",
@@ -6070,7 +6070,7 @@
     "set": "Guardians Rising",
     "setCode": "sm2",
     "text": [
-      "Basic Grass Pokémon and Basic Lightning Pokémon (both yours and your opponent's) take 30 less damage from the opponent's attacks (after applying Weakness and Resistance)."
+      "Basic Grass Pokémon and Basic Lightning Pokémon (both yours and your opponent’s) take 30 less damage from the opponent’s attacks (after applying Weakness and Resistance)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/116_hires.png"
   },
@@ -6087,7 +6087,7 @@
     "set": "Guardians Rising",
     "setCode": "sm2",
     "text": [
-      "The Retreat Cost of each Pokémon (both yours and your opponent's) that has any Psychic or Darkness Energy attached to it is ColorlessColorless less."
+      "The Retreat Cost of each Pokémon (both yours and your opponent’s) that has any Psychic or Darkness Energy attached to it is ColorlessColorless less."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/117_hires.png"
   },
@@ -6104,7 +6104,7 @@
     "set": "Guardians Rising",
     "setCode": "sm2",
     "text": [
-      "Fire Pokémon and Metal Pokémon (both yours and your opponent's) have no Weakness."
+      "Fire Pokémon and Metal Pokémon (both yours and your opponent’s) have no Weakness."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/118_hires.png"
   },
@@ -6138,7 +6138,7 @@
     "set": "Guardians Rising",
     "setCode": "sm2",
     "text": [
-      "Once during each player's turn, that player may search their deck for a Basic Water Pokémon or Basic Fighting Pokémon, put it onto their Bench, and shuffle their deck."
+      "Once during each player’s turn, that player may search their deck for a Basic Water Pokémon or Basic Fighting Pokémon, put it onto their Bench, and shuffle their deck."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/120_hires.png"
   },
@@ -6155,7 +6155,7 @@
     "set": "Guardians Rising",
     "setCode": "sm2",
     "text": [
-      "The attacks of the Pokémon this card is attached to do 30 more damage to your opponent's Active Pokémon-GX or Active Pokémon-EX (before applying Weakness and Resistance)."
+      "The attacks of the Pokémon this card is attached to do 30 more damage to your opponent’s Active Pokémon-GX or Active Pokémon-EX (before applying Weakness and Resistance)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/121_hires.png"
   },
@@ -6206,7 +6206,7 @@
     "set": "Guardians Rising",
     "setCode": "sm2",
     "text": [
-      "Discard a Special Energy from 1 of your opponent's Pokémon."
+      "Discard a Special Energy from 1 of your opponent’s Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/124_hires.png"
   },
@@ -6223,7 +6223,7 @@
     "set": "Guardians Rising",
     "setCode": "sm2",
     "text": [
-      "Choose up to 2 in any combination of Pokémon Tool cards and Stadium cards in play (yours or your opponent's) and discard them."
+      "Choose up to 2 in any combination of Pokémon Tool cards and Stadium cards in play (yours or your opponent’s) and discard them."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/125_hires.png"
   },
@@ -6346,7 +6346,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "During your opponent's next turn, if this Pokémon is damaged by an attack (even if this Pokémon is Knocked Out), put 8 damage counters on the Attacking Pokémon."
+        "text": "During your opponent’s next turn, if this Pokémon is damaged by an attack (even if this Pokémon is Knocked Out), put 8 damage counters on the Attacking Pokémon."
       },
       {
         "name": "Bright Flame",
@@ -6411,7 +6411,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "This attack does 50 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 50 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Blizzard Edge",
@@ -6432,7 +6432,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Move all damage counters from this Pokémon to your opponent's Active Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Move all damage counters from this Pokémon to your opponent’s Active Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6490,7 +6490,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "120",
-        "text": "Discard a Special Energy from your opponent's Active Pokémon."
+        "text": "Discard a Special Energy from your opponent’s Active Pokémon."
       },
       {
         "name": "Blue Surge-GX",
@@ -6571,7 +6571,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "This attack does 60 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 60 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6639,7 +6639,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50×",
-        "text": "This attack does 50 damage times the amount of Energy attached to all of your opponent's Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage times the amount of Energy attached to all of your opponent’s Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/135_hires.png"
@@ -6689,7 +6689,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Poisoned. Put 10 damage counters instead of 1 on that Pokémon between turns."
+        "text": "Your opponent’s Active Pokémon is now Poisoned. Put 10 damage counters instead of 1 on that Pokémon between turns."
       },
       {
         "name": "Total Shelter-GX",
@@ -6700,7 +6700,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "150",
-        "text": "Prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6749,7 +6749,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20×",
-        "text": "This attack does 20 damage times the amount of Energy attached to both Active Pokémon. This damage isn't affected by Weakness or Resistance."
+        "text": "This attack does 20 damage times the amount of Energy attached to both Active Pokémon. This damage isn’t affected by Weakness or Resistance."
       },
       {
         "name": "Tapu Cure-GX",
@@ -6773,7 +6773,7 @@
     "evolvesFrom": "Rockruff",
     "ability": {
       "name": "Bloodthirsty Eyes",
-      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may switch 1 of your opponent's Benched Pokémon with their Active Pokémon.",
+      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may switch 1 of your opponent’s Benched Pokémon with their Active Pokémon.",
       "type": "Ability"
     },
     "hp": "200",
@@ -6813,7 +6813,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50×",
-        "text": "This attack does 50 damage for each of your opponent's Benched Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage for each of your opponent’s Benched Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6866,7 +6866,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "150",
-        "text": "This Pokémon can't use Giga Hammer during your next turn."
+        "text": "This Pokémon can’t use Giga Hammer during your next turn."
       },
       {
         "name": "Algorithm-GX",
@@ -6948,7 +6948,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Put 2 of your opponent's Benched Pokémon and all cards attached to them into your opponent’s hand. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Put 2 of your opponent’s Benched Pokémon and all cards attached to them into your opponent’s hand. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6999,7 +6999,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "During your opponent's next turn, this Pokémon takes 30 less damage from attacks (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, this Pokémon takes 30 less damage from attacks (after applying Weakness and Resistance)."
       },
       {
         "name": "Shred",
@@ -7011,7 +7011,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "130",
-        "text": "This attack's damage isn't affected by any effects on your opponent's Active Pokémon."
+        "text": "This attack’s damage isn’t affected by any effects on your opponent’s Active Pokémon."
       },
       {
         "name": "Ultra Uppercut-GX",
@@ -7067,7 +7067,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Discard a Special Energy from your opponent's Active Pokémon."
+        "text": "Discard a Special Energy from your opponent’s Active Pokémon."
       },
       {
         "name": "Berserk",
@@ -7160,7 +7160,7 @@
     "evolvesFrom": "Dartrix",
     "ability": {
       "name": "Feather Arrow",
-      "text": "Once during your turn (before your attack), you may put 2 damage counters on 1 of your opponent's Pokémon.",
+      "text": "Once during your turn (before your attack), you may put 2 damage counters on 1 of your opponent’s Pokémon.",
       "type": "Ability"
     },
     "hp": "240",
@@ -7267,7 +7267,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "200",
-        "text": "Your opponent's Active Pokémon is now Burned. (You can't use more than 1 GX attack in a game.)"
+        "text": "Your opponent’s Active Pokémon is now Burned. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7313,7 +7313,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "During your opponent's next turn, if this Pokémon is damaged by an attack (even if this Pokémon is Knocked Out), put 8 damage counters on the Attacking Pokémon."
+        "text": "During your opponent’s next turn, if this Pokémon is damaged by an attack (even if this Pokémon is Knocked Out), put 8 damage counters on the Attacking Pokémon."
       },
       {
         "name": "Bright Flame",
@@ -7391,7 +7391,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "Discard an Energy from your opponent's Active Pokémon."
+        "text": "Discard an Energy from your opponent’s Active Pokémon."
       },
       {
         "name": "Grand Echo-GX",
@@ -7401,7 +7401,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Heal all damage from all of your Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "Heal all damage from all of your Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7446,7 +7446,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "This attack does 50 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 50 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Blizzard Edge",
@@ -7467,7 +7467,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Move all damage counters from this Pokémon to your opponent's Active Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Move all damage counters from this Pokémon to your opponent’s Active Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7525,7 +7525,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "120",
-        "text": "Discard a Special Energy from your opponent's Active Pokémon."
+        "text": "Discard a Special Energy from your opponent’s Active Pokémon."
       },
       {
         "name": "Blue Surge-GX",
@@ -7606,7 +7606,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "This attack does 60 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 60 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7674,7 +7674,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50×",
-        "text": "This attack does 50 damage times the amount of Energy attached to all of your opponent's Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage times the amount of Energy attached to all of your opponent’s Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/153_hires.png"
@@ -7724,7 +7724,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Poisoned. Put 10 damage counters instead of 1 on that Pokémon between turns."
+        "text": "Your opponent’s Active Pokémon is now Poisoned. Put 10 damage counters instead of 1 on that Pokémon between turns."
       },
       {
         "name": "Total Shelter-GX",
@@ -7735,7 +7735,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "150",
-        "text": "Prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7784,7 +7784,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20×",
-        "text": "This attack does 20 damage times the amount of Energy attached to both Active Pokémon. This damage isn't affected by Weakness or Resistance."
+        "text": "This attack does 20 damage times the amount of Energy attached to both Active Pokémon. This damage isn’t affected by Weakness or Resistance."
       },
       {
         "name": "Tapu Cure-GX",
@@ -7808,7 +7808,7 @@
     "evolvesFrom": "Rockruff",
     "ability": {
       "name": "Bloodthirsty Eyes",
-      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may switch 1 of your opponent's Benched Pokémon with their Active Pokémon.",
+      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may switch 1 of your opponent’s Benched Pokémon with their Active Pokémon.",
       "type": "Ability"
     },
     "hp": "200",
@@ -7848,7 +7848,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50×",
-        "text": "This attack does 50 damage for each of your opponent's Benched Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage for each of your opponent’s Benched Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7901,7 +7901,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "150",
-        "text": "This Pokémon can't use Giga Hammer during your next turn."
+        "text": "This Pokémon can’t use Giga Hammer during your next turn."
       },
       {
         "name": "Algorithm-GX",
@@ -7983,7 +7983,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Put 2 of your opponent's Benched Pokémon and all cards attached to them into your opponent’s hand. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Put 2 of your opponent’s Benched Pokémon and all cards attached to them into your opponent’s hand. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -8034,7 +8034,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "During your opponent's next turn, this Pokémon takes 30 less damage from attacks (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, this Pokémon takes 30 less damage from attacks (after applying Weakness and Resistance)."
       },
       {
         "name": "Shred",
@@ -8046,7 +8046,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "130",
-        "text": "This attack's damage isn't affected by any effects on your opponent's Active Pokémon."
+        "text": "This attack’s damage isn’t affected by any effects on your opponent’s Active Pokémon."
       },
       {
         "name": "Ultra Uppercut-GX",
@@ -8102,7 +8102,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Discard a Special Energy from your opponent's Active Pokémon."
+        "text": "Discard a Special Energy from your opponent’s Active Pokémon."
       },
       {
         "name": "Berserk",
@@ -8164,7 +8164,7 @@
     "set": "Guardians Rising",
     "setCode": "sm2",
     "text": [
-      "Discard a Special Energy from 1 of your opponent's Pokémon."
+      "Discard a Special Energy from 1 of your opponent’s Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/162_hires.png"
   },
@@ -8181,7 +8181,7 @@
     "set": "Guardians Rising",
     "setCode": "sm2",
     "text": [
-      "Choose up to 2 in any combination of Pokémon Tool cards and Stadium cards in play (yours or your opponent's) and discard them."
+      "Choose up to 2 in any combination of Pokémon Tool cards and Stadium cards in play (yours or your opponent’s) and discard them."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/163_hires.png"
   },
@@ -8215,7 +8215,7 @@
     "set": "Guardians Rising",
     "setCode": "sm2",
     "text": [
-      "Choose 1 of your Basic Pokémon in play. If you have a Stage 2 card in your hand that evolves from that Pokémon, put that card onto the Basic Pokémon to evolve it. You can't use this card during your first turn or on a Basic Pokémon that was put into play this turn."
+      "Choose 1 of your Basic Pokémon in play. If you have a Stage 2 card in your hand that evolves from that Pokémon, put that card onto the Basic Pokémon to evolve it. You can’t use this card during your first turn or on a Basic Pokémon that was put into play this turn."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/165_hires.png"
   },

--- a/json/cards/Gym Challenge.json
+++ b/json/cards/Gym Challenge.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "gym2-1",
-    "name": "Blaine's Arcanine",
+    "name": "Blaine’s Arcanine",
     "imageUrl": "https://images.pokemontcg.io/gym2/1.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -32,7 +32,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Blaine's Arcanine does 10 damage to itself."
+        "text": "Blaine’s Arcanine does 10 damage to itself."
       },
       {
         "name": "Firestorm",
@@ -44,7 +44,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "Discard 3 Energy cards attached to Blaine's Arcanine in order to use this attack."
+        "text": "Discard 3 Energy cards attached to Blaine’s Arcanine in order to use this attack."
       }
     ],
     "weaknesses": [
@@ -58,7 +58,7 @@
   },
   {
     "id": "gym2-2",
-    "name": "Blaine's Charizard",
+    "name": "Blaine’s Charizard",
     "imageUrl": "https://images.pokemontcg.io/gym2/2.png",
     "subtype": "Stage 2",
     "supertype": "Pokémon",
@@ -87,7 +87,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20+",
-        "text": "Discard all Energy cards attached to Blaine's Charizard. If all Energy cards attached to Blaine's Charizard provide 2 Energy, discard all of them. This attack does 20 damage plus 20 more damage for each Energy discarded in this way. ERRATA: Discard all Energy cards attached to Blaine's Charizard except 1."
+        "text": "Discard all Energy cards attached to Blaine’s Charizard. If all Energy cards attached to Blaine’s Charizard provide 2 Energy, discard all of them. This attack does 20 damage plus 20 more damage for each Energy discarded in this way. ERRATA: Discard all Energy cards attached to Blaine’s Charizard except 1."
       },
       {
         "name": "Flame Jet",
@@ -97,7 +97,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. Don't apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
+        "text": "Flip a coin. If heads, choose 1 of your opponent’s Pokémon. This attack does 40 damage to that Pokémon. Don’t apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
       }
     ],
     "weaknesses": [
@@ -117,7 +117,7 @@
   },
   {
     "id": "gym2-3",
-    "name": "Brock's Ninetales",
+    "name": "Brock’s Ninetales",
     "imageUrl": "https://images.pokemontcg.io/gym2/3.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -125,7 +125,7 @@
     "evolvesFrom": "Vulpix",
     "ability": {
       "name": "Shapeshift",
-      "text": "Once during your turn (before your attack), you may attach an Evolution card from your hand to Brock's Ninetales. (This doesn't count as evolving Brock's Ninetales.) Treat Brock's Ninetales as if it were that Pokémon instead. It can't evolve, devolve, or use the Pokémon Power of that Pokémon. During your turn, you may discard the Evolution card attached to Brock's Ninetales. This power can't be used if Brock's Ninetales is Asleep, Confused, or Paralyzed. If Brock's Ninetales becomes Asleep, Confused, or Paralyzed, discard all Evolution cards attached to it.",
+      "text": "Once during your turn (before your attack), you may attach an Evolution card from your hand to Brock’s Ninetales. (This doesn’t count as evolving Brock’s Ninetales.) Treat Brock’s Ninetales as if it were that Pokémon instead. It can’t evolve, devolve, or use the Pokémon Power of that Pokémon. During your turn, you may discard the Evolution card attached to Brock’s Ninetales. This power can’t be used if Brock’s Ninetales is Asleep, Confused, or Paralyzed. If Brock’s Ninetales becomes Asleep, Confused, or Paralyzed, discard all Evolution cards attached to it.",
       "type": "Pokémon Power"
     },
     "hp": "70",
@@ -164,7 +164,7 @@
   },
   {
     "id": "gym2-4",
-    "name": "Erika's Venusaur",
+    "name": "Erika’s Venusaur",
     "imageUrl": "https://images.pokemontcg.io/gym2/4.png",
     "subtype": "Stage 2",
     "supertype": "Pokémon",
@@ -192,7 +192,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, you may attach up to 2 Energy cards from your hand to Erika's Venusaur."
+        "text": "Flip a coin. If heads, you may attach up to 2 Energy cards from your hand to Erika’s Venusaur."
       },
       {
         "name": "Wide Solarbeam",
@@ -204,7 +204,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "20",
-        "text": "If your opponent has any Benched Pokémon, choose 2 of them (or 1 if he or she has only 1). This attack does 20 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, choose 2 of them (or 1 if he or she has only 1). This attack does 20 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -218,7 +218,7 @@
   },
   {
     "id": "gym2-5",
-    "name": "Giovanni's Gyarados",
+    "name": "Giovanni’s Gyarados",
     "imageUrl": "https://images.pokemontcg.io/gym2/5.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -247,7 +247,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip 2 coins. If both of them are heads, this attack does 20 damage to each other Pokémon (even your own). Don't apply Weakness and Resistance for this attack."
+        "text": "Flip 2 coins. If both of them are heads, this attack does 20 damage to each other Pokémon (even your own). Don’t apply Weakness and Resistance for this attack."
       },
       {
         "name": "Dragon Tornado",
@@ -259,7 +259,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "40",
-        "text": "Unless this attack Knocks Out the Defending Pokémon, choose 1 of your opponent's Benched Pokémon and switch it with the Defending Pokémon."
+        "text": "Unless this attack Knocks Out the Defending Pokémon, choose 1 of your opponent’s Benched Pokémon and switch it with the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -279,7 +279,7 @@
   },
   {
     "id": "gym2-6",
-    "name": "Giovanni's Machamp",
+    "name": "Giovanni’s Machamp",
     "imageUrl": "https://images.pokemontcg.io/gym2/6.png",
     "subtype": "Stage 2",
     "supertype": "Pokémon",
@@ -287,7 +287,7 @@
     "evolvesFrom": "Machoke",
     "ability": {
       "name": "Fortitude",
-      "text": "If Giovanni's Machamp would be Knocked Out by an opponent's attack, flip a coin. If heads, Giovanni's Machamp is not Knocked Out and its remaining HP become 10 instead. This power can't be used if Giovanni's Machamp is already Asleep, Confused, or Paralyzed.",
+      "text": "If Giovanni’s Machamp would be Knocked Out by an opponent’s attack, flip a coin. If heads, Giovanni’s Machamp is not Knocked Out and its remaining HP become 10 instead. This power can’t be used if Giovanni’s Machamp is already Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "100",
@@ -330,7 +330,7 @@
   },
   {
     "id": "gym2-7",
-    "name": "Giovanni's Nidoking",
+    "name": "Giovanni’s Nidoking",
     "imageUrl": "https://images.pokemontcg.io/gym2/7.png",
     "subtype": "Stage 2",
     "supertype": "Pokémon",
@@ -359,7 +359,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the Defending Pokémon's maximum HP is 50 or less, it can't attack Giovanni's Nidoking during your opponent's next turn. (Benching or evolving either Pokémon ends this effect.)"
+        "text": "If the Defending Pokémon’s maximum HP is 50 or less, it can’t attack Giovanni’s Nidoking during your opponent’s next turn. (Benching or evolving either Pokémon ends this effect.)"
       },
       {
         "name": "Tumbling Attack",
@@ -385,7 +385,7 @@
   },
   {
     "id": "gym2-8",
-    "name": "Giovanni's Persian",
+    "name": "Giovanni’s Persian",
     "imageUrl": "https://images.pokemontcg.io/gym2/8.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -393,7 +393,7 @@
     "evolvesFrom": "Meowth",
     "ability": {
       "name": "Call the Boss",
-      "text": "When you play Giovanni's Persian from your hand, you may search your deck for the Trainer card named Giovanni, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
+      "text": "When you play Giovanni’s Persian from your hand, you may search your deck for the Trainer card named Giovanni, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
       "type": "Pokémon Power"
     },
     "hp": "60",
@@ -436,7 +436,7 @@
   },
   {
     "id": "gym2-9",
-    "name": "Koga's Beedrill",
+    "name": "Koga’s Beedrill",
     "imageUrl": "https://images.pokemontcg.io/gym2/9.png",
     "subtype": "Stage 2",
     "supertype": "Pokémon",
@@ -472,7 +472,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Flip a coin. If tails, this attack does nothing. Either way, you can't use this attack again as long as Koga's Beedrill stays in play (even putting Koga's Beedrill on the Bench won't let you use it again)."
+        "text": "Flip a coin. If tails, this attack does nothing. Either way, you can’t use this attack again as long as Koga’s Beedrill stays in play (even putting Koga’s Beedrill on the Bench won’t let you use it again)."
       }
     ],
     "weaknesses": [
@@ -492,7 +492,7 @@
   },
   {
     "id": "gym2-10",
-    "name": "Koga's Ditto",
+    "name": "Koga’s Ditto",
     "imageUrl": "https://images.pokemontcg.io/gym2/10.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -518,7 +518,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, Koga's Ditto's maximum HP is now 80 and Koga's Ditto's Pound attack's base damage is 30 instead of 10. (Benching Koga's Ditto ends this effect.)"
+        "text": "Flip a coin. If heads, Koga’s Ditto’s maximum HP is now 80 and Koga’s Ditto’s Pound attack’s base damage is 30 instead of 10. (Benching Koga’s Ditto ends this effect.)"
       },
       {
         "name": "Pound",
@@ -547,7 +547,7 @@
   },
   {
     "id": "gym2-11",
-    "name": "Lt. Surge's Raichu",
+    "name": "Lt. Surge’s Raichu",
     "imageUrl": "https://images.pokemontcg.io/gym2/11.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -576,7 +576,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "Flip a coin. If heads, this attack does 20 damage plus 30 more damage to the Defending Pokémon and discard all Energy cards attached to Lt. Surge's Raichu. If tails, this attack does 20 damage."
+        "text": "Flip a coin. If heads, this attack does 20 damage plus 30 more damage to the Defending Pokémon and discard all Energy cards attached to Lt. Surge’s Raichu. If tails, this attack does 20 damage."
       },
       {
         "name": "Thundertackle",
@@ -588,7 +588,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "40",
-        "text": "Flip a coin. If heads, the Defending Pokémon is now Paralyzed. If tails, Lt. Surge's Raichu does 20 damage to itself."
+        "text": "Flip a coin. If heads, the Defending Pokémon is now Paralyzed. If tails, Lt. Surge’s Raichu does 20 damage to itself."
       }
     ],
     "weaknesses": [
@@ -602,7 +602,7 @@
   },
   {
     "id": "gym2-12",
-    "name": "Misty's Golduck",
+    "name": "Misty’s Golduck",
     "imageUrl": "https://images.pokemontcg.io/gym2/12.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -630,7 +630,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Flip a coin. If tails, discard all Energy cards attached to Misty's Golduck."
+        "text": "Flip a coin. If tails, discard all Energy cards attached to Misty’s Golduck."
       },
       {
         "name": "Super Removal",
@@ -640,7 +640,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, choose 1 Energy card attached to each of your opponent's Pokémon that has any Energy cards and discard those Energy cards."
+        "text": "Flip a coin. If heads, choose 1 Energy card attached to each of your opponent’s Pokémon that has any Energy cards and discard those Energy cards."
       }
     ],
     "weaknesses": [
@@ -654,7 +654,7 @@
   },
   {
     "id": "gym2-13",
-    "name": "Misty's Gyarados",
+    "name": "Misty’s Gyarados",
     "imageUrl": "https://images.pokemontcg.io/gym2/13.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -662,7 +662,7 @@
     "evolvesFrom": "Magikarp",
     "ability": {
       "name": "Rebellion",
-      "text": "Whenever Misty's Gyarados attacks, flip 2 coins. If both of them are tails, that attack does nothing. Instead, shuffle Misty's Gyarados and all cards attached to it into your deck. (This power works even if Misty's Gyarados is Confused.)",
+      "text": "Whenever Misty’s Gyarados attacks, flip 2 coins. If both of them are tails, that attack does nothing. Instead, shuffle Misty’s Gyarados and all cards attached to it into your deck. (This power works even if Misty’s Gyarados is Confused.)",
       "type": "Pokémon Power"
     },
     "hp": "100",
@@ -711,7 +711,7 @@
   },
   {
     "id": "gym2-14",
-    "name": "Rocket's Mewtwo",
+    "name": "Rocket’s Mewtwo",
     "imageUrl": "https://images.pokemontcg.io/gym2/14.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -738,7 +738,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, switch the number of damage counters on Rocket's Mewtwo with the number of damage counters on the Defending Pokémon (even if it would Knock Out either Pokémon). (It's okay if 1 of the Pokémon has no damage counters on it.)"
+        "text": "Flip a coin. If heads, switch the number of damage counters on Rocket’s Mewtwo with the number of damage counters on the Defending Pokémon (even if it would Knock Out either Pokémon). (It’s okay if 1 of the Pokémon has no damage counters on it.)"
       },
       {
         "name": "Hypnoblast",
@@ -774,7 +774,7 @@
   },
   {
     "id": "gym2-15",
-    "name": "Rocket's Zapdos",
+    "name": "Rocket’s Zapdos",
     "imageUrl": "https://images.pokemontcg.io/gym2/15.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -801,7 +801,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "If there are any Energy cards in your discard pile, attach 1 of them to Rocket's Zapdos."
+        "text": "If there are any Energy cards in your discard pile, attach 1 of them to Rocket’s Zapdos."
       },
       {
         "name": "Electroburn",
@@ -813,7 +813,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "70",
-        "text": "Rocket's Zapdos does damage to itself equal to 10 times the number of Energy cards attached to it."
+        "text": "Rocket’s Zapdos does damage to itself equal to 10 times the number of Energy cards attached to it."
       }
     ],
     "resistances": [
@@ -827,7 +827,7 @@
   },
   {
     "id": "gym2-16",
-    "name": "Sabrina's Alakazam",
+    "name": "Sabrina’s Alakazam",
     "imageUrl": "https://images.pokemontcg.io/gym2/16.png",
     "subtype": "Stage 2",
     "supertype": "Pokémon",
@@ -835,7 +835,7 @@
     "evolvesFrom": "Kadabra",
     "ability": {
       "name": "Psylink",
-      "text": "Sabrina's Alakazam always has a copy of every attack your Psychic Pokémon in play have (including their Energy costs and anything else required in order to use those attacks, such as discarding Energy cards). This power can't be used if Sabrina's Alakazam is Asleep, Confused, or Paralyzed.",
+      "text": "Sabrina’s Alakazam always has a copy of every attack your Psychic Pokémon in play have (including their Energy costs and anything else required in order to use those attacks, such as discarding Energy cards). This power can’t be used if Sabrina’s Alakazam is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "80",
@@ -864,7 +864,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "You can't use this attack during your next turn."
+        "text": "You can’t use this attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -946,7 +946,7 @@
   },
   {
     "id": "gym2-21",
-    "name": "Blaine's Ninetales",
+    "name": "Blaine’s Ninetales",
     "imageUrl": "https://images.pokemontcg.io/gym2/21.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -954,7 +954,7 @@
     "evolvesFrom": "Vulpix",
     "ability": {
       "name": "Healing Fire",
-      "text": "Whenever you attach a Fire Energy card from your hand to Blaine's Ninetales, remove 1 damage counter from it, if it has any. This power stops working while Blaine's Ninetales is Asleep, Confused, or Paralyzed.",
+      "text": "Whenever you attach a Fire Energy card from your hand to Blaine’s Ninetales, remove 1 damage counter from it, if it has any. This power stops working while Blaine’s Ninetales is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "60",
@@ -980,7 +980,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "Flip a coin. If tails, discard all Energy cards attached to Blaine's Ninetales."
+        "text": "Flip a coin. If tails, discard all Energy cards attached to Blaine’s Ninetales."
       }
     ],
     "weaknesses": [
@@ -994,7 +994,7 @@
   },
   {
     "id": "gym2-22",
-    "name": "Brock's Dugtrio",
+    "name": "Brock’s Dugtrio",
     "imageUrl": "https://images.pokemontcg.io/gym2/22.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -1021,7 +1021,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "All damage done to Brock's Dugtrio during your opponent's next turn is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "All damage done to Brock’s Dugtrio during your opponent’s next turn is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Earthdrill",
@@ -1032,7 +1032,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack can't be used unless Brock's Dugtrio used its Lie Low attack last turn."
+        "text": "This attack can’t be used unless Brock’s Dugtrio used its Lie Low attack last turn."
       }
     ],
     "weaknesses": [
@@ -1052,7 +1052,7 @@
   },
   {
     "id": "gym2-23",
-    "name": "Giovanni's Nidoqueen",
+    "name": "Giovanni’s Nidoqueen",
     "imageUrl": "https://images.pokemontcg.io/gym2/23.png",
     "subtype": "Stage 2",
     "supertype": "Pokémon",
@@ -1095,7 +1095,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "50+",
-        "text": "Flip a coin. If heads, this attack does 50 damage plus 50 more damage if you have at least 1 Giovanni's Nidoking on your Bench. If tails, this attack does nothing."
+        "text": "Flip a coin. If heads, this attack does 50 damage plus 50 more damage if you have at least 1 Giovanni’s Nidoking on your Bench. If tails, this attack does nothing."
       }
     ],
     "weaknesses": [
@@ -1109,7 +1109,7 @@
   },
   {
     "id": "gym2-24",
-    "name": "Giovanni's Pinsir",
+    "name": "Giovanni’s Pinsir",
     "imageUrl": "https://images.pokemontcg.io/gym2/24.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -1148,7 +1148,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "If you have any Benched Pokémon, flip a coin. If tails, choose 1 of your Benched Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If you have any Benched Pokémon, flip a coin. If tails, choose 1 of your Benched Pokémon. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1162,7 +1162,7 @@
   },
   {
     "id": "gym2-25",
-    "name": "Koga's Arbok",
+    "name": "Koga’s Arbok",
     "imageUrl": "https://images.pokemontcg.io/gym2/25.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -1190,7 +1190,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Koga's Arbok is now Poisoned."
+        "text": "Koga’s Arbok is now Poisoned."
       },
       {
         "name": "Poison Powder",
@@ -1200,7 +1200,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "If Koga's Arbok is Poisoned, this attack's base damage is 40 instead of 20 and the Defending Pokémon is now Poisoned."
+        "text": "If Koga’s Arbok is Poisoned, this attack’s base damage is 40 instead of 20 and the Defending Pokémon is now Poisoned."
       }
     ],
     "weaknesses": [
@@ -1214,7 +1214,7 @@
   },
   {
     "id": "gym2-26",
-    "name": "Koga's Muk",
+    "name": "Koga’s Muk",
     "imageUrl": "https://images.pokemontcg.io/gym2/26.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -1222,7 +1222,7 @@
     "evolvesFrom": "Grimer",
     "ability": {
       "name": "Energy Drain",
-      "text": "If an opponent's attack does damage to Koga's Muk (even if Koga's Muk is Knocked Out), flip a coin. If heads and it has any, choose 1 Energy card attached to the attacking Pokémon and discard it. This power can't be used if Koga's Muk is already Asleep, Confused, or Paralyzed when your opponent attacks.",
+      "text": "If an opponent’s attack does damage to Koga’s Muk (even if Koga’s Muk is Knocked Out), flip a coin. If heads and it has any, choose 1 Energy card attached to the attacking Pokémon and discard it. This power can’t be used if Koga’s Muk is already Asleep, Confused, or Paralyzed when your opponent attacks.",
       "type": "Pokémon Power"
     },
     "hp": "80",
@@ -1264,7 +1264,7 @@
   },
   {
     "id": "gym2-27",
-    "name": "Koga's Pidgeotto",
+    "name": "Koga’s Pidgeotto",
     "imageUrl": "https://images.pokemontcg.io/gym2/27.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -1302,7 +1302,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "10+",
-        "text": "Flip a coin. If heads, this attack does 10 damage plus 30 more damage, and, during your opponent's next turn, prevent all effects of attacks, including damage, done to Koga's Pidgeotto. If tails, this attack does 10 damage."
+        "text": "Flip a coin. If heads, this attack does 10 damage plus 30 more damage, and, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Koga’s Pidgeotto. If tails, this attack does 10 damage."
       }
     ],
     "weaknesses": [
@@ -1325,7 +1325,7 @@
   },
   {
     "id": "gym2-28",
-    "name": "Lt. Surge's Jolteon",
+    "name": "Lt. Surge’s Jolteon",
     "imageUrl": "https://images.pokemontcg.io/gym2/28.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -1353,7 +1353,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent can't play Trainer cards during his or her next turn."
+        "text": "Flip a coin. If heads, your opponent can’t play Trainer cards during his or her next turn."
       },
       {
         "name": "Thunder Flare",
@@ -1364,7 +1364,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
-        "text": "Does 30 damage plus 10 damage times the number of damage counters on Lt. Surge's Jolteon, then flip a coin. If tails, Lt. Surge's Jolteon does 30 damage to itself."
+        "text": "Does 30 damage plus 10 damage times the number of damage counters on Lt. Surge’s Jolteon, then flip a coin. If tails, Lt. Surge’s Jolteon does 30 damage to itself."
       }
     ],
     "weaknesses": [
@@ -1378,7 +1378,7 @@
   },
   {
     "id": "gym2-29",
-    "name": "Sabrina's Gengar",
+    "name": "Sabrina’s Gengar",
     "imageUrl": "https://images.pokemontcg.io/gym2/29.png",
     "subtype": "Stage 2",
     "supertype": "Pokémon",
@@ -1407,7 +1407,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "All Pokémon Powers stop working until the end of your opponent's next turn."
+        "text": "All Pokémon Powers stop working until the end of your opponent’s next turn."
       },
       {
         "name": "Shadow Bind",
@@ -1418,7 +1418,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "resistances": [
@@ -1432,7 +1432,7 @@
   },
   {
     "id": "gym2-30",
-    "name": "Sabrina's Golduck",
+    "name": "Sabrina’s Golduck",
     "imageUrl": "https://images.pokemontcg.io/gym2/30.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -1461,7 +1461,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Move 1 damage counter from each of your Pokémon that has any on it to the Defending Pokémon. (Don't apply Weakness and Resistance.)"
+        "text": "Move 1 damage counter from each of your Pokémon that has any on it to the Defending Pokémon. (Don’t apply Weakness and Resistance.)"
       },
       {
         "name": "Water Spray",
@@ -1486,7 +1486,7 @@
   },
   {
     "id": "gym2-31",
-    "name": "Blaine's Charmeleon",
+    "name": "Blaine’s Charmeleon",
     "imageUrl": "https://images.pokemontcg.io/gym2/31.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -1526,7 +1526,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "10×",
-        "text": "Flip 3 coins. For each heads, discard 1 Energy card attached to Blaine's Charmeleon. If you can't discard Energy cards, this attack does nothing. This attack does 10 damage times the number of heads to each of your opponent's Pokémon. Don't apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
+        "text": "Flip 3 coins. For each heads, discard 1 Energy card attached to Blaine’s Charmeleon. If you can’t discard Energy cards, this attack does nothing. This attack does 10 damage times the number of heads to each of your opponent’s Pokémon. Don’t apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
       }
     ],
     "weaknesses": [
@@ -1543,7 +1543,7 @@
   },
   {
     "id": "gym2-32",
-    "name": "Blaine's Dodrio",
+    "name": "Blaine’s Dodrio",
     "imageUrl": "https://images.pokemontcg.io/gym2/32.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -1591,7 +1591,7 @@
   },
   {
     "id": "gym2-33",
-    "name": "Blaine's Rapidash",
+    "name": "Blaine’s Rapidash",
     "imageUrl": "https://images.pokemontcg.io/gym2/33.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -1626,7 +1626,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
-        "text": "Flip a coin. If heads, this attack does 30 damage plus 10 more damage (to the Defending Pokémon) and 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) If tails, this attack does 30 damage (to the Defending Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 30 damage plus 10 more damage (to the Defending Pokémon) and 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) If tails, this attack does 30 damage (to the Defending Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1640,7 +1640,7 @@
   },
   {
     "id": "gym2-34",
-    "name": "Brock's Graveler",
+    "name": "Brock’s Graveler",
     "imageUrl": "https://images.pokemontcg.io/gym2/34.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -1680,7 +1680,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Does 10 damage to each Pokémon on each player's bench. (Don't apply Weakness and Resistance for Benched Pokémon.) Brock's Graveler does 50 damage to itself. If there is a Stadium card in play, discard it."
+        "text": "Does 10 damage to each Pokémon on each player’s bench. (Don’t apply Weakness and Resistance for Benched Pokémon.) Brock’s Graveler does 50 damage to itself. If there is a Stadium card in play, discard it."
       }
     ],
     "weaknesses": [
@@ -1697,7 +1697,7 @@
   },
   {
     "id": "gym2-35",
-    "name": "Brock's Primeape",
+    "name": "Brock’s Primeape",
     "imageUrl": "https://images.pokemontcg.io/gym2/35.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -1705,7 +1705,7 @@
     "evolvesFrom": "Mankey",
     "ability": {
       "name": "Scram",
-      "text": "If Brock's Primeape ever has exactly 10 HP left, shuffle it and all cards attached to it into your deck. This power stops working while Brock's Primeape is Asleep, Confused, or Paralyzed.",
+      "text": "If Brock’s Primeape ever has exactly 10 HP left, shuffle it and all cards attached to it into your deck. This power stops working while Brock’s Primeape is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "70",
@@ -1731,7 +1731,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Brock's Primeape does 20 damage to itself. If there is a Stadium card in play, discard it."
+        "text": "Brock’s Primeape does 20 damage to itself. If there is a Stadium card in play, discard it."
       }
     ],
     "weaknesses": [
@@ -1745,7 +1745,7 @@
   },
   {
     "id": "gym2-36",
-    "name": "Brock's Sandslash",
+    "name": "Brock’s Sandslash",
     "imageUrl": "https://images.pokemontcg.io/gym2/36.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -1773,7 +1773,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Pokémon Powers, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Pokémon Powers, or any other effects on the Defending Pokémon."
       },
       {
         "name": "Needle Ball",
@@ -1803,7 +1803,7 @@
   },
   {
     "id": "gym2-37",
-    "name": "Brock's Vulpix",
+    "name": "Brock’s Vulpix",
     "imageUrl": "https://images.pokemontcg.io/gym2/37.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -1839,7 +1839,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1856,14 +1856,14 @@
   },
   {
     "id": "gym2-38",
-    "name": "Erika's Bellsprout",
+    "name": "Erika’s Bellsprout",
     "imageUrl": "https://images.pokemontcg.io/gym2/38.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
     "level": "13",
     "ability": {
       "name": "Soak Up",
-      "text": "Once during your turn (before your attack), you may take up to 2 Grass Energy cards attached to other Pokémon and attach them to Erika's Bellsprout. This power can't be used if Erika's Bellsprout is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may take up to 2 Grass Energy cards attached to other Pokémon and attach them to Erika’s Bellsprout. This power can’t be used if Erika’s Bellsprout is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "40",
@@ -1887,7 +1887,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Choose 1 of your opponent's Benched Pokémon, and this attack does 10 damage to it. (Don't apply Weakness and resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Benched Pokémon, and this attack does 10 damage to it. (Don’t apply Weakness and resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1904,7 +1904,7 @@
   },
   {
     "id": "gym2-39",
-    "name": "Erika's Bulbasaur",
+    "name": "Erika’s Bulbasaur",
     "imageUrl": "https://images.pokemontcg.io/gym2/39.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -1957,7 +1957,7 @@
   },
   {
     "id": "gym2-40",
-    "name": "Erika's Clefairy",
+    "name": "Erika’s Clefairy",
     "imageUrl": "https://images.pokemontcg.io/gym2/40.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2016,7 +2016,7 @@
   },
   {
     "id": "gym2-41",
-    "name": "Erika's Ivysaur",
+    "name": "Erika’s Ivysaur",
     "imageUrl": "https://images.pokemontcg.io/gym2/41.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -2024,7 +2024,7 @@
     "evolvesFrom": "Bulbasaur",
     "ability": {
       "name": "Relaxing Scent",
-      "text": "As long as Erika's Ivysaur is your Active Pokémon, whenever an attack (even your own) does damage to any Pokémon (after applying Weakness and Resistance), that attack only does half the damage to that Pokémon (rounded up to the nearest 10). (Any other effects of attacks still happen.) This power stops working while Erika's Ivysaur is Asleep, Confused, or Paralyzed.",
+      "text": "As long as Erika’s Ivysaur is your Active Pokémon, whenever an attack (even your own) does damage to any Pokémon (after applying Weakness and Resistance), that attack only does half the damage to that Pokémon (rounded up to the nearest 10). (Any other effects of attacks still happen.) This power stops working while Erika’s Ivysaur is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "60",
@@ -2068,7 +2068,7 @@
   },
   {
     "id": "gym2-42",
-    "name": "Giovanni's Machoke",
+    "name": "Giovanni’s Machoke",
     "imageUrl": "https://images.pokemontcg.io/gym2/42.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -2096,7 +2096,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If tails, this attack does no damage to the Defending Pokémon and Giovanni's Machoke does 100 damage to itself."
+        "text": "Flip a coin. If tails, this attack does no damage to the Defending Pokémon and Giovanni’s Machoke does 100 damage to itself."
       },
       {
         "name": "Headlock",
@@ -2124,7 +2124,7 @@
   },
   {
     "id": "gym2-43",
-    "name": "Giovanni's Meowth",
+    "name": "Giovanni’s Meowth",
     "imageUrl": "https://images.pokemontcg.io/gym2/43.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2150,7 +2150,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, look at the top card of your opponent's deck. If it's a Trainer card, put it in your opponent's discard pile; otherwise, put it into his or her hand."
+        "text": "Flip a coin. If heads, look at the top card of your opponent’s deck. If it’s a Trainer card, put it in your opponent’s discard pile; otherwise, put it into his or her hand."
       },
       {
         "name": "Double Scratch",
@@ -2183,7 +2183,7 @@
   },
   {
     "id": "gym2-44",
-    "name": "Giovanni's Nidorina",
+    "name": "Giovanni’s Nidorina",
     "imageUrl": "https://images.pokemontcg.io/gym2/44.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -2212,7 +2212,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Giovanni's Nidorina does 20 damage to itself. Flip a coin. If heads, the Defending Pokémon is now Poisoned."
+        "text": "Giovanni’s Nidorina does 20 damage to itself. Flip a coin. If heads, the Defending Pokémon is now Poisoned."
       },
       {
         "name": "Body Slam",
@@ -2240,7 +2240,7 @@
   },
   {
     "id": "gym2-45",
-    "name": "Giovanni's Nidorino",
+    "name": "Giovanni’s Nidorino",
     "imageUrl": "https://images.pokemontcg.io/gym2/45.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -2287,7 +2287,7 @@
   },
   {
     "id": "gym2-46",
-    "name": "Koga's Golbat",
+    "name": "Koga’s Golbat",
     "imageUrl": "https://images.pokemontcg.io/gym2/46.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -2349,7 +2349,7 @@
   },
   {
     "id": "gym2-47",
-    "name": "Koga's Kakuna",
+    "name": "Koga’s Kakuna",
     "imageUrl": "https://images.pokemontcg.io/gym2/47.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -2357,7 +2357,7 @@
     "evolvesFrom": "Weedle",
     "ability": {
       "name": "Emerge",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, search your deck for an Evolution card named Koga's Beedrill and put it on Koga's Kakuna. (This counts as evolving Koga's Kakuna.) Shuffle your deck afterward. This power can't be used if Koga's Kakuna is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, search your deck for an Evolution card named Koga’s Beedrill and put it on Koga’s Kakuna. (This counts as evolving Koga’s Kakuna.) Shuffle your deck afterward. This power can’t be used if Koga’s Kakuna is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "60",
@@ -2382,7 +2382,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon is now Poisoned. It takes 20 Poison damage instead of 10 after each player's turn (even if it was already Poisoned)."
+        "text": "Flip a coin. If heads, the Defending Pokémon is now Poisoned. It takes 20 Poison damage instead of 10 after each player’s turn (even if it was already Poisoned)."
       }
     ],
     "weaknesses": [
@@ -2399,7 +2399,7 @@
   },
   {
     "id": "gym2-48",
-    "name": "Koga's Koffing",
+    "name": "Koga’s Koffing",
     "imageUrl": "https://images.pokemontcg.io/gym2/48.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2425,7 +2425,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Obscuring Gas",
@@ -2435,7 +2435,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, shuffle Koga's Koffing and all cards attached to it into your deck (after doing damage)."
+        "text": "Flip a coin. If heads, shuffle Koga’s Koffing and all cards attached to it into your deck (after doing damage)."
       }
     ],
     "weaknesses": [
@@ -2452,7 +2452,7 @@
   },
   {
     "id": "gym2-49",
-    "name": "Koga's Pidgey",
+    "name": "Koga’s Pidgey",
     "imageUrl": "https://images.pokemontcg.io/gym2/49.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2478,7 +2478,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put Koga's Pidgey and all cards attached to it on top of your deck. Then search your deck for any Basic Pokémon or Evolution card not named Koga's Pidgey. Show that card to your opponent, then put it into your hand. Shuffle your deck afterward."
+        "text": "Put Koga’s Pidgey and all cards attached to it on top of your deck. Then search your deck for any Basic Pokémon or Evolution card not named Koga’s Pidgey. Show that card to your opponent, then put it into your hand. Shuffle your deck afterward."
       },
       {
         "name": "Wing Attack",
@@ -2511,7 +2511,7 @@
   },
   {
     "id": "gym2-50",
-    "name": "Koga's Weezing",
+    "name": "Koga’s Weezing",
     "imageUrl": "https://images.pokemontcg.io/gym2/50.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -2540,7 +2540,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10+",
-        "text": "Flip a coin. If heads, this attack does 10 damage plus 30 more damage and Koga's Weezing does 30 damage to itself; if tails, this attack does 10 damage."
+        "text": "Flip a coin. If heads, this attack does 10 damage plus 30 more damage and Koga’s Weezing does 30 damage to itself; if tails, this attack does 10 damage."
       },
       {
         "name": "Toxic Cloud",
@@ -2551,7 +2551,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon is now Poisoned. It now takes 20 Poison damage instead of 10 after each player's turn (even if it was already Poisoned)."
+        "text": "Flip a coin. If heads, the Defending Pokémon is now Poisoned. It now takes 20 Poison damage instead of 10 after each player’s turn (even if it was already Poisoned)."
       }
     ],
     "weaknesses": [
@@ -2565,7 +2565,7 @@
   },
   {
     "id": "gym2-51",
-    "name": "Lt. Surge's Eevee",
+    "name": "Lt. Surge’s Eevee",
     "imageUrl": "https://images.pokemontcg.io/gym2/51.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2591,7 +2591,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at a random card from your opponent's hand. Your opponent shuffles that card into his or her deck."
+        "text": "Look at a random card from your opponent’s hand. Your opponent shuffles that card into his or her deck."
       },
       {
         "name": "Scratch",
@@ -2631,7 +2631,7 @@
   },
   {
     "id": "gym2-52",
-    "name": "Lt. Surge's Electrode",
+    "name": "Lt. Surge’s Electrode",
     "imageUrl": "https://images.pokemontcg.io/gym2/52.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -2639,7 +2639,7 @@
     "evolvesFrom": "Voltorb",
     "ability": {
       "name": "Shock Blast",
-      "text": "If Lt. Surge's Electrode is your Active Pokémon and gets damaged (even if it's Knocked Out), flip a coin. If tails, this power does 20 damage to each Active Pokémon. This power works even if Lt. Surge's Electrode is already Asleep, Confused, or Paralyzed when it takes damage.",
+      "text": "If Lt. Surge’s Electrode is your Active Pokémon and gets damaged (even if it’s Knocked Out), flip a coin. If tails, this power does 20 damage to each Active Pokémon. This power works even if Lt. Surge’s Electrode is already Asleep, Confused, or Paralyzed when it takes damage.",
       "type": "Pokémon Power"
     },
     "hp": "70",
@@ -2680,7 +2680,7 @@
   },
   {
     "id": "gym2-53",
-    "name": "Lt. Surge's Raticate",
+    "name": "Lt. Surge’s Raticate",
     "imageUrl": "https://images.pokemontcg.io/gym2/53.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -2707,7 +2707,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, Lt. Surge's Raticate's Double"
+        "text": "During your next turn, Lt. Surge’s Raticate’s Double"
       },
       {
         "name": "Double-edge",
@@ -2717,7 +2717,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Lt. Surge's Raticate does 20 damage to itself."
+        "text": "Lt. Surge’s Raticate does 20 damage to itself."
       }
     ],
     "weaknesses": [
@@ -2737,7 +2737,7 @@
   },
   {
     "id": "gym2-54",
-    "name": "Misty's Dewgong",
+    "name": "Misty’s Dewgong",
     "imageUrl": "https://images.pokemontcg.io/gym2/54.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -2766,7 +2766,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "If the Defending Pokémon is , this attack's base damage is doubled."
+        "text": "If the Defending Pokémon is , this attack’s base damage is doubled."
       },
       {
         "name": "Take Down",
@@ -2778,7 +2778,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "Misty's Dewgong does 20 damage to itself."
+        "text": "Misty’s Dewgong does 20 damage to itself."
       }
     ],
     "weaknesses": [
@@ -2792,7 +2792,7 @@
   },
   {
     "id": "gym2-55",
-    "name": "Sabrina's Haunter",
+    "name": "Sabrina’s Haunter",
     "imageUrl": "https://images.pokemontcg.io/gym2/55.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -2828,7 +2828,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Flip a coin. If heads, and if your opponent has any Benched Pokémon, choose 1 of them and this attack does 30 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, and if your opponent has any Benched Pokémon, choose 1 of them and this attack does 30 damage to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "resistances": [
@@ -2845,7 +2845,7 @@
   },
   {
     "id": "gym2-56",
-    "name": "Sabrina's Hypno",
+    "name": "Sabrina’s Hypno",
     "imageUrl": "https://images.pokemontcg.io/gym2/56.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -2873,7 +2873,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 Basic Pokémon in any player's discard pile. Put it onto that player's Bench. Put a number of damage counters on that Pokémon equal to half its HP (rounded down to the nearest 10). (You can't put a Pokémon on a Bench that's full.)"
+        "text": "Choose 1 Basic Pokémon in any player’s discard pile. Put it onto that player’s Bench. Put a number of damage counters on that Pokémon equal to half its HP (rounded down to the nearest 10). (You can’t put a Pokémon on a Bench that’s full.)"
       },
       {
         "name": "Pendulum Curse",
@@ -2897,7 +2897,7 @@
   },
   {
     "id": "gym2-57",
-    "name": "Sabrina's Jynx",
+    "name": "Sabrina’s Jynx",
     "imageUrl": "https://images.pokemontcg.io/gym2/57.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2923,7 +2923,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. Remove any number of damage counters from that Pokémon, then draw that many cards."
+        "text": "Choose 1 of your opponent’s Pokémon. Remove any number of damage counters from that Pokémon, then draw that many cards."
       },
       {
         "name": "Hug",
@@ -2933,7 +2933,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2947,7 +2947,7 @@
   },
   {
     "id": "gym2-58",
-    "name": "Sabrina's Kadabra",
+    "name": "Sabrina’s Kadabra",
     "imageUrl": "https://images.pokemontcg.io/gym2/58.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -3002,7 +3002,7 @@
   },
   {
     "id": "gym2-59",
-    "name": "Sabrina's Mr. Mime",
+    "name": "Sabrina’s Mr. Mime",
     "imageUrl": "https://images.pokemontcg.io/gym2/59.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3029,7 +3029,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10×",
-        "text": "Choose 1 of your opponent's Pokémon and flip 3 coins. This attack does 10 damage times the number of heads to that Pokémon. Don't apply Weakness and Resistance for this attack."
+        "text": "Choose 1 of your opponent’s Pokémon and flip 3 coins. This attack does 10 damage times the number of heads to that Pokémon. Don’t apply Weakness and Resistance for this attack."
       }
     ],
     "weaknesses": [
@@ -3043,7 +3043,7 @@
   },
   {
     "id": "gym2-60",
-    "name": "Blaine's Charmander",
+    "name": "Blaine’s Charmander",
     "imageUrl": "https://images.pokemontcg.io/gym2/60.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3069,7 +3069,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Use this attack only if there are any Energy cards attached to Blaine's Charmander. Flip a coin. If tails, discard 1 of those cards."
+        "text": "Use this attack only if there are any Energy cards attached to Blaine’s Charmander. Flip a coin. If tails, discard 1 of those cards."
       }
     ],
     "weaknesses": [
@@ -3086,7 +3086,7 @@
   },
   {
     "id": "gym2-61",
-    "name": "Blaine's Doduo",
+    "name": "Blaine’s Doduo",
     "imageUrl": "https://images.pokemontcg.io/gym2/61.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3119,7 +3119,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10×",
-        "text": "Does 10 damage times the number of damage counters on Blaine's Doduo."
+        "text": "Does 10 damage times the number of damage counters on Blaine’s Doduo."
       }
     ],
     "weaknesses": [
@@ -3142,7 +3142,7 @@
   },
   {
     "id": "gym2-62",
-    "name": "Blaine's Growlithe",
+    "name": "Blaine’s Growlithe",
     "imageUrl": "https://images.pokemontcg.io/gym2/62.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3168,7 +3168,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Search your deck for a Energy card and attach it to Blaine's Growlithe. Shuffle your deck afterward."
+        "text": "Search your deck for a Energy card and attach it to Blaine’s Growlithe. Shuffle your deck afterward."
       },
       {
         "name": "Body Slam",
@@ -3196,7 +3196,7 @@
   },
   {
     "id": "gym2-63",
-    "name": "Blaine's Mankey",
+    "name": "Blaine’s Mankey",
     "imageUrl": "https://images.pokemontcg.io/gym2/63.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3219,7 +3219,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, choose a card from your opponent's discard pile and put it on top of his or her deck."
+        "text": "Flip a coin. If heads, choose a card from your opponent’s discard pile and put it on top of his or her deck."
       },
       {
         "name": "Fury Swipes",
@@ -3245,7 +3245,7 @@
   },
   {
     "id": "gym2-64",
-    "name": "Blaine's Ponyta",
+    "name": "Blaine’s Ponyta",
     "imageUrl": "https://images.pokemontcg.io/gym2/64.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3272,7 +3272,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If you have any Benched Pokémon, flip a coin. If heads, switch Blaine's Ponyta with 1 of your Benched Pokémon."
+        "text": "If you have any Benched Pokémon, flip a coin. If heads, switch Blaine’s Ponyta with 1 of your Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -3289,7 +3289,7 @@
   },
   {
     "id": "gym2-65",
-    "name": "Blaine's Rhyhorn",
+    "name": "Blaine’s Rhyhorn",
     "imageUrl": "https://images.pokemontcg.io/gym2/65.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3327,7 +3327,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "Flip a coin. If heads and if your opponent has any Benched Pokémon, choose 1 of them and this attack does 20 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads and if your opponent has any Benched Pokémon, choose 1 of them and this attack does 20 damage to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3350,7 +3350,7 @@
   },
   {
     "id": "gym2-66",
-    "name": "Blaine's Vulpix",
+    "name": "Blaine’s Vulpix",
     "imageUrl": "https://images.pokemontcg.io/gym2/66.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3402,7 +3402,7 @@
   },
   {
     "id": "gym2-67",
-    "name": "Brock's Diglett",
+    "name": "Brock’s Diglett",
     "imageUrl": "https://images.pokemontcg.io/gym2/67.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3438,7 +3438,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Does 10 damage to each of your own Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your own Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3461,7 +3461,7 @@
   },
   {
     "id": "gym2-68",
-    "name": "Brock's Geodude",
+    "name": "Brock’s Geodude",
     "imageUrl": "https://images.pokemontcg.io/gym2/68.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3504,7 +3504,7 @@
   },
   {
     "id": "gym2-69",
-    "name": "Erika's Jigglypuff",
+    "name": "Erika’s Jigglypuff",
     "imageUrl": "https://images.pokemontcg.io/gym2/69.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3563,7 +3563,7 @@
   },
   {
     "id": "gym2-70",
-    "name": "Erika's Oddish",
+    "name": "Erika’s Oddish",
     "imageUrl": "https://images.pokemontcg.io/gym2/70.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3606,7 +3606,7 @@
   },
   {
     "id": "gym2-71",
-    "name": "Erika's Paras",
+    "name": "Erika’s Paras",
     "imageUrl": "https://images.pokemontcg.io/gym2/71.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3642,7 +3642,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon is now Poisoned and this attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, the Defending Pokémon is now Poisoned and this attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3659,7 +3659,7 @@
   },
   {
     "id": "gym2-72",
-    "name": "Giovanni's Machop",
+    "name": "Giovanni’s Machop",
     "imageUrl": "https://images.pokemontcg.io/gym2/72.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3695,7 +3695,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20×",
-        "text": "Flip a coin. If heads, this attack does 20 damage times the number of damage counters on Giovanni's Machop."
+        "text": "Flip a coin. If heads, this attack does 20 damage times the number of damage counters on Giovanni’s Machop."
       }
     ],
     "weaknesses": [
@@ -3712,7 +3712,7 @@
   },
   {
     "id": "gym2-73",
-    "name": "Giovanni's Magikarp",
+    "name": "Giovanni’s Magikarp",
     "imageUrl": "https://images.pokemontcg.io/gym2/73.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3738,7 +3738,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If tails, this attack does nothing. Either way, you can't use this attack again as long as Giovanni's Magikarp stays in play (even putting Giovanni's Magikarp on the Bench won't let you use it again)."
+        "text": "Flip a coin. If tails, this attack does nothing. Either way, you can’t use this attack again as long as Giovanni’s Magikarp stays in play (even putting Giovanni’s Magikarp on the Bench won’t let you use it again)."
       },
       {
         "name": "Flail Around",
@@ -3765,7 +3765,7 @@
   },
   {
     "id": "gym2-74",
-    "name": "Giovanni's Meowth",
+    "name": "Giovanni’s Meowth",
     "imageUrl": "https://images.pokemontcg.io/gym2/74.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3826,7 +3826,7 @@
   },
   {
     "id": "gym2-75",
-    "name": "Giovanni's Nidoran♀",
+    "name": "Giovanni’s Nidoran♀",
     "imageUrl": "https://images.pokemontcg.io/gym2/75.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3862,7 +3862,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Giovanni's Nidoran F does 20 damage to itself."
+        "text": "Giovanni’s Nidoran F does 20 damage to itself."
       }
     ],
     "weaknesses": [
@@ -3879,7 +3879,7 @@
   },
   {
     "id": "gym2-76",
-    "name": "Giovanni's Nidoran♂",
+    "name": "Giovanni’s Nidoran♂",
     "imageUrl": "https://images.pokemontcg.io/gym2/76.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3914,7 +3914,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "You can't use this attack unless Giovanni's Nidoran M has 2 or more damage counters on it."
+        "text": "You can’t use this attack unless Giovanni’s Nidoran M has 2 or more damage counters on it."
       }
     ],
     "weaknesses": [
@@ -3931,7 +3931,7 @@
   },
   {
     "id": "gym2-77",
-    "name": "Koga's Ekans",
+    "name": "Koga’s Ekans",
     "imageUrl": "https://images.pokemontcg.io/gym2/77.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3974,7 +3974,7 @@
   },
   {
     "id": "gym2-78",
-    "name": "Koga's Grimer",
+    "name": "Koga’s Grimer",
     "imageUrl": "https://images.pokemontcg.io/gym2/78.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4000,7 +4000,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If your opponent has any Benched Pokémon, flip a coin. If heads, choose 1 of your opponent's Benched Pokémon and switch it with the Defending Pokémon. The new Defending Pokémon is now Poisoned."
+        "text": "If your opponent has any Benched Pokémon, flip a coin. If heads, choose 1 of your opponent’s Benched Pokémon and switch it with the Defending Pokémon. The new Defending Pokémon is now Poisoned."
       },
       {
         "name": "Sludge Toss",
@@ -4027,7 +4027,7 @@
   },
   {
     "id": "gym2-79",
-    "name": "Koga's Koffing",
+    "name": "Koga’s Koffing",
     "imageUrl": "https://images.pokemontcg.io/gym2/79.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4053,7 +4053,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, this attack does 10 damage to each Benched Pokémon (including your own). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 10 damage to each Benched Pokémon (including your own). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4070,7 +4070,7 @@
   },
   {
     "id": "gym2-80",
-    "name": "Koga's Pidgey",
+    "name": "Koga’s Pidgey",
     "imageUrl": "https://images.pokemontcg.io/gym2/80.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4107,7 +4107,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -4130,7 +4130,7 @@
   },
   {
     "id": "gym2-81",
-    "name": "Koga's Tangela",
+    "name": "Koga’s Tangela",
     "imageUrl": "https://images.pokemontcg.io/gym2/81.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4184,7 +4184,7 @@
   },
   {
     "id": "gym2-82",
-    "name": "Koga's Weedle",
+    "name": "Koga’s Weedle",
     "imageUrl": "https://images.pokemontcg.io/gym2/82.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4237,7 +4237,7 @@
   },
   {
     "id": "gym2-83",
-    "name": "Koga's Zubat",
+    "name": "Koga’s Zubat",
     "imageUrl": "https://images.pokemontcg.io/gym2/83.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4261,7 +4261,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10×",
-        "text": "Does 10 damage times the number of Koga's Zubats you have in play. Before doing damage, you may search your deck for any number of Basic Pokémon named Koga's Zubat and put them onto your Bench. (You can't get more cards with this attack than you have room on your Bench.) If you do, shuffle your deck afterward."
+        "text": "Does 10 damage times the number of Koga’s Zubats you have in play. Before doing damage, you may search your deck for any number of Basic Pokémon named Koga’s Zubat and put them onto your Bench. (You can’t get more cards with this attack than you have room on your Bench.) If you do, shuffle your deck afterward."
       }
     ],
     "weaknesses": [
@@ -4284,7 +4284,7 @@
   },
   {
     "id": "gym2-84",
-    "name": "Lt. Surge's Pikachu",
+    "name": "Lt. Surge’s Pikachu",
     "imageUrl": "https://images.pokemontcg.io/gym2/84.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4325,7 +4325,7 @@
   },
   {
     "id": "gym2-85",
-    "name": "Lt. Surge's Rattata",
+    "name": "Lt. Surge’s Rattata",
     "imageUrl": "https://images.pokemontcg.io/gym2/85.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4348,7 +4348,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, Lt. Surge's Rattata's Quick Attack's base damage is doubled."
+        "text": "During your next turn, Lt. Surge’s Rattata’s Quick Attack’s base damage is doubled."
       },
       {
         "name": "Quick Attack",
@@ -4381,7 +4381,7 @@
   },
   {
     "id": "gym2-86",
-    "name": "Lt. Surge's Voltorb",
+    "name": "Lt. Surge’s Voltorb",
     "imageUrl": "https://images.pokemontcg.io/gym2/86.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4408,7 +4408,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If tails, Lt. Surge's Voltorb does 10 damage to itself."
+        "text": "Flip a coin. If tails, Lt. Surge’s Voltorb does 10 damage to itself."
       }
     ],
     "weaknesses": [
@@ -4425,7 +4425,7 @@
   },
   {
     "id": "gym2-87",
-    "name": "Misty's Horsea",
+    "name": "Misty’s Horsea",
     "imageUrl": "https://images.pokemontcg.io/gym2/87.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4466,7 +4466,7 @@
   },
   {
     "id": "gym2-88",
-    "name": "Misty's Magikarp",
+    "name": "Misty’s Magikarp",
     "imageUrl": "https://images.pokemontcg.io/gym2/88.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4492,7 +4492,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Misty's Magikarp."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Misty’s Magikarp."
       },
       {
         "name": "Leap",
@@ -4518,7 +4518,7 @@
   },
   {
     "id": "gym2-89",
-    "name": "Misty's Poliwag",
+    "name": "Misty’s Poliwag",
     "imageUrl": "https://images.pokemontcg.io/gym2/89.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4544,7 +4544,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Flip a coin. If tails, you can't use this attack during your next turn."
+        "text": "Flip a coin. If tails, you can’t use this attack during your next turn."
       },
       {
         "name": "Amnesia",
@@ -4554,7 +4554,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -4571,7 +4571,7 @@
   },
   {
     "id": "gym2-90",
-    "name": "Misty's Psyduck",
+    "name": "Misty’s Psyduck",
     "imageUrl": "https://images.pokemontcg.io/gym2/90.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4597,7 +4597,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip 3 coins. If exactly 1 is heads, draw a card. If exactly 2 are heads, this attack does 20 damage. If all 3 are heads, choose 1 of the Defending Pokémon's attacks. Misty's Psyduck copies that attack except for its Energy costs. (No matter what type the Defending Pokémon is, Misty's Psyduck's type is still .)"
+        "text": "Flip 3 coins. If exactly 1 is heads, draw a card. If exactly 2 are heads, this attack does 20 damage. If all 3 are heads, choose 1 of the Defending Pokémon’s attacks. Misty’s Psyduck copies that attack except for its Energy costs. (No matter what type the Defending Pokémon is, Misty’s Psyduck’s type is still .)"
       }
     ],
     "weaknesses": [
@@ -4614,7 +4614,7 @@
   },
   {
     "id": "gym2-91",
-    "name": "Misty's Seel",
+    "name": "Misty’s Seel",
     "imageUrl": "https://images.pokemontcg.io/gym2/91.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4640,7 +4640,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Mirage",
@@ -4650,7 +4650,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -4667,7 +4667,7 @@
   },
   {
     "id": "gym2-92",
-    "name": "Misty's Staryu",
+    "name": "Misty’s Staryu",
     "imageUrl": "https://images.pokemontcg.io/gym2/92.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4693,7 +4693,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Flip a coin. If heads, return Misty's Staryu and all cards attached to it to your hand. (Either way, this attack does its damage.)"
+        "text": "Flip a coin. If heads, return Misty’s Staryu and all cards attached to it to your hand. (Either way, this attack does its damage.)"
       }
     ],
     "weaknesses": [
@@ -4710,7 +4710,7 @@
   },
   {
     "id": "gym2-93",
-    "name": "Sabrina's Abra",
+    "name": "Sabrina’s Abra",
     "imageUrl": "https://images.pokemontcg.io/gym2/93.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4743,7 +4743,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "This attack can't be used unless Sabrina's Abra and the Defending Pokémon have the same number of Energy cards attached to them."
+        "text": "This attack can’t be used unless Sabrina’s Abra and the Defending Pokémon have the same number of Energy cards attached to them."
       }
     ],
     "weaknesses": [
@@ -4760,7 +4760,7 @@
   },
   {
     "id": "gym2-94",
-    "name": "Sabrina's Abra",
+    "name": "Sabrina’s Abra",
     "imageUrl": "https://images.pokemontcg.io/gym2/94.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4786,7 +4786,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at your opponent's hand."
+        "text": "Look at your opponent’s hand."
       },
       {
         "name": "Quick Attack",
@@ -4812,7 +4812,7 @@
   },
   {
     "id": "gym2-95",
-    "name": "Sabrina's Drowzee",
+    "name": "Sabrina’s Drowzee",
     "imageUrl": "https://images.pokemontcg.io/gym2/95.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4848,7 +4848,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Don't apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
+        "text": "Don’t apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
       }
     ],
     "weaknesses": [
@@ -4865,7 +4865,7 @@
   },
   {
     "id": "gym2-96",
-    "name": "Sabrina's Gastly",
+    "name": "Sabrina’s Gastly",
     "imageUrl": "https://images.pokemontcg.io/gym2/96.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4898,7 +4898,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Return Sabrina's Gastly and all Energy cards attached to it to your hand. (Discard all other cards attached to Sabrina's Gastly.)"
+        "text": "Return Sabrina’s Gastly and all Energy cards attached to it to your hand. (Discard all other cards attached to Sabrina’s Gastly.)"
       }
     ],
     "resistances": [
@@ -4915,14 +4915,14 @@
   },
   {
     "id": "gym2-97",
-    "name": "Sabrina's Gastly",
+    "name": "Sabrina’s Gastly",
     "imageUrl": "https://images.pokemontcg.io/gym2/97.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
     "level": "10",
     "ability": {
       "name": "Gaseous Form",
-      "text": "Sabrina's Gastly gets +10 HP for each Psychic Energy card attached to it. This power works even if Sabrina's Gastly is Asleep, Confused, or Paralyzed.",
+      "text": "Sabrina’s Gastly gets +10 HP for each Psychic Energy card attached to it. This power works even if Sabrina’s Gastly is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "40",
@@ -4964,7 +4964,7 @@
   },
   {
     "id": "gym2-98",
-    "name": "Sabrina's Porygon",
+    "name": "Sabrina’s Porygon",
     "imageUrl": "https://images.pokemontcg.io/gym2/98.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -5000,7 +5000,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "All damage done by attacks to Sabrina's Porygon during your opponent's next turn is reduced by 10 (after applying Weakness and Resistance)."
+        "text": "All damage done by attacks to Sabrina’s Porygon during your opponent’s next turn is reduced by 10 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -5023,7 +5023,7 @@
   },
   {
     "id": "gym2-99",
-    "name": "Sabrina's Psyduck",
+    "name": "Sabrina’s Psyduck",
     "imageUrl": "https://images.pokemontcg.io/gym2/99.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -5058,7 +5058,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Flip a coin. If heads, the Defending Pokémon is now Confused. If tails, this attack does no damage and Sabrina's Psyduck is now Confused."
+        "text": "Flip a coin. If heads, the Defending Pokémon is now Confused. If tails, this attack does no damage and Sabrina’s Psyduck is now Confused."
       }
     ],
     "weaknesses": [
@@ -5092,7 +5092,7 @@
   },
   {
     "id": "gym2-101",
-    "name": "Brock's Protection",
+    "name": "Brock’s Protection",
     "imageUrl": "https://images.pokemontcg.io/gym2/101.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -5103,7 +5103,7 @@
     "set": "Gym Challenge",
     "setCode": "gym2",
     "text": [
-      "Attach Brock's Protection to 1 of your Pokémon with Brock in its name. Energy cards attached to that Pokémon can't be removed by your opponent's attacks or Trainer cards. (This doesn't stop the rest of the attack or Trainer card from working normally.)"
+      "Attach Brock’s Protection to 1 of your Pokémon with Brock in its name. Energy cards attached to that Pokémon can’t be removed by your opponent’s attacks or Trainer cards. (This doesn’t stop the rest of the attack or Trainer card from working normally.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/101_hires.png"
   },
@@ -5120,13 +5120,13 @@
     "set": "Gym Challenge",
     "setCode": "gym2",
     "text": [
-      "Whenever a player plays a Trainer card other than a Stadium card, he or she flips a coin. If heads, that player plays that card normally. If tails, the player can't play that card. If the card isn't put into play, the player's opponent may use that card instead, if he or she does everything required in order to play that card (like discarding cards). Either way, the card goes to its owner's discard pile."
+      "Whenever a player plays a Trainer card other than a Stadium card, he or she flips a coin. If heads, that player plays that card normally. If tails, the player can’t play that card. If the card isn’t put into play, the player’s opponent may use that card instead, if he or she does everything required in order to play that card (like discarding cards). Either way, the card goes to its owner’s discard pile."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/102_hires.png"
   },
   {
     "id": "gym2-103",
-    "name": "Erika's Kindness",
+    "name": "Erika’s Kindness",
     "imageUrl": "https://images.pokemontcg.io/gym2/103.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -5137,7 +5137,7 @@
     "set": "Gym Challenge",
     "setCode": "gym2",
     "text": [
-      "Remove 2 damage counters from each Pokémon (yours and your opponent's) with any damage counters on it. If a Pokémon has just 1 damage counter, remove it."
+      "Remove 2 damage counters from each Pokémon (yours and your opponent’s) with any damage counters on it. If a Pokémon has just 1 damage counter, remove it."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/103_hires.png"
   },
@@ -5160,7 +5160,7 @@
   },
   {
     "id": "gym2-105",
-    "name": "Giovanni's Last Resort",
+    "name": "Giovanni’s Last Resort",
     "imageUrl": "https://images.pokemontcg.io/gym2/105.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -5194,7 +5194,7 @@
   },
   {
     "id": "gym2-107",
-    "name": "Lt. Surge's Secret Plan",
+    "name": "Lt. Surge’s Secret Plan",
     "imageUrl": "https://images.pokemontcg.io/gym2/107.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -5205,13 +5205,13 @@
     "set": "Gym Challenge",
     "setCode": "gym2",
     "text": [
-      "Put 1 card from your hand face down onto your Bench. (You can't play this card if your Bench is full.) Treat that card as a Basic Pokémon as long as it's face down. Flip the card if either player ever needs to know what it is in order to use an attack, a Pokémon Power, or a Trainer card. Flip the card if it ever uses an attack or Pokémon Power, evolves, retreats, is damaged by an attack, or is otherwise affected by an attack. At any time during your turn, you may flip the card over. When you flip that card over, if it isn't a Basic Pokémon, discard it and all cards attached to it."
+      "Put 1 card from your hand face down onto your Bench. (You can’t play this card if your Bench is full.) Treat that card as a Basic Pokémon as long as it’s face down. Flip the card if either player ever needs to know what it is in order to use an attack, a Pokémon Power, or a Trainer card. Flip the card if it ever uses an attack or Pokémon Power, evolves, retreats, is damaged by an attack, or is otherwise affected by an attack. At any time during your turn, you may flip the card over. When you flip that card over, if it isn’t a Basic Pokémon, discard it and all cards attached to it."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/107_hires.png"
   },
   {
     "id": "gym2-108",
-    "name": "Misty's Wish",
+    "name": "Misty’s Wish",
     "imageUrl": "https://images.pokemontcg.io/gym2/108.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -5239,7 +5239,7 @@
     "set": "Gym Challenge",
     "setCode": "gym2",
     "text": [
-      "Each Pokémon's Resistance is reduced by 20. (If a Pokémon's Resistance is ~30, it becomes -10.)"
+      "Each Pokémon’s Resistance is reduced by 20. (If a Pokémon’s Resistance is ~30, it becomes -10.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/109_hires.png"
   },
@@ -5262,7 +5262,7 @@
   },
   {
     "id": "gym2-111",
-    "name": "Blaine's Quiz #2",
+    "name": "Blaine’s Quiz #2",
     "imageUrl": "https://images.pokemontcg.io/gym2/111.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -5279,7 +5279,7 @@
   },
   {
     "id": "gym2-112",
-    "name": "Blaine's Quiz #3",
+    "name": "Blaine’s Quiz #3",
     "imageUrl": "https://images.pokemontcg.io/gym2/112.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -5324,13 +5324,13 @@
     "set": "Gym Challenge",
     "setCode": "gym2",
     "text": [
-      "Once during each player's turn (before attacking), that player may flip a coin. If heads, that player may shuffle 1 of his or her Pokémon in play with Koga in its name and any cards attached to it into his or her deck."
+      "Once during each player’s turn (before attacking), that player may flip a coin. If heads, that player may shuffle 1 of his or her Pokémon in play with Koga in its name and any cards attached to it into his or her deck."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/114_hires.png"
   },
   {
     "id": "gym2-115",
-    "name": "Koga's Ninja Trick",
+    "name": "Koga’s Ninja Trick",
     "imageUrl": "https://images.pokemontcg.io/gym2/115.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -5341,7 +5341,7 @@
     "set": "Gym Challenge",
     "setCode": "gym2",
     "text": [
-      "Attach Koga's Ninja Trick to your Active Pokémon with Koga in its name. If this Pokémon goes to your Bench, discard this card. When your opponent attacks, you may switch this Pokémon with 1 of your Benched Pokémon (before damage or other effects of attacks)."
+      "Attach Koga’s Ninja Trick to your Active Pokémon with Koga in its name. If this Pokémon goes to your Bench, discard this card. When your opponent attacks, you may switch this Pokémon with 1 of your Benched Pokémon (before damage or other effects of attacks)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/115_hires.png"
   },
@@ -5375,13 +5375,13 @@
     "set": "Gym Challenge",
     "setCode": "gym2",
     "text": [
-      "Discard 2 Energy cards from your hand in order to put 1 Basic Pokémon from your discard pile onto your Bench. (You can't play Max Revive if your Bench is full.)"
+      "Discard 2 Energy cards from your hand in order to put 1 Basic Pokémon from your discard pile onto your Bench. (You can’t play Max Revive if your Bench is full.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/117_hires.png"
   },
   {
     "id": "gym2-118",
-    "name": "Misty's Tears",
+    "name": "Misty’s Tears",
     "imageUrl": "https://images.pokemontcg.io/gym2/118.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -5398,7 +5398,7 @@
   },
   {
     "id": "gym2-119",
-    "name": "Rocket's Minefield Gym",
+    "name": "Rocket’s Minefield Gym",
     "imageUrl": "https://images.pokemontcg.io/gym2/119.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -5415,7 +5415,7 @@
   },
   {
     "id": "gym2-120",
-    "name": "Rocket's Secret Experiment",
+    "name": "Rocket’s Secret Experiment",
     "imageUrl": "https://images.pokemontcg.io/gym2/120.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -5426,13 +5426,13 @@
     "set": "Gym Challenge",
     "setCode": "gym2",
     "text": [
-      "Flip a coin. If heads, search your deck for any card and put it into your hand. Shuffle your deck afterward. If tails, you can't play Trainer cards until the end of your next turn."
+      "Flip a coin. If heads, search your deck for any card and put it into your hand. Shuffle your deck afterward. If tails, you can’t play Trainer cards until the end of your next turn."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/120_hires.png"
   },
   {
     "id": "gym2-121",
-    "name": "Sabrina's Psychic Control",
+    "name": "Sabrina’s Psychic Control",
     "imageUrl": "https://images.pokemontcg.io/gym2/121.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -5443,7 +5443,7 @@
     "set": "Gym Challenge",
     "setCode": "gym2",
     "text": [
-      "Flip a coin. If heads, choose a Trainer card in your opponent's discard pile that isn't put in play (like PlusPower or Mysterious Fossil). You may use that card as if it were in your hand, if you do everything required in order to play that card (like discarding cards). The card stays in your opponent's discard pile."
+      "Flip a coin. If heads, choose a Trainer card in your opponent’s discard pile that isn’t put in play (like PlusPower or Mysterious Fossil). You may use that card as if it were in your hand, if you do everything required in order to play that card (like discarding cards). The card stays in your opponent’s discard pile."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/121_hires.png"
   },
@@ -5511,7 +5511,7 @@
     "set": "Gym Challenge",
     "setCode": "gym2",
     "text": [
-      "Until the end of your opponent's next turn, prevent all damage from attacks done to your Benched Pokémon. (Any other effects of attacks still happen.)"
+      "Until the end of your opponent’s next turn, prevent all damage from attacks done to your Benched Pokémon. (Any other effects of attacks still happen.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/125_hires.png"
   },

--- a/json/cards/Gym Heroes.json
+++ b/json/cards/Gym Heroes.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "gym1-1",
-    "name": "Blaine's Moltres",
+    "name": "Blaine’s Moltres",
     "imageUrl": "https://images.pokemontcg.io/gym1/1.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -33,7 +33,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "90",
-        "text": "Flip a coin. If tails, shuffle Blaine's Moltres and all cards attached to it into your deck (after doing damage)."
+        "text": "Flip a coin. If tails, shuffle Blaine’s Moltres and all cards attached to it into your deck (after doing damage)."
       }
     ],
     "resistances": [
@@ -47,7 +47,7 @@
   },
   {
     "id": "gym1-2",
-    "name": "Brock's Rhydon",
+    "name": "Brock’s Rhydon",
     "imageUrl": "https://images.pokemontcg.io/gym1/2.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -55,7 +55,7 @@
     "evolvesFrom": "Rhyhorn",
     "ability": {
       "name": "Bench Guard",
-      "text": "As long as Brock's Rhydon is Benched, whenever 1 of your Benched Pokémon is damaged, you may do 10 of that damage to Brock's Rhydon instead. (If more than 1 of your Benched Pokémon is damaged at the same time, you may use this power once for each of them.)",
+      "text": "As long as Brock’s Rhydon is Benched, whenever 1 of your Benched Pokémon is damaged, you may do 10 of that damage to Brock’s Rhydon instead. (If more than 1 of your Benched Pokémon is damaged at the same time, you may use this power once for each of them.)",
       "type": "Pokémon Power"
     },
     "hp": "80",
@@ -107,7 +107,7 @@
   },
   {
     "id": "gym1-3",
-    "name": "Erika's Clefable",
+    "name": "Erika’s Clefable",
     "imageUrl": "https://images.pokemontcg.io/gym1/3.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -166,7 +166,7 @@
   },
   {
     "id": "gym1-4",
-    "name": "Erika's Dragonair",
+    "name": "Erika’s Dragonair",
     "imageUrl": "https://images.pokemontcg.io/gym1/4.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -196,7 +196,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Benched Pokémon. If tails, this attack does 10 damage to each of your own Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent’s Benched Pokémon. If tails, this attack does 10 damage to each of your own Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Take Away",
@@ -208,7 +208,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Shuffle Erika's Dragonair and all cards attached to it into your deck. Then, your opponent shuffles his or her Active Pokémon and all cards attached to it into his or her deck."
+        "text": "Shuffle Erika’s Dragonair and all cards attached to it into your deck. Then, your opponent shuffles his or her Active Pokémon and all cards attached to it into his or her deck."
       }
     ],
     "resistances": [
@@ -225,7 +225,7 @@
   },
   {
     "id": "gym1-5",
-    "name": "Erika's Vileplume",
+    "name": "Erika’s Vileplume",
     "imageUrl": "https://images.pokemontcg.io/gym1/5.png",
     "subtype": "Stage 2",
     "supertype": "Pokémon",
@@ -233,7 +233,7 @@
     "evolvesFrom": "Gloom",
     "ability": {
       "name": "Pollen Defense",
-      "text": "If an attack does damage to Erika's Vileplume while it's your Active Pokémon (even if it's Knocked Out), flip a coin. If heads, your opponent's Active Pokémon is now Confused. This power works even while Erika's Vileplume is Asleep, Confused, or Paralyzed.",
+      "text": "If an attack does damage to Erika’s Vileplume while it’s your Active Pokémon (even if it’s Knocked Out), flip a coin. If heads, your opponent’s Active Pokémon is now Confused. This power works even while Erika’s Vileplume is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "80",
@@ -260,7 +260,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "If Erika's Vileplume does damage to the Defending Pokémon (after applying Weakness and Resistance), remove a number of damage counters from Erika's Vileplume equal to half the damage done to the Defending Pokémon (rounded up to the nearest 10). If Erika's Vileplume has fewer damage counters than that, remove all of them."
+        "text": "If Erika’s Vileplume does damage to the Defending Pokémon (after applying Weakness and Resistance), remove a number of damage counters from Erika’s Vileplume equal to half the damage done to the Defending Pokémon (rounded up to the nearest 10). If Erika’s Vileplume has fewer damage counters than that, remove all of them."
       }
     ],
     "weaknesses": [
@@ -274,7 +274,7 @@
   },
   {
     "id": "gym1-6",
-    "name": "Lt. Surge's Electabuzz",
+    "name": "Lt. Surge’s Electabuzz",
     "imageUrl": "https://images.pokemontcg.io/gym1/6.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -302,7 +302,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Take up to 2 Energy cards from your discard pile and attach them to Lt. Surge's Electabuzz"
+        "text": "Take up to 2 Energy cards from your discard pile and attach them to Lt. Surge’s Electabuzz"
       },
       {
         "name": "Discharge",
@@ -311,7 +311,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30×",
-        "text": "Discard all Energy cards attach to Lt. Surge's Electabuzz in order to use this attack. Flip a number of coins equal to the number of Energy cards you discarded. This attack does 30 damage times the number of heads."
+        "text": "Discard all Energy cards attach to Lt. Surge’s Electabuzz in order to use this attack. Flip a number of coins equal to the number of Energy cards you discarded. This attack does 30 damage times the number of heads."
       }
     ],
     "weaknesses": [
@@ -328,7 +328,7 @@
   },
   {
     "id": "gym1-7",
-    "name": "Lt. Surge's Fearow",
+    "name": "Lt. Surge’s Fearow",
     "imageUrl": "https://images.pokemontcg.io/gym1/7.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -364,7 +364,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -384,14 +384,14 @@
   },
   {
     "id": "gym1-8",
-    "name": "Lt. Surge's Magneton",
+    "name": "Lt. Surge’s Magneton",
     "imageUrl": "https://images.pokemontcg.io/gym1/8.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
     "level": "30",
     "ability": {
       "name": "Energy Charge",
-      "text": "As often as you like during your turn (before your attack), if Lt. Surge's Magneton is your Active Pokémon, you may take 1 Lightning Energy card attached to 1 of your Pokémon and attach it to Lt. Surge's Magneton. This power can't be used if Lt. Surge's Magneton is Asleep, Confused, or Paralyzed.",
+      "text": "As often as you like during your turn (before your attack), if Lt. Surge’s Magneton is your Active Pokémon, you may take 1 Lightning Energy card attached to 1 of your Pokémon and attach it to Lt. Surge’s Magneton. This power can’t be used if Lt. Surge’s Magneton is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "70",
@@ -419,7 +419,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
-        "text": "Flip a coin. If tails, Lt. Surge's Magneton does 20 damage to itself."
+        "text": "Flip a coin. If tails, Lt. Surge’s Magneton does 20 damage to itself."
       }
     ],
     "weaknesses": [
@@ -436,7 +436,7 @@
   },
   {
     "id": "gym1-9",
-    "name": "Misty's Seadra",
+    "name": "Misty’s Seadra",
     "imageUrl": "https://images.pokemontcg.io/gym1/9.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -491,7 +491,7 @@
   },
   {
     "id": "gym1-10",
-    "name": "Misty's Tentacruel",
+    "name": "Misty’s Tentacruel",
     "imageUrl": "https://images.pokemontcg.io/gym1/10.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -499,7 +499,7 @@
     "evolvesFrom": "Tentacool",
     "ability": {
       "name": "Flee",
-      "text": "If an attack does damage to Misty's Tentacruel while it's your Active Pokémon, you may switch it with 1 of your Benched Pokémon, which prevents all other effects of that attack on Misty's Tentacruel. This power can't be used if Misty's Tentacruel is already Asleep, Confused, or Paralyzed.",
+      "text": "If an attack does damage to Misty’s Tentacruel while it’s your Active Pokémon, you may switch it with 1 of your Benched Pokémon, which prevents all other effects of that attack on Misty’s Tentacruel. This power can’t be used if Misty’s Tentacruel is already Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "70",
@@ -537,7 +537,7 @@
   },
   {
     "id": "gym1-11",
-    "name": "Rocket's Hitmonchan",
+    "name": "Rocket’s Hitmonchan",
     "imageUrl": "https://images.pokemontcg.io/gym1/11.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -564,7 +564,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If an attack does damage to Rocket's Hitmonchan during your opponent's next turn (even if Rocket's Hitmonchan is Knocked Out), flip a coin. If heads, Rocket's Hitmonchan attacks your opponent's Active Pokémon for double that amount of damage. (If Rocket's Hitmonchan takes 20 damage, it does 40 damage to that Pokémon.)"
+        "text": "If an attack does damage to Rocket’s Hitmonchan during your opponent’s next turn (even if Rocket’s Hitmonchan is Knocked Out), flip a coin. If heads, Rocket’s Hitmonchan attacks your opponent’s Active Pokémon for double that amount of damage. (If Rocket’s Hitmonchan takes 20 damage, it does 40 damage to that Pokémon.)"
       },
       {
         "name": "Magnum Punch",
@@ -589,7 +589,7 @@
   },
   {
     "id": "gym1-12",
-    "name": "Rocket's Moltres",
+    "name": "Rocket’s Moltres",
     "imageUrl": "https://images.pokemontcg.io/gym1/12.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -618,7 +618,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "If an attack does damage to Rocket's Moltres during your opponent's next turn (even if Rocket's Moltres is Knocked Out), Rocket's Moltres attacks your opponent's Active Pokémon for 10 damage. (Apply Weakness and Resistance.)"
+        "text": "If an attack does damage to Rocket’s Moltres during your opponent’s next turn (even if Rocket’s Moltres is Knocked Out), Rocket’s Moltres attacks your opponent’s Active Pokémon for 10 damage. (Apply Weakness and Resistance.)"
       }
     ],
     "resistances": [
@@ -632,7 +632,7 @@
   },
   {
     "id": "gym1-13",
-    "name": "Rocket's Scyther",
+    "name": "Rocket’s Scyther",
     "imageUrl": "https://images.pokemontcg.io/gym1/13.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -658,7 +658,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Whenever Rocket's Scyther is attacked, your opponent flips a coin. If tails, that attack does no damage to Rocket's Scyther. (Any other effects of the attack still happen.) This effect lasts until Rocket's Scyther takes damage (or is Benched or is evolved)."
+        "text": "Whenever Rocket’s Scyther is attacked, your opponent flips a coin. If tails, that attack does no damage to Rocket’s Scyther. (Any other effects of the attack still happen.) This effect lasts until Rocket’s Scyther takes damage (or is Benched or is evolved)."
       },
       {
         "name": "Blinding Scythe",
@@ -692,7 +692,7 @@
   },
   {
     "id": "gym1-14",
-    "name": "Sabrina's Gengar",
+    "name": "Sabrina’s Gengar",
     "imageUrl": "https://images.pokemontcg.io/gym1/14.png",
     "subtype": "Stage 2",
     "supertype": "Pokémon",
@@ -719,7 +719,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put a damage counter on each of your opponent's Pokémon that already has any damage counters on it."
+        "text": "Put a damage counter on each of your opponent’s Pokémon that already has any damage counters on it."
       },
       {
         "name": "Call of the Night",
@@ -789,7 +789,7 @@
     "set": "Gym Heroes",
     "setCode": "gym1",
     "text": [
-      "You can play this card only if you have at least 1 Basic Pokémon card in your hand. Put a Basic Pokémon card from your hand into play as your Active Pokémon. Put your old Active Pokémon onto your Bench. (You can't play this card if your Bench is full.)"
+      "You can play this card only if you have at least 1 Basic Pokémon card in your hand. Put a Basic Pokémon card from your hand into play as your Active Pokémon. Put your old Active Pokémon onto your Bench. (You can’t play this card if your Bench is full.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/17_hires.png"
   },
@@ -806,13 +806,13 @@
     "set": "Gym Heroes",
     "setCode": "gym1",
     "text": [
-      "Discard 2 of the other cards in your hand in order to play this card. If this turn's attack does damage to the Defending Pokémon (after applying Weakness and Resistance), and if the attacking Pokémon has Misty in its name, the attack does 20 more damage to the Defending Pokémon."
+      "Discard 2 of the other cards in your hand in order to play this card. If this turn’s attack does damage to the Defending Pokémon (after applying Weakness and Resistance), and if the attacking Pokémon has Misty in its name, the attack does 20 more damage to the Defending Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/18_hires.png"
   },
   {
     "id": "gym1-19",
-    "name": "The Rocket's Trap",
+    "name": "The Rocket’s Trap",
     "imageUrl": "https://images.pokemontcg.io/gym1/19.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -823,13 +823,13 @@
     "set": "Gym Heroes",
     "setCode": "gym1",
     "text": [
-      "Flip a coin. If heads, choose up to 3 cards at random from your opponent's hand (don't look at them). Your opponent shuffles those cards into his or her deck."
+      "Flip a coin. If heads, choose up to 3 cards at random from your opponent’s hand (don’t look at them). Your opponent shuffles those cards into his or her deck."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/19_hires.png"
   },
   {
     "id": "gym1-20",
-    "name": "Brock's Golem",
+    "name": "Brock’s Golem",
     "imageUrl": "https://images.pokemontcg.io/gym1/20.png",
     "subtype": "Stage 2",
     "supertype": "Pokémon",
@@ -861,7 +861,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "If your opponent has any Benched Pokémon, choose up to 3 of them. This attack does 10 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, choose up to 3 of them. This attack does 10 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Fissure",
@@ -887,7 +887,7 @@
   },
   {
     "id": "gym1-21",
-    "name": "Brock's Onix",
+    "name": "Brock’s Onix",
     "imageUrl": "https://images.pokemontcg.io/gym1/21.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -926,7 +926,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "If your opponent has any Benched Pokémon, choose up to 2 of them. This attack does 20 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.) Brock's Onix can't attack during your next turn."
+        "text": "If your opponent has any Benched Pokémon, choose up to 2 of them. This attack does 20 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.) Brock’s Onix can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -943,7 +943,7 @@
   },
   {
     "id": "gym1-22",
-    "name": "Brock's Rhyhorn",
+    "name": "Brock’s Rhyhorn",
     "imageUrl": "https://images.pokemontcg.io/gym1/22.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -982,7 +982,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Brock's Rhyhorn does 10 damage to itself."
+        "text": "Brock’s Rhyhorn does 10 damage to itself."
       }
     ],
     "weaknesses": [
@@ -1005,7 +1005,7 @@
   },
   {
     "id": "gym1-23",
-    "name": "Brock's Sandslash",
+    "name": "Brock’s Sandslash",
     "imageUrl": "https://images.pokemontcg.io/gym1/23.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -1043,7 +1043,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -1063,7 +1063,7 @@
   },
   {
     "id": "gym1-24",
-    "name": "Brock's Zubat",
+    "name": "Brock’s Zubat",
     "imageUrl": "https://images.pokemontcg.io/gym1/24.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -1086,7 +1086,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Draw a card. Then, switch Brock's Zubat with 1 of your Benched Pokémon. You can't use this attack if your Bench is empty."
+        "text": "Draw a card. Then, switch Brock’s Zubat with 1 of your Benched Pokémon. You can’t use this attack if your Bench is empty."
       },
       {
         "name": "Wing Attack",
@@ -1119,7 +1119,7 @@
   },
   {
     "id": "gym1-25",
-    "name": "Erika's Clefairy",
+    "name": "Erika’s Clefairy",
     "imageUrl": "https://images.pokemontcg.io/gym1/25.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -1179,7 +1179,7 @@
   },
   {
     "id": "gym1-26",
-    "name": "Erika's Victreebel",
+    "name": "Erika’s Victreebel",
     "imageUrl": "https://images.pokemontcg.io/gym1/26.png",
     "subtype": "Stage 2",
     "supertype": "Pokémon",
@@ -1187,7 +1187,7 @@
     "evolvesFrom": "Weepinbell",
     "ability": {
       "name": "Fragrance Trap",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, and if your opponent has any Benched Pokémon, choose 1 of them and switch it with his or her Active Pokémon. This power can't be used if Erika's Victreebel is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, and if your opponent has any Benched Pokémon, choose 1 of them and switch it with his or her Active Pokémon. This power can’t be used if Erika’s Victreebel is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "80",
@@ -1228,7 +1228,7 @@
   },
   {
     "id": "gym1-27",
-    "name": "Lt. Surge's Electabuzz",
+    "name": "Lt. Surge’s Electabuzz",
     "imageUrl": "https://images.pokemontcg.io/gym1/27.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -1256,7 +1256,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Take up to 2 Energy cards from your discard pile and attach them to Lt. Surge's Electabuzz"
+        "text": "Take up to 2 Energy cards from your discard pile and attach them to Lt. Surge’s Electabuzz"
       },
       {
         "name": "Electric Current",
@@ -1266,7 +1266,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Take 1 Energy card attached to Lt. Surge's Electabuzz and attach it to 1 of your Benched Pokémon. If you have no Benched Pokémon, discard that Energy card."
+        "text": "Take 1 Energy card attached to Lt. Surge’s Electabuzz and attach it to 1 of your Benched Pokémon. If you have no Benched Pokémon, discard that Energy card."
       }
     ],
     "weaknesses": [
@@ -1283,7 +1283,7 @@
   },
   {
     "id": "gym1-28",
-    "name": "Lt. Surge's Raichu",
+    "name": "Lt. Surge’s Raichu",
     "imageUrl": "https://images.pokemontcg.io/gym1/28.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -1324,7 +1324,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "Discard all Energy cards attached to Lt. Surge's Raichu in order to use this attack."
+        "text": "Discard all Energy cards attached to Lt. Surge’s Raichu in order to use this attack."
       }
     ],
     "weaknesses": [
@@ -1338,7 +1338,7 @@
   },
   {
     "id": "gym1-29",
-    "name": "Misty's Cloyster",
+    "name": "Misty’s Cloyster",
     "imageUrl": "https://images.pokemontcg.io/gym1/29.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -1346,7 +1346,7 @@
     "evolvesFrom": "Shellder",
     "ability": {
       "name": "Shell Armor",
-      "text": "You may reduce all damage done by attacks to Misty's Cloyster by 10 (after applying Weakness and Resistance). (Any other effects of attacks still happen.) This power can't be used if Misty's Cloyster is Asleep, Confused, or Paralyzed.",
+      "text": "You may reduce all damage done by attacks to Misty’s Cloyster by 10 (after applying Weakness and Resistance). (Any other effects of attacks still happen.) This power can’t be used if Misty’s Cloyster is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "60",
@@ -1387,7 +1387,7 @@
   },
   {
     "id": "gym1-30",
-    "name": "Misty's Goldeen",
+    "name": "Misty’s Goldeen",
     "imageUrl": "https://images.pokemontcg.io/gym1/30.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -1427,7 +1427,7 @@
   },
   {
     "id": "gym1-31",
-    "name": "Misty's Poliwrath",
+    "name": "Misty’s Poliwrath",
     "imageUrl": "https://images.pokemontcg.io/gym1/31.png",
     "subtype": "Stage 2",
     "supertype": "Pokémon",
@@ -1459,7 +1459,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "30",
-        "text": "Does 10 damage to each Pokémon that isn't on each player's Bench. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each Pokémon that isn’t on each player’s Bench. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1473,7 +1473,7 @@
   },
   {
     "id": "gym1-32",
-    "name": "Misty's Tentacool",
+    "name": "Misty’s Tentacool",
     "imageUrl": "https://images.pokemontcg.io/gym1/32.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -1506,7 +1506,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Search your deck for any number of Pokémon named Tentacool, Tentacruel, Misty's Tentacool, or Misty's Tentacruel. Show those cards to your opponent, then put them into your hand. Shuffle your deck afterward."
+        "text": "Search your deck for any number of Pokémon named Tentacool, Tentacruel, Misty’s Tentacool, or Misty’s Tentacruel. Show those cards to your opponent, then put them into your hand. Shuffle your deck afterward."
       }
     ],
     "weaknesses": [
@@ -1523,7 +1523,7 @@
   },
   {
     "id": "gym1-33",
-    "name": "Rocket's Snorlax",
+    "name": "Rocket’s Snorlax",
     "imageUrl": "https://images.pokemontcg.io/gym1/33.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -1531,7 +1531,7 @@
     "evolvesFrom": "Munchlax",
     "ability": {
       "name": "Restless Sleep",
-      "text": "If your opponent's attack does damage to Rocket's Snorlax and Rocket's Snorlax is already Asleep (even if it's Knocked Out), this power does 20 damage to the attacking Pokémon.",
+      "text": "If your opponent’s attack does damage to Rocket’s Snorlax and Rocket’s Snorlax is already Asleep (even if it’s Knocked Out), this power does 20 damage to the attacking Pokémon.",
       "type": "Pokémon Power"
     },
     "hp": "90",
@@ -1560,7 +1560,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "Rocket's Snorlax is now Asleep (after doing damage)."
+        "text": "Rocket’s Snorlax is now Asleep (after doing damage)."
       }
     ],
     "weaknesses": [
@@ -1580,7 +1580,7 @@
   },
   {
     "id": "gym1-34",
-    "name": "Sabrina's Venomoth",
+    "name": "Sabrina’s Venomoth",
     "imageUrl": "https://images.pokemontcg.io/gym1/34.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -1637,7 +1637,7 @@
   },
   {
     "id": "gym1-35",
-    "name": "Blaine's Growlithe",
+    "name": "Blaine’s Growlithe",
     "imageUrl": "https://images.pokemontcg.io/gym1/35.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -1673,7 +1673,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Blaine's Growlithe does 10 damage to itself."
+        "text": "Blaine’s Growlithe does 10 damage to itself."
       }
     ],
     "weaknesses": [
@@ -1690,7 +1690,7 @@
   },
   {
     "id": "gym1-36",
-    "name": "Blaine's Kangaskhan",
+    "name": "Blaine’s Kangaskhan",
     "imageUrl": "https://images.pokemontcg.io/gym1/36.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -1712,7 +1712,7 @@
     ],
     "attacks": [
       {
-        "name": "Child's Punch",
+        "name": "Child’s Punch",
         "cost": [
           "Colorless"
         ],
@@ -1749,7 +1749,7 @@
   },
   {
     "id": "gym1-37",
-    "name": "Blaine's Magmar",
+    "name": "Blaine’s Magmar",
     "imageUrl": "https://images.pokemontcg.io/gym1/37.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -1805,7 +1805,7 @@
   },
   {
     "id": "gym1-38",
-    "name": "Brock's Geodude",
+    "name": "Brock’s Geodude",
     "imageUrl": "https://images.pokemontcg.io/gym1/38.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -1841,7 +1841,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Benched Pokémon and flip a coin. If heads, this attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) This attack can't be used if your opponent has no Benched Pokémon."
+        "text": "Choose 1 of your opponent’s Benched Pokémon and flip a coin. If heads, this attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) This attack can’t be used if your opponent has no Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -1858,7 +1858,7 @@
   },
   {
     "id": "gym1-39",
-    "name": "Brock's Golbat",
+    "name": "Brock’s Golbat",
     "imageUrl": "https://images.pokemontcg.io/gym1/39.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -1896,7 +1896,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "10",
-        "text": "Does 10 damage to each of your opponent's Pokémon. Don't apply Weakness and Resistance."
+        "text": "Does 10 damage to each of your opponent’s Pokémon. Don’t apply Weakness and Resistance."
       }
     ],
     "weaknesses": [
@@ -1919,7 +1919,7 @@
   },
   {
     "id": "gym1-40",
-    "name": "Brock's Graveler",
+    "name": "Brock’s Graveler",
     "imageUrl": "https://images.pokemontcg.io/gym1/40.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -1966,7 +1966,7 @@
   },
   {
     "id": "gym1-41",
-    "name": "Brock's Lickitung",
+    "name": "Brock’s Lickitung",
     "imageUrl": "https://images.pokemontcg.io/gym1/41.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2029,14 +2029,14 @@
   },
   {
     "id": "gym1-42",
-    "name": "Erika's Dratini",
+    "name": "Erika’s Dratini",
     "imageUrl": "https://images.pokemontcg.io/gym1/42.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
     "level": "14",
     "ability": {
       "name": "Strange Barrier",
-      "text": "Whenever an attack by a Basic Pokémon (including your own) does 20 or more damage to Erika's Dratini (after applying Weakness and Resistance), reduce that damage to 10. (Any other effects of attacks still happen.) This power stops working while Erika's Dratini is Asleep, Confused, or Paralyzed.",
+      "text": "Whenever an attack by a Basic Pokémon (including your own) does 20 or more damage to Erika’s Dratini (after applying Weakness and Resistance), reduce that damage to 10. (Any other effects of attacks still happen.) This power stops working while Erika’s Dratini is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "40",
@@ -2078,7 +2078,7 @@
   },
   {
     "id": "gym1-43",
-    "name": "Erika's Exeggcute",
+    "name": "Erika’s Exeggcute",
     "imageUrl": "https://images.pokemontcg.io/gym1/43.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2104,7 +2104,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, whenever Erika's Exeggcute takes damage, divide that damage in half (rounded down to the nearest 10). (Any other effects still happen.)"
+        "text": "During your opponent’s next turn, whenever Erika’s Exeggcute takes damage, divide that damage in half (rounded down to the nearest 10). (Any other effects still happen.)"
       },
       {
         "name": "Egg Bomb",
@@ -2114,7 +2114,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If tails, this attack does nothing to the Defending Pokémon and Erika's Exeggcute does 20 damage to itself."
+        "text": "Flip a coin. If tails, this attack does nothing to the Defending Pokémon and Erika’s Exeggcute does 20 damage to itself."
       }
     ],
     "weaknesses": [
@@ -2131,7 +2131,7 @@
   },
   {
     "id": "gym1-44",
-    "name": "Erika's Exeggutor",
+    "name": "Erika’s Exeggutor",
     "imageUrl": "https://images.pokemontcg.io/gym1/44.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -2184,7 +2184,7 @@
   },
   {
     "id": "gym1-45",
-    "name": "Erika's Gloom",
+    "name": "Erika’s Gloom",
     "imageUrl": "https://images.pokemontcg.io/gym1/45.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -2208,7 +2208,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, remove 4 damage counters from Erika's Gloom. If Erika's Gloom has fewer damage counters than that, remove all of them."
+        "text": "Flip a coin. If heads, remove 4 damage counters from Erika’s Gloom. If Erika’s Gloom has fewer damage counters than that, remove all of them."
       },
       {
         "name": "Magic Pollen",
@@ -2237,7 +2237,7 @@
   },
   {
     "id": "gym1-46",
-    "name": "Erika's Gloom",
+    "name": "Erika’s Gloom",
     "imageUrl": "https://images.pokemontcg.io/gym1/46.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -2265,7 +2265,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Both the Defending Pokémon and Erika's Gloom are now Asleep (after dealing damage)."
+        "text": "Both the Defending Pokémon and Erika’s Gloom are now Asleep (after dealing damage)."
       },
       {
         "name": "Vile Smell",
@@ -2276,7 +2276,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Both the Defending Pokémon and Erika's Gloom are now Confused (after doing damage)."
+        "text": "Both the Defending Pokémon and Erika’s Gloom are now Confused (after doing damage)."
       }
     ],
     "weaknesses": [
@@ -2294,14 +2294,14 @@
   },
   {
     "id": "gym1-47",
-    "name": "Erika's Oddish",
+    "name": "Erika’s Oddish",
     "imageUrl": "https://images.pokemontcg.io/gym1/47.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
     "level": "12",
     "ability": {
       "name": "Photosynthesis",
-      "text": "All Energy cards attached to Erika's Oddish provide Grass Energy instead of their usual type. This power works even while Erika's Oddish is Asleep, Confused, or Paralyzed.",
+      "text": "All Energy cards attached to Erika’s Oddish provide Grass Energy instead of their usual type. This power works even while Erika’s Oddish is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "40",
@@ -2343,7 +2343,7 @@
   },
   {
     "id": "gym1-48",
-    "name": "Erika's Weepinbell",
+    "name": "Erika’s Weepinbell",
     "imageUrl": "https://images.pokemontcg.io/gym1/48.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -2380,7 +2380,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Before doing damage, choose 1 of your opponent's Benched Pokémon and switch it with his or her Active Pokémon. This attack can't be used if your opponent has no Benched Pokémon."
+        "text": "Before doing damage, choose 1 of your opponent’s Benched Pokémon and switch it with his or her Active Pokémon. This attack can’t be used if your opponent has no Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -2397,7 +2397,7 @@
   },
   {
     "id": "gym1-49",
-    "name": "Erika's Weepinbell",
+    "name": "Erika’s Weepinbell",
     "imageUrl": "https://images.pokemontcg.io/gym1/49.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -2454,7 +2454,7 @@
   },
   {
     "id": "gym1-50",
-    "name": "Lt. Surge's Magnemite",
+    "name": "Lt. Surge’s Magnemite",
     "imageUrl": "https://images.pokemontcg.io/gym1/50.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2508,7 +2508,7 @@
   },
   {
     "id": "gym1-51",
-    "name": "Lt. Surge's Raticate",
+    "name": "Lt. Surge’s Raticate",
     "imageUrl": "https://images.pokemontcg.io/gym1/51.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -2535,7 +2535,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Does damage to the Defending Pokémon equal to half the Defending Pokémon's remaining HP (rounded up to the nearest 10)."
+        "text": "Does damage to the Defending Pokémon equal to half the Defending Pokémon’s remaining HP (rounded up to the nearest 10)."
       }
     ],
     "weaknesses": [
@@ -2555,7 +2555,7 @@
   },
   {
     "id": "gym1-52",
-    "name": "Lt. Surge's Spearow",
+    "name": "Lt. Surge’s Spearow",
     "imageUrl": "https://images.pokemontcg.io/gym1/52.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2601,7 +2601,7 @@
   },
   {
     "id": "gym1-53",
-    "name": "Misty's Poliwhirl",
+    "name": "Misty’s Poliwhirl",
     "imageUrl": "https://images.pokemontcg.io/gym1/53.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -2641,7 +2641,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
-        "text": "Flip a number of coins equal to the number of Energy attached to Misty's Poliwhirl. This attack does 30 damage plus 10 damage for each heads."
+        "text": "Flip a number of coins equal to the number of Energy attached to Misty’s Poliwhirl. This attack does 30 damage plus 10 damage for each heads."
       }
     ],
     "weaknesses": [
@@ -2659,7 +2659,7 @@
   },
   {
     "id": "gym1-54",
-    "name": "Misty's Psyduck",
+    "name": "Misty’s Psyduck",
     "imageUrl": "https://images.pokemontcg.io/gym1/54.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2694,7 +2694,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, you may search your deck for a Basic Pokémon with Misty in its name and put it onto your Bench. (You can't use this attack if your Bench is full.) Shuffle your deck afterward."
+        "text": "Flip a coin. If heads, you may search your deck for a Basic Pokémon with Misty in its name and put it onto your Bench. (You can’t use this attack if your Bench is full.) Shuffle your deck afterward."
       }
     ],
     "weaknesses": [
@@ -2711,7 +2711,7 @@
   },
   {
     "id": "gym1-55",
-    "name": "Misty's Seaking",
+    "name": "Misty’s Seaking",
     "imageUrl": "https://images.pokemontcg.io/gym1/55.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -2748,7 +2748,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "If your opponent has any Benched Pokémon, choose 1 of them and flip a coin. If heads, this attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, choose 1 of them and flip a coin. If heads, this attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2762,7 +2762,7 @@
   },
   {
     "id": "gym1-56",
-    "name": "Misty's Starmie",
+    "name": "Misty’s Starmie",
     "imageUrl": "https://images.pokemontcg.io/gym1/56.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -2790,7 +2790,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "Does 10 damage plus 10 more damage for each W Energy attached to Misty's Starmie but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "Does 10 damage plus 10 more damage for each W Energy attached to Misty’s Starmie but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       },
       {
         "name": "Bubblebeam",
@@ -2815,7 +2815,7 @@
   },
   {
     "id": "gym1-57",
-    "name": "Misty's Tentacool",
+    "name": "Misty’s Tentacool",
     "imageUrl": "https://images.pokemontcg.io/gym1/57.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2842,7 +2842,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent can't attach Energy cards to the Defending Pokémon during his or her next turn."
+        "text": "Flip a coin. If heads, your opponent can’t attach Energy cards to the Defending Pokémon during his or her next turn."
       }
     ],
     "weaknesses": [
@@ -2859,7 +2859,7 @@
   },
   {
     "id": "gym1-58",
-    "name": "Sabrina's Haunter",
+    "name": "Sabrina’s Haunter",
     "imageUrl": "https://images.pokemontcg.io/gym1/58.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -2884,7 +2884,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30×",
-        "text": "Flip a number of coins equal to the total number of Sabrina's Gastlys, Sabrina's Haunters, and Sabrina's Gengars you have in play. This attack does 30 damage times the number of heads."
+        "text": "Flip a number of coins equal to the total number of Sabrina’s Gastlys, Sabrina’s Haunters, and Sabrina’s Gengars you have in play. This attack does 30 damage times the number of heads."
       }
     ],
     "resistances": [
@@ -2901,7 +2901,7 @@
   },
   {
     "id": "gym1-59",
-    "name": "Sabrina's Jynx",
+    "name": "Sabrina’s Jynx",
     "imageUrl": "https://images.pokemontcg.io/gym1/59.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2952,7 +2952,7 @@
   },
   {
     "id": "gym1-60",
-    "name": "Sabrina's Slowbro",
+    "name": "Sabrina’s Slowbro",
     "imageUrl": "https://images.pokemontcg.io/gym1/60.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -2980,7 +2980,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, remove 3 damage counters from Sabrina's Slowbro and Sabrina's Slowbro is now Asleep. If Sabrina's Slowbro has fewer damage counters than that, remove all of them."
+        "text": "Flip a coin. If heads, remove 3 damage counters from Sabrina’s Slowbro and Sabrina’s Slowbro is now Asleep. If Sabrina’s Slowbro has fewer damage counters than that, remove all of them."
       },
       {
         "name": "Screaming Headbutt",
@@ -2991,7 +2991,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "You can't use this attack during your next turn."
+        "text": "You can’t use this attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -3005,7 +3005,7 @@
   },
   {
     "id": "gym1-61",
-    "name": "Blaine's Charmander",
+    "name": "Blaine’s Charmander",
     "imageUrl": "https://images.pokemontcg.io/gym1/61.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3031,7 +3031,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Discard 1 Energy card attached to Blaine's Charmander in order to use this attack. If the Defending Pokémon has any Energy cards attached to it, choose 1 of them and discard it."
+        "text": "Discard 1 Energy card attached to Blaine’s Charmander in order to use this attack. If the Defending Pokémon has any Energy cards attached to it, choose 1 of them and discard it."
       },
       {
         "name": "Slash",
@@ -3058,7 +3058,7 @@
   },
   {
     "id": "gym1-62",
-    "name": "Blaine's Growlithe",
+    "name": "Blaine’s Growlithe",
     "imageUrl": "https://images.pokemontcg.io/gym1/62.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3085,7 +3085,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Does 10 damage to each Pokémon on your opponent's Bench. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each Pokémon on your opponent’s Bench. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3102,7 +3102,7 @@
   },
   {
     "id": "gym1-63",
-    "name": "Blaine's Ponyta",
+    "name": "Blaine’s Ponyta",
     "imageUrl": "https://images.pokemontcg.io/gym1/63.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3126,7 +3126,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Blaine's Ponyta."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Blaine’s Ponyta."
       }
     ],
     "weaknesses": [
@@ -3143,7 +3143,7 @@
   },
   {
     "id": "gym1-64",
-    "name": "Blaine's Tauros",
+    "name": "Blaine’s Tauros",
     "imageUrl": "https://images.pokemontcg.io/gym1/64.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3181,7 +3181,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20×",
-        "text": "Flip 4 coins. This attack does 20 damage times the number of heads to the Defending Pokémon and 20 damage times the number tails to Blaine's Tauros."
+        "text": "Flip 4 coins. This attack does 20 damage times the number of heads to the Defending Pokémon and 20 damage times the number tails to Blaine’s Tauros."
       }
     ],
     "weaknesses": [
@@ -3201,14 +3201,14 @@
   },
   {
     "id": "gym1-65",
-    "name": "Blaine's Vulpix",
+    "name": "Blaine’s Vulpix",
     "imageUrl": "https://images.pokemontcg.io/gym1/65.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
     "level": "9",
     "ability": {
       "name": "Natural Healing",
-      "text": "Once during your turn (before your attack), you may remove 1 damage counter from Blaine's Vulpix. This power can't be used if Blaine's Vulpix is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may remove 1 damage counter from Blaine’s Vulpix. This power can’t be used if Blaine’s Vulpix is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "40",
@@ -3251,7 +3251,7 @@
   },
   {
     "id": "gym1-66",
-    "name": "Brock's Geodude",
+    "name": "Brock’s Geodude",
     "imageUrl": "https://images.pokemontcg.io/gym1/66.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3277,7 +3277,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, you may search your deck for a Basic Pokémon card with Brock in its name and put it onto your Bench. Shuffle your deck afterward. (You can't use this attack if your Bench is full.)"
+        "text": "Flip a coin. If heads, you may search your deck for a Basic Pokémon card with Brock in its name and put it onto your Bench. Shuffle your deck afterward. (You can’t use this attack if your Bench is full.)"
       },
       {
         "name": "Hook Shot",
@@ -3287,7 +3287,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Don't apply Resistance for this attack. (Any other effects that would happen after applying Resistance still happen.)"
+        "text": "Don’t apply Resistance for this attack. (Any other effects that would happen after applying Resistance still happen.)"
       }
     ],
     "weaknesses": [
@@ -3304,7 +3304,7 @@
   },
   {
     "id": "gym1-67",
-    "name": "Brock's Mankey",
+    "name": "Brock’s Mankey",
     "imageUrl": "https://images.pokemontcg.io/gym1/67.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3353,7 +3353,7 @@
   },
   {
     "id": "gym1-68",
-    "name": "Brock's Mankey",
+    "name": "Brock’s Mankey",
     "imageUrl": "https://images.pokemontcg.io/gym1/68.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3386,7 +3386,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Does 40 damage minus 10 damage for each damage counter on Brock's Mankey."
+        "text": "Does 40 damage minus 10 damage for each damage counter on Brock’s Mankey."
       }
     ],
     "weaknesses": [
@@ -3403,7 +3403,7 @@
   },
   {
     "id": "gym1-69",
-    "name": "Brock's Onix",
+    "name": "Brock’s Onix",
     "imageUrl": "https://images.pokemontcg.io/gym1/69.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3459,7 +3459,7 @@
   },
   {
     "id": "gym1-70",
-    "name": "Brock's Rhyhorn",
+    "name": "Brock’s Rhyhorn",
     "imageUrl": "https://images.pokemontcg.io/gym1/70.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3511,7 +3511,7 @@
   },
   {
     "id": "gym1-71",
-    "name": "Brock's Sandshrew",
+    "name": "Brock’s Sandshrew",
     "imageUrl": "https://images.pokemontcg.io/gym1/71.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3537,7 +3537,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to Brock's Sandshrew during your opponent's next turn. (Any other effects of attacks still happen.)"
+        "text": "Flip a coin. If heads, prevent all damage done to Brock’s Sandshrew during your opponent’s next turn. (Any other effects of attacks still happen.)"
       },
       {
         "name": "Rolling Attack",
@@ -3570,7 +3570,7 @@
   },
   {
     "id": "gym1-72",
-    "name": "Brock's Sandshrew",
+    "name": "Brock’s Sandshrew",
     "imageUrl": "https://images.pokemontcg.io/gym1/72.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3597,7 +3597,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3620,7 +3620,7 @@
   },
   {
     "id": "gym1-73",
-    "name": "Brock's Vulpix",
+    "name": "Brock’s Vulpix",
     "imageUrl": "https://images.pokemontcg.io/gym1/73.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3673,7 +3673,7 @@
   },
   {
     "id": "gym1-74",
-    "name": "Brock's Zubat",
+    "name": "Brock’s Zubat",
     "imageUrl": "https://images.pokemontcg.io/gym1/74.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3729,7 +3729,7 @@
   },
   {
     "id": "gym1-75",
-    "name": "Erika's Bellsprout",
+    "name": "Erika’s Bellsprout",
     "imageUrl": "https://images.pokemontcg.io/gym1/75.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3782,7 +3782,7 @@
   },
   {
     "id": "gym1-76",
-    "name": "Erika's Bellsprout",
+    "name": "Erika’s Bellsprout",
     "imageUrl": "https://images.pokemontcg.io/gym1/76.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3808,7 +3808,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Erika's Bellsprout does 10 damage to itself."
+        "text": "Erika’s Bellsprout does 10 damage to itself."
       }
     ],
     "weaknesses": [
@@ -3825,7 +3825,7 @@
   },
   {
     "id": "gym1-77",
-    "name": "Erika's Exeggcute",
+    "name": "Erika’s Exeggcute",
     "imageUrl": "https://images.pokemontcg.io/gym1/77.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3851,7 +3851,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10×",
-        "text": "Flip a number of coins equal to the number of Energy attached to Erika's Exeggcute. This attack does 10 damage times the number of heads."
+        "text": "Flip a number of coins equal to the number of Energy attached to Erika’s Exeggcute. This attack does 10 damage times the number of heads."
       },
       {
         "name": "Psychic",
@@ -3878,7 +3878,7 @@
   },
   {
     "id": "gym1-78",
-    "name": "Erika's Oddish",
+    "name": "Erika’s Oddish",
     "imageUrl": "https://images.pokemontcg.io/gym1/78.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3904,7 +3904,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If there are any damage counters on Erika's Oddish, remove 1 of them."
+        "text": "If there are any damage counters on Erika’s Oddish, remove 1 of them."
       },
       {
         "name": "Sporadic Sponging",
@@ -3914,7 +3914,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If Erika's Oddish has any damage counters on it, flip a coin. If heads, remove 1 of those damage counters."
+        "text": "If Erika’s Oddish has any damage counters on it, flip a coin. If heads, remove 1 of those damage counters."
       }
     ],
     "weaknesses": [
@@ -3931,7 +3931,7 @@
   },
   {
     "id": "gym1-79",
-    "name": "Erika's Tangela",
+    "name": "Erika’s Tangela",
     "imageUrl": "https://images.pokemontcg.io/gym1/79.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3969,7 +3969,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 20 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 20 damage to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3986,7 +3986,7 @@
   },
   {
     "id": "gym1-80",
-    "name": "Lt. Surge's Magnemite",
+    "name": "Lt. Surge’s Magnemite",
     "imageUrl": "https://images.pokemontcg.io/gym1/80.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4039,7 +4039,7 @@
   },
   {
     "id": "gym1-81",
-    "name": "Lt. Surge's Pikachu",
+    "name": "Lt. Surge’s Pikachu",
     "imageUrl": "https://images.pokemontcg.io/gym1/81.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4066,7 +4066,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Take 1 Energy card from your discard pile and attach it to Lt. Surge's Pikachu."
+        "text": "Take 1 Energy card from your discard pile and attach it to Lt. Surge’s Pikachu."
       },
       {
         "name": "Lightning Tail",
@@ -4093,7 +4093,7 @@
   },
   {
     "id": "gym1-82",
-    "name": "Lt. Surge's Rattata",
+    "name": "Lt. Surge’s Rattata",
     "imageUrl": "https://images.pokemontcg.io/gym1/82.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4119,7 +4119,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, Lt. Surge's Rattata's Gnaw attack's base damage is doubled."
+        "text": "During your next turn, Lt. Surge’s Rattata’s Gnaw attack’s base damage is doubled."
       },
       {
         "name": "Gnaw",
@@ -4152,7 +4152,7 @@
   },
   {
     "id": "gym1-83",
-    "name": "Lt. Surge's Spearow",
+    "name": "Lt. Surge’s Spearow",
     "imageUrl": "https://images.pokemontcg.io/gym1/83.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4208,7 +4208,7 @@
   },
   {
     "id": "gym1-84",
-    "name": "Lt. Surge's Voltorb",
+    "name": "Lt. Surge’s Voltorb",
     "imageUrl": "https://images.pokemontcg.io/gym1/84.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4261,7 +4261,7 @@
   },
   {
     "id": "gym1-85",
-    "name": "Misty's Goldeen",
+    "name": "Misty’s Goldeen",
     "imageUrl": "https://images.pokemontcg.io/gym1/85.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4313,7 +4313,7 @@
   },
   {
     "id": "gym1-86",
-    "name": "Misty's Horsea",
+    "name": "Misty’s Horsea",
     "imageUrl": "https://images.pokemontcg.io/gym1/86.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4346,7 +4346,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -4363,7 +4363,7 @@
   },
   {
     "id": "gym1-87",
-    "name": "Misty's Poliwag",
+    "name": "Misty’s Poliwag",
     "imageUrl": "https://images.pokemontcg.io/gym1/87.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4416,7 +4416,7 @@
   },
   {
     "id": "gym1-88",
-    "name": "Misty's Seel",
+    "name": "Misty’s Seel",
     "imageUrl": "https://images.pokemontcg.io/gym1/88.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4460,7 +4460,7 @@
   },
   {
     "id": "gym1-89",
-    "name": "Misty's Shellder",
+    "name": "Misty’s Shellder",
     "imageUrl": "https://images.pokemontcg.io/gym1/89.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4513,7 +4513,7 @@
   },
   {
     "id": "gym1-90",
-    "name": "Misty's Staryu",
+    "name": "Misty’s Staryu",
     "imageUrl": "https://images.pokemontcg.io/gym1/90.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4540,7 +4540,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Pokémon Powers, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Pokémon Powers, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -4557,7 +4557,7 @@
   },
   {
     "id": "gym1-91",
-    "name": "Sabrina's Abra",
+    "name": "Sabrina’s Abra",
     "imageUrl": "https://images.pokemontcg.io/gym1/91.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4580,7 +4580,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Return a Energy card attached to Sabrina's Abra to your hand in order to use this attack."
+        "text": "Return a Energy card attached to Sabrina’s Abra to your hand in order to use this attack."
       }
     ],
     "weaknesses": [
@@ -4597,7 +4597,7 @@
   },
   {
     "id": "gym1-92",
-    "name": "Sabrina's Drowzee",
+    "name": "Sabrina’s Drowzee",
     "imageUrl": "https://images.pokemontcg.io/gym1/92.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4623,7 +4623,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack during your opponent’s next turn."
       },
       {
         "name": "Headbutt",
@@ -4650,7 +4650,7 @@
   },
   {
     "id": "gym1-93",
-    "name": "Sabrina's Gastly",
+    "name": "Sabrina’s Gastly",
     "imageUrl": "https://images.pokemontcg.io/gym1/93.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4677,7 +4677,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "resistances": [
@@ -4694,7 +4694,7 @@
   },
   {
     "id": "gym1-94",
-    "name": "Sabrina's Mr. Mime",
+    "name": "Sabrina’s Mr. Mime",
     "imageUrl": "https://images.pokemontcg.io/gym1/94.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4745,7 +4745,7 @@
   },
   {
     "id": "gym1-95",
-    "name": "Sabrina's Slowpoke",
+    "name": "Sabrina’s Slowpoke",
     "imageUrl": "https://images.pokemontcg.io/gym1/95.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4772,7 +4772,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Sabrina's Slowpoke is now Asleep (after doing damage)."
+        "text": "Sabrina’s Slowpoke is now Asleep (after doing damage)."
       }
     ],
     "weaknesses": [
@@ -4790,7 +4790,7 @@
   },
   {
     "id": "gym1-96",
-    "name": "Sabrina's Venonat",
+    "name": "Sabrina’s Venonat",
     "imageUrl": "https://images.pokemontcg.io/gym1/96.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -4843,7 +4843,7 @@
   },
   {
     "id": "gym1-97",
-    "name": "Blaine's Quiz #1",
+    "name": "Blaine’s Quiz #1",
     "imageUrl": "https://images.pokemontcg.io/gym1/97.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -4922,7 +4922,7 @@
     "set": "Gym Heroes",
     "setCode": "gym1",
     "text": [
-      "You can play this card only if you have at least 1 Basic Pokémon card in your hand. Put a Basic Pokémon card from your hand into play as your Active Pokémon. Put your old Active Pokémon onto your Bench. (You can't play this card if your Bench is full.)"
+      "You can play this card only if you have at least 1 Basic Pokémon card in your hand. Put a Basic Pokémon card from your hand into play as your Active Pokémon. Put your old Active Pokémon onto your Bench. (You can’t play this card if your Bench is full.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/101_hires.png"
   },
@@ -4939,7 +4939,7 @@
     "set": "Gym Heroes",
     "setCode": "gym1",
     "text": [
-      "Discard 2 of the other cards in your hand in order to play this card. If this turn's attack does damage to the Defending Pokémon (after applying Weakness and Resistance), and if the attacking Pokémon has Misty in its name, the attack does 20 more damage to the Defending Pokémon."
+      "Discard 2 of the other cards in your hand in order to play this card. If this turn’s attack does damage to the Defending Pokémon (after applying Weakness and Resistance), and if the attacking Pokémon has Misty in its name, the attack does 20 more damage to the Defending Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/102_hires.png"
   },
@@ -4962,7 +4962,7 @@
   },
   {
     "id": "gym1-104",
-    "name": "The Rocket's Training Gym",
+    "name": "The Rocket’s Training Gym",
     "imageUrl": "https://images.pokemontcg.io/gym1/104.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -4979,7 +4979,7 @@
   },
   {
     "id": "gym1-105",
-    "name": "Blaine's Last Resort",
+    "name": "Blaine’s Last Resort",
     "imageUrl": "https://images.pokemontcg.io/gym1/105.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -4990,13 +4990,13 @@
     "set": "Gym Heroes",
     "setCode": "gym1",
     "text": [
-      "You can't play this card if you have any cards in your hand other than Blaine's Last Resort. Show your hand to your opponent, then draw 5 cards."
+      "You can’t play this card if you have any cards in your hand other than Blaine’s Last Resort. Show your hand to your opponent, then draw 5 cards."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/105_hires.png"
   },
   {
     "id": "gym1-106",
-    "name": "Brock's Training Method",
+    "name": "Brock’s Training Method",
     "imageUrl": "https://images.pokemontcg.io/gym1/106.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -5024,7 +5024,7 @@
     "set": "Gym Heroes",
     "setCode": "gym1",
     "text": [
-      "During each player's turn, that player may choose to discard an Energy card attached to 1 of his or her Pokémon with Erika in its name. If that player does so, that Pokémon is no longer Asleep, Confused, Paralyzed or Poisoned."
+      "During each player’s turn, that player may choose to discard an Energy card attached to 1 of his or her Pokémon with Erika in its name. If that player does so, that Pokémon is no longer Asleep, Confused, Paralyzed or Poisoned."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/107_hires.png"
   },
@@ -5047,7 +5047,7 @@
   },
   {
     "id": "gym1-109",
-    "name": "Erika's Maids",
+    "name": "Erika’s Maids",
     "imageUrl": "https://images.pokemontcg.io/gym1/109.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -5064,7 +5064,7 @@
   },
   {
     "id": "gym1-110",
-    "name": "Erika's Perfume",
+    "name": "Erika’s Perfume",
     "imageUrl": "https://images.pokemontcg.io/gym1/110.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -5075,7 +5075,7 @@
     "set": "Gym Heroes",
     "setCode": "gym1",
     "text": [
-      "Look at your opponent's hand. If he or she has any Basic Pokémon cards there, you may put any number of them onto your opponent's Bench (as long as there's room)."
+      "Look at your opponent’s hand. If he or she has any Basic Pokémon cards there, you may put any number of them onto your opponent’s Bench (as long as there’s room)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/110_hires.png"
   },
@@ -5092,13 +5092,13 @@
     "set": "Gym Heroes",
     "setCode": "gym1",
     "text": [
-      "In order to play this card, you can't have any Basic Pokémon cards in your hand. Show your hand to your opponent, then search your deck for a Basic Pokémon card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
+      "In order to play this card, you can’t have any Basic Pokémon cards in your hand. Show your hand to your opponent, then search your deck for a Basic Pokémon card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/111_hires.png"
   },
   {
     "id": "gym1-112",
-    "name": "Lt. Surge's Treaty",
+    "name": "Lt. Surge’s Treaty",
     "imageUrl": "https://images.pokemontcg.io/gym1/112.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -5126,13 +5126,13 @@
     "set": "Gym Heroes",
     "setCode": "gym1",
     "text": [
-      "Flip 2 coins. If both of them are heads, choose 1 of your opponent's Benched Pokémon and return it and all cards attached to it to his or her hand. If 1 or both of them are tails, your turn ends immediately (you can't attack this turn)."
+      "Flip 2 coins. If both of them are heads, choose 1 of your opponent’s Benched Pokémon and return it and all cards attached to it to his or her hand. If 1 or both of them are tails, your turn ends immediately (you can’t attack this turn)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/113_hires.png"
   },
   {
     "id": "gym1-114",
-    "name": "Misty's Wrath",
+    "name": "Misty’s Wrath",
     "imageUrl": "https://images.pokemontcg.io/gym1/114.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -5160,7 +5160,7 @@
     "set": "Gym Heroes",
     "setCode": "gym1",
     "text": [
-      "Don't apply Resistance to any attacks made by Pokémon with Brock in their names."
+      "Don’t apply Resistance to any attacks made by Pokémon with Brock in their names."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/115_hires.png"
   },
@@ -5177,13 +5177,13 @@
     "set": "Gym Heroes",
     "setCode": "gym1",
     "text": [
-      "For your attack this turn, your Active Pokémon can use any attack from its Basic Pokémon card or any Evolution card attached to it. (You still have to pay for that attack's Energy cost.)"
+      "For your attack this turn, your Active Pokémon can use any attack from its Basic Pokémon card or any Evolution card attached to it. (You still have to pay for that attack’s Energy cost.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/116_hires.png"
   },
   {
     "id": "gym1-117",
-    "name": "Sabrina's ESP",
+    "name": "Sabrina’s ESP",
     "imageUrl": "https://images.pokemontcg.io/gym1/117.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -5194,7 +5194,7 @@
     "set": "Gym Heroes",
     "setCode": "gym1",
     "text": [
-      "Attach Sabrina's ESP to 1 of your Pokémon with Sabrina in its name. At the end of your turn, discard Sabrina's ESP. If that Pokémon uses an attack that involves flipping coins, Sabrina's ESP lets you re-flip those coins once. If you do, re-flip all the coins."
+      "Attach Sabrina’s ESP to 1 of your Pokémon with Sabrina in its name. At the end of your turn, discard Sabrina’s ESP. If that Pokémon uses an attack that involves flipping coins, Sabrina’s ESP lets you re-flip those coins once. If you do, re-flip all the coins."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/117_hires.png"
   },
@@ -5211,7 +5211,7 @@
     "set": "Gym Heroes",
     "setCode": "gym1",
     "text": [
-      "Look at your opponent's hand. Then, you may discard as many other cards as you want from your hand and draw that many cards."
+      "Look at your opponent’s hand. Then, you may discard as many other cards as you want from your hand and draw that many cards."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/118_hires.png"
   },
@@ -5228,7 +5228,7 @@
     "set": "Gym Heroes",
     "setCode": "gym1",
     "text": [
-      "Flip a coin. If heads, your opponent sets aside all the cards in his or her hand face down. Nobody may look at those cards. At the end of your opponent's next turn, your opponent puts those cards back into his or her hand. If tails, your turn ends immediately (you can't attack this turn)."
+      "Flip a coin. If heads, your opponent sets aside all the cards in his or her hand face down. Nobody may look at those cards. At the end of your opponent’s next turn, your opponent puts those cards back into his or her hand. If tails, your turn ends immediately (you can’t attack this turn)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/119_hires.png"
   },
@@ -5245,13 +5245,13 @@
     "set": "Gym Heroes",
     "setCode": "gym1",
     "text": [
-      "Whenever a player attacks with a Pokémon with Lt. Surge in its name, he or she may flip a coin. If heads, and if that Pokémon's attack does damage to the Defending Pokémon (after applying Weakness and Resistance), that attack does 10 more damage to the Defending Pokémon. If tails, the attacking Pokémon does 10 damage to itself in addition to whatever its attack usually does."
+      "Whenever a player attacks with a Pokémon with Lt. Surge in its name, he or she may flip a coin. If heads, and if that Pokémon’s attack does damage to the Defending Pokémon (after applying Weakness and Resistance), that attack does 10 more damage to the Defending Pokémon. If tails, the attacking Pokémon does 10 damage to itself in addition to whatever its attack usually does."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/120_hires.png"
   },
   {
     "id": "gym1-121",
-    "name": "Blaine's Gamble",
+    "name": "Blaine’s Gamble",
     "imageUrl": "https://images.pokemontcg.io/gym1/121.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -5285,7 +5285,7 @@
   },
   {
     "id": "gym1-123",
-    "name": "Misty's Duel",
+    "name": "Misty’s Duel",
     "imageUrl": "https://images.pokemontcg.io/gym1/123.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -5296,7 +5296,7 @@
     "set": "Gym Heroes",
     "setCode": "gym1",
     "text": [
-      "You and your opponent play a game of Rock-Paper-Scissors. The winner shuffles his or her hand into his or her deck and draws a new hand of 5 cards. (If you don't know jow to play Rock-Paper-Scissors, flip a coin to decide who's the winner.)"
+      "You and your opponent play a game of Rock-Paper-Scissors. The winner shuffles his or her hand into his or her deck and draws a new hand of 5 cards. (If you don’t know jow to play Rock-Paper-Scissors, flip a coin to decide who’s the winner.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/123_hires.png"
   },
@@ -5319,7 +5319,7 @@
   },
   {
     "id": "gym1-125",
-    "name": "Sabrina's Gaze",
+    "name": "Sabrina’s Gaze",
     "imageUrl": "https://images.pokemontcg.io/gym1/125.png",
     "subtype": "",
     "supertype": "Trainer",

--- a/json/cards/HS—Triumphant.json
+++ b/json/cards/HS—Triumphant.json
@@ -44,7 +44,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "During your opponent's next turn, any damage done to Aggron by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Aggron by attacks is reduced by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -143,7 +143,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at the top 5 cards of either player's deck and put them back on top of that player's deck in any order."
+        "text": "Look at the top 5 cards of either player’s deck and put them back on top of that player’s deck in any order."
       },
       {
         "name": "Leaf Bind",
@@ -272,7 +272,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "70",
-        "text": "Does 20 damage to each of your opponent's Benched Pokémon that has any damage counters on it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to each of your opponent’s Benched Pokémon that has any damage counters on it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -349,7 +349,7 @@
     "evolvesFrom": "Porygon2",
     "ability": {
       "name": "Dimension Transfer",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, search your discard pile for a Trainer card, show it to your opponent, and put it on top of your deck. This power can't be used if Porygon-Z is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, search your discard pile for a Trainer card, show it to your opponent, and put it on top of your deck. This power can’t be used if Porygon-Z is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -397,7 +397,7 @@
     "evolvesFrom": "Ponyta",
     "ability": {
       "name": "Fiery Spirit",
-      "text": "Rapidash can't be Confused.",
+      "text": "Rapidash can’t be Confused.",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -423,7 +423,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "The Defending Pokémon is now Burned and can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon is now Burned and can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -443,7 +443,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Heal Block",
-      "text": "If you have Lunatone in play, damage counters can't be removed from any Pokémon (both yours and your opponent's). (Damage counters can still be moved.)",
+      "text": "If you have Lunatone in play, damage counters can’t be removed from any Pokémon (both yours and your opponent’s). (Damage counters can still be moved.)",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -467,7 +467,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -532,7 +532,7 @@
     "evolvesFrom": "Venonat",
     "ability": {
       "name": "Poison Moth Wind",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, your opponent's Active Pokémon is now Poisoned. If tails, your Active Pokémon is now Poisoned. This power can't be used if Venomoth is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, your opponent’s Active Pokémon is now Poisoned. If tails, your Active Pokémon is now Poisoned. This power can’t be used if Venomoth is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -578,7 +578,7 @@
     "evolvesFrom": "Weepinbell",
     "ability": {
       "name": "Tangling Tendrils",
-      "text": "As long as Victreebel is your Active Pokémon, your opponent's Active Pokémon's Retreat Cost is ColorlessColorless more.",
+      "text": "As long as Victreebel is your Active Pokémon, your opponent’s Active Pokémon’s Retreat Cost is ColorlessColorless more.",
       "type": "Poké-Body"
     },
     "hp": "110",
@@ -645,7 +645,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Choose 2 cards from your opponent's hand without looking. Look at the cards you chose, then have your opponent shuffle those cards into his or her deck."
+        "text": "Choose 2 cards from your opponent’s hand without looking. Look at the cards you chose, then have your opponent shuffle those cards into his or her deck."
       },
       {
         "name": "Tail Spank",
@@ -655,7 +655,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "60",
-        "text": "Discard 2 cards from your hand. (If you can't discard 2 cards from your hand, this attack does nothing.)"
+        "text": "Discard 2 cards from your hand. (If you can’t discard 2 cards from your hand, this attack does nothing.)"
       }
     ],
     "weaknesses": [
@@ -695,7 +695,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, choose 1 Energy card attached to 1 of your opponent's Pokémon and put it in the Lost Zone."
+        "text": "Flip a coin. If heads, choose 1 Energy card attached to 1 of your opponent’s Pokémon and put it in the Lost Zone."
       },
       {
         "name": "Breakdown",
@@ -706,7 +706,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Count the number of cards in your opponent's hand. Put that many damage counters on the Defending Pokémon."
+        "text": "Count the number of cards in your opponent’s hand. Put that many damage counters on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -810,7 +810,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon."
+        "text": "Switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon."
       },
       {
         "name": "Stick and Absorb",
@@ -821,7 +821,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Remove 3 damage counters from Carnivine. The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "Remove 3 damage counters from Carnivine. The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1042,7 +1042,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 50 damage to each of your opponent's Pokémon that has any Energy cards attached to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 50 damage to each of your opponent’s Pokémon that has any Energy cards attached to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1089,7 +1089,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance. Elekid is now Asleep."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. This attack’s damage isn’t affected by Weakness or Resistance. Elekid is now Asleep."
       }
     ],
     "nationalPokedexNumber": 239,
@@ -1174,7 +1174,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Your opponent can't use any Poké-Powers on his or her Pokémon on his or her next turn."
+        "text": "Your opponent can’t use any Poké-Powers on his or her Pokémon on his or her next turn."
       },
       {
         "name": "Bench Manipulation",
@@ -1185,7 +1185,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40×",
-        "text": "Your opponent flips a coin for each of his or her Benched Pokémon. This attack does 40 damage times the number of tails. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Your opponent flips a coin for each of his or her Benched Pokémon. This attack does 40 damage times the number of tails. This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -1286,7 +1286,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "60",
-        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.) Lunatone does 60 damage to itself."
+        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent’s). (Don’t apply Weakness and Resistance for Benched Pokémon.) Lunatone does 60 damage to itself."
       }
     ],
     "weaknesses": [
@@ -1379,7 +1379,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "For each Fire Energy attached to Magmortar, discard the top card from your opponent's deck. Then, flip a coin. If tails, discard all Fire Energy attached to Magmortar."
+        "text": "For each Fire Energy attached to Magmortar, discard the top card from your opponent’s deck. Then, flip a coin. If tails, discard all Fire Energy attached to Magmortar."
       },
       {
         "name": "Burst Punch",
@@ -1480,7 +1480,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "During your opponent's next turn, the attack cost of each of the Defending Pokémon's attacks is ColorlessColorless more."
+        "text": "During your opponent’s next turn, the attack cost of each of the Defending Pokémon’s attacks is ColorlessColorless more."
       },
       {
         "name": "Quick Attack",
@@ -1813,7 +1813,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 2 damage counters on 1 of your opponent's Pokémon."
+        "text": "Put 2 damage counters on 1 of your opponent’s Pokémon."
       },
       {
         "name": "Sleep Poison",
@@ -1980,7 +1980,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon for each Energy attached to Lickilicky. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon for each Energy attached to Lickilicky. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Stick and Absorb",
@@ -1991,7 +1991,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Remove 2 damage counters from Lickilicky. The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "Remove 2 damage counters from Lickilicky. The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2080,7 +2080,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       },
       {
         "name": "Strength",
@@ -2517,7 +2517,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Benched Pokémon. If tails, this attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent’s Benched Pokémon. If tails, this attack does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Hammer In",
@@ -2720,7 +2720,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 2 of your opponent's Pokémon. This attack does 20 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 2 of your opponent’s Pokémon. This attack does 20 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Surf",
@@ -2785,7 +2785,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Filp a coin. If heads, look at your opponent's hand, choose 1 card, and discard it."
+        "text": "Filp a coin. If heads, look at your opponent’s hand, choose 1 card, and discard it."
       }
     ],
     "weaknesses": [
@@ -2828,7 +2828,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "U-turn",
@@ -2995,7 +2995,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon."
+        "text": "Switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon."
       },
       {
         "name": "Careless Tackle",
@@ -3046,7 +3046,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to Bronzor during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to Bronzor during your opponent’s next turn."
       },
       {
         "name": "Tackle",
@@ -3104,7 +3104,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, Carvanha's Bite attack's base damage is 40."
+        "text": "During your next turn, Carvanha’s Bite attack’s base damage is 40."
       },
       {
         "name": "Bite",
@@ -3136,7 +3136,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Lonely Bone",
-      "text": "Any damage done to Cubone by your opponent's attacks is reduced by 20 for each Marowak in your discard pile (after applying Weakness and Resistance).",
+      "text": "Any damage done to Cubone by your opponent’s attacks is reduced by 20 for each Marowak in your discard pile (after applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "40",
@@ -3209,7 +3209,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to Diglett during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to Diglett during your opponent’s next turn."
       },
       {
         "name": "Mini Earthquake",
@@ -3219,7 +3219,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3267,7 +3267,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Ram",
@@ -3319,7 +3319,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 1 damage counter on 1 of your opponent's Pokémon."
+        "text": "Put 1 damage counter on 1 of your opponent’s Pokémon."
       }
     ],
     "weaknesses": [
@@ -3470,7 +3470,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Benched Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Benched Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3889,7 +3889,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Filp a coin. If heads, this attack does 30 damage to 1 of your opponent's Pokémon. If tails, this attack does 30 damage to 1 of your Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Filp a coin. If heads, this attack does 30 damage to 1 of your opponent’s Pokémon. If tails, this attack does 30 damage to 1 of your Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3931,7 +3931,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Flip a coin. If heads, choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Haunt",
@@ -4174,7 +4174,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -4259,7 +4259,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If you don't have Illumise in play, this attack does nothing. Choose 1 of your opponent's Benched Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If you don’t have Illumise in play, this attack does nothing. Choose 1 of your opponent’s Benched Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Firefly Light",
@@ -4338,7 +4338,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Free Flight",
-      "text": "If Yanma has no Energy attached to it, Yanma's Retreat Cost is 0.",
+      "text": "If Yanma has no Energy attached to it, Yanma’s Retreat Cost is 0.",
       "type": "Poké-Body"
     },
     "hp": "50",
@@ -4398,7 +4398,7 @@
     "setCode": "hgss4",
     "text": [
       "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.",
-      "You may use this card only if you have more Prize cards left than your opponent. During this turn, each of your Active Pokémon's attacks does 40 more damage to your opponent's Active Pokemon (before applying Weakness and Resistance)."
+      "You may use this card only if you have more Prize cards left than your opponent. During this turn, each of your Active Pokémon’s attacks does 40 more damage to your opponent’s Active Pokemon (before applying Weakness and Resistance)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss4/85_hires.png"
   },
@@ -4415,8 +4415,8 @@
     "set": "HS—Triumphant",
     "setCode": "hgss4",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "Each Pokémon LEGEND in play (both yours and your opponent's) gets +30 HP."
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
+      "Each Pokémon LEGEND in play (both yours and your opponent’s) gets +30 HP."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss4/86_hires.png"
   },
@@ -4433,7 +4433,7 @@
     "set": "HS—Triumphant",
     "setCode": "hgss4",
     "text": [
-      "Discard 2 cards from your hand. Search your discard pile for a Trainer card, show it to your opponent, and put it into your hand. You can't choose Junk Arm with the effect of this card."
+      "Discard 2 cards from your hand. Search your discard pile for a Trainer card, show it to your opponent, and put it into your hand. You can’t choose Junk Arm with the effect of this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss4/87_hires.png"
   },
@@ -4523,7 +4523,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "70",
-        "text": "Choose 1 Pokémon from your hand and put it in the Lost Zone. (If you can't put a Pokémon in the Lost Zone, this attack does nothing.)"
+        "text": "Choose 1 Pokémon from your hand and put it in the Lost Zone. (If you can’t put a Pokémon in the Lost Zone, this attack does nothing.)"
       }
     ],
     "weaknesses": [
@@ -4549,7 +4549,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Forest Breath",
-      "text": "Once during your turn (before your attack), if Celebi is your Active Pokémon, you may attach a Grass Energy card from your hand to 1 of your Pokémon. This power can't be used if Celebi is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Celebi is your Active Pokémon, you may attach a Grass Energy card from your hand to 1 of your Pokémon. This power can’t be used if Celebi is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -4575,7 +4575,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "During your opponent's next turn, prevent all damage done to Celebi by attacks from your opponent's Stage 1 or Stage 2 Pokémon."
+        "text": "During your opponent’s next turn, prevent all damage done to Celebi by attacks from your opponent’s Stage 1 or Stage 2 Pokémon."
       }
     ],
     "weaknesses": [
@@ -4596,7 +4596,7 @@
     "evolvesFrom": "Voltorb",
     "ability": {
       "name": "Energymite",
-      "text": "Once during your turn (before your attack), you may use this power. If you do, Electrode is Knocked Out. Look at the top 7 cards of your deck. Choose as many Energy cards as you like and attach them to your Pokémon in any way you like. Discard the other cards. This power can't be used if Electrode is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may use this power. If you do, Electrode is Knocked Out. Look at the top 7 cards of your deck. Choose as many Energy cards as you like and attach them to your Pokémon in any way you like. Discard the other cards. This power can’t be used if Electrode is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -4621,7 +4621,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Does 10 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4648,7 +4648,7 @@
     "evolvesFrom": "Haunter",
     "ability": {
       "name": "Catastrophe",
-      "text": "As long as Gengar is your Active Pokémon, if any of your opponent's Pokémon would be Knocked Out, put that Pokémon in the Lost Zone instead of discarding it. (Discard all cards attached to that Pokémon.)",
+      "text": "As long as Gengar is your Active Pokémon, if any of your opponent’s Pokémon would be Knocked Out, put that Pokémon in the Lost Zone instead of discarding it. (Discard all cards attached to that Pokémon.)",
       "type": "Poké-Body"
     },
     "hp": "130",
@@ -4669,7 +4669,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at your opponent's hand and choose a number of Pokémon you find there up to the number of Psychic Energy attached to Gengar. Put the Pokémon you chose in the Lost Zone."
+        "text": "Look at your opponent’s hand and choose a number of Pokémon you find there up to the number of Psychic Energy attached to Gengar. Put the Pokémon you chose in the Lost Zone."
       },
       {
         "name": "Cursed Drop",
@@ -4679,7 +4679,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Put 4 damage counters on your opponent's Pokémon in any way you like."
+        "text": "Put 4 damage counters on your opponent’s Pokémon in any way you like."
       }
     ],
     "weaknesses": [
@@ -4767,7 +4767,7 @@
     "evolvesFrom": "Magneton",
     "ability": {
       "name": "Magnetic Draw",
-      "text": "Once during your turn (before your attack), you may draw cards until you have 6 cards in your hand. This power can't be used if Magnezone is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may draw cards until you have 6 cards in your hand. This power can’t be used if Magnezone is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "140",
@@ -4820,7 +4820,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Lost Link",
-      "text": "Mew can use the attacks of all of the Pokémon in the Lost Zone (both yours and your opponent's). (You still need the necessary Energy to use each attack.)",
+      "text": "Mew can use the attacks of all of the Pokémon in the Lost Zone (both yours and your opponent’s). (You still need the necessary Energy to use each attack.)",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -4862,7 +4862,7 @@
     "evolvesFrom": "Yanma",
     "ability": {
       "name": "Insight",
-      "text": "If you have the same number of cards in your hand as your opponent the attack cost of each of Yanmega's attacks is 0.",
+      "text": "If you have the same number of cards in your hand as your opponent the attack cost of each of Yanmega’s attacks is 0.",
       "type": "Poké-Body"
     },
     "hp": "110",
@@ -4884,7 +4884,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 40 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Sonicboom",
@@ -4895,7 +4895,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "This attack's damage isn't affected by Weakness or Resistance."
+        "text": "This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -4971,16 +4971,16 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "Choose 2 Energy attached to Darkrai & Cresselia LEGEND and put them in the Lost Zone. If any of your opponent's Pokémon would be Knocked Out by damage from this attack, put that Pokémon and all cards attached to it in the Lost Zone instead of discarding it."
+        "text": "Choose 2 Energy attached to Darkrai & Cresselia LEGEND and put them in the Lost Zone. If any of your opponent’s Pokémon would be Knocked Out by damage from this attack, put that Pokémon and all cards attached to it in the Lost Zone instead of discarding it."
       },
       {
-        "name": "Moon's Invite",
+        "name": "Moon’s Invite",
         "cost": [
           "Psychic"
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Move as many damage counters on your opponent's Pokémon as you like to any of your opponent's other Pokémon in any way you like."
+        "text": "Move as many damage counters on your opponent’s Pokémon as you like to any of your opponent’s other Pokémon in any way you like."
       }
     ],
     "weaknesses": [
@@ -5054,7 +5054,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Benched Pokémon. Put that Pokémon and all cards attached to it back into your opponent's hand."
+        "text": "Choose 1 of your opponent’s Benched Pokémon. Put that Pokémon and all cards attached to it back into your opponent’s hand."
       },
       {
         "name": "Time Control",
@@ -5065,7 +5065,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Discard all Metal Energy attached to Palkia & Dialga LEGEND. Add the top 2 cards of your opponent's deck to his or her Prize cards."
+        "text": "Discard all Metal Energy attached to Palkia & Dialga LEGEND. Add the top 2 cards of your opponent’s deck to his or her Prize cards."
       }
     ],
     "weaknesses": [

--- a/json/cards/HS—Undaunted.json
+++ b/json/cards/HS—Undaunted.json
@@ -8,7 +8,7 @@
     "evolvesFrom": "Gloom",
     "ability": {
       "name": "Hustle Step",
-      "text": "Once during your turn (before your attack), you may remove 1 damage counter from each of your Pokémon. This power can't be used if Bellossom is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may remove 1 damage counter from each of your Pokémon. This power can’t be used if Bellossom is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -79,7 +79,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Move up to 4 damage counters from any of your Pokémon to any of your opponent's Pokémon in any way you like."
+        "text": "Move up to 4 damage counters from any of your Pokémon to any of your opponent’s Pokémon in any way you like."
       },
       {
         "name": "Psybeam",
@@ -132,7 +132,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Everyone Explode Now",
@@ -394,7 +394,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Portrait",
-      "text": "Once during your turn (before your attack), if Smeargle is your Active Pokémon, you may look at your opponent's hand. If you do, choose a Supporter card you find there and use the effect of that card as the effect of this power. This power can't be used if Smeargle is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Smeargle is your Active Pokémon, you may look at your opponent’s hand. If you do, choose a Supporter card you find there and use the effect of that card as the effect of this power. This power can’t be used if Smeargle is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -517,7 +517,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "During your opponent's next turn, prevent all effects, including damage, done to Umbreon by attacks from your opponent's Pokémon that has any Poké-Powers or Poké-Bodies."
+        "text": "During your opponent’s next turn, prevent all effects, including damage, done to Umbreon by attacks from your opponent’s Pokémon that has any Poké-Powers or Poké-Bodies."
       },
       {
         "name": "Quick Blow",
@@ -554,7 +554,7 @@
     "evolvesFrom": "Doduo",
     "ability": {
       "name": "Retreat Aid",
-      "text": "As long as Dodrio is on your Bench, your Active Pokémon's Retreat Cost is ColorlessColorless less.",
+      "text": "As long as Dodrio is on your Bench, your Active Pokémon’s Retreat Cost is ColorlessColorless less.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -681,7 +681,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Gyro Ball",
@@ -805,7 +805,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon that has any damage counters on it. This attack does 50 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon that has any damage counters on it. This attack does 50 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -853,7 +853,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Vengeance",
@@ -1038,7 +1038,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30×",
-        "text": "Look at your opponent's hand. This attack does 30 damage times the number of Trainer, Supporter, and Stadium cards in your opponent's hand."
+        "text": "Look at your opponent’s hand. This attack does 30 damage times the number of Trainer, Supporter, and Stadium cards in your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -1064,7 +1064,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Mischievous Trick",
-      "text": "Once during your turn (before your attack), you may switch 1 of your face-down Prize cards with the top card of your deck. This power can't be used if Rotom is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may switch 1 of your face-down Prize cards with the top card of your deck. This power can’t be used if Rotom is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -1088,7 +1088,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage for each Energy attached to that Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage for each Energy attached to that Pokémon. This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -1256,7 +1256,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "During your next turn, Vespiquen's Retreat Cost is 0."
+        "text": "During your next turn, Vespiquen’s Retreat Cost is 0."
       }
     ],
     "weaknesses": [
@@ -1277,7 +1277,7 @@
     "evolvesFrom": "Gloom",
     "ability": {
       "name": "Allergy Flower",
-      "text": "Each player can't play any Trainer cards from his or her hand.",
+      "text": "Each player can’t play any Trainer cards from his or her hand.",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -1325,7 +1325,7 @@
     "evolvesFrom": "Sneasel",
     "ability": {
       "name": "Claw Snag",
-      "text": "Once during your turn, when you play Weavile from your hand to evolve 1 of your Pokémon, you may look at your opponent's hand. Choose a card from your opponent's hand and discard it.",
+      "text": "Once during your turn, when you play Weavile from your hand to evolve 1 of your Pokémon, you may look at your opponent’s hand. Choose a card from your opponent’s hand and discard it.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -1347,7 +1347,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
       }
     ],
     "weaknesses": [
@@ -1486,7 +1486,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to Jolteon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to Jolteon during your opponent’s next turn."
       },
       {
         "name": "Mach Bolt",
@@ -1669,7 +1669,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon. The new Defending Pokémon is now Confused and Poisoned."
+        "text": "Switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon. The new Defending Pokémon is now Confused and Poisoned."
       },
       {
         "name": "Pester",
@@ -1777,7 +1777,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1918,7 +1918,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "During your opponent's next turn, if Scyther would be damaged by an attack, flip a coin. If heads, prevent that attack's damage done to Scyther."
+        "text": "During your opponent’s next turn, if Scyther would be damaged by an attack, flip a coin. If heads, prevent that attack’s damage done to Scyther."
       }
     ],
     "weaknesses": [
@@ -2079,7 +2079,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of attacks, including damage, done to Togetic during your opponent's next turn."
+        "text": "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of attacks, including damage, done to Togetic during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2184,7 +2184,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 2 of your opponent's Pokémon. This attack does 30 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 2 of your opponent’s Pokémon. This attack does 30 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2440,7 +2440,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done to Drifloon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Drifloon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Pull",
@@ -2449,7 +2449,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, switch the Defending Pokémon with 1 of your opponent's Benched Pokémon."
+        "text": "Flip a coin. If heads, switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -2665,7 +2665,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, the Defending Pokémon's Retreat Cost is Colorless more."
+        "text": "During your opponent’s next turn, the Defending Pokémon’s Retreat Cost is Colorless more."
       },
       {
         "name": "Sludge Toss",
@@ -2717,7 +2717,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to Hitmonchan during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to Hitmonchan during your opponent’s next turn."
       },
       {
         "name": "Sky Uppercut",
@@ -2727,7 +2727,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -3082,7 +3082,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, choose 1 card from your opponent's hand without looking. Look at that card you chose, then have your opponent shuffle that card into his or her deck."
+        "text": "Flip a coin. If heads, choose 1 card from your opponent’s hand without looking. Look at that card you chose, then have your opponent shuffle that card into his or her deck."
       }
     ],
     "weaknesses": [
@@ -3332,7 +3332,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, Pineco's Surprise Attack attack's base damage is 80."
+        "text": "During your next turn, Pineco’s Surprise Attack attack’s base damage is 80."
       },
       {
         "name": "Surprise Attack",
@@ -3438,7 +3438,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "During your next turn, Scyther can't use Slashing Strike."
+        "text": "During your next turn, Scyther can’t use Slashing Strike."
       }
     ],
     "weaknesses": [
@@ -3515,7 +3515,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Active Volcano",
-      "text": "Once during your turn (before your attack), you may discard the top card of your deck. If that card is a Fire Energy card, attach it to Slugma. This power can't be used if Slugma is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may discard the top card of your deck. If that card is a Fire Energy card, attach it to Slugma. This power can’t be used if Slugma is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -3715,8 +3715,8 @@
     "set": "HS—Undaunted",
     "setCode": "hgss3",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "Once during each player's turn, that player may flip a coin. If heads, the player searches his or her discard pile for a basic Energy card, shows it to his or her opponent, and puts it into his or her hand."
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
+      "Once during each player’s turn, that player may flip a coin. If heads, the player searches his or her discard pile for a basic Energy card, shows it to his or her opponent, and puts it into his or her hand."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss3/71_hires.png"
   },
@@ -3733,7 +3733,7 @@
     "set": "HS—Undaunted",
     "setCode": "hgss3",
     "text": [
-      "Attach Defender to 1 of your Pokémon. Discard this card at the end of your opponent's next turn. Any damage done to the Pokémon Defender is attached to by an opponent's attack is reduced by 20 (after applying Weakness and Resistance)."
+      "Attach Defender to 1 of your Pokémon. Discard this card at the end of your opponent’s next turn. Any damage done to the Pokémon Defender is attached to by an opponent’s attack is reduced by 20 (after applying Weakness and Resistance)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss3/72_hires.png"
   },
@@ -3802,14 +3802,14 @@
     "set": "HS—Undaunted",
     "setCode": "hgss3",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
       "Each Pokémon in play has no Resistance."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss3/76_hires.png"
   },
   {
     "id": "hgss3-77",
-    "name": "Sage's Training",
+    "name": "Sage’s Training",
     "imageUrl": "https://images.pokemontcg.io/hgss3/77.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -3827,7 +3827,7 @@
   },
   {
     "id": "hgss3-78",
-    "name": "Team Rocket's Trickery",
+    "name": "Team Rocket’s Trickery",
     "imageUrl": "https://images.pokemontcg.io/hgss3/78.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -3856,7 +3856,7 @@
     "set": "HS—Undaunted",
     "setCode": "hgss3",
     "text": [
-      "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect if the Pokémon that Darkness Energy is attached to isn't Darkness. Darkness Energy provides Darkness Energy. (Doesn't count as a basic Energy card.)"
+      "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect if the Pokémon that Darkness Energy is attached to isn’t Darkness. Darkness Energy provides Darkness Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss3/79_hires.png"
   },
@@ -3873,7 +3873,7 @@
     "set": "HS—Undaunted",
     "setCode": "hgss3",
     "text": [
-      "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn't Metal. Metal Energy provides Metal Energy. (Doesn't count as a basic Energy card.)"
+      "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn’t Metal. Metal Energy provides Metal Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss3/80_hires.png"
   },
@@ -3932,7 +3932,7 @@
     "evolvesFrom": "Houndour",
     "ability": {
       "name": "Fire Breath",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, the Defending Pokémon is now Burned. This power can't be used if Houndoom is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, the Defending Pokémon is now Burned. This power can’t be used if Houndoom is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -3958,7 +3958,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3985,7 +3985,7 @@
     "evolvesFrom": "Pikachu",
     "ability": {
       "name": "Voltage Increase",
-      "text": "As often as you like during your turn (before your attack), you may move a Lightning Energy attached to 1 of your Pokémon to Raichu. This power can't be used if Raichu is affected by a Special Condition.",
+      "text": "As often as you like during your turn (before your attack), you may move a Lightning Energy attached to 1 of your Pokémon to Raichu. This power can’t be used if Raichu is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -4038,7 +4038,7 @@
     "evolvesFrom": "Scyther",
     "ability": {
       "name": "Red Armor",
-      "text": "Prevent all damage done to Scizor by attacks from your opponent's Pokémon that have any Special Energy cards attached to them.",
+      "text": "Prevent all damage done to Scizor by attacks from your opponent’s Pokémon that have any Special Energy cards attached to them.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -4090,8 +4090,8 @@
     "supertype": "Pokémon",
     "evolvesFrom": "Slowpoke",
     "ability": {
-      "name": "Opponent's Choice",
-      "text": "Once during your turn (before your attack), you may reveal the top 2 cards of your deck and your opponent chooses 1 of them. Put that card into your hand and the other card on the bottom of your deck. This power can't be used if Slowking is affected by a Special Condition.",
+      "name": "Opponent’s Choice",
+      "text": "Once during your turn (before your attack), you may reveal the top 2 cards of your deck and your opponent chooses 1 of them. Put that card into your hand and the other card on the bottom of your deck. This power can’t be used if Slowking is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -4139,7 +4139,7 @@
     "evolvesFrom": "Eevee",
     "ability": {
       "name": "Cloud-Covered Moon",
-      "text": "Once during your turn (before your attack), if Umbreon is your Active Pokémon, you may flip a coin. If heads, return Umbreon and all cards attached to it to your hand. This power can't be used if Umbreon is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Umbreon is your Active Pokémon, you may flip a coin. If heads, return Umbreon and all cards attached to it to your hand. This power can’t be used if Umbreon is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -4242,7 +4242,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Discard the top 5 cards from your opponent's deck. This attack does 30 damage times the number of Energy cards you discarded to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard the top 5 cards from your opponent’s deck. This attack does 30 damage times the number of Energy cards you discarded to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Massive Eruption",
@@ -4301,7 +4301,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Space Virus",
-      "text": "If your opponent's Pokémon is Knocked Out by damage from an attack of Rayquaza & Deoxys LEGEND, take 1 more Prize card.",
+      "text": "If your opponent’s Pokémon is Knocked Out by damage from an attack of Rayquaza & Deoxys LEGEND, take 1 more Prize card.",
       "type": "Poké-Body"
     },
     "retreatCost": [
@@ -4363,7 +4363,7 @@
     "set": "HS—Undaunted",
     "setCode": "hgss3",
     "text": [
-      "Return any Stadium card in play to its player's hand!"
+      "Return any Stadium card in play to its player’s hand!"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss3/THREE_hires.png"
   }

--- a/json/cards/HS—Unleashed.json
+++ b/json/cards/HS—Unleashed.json
@@ -31,7 +31,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose a number of your opponent's Stage 1 or Stage 2 Evolved Pokémon up to the amount of Energy attached to Jirachi. Remove the highest Stage Evolution card from each of those Pokémon and put those cards back into your opponent's hand."
+        "text": "Choose a number of your opponent’s Stage 1 or Stage 2 Evolved Pokémon up to the amount of Energy attached to Jirachi. Remove the highest Stage Evolution card from each of those Pokémon and put those cards back into your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -191,7 +191,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 2 of your opponent's Benched Pokémon. This attack does 40 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 2 of your opponent’s Benched Pokémon. This attack does 40 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -212,7 +212,7 @@
     "evolvesFrom": "Misdreavus",
     "ability": {
       "name": "Magical Trans",
-      "text": "Once during your turn (before your attack), you may move a Psychic Energy attached to 1 of your Pokémon to another of your Pokémon. This power can't be used if Mismagius is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may move a Psychic Energy attached to 1 of your Pokémon to another of your Pokémon. This power can’t be used if Mismagius is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -236,7 +236,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Does 10 damage to each of your opponent's Benched Pokémon that has any damage counters on it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Benched Pokémon that has any damage counters on it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -283,7 +283,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Switch Octillery with 1 of your Benched Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) Switch Octillery with 1 of your Benched Pokémon."
       },
       {
         "name": "Ink Bomb",
@@ -294,7 +294,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -315,7 +315,7 @@
     "evolvesFrom": "Poliwhirl",
     "ability": {
       "name": "Leap Frog",
-      "text": "Once during your turn (before your attack), you may choose a Water Pokémon on your Bench and switch it with your Active Pokémon. This power can't be used if Politoed is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may choose a Water Pokémon on your Bench and switch it with your Active Pokémon. This power can’t be used if Politoed is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -444,7 +444,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -626,7 +626,7 @@
     "evolvesFrom": "Wartortle",
     "ability": {
       "name": "Wash Out",
-      "text": "As often as you like during your turn (before your attack), you may move a Water Energy attached to 1 of your Benched Pokémon to your Active Pokémon. This power can't be used if Blastoise is affected by a Special Condition.",
+      "text": "As often as you like during your turn (before your attack), you may move a Water Energy attached to 1 of your Benched Pokémon to your Active Pokémon. This power can’t be used if Blastoise is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "130",
@@ -655,7 +655,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Return 2 Water Energy attached to Blastoise to your hand. Choose 1 of your opponent's Pokémon. This attack does 100 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Return 2 Water Energy attached to Blastoise to your hand. Choose 1 of your opponent’s Pokémon. This attack does 100 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -787,7 +787,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Water Acceleration",
-      "text": "Once during your turn (before your attack), you may attach a Water Energy card from your hand to Floatzel. This power can't be used if Floatzel is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may attach a Water Energy card from your hand to Floatzel. This power can’t be used if Floatzel is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -850,7 +850,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Stream Pump",
@@ -953,7 +953,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "During your next turn, each of Lucario's attacks does 30 more damage to the Defending Pokémon (before applying Weakness and Resistance)."
+        "text": "During your next turn, each of Lucario’s attacks does 30 more damage to the Defending Pokémon (before applying Weakness and Resistance)."
       },
       {
         "name": "Magnum Punch",
@@ -1056,7 +1056,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Dynamic Punch",
@@ -1118,7 +1118,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. Flip a coin until you get tails. This attack does 50 damage times the number of heads to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. Flip a coin until you get tails. This attack does 50 damage times the number of heads to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1209,7 +1209,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "During your opponent's next turn, any damage done to Steelix by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Steelix by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Steel Swing",
@@ -1409,7 +1409,7 @@
     "evolvesFrom": "Cherubi",
     "ability": {
       "name": "Sunny Heal",
-      "text": "Once during your turn (before your attack), you may remove 1 damage counter from your Active Pokémon. This power can't be used if Cherrim is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may remove 1 damage counter from your Active Pokémon. This power can’t be used if Cherrim is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -1515,7 +1515,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2066,7 +2066,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Razor Fin",
@@ -2171,7 +2171,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Surf",
@@ -2224,7 +2224,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Move an Energy card attached to the Defending Pokémon to another of your opponent's Pokémon."
+        "text": "Move an Energy card attached to the Defending Pokémon to another of your opponent’s Pokémon."
       },
       {
         "name": "Tail Smash",
@@ -2319,7 +2319,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2567,7 +2567,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Discard the top card of your opponent's deck. Then, remove 2 damage counters from Larvitar."
+        "text": "Discard the top card of your opponent’s deck. Then, remove 2 damage counters from Larvitar."
       },
       {
         "name": "Reckless Charge",
@@ -2786,7 +2786,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2902,7 +2902,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "Onix can't attack during your next turn."
+        "text": "Onix can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -3052,7 +3052,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3188,7 +3188,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Remove 4 damage counters from Spearow. Spearow can't retreat during your next turn."
+        "text": "Remove 4 damage counters from Spearow. Spearow can’t retreat during your next turn."
       },
       {
         "name": "Flap",
@@ -3605,7 +3605,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 2 of your opponent's Benched Pokémon. This attack does 10 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 2 of your opponent’s Benched Pokémon. This attack does 10 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3628,7 +3628,7 @@
   },
   {
     "id": "hgss2-71",
-    "name": "Cheerleader's Cheer",
+    "name": "Cheerleader’s Cheer",
     "imageUrl": "https://images.pokemontcg.io/hgss2/71.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -3663,7 +3663,7 @@
   },
   {
     "id": "hgss2-73",
-    "name": "Emcee's Chatter",
+    "name": "Emcee’s Chatter",
     "imageUrl": "https://images.pokemontcg.io/hgss2/73.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -3698,7 +3698,7 @@
   },
   {
     "id": "hgss2-75",
-    "name": "Engineer's Adjustments",
+    "name": "Engineer’s Adjustments",
     "imageUrl": "https://images.pokemontcg.io/hgss2/75.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -3733,7 +3733,7 @@
   },
   {
     "id": "hgss2-77",
-    "name": "Interviewer's Questions",
+    "name": "Interviewer’s Questions",
     "imageUrl": "https://images.pokemontcg.io/hgss2/77.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -3886,7 +3886,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3913,7 +3913,7 @@
     "evolvesFrom": "Seadra",
     "ability": {
       "name": "Spray Splash",
-      "text": "Once during your turn (before your attack), you may put 1 damage counter on 1 of your opponent's Pokémon. This power can't be used if Kingdra is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may put 1 damage counter on 1 of your opponent’s Pokémon. This power can’t be used if Kingdra is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "130",
@@ -3937,7 +3937,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "60",
-        "text": "If your opponent has any Fire Pokémon in play, this attack's base damage is 20 instead of 60."
+        "text": "If your opponent has any Fire Pokémon in play, this attack’s base damage is 20 instead of 60."
       }
     ],
     "weaknesses": [
@@ -3958,7 +3958,7 @@
     "evolvesFrom": "Chinchou",
     "ability": {
       "name": "Submerge",
-      "text": "Once during your turn (before your attack), you may use this power. Lanturn's type is Water until the end of your turn. This power can't be used if Lanturn is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may use this power. Lanturn’s type is Water until the end of your turn. This power can’t be used if Lanturn is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -4006,7 +4006,7 @@
     "evolvesFrom": "Onix",
     "ability": {
       "name": "Perfect Metal",
-      "text": "Steelix can't be affected by any Special Conditions.",
+      "text": "Steelix can’t be affected by any Special Conditions.",
       "type": "Poké-Body"
     },
     "hp": "140",
@@ -4095,7 +4095,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 20 damage to each Pokémon in play (both yours and your opponent's) (excluding any Darkness Pokémon). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to each Pokémon in play (both yours and your opponent’s) (excluding any Darkness Pokémon). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Power Claw",
@@ -4106,7 +4106,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "This attack's damage isn't affected by Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       },
       {
         "name": "Megaton Tail",
@@ -4145,7 +4145,7 @@
     "evolvesFrom": "Teddiursa",
     "ability": {
       "name": "Berserk",
-      "text": "If Ursaring has any damage counters on it, each of Ursaring's attacks does 60 more damage (before applying Weakness and Resistance).",
+      "text": "If Ursaring has any damage counters on it, each of Ursaring’s attacks does 60 more damage (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "110",
@@ -4173,7 +4173,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Discard the top card from your opponent's deck."
+        "text": "Discard the top card from your opponent’s deck."
       },
       {
         "name": "Megaton Lariat",
@@ -4259,7 +4259,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Discard all Energy attached to Entei & Raikou LEGEND. This attack does 80 damage to each Pokémon that has any Poké-Powers (both yours and your opponent's). This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Discard all Energy attached to Entei & Raikou LEGEND. This attack does 80 damage to each Pokémon that has any Poké-Powers (both yours and your opponent’s). This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -4331,7 +4331,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "150",
-        "text": "Raikou & Suicune LEGEND does 50 damage to itself, and don't apply Weakness to this damage."
+        "text": "Raikou & Suicune LEGEND does 50 damage to itself, and don’t apply Weakness to this damage."
       },
       {
         "name": "Aurora Gain",
@@ -4414,7 +4414,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Return 2 Water Energy attached to Suicune & Entei LEGEND to your hand. Choose one of your opponent's Benched Pokémon. This attack does 100 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Return 2 Water Energy attached to Suicune & Entei LEGEND to your hand. Choose one of your opponent’s Benched Pokémon. This attack does 100 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Bursting Inferno",

--- a/json/cards/HeartGold & SoulSilver.json
+++ b/json/cards/HeartGold & SoulSilver.json
@@ -257,7 +257,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "During your opponent's next turn, any damage done to Hitmontop by attacks is increased by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Hitmontop by attacks is increased by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -294,7 +294,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10x",
-        "text": "Does 10 damage times the number of Pokémon in play (both yours and your opponent's)."
+        "text": "Does 10 damage times the number of Pokémon in play (both yours and your opponent’s)."
       },
       {
         "name": "Leaf Guard",
@@ -303,7 +303,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "During your opponent's next turn, any damage done to Jumpluff by attacks is reduced by 30 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Jumpluff by attacks is reduced by 30 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -330,7 +330,7 @@
     "evolvesFrom": "Vulpix",
     "ability": {
       "name": "Roast Reveal",
-      "text": "Once during your turn (before your attack), you may discard a Fire Energy card from your hand. If you do, draw 3 cards. This power can't be used if Ninetales is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may discard a Fire Energy card from your hand. If you do, draw 3 cards. This power can’t be used if Ninetales is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -377,7 +377,7 @@
     "evolvesFrom": "Hoothoot",
     "ability": {
       "name": "Night Sight",
-      "text": "Once during your turn (before your attack), you may draw a card. This power can't be used if Noctowl is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may draw a card. This power can’t be used if Noctowl is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -453,7 +453,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Mud Shot",
@@ -585,7 +585,7 @@
     "evolvesFrom": "Slowpoke",
     "ability": {
       "name": "Second Sight",
-      "text": "Once during your turn (before your attack), you may look at the top 3 cards of either player's deck and put them back on top of that player's deck in any order. This power can't be used if Slowking is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may look at the top 3 cards of either player’s deck and put them back on top of that player’s deck in any order. This power can’t be used if Slowking is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -995,7 +995,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 20 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Surf",
@@ -1133,7 +1133,7 @@
     "evolvesFrom": "Drowzee",
     "ability": {
       "name": "Sleep Pendulum",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, the Defending Pokémon is now Asleep. This power can't be used if Hypno is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, the Defending Pokémon is now Asleep. This power can’t be used if Hypno is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -1160,7 +1160,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1211,7 +1211,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1258,7 +1258,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -1362,7 +1362,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip 3 coins. For each heads, discard a card from your opponent's hand without looking."
+        "text": "Flip 3 coins. For each heads, discard a card from your opponent’s hand without looking."
       },
       {
         "name": "Sneaky Attack",
@@ -1501,7 +1501,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Move an Energy card attached to 1 of your opponent's Pokémon to another of your opponent's Pokémon. Smoochum is now Asleep."
+        "text": "Move an Energy card attached to 1 of your opponent’s Pokémon to another of your opponent’s Pokémon. Smoochum is now Asleep."
       }
     ],
     "nationalPokedexNumber": 238,
@@ -1519,7 +1519,7 @@
     "evolvesFrom": "Sunkern",
     "ability": {
       "name": "Sunshine Grace",
-      "text": "Once during your turn (before your attack), you may search your deck for a Grass Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward. This power can't be used if Sunflora is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may search your deck for a Grass Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward. This power can’t be used if Sunflora is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -1639,7 +1639,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Weakness or Resistance. Tyrogue is now Asleep."
+        "text": "This attack’s damage isn’t affected by Weakness or Resistance. Tyrogue is now Asleep."
       }
     ],
     "nationalPokedexNumber": 236,
@@ -1689,7 +1689,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "90",
-        "text": "Weezing does 90 damage to itself, and don't apply Weakness to this damage."
+        "text": "Weezing does 90 damage to itself, and don’t apply Weakness to this damage."
       }
     ],
     "weaknesses": [
@@ -1905,7 +1905,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1957,7 +1957,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "This attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2007,7 +2007,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       },
       {
         "name": "Double Spin",
@@ -2113,7 +2113,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Thundershock",
@@ -2221,7 +2221,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Igglybuff is now Asleep. During your opponent's next turn, the attack cost of each of the Defending Pokémon's attacks is Colorless more."
+        "text": "Igglybuff is now Asleep. During your opponent’s next turn, the attack cost of each of the Defending Pokémon’s attacks is Colorless more."
       }
     ],
     "nationalPokedexNumber": 174,
@@ -2267,7 +2267,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Mantine can't attack during your next turn."
+        "text": "Mantine can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -2793,7 +2793,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "During your opponent's next turn, any damage done to Wigglytuff by attacks is reduced by 10 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Wigglytuff by attacks is reduced by 10 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -2987,7 +2987,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done to Clefairy by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Clefairy by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Slap",
@@ -3091,7 +3091,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon. The new Defending Pokémon is now Asleep."
+        "text": "Switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon. The new Defending Pokémon is now Asleep."
       },
       {
         "name": "Gentle Slap",
@@ -3437,7 +3437,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Shuffle your hand into your deck. Then, draw a number of cards equal to the number of cards in your opponent's hand."
+        "text": "Shuffle your hand into your deck. Then, draw a number of cards equal to the number of cards in your opponent’s hand."
       },
       {
         "name": "Lick",
@@ -3486,7 +3486,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Suffocating Gas",
@@ -3638,7 +3638,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Search your deck for a number of Lightning Energy cards up to the number of Mareep in play (both yours and your opponent's) and attach them to Mareep. Shuffle your deck afterward."
+        "text": "Search your deck for a number of Lightning Energy cards up to the number of Mareep in play (both yours and your opponent’s) and attach them to Mareep. Shuffle your deck afterward."
       },
       {
         "name": "Ram",
@@ -3960,7 +3960,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to Sandshrew by attacks during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all damage done to Sandshrew by attacks during your opponent’s next turn."
       },
       {
         "name": "Rollout",
@@ -4017,7 +4017,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at your opponent's hand."
+        "text": "Look at your opponent’s hand."
       },
       {
         "name": "Scratch",
@@ -4174,7 +4174,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -4420,7 +4420,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack during your opponent’s next turn."
       },
       {
         "name": "Watering",
@@ -4482,7 +4482,7 @@
     "setCode": "hgss1",
     "text": [
       "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.",
-      "Shuffle your hand into your deck. Then, draw a number of cards equal to the number of cards in your opponent's hand."
+      "Shuffle your hand into your deck. Then, draw a number of cards equal to the number of cards in your opponent’s hand."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss1/90_hires.png"
   },
@@ -4637,13 +4637,13 @@
     "set": "HeartGold & SoulSilver",
     "setCode": "hgss1",
     "text": [
-      "Flip a coin. If heads, choose 1 of your opponent's Benched Pokémon and switch it with your opponent's Active Pokémon."
+      "Flip a coin. If heads, choose 1 of your opponent’s Benched Pokémon and switch it with your opponent’s Active Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss1/99_hires.png"
   },
   {
     "id": "hgss1-100",
-    "name": "Professor Elm's Training Method",
+    "name": "Professor Elm’s Training Method",
     "imageUrl": "https://images.pokemontcg.io/hgss1/100.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4661,7 +4661,7 @@
   },
   {
     "id": "hgss1-101",
-    "name": "Professor Oak's New Theory",
+    "name": "Professor Oak’s New Theory",
     "imageUrl": "https://images.pokemontcg.io/hgss1/101.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4866,7 +4866,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "60",
-        "text": "Does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Heavy Impact",
@@ -4904,7 +4904,7 @@
     "evolvesFrom": "Croconaw",
     "ability": {
       "name": "Rain Dance",
-      "text": "As often as you like during your turn (before your attack), you may attach a Water Energy card from your hand to 1 of your Water Pokémon. This power can't be used if Feraligatr is affected by a Special Condition.",
+      "text": "As often as you like during your turn (before your attack), you may attach a Water Energy card from your hand to 1 of your Water Pokémon. This power can’t be used if Feraligatr is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "140",
@@ -4954,7 +4954,7 @@
     "evolvesFrom": "Bayleef",
     "ability": {
       "name": "Leaf Trans",
-      "text": "As often as you like during your turn (before your attack), you may move a Grass Energy attached to 1 of your Pokémon to another of your Pokémon. This power can't be used if Meganium is affected by a Special Condition.",
+      "text": "As often as you like during your turn (before your attack), you may move a Grass Energy attached to 1 of your Pokémon to another of your Pokémon. This power can’t be used if Meganium is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "150",
@@ -5009,7 +5009,7 @@
     "evolvesFrom": "Quilava",
     "ability": {
       "name": "Afterburner",
-      "text": "Once during your turn (before your attack), you may search your discard pile for a Fire Energy card and attach it to 1 of your Pokémon. If you do, put 1 damage counter on that Pokémon. This power can't be used if Typhlosion is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may search your discard pile for a Fire Energy card and attach it to 1 of your Pokémon. If you do, put 1 damage counter on that Pokémon. This power can’t be used if Typhlosion is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "140",
@@ -5387,7 +5387,7 @@
     "set": "HeartGold & SoulSilver",
     "setCode": "hgss1",
     "text": [
-      "Look at your opponent's hand!"
+      "Look at your opponent’s hand!"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss1/ONE_hires.png"
   }

--- a/json/cards/Hidden Legends.json
+++ b/json/cards/Hidden Legends.json
@@ -27,7 +27,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "Does 10 damage plus 20 more damage for each Special Energy card in your opponent's discard pile."
+        "text": "Does 10 damage plus 20 more damage for each Special Energy card in your opponent’s discard pile."
       },
       {
         "name": "Darkness Chant",
@@ -37,7 +37,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Count the number of Basic Pokémon or Evolution cards in your discard pile. Put that many damage counters on the Defending Pokémon. You can't put more than 6 damage counters on the Defending Pokémon in this way."
+        "text": "Count the number of Basic Pokémon or Evolution cards in your discard pile. Put that many damage counters on the Defending Pokémon. You can’t put more than 6 damage counters on the Defending Pokémon in this way."
       }
     ],
     "weaknesses": [
@@ -64,7 +64,7 @@
     "evolvesFrom": "Baltoy",
     "ability": {
       "name": "Primal Pull",
-      "text": "As long as Claydol is your Active Pokémon, each player's Evolved Pokémon pays Colorless more Energy to use its attacks.\"",
+      "text": "As long as Claydol is your Active Pokémon, each player’s Evolved Pokémon pays Colorless more Energy to use its attacks.\"",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -125,7 +125,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Flip a coin. If heads, look at your opponent's hand and choose 1 card. Your opponent discards the card you chose."
+        "text": "Flip a coin. If heads, look at your opponent’s hand and choose 1 card. Your opponent discards the card you chose."
       },
       {
         "name": "Triple Poison",
@@ -225,7 +225,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       },
       {
         "name": "Mass Destruction",
@@ -277,7 +277,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Bass Control",
@@ -287,7 +287,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Does 30 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 30 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Thunderous Roar",
@@ -360,7 +360,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "This attack's damage isn't affected by Weakness or Resistance."
+        "text": "This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -431,7 +431,7 @@
     "evolvesFrom": "Machoke",
     "ability": {
       "name": "Overzealous",
-      "text": "If your opponent has any Pokémon-ex in play, each of Machamp's attacks do 30 more damage to the Defending Pokémon.",
+      "text": "If your opponent has any Pokémon-ex in play, each of Machamp’s attacks do 30 more damage to the Defending Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -457,7 +457,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       },
       {
         "name": "Cross Chop",
@@ -521,7 +521,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "10+",
-        "text": "Does 10 damage plus 10 more damage for each card in your opponent's hand."
+        "text": "Does 10 damage plus 10 more damage for each card in your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -542,7 +542,7 @@
     "evolvesFrom": "Metang",
     "ability": {
       "name": "Metal Juncture",
-      "text": "As often as you like during your turn (before your attack), you may move a Metal Energy card attached to 1 of your Benched Pokémon to your Active Pokémon. This power can't be used if Metagross is affected by a Special Condition.",
+      "text": "As often as you like during your turn (before your attack), you may move a Metal Energy card attached to 1 of your Benched Pokémon to your Active Pokémon. This power can’t be used if Metagross is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -597,7 +597,7 @@
     "evolvesFrom": "Feebas",
     "ability": {
       "name": "Healing Shower",
-      "text": "Once during your turn, when you play Milotic from your hand to evolve 1 of your Pokémon, you may remove all damage counters from all of your Pokémon and your opponent's Pokémon (excluding Pokémon-ex).",
+      "text": "Once during your turn, when you play Milotic from your hand to evolve 1 of your Pokémon, you may remove all damage counters from all of your Pokémon and your opponent’s Pokémon (excluding Pokémon-ex).",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -655,7 +655,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Crust",
-      "text": "Any damage done to Pinsir by attacks from your opponent's Basic Pokémon is reduced by 30 (after applying Weakness and Resistance).",
+      "text": "Any damage done to Pinsir by attacks from your opponent’s Basic Pokémon is reduced by 30 (after applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -680,7 +680,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Weakness or Resistance."
+        "text": "This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -722,7 +722,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Look at your opponent's hand and choose 1 Basic Pokémon or Evolution card you find there. Your opponent puts it at the bottom of his or her deck."
+        "text": "Look at your opponent’s hand and choose 1 Basic Pokémon or Evolution card you find there. Your opponent puts it at the bottom of his or her deck."
       },
       {
         "name": "Supernatural Power",
@@ -760,7 +760,7 @@
     "evolvesFrom": "Sealeo",
     "ability": {
       "name": "Crush Draw",
-      "text": "Once during your turn (before your attack), you may reveal the top card of your deck. If that card is a basic Energy card, attach it to 1 of your Pokémon. If not, put the card back on your deck. This power can't be used if Walrein is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may reveal the top card of your deck. If that card is a basic Energy card, attach it to 1 of your Pokémon. If not, put the card back on your deck. This power can’t be used if Walrein is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -788,7 +788,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Flip a coin. If heads, each Defending Pokémon can't attack during your opponent's next turn."
+        "text": "Flip a coin. If heads, each Defending Pokémon can’t attack during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -809,7 +809,7 @@
     "evolvesFrom": "Gloom",
     "ability": {
       "name": "Heal Dance",
-      "text": "Once during your turn (before your attack), you may remove 2 damage counters from 1 of your Pokémon. You can't use more than 1 Heal Dance Poké-Power each turn. This power can't be used if Bellossom is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may remove 2 damage counters from 1 of your Pokémon. You can’t use more than 1 Heal Dance Poké-Power each turn. This power can’t be used if Bellossom is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -890,7 +890,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Search your opponent's discard pile for a Supporter card and use the effect of that card as the effect of this attack. (The Supporter card remains in your opponent's discard pile.)"
+        "text": "Search your opponent’s discard pile for a Supporter card and use the effect of that card as the effect of this attack. (The Supporter card remains in your opponent’s discard pile.)"
       },
       {
         "name": "Psychic Boom",
@@ -1132,7 +1132,7 @@
     "evolvesFrom": "Vulpix",
     "ability": {
       "name": "Safeguard",
-      "text": "Prevent all effects of attacks, including damage, done to Ninetales by your opponent's Pokémon-ex.",
+      "text": "Prevent all effects of attacks, including damage, done to Ninetales by your opponent’s Pokémon-ex.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -1188,7 +1188,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Temperamental Weather",
-      "text": "Once during your turn (before your attack), you may search your deck for Castform, Sunny Castform, or Snow-cloud Castform and switch it with Rain Castform. (Any cards attached to Rain Castform, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) Shuffle Rain Castform back into your deck. You can't use more than 1 Temperamental Weather Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for Castform, Sunny Castform, or Snow-cloud Castform and switch it with Rain Castform. (Any cards attached to Rain Castform, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) Shuffle Rain Castform back into your deck. You can’t use more than 1 Temperamental Weather Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -1286,7 +1286,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Temperamental Weather",
-      "text": "Once during your turn (before your attack), you may search your deck for Castform, Rain Castform, or Sunny Castform and switch it with Snow-cloud Castform. (Any cards attached to Snow-cloud Castform, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) Shuffle Snow-cloud Castform back into your deck. You can't use more than 1 Temperamental Weather Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for Castform, Rain Castform, or Sunny Castform and switch it with Snow-cloud Castform. (Any cards attached to Snow-cloud Castform, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) Shuffle Snow-cloud Castform back into your deck. You can’t use more than 1 Temperamental Weather Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -1343,7 +1343,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Temperamental Weather",
-      "text": "Once during your turn (before your attack), you may search your deck for Castform, Rain Castform, or Snow-cloud Castform and switch it with Sunny Castform. (Any cards attached to Sunny Castform, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) Shuffle Sunny Castform back into your deck. You can't use more than 1 Temperamental Weather Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for Castform, Rain Castform, or Snow-cloud Castform and switch it with Sunny Castform. (Any cards attached to Sunny Castform, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) Shuffle Sunny Castform back into your deck. You can’t use more than 1 Temperamental Weather Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -1448,7 +1448,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Levitate",
-      "text": "If Beldum has any Energy attached to it, Beldum's Retreat Cost is 0.",
+      "text": "If Beldum has any Energy attached to it, Beldum’s Retreat Cost is 0.",
       "type": "Poké-Body"
     },
     "hp": "50",
@@ -1502,7 +1502,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Magnetic Call",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, search your deck for a Water Basic Pokémon and put it onto your Bench. Shuffle your deck afterward. This power can't be used if Beldum is affected by a Special Condition.\"",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, search your deck for a Water Basic Pokémon and put it onto your Bench. Shuffle your deck afterward. This power can’t be used if Beldum is affected by a Special Condition.\"",
       "type": "Poké-Power"
     },
     "hp": "50",
@@ -1557,7 +1557,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Temperamental Weather",
-      "text": "Once during your turn (before your attack), you may search your deck for Sunny Castform, Rain Castform, or Snow-cloud Castform and switch it with Castform. (Any cards attached to Castform, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) Shuffle Castform back into your deck. You can't use more than 1 Temperamental Weather Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for Sunny Castform, Rain Castform, or Snow-cloud Castform and switch it with Castform. (Any cards attached to Castform, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) Shuffle Castform back into your deck. You can’t use more than 1 Temperamental Weather Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -1682,7 +1682,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Draw a number of cards up to the number of your opponent's Basic Pokémon in play. (You can't have more than 10 cards in your hand in this way.)"
+        "text": "Draw a number of cards up to the number of your opponent’s Basic Pokémon in play. (You can’t have more than 10 cards in your hand in this way.)"
       },
       {
         "name": "Surf",
@@ -1746,7 +1746,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Flip a coin. If tails, Dodrio can't use Slashing Strike during your next turn."
+        "text": "Flip a coin. If tails, Dodrio can’t use Slashing Strike during your next turn."
       }
     ],
     "weaknesses": [
@@ -1773,7 +1773,7 @@
     "evolvesFrom": "Snorunt",
     "ability": {
       "name": "Ice Wall",
-      "text": "Any damage done to Glalie by attacks from your opponent's Pokémon with any Special Energy cards attached to it is reduced by 40 (after applying Weakness and Resistance).",
+      "text": "Any damage done to Glalie by attacks from your opponent’s Pokémon with any Special Energy cards attached to it is reduced by 40 (after applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -1799,7 +1799,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Flip a coin. If heads, put 1 damage counter on each of your opponent's Benched Pokémon."
+        "text": "Flip a coin. If heads, put 1 damage counter on each of your opponent’s Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -1976,7 +1976,7 @@
     "evolvesFrom": "Chinchou",
     "ability": {
       "name": "Energy Grounding",
-      "text": "Once during your opponent's turn, when any of your Pokémon is Knocked Out by your opponent's attacks, you may use this power. Choose a basic Energy card discarded from the Knocked Out Pokémon and attach it to Lanturn. You can't use more than 1 Energy Grounding each turn.",
+      "text": "Once during your opponent’s turn, when any of your Pokémon is Knocked Out by your opponent’s attacks, you may use this power. Choose a basic Energy card discarded from the Knocked Out Pokémon and attach it to Lanturn. You can’t use more than 1 Energy Grounding each turn.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -2003,7 +2003,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "You may discard all Lightning Energy attached to Lanturn. If you do, this attack's base damage is 90 instead of 50."
+        "text": "You may discard all Lightning Energy attached to Lanturn. If you do, this attack’s base damage is 90 instead of 50."
       }
     ],
     "weaknesses": [
@@ -2107,7 +2107,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. This attack does 10 damage to the new Defending Pokémon."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. This attack does 10 damage to the new Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -2128,7 +2128,7 @@
     "evolvesFrom": "Machop",
     "ability": {
       "name": "Strikes Back",
-      "text": "If Machoke is your Active Pokémon and is damaged by an opponent's attack (even if Machoke is Knocked Out), put 1 damage counter on the Attacking Pokémon.",
+      "text": "If Machoke is your Active Pokémon and is damaged by an opponent’s attack (even if Machoke is Knocked Out), put 1 damage counter on the Attacking Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -2283,7 +2283,7 @@
     "evolvesFrom": "Beldum",
     "ability": {
       "name": "Levitate",
-      "text": "If Metang has any Energy attached to it, Metang's Retreat Cost is 0.",
+      "text": "If Metang has any Energy attached to it, Metang’s Retreat Cost is 0.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -2358,7 +2358,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Feint Attack",
@@ -2369,7 +2369,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 40 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
       }
     ],
     "weaknesses": [
@@ -2478,7 +2478,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Does 10 damage to each of your opponent's Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Does 10 damage to each of your opponent’s Pokémon. This attack’s damage isn’t affected by Weakness or Resistance."
       },
       {
         "name": "Skull Bash",
@@ -2580,7 +2580,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Rainbow Star",
@@ -2632,7 +2632,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Swallow Up",
@@ -2643,7 +2643,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50+",
-        "text": "Before doing damage, count the remaining HP of the Defending Pokémon and Swalot. If the Defending Pokémon has fewer remaining HP than Swalot's, this attack does 50 damage plus 30 more damage."
+        "text": "Before doing damage, count the remaining HP of the Defending Pokémon and Swalot. If the Defending Pokémon has fewer remaining HP than Swalot’s, this attack does 50 damage plus 30 more damage."
       }
     ],
     "weaknesses": [
@@ -2931,7 +2931,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Choose 2 of your opponent's Benched Pokémon. This attack does 10 damage to each of those Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 2 of your opponent’s Benched Pokémon. This attack does 10 damage to each of those Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2973,7 +2973,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Lightning Ball",
@@ -3074,7 +3074,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       },
       {
         "name": "Rage",
@@ -3962,7 +3962,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Freefloating",
-      "text": "If Tentacool has no Energy attached to it, Tentacool's Retreat Cost is 0.",
+      "text": "If Tentacool has no Energy attached to it, Tentacool’s Retreat Cost is 0.",
       "type": "Poké-Body"
     },
     "hp": "50",
@@ -4276,7 +4276,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 card from your opponent's hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
+        "text": "Choose 1 card from your opponent’s hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
       }
     ],
     "weaknesses": [
@@ -4305,7 +4305,7 @@
     "set": "Hidden Legends",
     "setCode": "ex5",
     "text": [
-      "Attach this card to 1 of your Evolved Pokémon (excluding Pokémon-ex and Pokémon that has an owner in its name) in play. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Ancient Technical Machine (Ice)."
+      "Attach this card to 1 of your Evolved Pokémon (excluding Pokémon-ex and Pokémon that has an owner in its name) in play. That Pokémon may use this card’s attack instead of its own. At the end of your turn, discard Ancient Technical Machine (Ice)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex5/84_hires.png"
   },
@@ -4323,7 +4323,7 @@
     "set": "Hidden Legends",
     "setCode": "ex5",
     "text": [
-      "Attach this card to 1 of your Evolved Pokémon (excluding Pokémon-ex and Pokémon that has an owner in its name) in play. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Ancient Technical Machine (Rock)."
+      "Attach this card to 1 of your Evolved Pokémon (excluding Pokémon-ex and Pokémon that has an owner in its name) in play. That Pokémon may use this card’s attack instead of its own. At the end of your turn, discard Ancient Technical Machine (Rock)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex5/85_hires.png"
   },
@@ -4341,7 +4341,7 @@
     "set": "Hidden Legends",
     "setCode": "ex5",
     "text": [
-      "Attach this card to 1 of your Evolved Pokémon (excluding Pokémon-ex and Pokémon that has an owner in its name) in play. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Ancient Technical Machine (Steel)."
+      "Attach this card to 1 of your Evolved Pokémon (excluding Pokémon-ex and Pokémon that has an owner in its name) in play. That Pokémon may use this card’s attack instead of its own. At the end of your turn, discard Ancient Technical Machine (Steel)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex5/86_hires.png"
   },
@@ -4359,7 +4359,7 @@
     "set": "Hidden Legends",
     "setCode": "ex5",
     "text": [
-      "Don't apply Weakness for all Pokémon in play (excluding Pokémon-ex and Pokémon that has an owner in its name).",
+      "Don’t apply Weakness for all Pokémon in play (excluding Pokémon-ex and Pokémon that has an owner in its name).",
       "This card stays in play when you play it. Discard this card if another Stadium card comes into play."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex5/87_hires.png"
@@ -4434,14 +4434,14 @@
     "set": "Hidden Legends",
     "setCode": "ex5",
     "text": [
-      "Any damage done by attacks from Psychic Pokémon and Fighting Pokémon (both yours and your opponent's) is not affected by Resistance.\"",
+      "Any damage done by attacks from Psychic Pokémon and Fighting Pokémon (both yours and your opponent’s) is not affected by Resistance.\"",
       "This card stays in play when you play it. Discard this card if another Stadium card comes into play."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex5/91_hires.png"
   },
   {
     "id": "ex5-92",
-    "name": "Steven's Advice",
+    "name": "Steven’s Advice",
     "imageUrl": "https://images.pokemontcg.io/ex5/92.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4453,7 +4453,7 @@
     "set": "Hidden Legends",
     "setCode": "ex5",
     "text": [
-      "Draw a number of cards up to the number of your opponent's Pokémon in play. If you have more than 7 cards (including this one) in your hand you can't play this card.\"\"",
+      "Draw a number of cards up to the number of your opponent’s Pokémon in play. If you have more than 7 cards (including this one) in your hand you can’t play this card.\"\"",
       "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex5/92_hires.png"
@@ -4467,7 +4467,7 @@
     "level": "ex",
     "ability": {
       "name": "Mark of Antiquity",
-      "text": "As long as Groudon ex is your Active Pokémon, each player's Kyogre ex and Rayquaza ex can't attack.",
+      "text": "As long as Groudon ex is your Active Pokémon, each player’s Kyogre ex and Rayquaza ex can’t attack.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -4494,7 +4494,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "This attack's damage is not affected by Resistance."
+        "text": "This attack’s damage is not affected by Resistance."
       },
       {
         "name": "Crushing Mantle",
@@ -4526,7 +4526,7 @@
     "level": "ex",
     "ability": {
       "name": "Mark of Antiquity",
-      "text": "As long as Kyogre ex is your Active Pokémon, each player's Groudon ex and Rayquaza ex can't attack.",
+      "text": "As long as Kyogre ex is your Active Pokémon, each player’s Groudon ex and Rayquaza ex can’t attack.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -4553,7 +4553,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Super Tidal Wave",
@@ -4609,7 +4609,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Before doing damage, you may choose 1 of your opponent's Benched Pokémon and switch it with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. If you do, this attack does 40 damage to the new Defending Pokémon."
+        "text": "Before doing damage, you may choose 1 of your opponent’s Benched Pokémon and switch it with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. If you do, this attack does 40 damage to the new Defending Pokémon."
       },
       {
         "name": "Extra Comet Punch",
@@ -4672,7 +4672,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. The new Defending Pokémon is now Burned and Confused."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. The new Defending Pokémon is now Burned and Confused."
       },
       {
         "name": "Fire Blast",
@@ -4732,7 +4732,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Flip a coin. If heads, your opponent can't attach Energy cards from his or her hand to the Defending Pokémon during his or her next turn."
+        "text": "Flip a coin. If heads, your opponent can’t attach Energy cards from his or her hand to the Defending Pokémon during his or her next turn."
       }
     ],
     "weaknesses": [
@@ -4829,7 +4829,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Does 20 damage to each of your opponent's Benched Pokémon of the same type as the Defending Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to each of your opponent’s Benched Pokémon of the same type as the Defending Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4857,7 +4857,7 @@
     "evolvesFrom": "Gloom",
     "ability": {
       "name": "Block Dust",
-      "text": "As long as Vileplume ex is your Active Pokémon, your opponent can't play any Trainer cards (except for Supporter cards) from his or her hand.",
+      "text": "As long as Vileplume ex is your Active Pokémon, your opponent can’t play any Trainer cards (except for Supporter cards) from his or her hand.",
       "type": "Poké-Body"
     },
     "hp": "140",

--- a/json/cards/Holon Phantoms.json
+++ b/json/cards/Holon Phantoms.json
@@ -31,7 +31,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "70",
-        "text": "If you have any Supporter cards in play, this attack's base damage is 20 instead of 70."
+        "text": "If you have any Supporter cards in play, this attack’s base damage is 20 instead of 70."
       },
       {
         "name": "Fossil Charge",
@@ -42,7 +42,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "You may discard a Claw Fossil, Mysterious Fossil, Root Fossil, or Holon Fossil from your hand. If you do, choose 1 of your opponent's Benched Pokémon and do 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "You may discard a Claw Fossil, Mysterious Fossil, Root Fossil, or Holon Fossil from your hand. If you do, choose 1 of your opponent’s Benched Pokémon and do 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -85,7 +85,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Put 5 damage counters on the Defending Pokémon at the end of your opponent's next turn."
+        "text": "Put 5 damage counters on the Defending Pokémon at the end of your opponent’s next turn."
       },
       {
         "name": "Poison Tentacles",
@@ -116,7 +116,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Form Change",
-      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys and switch it with Deoxys. (Any cards attached to Deoxys, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys on top of your deck. Shuffle your deck afterward. You can't use more than 1 Form Change Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys and switch it with Deoxys. (Any cards attached to Deoxys, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Form Change Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -162,7 +162,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Form Change",
-      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys and switch it with Deoxys. (Any cards attached to Deoxys, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys on top of your deck. Shuffle your deck afterward. You can't use more than 1 Form Change Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys and switch it with Deoxys. (Any cards attached to Deoxys, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Form Change Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -188,7 +188,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "During your opponent's next turn, any damage done to Deoxys by attacks is reduced by 30 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Deoxys by attacks is reduced by 30 (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -208,7 +208,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Form Change",
-      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys and switch it with Deoxys. (Any cards attached to Deoxys, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys on top of your deck. Shuffle your deck afterward. You can't use more than 1 Form Change Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys and switch it with Deoxys. (Any cards attached to Deoxys, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Form Change Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -233,7 +233,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "During your next turn, Deoxys's attacks do 40 more damage to the Defending Pokémon (before applying Weakness and Resistance)."
+        "text": "During your next turn, Deoxys’s attacks do 40 more damage to the Defending Pokémon (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -253,7 +253,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Form Change",
-      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys and switch it with Deoxys. (Any cards attached to Deoxys, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys on top of your deck. Shuffle your deck afterward. You can't use more than 1 Form Change Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys and switch it with Deoxys. (Any cards attached to Deoxys, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Form Change Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -298,7 +298,7 @@
     "evolvesFrom": "Vibrava",
     "ability": {
       "name": "Delta Supply",
-      "text": "Once during your turn (before your attack), you may attach a basic Energy card or a δ Rainbow Energy card from your hand to 1 of your Pokémon that has δ on its card. This power can't be used if Flygon is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may attach a basic Energy card or a δ Rainbow Energy card from your hand to 1 of your Pokémon that has δ on its card. This power can’t be used if Flygon is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -326,7 +326,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -470,7 +470,7 @@
     "evolvesFrom": "Seadra",
     "ability": {
       "name": "Dragon Curse",
-      "text": "Once during your turn (before your attack), if Kingdra is your Active Pokémon, you may put 2 damage counters on 1 of your opponent's Pokémon with δ on its card. This power can't be used if Kingdra is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Kingdra is your Active Pokémon, you may put 2 damage counters on 1 of your opponent’s Pokémon with δ on its card. This power can’t be used if Kingdra is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -529,7 +529,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Dual Aura",
-      "text": "As long as you have Latios or Latios ex in play, each player's Evolved Pokémon (excluding Pokémon-ex) can't use any Poké-Bodies.",
+      "text": "As long as you have Latios or Latios ex in play, each player’s Evolved Pokémon (excluding Pokémon-ex) can’t use any Poké-Bodies.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -594,7 +594,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Dual Aura (Duaru oora)",
-      "text": "As long as you have Latias or Latias ex in play, each player's Evolved Pokémon (excluding Pokémon-ex) can't use any Poké-Bodies.",
+      "text": "As long as you have Latias or Latias ex in play, each player’s Evolved Pokémon (excluding Pokémon-ex) can’t use any Poké-Bodies.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -692,7 +692,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
-        "text": "Does 30 damage plus 10 more damage for each Omanyte, Omastar, Kabuto, Kabutops, and Kabutops ex in your discard pile. You can't add more than 60 damage in this way."
+        "text": "Does 30 damage plus 10 more damage for each Omanyte, Omastar, Kabuto, Kabutops, and Kabutops ex in your discard pile. You can’t add more than 60 damage in this way."
       }
     ],
     "weaknesses": [
@@ -713,7 +713,7 @@
     "evolvesFrom": "Pidgeotto",
     "ability": {
       "name": "Delta Reserve",
-      "text": "As long as Pidgeot has any Holon Energy cards attached to it, each player's Pokémon (excluding Pokémon that has δ on its card) can't use any Poké-Powers.",
+      "text": "As long as Pidgeot has any Holon Energy cards attached to it, each player’s Pokémon (excluding Pokémon that has δ on its card) can’t use any Poké-Powers.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -783,7 +783,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Does 20 damage to each Pokémon that has any Poké-Powers or Poké-Bodies (both yours and your opponent's). Don't apply Weakness or Resistance."
+        "text": "Does 20 damage to each Pokémon that has any Poké-Powers or Poké-Bodies (both yours and your opponent’s). Don’t apply Weakness or Resistance."
       },
       {
         "name": "Metallic Thunder",
@@ -794,7 +794,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "You may discard 2 Metal Energy attached to Raichu. If you do, this attack's base damage is 90 instead of 50."
+        "text": "You may discard 2 Metal Energy attached to Raichu. If you do, this attack’s base damage is 90 instead of 50."
       }
     ],
     "weaknesses": [
@@ -883,7 +883,7 @@
     "evolvesFrom": "Gloom",
     "ability": {
       "name": "Poison Pollen",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, choose 1 of the Defending Pokémon. That Pokémon is now Poisoned. This power can't be used if Vileplume is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, choose 1 of the Defending Pokémon. That Pokémon is now Poisoned. This power can’t be used if Vileplume is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -909,7 +909,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "Look at your opponent's hand. This attack does 30 damage plus 10 more damage for each Trainer card in your opponent's hand."
+        "text": "Look at your opponent’s hand. This attack does 30 damage plus 10 more damage for each Trainer card in your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -948,7 +948,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at the top 5 cards of either player's deck and put them back on top of that player's deck in any order."
+        "text": "Look at the top 5 cards of either player’s deck and put them back on top of that player’s deck in any order."
       },
       {
         "name": "Overrun",
@@ -958,7 +958,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Choose 1 of your opponent's Benched Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Benched Pokémon. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1010,7 +1010,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "During your opponent's next turn, Bellossom has no Weakness."
+        "text": "During your opponent’s next turn, Bellossom has no Weakness."
       }
     ],
     "weaknesses": [
@@ -1230,7 +1230,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
       },
       {
         "name": "Surprise",
@@ -1240,7 +1240,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Choose 1 card from your opponent's hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
+        "text": "Choose 1 card from your opponent’s hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
       }
     ],
     "weaknesses": [
@@ -1285,7 +1285,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Swift",
@@ -1296,7 +1296,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
       }
     ],
     "weaknesses": [
@@ -1345,7 +1345,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Does 10 damage to 2 of your opponent's Benched Pokémon (1 if there is only 1). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 2 of your opponent’s Benched Pokémon (1 if there is only 1). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1420,7 +1420,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Clear Body",
-      "text": "Regice can't be affected by any Special Conditions.",
+      "text": "Regice can’t be affected by any Special Conditions.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -1467,7 +1467,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Clear Body",
-      "text": "Regirock can't be affected by any Special Conditions.",
+      "text": "Regirock can’t be affected by any Special Conditions.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -1494,7 +1494,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Does 10 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1514,7 +1514,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Clear Body",
-      "text": "Registeel can't be affected by any Special Conditions.",
+      "text": "Registeel can’t be affected by any Special Conditions.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -1641,7 +1641,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Choose 1 card from your opponent's hand without looking and discard it."
+        "text": "Choose 1 card from your opponent’s hand without looking and discard it."
       }
     ],
     "resistances": [
@@ -1812,7 +1812,7 @@
     "evolvesFrom": "Mysterious Fossil",
     "ability": {
       "name": "Primal Light",
-      "text": "Once during your turn (before your attack), you may search your deck for a basic Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward. This power can't be used if Aerodactyl is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may search your deck for a basic Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward. This power can’t be used if Aerodactyl is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -1834,7 +1834,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "During your opponent's next turn, any damage done to Aerodactyl by attacks is reduced by 10 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Aerodactyl by attacks is reduced by 10 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -1882,7 +1882,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent’s). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Take Down",
@@ -1913,7 +1913,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Delta Support",
-      "text": "Once during your turn (before your attack), if you have a Supporter card with Holon in its name in play, you may search your discard pile for a basic Energy card or a δ Rainbow Energy card, show it to your opponent, and put it into your hand. This power can't be used if Chimecho is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if you have a Supporter card with Holon in its name in play, you may search your discard pile for a basic Energy card or a δ Rainbow Energy card, show it to your opponent, and put it into your hand. This power can’t be used if Chimecho is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -1978,7 +1978,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Hyper Beam",
@@ -2084,7 +2084,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       },
       {
         "name": "Double Spin",
@@ -2147,7 +2147,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 2 of your opponent's Pokémon. This attack does 30 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 2 of your opponent’s Pokémon. This attack does 30 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2197,7 +2197,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2222,7 +2222,7 @@
     "evolvesFrom": "Psyduck",
     "ability": {
       "name": "Delta Block",
-      "text": "As long as any Stadium card with Holon in its name is in play, your opponent can't play any Stadium cards from his or her hand.",
+      "text": "As long as any Stadium card with Holon in its name is in play, your opponent can’t play any Stadium cards from his or her hand.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -2247,7 +2247,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "Choose 1 card from your opponent's hand without looking. Look at the card you chose. If that card is a Trainer card, this attack does 30 damage plus 30 more damage, and discard that card. If that card is not a Trainer card, return it to your opponent's hand."
+        "text": "Choose 1 card from your opponent’s hand without looking. Look at the card you chose. If that card is a Trainer card, this attack does 30 damage plus 30 more damage, and discard that card. If that card is not a Trainer card, return it to your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -2261,7 +2261,7 @@
   },
   {
     "id": "ex13-44",
-    "name": "Holon's Castform",
+    "name": "Holon’s Castform",
     "imageUrl": "https://images.pokemontcg.io/ex13/44.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2748,7 +2748,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "If Sharpedo has any Holon Energy cards attached to it, choose 1 card from your opponent's hand without looking and discard it."
+        "text": "If Sharpedo has any Holon Energy cards attached to it, choose 1 card from your opponent’s hand without looking and discard it."
       },
       {
         "name": "Swift Turn",
@@ -2864,7 +2864,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       },
       {
         "name": "Earthquake",
@@ -2875,7 +2875,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3393,7 +3393,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Benched Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Benched Pokémon. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3856,7 +3856,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4216,7 +4216,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -4352,7 +4352,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Mud Slap",
@@ -4392,7 +4392,7 @@
     "setCode": "ex13",
     "text": [
       "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.",
-      "Discard a card from your hand. If you can't discard a card from your hand, you can't play this card. Draw 3 cards. If you discarded a Pokémon that has δ on its card, draw 4 cards instead."
+      "Discard a card from your hand. If you can’t discard a card from your hand, you can’t play this card. Draw 3 cards. If you discarded a Pokémon that has δ on its card, draw 4 cards instead."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/85_hires.png"
   },
@@ -4428,14 +4428,14 @@
     "set": "Holon Phantoms",
     "setCode": "ex13",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "Each player's Pokémon that has δ on its card can use attacks on this card instead of its own."
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
+      "Each player’s Pokémon that has δ on its card can use attacks on this card instead of its own."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/87_hires.png"
   },
   {
     "id": "ex13-88",
-    "name": "Mr. Stone's Project",
+    "name": "Mr. Stone’s Project",
     "imageUrl": "https://images.pokemontcg.io/ex13/88.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4454,7 +4454,7 @@
   },
   {
     "id": "ex13-89",
-    "name": "Professor Cozmo's Discovery",
+    "name": "Professor Cozmo’s Discovery",
     "imageUrl": "https://images.pokemontcg.io/ex13/89.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4503,8 +4503,8 @@
     "set": "Holon Phantoms",
     "setCode": "ex13",
     "text": [
-      "Play Claw Fossil as if it were a Basic Pokémon. While in play, Claw Fossil counts as a Colorless Pokémon (as well as a Trainer card). Claw Fossil has no attacks of its own, can't retreat, and can't be affected by any Special Conditions. If Claw Fossil is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Claw Fossil from play.",
-      "If Claw Fossil is your Active Pokémon and is damaged by an opponent's attack (even if Claw Fossil is Knocked Out), put 1 damage counter on the Attacking Pokémon."
+      "Play Claw Fossil as if it were a Basic Pokémon. While in play, Claw Fossil counts as a Colorless Pokémon (as well as a Trainer card). Claw Fossil has no attacks of its own, can’t retreat, and can’t be affected by any Special Conditions. If Claw Fossil is Knocked Out, it doesn’t count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Claw Fossil from play.",
+      "If Claw Fossil is your Active Pokémon and is damaged by an opponent’s attack (even if Claw Fossil is Knocked Out), put 1 damage counter on the Attacking Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/91_hires.png"
   },
@@ -4522,7 +4522,7 @@
     "set": "Holon Phantoms",
     "setCode": "ex13",
     "text": [
-      "Play Mysterious Fossil as if it were a Basic Pokémon. While in play, Mysterious Fossil counts as a Colorless Pokémon (as well as a Trainer card). Mysterious Fossil has no attacks of its own, can't retreat, and can't be affected by any Special Conditions. If Mysterious Fossil is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Mysterious Fossil from play."
+      "Play Mysterious Fossil as if it were a Basic Pokémon. While in play, Mysterious Fossil counts as a Colorless Pokémon (as well as a Trainer card). Mysterious Fossil has no attacks of its own, can’t retreat, and can’t be affected by any Special Conditions. If Mysterious Fossil is Knocked Out, it doesn’t count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Mysterious Fossil from play."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/92_hires.png"
   },
@@ -4540,7 +4540,7 @@
     "set": "Holon Phantoms",
     "setCode": "ex13",
     "text": [
-      "Play Root Fossil as if it were a Basic Pokémon. While in play, Root Fossil counts as a Colorless Pokémon (as well as a Trainer card). Root Fossil has no attacks of its own, can't retreat, and can't be affected by any Special Conditions. If Root Fossil is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Root Fossil from play.",
+      "Play Root Fossil as if it were a Basic Pokémon. While in play, Root Fossil counts as a Colorless Pokémon (as well as a Trainer card). Root Fossil has no attacks of its own, can’t retreat, and can’t be affected by any Special Conditions. If Root Fossil is Knocked Out, it doesn’t count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Root Fossil from play.",
       "At any time between turns, remove 1 damage counter from Root Fossil."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/93_hires.png"
@@ -4558,7 +4558,7 @@
     "set": "Holon Phantoms",
     "setCode": "ex13",
     "text": [
-      "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect unless the Attacking Pokémon is Darkness or has Dark in its name. Darkness Energy provides Darkness Energy. (Doesn't count as a basic Energy card.)"
+      "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect unless the Attacking Pokémon is Darkness or has Dark in its name. Darkness Energy provides Darkness Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/94_hires.png"
   },
@@ -4575,7 +4575,7 @@
     "set": "Holon Phantoms",
     "setCode": "ex13",
     "text": [
-      "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn't Metal. Metal Energy provides Metal Energy. (Doesn't count as a basic Energy card.)"
+      "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn’t Metal. Metal Energy provides Metal Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/95_hires.png"
   },
@@ -4609,7 +4609,7 @@
     "set": "Holon Phantoms",
     "setCode": "ex13",
     "text": [
-      "Attach Dark Metal Energy to 1 of your Pokémon. While in play, Dark Metal Energy provides Darkness and Metal Energy, but provides only 1 Energy at a time. (Doesn't count as a basic energy card when not in play and has no effect other than providing Energy.)"
+      "Attach Dark Metal Energy to 1 of your Pokémon. While in play, Dark Metal Energy provides Darkness and Metal Energy, but provides only 1 Energy at a time. (Doesn’t count as a basic energy card when not in play and has no effect other than providing Energy.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/97_hires.png"
   },
@@ -4640,7 +4640,7 @@
     "evolvesFrom": "Corphish",
     "ability": {
       "name": "Splash Back",
-      "text": "Once during your turn (before your attack), if your opponent has 4 or more Benched Pokémon, you may choose 1 of them and return that Pokémon and all cards attached to it to his or her hand. This power can't be used if Crawdaunt ex is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if your opponent has 4 or more Benched Pokémon, you may choose 1 of them and return that Pokémon and all cards attached to it to his or her hand. This power can’t be used if Crawdaunt ex is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -4690,7 +4690,7 @@
     "level": "ex",
     "ability": {
       "name": "Psychic Vision",
-      "text": "Once during your turn (before your attack), if Mew ex is on your Bench, you may look at your opponent's hand.",
+      "text": "Once during your turn (before your attack), if Mew ex is on your Bench, you may look at your opponent’s hand.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -4729,7 +4729,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "You may discard 2 Energy attached to Mew ex. If you do, you may remove the highest Stage Evolution card from the Defending Pokémon and shuffle that card into your opponent's deck."
+        "text": "You may discard 2 Energy attached to Mew ex. If you do, you may remove the highest Stage Evolution card from the Defending Pokémon and shuffle that card into your opponent’s deck."
       }
     ],
     "weaknesses": [
@@ -4751,7 +4751,7 @@
     "evolvesFrom": "Poochyena",
     "ability": {
       "name": "Driving Howl",
-      "text": "Once during your turn (before your attack), you may choose 1 of the Defending Pokémon and switch it with 1 of your opponent's Benched Pokémon. Your opponent chooses the Benched Pokémon to switch. This power can't be used if Mightyena ex is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may choose 1 of the Defending Pokémon and switch it with 1 of your opponent’s Benched Pokémon. Your opponent chooses the Benched Pokémon to switch. This power can’t be used if Mightyena ex is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -4823,7 +4823,7 @@
     "set": "Holon Phantoms",
     "setCode": "ex13",
     "text": [
-      "You can't put more than 1 Pokémon Star in your deck."
+      "You can’t put more than 1 Pokémon Star in your deck."
     ],
     "types": [
       "Fire"
@@ -4878,7 +4878,7 @@
     "set": "Holon Phantoms",
     "setCode": "ex13",
     "text": [
-      "You can't have more than 1 Pokémon Star in your deck."
+      "You can’t have more than 1 Pokémon Star in your deck."
     ],
     "types": [
       "Psychic"
@@ -4931,7 +4931,7 @@
     "set": "Holon Phantoms",
     "setCode": "ex13",
     "text": [
-      "You can't have more than 1 Pokémon Star in your deck."
+      "You can’t have more than 1 Pokémon Star in your deck."
     ],
     "types": [
       "Lightning"
@@ -5081,7 +5081,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. Count the amount of Energy attached to that Pokémon. Put that many damage counters on the Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. Count the amount of Energy attached to that Pokémon. Put that many damage counters on the Pokémon."
       }
     ],
     "weaknesses": [

--- a/json/cards/Jungle.json
+++ b/json/cards/Jungle.json
@@ -29,7 +29,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. Metronome copies that attack except for its Energy costs and anything else required in order to use that attack, such as discarding Energy cards. (No matter what type the Defending Pokémon is, Clefable's type is still Colorless.)"
+        "text": "Choose 1 of the Defending Pokémon’s attacks. Metronome copies that attack except for its Energy costs and anything else required in order to use that attack, such as discarding Energy cards. (No matter what type the Defending Pokémon is, Clefable’s type is still Colorless.)"
       },
       {
         "name": "Minimize",
@@ -39,7 +39,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "All damage done by attacks to Clefable during your opponent's next turn is reduce by 20 (after applying Weakness and Resistance)."
+        "text": "All damage done by attacks to Clefable during your opponent’s next turn is reduce by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -98,7 +98,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "If the Defending Pokémon isn't Colorless, this attack does 10 damage to each Benched Pokémon of the same type as the Defending Pokémon (including your own)."
+        "text": "If the Defending Pokémon isn’t Colorless, this attack does 10 damage to each Benched Pokémon of the same type as the Defending Pokémon (including your own)."
       }
     ],
     "weaknesses": [
@@ -287,7 +287,7 @@
     "evolvesFrom": "Mime Jr.",
     "ability": {
       "name": "Invisible Wall",
-      "text": "Whenever an attack (including your own) does 30 or more damage to Mr. Mime (after applying Weakness and Resistance), prevent that damage. (Any other effects of attacks still happen.) This power can't be used if Mr. Mime is Asleep, Confused, or Paralyzed.",
+      "text": "Whenever an attack (including your own) does 30 or more damage to Mr. Mime (after applying Weakness and Resistance), prevent that damage. (Any other effects of attacks still happen.) This power can’t be used if Mr. Mime is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "40",
@@ -418,7 +418,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Unless this attack Knocks Out the Defending Pokémon, return the Defending Pokémon and all cards attached to it to your opponent's hand."
+        "text": "Unless this attack Knocks Out the Defending Pokémon, return the Defending Pokémon and all cards attached to it to your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -514,7 +514,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, Scyther's Slash attack's base damage is 60 instead of 30."
+        "text": "During your next turn, Scyther’s Slash attack’s base damage is 60 instead of 30."
       },
       {
         "name": "Slash",
@@ -556,7 +556,7 @@
     "evolvesFrom": "Munchlax",
     "ability": {
       "name": "Thick Skinned",
-      "text": "Snorlax can't become Asleep, Confused, Paralyzed, or Poisoned. This power can't be used if Snorlax is already Asleep, Confused, or Paralyzed.",
+      "text": "Snorlax can’t become Asleep, Confused, Paralyzed, or Poisoned. This power can’t be used if Snorlax is already Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "90",
@@ -645,7 +645,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
-        "text": "Does 30 damage plus 10 more damage for each Energy attached to Vaporeon but not used to pay for this attack's Energy cost. Extra Energy after the 2nd doesn't count."
+        "text": "Does 30 damage plus 10 more damage for each Energy attached to Vaporeon but not used to pay for this attack’s Energy cost. Extra Energy after the 2nd doesn’t count."
       }
     ],
     "weaknesses": [
@@ -667,7 +667,7 @@
     "evolvesFrom": "Venonat",
     "ability": {
       "name": "Shift",
-      "text": "Once during your turn (before your attack), you may change the type of Venomoth to the type of any other Pokémon in play other than Colorless. This power can't be used if Venomoth is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may change the type of Venomoth to the type of any other Pokémon in play other than Colorless. This power can’t be used if Venomoth is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "70",
@@ -747,7 +747,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -769,7 +769,7 @@
     "evolvesFrom": "Gloom",
     "ability": {
       "name": "Heal",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, remove 1 damage counter from 1 of your Pokémon. This power can't be used if Vileplume is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, remove 1 damage counter from 1 of your Pokémon. This power can’t be used if Vileplume is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "80",
@@ -897,7 +897,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. Metronome copies that attack except for its Energy costs and anything else required in order to use that attack, such as discarding Energy cards. (No matter what type the Defending Pokémon is, Clefable's type is still Colorless.)"
+        "text": "Choose 1 of the Defending Pokémon’s attacks. Metronome copies that attack except for its Energy costs and anything else required in order to use that attack, such as discarding Energy cards. (No matter what type the Defending Pokémon is, Clefable’s type is still Colorless.)"
       },
       {
         "name": "Minimize",
@@ -907,7 +907,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "All damage done by attacks to Clefable during your opponent's next turn is reduce by 20 (after applying Weakness and Resistance)."
+        "text": "All damage done by attacks to Clefable during your opponent’s next turn is reduce by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -966,7 +966,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "If the Defending Pokémon isn't Colorless, this attack does 10 damage to each Benched Pokémon of the same type as the Defending Pokémon (including your own)."
+        "text": "If the Defending Pokémon isn’t Colorless, this attack does 10 damage to each Benched Pokémon of the same type as the Defending Pokémon (including your own)."
       }
     ],
     "weaknesses": [
@@ -1155,7 +1155,7 @@
     "evolvesFrom": "Mime Jr.",
     "ability": {
       "name": "Invisible Wall",
-      "text": "Whenever an attack (including your own) does 30 or more damage to Mr. Mime (after applying Weakness and Resistance), prevent that damage. (Any other effects of attacks still happen.) This power can't be used if Mr. Mime is Asleep, Confused, or Paralyzed.",
+      "text": "Whenever an attack (including your own) does 30 or more damage to Mr. Mime (after applying Weakness and Resistance), prevent that damage. (Any other effects of attacks still happen.) This power can’t be used if Mr. Mime is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "40",
@@ -1286,7 +1286,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Unless this attack Knocks Out the Defending Pokémon, return the Defending Pokémon and all cards attached to it to your opponent's hand."
+        "text": "Unless this attack Knocks Out the Defending Pokémon, return the Defending Pokémon and all cards attached to it to your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -1382,7 +1382,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, Scyther's Slash attack's base damage is 60 instead of 30."
+        "text": "During your next turn, Scyther’s Slash attack’s base damage is 60 instead of 30."
       },
       {
         "name": "Slash",
@@ -1424,7 +1424,7 @@
     "evolvesFrom": "Munchlax",
     "ability": {
       "name": "Thick Skinned",
-      "text": "Snorlax can't become Asleep, Confused, Paralyzed, or Poisoned. This power can't be used if Snorlax is already Asleep, Confused, or Paralyzed.",
+      "text": "Snorlax can’t become Asleep, Confused, Paralyzed, or Poisoned. This power can’t be used if Snorlax is already Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "90",
@@ -1513,7 +1513,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
-        "text": "Does 30 damage plus 10 more damage for each Energy attached to Vaporeon but not used to pay for this attack's Energy cost. Extra Energy after the 2nd doesn't count."
+        "text": "Does 30 damage plus 10 more damage for each Energy attached to Vaporeon but not used to pay for this attack’s Energy cost. Extra Energy after the 2nd doesn’t count."
       }
     ],
     "weaknesses": [
@@ -1535,7 +1535,7 @@
     "evolvesFrom": "Venonat",
     "ability": {
       "name": "Shift",
-      "text": "Once during your turn (before your attack), you may change the type of Venomoth to the type of any other Pokémon in play other than Colorless. This power can't be used if Venomoth is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may change the type of Venomoth to the type of any other Pokémon in play other than Colorless. This power can’t be used if Venomoth is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "70",
@@ -1615,7 +1615,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1637,7 +1637,7 @@
     "evolvesFrom": "Gloom",
     "ability": {
       "name": "Heal",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, remove 1 damage counter from 1 of your Pokémon. This power can't be used if Vileplume is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, remove 1 damage counter from 1 of your Pokémon. This power can’t be used if Vileplume is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "80",
@@ -1923,7 +1923,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Fearow."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Fearow."
       },
       {
         "name": "Drill Peck",
@@ -2108,7 +2108,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Search your deck for a Fighting Basic Pokémon card and put it onto your Bench. Shuffle your deck afterward. (You can't use this attack if your Bench is full.)"
+        "text": "Search your deck for a Fighting Basic Pokémon card and put it onto your Bench. Shuffle your deck afterward. (You can’t use this attack if your Bench is full.)"
       }
     ],
     "weaknesses": [
@@ -2272,7 +2272,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "If the Defending Pokémon attacks Persian during your opponent's next turn, any damage done by the attack is reduce by 10 (after applying Weakness and Resistance). (Benching either Pokémon ends this effect.)"
+        "text": "If the Defending Pokémon attacks Persian during your opponent’s next turn, any damage done by the attack is reduce by 10 (after applying Weakness and Resistance). (Benching either Pokémon ends this effect.)"
       }
     ],
     "weaknesses": [
@@ -2381,7 +2381,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Rapidash."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Rapidash."
       }
     ],
     "weaknesses": [
@@ -2660,7 +2660,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Search your deck for a Basic Pokémon named Bellsprout and put it onto your Bench. Shuffle your deck afterward. (You can't use this attack if your Bench is full.)"
+        "text": "Search your deck for a Basic Pokémon named Bellsprout and put it onto your Bench. Shuffle your deck afterward. (You can’t use this attack if your Bench is full.)"
       }
     ],
     "weaknesses": [
@@ -2703,7 +2703,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the Defending Pokémon attacks Cubone during your opponent's next turn, any damage done by the attack is reduced by 20 (after applying Weakness and Resistance). (Benching either Pokémon ends this effect.)"
+        "text": "If the Defending Pokémon attacks Cubone during your opponent’s next turn, any damage done by the attack is reduced by 20 (after applying Weakness and Resistance). (Benching either Pokémon ends this effect.)"
       },
       {
         "name": "Rage",
@@ -2762,7 +2762,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack Eevee during your opponent's next turn. (Benching either Pokémon ends this effect.)"
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack Eevee during your opponent’s next turn. (Benching either Pokémon ends this effect.)"
       },
       {
         "name": "Quick Attack",
@@ -2961,7 +2961,7 @@
     "level": "7",
     "ability": {
       "name": "Peek",
-      "text": "Once during your turn (before your attack), you may look at one of the following: the top card of either player's deck, a random card from your opponent's hand, or one of either player's Prizes. This power can't be used if Mankey is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may look at one of the following: the top card of either player’s deck, a random card from your opponent’s hand, or one of either player’s Prizes. This power can’t be used if Mankey is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "30",
@@ -3085,7 +3085,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Search your deck for a Basic Pokémon named Nidoran M or Nidoran F and put it onto your Bench. Shuffle your deck afterward. (You can't use this attack if your Bench is full.)"
+        "text": "Search your deck for a Basic Pokémon named Nidoran M or Nidoran F and put it onto your Bench. Shuffle your deck afterward. (You can’t use this attack if your Bench is full.)"
       }
     ],
     "weaknesses": [
@@ -3138,7 +3138,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Search your deck for a Basic Pokémon named Oddish and put it onto your Bench. Shuffle your deck afterward. (You can't use this attack if your Bench is full.)"
+        "text": "Search your deck for a Basic Pokémon named Oddish and put it onto your Bench. Shuffle your deck afterward. (You can’t use this attack if your Bench is full.)"
       }
     ],
     "weaknesses": [
@@ -3237,7 +3237,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3282,7 +3282,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack Rhyhorn during your opponent's next turn. (Benching either Pokémon ends this effect.)"
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack Rhyhorn during your opponent’s next turn. (Benching either Pokémon ends this effect.)"
       },
       {
         "name": "Horn Attack",

--- a/json/cards/Kalos Starter Set.json
+++ b/json/cards/Kalos Starter Set.json
@@ -26,7 +26,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -701,7 +701,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "40",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Aqua Edge",
@@ -997,7 +997,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Metal Claw",
@@ -1585,7 +1585,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Sharp Fang",
@@ -1636,7 +1636,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Sharp Fang",
@@ -1672,7 +1672,7 @@
     "set": "Kalos Starter Set",
     "setCode": "xy0",
     "text": [
-      "Flip a coin. If heads, discard an Energy attached to 1 of your opponent's Pokémon."
+      "Flip a coin. If heads, discard an Energy attached to 1 of your opponent’s Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy0/34_hires.png"
   },
@@ -1706,7 +1706,7 @@
     "set": "Kalos Starter Set",
     "setCode": "xy0",
     "text": [
-      "Flip a coin. If heads, switch 1 of your opponent's Benched Pokémon with his or her Active Pokémon."
+      "Flip a coin. If heads, switch 1 of your opponent’s Benched Pokémon with his or her Active Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy0/36_hires.png"
   },

--- a/json/cards/Legend Maker.json
+++ b/json/cards/Legend Maker.json
@@ -8,7 +8,7 @@
     "evolvesFrom": "Mysterious Fossil",
     "ability": {
       "name": "Reactive Protection",
-      "text": "Any damage done to Aerodactyl by attacks from your opponent's Pokémon is reduced by 10 for each React Energy card attached to Aerodactyl (after applying Weakness and Resistance).",
+      "text": "Any damage done to Aerodactyl by attacks from your opponent’s Pokémon is reduced by 10 for each React Energy card attached to Aerodactyl (after applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -40,7 +40,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "During your opponent's next turn, prevent all effects, including damage, done to Aerodactyl by attacks from your opponent's Pokémon-ex."
+        "text": "During your opponent’s next turn, prevent all effects, including damage, done to Aerodactyl by attacks from your opponent’s Pokémon-ex."
       }
     ],
     "weaknesses": [
@@ -103,7 +103,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 60 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) During your next turn, Aggron can't use Bound Crush."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 60 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) During your next turn, Aggron can’t use Bound Crush."
       }
     ],
     "weaknesses": [
@@ -151,7 +151,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Count the number of React Energy cards attached to Cradily and choose up to that number of your opponent's Evolved Pokémon. Remove the highest Stage Evolution card from each of those Pokémon, then have your opponent shuffle those cards into his or her deck."
+        "text": "Count the number of React Energy cards attached to Cradily and choose up to that number of your opponent’s Evolved Pokémon. Remove the highest Stage Evolution card from each of those Pokémon, then have your opponent shuffle those cards into his or her deck."
       },
       {
         "name": "Linear Attack",
@@ -161,7 +161,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Mud Shot",
@@ -193,7 +193,7 @@
     "evolvesFrom": "Skitty",
     "ability": {
       "name": "Reactive Shift",
-      "text": "Once during your turn (before your attack), you may move a React Energy card attached to 1 of your Pokémon to another of your Pokémon. This power can't be used if Delcatty is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may move a React Energy card attached to 1 of your Pokémon to another of your Pokémon. This power can’t be used if Delcatty is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -249,7 +249,7 @@
     "evolvesFrom": "Haunter",
     "ability": {
       "name": "Shadow Curse",
-      "text": "If Gengar would be Knocked Out by damage from an opponent's attack, you may put 3 damage counters on 1 of your opponent's Pokémon.",
+      "text": "If Gengar would be Knocked Out by damage from an opponent’s attack, you may put 3 damage counters on 1 of your opponent’s Pokémon.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -273,7 +273,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 2 damage counters on your opponent's Pokémon in any way you like. If Gengar has any React Energy cards attached to it, put 4 damage counters instead."
+        "text": "Put 2 damage counters on your opponent’s Pokémon in any way you like. If Gengar has any React Energy cards attached to it, put 4 damage counters instead."
       },
       {
         "name": "Super Psy Bolt",
@@ -342,7 +342,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage for each damage counter on Golem to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage for each damage counter on Golem to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Rock Tumble",
@@ -354,7 +354,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "70",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -530,7 +530,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Type Change",
-      "text": "Once during your turn (before your attack), you may choose 1 of the Defending Pokémon. Mew is the same type as that Pokémon (all if that Pokémon is more than 1 type) until the end of your turn. This power can't be used if Mew is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may choose 1 of the Defending Pokémon. Mew is the same type as that Pokémon (all if that Pokémon is more than 1 type) until the end of your turn. This power can’t be used if Mew is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -555,7 +555,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "If Mew and the Defending Pokémon have a different amount of Energy attached to them, this attack's base damage is 20 instead of 50."
+        "text": "If Mew and the Defending Pokémon have a different amount of Energy attached to them, this attack’s base damage is 20 instead of 50."
       }
     ],
     "weaknesses": [
@@ -576,7 +576,7 @@
     "evolvesFrom": "Grimer",
     "ability": {
       "name": "Stench",
-      "text": "As long as Muk is your Active Pokémon, each player's Pokémon can't use any Poké-Powers.",
+      "text": "As long as Muk is your Active Pokémon, each player’s Pokémon can’t use any Poké-Powers.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -602,7 +602,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "The Defending Pokémon is now Poisoned. The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon is now Poisoned. The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Sludge Toss",
@@ -697,7 +697,7 @@
     "evolvesFrom": "Weepinbell",
     "ability": {
       "name": "Nectar Pod",
-      "text": "Once during your turn (before your attack), you may switch 1 of your opponent's Benched Stage 2 Evolved Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. This power can't be used if Victreebel is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may switch 1 of your opponent’s Benched Stage 2 Evolved Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. This power can’t be used if Victreebel is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -816,7 +816,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shining Horn",
-      "text": "As long as Absol is the only Pokémon you have in play, your opponent's Basic Pokémon can't attack.",
+      "text": "As long as Absol is the only Pokémon you have in play, your opponent’s Basic Pokémon can’t attack.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -850,7 +850,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
       }
     ],
     "weaknesses": [
@@ -876,7 +876,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Rear Sensor",
-      "text": "Each player's Active Basic Pokémon (excluding Pokémon-ex) can't use any Poké-Powers.",
+      "text": "Each player’s Active Basic Pokémon (excluding Pokémon-ex) can’t use any Poké-Powers.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -900,7 +900,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at the top 5 cards of either player's deck and put them back on top of that player's deck in any order you like."
+        "text": "Look at the top 5 cards of either player’s deck and put them back on top of that player’s deck in any order you like."
       },
       {
         "name": "Disorder",
@@ -953,7 +953,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "Does 30 damage plus 20 more damage for each Water Energy attached to Gorebyss but not used to pay for this attack's Energy cost. You can't add more than 40 damage in this way."
+        "text": "Does 30 damage plus 20 more damage for each Water Energy attached to Gorebyss but not used to pay for this attack’s Energy cost. You can’t add more than 40 damage in this way."
       }
     ],
     "weaknesses": [
@@ -974,7 +974,7 @@
     "evolvesFrom": "Clamperl",
     "ability": {
       "name": "Reactive Generator",
-      "text": "Once during your turn (before your attack), if Huntail has no React Energy cards attached to it, you may search your deck for a React Energy card and attach it to Huntail. Shuffle your deck afterward. This power can't be used if Huntail is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Huntail has no React Energy cards attached to it, you may search your deck for a React Energy card and attach it to Huntail. Shuffle your deck afterward. This power can’t be used if Huntail is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -1058,7 +1058,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40+",
-        "text": "Does 40 damage plus 20 more damage for each Water Energy attached to Lanturn but not used to pay for this attack's Energy cost. You can't add more then 40 damage in this way."
+        "text": "Does 40 damage plus 20 more damage for each Water Energy attached to Lanturn but not used to pay for this attack’s Energy cost. You can’t add more then 40 damage in this way."
       }
     ],
     "weaknesses": [
@@ -1078,7 +1078,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Sol Shade",
-      "text": "As long as you have Solrock in play, each player's Fire Pokémon (excluding Pokémon-ex) can't use any Poké-Powers.",
+      "text": "As long as you have Solrock in play, each player’s Fire Pokémon (excluding Pokémon-ex) can’t use any Poké-Powers.",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -1155,7 +1155,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Burning Sensation",
@@ -1190,7 +1190,7 @@
     "evolvesFrom": "Magnemite",
     "ability": {
       "name": "Reactive Recharge",
-      "text": "If Magneton would be Knocked Out by damage from an opponent's attack, you may move any number of React Energy cards from Magneton to your Pokémon in any way you like.",
+      "text": "If Magneton would be Knocked Out by damage from an opponent’s attack, you may move any number of React Energy cards from Magneton to your Pokémon in any way you like.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -1215,7 +1215,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "If Magneton has any React Energy cards attached to it, this attack does 30 damage plus 10 more damage for each Magnemite and Magneton (both yours and your opponent's) in play."
+        "text": "If Magneton has any React Energy cards attached to it, this attack does 30 damage plus 10 more damage for each Magnemite and Magneton (both yours and your opponent’s) in play."
       },
       {
         "name": "Magnetic Blast",
@@ -1257,7 +1257,7 @@
     "evolvesFrom": "Omanyte",
     "ability": {
       "name": "Ancient Fang",
-      "text": "As long as you have Kabuto, Kabutops, or Kabutops ex in play, Omastar's attacks do 20 more damage to the Defending Pokémon (before applying Weakness and Resistance).",
+      "text": "As long as you have Kabuto, Kabutops, or Kabutops ex in play, Omastar’s attacks do 20 more damage to the Defending Pokémon (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -1281,7 +1281,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Before doing damage, you may choose 1 of your opponent's Benched Pokémon and switch it with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
+        "text": "Before doing damage, you may choose 1 of your opponent’s Benched Pokémon and switch it with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
       },
       {
         "name": "Hydro Splash",
@@ -1312,7 +1312,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shining Horn",
-      "text": "As long as Pinsir is the only Pokémon you have in play, your opponent's Basic Pokémon can't attack.",
+      "text": "As long as Pinsir is the only Pokémon you have in play, your opponent’s Basic Pokémon can’t attack.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -1346,7 +1346,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Does 20 damage to 1 of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1366,7 +1366,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Luna Shade",
-      "text": "As long as you have Lunatone in play, each player's Colorless Pokémon (excluding Pokémon-ex) can't use any Poké-Powers.",
+      "text": "As long as you have Lunatone in play, each player’s Colorless Pokémon (excluding Pokémon-ex) can’t use any Poké-Powers.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -1419,7 +1419,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Pattern Distraction",
-      "text": "As long as Spinda is your Active Pokémon, whenever your opponent's Basic Pokémon tries to attack, your opponent flips a coin. If tails, that attack does nothing. You can't use more than 1 Pattern Distraction Poké-Body each turn.",
+      "text": "As long as Spinda is your Active Pokémon, whenever your opponent’s Basic Pokémon tries to attack, your opponent flips a coin. If tails, that attack does nothing. You can’t use more than 1 Pattern Distraction Poké-Body each turn.",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -1559,7 +1559,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Put 7 damage counters on the Defending Pokémon at the end of your opponent's next turn."
+        "text": "Put 7 damage counters on the Defending Pokémon at the end of your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1609,7 +1609,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If Anorith has any React Energy cards attached to it, this attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If Anorith has any React Energy cards attached to it, this attack does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1633,7 +1633,7 @@
     "evolvesFrom": "Wurmple",
     "ability": {
       "name": "Emerge",
-      "text": "Once during your turn (before your attack), if Cascoon is your Active Pokémon, you may flip a coin. If heads, search your deck for a card that evolves from Cascoon and put it onto Cascoon. (This counts as evolving Cascoon.) Shuffle your deck afterward. This power can't be used if Cascoon is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Cascoon is your Active Pokémon, you may flip a coin. If heads, search your deck for a card that evolves from Cascoon and put it onto Cascoon. (This counts as evolving Cascoon.) Shuffle your deck afterward. This power can’t be used if Cascoon is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -1682,7 +1682,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Deadlock",
-      "text": "As long as Dunsparce is your Active Pokémon, your opponent's Dunsparce can't attack.",
+      "text": "As long as Dunsparce is your Active Pokémon, your opponent’s Dunsparce can’t attack.",
       "type": "Poké-Body"
     },
     "hp": "50",
@@ -1863,7 +1863,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Does 10 damage to 2 of your opponent's Benched Pokémon (1 if there is only 1). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 2 of your opponent’s Benched Pokémon (1 if there is only 1). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1973,7 +1973,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "During your opponent's next turn, any damage done to Kabuto by attacks is reduced by 10 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Kabuto by attacks is reduced by 10 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -2020,7 +2020,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Quick Attack",
@@ -2112,7 +2112,7 @@
     "evolvesFrom": "Machop",
     "ability": {
       "name": "Paranoid",
-      "text": "As long as Machoke is Confused, Machoke's attacks do 50 more damage to the Defending Pokémon (before applying Weakness and Resistance).",
+      "text": "As long as Machoke is Confused, Machoke’s attacks do 50 more damage to the Defending Pokémon (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -2291,7 +2291,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Reactive Aroma",
-      "text": "As long as Roselia has any React Energy cards attached to it, remove 1 damage counter from each of your Pokémon (excluding Pokémon-ex) that has any React Energy cards attached to it between turns. You can't use more than 1 Reactive Aroma Poké-Body each turn.",
+      "text": "As long as Roselia has any React Energy cards attached to it, remove 1 damage counter from each of your Pokémon (excluding Pokémon-ex) that has any React Energy cards attached to it between turns. You can’t use more than 1 Reactive Aroma Poké-Body each turn.",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -2315,7 +2315,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. The new Defending Pokémon is now Poisoned."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. The new Defending Pokémon is now Poisoned."
       }
     ],
     "weaknesses": [
@@ -2339,7 +2339,7 @@
     "evolvesFrom": "Spheal",
     "ability": {
       "name": "Power Circulation",
-      "text": "Once during your turn (before your attack), you may search your discard pile for a basic Energy card, show it to your opponent, and put it on top of your deck. If you do, put 1 damage counter on Sealeo. This power can't be used if Sealeo is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may search your discard pile for a basic Energy card, show it to your opponent, and put it on top of your deck. If you do, put 1 damage counter on Sealeo. This power can’t be used if Sealeo is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -2411,7 +2411,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If the Defending Pokémon is a Basic Pokémon, that Pokémon can't attack during your opponent's next turn."
+        "text": "If the Defending Pokémon is a Basic Pokémon, that Pokémon can’t attack during your opponent’s next turn."
       },
       {
         "name": "Gentle Wrap",
@@ -2422,7 +2422,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2452,7 +2452,7 @@
     "evolvesFrom": "Tentacool",
     "ability": {
       "name": "Reactive Shield",
-      "text": "As long as Tentacruel has any React Energy cards attached to it, prevent all effects, including damage, done to any of your Tentacruel in play by attacks from your opponent's Pokémon-ex.",
+      "text": "As long as Tentacruel has any React Energy cards attached to it, prevent all effects, including damage, done to any of your Tentacruel in play by attacks from your opponent’s Pokémon-ex.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -2473,7 +2473,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Fury Strikes",
@@ -2731,7 +2731,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Lightning Ball",
@@ -2783,7 +2783,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Clamperl during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Clamperl during your opponent’s next turn."
       },
       {
         "name": "Clamp Splash",
@@ -2893,7 +2893,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.) Geodude does 50 damage to itself."
+        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent’s). (Don’t apply Weakness and Resistance for Benched Pokémon.) Geodude does 50 damage to itself."
       }
     ],
     "weaknesses": [
@@ -3093,7 +3093,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3212,7 +3212,7 @@
     "evolvesFrom": "Mysterious Fossil",
     "ability": {
       "name": "Ancient Tentacles",
-      "text": "Damage done to your opponent's Pokémon by your Omanyte, Omastar, Kabuto, Kabutops, or Kabutops ex isn't affected by Resistance.",
+      "text": "Damage done to your opponent’s Pokémon by your Omanyte, Omastar, Kabuto, Kabutops, or Kabutops ex isn’t affected by Resistance.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -3236,7 +3236,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Damage done to your opponent's Pokémon by your Omanyte, Omastar, Kabuto, Kabutops, or Kabutops ex isn't affected by Resistance."
+        "text": "Damage done to your opponent’s Pokémon by your Omanyte, Omastar, Kabuto, Kabutops, or Kabutops ex isn’t affected by Resistance."
       },
       {
         "name": "Rising Lunge",
@@ -3586,7 +3586,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Benched Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Benched Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Double Pinchers",
@@ -3727,7 +3727,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Poison Payback",
-      "text": "If Wurmple is your Active Pokémon and is damaged by an opponent's attack (even if Wurmple is Knocked Out), the Attacking Pokémon is now Poisoned.",
+      "text": "If Wurmple is your Active Pokémon and is damaged by an opponent’s attack (even if Wurmple is Knocked Out), the Attacking Pokémon is now Poisoned.",
       "type": "Poké-Body"
     },
     "hp": "50",
@@ -3751,7 +3751,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
       }
     ],
     "weaknesses": [
@@ -3828,7 +3828,7 @@
     "set": "Legend Maker",
     "setCode": "ex12",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
       "At any time between turns, each player puts 1 damage counter on his or her Pokémon that has a Poké-Power."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex12/72_hires.png"
@@ -3866,8 +3866,8 @@
     "set": "Legend Maker",
     "setCode": "ex12",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "Put 4 damage counters instead of 2 on each Burned Pokémon between turns. The Special Condition Burned can't be removed by evolving or devolving the Burned Pokémon."
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
+      "Put 4 damage counters instead of 2 on each Burned Pokémon between turns. The Special Condition Burned can’t be removed by evolving or devolving the Burned Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex12/74_hires.png"
   },
@@ -3885,8 +3885,8 @@
     "set": "Legend Maker",
     "setCode": "ex12",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "Each player can't have more than 3 Benched Pokémon. When Giant Stump comes into play, each player discards Benched Pokémon and any cards attached to them until he or she has 3 Benched Pokémon. (You discard your Pokémon first.)"
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
+      "Each player can’t have more than 3 Benched Pokémon. When Giant Stump comes into play, each player discards Benched Pokémon and any cards attached to them until he or she has 3 Benched Pokémon. (You discard your Pokémon first.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex12/75_hires.png"
   },
@@ -3904,8 +3904,8 @@
     "set": "Legend Maker",
     "setCode": "ex12",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "Once during each player's turn, if the player has no Special Energy cards in his or her discard pile, that player searches his or her discard pile for a basic Energy card, shows it to the opponent, and puts it into his or her hand."
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
+      "Once during each player’s turn, if the player has no Special Energy cards in his or her discard pile, that player searches his or her discard pile for a basic Energy card, shows it to the opponent, and puts it into his or her hand."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex12/76_hires.png"
   },
@@ -3923,8 +3923,8 @@
     "set": "Legend Maker",
     "setCode": "ex12",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "Once during each player's turn, that player may put an Omanyte, Kabuto, Aerodactyl, Aerodactyl ex, Lileep, or Anorith onto his or her Bench from his or her hand. Treat the new Benched Pokémon as Basic Pokémon."
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
+      "Once during each player’s turn, that player may put an Omanyte, Kabuto, Aerodactyl, Aerodactyl ex, Lileep, or Anorith onto his or her Bench from his or her hand. Treat the new Benched Pokémon as Basic Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex12/77_hires.png"
   },
@@ -3942,8 +3942,8 @@
     "set": "Legend Maker",
     "setCode": "ex12",
     "text": [
-      "Play Claw Fossil as if it were a Basic Pokémon. While in play, Claw Fossil counts as a Colorless Pokémon (as well as a Trainer card). Claw Fossil has no attacks of its own, can't retreat, and can't be affected by any Special Conditions. If Claw Fossil is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Claw Fossil from play.",
-      "If Claw Fossil is your Active Pokémon and is damaged by an opponent's attack (even if Claw Fossil is Knocked Out), put 1 damage counter on the Attacking Pokémon."
+      "Play Claw Fossil as if it were a Basic Pokémon. While in play, Claw Fossil counts as a Colorless Pokémon (as well as a Trainer card). Claw Fossil has no attacks of its own, can’t retreat, and can’t be affected by any Special Conditions. If Claw Fossil is Knocked Out, it doesn’t count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Claw Fossil from play.",
+      "If Claw Fossil is your Active Pokémon and is damaged by an opponent’s attack (even if Claw Fossil is Knocked Out), put 1 damage counter on the Attacking Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex12/78_hires.png"
   },
@@ -3961,7 +3961,7 @@
     "set": "Legend Maker",
     "setCode": "ex12",
     "text": [
-      "Play Mysterious Fossil as if it were a Basic Pokémon. While in play, Mysterious Fossil counts as a Colorless Pokémon (as well as a Trainer card). Mysterious Fossil has no attacks of its own, can't retreat, and can't be affected by any Special Conditions. If Mysterious Fossil is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Mysterious Fossil from play."
+      "Play Mysterious Fossil as if it were a Basic Pokémon. While in play, Mysterious Fossil counts as a Colorless Pokémon (as well as a Trainer card). Mysterious Fossil has no attacks of its own, can’t retreat, and can’t be affected by any Special Conditions. If Mysterious Fossil is Knocked Out, it doesn’t count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Mysterious Fossil from play."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex12/79_hires.png"
   },
@@ -3979,7 +3979,7 @@
     "set": "Legend Maker",
     "setCode": "ex12",
     "text": [
-      "Play Root Fossil as if it were a Basic Pokémon. While in play, Root Fossil counts as a Colorless Pokémon (as well as a Trainer card). Root Fossil has no attacks of its own, can't retreat, and can't be affected by any Special Conditions. If Root Fossil is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Root Fossil from play.",
+      "Play Root Fossil as if it were a Basic Pokémon. While in play, Root Fossil counts as a Colorless Pokémon (as well as a Trainer card). Root Fossil has no attacks of its own, can’t retreat, and can’t be affected by any Special Conditions. If Root Fossil is Knocked Out, it doesn’t count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Root Fossil from play.",
       "At any time between turns, remove 1 damage counter from Root Fossil."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex12/80_hires.png"
@@ -4066,7 +4066,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4140,7 +4140,7 @@
     "evolvesFrom": "Shuppet",
     "ability": {
       "name": "Shady Move",
-      "text": "Once during your turn (before your attack), if Banette ex is your Active Pokémon, you may move 1 damage counter from either player's Pokémon to another Pokémon (yours or your opponent's). This power can't be used if Banette ex is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Banette ex is your Active Pokémon, you may move 1 damage counter from either player’s Pokémon to another Pokémon (yours or your opponent’s). This power can’t be used if Banette ex is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -4168,7 +4168,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "Does 30 damage plus 10 more damage for each Supporter card in your discard pile. You can't add more than 60 damage in this way."
+        "text": "Does 30 damage plus 10 more damage for each Supporter card in your discard pile. You can’t add more than 60 damage in this way."
       }
     ],
     "weaknesses": [
@@ -4196,7 +4196,7 @@
     "evolvesFrom": "Cascoon",
     "ability": {
       "name": "Safeguard",
-      "text": "Prevent all effects of attacks, including damage, done to Dustox ex by your opponent's Pokémon-ex.",
+      "text": "Prevent all effects of attacks, including damage, done to Dustox ex by your opponent’s Pokémon-ex.",
       "type": "Poké-Body"
     },
     "hp": "140",
@@ -4340,7 +4340,7 @@
     "evolvesFrom": "Sealeo",
     "ability": {
       "name": "Icy Aura",
-      "text": "As long as Walrein ex is your Active Pokémon, put 1 damage count on each Active Pokémon (both yours and your opponent's) between turns, excluding Water Pokémon.",
+      "text": "As long as Walrein ex is your Active Pokémon, put 1 damage count on each Active Pokémon (both yours and your opponent’s) between turns, excluding Water Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "150",
@@ -4370,7 +4370,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 40 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "nationalPokedexNumber": 365,
@@ -4395,7 +4395,7 @@
     "set": "Legend Maker",
     "setCode": "ex12",
     "text": [
-      "You can't have more than 1 Pokémon Star in your deck."
+      "You can’t have more than 1 Pokémon Star in your deck."
     ],
     "types": [
       "Water"
@@ -4408,7 +4408,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Prevent all effects of an attack, including damage, done to Regice Star by your opponent's Pokémon-ex during your opponent's next turn."
+        "text": "Prevent all effects of an attack, including damage, done to Regice Star by your opponent’s Pokémon-ex during your opponent’s next turn."
       },
       {
         "name": "Final Blizzard",
@@ -4419,7 +4419,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "If your opponent has only 1 Prize card left and Regice Star is the only Pokémon you have in play, this attack does 30 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has only 1 Prize card left and Regice Star is the only Pokémon you have in play, this attack does 30 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4450,7 +4450,7 @@
     "set": "Legend Maker",
     "setCode": "ex12",
     "text": [
-      "You can't have more than 1 Pokémon Star in your deck."
+      "You can’t have more than 1 Pokémon Star in your deck."
     ],
     "types": [
       "Fighting"
@@ -4474,7 +4474,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "If your opponent has only 1 Prize card left and Regirock Star is the only Pokémon you have in play, this attack's base damage is 100 instead of 30."
+        "text": "If your opponent has only 1 Prize card left and Regirock Star is the only Pokémon you have in play, this attack’s base damage is 100 instead of 30."
       }
     ],
     "weaknesses": [
@@ -4505,7 +4505,7 @@
     "set": "Legend Maker",
     "setCode": "ex12",
     "text": [
-      "You can't have more than 1 Pokémon Star in your deck."
+      "You can’t have more than 1 Pokémon Star in your deck."
     ],
     "types": [
       "Metal"
@@ -4518,7 +4518,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "During your opponent's next turn, any damage done to Registeel Star by attacks is reduced by 10 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Registeel Star by attacks is reduced by 10 (after applying Weakness and Resistance)."
       },
       {
         "name": "Final Laser",
@@ -4529,7 +4529,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "10",
-        "text": "Put 3 damage counters on your opponent's Pokémon in any way you like. If your opponent has only 1 Prize card left and Registeel Star is the only Pokémon you have in play, put 6 damage counters instead."
+        "text": "Put 3 damage counters on your opponent’s Pokémon in any way you like. If your opponent has only 1 Prize card left and Registeel Star is the only Pokémon you have in play, put 6 damage counters instead."
       }
     ],
     "weaknesses": [

--- a/json/cards/Legendary Collection.json
+++ b/json/cards/Legendary Collection.json
@@ -9,7 +9,7 @@
     "evolvesFrom": "Kadabra",
     "ability": {
       "name": "Damage Swap",
-      "text": "As often as you like during your turn (before your attack), you may move 1 damage counter from one of your Pokémon to another as long as you don't K-O that Pokémon. This power can't be used if Alakazam is Asleep, Confused, or Paralyzed.",
+      "text": "As often as you like during your turn (before your attack), you may move 1 damage counter from one of your Pokémon to another as long as you don’t K-O that Pokémon. This power can’t be used if Alakazam is Asleep, Confused, or Paralyzed.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -92,7 +92,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
-        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Benched Pokémon. If tails, this attack does 10 damage to each of your own Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent’s Benched Pokémon. If tails, this attack does 10 damage to each of your own Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "resistances": [
@@ -114,7 +114,7 @@
     "evolvesFrom": "Charmeleon",
     "ability": {
       "name": "Energy Burn",
-      "text": "As often as you like during your turn (before your attack), you may turn all Energy attached to Charizard into R for the rest of the turn. This power can't be used if Charizard is Asleep, Confused, or Paralyzed.",
+      "text": "As often as you like during your turn (before your attack), you may turn all Energy attached to Charizard into R for the rest of the turn. This power can’t be used if Charizard is Asleep, Confused, or Paralyzed.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -192,7 +192,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "Does 30 damage plus 20 more damage for each W Energy attached to Dark Blastoise but not used to pay for this attack. You can't add more than 40 damage in this way."
+        "text": "Does 30 damage plus 20 more damage for each W Energy attached to Dark Blastoise but not used to pay for this attack. You can’t add more than 40 damage in this way."
       },
       {
         "name": "Rocket Tackle",
@@ -203,7 +203,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Dark Blastoise does 10 damage to itself. Flip a coin. If heads, prevent all damage done to Dark Blastoise during your opponent's next turn. (Any other effects of attacks still happen.)"
+        "text": "Dark Blastoise does 10 damage to itself. Flip a coin. If heads, prevent all damage done to Dark Blastoise during your opponent’s next turn. (Any other effects of attacks still happen.)"
       }
     ],
     "weaknesses": [
@@ -291,7 +291,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, choose 1 of your opponent's Benched Pokémon and switch it with the Defending Pokémon. This attack can't be used if your opponent has no Benched Pokémon."
+        "text": "Flip a coin. If heads, choose 1 of your opponent’s Benched Pokémon and switch it with the Defending Pokémon. This attack can’t be used if your opponent has no Benched Pokémon."
       },
       {
         "name": "Poison Claws",
@@ -350,7 +350,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Flip a coin. If heads, flip another coin. If the second coin is heads, this attack does 20 damage to each of your opponent's Benched Pokémon. If the second coin is tails, this attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon"
+        "text": "Flip a coin. If heads, flip another coin. If the second coin is heads, this attack does 20 damage to each of your opponent’s Benched Pokémon. If the second coin is tails, this attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon"
       }
     ],
     "weaknesses": [
@@ -528,7 +528,7 @@
     "evolvesFrom": "Haunter",
     "ability": {
       "name": "Curse",
-      "text": "Once during your turn (before your attack), you may move 1 damage counter from 1 of your opponent's Pokémon to another (even if it would Knock Out the other Pokémon). This power can't be used if Gengar is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may move 1 damage counter from 1 of your opponent’s Pokémon to another (even if it would Knock Out the other Pokémon). This power can’t be used if Gengar is Asleep, Confused, or Paralyzed.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -554,7 +554,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "resistances": [
@@ -658,7 +658,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 20 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 20 damage to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "High Jump Kick",
@@ -898,7 +898,7 @@
     "evolvesFrom": "Ivysaur",
     "ability": {
       "name": "Energy Trans",
-      "text": "As often as you like during your turn (before attack), you may take 1 Grass Energy card attached to 1 of your Pokémon and attach it to a different one. This power can't be used if Venusaur is Asleep, Confused, or Paralyzed.",
+      "text": "As often as you like during your turn (before attack), you may take 1 Grass Energy card attached to 1 of your Pokémon and attach it to a different one. This power can’t be used if Venusaur is Asleep, Confused, or Paralyzed.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -1150,7 +1150,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "If the Defending Pokémon isn't Colorless, this attack does 10 damage to each Benched Pokémon of the same type as the Defending Pokémon (including your own)."
+        "text": "If the Defending Pokémon isn’t Colorless, this attack does 10 damage to each Benched Pokémon of the same type as the Defending Pokémon (including your own)."
       }
     ],
     "weaknesses": [
@@ -1261,7 +1261,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "Does 20 damage to each Pokémon on each player's Bench. (Don't apply Weakness and Resistance for Benched Pokémon.) Golem does 100 damage to itself."
+        "text": "Does 20 damage to each Pokémon on each player’s Bench. (Don’t apply Weakness and Resistance for Benched Pokémon.) Golem does 100 damage to itself."
       }
     ],
     "weaknesses": [
@@ -1303,7 +1303,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at up to 3 cards from the top of either player's deck and rearrange them as you like."
+        "text": "Look at up to 3 cards from the top of either player’s deck and rearrange them as you like."
       },
       {
         "name": "Dark Mind",
@@ -1314,7 +1314,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1463,7 +1463,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Don't apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
+        "text": "Don’t apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
       },
       {
         "name": "Selfdestruct",
@@ -1475,7 +1475,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "Does 20 damage to each Pokémon on each player's Bench. (Don't apply Weakness and Resistance for Benched Pokémon.) Magneton does 100 damage to itself."
+        "text": "Does 20 damage to each Pokémon on each player’s Bench. (Don’t apply Weakness and Resistance for Benched Pokémon.) Magneton does 100 damage to itself."
       }
     ],
     "weaknesses": [
@@ -1518,7 +1518,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, choose a basic Energy card attached to 1 of your opponent's Pokémon and attach it to another of your opponent's Pokémon of your choice."
+        "text": "Flip a coin. If heads, choose a basic Energy card attached to 1 of your opponent’s Pokémon and attach it to another of your opponent’s Pokémon of your choice."
       },
       {
         "name": "Telekinesis",
@@ -1529,7 +1529,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. Don't apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. Don’t apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
       }
     ],
     "weaknesses": [
@@ -1570,7 +1570,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "You may discard any number of R Energy cards attached to Moltres when you use this attack. If you do, discard that many cards from the top of your opponent's deck."
+        "text": "You may discard any number of R Energy cards attached to Moltres when you use this attack. If you do, discard that many cards from the top of your opponent’s deck."
       },
       {
         "name": "Dive Bomb",
@@ -1638,7 +1638,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Defender is now Poisoned. It now takes 20 Poison damage instead of 10 after each player's turn (even if it was already Poisoned)."
+        "text": "Defender is now Poisoned. It now takes 20 Poison damage instead of 10 after each player’s turn (even if it was already Poisoned)."
       }
     ],
     "weaknesses": [
@@ -1744,7 +1744,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Unless this attack Knocks Out the Defending Pokémon, return the Defending Pokémon and all cards attached to it to your opponent's hand."
+        "text": "Unless this attack Knocks Out the Defending Pokémon, return the Defending Pokémon and all cards attached to it to your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -2014,7 +2014,7 @@
     "evolvesFrom": "Dratini",
     "ability": {
       "name": "Evolutionary Light",
-      "text": "Once during your turn (before your attack), you may search your deck for an Evolution card. Show it to your opponent and put it into your hand. Shuffle your deck afterward. This power can't be used if Dark Dragonair is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may search your deck for an Evolution card. Show it to your opponent and put it into your hand. Shuffle your deck afterward. This power can’t be used if Dark Dragonair is Asleep, Confused, or Paralyzed.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -2095,7 +2095,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "If an attack does damage to Dark Wartortle during your opponent's next turn (even if Dark Wartortle is Knocked Out), Dark Wartortle attacks the Defending Pokémon for an equal amount of damage."
+        "text": "If an attack does damage to Dark Wartortle during your opponent’s next turn (even if Dark Wartortle is Knocked Out), Dark Wartortle attacks the Defending Pokémon for an equal amount of damage."
       }
     ],
     "weaknesses": [
@@ -2246,7 +2246,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Fearow."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Fearow."
       },
       {
         "name": "Drill Peck",
@@ -2359,7 +2359,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "During your opponent's next turn, whenever 30 or less damage is done to Graveler (after applying Weakness and Resistance), prevent that damage. (Any other effects of attacks still happen.)"
+        "text": "During your opponent’s next turn, whenever 30 or less damage is done to Graveler (after applying Weakness and Resistance), prevent that damage. (Any other effects of attacks still happen.)"
       },
       {
         "name": "Rock Throw",
@@ -2670,7 +2670,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to Kakuna during opponent's next turn. (any other effects of attacks still happen.)"
+        "text": "Flip a coin. If heads, prevent all damage done to Kakuna during opponent’s next turn. (any other effects of attacks still happen.)"
       },
       {
         "name": "Poisonpowder",
@@ -2888,7 +2888,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to Metapod on opponent's next turn. (any other effects of attacks still happen.)"
+        "text": "Flip a coin. If heads, prevent all damage done to Metapod on opponent’s next turn. (any other effects of attacks still happen.)"
       },
       {
         "name": "Stun Spore",
@@ -3059,7 +3059,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "Does 10 damage plus 10 more damage for each Energy attached to Omanyte but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "Does 10 damage plus 10 more damage for each Energy attached to Omanyte but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       }
     ],
     "weaknesses": [
@@ -3104,7 +3104,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "Does 20 damage plus 10 more damage for each Energy attached to Omastar but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "Does 20 damage plus 10 more damage for each Energy attached to Omastar but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       },
       {
         "name": "Spike Cannon",
@@ -3217,7 +3217,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Rapidash."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Rapidash."
       }
     ],
     "weaknesses": [
@@ -3269,7 +3269,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "(?) Does damage to defender equal to half the defender's remaining HP (rounded up to the nearest 10)."
+        "text": "(?) Does damage to defender equal to half the defender’s remaining HP (rounded up to the nearest 10)."
       }
     ],
     "weaknesses": [
@@ -3375,7 +3375,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "Does 20 damage plus 10 more damage for each Energy attached to Seadra but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "Does 20 damage plus 10 more damage for each Energy attached to Seadra but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       },
       {
         "name": "Agility",
@@ -3386,7 +3386,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Seadra."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Seadra."
       }
     ],
     "weaknesses": [
@@ -3410,7 +3410,7 @@
     "level": "20",
     "ability": {
       "name": "Thick Skinned",
-      "text": "Snorlax can't become Asleep, Confused, Paralyzed, or Poisoned. This power can't be used if Snorlax is already Asleep, Confused, or Paralyzed.",
+      "text": "Snorlax can’t become Asleep, Confused, Paralyzed, or Poisoned. This power can’t be used if Snorlax is already Asleep, Confused, or Paralyzed.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -3839,7 +3839,7 @@
     "level": "10",
     "ability": {
       "name": "Long Distance Hypnosis",
-      "text": "Once during your turn (before your attack) you may flip a coin. If heads defender is now Asleep; if tails, your active Pokémon is now Asleep. The power can't be used if Drowzee is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack) you may flip a coin. If heads defender is now Asleep; if tails, your active Pokémon is now Asleep. The power can’t be used if Drowzee is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "50",
@@ -3904,7 +3904,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack Eevee during your opponent's next turn. (Benching either Pokémon ends this effect.)"
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack Eevee during your opponent’s next turn. (Benching either Pokémon ends this effect.)"
       },
       {
         "name": "Quick Attack",
@@ -4126,7 +4126,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "All damage done by attacks to Grimer during your opponent's next turn is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "All damage done by attacks to Grimer during your opponent’s next turn is reduced by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -4234,7 +4234,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Does 10 damage to each Pokémon on each player's Bench. (Don't apply Weakness and Resistance for Benched Pokémon.) Magnemite does 40 damage to itself."
+        "text": "Does 10 damage to each Pokémon on each player’s Bench. (Don’t apply Weakness and Resistance for Benched Pokémon.) Magnemite does 40 damage to itself."
       }
     ],
     "weaknesses": [
@@ -4274,7 +4274,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Shuffle your opponent's deck."
+        "text": "Shuffle your opponent’s deck."
       },
       {
         "name": "Anger",
@@ -4337,7 +4337,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Search your deck for a Basic Pokémon named Nidoran M or Nidoran F and put it onto your Bench. Shuffle your deck afterward. (You can't use this attack if your Bench is full.)"
+        "text": "Search your deck for a Basic Pokémon named Nidoran M or Nidoran F and put it onto your Bench. Shuffle your deck afterward. (You can’t use this attack if your Bench is full.)"
       }
     ],
     "weaknesses": [
@@ -4435,7 +4435,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "During opponent's next turn, prevent 30 or less damage (after applying weakness and resistance). (any other effects of attacks still happen.)"
+        "text": "During opponent’s next turn, prevent 30 or less damage (after applying weakness and resistance). (any other effects of attacks still happen.)"
       }
     ],
     "weaknesses": [
@@ -4529,7 +4529,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4636,7 +4636,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "Does 20 damage plus 10 more for each Energy attaches to Psyduck but not used to pay for this attack's energy cost. You can add more then 20 damage this way."
+        "text": "Does 20 damage plus 10 more for each Energy attaches to Psyduck but not used to pay for this attack’s energy cost. You can add more then 20 damage this way."
       }
     ],
     "weaknesses": [
@@ -4727,7 +4727,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack Rhyhorn during your opponent's next turn. (Benching either Pokémon ends this effect.)"
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack Rhyhorn during your opponent’s next turn. (Benching either Pokémon ends this effect.)"
       },
       {
         "name": "Horn Attack",
@@ -4787,7 +4787,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If defender tries to attack during opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If defender tries to attack during opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -4879,7 +4879,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, remove a damage counter from Slowpoke. This attack can't be used if Slowpoke has no damage counters on it."
+        "text": "Flip a coin. If heads, remove a damage counter from Slowpoke. This attack can’t be used if Slowpoke has no damage counters on it."
       },
       {
         "name": "Scavenge",
@@ -5000,7 +5000,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to Squirtle during opponent's next turn. (Any other effects of attacks still happen.)"
+        "text": "Flip a coin. If heads, prevent all damage done to Squirtle during opponent’s next turn. (Any other effects of attacks still happen.)"
       }
     ],
     "weaknesses": [
@@ -5024,7 +5024,7 @@
     "level": "10",
     "ability": {
       "name": "Cowardice",
-      "text": "At any time during your turn (before your attack), you may return Tentacool to your hand. (Discard all cards attached to Tentacool.) This power can't be used the turn you put Tentacool into play or if Tentacool is Asleep, Confused, or Paralyzed.",
+      "text": "At any time during your turn (before your attack), you may return Tentacool to your hand. (Discard all cards attached to Tentacool.) This power can’t be used the turn you put Tentacool into play or if Tentacool is Asleep, Confused, or Paralyzed.",
       "type": "Poké-Power"
     },
     "hp": "30",
@@ -5203,7 +5203,7 @@
     "set": "Legendary Collection",
     "setCode": "base6",
     "text": [
-      "If you play this card from your hand, the Pokémon you attach it to is no longer Asleep, Confused, Paralyzed, or Poisoned. Full Heal Energy Provides energy. (Doesn't count as a basic Energy card.)"
+      "If you play this card from your hand, the Pokémon you attach it to is no longer Asleep, Confused, Paralyzed, or Poisoned. Full Heal Energy Provides energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base6/100_hires.png"
   },
@@ -5220,7 +5220,7 @@
     "set": "Legendary Collection",
     "setCode": "base6",
     "text": [
-      "If you play this card from your hand, remove 1 damage counter from the Pokémon you attach it to, if it has any. Potion Energy provides energy. (Doesn't count as a basic Energy card.)"
+      "If you play this card from your hand, remove 1 damage counter from the Pokémon you attach it to, if it has any. Potion Energy provides energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base6/101_hires.png"
   },
@@ -5277,7 +5277,7 @@
   },
   {
     "id": "base6-105",
-    "name": "The Boss's Way",
+    "name": "The Boss’s Way",
     "imageUrl": "https://images.pokemontcg.io/base6/105.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -5305,7 +5305,7 @@
     "set": "Legendary Collection",
     "setCode": "base6",
     "text": [
-      "Ask your opponent if he or she accepts your challenge. If your opponent declines (or if both Benches are full), draw 2 cards. If your opponent accepts, each of you searches your decks for any number of Basic Pokémon cards and puts them face down onto your Benches. (A player can't do this if his or her Bench is full.) When you both have finished, shuffle your decks and turn those cards face up."
+      "Ask your opponent if he or she accepts your challenge. If your opponent declines (or if both Benches are full), draw 2 cards. If your opponent accepts, each of you searches your decks for any number of Basic Pokémon cards and puts them face down onto your Benches. (A player can’t do this if his or her Bench is full.) When you both have finished, shuffle your decks and turn those cards face up."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base6/106_hires.png"
   },
@@ -5357,7 +5357,7 @@
     "set": "Legendary Collection",
     "setCode": "base6",
     "text": [
-      "Play Mysterious Fossil as if it were a Basic Pokémon. While in play, Mysterious Fossil counts as a Pokémon (instead of a Trainer card). Mysterious Fossil has no attacks, can't retreat, and can't be Asleep, Confused, Paralyzed, or Poisoned. If Mysterious Fossil is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Mysterious Fossil from play. (Major text change in Legend Maker. Requires reference.)"
+      "Play Mysterious Fossil as if it were a Basic Pokémon. While in play, Mysterious Fossil counts as a Pokémon (instead of a Trainer card). Mysterious Fossil has no attacks, can’t retreat, and can’t be Asleep, Confused, Paralyzed, or Poisoned. If Mysterious Fossil is Knocked Out, it doesn’t count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Mysterious Fossil from play. (Major text change in Legend Maker. Requires reference.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base6/109_hires.png"
   },

--- a/json/cards/Legendary Treasures.json
+++ b/json/cards/Legendary Treasures.json
@@ -90,7 +90,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Flog",
@@ -737,7 +737,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "During your next turn, this Pokémon's Leaf Wallop attack does 40 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s Leaf Wallop attack does 40 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -946,7 +946,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 40 damage to 2 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 40 damage to 2 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Scorching Fire",
@@ -1124,7 +1124,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Victory Star",
-      "text": "Once during your turn, after you flip any coins for an attack, you may ignore all effects of those coin flips and begin flipping those coins again. You can't use more than 1 Victory Star Ability each turn.",
+      "text": "Once during your turn, after you flip any coins for an attack, you may ignore all effects of those coin flips and begin flipping those coins again. You can’t use more than 1 Victory Star Ability each turn.",
       "type": "Ability"
     },
     "hp": "60",
@@ -1755,7 +1755,7 @@
         "text": ""
       },
       {
-        "name": "Emperor's Strike",
+        "name": "Emperor’s Strike",
         "cost": [
           "Water",
           "Water",
@@ -2159,7 +2159,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 30 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2217,7 +2217,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "This Pokémon can't use Hail Blizzard during your next turn."
+        "text": "This Pokémon can’t use Hail Blizzard during your next turn."
       }
     ],
     "weaknesses": [
@@ -2309,7 +2309,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 50 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 50 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Thundering Hurricane",
@@ -2414,7 +2414,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 30 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 30 (before applying Weakness and Resistance)."
       },
       {
         "name": "Electrishower",
@@ -2423,7 +2423,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3148,7 +3148,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20+",
-        "text": "If any of your Pokémon were Knocked Out by damage from an opponent's attack during his or her last turn, this attack does 70 more damage."
+        "text": "If any of your Pokémon were Knocked Out by damage from an opponent’s attack during his or her last turn, this attack does 70 more damage."
       },
       {
         "name": "Poison Jab",
@@ -3384,7 +3384,7 @@
     "evolvesFrom": "Trubbish",
     "ability": {
       "name": "Garbotoxin",
-      "text": "If this Pokémon has a Pokémon Tool card attached to it, each Pokémon in play, in each player's hand, and in each player's discard pile has no Abilities (except for Garbotoxin).",
+      "text": "If this Pokémon has a Pokémon Tool card attached to it, each Pokémon in play, in each player’s hand, and in each player’s discard pile has no Abilities (except for Garbotoxin).",
       "type": "Ability"
     },
     "hp": "100",
@@ -3581,7 +3581,7 @@
     "evolvesFrom": "Gothorita",
     "ability": {
       "name": "Magic Room",
-      "text": "As long as this Pokémon is your Active Pokémon, your opponent can't play any Item cards from his or her hand.",
+      "text": "As long as this Pokémon is your Active Pokémon, your opponent can’t play any Item cards from his or her hand.",
       "type": "Ability"
     },
     "hp": "130",
@@ -3838,7 +3838,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 4 damage counters on your opponent's Pokémon in any way you like."
+        "text": "Put 4 damage counters on your opponent’s Pokémon in any way you like."
       },
       {
         "name": "Eerie Glow",
@@ -3899,7 +3899,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "During your next turn, this Pokémon's Echoed Voice attack does 50 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s Echoed Voice attack does 50 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -3972,7 +3972,7 @@
     "evolvesFrom": "Riolu",
     "ability": {
       "name": "Reflexive Retaliation",
-      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), put 2 damage counters on the Attacking Pokémon.",
+      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack (even if this Pokémon is Knocked Out), put 2 damage counters on the Attacking Pokémon.",
       "type": "Ability"
     },
     "hp": "100",
@@ -3997,7 +3997,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4106,7 +4106,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "Does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4153,7 +4153,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Rumble",
@@ -4163,7 +4163,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -4212,7 +4212,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "If any of your Pokémon were Knocked Out by damage from an opponent's attack during his or her last turn, this attack does 60 more damage."
+        "text": "If any of your Pokémon were Knocked Out by damage from an opponent’s attack during his or her last turn, this attack does 60 more damage."
       },
       {
         "name": "Land Crush",
@@ -4273,7 +4273,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent’s). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4349,7 +4349,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Sealing Scream",
-      "text": "Each player can't play any ACE SPEC cards from his or her hand.",
+      "text": "Each player can’t play any ACE SPEC cards from his or her hand.",
       "type": "Ability"
     },
     "hp": "80",
@@ -4373,7 +4373,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Shuffle your hand into your deck. Then, draw a number of cards equal to the number of cards in your opponent's hand."
+        "text": "Shuffle your hand into your deck. Then, draw a number of cards equal to the number of cards in your opponent’s hand."
       }
     ],
     "nationalPokedexNumber": 442,
@@ -4417,7 +4417,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": "Does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4591,7 +4591,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "The Defending Pokémon can't attack during your opponent's next turn."
+        "text": "The Defending Pokémon can’t attack during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -4701,7 +4701,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": "This attack's damage isn't affected by any effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by any effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -4803,7 +4803,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "This attack's damage isn't affected by any effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by any effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -5073,7 +5073,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "150",
-        "text": "This Pokémon can't attack during your next turn."
+        "text": "This Pokémon can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -5151,7 +5151,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Overflow",
-      "text": "If your opponent's Pokémon is Knocked Out by damage from an attack of this Pokémon, take 1 more Prize card.",
+      "text": "If your opponent’s Pokémon is Knocked Out by damage from an attack of this Pokémon, take 1 more Prize card.",
       "type": "Ability"
     },
     "hp": "180",
@@ -5182,7 +5182,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "Discard a Plasma Energy attached to this Pokémon. If you can't discard a Plasma Energy, this attack does nothing."
+        "text": "Discard a Plasma Energy attached to this Pokémon. If you can’t discard a Plasma Energy, this attack does nothing."
       }
     ],
     "weaknesses": [
@@ -5336,7 +5336,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "During your next turn, this Pokémon's Echoed Voice attack does 50 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s Echoed Voice attack does 50 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -5356,7 +5356,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Rough Skin",
-      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), put 2 damage counters on the Attacking Pokémon.",
+      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack (even if this Pokémon is Knocked Out), put 2 damage counters on the Attacking Pokémon.",
       "type": "Ability"
     },
     "hp": "100",
@@ -5383,7 +5383,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "nationalPokedexNumber": 621,
@@ -5418,7 +5418,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "If any of your Pokémon were Knocked Out by damage from an opponent's attack during his or her last turn, this attack does 70 more damage."
+        "text": "If any of your Pokémon were Knocked Out by damage from an opponent’s attack during his or her last turn, this attack does 70 more damage."
       },
       {
         "name": "Head Charge",
@@ -5528,7 +5528,7 @@
     "set": "Legendary Treasures",
     "setCode": "bw11",
     "text": [
-      "Put a Pokémon from your hand face down in front of you and tell your opponent its name. Your opponent guesses the height of that Pokémon. Reveal that Pokémon. If your opponent guessed right, he or she draws 3 cards. If your opponent guessed wrong, you draw 3 cards. Return the Pokémon to your hand. (You can't choose a Pokémon that doesn't have the height printed on the card.)"
+      "Put a Pokémon from your hand face down in front of you and tell your opponent its name. Your opponent guesses the height of that Pokémon. Reveal that Pokémon. If your opponent guessed right, he or she draws 3 cards. If your opponent guessed wrong, you draw 3 cards. Return the Pokémon to your hand. (You can’t choose a Pokémon that doesn’t have the height printed on the card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw11/110_hires.png"
   },
@@ -5545,7 +5545,7 @@
     "set": "Legendary Treasures",
     "setCode": "bw11",
     "text": [
-      "Flip a coin. If heads, discard an Energy attached to 1 of your opponent's Pokémon."
+      "Flip a coin. If heads, discard an Energy attached to 1 of your opponent’s Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw11/111_hires.png"
   },
@@ -5976,7 +5976,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
       },
       {
         "name": "Peck",
@@ -6198,7 +6198,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Move all damage counters from this Pokémon to the Defending Pokémon. This Pokémon can't use Eternal Radiance during your next turn."
+        "text": "Move all damage counters from this Pokémon to the Defending Pokémon. This Pokémon can’t use Eternal Radiance during your next turn."
       }
     ],
     "weaknesses": [
@@ -6293,7 +6293,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Mud-Slap",
@@ -6349,7 +6349,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, switch 1 of your opponent's Benched Pokémon with the Defending Pokémon."
+        "text": "Flip a coin. If heads, switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -6647,7 +6647,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "During your next turn, this Pokémon's Echoed Voice attack does 50 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s Echoed Voice attack does 50 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -6845,7 +6845,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Versatile",
-      "text": "This Pokémon can use the attacks of any Pokémon in play (both yours and your opponent's). (You still need the necessary Energy to use each attack.)",
+      "text": "This Pokémon can use the attacks of any Pokémon in play (both yours and your opponent’s). (You still need the necessary Energy to use each attack.)",
       "type": "Ability"
     },
     "hp": "120",

--- a/json/cards/Legends Awakened.json
+++ b/json/cards/Legends Awakened.json
@@ -8,7 +8,7 @@
     "level": "50",
     "ability": {
       "name": "Form Change",
-      "text": "Once during your turn (before your attack), you may search your deck for any Deoxys and switch it with Deoxys Normal Forme. (Any cards attached to Deoxys Normal Forme, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys Normal Forme on top of your deck. Shuffle your deck afterward. You can't use more than 1 Form Change Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for any Deoxys and switch it with Deoxys Normal Forme. (Any cards attached to Deoxys Normal Forme, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys Normal Forme on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Form Change Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -33,7 +33,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "Does 20 damage plus 10 more damage for each Energy attached to all of your opponent's Pokémon."
+        "text": "Does 20 damage plus 10 more damage for each Energy attached to all of your opponent’s Pokémon."
       }
     ],
     "weaknesses": [
@@ -90,7 +90,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Flip a coin for each of your opponent's Pokémon. If that coin flip is heads, this attack does 50 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin for each of your opponent’s Pokémon. If that coin flip is heads, this attack does 50 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -137,7 +137,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Discard a Psychic Energy attached to Froslass. During your opponent's next turn, if Froslass would be Knocked Out by damage from an attack, the Attacking Pokémon is Knocked Out."
+        "text": "Discard a Psychic Energy attached to Froslass. During your opponent’s next turn, if Froslass would be Knocked Out by damage from an attack, the Attacking Pokémon is Knocked Out."
       },
       {
         "name": "Icy Breath",
@@ -147,7 +147,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "The Defending Pokémon is now Asleep. Put 1 damage counter on each of your opponent's Benched Pokémon."
+        "text": "The Defending Pokémon is now Asleep. Put 1 damage counter on each of your opponent’s Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -190,7 +190,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Benched Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Flip a coin. If heads, prevent all effects of an attack, including damage, done to Giratina during your opponent's next turn."
+        "text": "Choose 1 of your opponent’s Benched Pokémon. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) Flip a coin. If heads, prevent all effects of an attack, including damage, done to Giratina during your opponent’s next turn."
       },
       {
         "name": "Brutal Edge",
@@ -286,7 +286,7 @@
     "level": "47",
     "ability": {
       "name": "Flash Fire",
-      "text": "Once during your turn (before your attack), you may move a Fire Energy attached to 1 of your Pokémon to Heatran. This power can't be used if Heatran is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may move a Fire Energy attached to 1 of your Pokémon to Heatran. This power can’t be used if Heatran is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -366,7 +366,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "40+",
-        "text": "You may discard 2 cards from your hand. If you do, this attack does 40 damage plus 20 more damage and does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "You may discard 2 cards from your hand. If you do, this attack does 40 damage plus 20 more damage and does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -388,7 +388,7 @@
     "evolvesFrom": "Luxio",
     "ability": {
       "name": "Rivalry",
-      "text": "If your opponent has any Pokémon LV.X in play, each of Luxray's attacks does 50 more damage to the Active Pokémon (before applying Weakness and Resistance).",
+      "text": "If your opponent has any Pokémon LV.X in play, each of Luxray’s attacks does 50 more damage to the Active Pokémon (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -485,7 +485,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60+",
-        "text": "You may do 60 damage plus 40 more damage and 40 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) If you do, Mamoswine does 40 damage to itself."
+        "text": "You may do 60 damage plus 40 more damage and 40 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) If you do, Mamoswine does 40 damage to itself."
       }
     ],
     "weaknesses": [
@@ -513,7 +513,7 @@
     "evolvesFrom": "Metang",
     "ability": {
       "name": "Magnetic Reversal",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. This power can't be used if Metagross is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon. This power can’t be used if Metagross is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -541,7 +541,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "During your next turn, Metagross's Extra Comet Punch attack's base damage is 100."
+        "text": "During your next turn, Metagross’s Extra Comet Punch attack’s base damage is 100."
       }
     ],
     "weaknesses": [
@@ -621,7 +621,7 @@
     "evolvesFrom": "Poliwhirl",
     "ability": {
       "name": "Enthusiasm",
-      "text": "If you have Poliwag, Poliwhirl, and Poliwrath in play, each of these Pokémon's attacks does 60 more damage to the Defending Pokémon (before applying Weakness and Resistance).",
+      "text": "If you have Poliwag, Poliwhirl, and Poliwrath in play, each of these Pokémon’s attacks does 60 more damage to the Defending Pokémon (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -668,7 +668,7 @@
     "evolvesFrom": "Nosepass",
     "ability": {
       "name": "Steel Coating",
-      "text": "Any damage done to Probopass by your opponent's attacks is reduced by 10 for each Metal Energy attached to Probopass (after applying Weakness and Resistance). You can't reduce more than 20 damage in this way.",
+      "text": "Any damage done to Probopass by your opponent’s attacks is reduced by 10 for each Metal Energy attached to Probopass (after applying Weakness and Resistance). You can’t reduce more than 20 damage in this way.",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -696,7 +696,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Choose a number of your opponent's Benched Pokémon up to the amount of Metal Energy attached to Probopass. This attack does 20 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose a number of your opponent’s Benched Pokémon up to the amount of Metal Energy attached to Probopass. This attack does 20 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -717,7 +717,7 @@
     "level": "56",
     "ability": {
       "name": "Speed Gain",
-      "text": "Once during your turn (before your attack), you may flip a coin until you get tails. For each heads, search your discard pile for a basic Fire Energy card or a basic Lightning Energy card and attach it to Rayquaza. This power can't be used if Rayquaza is affected by a Special Condition or if you have another Rayquaza in play.",
+      "text": "Once during your turn (before your attack), you may flip a coin until you get tails. For each heads, search your discard pile for a basic Fire Energy card or a basic Lightning Energy card and attach it to Rayquaza. This power can’t be used if Rayquaza is affected by a Special Condition or if you have another Rayquaza in play.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -773,7 +773,7 @@
     "level": "52",
     "ability": {
       "name": "Slow Start",
-      "text": "Regigigas can't attack until your opponent has 3 or less Prize cards left.",
+      "text": "Regigigas can’t attack until your opponent has 3 or less Prize cards left.",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -803,7 +803,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "If the Defending Pokémon already has any damage counters on it, this attack's base damage is 40 instead of 120."
+        "text": "If the Defending Pokémon already has any damage counters on it, this attack’s base damage is 40 instead of 120."
       }
     ],
     "weaknesses": [
@@ -824,7 +824,7 @@
     "level": "44",
     "ability": {
       "name": "Curse Breath",
-      "text": "Once during your turn, when you put Spiritomb from your hand onto your Bench, you may put 1 damage counter on all Pokémon that already have any damage counters on them (both yours and your opponent's). You can't use more than 1 Curse Breath Poké-Power each turn.",
+      "text": "Once during your turn, when you put Spiritomb from your hand onto your Bench, you may put 1 damage counter on all Pokémon that already have any damage counters on them (both yours and your opponent’s). You can’t use more than 1 Curse Breath Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -849,7 +849,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Move 1 damage counter from 1 of your Pokémon to 1 of your opponent's Pokémon."
+        "text": "Move 1 damage counter from 1 of your Pokémon to 1 of your opponent’s Pokémon."
       }
     ],
     "resistances": [
@@ -887,7 +887,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon."
+        "text": "Does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon."
       },
       {
         "name": "Pursue and Turn",
@@ -927,7 +927,7 @@
     "evolvesFrom": "Anorith",
     "ability": {
       "name": "Fossil Armor",
-      "text": "If Armaldo would be damaged by an attack, prevent that attack's damage done to Armaldo if that damage is 60 or less.",
+      "text": "If Armaldo would be damaged by an attack, prevent that attack’s damage done to Armaldo if that damage is 60 or less.",
       "type": "Poké-Body"
     },
     "hp": "140",
@@ -999,7 +999,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1099,7 +1099,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Before doing damage, you may switch 1 of the Defending Pokémon with 1 of your opponent's Benched Pokémon. If you do, this attack does 30 damage to the new Defending Pokémon. If the Defending Pokémon would be Knocked Out by this attack, you may remove all damage counters from Cradily."
+        "text": "Before doing damage, you may switch 1 of the Defending Pokémon with 1 of your opponent’s Benched Pokémon. If you do, this attack does 30 damage to the new Defending Pokémon. If the Defending Pokémon would be Knocked Out by this attack, you may remove all damage counters from Cradily."
       },
       {
         "name": "Acid",
@@ -1110,7 +1110,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1192,7 +1192,7 @@
     "evolvesFrom": "Skitty",
     "ability": {
       "name": "Attracting Body",
-      "text": "If Delcatty is your Active Pokémon and is damaged by an opponent's attack (even if Delcatty is Knocked Out), flip a coin. If heads, the Attacking Pokémon is now Confused.",
+      "text": "If Delcatty is your Active Pokémon and is damaged by an opponent’s attack (even if Delcatty is Knocked Out), flip a coin. If heads, the Attacking Pokémon is now Confused.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -1237,7 +1237,7 @@
     "level": "50",
     "ability": {
       "name": "Form Change",
-      "text": "Once during your turn (before your attack), you may search your deck for any Deoxys and switch it with Deoxys Attack Forme. (Any cards attached to Deoxys Attack Forme, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys Attack Forme on top of your deck. Shuffle your deck afterward. You can't use more than 1 Form Change Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for any Deoxys and switch it with Deoxys Attack Forme. (Any cards attached to Deoxys Attack Forme, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys Attack Forme on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Form Change Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -1264,7 +1264,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "During your next turn, Deoxys's Psychic Boost attack's base damage is 20."
+        "text": "During your next turn, Deoxys’s Psychic Boost attack’s base damage is 20."
       }
     ],
     "weaknesses": [
@@ -1285,7 +1285,7 @@
     "level": "50",
     "ability": {
       "name": "Form Change",
-      "text": "Once during your turn (before your attack), you may search your deck for any Deoxys and switch it with Deoxys Defense Forme. (Any cards attached to Deoxys Defense Forme, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys Defense Forme on top of your deck. Shuffle your deck afterward. You can't use more than 1 Form Change Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for any Deoxys and switch it with Deoxys Defense Forme. (Any cards attached to Deoxys Defense Forme, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys Defense Forme on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Form Change Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -1312,7 +1312,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "During your opponent's next turn, prevent all effects of an attack, and any damage done to Deoxys by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, prevent all effects of an attack, and any damage done to Deoxys by attacks is reduced by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -1333,7 +1333,7 @@
     "level": "50",
     "ability": {
       "name": "Form Change",
-      "text": "Once during your turn (before your attack), you may search your deck for any Deoxys and switch it with Deoxys Speed Forme. (Any cards attached to Deoxys Speed Forme, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys Speed Forme on top of your deck. Shuffle your deck afterward. You can't use more than 1 Form Change Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for any Deoxys and switch it with Deoxys Speed Forme. (Any cards attached to Deoxys Speed Forme, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys Speed Forme on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Form Change Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -1355,7 +1355,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
       }
     ],
     "weaknesses": [
@@ -1376,7 +1376,7 @@
     "level": "33",
     "ability": {
       "name": "Ditto DNA",
-      "text": "As long as Ditto is your Active Pokémon, its maximum HP is the same as your opponent's Active Pokémon. Ditto can use the attacks of that Pokémon as its own. (You still need the necessary Energy to use each attack.) If that Pokémon is no longer your opponent’s Active Pokémon, choose 1 of your opponent’s Active Pokémon for Ditto to copy.",
+      "text": "As long as Ditto is your Active Pokémon, its maximum HP is the same as your opponent’s Active Pokémon. Ditto can use the attacks of that Pokémon as its own. (You still need the necessary Energy to use each attack.) If that Pokémon is no longer your opponent’s Active Pokémon, choose 1 of your opponent’s Active Pokémon for Ditto to copy.",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -1411,7 +1411,7 @@
     "evolvesFrom": "Pineco",
     "ability": {
       "name": "Iron Shell",
-      "text": "Whenever you attach a basic Energy card from your hand to Forretress (excluding effects of attacks), you may flip a coin. If tails, put 2 damage counters on each Pokémon (both yours and your opponent's) (excluding any Forretress).",
+      "text": "Whenever you attach a basic Energy card from your hand to Forretress (excluding effects of attacks), you may flip a coin. If tails, put 2 damage counters on each Pokémon (both yours and your opponent’s) (excluding any Forretress).",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -1498,7 +1498,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "Discard 2 Fighting Energy attached to Groudon and this attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard 2 Fighting Energy attached to Groudon and this attack does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1525,7 +1525,7 @@
     "level": "45",
     "ability": {
       "name": "Smelt",
-      "text": "Once during your turn (before your attack), you may move a Metal Energy attached to 1 of your Pokémon to Heatran. This power can't be used if Heatran is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may move a Metal Energy attached to 1 of your Pokémon to Heatran. This power can’t be used if Heatran is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -1603,7 +1603,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Discard all Energy attached to Jirachi. The Defending Pokémon is Knocked Out at the end of your opponent's next turn."
+        "text": "Discard all Energy attached to Jirachi. The Defending Pokémon is Knocked Out at the end of your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1662,7 +1662,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Discard 2 Water Energy attached to Kyogre. This attack does 20 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard 2 Water Energy attached to Kyogre. This attack does 20 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1739,7 +1739,7 @@
     "level": "55",
     "ability": {
       "name": "Psychic Bind",
-      "text": "Once during your turn, when you put Mesprit from your hand onto your Bench, you may use this power. Your opponent can't use any Poké-Powers on his or her Pokémon during your opponent's next turn.",
+      "text": "Once during your turn, when you put Mesprit from your hand onto your Bench, you may use this power. Your opponent can’t use any Poké-Powers on his or her Pokémon during your opponent’s next turn.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -1806,7 +1806,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "60",
-        "text": "If Poliwrath was damaged by an attack during your opponent's last turn, this attack does nothing."
+        "text": "If Poliwrath was damaged by an attack during your opponent’s last turn, this attack does nothing."
       },
       {
         "name": "Submission",
@@ -1838,7 +1838,7 @@
     "level": "43",
     "ability": {
       "name": "Regi Move",
-      "text": "Once during your turn (before your attack), you may use this power. Discard 2 cards from your hand and choose 1 of your opponent's Active Pokémon that isn't an Evolved Pokémon. Then, your opponent switches that Pokémon with 1 of his or her Benched Pokémon. This power can't be used if Regice is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may use this power. Discard 2 cards from your hand and choose 1 of your opponent’s Active Pokémon that isn’t an Evolved Pokémon. Then, your opponent switches that Pokémon with 1 of his or her Benched Pokémon. This power can’t be used if Regice is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -1866,7 +1866,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "If Regice was damaged by an attack during your opponent's last turn, the Defending Pokémon is now Paralyzed."
+        "text": "If Regice was damaged by an attack during your opponent’s last turn, the Defending Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -1916,7 +1916,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "Flip a coin. If heads, this attack does 60 damage plus 20 more damage and does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 60 damage plus 20 more damage and does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1937,7 +1937,7 @@
     "level": "51",
     "ability": {
       "name": "Regi Cycle",
-      "text": "Once during your turn (before your attack), if you have a Fighting Energy card in your discard pile, you may discard 2 cards from your hand. Then, attach a Fighting Energy card from your discard pile to Regirock. This power can't be used if Regirock is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if you have a Fighting Energy card in your discard pile, you may discard 2 cards from your hand. Then, attach a Fighting Energy card from your discard pile to Regirock. This power can’t be used if Regirock is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -1986,7 +1986,7 @@
     "level": "50",
     "ability": {
       "name": "Regi Heal",
-      "text": "Once during your turn (before your attack), you may discard 2 cards from your hand. Then, remove 3 damage counters from Registeel. This power can't be used if Registeel is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may discard 2 cards from your hand. Then, remove 3 damage counters from Registeel. This power can’t be used if Registeel is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -2043,7 +2043,7 @@
     "evolvesFrom": "Nincada",
     "ability": {
       "name": "Resent",
-      "text": "Once during your opponent's turn, if Shedinja would be Knocked Out by damage from an attack, you may put 4 damage counters on the Attacking Pokémon and each of your opponent's Pokémon that has the same name as the Attacking Pokémon.",
+      "text": "Once during your opponent’s turn, if Shedinja would be Knocked Out by damage from an attack, you may put 4 damage counters on the Attacking Pokémon and each of your opponent’s Pokémon that has the same name as the Attacking Pokémon.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -2079,7 +2079,7 @@
     "level": "32",
     "ability": {
       "name": "White Smoke",
-      "text": "As long as Torkoal is your Active Pokémon, prevent all effects, including damage, done to your Benched Pokémon by your opponent's attacks.",
+      "text": "As long as Torkoal is your Active Pokémon, prevent all effects, including damage, done to your Benched Pokémon by your opponent’s attacks.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -2126,7 +2126,7 @@
     "level": "16",
     "ability": {
       "name": "!",
-      "text": "Once during your turn, when you put Unown ! from your hand onto your Bench, you may flip a coin. If heads, put 2 damage counters on 1 of your opponent's Pokémon. If tails, put 2 damage counters on 1 of your Pokémon.",
+      "text": "Once during your turn, when you put Unown ! from your hand onto your Bench, you may flip a coin. If heads, put 2 damage counters on 1 of your opponent’s Pokémon. If tails, put 2 damage counters on 1 of your Pokémon.",
       "type": "Poké-Power"
     },
     "hp": "50",
@@ -2150,7 +2150,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "Flip a coin. If heads, this attack does 10 damage plus 10 more damage. If tails, Unown ! does 10 damage to itself, and this attack's damage isn't affected by Weakness or Resistance."
+        "text": "Flip a coin. If heads, this attack does 10 damage plus 10 more damage. If tails, Unown ! does 10 damage to itself, and this attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -2238,7 +2238,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "The Defending Pokémon is now Burned and Poisoned. Before applying these effects, you may switch 1 of the Defending Pokémon with 1 of your opponent's Benched Pokémon. The new Defending Pokémon is now Burned and Poisoned."
+        "text": "The Defending Pokémon is now Burned and Poisoned. Before applying these effects, you may switch 1 of the Defending Pokémon with 1 of your opponent’s Benched Pokémon. The new Defending Pokémon is now Burned and Poisoned."
       },
       {
         "name": "Energy Dissolve",
@@ -2249,7 +2249,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Discard an Energy attached to the Defending Pokémon at the end of your opponent's next turn."
+        "text": "Discard an Energy attached to the Defending Pokémon at the end of your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2271,7 +2271,7 @@
     "evolvesFrom": "Gloom",
     "ability": {
       "name": "Energy Reaction",
-      "text": "Once during your turn (before your attack), when you attach a Grass or Psychic Energy card from your hand to Vileplume (excluding effects of attacks or Poké-Powers), you may use this power. If you attach a Grass Energy card, the Defending Pokémon is now Asleep. If you attach a Psychic Energy card, the Defending Pokémon is now Poisoned. This power can't be used if Vileplume is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), when you attach a Grass or Psychic Energy card from your hand to Vileplume (excluding effects of attacks or Poké-Powers), you may use this power. If you attach a Grass Energy card, the Defending Pokémon is now Asleep. If you attach a Psychic Energy card, the Defending Pokémon is now Poisoned. This power can’t be used if Vileplume is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -2298,7 +2298,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Flip a coin. If heads, your opponent can't play any Trainer, Supporter, or Stadium cards from his or her hand during your opponent's next turn."
+        "text": "Flip a coin. If heads, your opponent can’t play any Trainer, Supporter, or Stadium cards from his or her hand during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2339,7 +2339,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "During your opponent's next turn, any damage done to Anorith by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Anorith by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "X-Scissor",
@@ -2428,7 +2428,7 @@
     "level": "35",
     "ability": {
       "name": "Temperament",
-      "text": "Once during your turn (before your attack), you may search your deck for any Castform and switch it with Castform. (Any cards attached to Castform, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Castform on top of your deck. Shuffle your deck afterward. You can't use more than 1 Temperament Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for any Castform and switch it with Castform. (Any cards attached to Castform, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Castform on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Temperament Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -2474,7 +2474,7 @@
     "level": "35",
     "ability": {
       "name": "Temperament",
-      "text": "Once during your turn (before your attack), you may search your deck for any Castform and switch it with Castform Rain Form. (Any cards attached to Castform Rain Form, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) Shuffle Castform Rain Form back into your deck. You can't use more than 1 Temperament Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for any Castform and switch it with Castform Rain Form. (Any cards attached to Castform Rain Form, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) Shuffle Castform Rain Form back into your deck. You can’t use more than 1 Temperament Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -2520,7 +2520,7 @@
     "level": "35",
     "ability": {
       "name": "Temperament",
-      "text": "Once during your turn (before your attack), you may search your deck for any Castform and switch it with Castform Snow-cloud Form. (Any cards attached to Castform Snow-cloud Form, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) Shuffle Castform Snow-cloud Form back into your deck. You can't use more than 1 Temperament Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for any Castform and switch it with Castform Snow-cloud Form. (Any cards attached to Castform Snow-cloud Form, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) Shuffle Castform Snow-cloud Form back into your deck. You can’t use more than 1 Temperament Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -2545,7 +2545,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "This attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2566,7 +2566,7 @@
     "level": "35",
     "ability": {
       "name": "Temperament",
-      "text": "Once during your turn (before your attack), you may search your deck for any Castform and switch it with Castform Sunny Form. (Any cards attached to Castform Sunny Form, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) Shuffle Castform Sunny Form back into your deck. You can't use more than 1 Temperament Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for any Castform and switch it with Castform Sunny Form. (Any cards attached to Castform Sunny Form, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) Shuffle Castform Sunny Form back into your deck. You can’t use more than 1 Temperament Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -2685,7 +2685,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "During your opponent's next turn, any damage done to Drifblim by attacks is reduced by 10 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Drifblim by attacks is reduced by 10 (after applying Weakness and Resistance)."
       },
       {
         "name": "Whirlwind",
@@ -2743,7 +2743,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Each player counts the number of cards in his or her opponent's hand. Each player shuffles his or her hand into his or her deck. Then, each player draws a number of cards equal to the number of cards his or her opponent had."
+        "text": "Each player counts the number of cards in his or her opponent’s hand. Each player shuffles his or her hand into his or her deck. Then, each player draws a number of cards equal to the number of cards his or her opponent had."
       },
       {
         "name": "Super Eggsplosion",
@@ -2883,7 +2883,7 @@
     "evolvesFrom": "Houndour",
     "ability": {
       "name": "Revenge Fang",
-      "text": "If you have less Benched Pokémon than your opponent, each of Houndoom's attacks does 40 more damage to the Active Pokémon (before applying Weakness and Resistance).",
+      "text": "If you have less Benched Pokémon than your opponent, each of Houndoom’s attacks does 40 more damage to the Active Pokémon (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -2959,7 +2959,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Move an Energy card attached to the Defending Pokémon to another of your opponent's Pokémon."
+        "text": "Move an Energy card attached to the Defending Pokémon to another of your opponent’s Pokémon."
       },
       {
         "name": "Confuse Ray",
@@ -3011,7 +3011,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 30 damage to each of your opponent's Pokémon that has any Energy cards attached to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to each of your opponent’s Pokémon that has any Energy cards attached to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Aqua Bolt",
@@ -3120,7 +3120,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Spike Lariat",
@@ -3173,7 +3173,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Thunderous Claw",
@@ -3235,7 +3235,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "40",
-        "text": "Flip a coin. If tails, Marowak can't use Heavy Bone during your next turn."
+        "text": "Flip a coin. If tails, Marowak can’t use Heavy Bone during your next turn."
       },
       {
         "name": "Bone Rush",
@@ -3418,7 +3418,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "If the Defending Pokémon isn't an Evolved Pokémon, that Pokémon can't attack, retreat, or use any Poké-Powers during your opponent's next turn."
+        "text": "If the Defending Pokémon isn’t an Evolved Pokémon, that Pokémon can’t attack, retreat, or use any Poké-Powers during your opponent’s next turn."
       },
       {
         "name": "Harass",
@@ -3456,7 +3456,7 @@
     "evolvesFrom": "Nincada",
     "ability": {
       "name": "Cast-off Shell",
-      "text": "Once during your turn, when you play Ninjask from your hand to evolve 1 of your Pokémon and if your Bench isn't full, you may put Shedinja onto your Bench as a Basic Pokémon from your hand or your discard pile.",
+      "text": "Once during your turn, when you play Ninjask from your hand to evolve 1 of your Pokémon and if your Bench isn’t full, you may put Shedinja onto your Bench as a Basic Pokémon from your hand or your discard pile.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -3525,7 +3525,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
       },
       {
         "name": "Fasten Claws",
@@ -3702,7 +3702,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon that has any Poké-Powers or Poké-Bodies. This attack does 50 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon that has any Poké-Powers or Poké-Bodies. This attack does 50 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3745,7 +3745,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Before doing damage, count the remaining HP of the Defending Pokémon and Swalot. If the Defending Pokémon has fewer remaining HP than Swalot's, this attack does 80 damage instead."
+        "text": "Before doing damage, count the remaining HP of the Defending Pokémon and Swalot. If the Defending Pokémon has fewer remaining HP than Swalot’s, this attack does 80 damage instead."
       },
       {
         "name": "Gunk Shot",
@@ -3778,7 +3778,7 @@
     "evolvesFrom": "Taillow",
     "ability": {
       "name": "Big Wing",
-      "text": "If Swellow has no Energy attached to it, Swellow's Retreat Cost is 0.",
+      "text": "If Swellow has no Energy attached to it, Swellow’s Retreat Cost is 0.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -3803,7 +3803,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "If Swellow was on your Bench this turn, this attack's base damage is 60 instead of 30."
+        "text": "If Swellow was on your Bench this turn, this attack’s base damage is 60 instead of 30."
       }
     ],
     "weaknesses": [
@@ -3903,7 +3903,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Search your opponent's discard pile for up to 2 Energy cards and attach them to any of your opponent's Pokémon in any way you like. For each Energy card attached in this way, this attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Search your opponent’s discard pile for up to 2 Energy cards and attach them to any of your opponent’s Pokémon in any way you like. For each Energy card attached in this way, this attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Dangerous Poison",
@@ -3980,7 +3980,7 @@
     "level": "16",
     "ability": {
       "name": "RETIRE",
-      "text": "Once during your turn, if Unown R is on your Bench, you may discard Unown R and all cards attached to it. (This doesn't count as a Knocked Out Pokémon.) Then, draw a card.",
+      "text": "Once during your turn, if Unown R is on your Bench, you may discard Unown R and all cards attached to it. (This doesn’t count as a Knocked Out Pokémon.) Then, draw a card.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -4025,7 +4025,7 @@
     "level": "15",
     "ability": {
       "name": "UNSEEN",
-      "text": "As long as Unown U is on your Bench, prevent all effects of attacks, including damage, done by your opponent's Pokémon to any Unown on your Bench.",
+      "text": "As long as Unown U is on your Bench, prevent all effects of attacks, including damage, done by your opponent’s Pokémon to any Unown on your Bench.",
       "type": "Poké-Body"
     },
     "hp": "50",
@@ -4070,7 +4070,7 @@
     "level": "17",
     "ability": {
       "name": "VACATION",
-      "text": "Once during your turn (before your attack), you may remove 2 damage counters from each of your Pokémon. If you do, your turn ends. This power can't be used if Unown V is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may remove 2 damage counters from each of your Pokémon. If you do, your turn ends. This power can’t be used if Unown V is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -4094,7 +4094,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4115,7 +4115,7 @@
     "level": "21",
     "ability": {
       "name": "WALL",
-      "text": "As long as Unown W is your Active Pokémon, any damage done to your Pokémon by an opponent's attack is reduced by 10 (after applying Weakness and Resistance).",
+      "text": "As long as Unown W is your Active Pokémon, any damage done to your Pokémon by an opponent’s attack is reduced by 10 (after applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -4255,7 +4255,7 @@
     "level": "9",
     "ability": {
       "name": "Metal Chain",
-      "text": "Once during your turn (before your attack), when you attach a Metal Energy card from your hand to Beldum (excluding effects of attacks or Poké-Powers), you may search your deck for Beldum and put it onto your Bench. Shuffle your deck afterward. This power can't be used if Beldum is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), when you attach a Metal Energy card from your hand to Beldum (excluding effects of attacks or Poké-Powers), you may search your deck for Beldum and put it onto your Bench. Shuffle your deck afterward. This power can’t be used if Beldum is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "50",
@@ -4389,7 +4389,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't use any Poké-Powers during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t use any Poké-Powers during your opponent’s next turn."
       },
       {
         "name": "Careless Tackle",
@@ -4600,7 +4600,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, choose 1 card from your opponent's hand without looking and discard it."
+        "text": "Flip a coin. If heads, choose 1 card from your opponent’s hand without looking and discard it."
       },
       {
         "name": "Irongrip",
@@ -5004,7 +5004,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon that doesn't have any damage counters on it. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon that doesn’t have any damage counters on it. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -5105,7 +5105,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Gastro Acid",
@@ -5157,7 +5157,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, if Hitmonchan is damaged by an opponent's attack (even if Hitmonchan is Knocked Out), put 4 damage counters on the Attacking Pokémon."
+        "text": "During your opponent’s next turn, if Hitmonchan is damaged by an opponent’s attack (even if Hitmonchan is Knocked Out), put 4 damage counters on the Attacking Pokémon."
       },
       {
         "name": "Gut Strike",
@@ -5167,7 +5167,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "If Tyrogue is anywhere under Hitmonchan, this attack's base damage is 60 instead of 30."
+        "text": "If Tyrogue is anywhere under Hitmonchan, this attack’s base damage is 60 instead of 30."
       }
     ],
     "weaknesses": [
@@ -5208,7 +5208,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "If Tyrogue is anywhere under Hitmonlee, you may do 30 damage to any 1 Benched Pokémon instead. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If Tyrogue is anywhere under Hitmonlee, you may do 30 damage to any 1 Benched Pokémon instead. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Mega Kick",
@@ -5311,7 +5311,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Reverse Thrust",
@@ -5482,7 +5482,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Choose 1 card from your opponent's hand without looking. Look at that card you chose, then have your opponent shuffle that card into his or her deck."
+        "text": "Choose 1 card from your opponent’s hand without looking. Look at that card you chose, then have your opponent shuffle that card into his or her deck."
       },
       {
         "name": "Absorb",
@@ -5655,7 +5655,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -5921,7 +5921,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "This attack does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.) Pineco does 50 damage to itself."
+        "text": "This attack does 10 damage to each Benched Pokémon (both yours and your opponent’s). (Don’t apply Weakness and Resistance for Benched Pokémon.) Pineco does 50 damage to itself."
       }
     ],
     "weaknesses": [
@@ -6073,7 +6073,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Ambush",
@@ -6244,7 +6244,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
       },
       {
         "name": "Scratch",
@@ -6296,7 +6296,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at your opponent's hand. If your opponent has any Pokémon Tool or Technical Machine cards in his or her hand, put those cards on top of his or her deck. Your opponent shuffles his or her deck afterward."
+        "text": "Look at your opponent’s hand. If your opponent has any Pokémon Tool or Technical Machine cards in his or her hand, put those cards on top of his or her deck. Your opponent shuffles his or her deck afterward."
       },
       {
         "name": "Slash",
@@ -6521,7 +6521,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, Taillow's Peck attack's base damage is 30."
+        "text": "During your next turn, Taillow’s Peck attack’s base damage is 30."
       },
       {
         "name": "Peck",
@@ -6579,7 +6579,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Tentacool during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Tentacool during your opponent’s next turn."
       },
       {
         "name": "Mysterious Beam",
@@ -6746,7 +6746,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Yanma during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Yanma during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -6781,14 +6781,14 @@
     "set": "Legends Awakened",
     "setCode": "dp6",
     "text": [
-      "Attach Bubble Coat to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
-      "As long as Bubble Coat is attached to a Pokémon, that Pokémon has no Weakness. If that Pokémon is damaged by an opponent's attack, discard this card at the end of the turn."
+      "Attach Bubble Coat to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
+      "As long as Bubble Coat is attached to a Pokémon, that Pokémon has no Weakness. If that Pokémon is damaged by an opponent’s attack, discard this card at the end of the turn."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp6/129_hires.png"
   },
   {
     "id": "dp6-130",
-    "name": "Buck's Training",
+    "name": "Buck’s Training",
     "imageUrl": "https://images.pokemontcg.io/dp6/130.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -6801,13 +6801,13 @@
     "setCode": "dp6",
     "text": [
       "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.",
-      "Draw 2 cards. As long as Buck's Training is next to your Active Pokémon, each of your Active Pokémon's attacks does 10 more damage to the Active Pokémon (before applying Weakness and Resistance)."
+      "Draw 2 cards. As long as Buck’s Training is next to your Active Pokémon, each of your Active Pokémon’s attacks does 10 more damage to the Active Pokémon (before applying Weakness and Resistance)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp6/130_hires.png"
   },
   {
     "id": "dp6-131",
-    "name": "Cynthia's Feelings",
+    "name": "Cynthia’s Feelings",
     "imageUrl": "https://images.pokemontcg.io/dp6/131.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -6820,7 +6820,7 @@
     "setCode": "dp6",
     "text": [
       "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.",
-      "Shuffle your hand into your deck. Then, draw 4 cards. If any of your Pokémon were Knocked Out during your opponent's last turn, draw 4 more cards."
+      "Shuffle your hand into your deck. Then, draw 4 cards. If any of your Pokémon were Knocked Out during your opponent’s last turn, draw 4 more cards."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp6/131_hires.png"
   },
@@ -6873,8 +6873,8 @@
     "set": "Legends Awakened",
     "setCode": "dp6",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "Each Pokémon that isn't an Evolved Pokémon in play (both yours and your opponent's) gets +20 HP."
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
+      "Each Pokémon that isn’t an Evolved Pokémon in play (both yours and your opponent’s) gets +20 HP."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp6/134_hires.png"
   },
@@ -6891,8 +6891,8 @@
     "set": "Legends Awakened",
     "setCode": "dp6",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "Once during each player's turn, that player may choose a Fire or Fighting Energy attached to 1 of his or her Pokémon and move that Energy to 1 of his or her Fire or Fighting Pokémon."
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
+      "Once during each player’s turn, that player may choose a Fire or Fighting Energy attached to 1 of his or her Pokémon and move that Energy to 1 of his or her Fire or Fighting Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp6/135_hires.png"
   },
@@ -6909,7 +6909,7 @@
     "set": "Legends Awakened",
     "setCode": "dp6",
     "text": [
-      "Attach this card to 1 of your Pokémon in play. That Pokémon may use this card's attack instead of its own."
+      "Attach this card to 1 of your Pokémon in play. That Pokémon may use this card’s attack instead of its own."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp6/136_hires.png"
   },
@@ -6926,7 +6926,7 @@
     "set": "Legends Awakened",
     "setCode": "dp6",
     "text": [
-      "Attach this card to 1 of your Pokémon in play. That Pokémon may use this card's attack instead of its own."
+      "Attach this card to 1 of your Pokémon in play. That Pokémon may use this card’s attack instead of its own."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp6/137_hires.png"
   },
@@ -6944,8 +6944,8 @@
     "set": "Legends Awakened",
     "setCode": "dp6",
     "text": [
-      "Play Claw Fossil as if it were a Colorless Basic Pokémon. (Claw Fossil counts as a Trainer card as well, but if Claw Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Claw Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Claw Fossil from play. (This doesn't count as a Knocked Out Pokémon.)",
-      "If Claw Fossil is your Active Pokémon and is damaged by an opponent's attack (even if Claw Fossil is Knocked Out), put 1 damage counter on the Attacking Pokémon."
+      "Play Claw Fossil as if it were a Colorless Basic Pokémon. (Claw Fossil counts as a Trainer card as well, but if Claw Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Claw Fossil can’t be affected by any Special Conditions and can’t retreat. At any time during your turn before your attack, you may discard Claw Fossil from play. (This doesn’t count as a Knocked Out Pokémon.)",
+      "If Claw Fossil is your Active Pokémon and is damaged by an opponent’s attack (even if Claw Fossil is Knocked Out), put 1 damage counter on the Attacking Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp6/138_hires.png"
   },
@@ -6963,7 +6963,7 @@
     "set": "Legends Awakened",
     "setCode": "dp6",
     "text": [
-      "Play Root Fossil as if it were a Colorless Basic Pokémon. (Root Fossil counts as a Trainer card as well, but if Root Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Root Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Root Fossil from play. (This doesn't count as a Knocked Out Pokémon.)",
+      "Play Root Fossil as if it were a Colorless Basic Pokémon. (Root Fossil counts as a Trainer card as well, but if Root Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Root Fossil can’t be affected by any Special Conditions and can’t retreat. At any time during your turn before your attack, you may discard Root Fossil from play. (This doesn’t count as a Knocked Out Pokémon.)",
       "At any time between turns, remove 1 damage counter from Root Fossil."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp6/139_hires.png"
@@ -7004,7 +7004,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. Put 1 damage counter on that Pokémon for each Energy attached to all of your opponent's Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. Put 1 damage counter on that Pokémon for each Energy attached to all of your opponent’s Pokémon."
       }
     ],
     "weaknesses": [
@@ -7077,7 +7077,7 @@
     "level": "X",
     "ability": {
       "name": "Electric Trans",
-      "text": "As often as you like during your turn (before your attack), you may move a Lightning or Metal Energy attached to 1 of your Pokémon to another of your Pokémon. This power can't be used if Magnezone is affected by a Special Condition.",
+      "text": "As often as you like during your turn (before your attack), you may move a Lightning or Metal Energy attached to 1 of your Pokémon to another of your Pokémon. This power can’t be used if Magnezone is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "140",
@@ -7167,7 +7167,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "200",
-        "text": "If you don't have Uxie LV.X and Azelf LV.X in play, this attack does nothing. Discard all Energy attached to Mesprit."
+        "text": "If you don’t have Uxie LV.X and Azelf LV.X in play, this attack does nothing. Discard all Energy attached to Mesprit."
       }
     ],
     "weaknesses": [
@@ -7188,7 +7188,7 @@
     "level": "X",
     "ability": {
       "name": "Psybarrier",
-      "text": "Prevent all effects of attacks, including damage, done to Mewtwo by your opponent's Pokémon that isn't an Evolved Pokémon.",
+      "text": "Prevent all effects of attacks, including damage, done to Mewtwo by your opponent’s Pokémon that isn’t an Evolved Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -7302,7 +7302,7 @@
     "level": "X",
     "ability": {
       "name": "Trade Off",
-      "text": "Once during your turn (before your attack), you may look at the top 2 cards of your deck, choose 1 of them, and put it into your hand. Put the other card on the bottom of your deck. This power can't be used if Uxie is affected by a Special Condition. You can't use more than 1 Trade Off Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may look at the top 2 cards of your deck, choose 1 of them, and put it into your hand. Put the other card on the bottom of your deck. This power can’t be used if Uxie is affected by a Special Condition. You can’t use more than 1 Trade Off Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -7330,7 +7330,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "60",
-        "text": "Uxie can't use Zen Blade during your next turn."
+        "text": "Uxie can’t use Zen Blade during your next turn."
       }
     ],
     "weaknesses": [

--- a/json/cards/Majestic Dawn.json
+++ b/json/cards/Majestic Dawn.json
@@ -35,7 +35,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Benched Pokémon. If tails, this attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent’s Benched Pokémon. If tails, this attack does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -81,7 +81,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at the top 5 cards of either player's deck and put them back on top of that player's deck in any order."
+        "text": "Look at the top 5 cards of either player’s deck and put them back on top of that player’s deck in any order."
       },
       {
         "name": "Healing Light",
@@ -138,7 +138,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "At the end of your opponent's next turn, the Defending Pokémon is now Asleep."
+        "text": "At the end of your opponent’s next turn, the Defending Pokémon is now Asleep."
       },
       {
         "name": "Dark Resolve",
@@ -187,7 +187,7 @@
     "set": "Majestic Dawn",
     "setCode": "dp5",
     "text": [
-      "If an Active Pokémon has Weakness to Metal type, Dialga's attacks do 20 more damage to that Pokémon (before applying Weakness and Resistance)."
+      "If an Active Pokémon has Weakness to Metal type, Dialga’s attacks do 20 more damage to that Pokémon (before applying Weakness and Resistance)."
     ],
     "types": [
       "Metal"
@@ -259,7 +259,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Glaceon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Glaceon during your opponent’s next turn."
       },
       {
         "name": "Speed Slide",
@@ -270,7 +270,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "This attack's damage isn't affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -292,7 +292,7 @@
     "evolvesFrom": "Kabuto",
     "ability": {
       "name": "Primal Shell",
-      "text": "As long as Kabutops is your Active Pokémon, your opponent can't play any Trainer cards from his or her hand.",
+      "text": "As long as Kabutops is your Active Pokémon, your opponent can’t play any Trainer cards from his or her hand.",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -319,7 +319,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "Does 10 damage to each of your opponent's Benched Pokémon that has any damage counters on it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Benched Pokémon that has any damage counters on it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -361,7 +361,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Leaf Guard",
@@ -372,7 +372,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "During your opponent's next turn, any damage done to Leafeon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Leafeon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -580,7 +580,7 @@
     "set": "Majestic Dawn",
     "setCode": "dp5",
     "text": [
-      "If an Active Pokémon has Weakness to Water type, Palkia's attacks do 20 more damage to that Pokémon (before applying Weakness and Resistance)."
+      "If an Active Pokémon has Weakness to Water type, Palkia’s attacks do 20 more damage to that Pokémon (before applying Weakness and Resistance)."
     ],
     "types": [
       "Water"
@@ -605,7 +605,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "You may return an Energy card attached to Palkia to your hand. If you do, choose an Energy card attached to the Defending Pokémon and return it to your opponent's hand."
+        "text": "You may return an Energy card attached to Palkia to your hand. If you do, choose an Energy card attached to the Defending Pokémon and return it to your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -732,7 +732,7 @@
     "level": "45",
     "ability": {
       "name": "Sheet Lightning",
-      "text": "Once during your turn, when you put Zapdos from your hand onto your Bench, you may flip a coin. If heads, put 1 damage counter on each of your opponent's Pokémon.",
+      "text": "Once during your turn, when you put Zapdos from your hand onto your Bench, you may flip a coin. If heads, put 1 damage counter on each of your opponent’s Pokémon.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -759,7 +759,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "Does 40 damage to 1 of your Pokémon, and don't apply Weakness and Resistance to this damage."
+        "text": "Does 40 damage to 1 of your Pokémon, and don’t apply Weakness and Resistance to this damage."
       }
     ],
     "weaknesses": [
@@ -787,7 +787,7 @@
     "evolvesFrom": "Old Amber",
     "ability": {
       "name": "Primal Claw",
-      "text": "After your opponent's Pokémon uses a Poké-Power, put 2 damage counters on that Pokémon.",
+      "text": "After your opponent’s Pokémon uses a Poké-Power, put 2 damage counters on that Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -840,7 +840,7 @@
     "evolvesFrom": "Bronzor",
     "ability": {
       "name": "Cursed Alloy",
-      "text": "As long as Bronzong is your Active Pokémon, put 1 damage counter on each of your opponent's Pokémon that has any Poké-Powers between turns.",
+      "text": "As long as Bronzong is your Active Pokémon, put 1 damage counter on each of your opponent’s Pokémon that has any Poké-Powers between turns.",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -866,7 +866,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 1 damage counter on each of your opponent's Pokémon that already has damage counters on it."
+        "text": "Put 1 damage counter on each of your opponent’s Pokémon that already has damage counters on it."
       },
       {
         "name": "Coating",
@@ -877,7 +877,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "During your opponent's next turn, any damage done to Bronzong by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Bronzong by attacks is reduced by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -926,7 +926,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 2 of your opponent's Pokémon. This attack does 30 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 2 of your opponent’s Pokémon. This attack does 30 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Surf Together",
@@ -937,7 +937,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50+",
-        "text": "Does 50 damage plus 10 more damage for each of your Benched Pokémon. Flip a coin. If tails, this attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 50 damage plus 10 more damage for each of your Benched Pokémon. Flip a coin. If tails, this attack does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -959,7 +959,7 @@
     "evolvesFrom": "Eevee",
     "ability": {
       "name": "Sunlight Veil",
-      "text": "Each of your Pokémon that evolves from Eevee gets +20 HP. You can't use more than 1 Sunlight Veil Poké-Body each turn.",
+      "text": "Each of your Pokémon that evolves from Eevee gets +20 HP. You can’t use more than 1 Sunlight Veil Poké-Body each turn.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -1080,7 +1080,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Icy Wind",
@@ -1183,7 +1183,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Mega Bravo",
@@ -1241,7 +1241,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "You may discard 2 Energy attached to Jolteon. If you do, this attack's base damage is 90 instead of 50."
+        "text": "You may discard 2 Energy attached to Jolteon. If you do, this attack’s base damage is 90 instead of 50."
       }
     ],
     "weaknesses": [
@@ -1356,7 +1356,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If Plusle is on your Bench, this attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If Plusle is on your Bench, this attack does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1384,7 +1384,7 @@
     "evolvesFrom": "Omanyte",
     "ability": {
       "name": "Primal Swirl",
-      "text": "Once during your turn, when you play Omastar from your hand to evolve 1 of your Pokémon, you may remove the highest Stage Evolution card from each of your opponent's Benched Evolved Pokémon and put those cards back into his or her hand. You can't use more than 1 Primal Swirl Poké-Power each turn.",
+      "text": "Once during your turn, when you play Omastar from your hand to evolve 1 of your Pokémon, you may remove the highest Stage Evolution card from each of your opponent’s Benched Evolved Pokémon and put those cards back into his or her hand. You can’t use more than 1 Primal Swirl Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -1449,7 +1449,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
       },
       {
         "name": "Whirlpool",
@@ -1630,7 +1630,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "Torterra can't use Frenzy Plant during your next turn."
+        "text": "Torterra can’t use Frenzy Plant during your next turn."
       }
     ],
     "weaknesses": [
@@ -1704,7 +1704,7 @@
     "evolvesFrom": "Eevee",
     "ability": {
       "name": "Moonlight Veil",
-      "text": "Each of your Pokémon that evolves from Eevee has no Weakness, and that Pokémon's Retreat Cost is 0.",
+      "text": "Each of your Pokémon that evolves from Eevee has no Weakness, and that Pokémon’s Retreat Cost is 0.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -1875,7 +1875,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Choose 1 card from your opponent's hand without looking. Look at that card you chose, then have your opponent shuffle that card into his or her deck."
+        "text": "Choose 1 card from your opponent’s hand without looking. Look at that card you chose, then have your opponent shuffle that card into his or her deck."
       },
       {
         "name": "Hang High",
@@ -1886,7 +1886,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 40 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2239,7 +2239,7 @@
     "evolvesFrom": "Burmy",
     "ability": {
       "name": "Disturbance Scales",
-      "text": "Any damage done by attacks from your Pokémon to the Defending Pokémon isn't affected by Resistance.",
+      "text": "Any damage done by attacks from your Pokémon to the Defending Pokémon isn’t affected by Resistance.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -2377,7 +2377,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Wash Over",
@@ -2388,7 +2388,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Does 10 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2429,7 +2429,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Raichu during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Raichu during your opponent’s next turn."
       },
       {
         "name": "Thunderbolt",
@@ -2706,7 +2706,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Return Aipom and all cards attached to it to your hand. (If you don't have any Benched Pokémon, this attack does nothing.)"
+        "text": "Return Aipom and all cards attached to it to your hand. (If you don’t have any Benched Pokémon, this attack does nothing.)"
       }
     ],
     "weaknesses": [
@@ -2912,7 +2912,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Burmy Sandy Cloak during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Burmy Sandy Cloak during your opponent’s next turn."
       },
       {
         "name": "Tackle",
@@ -2962,7 +2962,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Shuffle your hand into your deck. Then, draw a number of cards equal to the number of cards in your opponent's hand."
+        "text": "Shuffle your hand into your deck. Then, draw a number of cards equal to the number of cards in your opponent’s hand."
       },
       {
         "name": "Chatter",
@@ -2972,7 +2972,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3061,7 +3061,7 @@
     "set": "Majestic Dawn",
     "setCode": "dp5",
     "text": [
-      "If Chimchar is Paralyzed, remove the Special Condition Paralyzed from Chimchar at the end of each player's turn."
+      "If Chimchar is Paralyzed, remove the Special Condition Paralyzed from Chimchar at the end of each player’s turn."
     ],
     "types": [
       "Fire"
@@ -3122,7 +3122,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3175,7 +3175,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -3402,7 +3402,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -3452,7 +3452,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Tackle",
@@ -3601,7 +3601,7 @@
     "evolvesFrom": "Dome Fossil",
     "ability": {
       "name": "Ancient Guidance",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, search your deck for Helix Fossil, Dome Fossil, or Old Amber and put it onto your Bench. Shuffle your deck afterward. This power can't be used if Kabuto is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, search your deck for Helix Fossil, Dome Fossil, or Old Amber and put it onto your Bench. Shuffle your deck afterward. This power can’t be used if Kabuto is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -3700,7 +3700,7 @@
     "evolvesFrom": "Helix Fossil",
     "ability": {
       "name": "Call Up",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, search your discard pile for Helix Fossil, Dome Fossil, or Old Amber and put it onto your Bench. This power can't be used if Omanyte is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, search your discard pile for Helix Fossil, Dome Fossil, or Old Amber and put it onto your Bench. This power can’t be used if Omanyte is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -3725,7 +3725,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Does 10 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3871,7 +3871,7 @@
     "set": "Majestic Dawn",
     "setCode": "dp5",
     "text": [
-      "If Piplup is Poisoned, remove the Special Condition Poisoned from Piplup at the end of each player's turn."
+      "If Piplup is Poisoned, remove the Special Condition Poisoned from Piplup at the end of each player’s turn."
     ],
     "types": [
       "Water"
@@ -3884,7 +3884,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -3938,7 +3938,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4209,7 +4209,7 @@
     "set": "Majestic Dawn",
     "setCode": "dp5",
     "text": [
-      "If Turtwig is Confused, remove the Special Condition Confused from Turtwig at the end of each player's turn."
+      "If Turtwig is Confused, remove the Special Condition Confused from Turtwig at the end of each player’s turn."
     ],
     "types": [
       "Grass"
@@ -4257,7 +4257,7 @@
     "set": "Majestic Dawn",
     "setCode": "dp5",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
       "Whenever any player attaches an Energy card from his or her hand to Grass Pokémon or Water Pokémon, remove 1 damage counter and all Special Conditions from that Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp5/79_hires.png"
@@ -4294,7 +4294,7 @@
     "set": "Majestic Dawn",
     "setCode": "dp5",
     "text": [
-      "Flip 3 coins. For each heads, put a basic Energy card from your discard pile into your hand. If you don't have that many basic Energy cards in your discard pile, put all of them into your hand."
+      "Flip 3 coins. For each heads, put a basic Energy card from your discard pile into your hand. If you don’t have that many basic Energy cards in your discard pile, put all of them into your hand."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp5/81_hires.png"
   },
@@ -4319,7 +4319,7 @@
   },
   {
     "id": "dp5-83",
-    "name": "Mom's Kindness",
+    "name": "Mom’s Kindness",
     "imageUrl": "https://images.pokemontcg.io/dp5/83.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4350,8 +4350,8 @@
     "set": "Majestic Dawn",
     "setCode": "dp5",
     "text": [
-      "Play Old Amber as if it were a Colorless Basic Pokémon. (Old Amber counts as a Trainer card as well, but if Old Amber is Knocked Out, this counts as a Knocked Out Pokémon.) Old Amber can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Old Amber from play. (This doesn't count as a Knocked Out Pokémon.)",
-      "As long as Old Amber is on your Bench, prevent all damage done to Old Amber by attacks (both yours and your opponent's)."
+      "Play Old Amber as if it were a Colorless Basic Pokémon. (Old Amber counts as a Trainer card as well, but if Old Amber is Knocked Out, this counts as a Knocked Out Pokémon.) Old Amber can’t be affected by any Special Conditions and can’t retreat. At any time during your turn before your attack, you may discard Old Amber from play. (This doesn’t count as a Knocked Out Pokémon.)",
+      "As long as Old Amber is on your Bench, prevent all damage done to Old Amber by attacks (both yours and your opponent’s)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp5/84_hires.png"
   },
@@ -4387,7 +4387,7 @@
     "set": "Majestic Dawn",
     "setCode": "dp5",
     "text": [
-      "Reveal cards from your deck until you reveal a Pokémon. Show that Pokémon to your opponent and put it into your hand. Shuffle the other revealed cards back into your deck. (If you don't reveal a Pokémon, shuffle all the revealed cards back into your deck.)"
+      "Reveal cards from your deck until you reveal a Pokémon. Show that Pokémon to your opponent and put it into your hand. Shuffle the other revealed cards back into your deck. (If you don’t reveal a Pokémon, shuffle all the revealed cards back into your deck.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp5/86_hires.png"
   },
@@ -4441,7 +4441,7 @@
     "set": "Majestic Dawn",
     "setCode": "dp5",
     "text": [
-      "Play Dome Fossil as if it were a Colorless Basic Pokémon. (Dome Fossil counts as a Trainer card as well, but if Dome Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Dome Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Dome Fossil from play. (This doesn't count as a Knocked Out Pokémon.)",
+      "Play Dome Fossil as if it were a Colorless Basic Pokémon. (Dome Fossil counts as a Trainer card as well, but if Dome Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Dome Fossil can’t be affected by any Special Conditions and can’t retreat. At any time during your turn before your attack, you may discard Dome Fossil from play. (This doesn’t count as a Knocked Out Pokémon.)",
       "When you attach a Fighting Energy card from your hand to Dome Fossil (excluding effects of attacks or Poké-Powers), search your deck for a card that evolves from Dome Fossil and put it onto Dome Fossil (this counts as evolving Dome Fossil). Shuffle your deck afterward."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp5/89_hires.png"
@@ -4478,7 +4478,7 @@
     "set": "Majestic Dawn",
     "setCode": "dp5",
     "text": [
-      "Play Helix Fossil as if it were a Colorless Basic Pokémon. (Helix Fossil counts as a Trainer card as well, but if Helix Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Helix Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Helix Fossil from play. (This doesn't count as a Knocked Out Pokémon.)",
+      "Play Helix Fossil as if it were a Colorless Basic Pokémon. (Helix Fossil counts as a Trainer card as well, but if Helix Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Helix Fossil can’t be affected by any Special Conditions and can’t retreat. At any time during your turn before your attack, you may discard Helix Fossil from play. (This doesn’t count as a Knocked Out Pokémon.)",
       "When you attach a Water Energy card from your hand to Helix Fossil (excluding effects of attacks or Poké-Powers), search your deck for a card that evolves from Helix Fossil and put it onto Helix Fossil (this counts as evolving Helix Fossil). Shuffle your deck afterward."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp5/91_hires.png"
@@ -4513,7 +4513,7 @@
     "set": "Majestic Dawn",
     "setCode": "dp5",
     "text": [
-      "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect if the Pokémon that Darkness Energy is attached to isn't Darkness. Darkness Energy provides Darkness Energy. (Doesn't count as a basic Energy card.)"
+      "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect if the Pokémon that Darkness Energy is attached to isn’t Darkness. Darkness Energy provides Darkness Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp5/93_hires.png"
   },
@@ -4547,7 +4547,7 @@
     "set": "Majestic Dawn",
     "setCode": "dp5",
     "text": [
-      "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn't Metal. Metal Energy provides Metal Energy. (Doesn't count as a basic Energy card.)"
+      "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn’t Metal. Metal Energy provides Metal Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp5/95_hires.png"
   },
@@ -4577,7 +4577,7 @@
     "level": "X",
     "ability": {
       "name": "Dragon Pulse",
-      "text": "Once during your turn (before your attack), when you put Garchomp LV.X from your hand onto your Active Garchomp, you may flip 3 coins. For each heads, put 1 damage counter on each of your opponent's Benched Pokémon.",
+      "text": "Once during your turn (before your attack), when you put Garchomp LV.X from your hand onto your Active Garchomp, you may flip 3 coins. For each heads, put 1 damage counter on each of your opponent’s Benched Pokémon.",
       "type": "Poké-Power"
     },
     "hp": "140",
@@ -4622,7 +4622,7 @@
     "level": "X",
     "ability": {
       "name": "Chilly Breath",
-      "text": "As long as Glaceon is your Active Pokémon, your opponent's Pokémon can't use any Poké-Powers.",
+      "text": "As long as Glaceon is your Active Pokémon, your opponent’s Pokémon can’t use any Poké-Powers.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -4651,7 +4651,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "Flip a coin. If heads, this attack does 20 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 20 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4672,7 +4672,7 @@
     "level": "X",
     "ability": {
       "name": "Energy Forcing",
-      "text": "Once during your turn (before your attack), you may attach an Energy card from your hand to 1 of your Pokémon. This power can't be used if Leafeon is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may attach an Energy card from your hand to 1 of your Pokémon. This power can’t be used if Leafeon is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -4728,7 +4728,7 @@
     "level": "X",
     "ability": {
       "name": "Mode Crash",
-      "text": "Once during your turn (before your attack), when you put Porygon-Z LV.X from your hand onto your Active Porygon-Z, you may discard all of your opponent's Special Energy cards in play.",
+      "text": "Once during your turn (before your attack), when you put Porygon-Z LV.X from your hand onto your Active Porygon-Z, you may discard all of your opponent’s Special Energy cards in play.",
       "type": "Poké-Power"
     },
     "hp": "130",

--- a/json/cards/Mysterious Treasures.json
+++ b/json/cards/Mysterious Treasures.json
@@ -72,7 +72,7 @@
     "evolvesFrom": "Kadabra",
     "ability": {
       "name": "Power Cancel",
-      "text": "Once during your opponent's turn, when your opponent's Pokémon uses any Poké-Power, you may discard 2 cards from your hand and prevent all effects of that Poké-Power. (This counts as that Pokémon using its Poké-Power.) This power can't be used if Alakazam is affected by a Special Condition.",
+      "text": "Once during your opponent’s turn, when your opponent’s Pokémon uses any Poké-Power, you may discard 2 cards from your hand and prevent all effects of that Poké-Power. (This counts as that Pokémon using its Poké-Power.) This power can’t be used if Alakazam is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -98,7 +98,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "During your opponent's next turn, any damage done to Alakazam by attacks from your opponent's Stage 2 Evolved Pokémon is reduced by 30 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Alakazam by attacks from your opponent’s Stage 2 Evolved Pokémon is reduced by 30 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -140,7 +140,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent flips a coin until he or she gets heads. For each tails, remove an Energy card attached to the Defending Pokémon and put it on the bottom of your opponent's deck."
+        "text": "Your opponent flips a coin until he or she gets heads. For each tails, remove an Energy card attached to the Defending Pokémon and put it on the bottom of your opponent’s deck."
       },
       {
         "name": "Charity Tail",
@@ -150,7 +150,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "80",
-        "text": "Before Ambipom does damage, your opponent may discard 2 cards from his or her hand. If he or she does, this attack's base damage is 10 instead of 80."
+        "text": "Before Ambipom does damage, your opponent may discard 2 cards from his or her hand. If he or she does, this attack’s base damage is 10 instead of 80."
       }
     ],
     "weaknesses": [
@@ -171,7 +171,7 @@
     "level": "50",
     "ability": {
       "name": "Downer Material",
-      "text": "If you have Uxie and Mesprit in play, the attack cost of each of your opponent's Basic Pokémon's attack is Colorless more. You can't use more than 1 Downer Material Poké-Body each turn.",
+      "text": "If you have Uxie and Mesprit in play, the attack cost of each of your opponent’s Basic Pokémon’s attack is Colorless more. You can’t use more than 1 Downer Material Poké-Body each turn.",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -195,7 +195,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "During your opponent's next turn, your opponent can't attach any Special Energy cards from his or her hand to any of his or her Pokémon."
+        "text": "During your opponent’s next turn, your opponent can’t attach any Special Energy cards from his or her hand to any of his or her Pokémon."
       }
     ],
     "weaknesses": [
@@ -217,7 +217,7 @@
     "evolvesFrom": "Chansey",
     "ability": {
       "name": "Kind Egg",
-      "text": "Once during your turn (before your attack), if Happiny is anywhere under Blissey, you may choose a number of cards in your hand up to the amount of Energy attached to Blissey and put those cards on top of your deck. Shuffle your deck afterward. Then, draw that many cards. This power can't be used if Blissey is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Happiny is anywhere under Blissey, you may choose a number of cards in your hand up to the amount of Energy attached to Blissey and put those cards on top of your deck. Shuffle your deck afterward. Then, draw that many cards. This power can’t be used if Blissey is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "130",
@@ -265,7 +265,7 @@
     "evolvesFrom": "Bronzor",
     "ability": {
       "name": "Miracle Oracle",
-      "text": "Once during your turn (before your attack), you may draw a card. Then, discard a card from your hand. If you discard an Energy card, draw 1 more card. This power can't be used if Bronzong is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may draw a card. Then, discard a card from your hand. If you discard an Energy card, draw 1 more card. This power can’t be used if Bronzong is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -403,7 +403,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Choose 1 card from your opponent's hand without looking and discard it."
+        "text": "Choose 1 card from your opponent’s hand without looking and discard it."
       }
     ],
     "weaknesses": [
@@ -425,7 +425,7 @@
     "evolvesFrom": "Gabite",
     "ability": {
       "name": "Rainbow Scale",
-      "text": "If an Active Pokémon has Weakness to any of the types of Energy attached to Garchomp, Garchomp's attacks do 40 more damage to that Pokémon (before applying Weakness and Resistance). Rainbow Scale Poké-Body can't be used if Garchomp has any Special Energy cards attached to it.",
+      "text": "If an Active Pokémon has Weakness to any of the types of Energy attached to Garchomp, Garchomp’s attacks do 40 more damage to that Pokémon (before applying Weakness and Resistance). Rainbow Scale Poké-Body can’t be used if Garchomp has any Special Energy cards attached to it.",
       "type": "Poké-Body"
     },
     "hp": "130",
@@ -470,7 +470,7 @@
     "evolvesFrom": "Murkrow",
     "ability": {
       "name": "Dark Genes",
-      "text": "As long as Honchkrow has the Energy necessary to use its attack, each of your Murkrow can use Honchkrow's attack as its own without the necessary Energy to use that attack.",
+      "text": "As long as Honchkrow has the Energy necessary to use its attack, each of your Murkrow can use Honchkrow’s attack as its own without the necessary Energy to use that attack.",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -496,7 +496,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Choose 1 card from your opponent's hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
+        "text": "Choose 1 card from your opponent’s hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
       }
     ],
     "weaknesses": [
@@ -524,7 +524,7 @@
     "evolvesFrom": "Finneon",
     "ability": {
       "name": "Lure Ring",
-      "text": "Once during your turn (before your attack), if Lumineon is your Active Pokémon, you may choose 1 of your opponent's Benched Pokémon that has maximum HP of 100 or more and switch it with 1 of the Defending Pokémon. This power can't be used if Lumineon is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Lumineon is your Active Pokémon, you may choose 1 of your opponent’s Benched Pokémon that has maximum HP of 100 or more and switch it with 1 of the Defending Pokémon. This power can’t be used if Lumineon is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -593,7 +593,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Flame Drum",
@@ -604,7 +604,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "If Magby isn't anywhere under Magmortar, discard 2 Energy cards from your hand. (If you can't discard 2 Energy cards from your hand, this attack does nothing.)"
+        "text": "If Magby isn’t anywhere under Magmortar, discard 2 Energy cards from your hand. (If you can’t discard 2 Energy cards from your hand, this attack does nothing.)"
       }
     ],
     "weaknesses": [
@@ -684,7 +684,7 @@
     "level": "50",
     "ability": {
       "name": "Upper Material",
-      "text": "If you have Uxie and Azelf in play, the Retreat Cost for each Uxie, Mesprit, and Azelf (both yours and your opponent's) is 0.",
+      "text": "If you have Uxie and Azelf in play, the Retreat Cost for each Uxie, Mesprit, and Azelf (both yours and your opponent’s) is 0.",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -788,7 +788,7 @@
     "evolvesFrom": "Quilava",
     "ability": {
       "name": "Firestarter",
-      "text": "Once during your turn (before your attack), you may attach a Fire Energy card from your discard pile to 1 of your Benched Pokémon. This power can't be used if Typhlosion is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may attach a Fire Energy card from your discard pile to 1 of your Benched Pokémon. This power can’t be used if Typhlosion is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -860,7 +860,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40+",
-        "text": "If your opponent has only 1 Prize card left, this attack does 40 damage plus 40 more damage and discard the top 3 cards from your opponent's deck."
+        "text": "If your opponent has only 1 Prize card left, this attack does 40 damage plus 40 more damage and discard the top 3 cards from your opponent’s deck."
       },
       {
         "name": "Ground Burn",
@@ -899,7 +899,7 @@
     "level": "50",
     "ability": {
       "name": "Memory Out",
-      "text": "Once during your opponent's turn, if Uxie is damaged by an opponent's attack (even if Uxie is Knocked Out), you may use this power. The Attacking Pokémon can't use that attack during your opponent's next turn.",
+      "text": "Once during your opponent’s turn, if Uxie is damaged by an opponent’s attack (even if Uxie is Knocked Out), you may use this power. The Attacking Pokémon can’t use that attack during your opponent’s next turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -945,7 +945,7 @@
     "evolvesFrom": "Snover",
     "ability": {
       "name": "Glacier Snow",
-      "text": "If Abomasnow is your Active Pokémon and is damaged by an opponent's attack (even if Abomasnow is Knocked Out), the Attacking Pokémon is now Asleep.",
+      "text": "If Abomasnow is your Active Pokémon and is damaged by an opponent’s attack (even if Abomasnow is Knocked Out), the Attacking Pokémon is now Asleep.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -973,7 +973,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Flip a coin. If heads, put 1 damage counter on each of your opponent's Benched Pokémon."
+        "text": "Flip a coin. If heads, put 1 damage counter on each of your opponent’s Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -995,7 +995,7 @@
     "evolvesFrom": "Spinarak",
     "ability": {
       "name": "Sticky",
-      "text": "The Retreat Cost for each player's Pokémon (excluding Ariados) is Colorless more.",
+      "text": "The Retreat Cost for each player’s Pokémon (excluding Ariados) is Colorless more.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -1042,7 +1042,7 @@
     "evolvesFrom": "Shieldon",
     "ability": {
       "name": "Protective Wall",
-      "text": "Prevent all damage done to your Benched Pokémon by your opponent's attacks.",
+      "text": "Prevent all damage done to your Benched Pokémon by your opponent’s attacks.",
       "type": "Poké-Body"
     },
     "hp": "130",
@@ -1070,7 +1070,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "If Bastiodon was damaged by an attack during your opponent's last turn, this attack does 40 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If Bastiodon was damaged by an attack during your opponent’s last turn, this attack does 40 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1169,7 +1169,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 50 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Flip a coin. If tails, shuffle Crobat and all cards attached to it back into your deck."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 50 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) Flip a coin. If tails, shuffle Crobat and all cards attached to it back into your deck."
       }
     ],
     "weaknesses": [
@@ -1248,7 +1248,7 @@
     "evolvesFrom": "Snorunt",
     "ability": {
       "name": "Craggy Face",
-      "text": "As long as Glalie is your Active Pokémon, any damage done by attacks from your opponent's Stage 2 Evolved Pokémon is reduced by 20 (before applying Weakness and Resistance).",
+      "text": "As long as Glalie is your Active Pokémon, any damage done by attacks from your opponent’s Stage 2 Evolved Pokémon is reduced by 20 (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -1275,7 +1275,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Flip a coin. If heads, your opponent can't play any Trainer cards or Supporter cards from his or her hand during your opponent's next turn."
+        "text": "Flip a coin. If heads, your opponent can’t play any Trainer cards or Supporter cards from his or her hand during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1297,7 +1297,7 @@
     "evolvesFrom": "Magikarp",
     "ability": {
       "name": "Dragon DNA",
-      "text": "Gyarados can use any attack from its Basic Pokémon. (You still have to pay for that attack's Energy cost.) If Gyarados uses any attack from its Basic Pokémon, that attack does 30 more damage to the Active Pokémon (before applying Weakness and Resistance).",
+      "text": "Gyarados can use any attack from its Basic Pokémon. (You still have to pay for that attack’s Energy cost.) If Gyarados uses any attack from its Basic Pokémon, that attack does 30 more damage to the Active Pokémon (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -1326,7 +1326,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "Flip a coin until you get tails. For each heads, choose 1 card from your opponent's hand without looking and discard it. If the first coin is tails, Gyarados is now Confused."
+        "text": "Flip a coin until you get tails. For each heads, choose 1 card from your opponent’s hand without looking and discard it. If the first coin is tails, Gyarados is now Confused."
       }
     ],
     "weaknesses": [
@@ -1434,7 +1434,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "Does 20 damage to each of your opponent's Benched Pokémon that is the same type as the Defending Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to each of your opponent’s Benched Pokémon that is the same type as the Defending Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1486,7 +1486,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "Mantine can't use Giant Wave during your next turn."
+        "text": "Mantine can’t use Giant Wave during your next turn."
       }
     ],
     "weaknesses": [
@@ -1513,7 +1513,7 @@
     "level": "33",
     "ability": {
       "name": "Airy Wall",
-      "text": "If your opponent's Pokémon that has 2 or less Energy cards attached to it attacks Mr. Mime, prevent all damage done to Mr. Mime from that attack. If Mime Jr. is anywhere under Mr. Mime, prevent all effects of that attack, including damage, done to Mr. Mime.",
+      "text": "If your opponent’s Pokémon that has 2 or less Energy cards attached to it attacks Mr. Mime, prevent all damage done to Mr. Mime from that attack. If Mime Jr. is anywhere under Mr. Mime, prevent all effects of that attack, including damage, done to Mr. Mime.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -1538,7 +1538,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Put a coin next to your Active Pokémon without showing your opponent and cover it with your hand. Your opponent guesses if the coin is heads or tails. If he or she is wrong, this attack does 50 damage to the Defending Pokémon. If he or she is right, Mr. Mime does 20 damage to itself, and this attack's damage isn't affected by Weakness or Resistance."
+        "text": "Put a coin next to your Active Pokémon without showing your opponent and cover it with your hand. Your opponent guesses if the coin is heads or tails. If he or she is wrong, this attack does 50 damage to the Defending Pokémon. If he or she is right, Mr. Mime does 20 damage to itself, and this attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -1560,7 +1560,7 @@
     "evolvesFrom": "Nidorina",
     "ability": {
       "name": "Mother Pheromone",
-      "text": "The attack cost of your Nidoran ♀, Nidorina, Nidoran ♂, Nidorino, and Nidoking's attack is Colorless less.",
+      "text": "The attack cost of your Nidoran ♀, Nidorina, Nidoran ♂, Nidorino, and Nidoking’s attack is Colorless less.",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -1587,7 +1587,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": "If you have the same number of or less Benched Pokémon than your opponent, this attack's base damage is 50 instead of 90."
+        "text": "If you have the same number of or less Benched Pokémon than your opponent, this attack’s base damage is 50 instead of 90."
       }
     ],
     "weaknesses": [
@@ -1615,7 +1615,7 @@
     "evolvesFrom": "Vulpix",
     "ability": {
       "name": "Color Shift",
-      "text": "Once during your turn (before your attack), you may choose 1 of your opponent's Pokémon. Ninetales is the same type as that Pokémon (all if that Pokémon is more than 1 type) until the end of your turn. This power can't be used if Ninetales is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may choose 1 of your opponent’s Pokémon. Ninetales is the same type as that Pokémon (all if that Pokémon is more than 1 type) until the end of your turn. This power can’t be used if Ninetales is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -1682,7 +1682,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "As long as the Defending Pokémon's remaining HP is 60 or less, this attack's base damage is 60 instead of 30."
+        "text": "As long as the Defending Pokémon’s remaining HP is 60 or less, this attack’s base damage is 60 instead of 30."
       },
       {
         "name": "Hasty Headbutt",
@@ -1693,7 +1693,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "Rampardos does 20 damage to itself. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "Rampardos does 20 damage to itself. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -1715,7 +1715,7 @@
     "evolvesFrom": "Vigoroth",
     "ability": {
       "name": "Energetic Impulse",
-      "text": "Once during your turn (before your attack), if Slaking is your Active Pokémon, you may flip a coin. If heads, Slaking's Lazy Blow attack's base damage is 130 during this turn. If tails, Slaking can't attack or retreat during this turn. (If Slaking is no longer your Active Pokémon, this effect ends.)",
+      "text": "Once during your turn (before your attack), if Slaking is your Active Pokémon, you may flip a coin. If heads, Slaking’s Lazy Blow attack’s base damage is 130 during this turn. If tails, Slaking can’t attack or retreat during this turn. (If Slaking is no longer your Active Pokémon, this effect ends.)",
       "type": "Poké-Power"
     },
     "hp": "140",
@@ -1785,7 +1785,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "If Bonsly is anywhere under Sudowoodo, flip a coin. If heads, prevent all effects of an attack, including damage, done to Sudowoodo during your opponent's next turn."
+        "text": "If Bonsly is anywhere under Sudowoodo, flip a coin. If heads, prevent all effects of an attack, including damage, done to Sudowoodo during your opponent’s next turn."
       },
       {
         "name": "Persuade",
@@ -1795,7 +1795,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon. The new Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon. The new Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1817,7 +1817,7 @@
     "evolvesFrom": "Croagunk",
     "ability": {
       "name": "Poison Sacs",
-      "text": "Your opponent can't remove the Special Condition Poisoned by evolving or devolving his or her Poisoned Pokémon. (This also includes putting a Pokémon Level-Up card onto the Poisoned Pokémon.)",
+      "text": "Your opponent can’t remove the Special Condition Poisoned by evolving or devolving his or her Poisoned Pokémon. (This also includes putting a Pokémon Level-Up card onto the Poisoned Pokémon.)",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -1863,7 +1863,7 @@
     "level": "16",
     "ability": {
       "name": "ITEM",
-      "text": "Once during your turn (before your attack), if you have Unown I, Unown T, Unown E, and Unown M on your Bench, you may search your deck for a Trainer card, show it to your opponent, and put it into your hand. Shuffle your deck afterward. You can't use more than 1 ITEM Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), if you have Unown I, Unown T, Unown E, and Unown M on your Bench, you may search your deck for a Trainer card, show it to your opponent, and put it into your hand. Shuffle your deck afterward. You can’t use more than 1 ITEM Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "50",
@@ -1887,7 +1887,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose an Energy card attached to the Defending Pokémon and put it face down. Treat that card as a Special Energy card that provides Colorless Energy and doesn't have any effect other than providing Energy. Put that card face up at the end of your opponent's next turn."
+        "text": "Choose an Energy card attached to the Defending Pokémon and put it face down. Treat that card as a Special Energy card that provides Colorless Energy and doesn’t have any effect other than providing Energy. Put that card face up at the end of your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1930,7 +1930,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "The Defending Pokémon is now Confused. During your opponent's next turn, that Pokémon's attacks do 60 more damage to the Active Pokémon (before applying Weakness and Resistance)."
+        "text": "The Defending Pokémon is now Confused. During your opponent’s next turn, that Pokémon’s attacks do 60 more damage to the Active Pokémon (before applying Weakness and Resistance)."
       },
       {
         "name": "Defensive Claw",
@@ -1964,7 +1964,7 @@
     "evolvesFrom": "Sealeo",
     "ability": {
       "name": "Freeze-up",
-      "text": "Once during your turn, when you play Walrein from your hand to evolve 1 of your Pokémon, you may flip 2 coins. If both are heads, discard 1 of the Defending Pokémon and all cards attached to it. (This doesn't count as a Knocked Out Pokémon.)",
+      "text": "Once during your turn, when you play Walrein from your hand to evolve 1 of your Pokémon, you may flip 2 coins. If both are heads, discard 1 of the Defending Pokémon and all cards attached to it. (This doesn’t count as a Knocked Out Pokémon.)",
       "type": "Poké-Power"
     },
     "hp": "130",
@@ -1992,7 +1992,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "If your opponent doesn't discard a card from his or her hand, the Defending Pokémon is now Paralyzed."
+        "text": "If your opponent doesn’t discard a card from his or her hand, the Defending Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -2214,7 +2214,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2265,7 +2265,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2366,7 +2366,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 3 of your opponent's Evolved Pokémon. This attack does 30 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 3 of your opponent’s Evolved Pokémon. This attack does 30 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2472,7 +2472,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, put 4 damage counters on 1 of your opponent's Pokémon. If tails, remove 4 damage counters from 1 of your Pokémon."
+        "text": "Flip a coin. If heads, put 4 damage counters on 1 of your opponent’s Pokémon. If tails, remove 4 damage counters from 1 of your Pokémon."
       }
     ],
     "weaknesses": [
@@ -2563,7 +2563,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Look at your opponent's hand."
+        "text": "Look at your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -2627,7 +2627,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Does 10 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2841,7 +2841,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20x",
-        "text": "Does 20 damage times the number of Colorless Energy in the Defending Pokémon's Retreat Cost (after applying effects to the Retreat Cost)."
+        "text": "Does 20 damage times the number of Colorless Energy in the Defending Pokémon’s Retreat Cost (after applying effects to the Retreat Cost)."
       },
       {
         "name": "Swirling Ripple",
@@ -2963,7 +2963,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Benched Pokémon. This attack does 40 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Benched Pokémon. This attack does 40 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3055,7 +3055,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Rocket Tackle",
@@ -3066,7 +3066,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Pupitar does 10 damage to itself. Flip a coin. If heads, prevent all damage done to Pupitar by attacks during your opponent's next turn."
+        "text": "Pupitar does 10 damage to itself. Flip a coin. If heads, prevent all damage done to Pupitar by attacks during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3161,7 +3161,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, if Sandslash is damaged by an opponent's attack (even if Sandslash is Knocked Out), put 4 damage counters on the Attacking Pokémon."
+        "text": "During your opponent’s next turn, if Sandslash is damaged by an opponent’s attack (even if Sandslash is Knocked Out), put 4 damage counters on the Attacking Pokémon."
       },
       {
         "name": "Poison Spike",
@@ -3221,7 +3221,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3267,7 +3267,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "During your opponent's next turn, any damage done to Shieldon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Shieldon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Shield Attack",
@@ -3389,7 +3389,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "During your opponent's next turn, whenever your opponent flips a coin, treat it as tails."
+        "text": "During your opponent’s next turn, whenever your opponent flips a coin, treat it as tails."
       }
     ],
     "weaknesses": [
@@ -3410,7 +3410,7 @@
     "level": "15",
     "ability": {
       "name": "MAGNET",
-      "text": "Once during your turn (before your attack), if Unown M is your Active Pokémon, you may flip a coin. If heads, switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. This power can't be used if Unown M is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Unown M is your Active Pokémon, you may flip a coin. If heads, switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon. This power can’t be used if Unown M is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "50",
@@ -3434,7 +3434,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, this attack does 30 damage. If tails, this attack does 30 damage to 1 of your Pokémon, and this attack's damage isn't affected by Weakness or Resistance."
+        "text": "Flip a coin. If heads, this attack does 30 damage. If tails, this attack does 30 damage to 1 of your Pokémon, and this attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -3455,7 +3455,7 @@
     "level": "14",
     "ability": {
       "name": "THROW",
-      "text": "Once during your turn (before your attack), if Unown T is your Active Pokémon, you may discard a card from your hand. Then, flip a coin. If heads, put 2 damage counters on 1 of your opponent's Benched Pokémon. This power can't be used if Unown T is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Unown T is your Active Pokémon, you may discard a card from your hand. Then, flip a coin. If heads, put 2 damage counters on 1 of your opponent’s Benched Pokémon. This power can’t be used if Unown T is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "50",
@@ -3479,7 +3479,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at your opponent's hand and choose 1 card, then have your opponent shuffle that card into his or her deck. Then, show your opponent your hand and he or she chooses 1 card. Shuffle that card into your deck."
+        "text": "Look at your opponent’s hand and choose 1 card, then have your opponent shuffle that card into his or her deck. Then, show your opponent your hand and he or she chooses 1 card. Shuffle that card into your deck."
       }
     ],
     "weaknesses": [
@@ -3520,7 +3520,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If Vigoroth evolved from Slakoth during this turn and Slakoth was Asleep, this attack's base damage is 60 instead of 10."
+        "text": "If Vigoroth evolved from Slakoth during this turn and Slakoth was Asleep, this attack’s base damage is 60 instead of 10."
       },
       {
         "name": "Fury Swipes",
@@ -3637,7 +3637,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Before doing damage, discard all Pokémon Tool cards attached to that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) Before doing damage, discard all Pokémon Tool cards attached to that Pokémon."
       }
     ],
     "weaknesses": [
@@ -3731,7 +3731,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3868,7 +3868,7 @@
     "set": "Mysterious Treasures",
     "setCode": "dp2",
     "text": [
-      "If Buizel is Asleep, remove the Special Condition Asleep from Buizel at the end of each player's turn."
+      "If Buizel is Asleep, remove the Special Condition Asleep from Buizel at the end of each player’s turn."
     ],
     "types": [
       "Water"
@@ -3927,7 +3927,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to Chansey by attacks during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all damage done to Chansey by attacks during your opponent’s next turn."
       },
       {
         "name": "Double-edge",
@@ -4040,7 +4040,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent can't play any Supporter cards from his or her hand during his or her next turn."
+        "text": "Flip a coin. If heads, your opponent can’t play any Supporter cards from his or her hand during his or her next turn."
       },
       {
         "name": "Finger Poke",
@@ -4156,7 +4156,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Doduo can't use Accelerating Stab during your next turn."
+        "text": "Doduo can’t use Accelerating Stab during your next turn."
       }
     ],
     "weaknesses": [
@@ -4205,7 +4205,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, your opponent can't attach any Energy cards from his or her hand to the Active Pokémon during his or her next turn."
+        "text": "Flip a coin. If heads, your opponent can’t attach any Energy cards from his or her hand to the Active Pokémon during his or her next turn."
       }
     ],
     "weaknesses": [
@@ -4254,7 +4254,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin for each Energy attached to Exeggcute. Choose 1 of your opponent's Pokémon. For each heads, this attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin for each Energy attached to Exeggcute. Choose 1 of your opponent’s Pokémon. For each heads, this attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4297,7 +4297,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Finneon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Finneon during your opponent’s next turn."
       },
       {
         "name": "Tackle",
@@ -4351,7 +4351,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 2 of your opponent's Benched Pokémon. This attack does 10 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 2 of your opponent’s Benched Pokémon. This attack does 10 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4856,7 +4856,7 @@
     "level": "15",
     "ability": {
       "name": "Electro Recycle",
-      "text": "Once during your turn (before your attack), if Pichu is anywhere under Pikachu, you may search your discard pile for a Lightning Energy card, show it to your opponent, and put it into your hand. This power can't be used if Pikachu is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Pichu is anywhere under Pikachu, you may search your discard pile for a Lightning Energy card, show it to your opponent, and put it into your hand. This power can’t be used if Pikachu is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -4930,7 +4930,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Numbing Water",
@@ -4983,7 +4983,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Ram",
@@ -5077,7 +5077,7 @@
     "set": "Mysterious Treasures",
     "setCode": "dp2",
     "text": [
-      "If Shinx is Burned, remove the Special Condition Burned from Shinx at the end of each player's turn."
+      "If Shinx is Burned, remove the Special Condition Burned from Shinx at the end of each player’s turn."
     ],
     "types": [
       "Lightning"
@@ -5236,7 +5236,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at your opponent's hand."
+        "text": "Look at your opponent’s hand."
       },
       {
         "name": "Snowball Fight",
@@ -5299,7 +5299,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, during your next turn, Spheal's Rollout attack's base damage is 40."
+        "text": "Flip a coin. If heads, during your next turn, Spheal’s Rollout attack’s base damage is 40."
       }
     ],
     "weaknesses": [
@@ -5342,7 +5342,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Double Scratch",
@@ -5395,7 +5395,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. The new Defending Pokémon is now Asleep."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon. The new Defending Pokémon is now Asleep."
       }
     ],
     "weaknesses": [
@@ -5544,7 +5544,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -5620,7 +5620,7 @@
   },
   {
     "id": "dp2-109",
-    "name": "Bebe's Search",
+    "name": "Bebe’s Search",
     "imageUrl": "https://images.pokemontcg.io/dp2/109.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -5633,7 +5633,7 @@
     "setCode": "dp2",
     "text": [
       "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.",
-      "Choose a card from your hand and put it on top of your deck. Search your deck for a Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward. (If this is the only card in your hand, you can't play this card.)"
+      "Choose a card from your hand and put it on top of your deck. Search your deck for a Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward. (If this is the only card in your hand, you can’t play this card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp2/109_hires.png"
   },
@@ -5687,8 +5687,8 @@
     "set": "Mysterious Treasures",
     "setCode": "dp2",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "Apply Weakness for each Pokémon (both your and your opponent's) as ×2 instead."
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
+      "Apply Weakness for each Pokémon (both your and your opponent’s) as ×2 instead."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp2/112_hires.png"
   },
@@ -5724,13 +5724,13 @@
     "set": "Mysterious Treasures",
     "setCode": "dp2",
     "text": [
-      "Reveal cards from your deck until you reveal a Pokémon. Show that Pokémon to your opponent and put it into your hand. Shuffle the other revealed cards back into your deck. (If you don't reveal a Pokémon, shuffle all the revealed cards back into your deck.)"
+      "Reveal cards from your deck until you reveal a Pokémon. Show that Pokémon to your opponent and put it into your hand. Shuffle the other revealed cards back into your deck. (If you don’t reveal a Pokémon, shuffle all the revealed cards back into your deck.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp2/114_hires.png"
   },
   {
     "id": "dp2-115",
-    "name": "Team Galactic's Wager",
+    "name": "Team Galactic’s Wager",
     "imageUrl": "https://images.pokemontcg.io/dp2/115.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -5761,8 +5761,8 @@
     "set": "Mysterious Treasures",
     "setCode": "dp2",
     "text": [
-      "Play Armor Fossil as if it were a Colorless Basic Pokémon. (Armor Fossil counts as a Trainer card as well, but if Armor Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Armor Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Armor Fossil from play. (This doesn't count as a Knocked Out Pokémon.)",
-      "Whenever Armor Fossil would be damaged by your opponent's attack, flip a coin until you get tails. For each heads, reduce that damage by 10."
+      "Play Armor Fossil as if it were a Colorless Basic Pokémon. (Armor Fossil counts as a Trainer card as well, but if Armor Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Armor Fossil can’t be affected by any Special Conditions and can’t retreat. At any time during your turn before your attack, you may discard Armor Fossil from play. (This doesn’t count as a Knocked Out Pokémon.)",
+      "Whenever Armor Fossil would be damaged by your opponent’s attack, flip a coin until you get tails. For each heads, reduce that damage by 10."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp2/116_hires.png"
   },
@@ -5780,8 +5780,8 @@
     "set": "Mysterious Treasures",
     "setCode": "dp2",
     "text": [
-      "Play Skull Fossil as if it were a Colorless Basic Pokémon. (Skull Fossil counts as a Trainer card as well, but if Skull Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Skull Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Skull Fossil from play. (This doesn't count as a Knocked Out Pokémon.)",
-      "During your opponent's turn, if Skull Fossil would be Knocked Out by damage from an opponent’s attack, flip a coin until you get tails. For each heads, put 1 damage counter on the Attacking Pokémon."
+      "Play Skull Fossil as if it were a Colorless Basic Pokémon. (Skull Fossil counts as a Trainer card as well, but if Skull Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Skull Fossil can’t be affected by any Special Conditions and can’t retreat. At any time during your turn before your attack, you may discard Skull Fossil from play. (This doesn’t count as a Knocked Out Pokémon.)",
+      "During your opponent’s turn, if Skull Fossil would be Knocked Out by damage from an opponent’s attack, flip a coin until you get tails. For each heads, put 1 damage counter on the Attacking Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp2/117_hires.png"
   },
@@ -5815,7 +5815,7 @@
     "set": "Mysterious Treasures",
     "setCode": "dp2",
     "text": [
-      "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect if the Pokémon that Darkness Energy is attached to isn't Darkness. Darkness Energy provides Darkness Energy. (Doesn't count as a basic Energy card.)"
+      "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect if the Pokémon that Darkness Energy is attached to isn’t Darkness. Darkness Energy provides Darkness Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp2/119_hires.png"
   },
@@ -5832,7 +5832,7 @@
     "set": "Mysterious Treasures",
     "setCode": "dp2",
     "text": [
-      "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn't Metal. Metal Energy provides Metal Energy. (Doesn't count as a basic Energy card.)"
+      "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn’t Metal. Metal Energy provides Metal Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp2/120_hires.png"
   },
@@ -5875,7 +5875,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "Discard all of your opponent's Pokémon Tool cards and Stadium cards in play. If you do, prevent all effects, including damage, done to Electivire during your opponent's next turn."
+        "text": "Discard all of your opponent’s Pokémon Tool cards and Stadium cards in play. If you do, prevent all effects, including damage, done to Electivire during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -5902,7 +5902,7 @@
     "level": "X",
     "ability": {
       "name": "Stance",
-      "text": "Once during your turn (before your attack), when you put Lucario LV. X from your hand onto your Active Lucario, you may use this power. Prevent all effects of an attack, including damage, done to Lucario during your opponent's next turn. (If Lucario is no longer your Active Pokémon, this effect ends.)",
+      "text": "Once during your turn (before your attack), when you put Lucario LV. X from your hand onto your Active Lucario, you may use this power. Prevent all effects of an attack, including damage, done to Lucario during your opponent’s next turn. (If Lucario is no longer your Active Pokémon, this effect ends.)",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -5931,7 +5931,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "During your opponent's next turn, any damage done to Lucario by attacks is increased by 30 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Lucario by attacks is increased by 30 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -5952,7 +5952,7 @@
     "level": "X",
     "ability": {
       "name": "Torrid Wave",
-      "text": "Once during your turn (before your attack), if Magmortar is your Active Pokémon, you may choose 1 of the Defending Pokémon. That Pokémon is now Burned. Put 3 damage counters instead of 2 on that Pokémon between turns. This power can't be used if Magmortar is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Magmortar is your Active Pokémon, you may choose 1 of the Defending Pokémon. That Pokémon is now Burned. Put 3 damage counters instead of 2 on that Pokémon between turns. This power can’t be used if Magmortar is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "130",
@@ -5984,7 +5984,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Discard 2 Fire Energy attached to Magmortar. Choose 1 of your opponent's Pokémon. This attack does 100 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) During your next turn, Magmortar can't use Flame Bluster."
+        "text": "Discard 2 Fire Energy attached to Magmortar. Choose 1 of your opponent’s Pokémon. This attack does 100 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) During your next turn, Magmortar can’t use Flame Bluster."
       }
     ],
     "weaknesses": [

--- a/json/cards/Neo Destiny.json
+++ b/json/cards/Neo Destiny.json
@@ -9,7 +9,7 @@
     "evolvesFrom": "Flaaffy",
     "ability": {
       "name": "Conductivity",
-      "text": "Whenever your opponent attaches an Energy card to a Pokémon from his or her hand, this Power does 10 damage to that Pokémon. (Don't apply Weakness and Resistance) This power stops working if you have more than 1 Dark Ampharos in play or while Dark Ampharos is Asleep, Confused or Paralysed.",
+      "text": "Whenever your opponent attaches an Energy card to a Pokémon from his or her hand, this Power does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance) This power stops working if you have more than 1 Dark Ampharos in play or while Dark Ampharos is Asleep, Confused or Paralysed.",
       "type": "Pokémon Power"
     },
     "hp": "70",
@@ -58,7 +58,7 @@
     "evolvesFrom": "Zubat",
     "ability": {
       "name": "Surprise Bite",
-      "text": "When you play Dark Crobat from your hand, you may choose 1 of your opponent's Pokémon. This power does 20 damage do that Pokémon. (Don't apply Weakness and Resistance.)",
+      "text": "When you play Dark Crobat from your hand, you may choose 1 of your opponent’s Pokémon. This power does 20 damage do that Pokémon. (Don’t apply Weakness and Resistance.)",
       "type": "Pokémon Power"
     },
     "hp": "70",
@@ -80,7 +80,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin for each of your opponent's Pokémon. For each heads, this attack does 10 damage to that Pokémon. Don't apply Weakness and Resistance. Remove a number of damage counters from Dark Crobat equal to the damage dealt. If Dark Crobat has fewer damage counters than that, remove all of them."
+        "text": "Flip a coin for each of your opponent’s Pokémon. For each heads, this attack does 10 damage to that Pokémon. Don’t apply Weakness and Resistance. Remove a number of damage counters from Dark Crobat equal to the damage dealt. If Dark Crobat has fewer damage counters than that, remove all of them."
       }
     ],
     "weaknesses": [
@@ -130,7 +130,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "If your opponent has any Benched Pokémon, flip a coin. If heads, return the Defending Pokémon and all cards attached to it to your opponent's hand. If tails, your opponent chooses 1 of his or her Benched Pokémon and switches it with the Defending Pokémon."
+        "text": "If your opponent has any Benched Pokémon, flip a coin. If heads, return the Defending Pokémon and all cards attached to it to your opponent’s hand. If tails, your opponent chooses 1 of his or her Benched Pokémon and switches it with the Defending Pokémon."
       },
       {
         "name": "Giant Tusk",
@@ -196,7 +196,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Does 10 damage to each of your opponent's Pokémon for each Energy card attached to that Pokémon. Don't apply Weakness and Resistance."
+        "text": "Does 10 damage to each of your opponent’s Pokémon for each Energy card attached to that Pokémon. Don’t apply Weakness and Resistance."
       }
     ],
     "weaknesses": [
@@ -218,7 +218,7 @@
     "evolvesFrom": "Croconaw",
     "ability": {
       "name": "Scare",
-      "text": "As long as Dark Feraligatr is your Active Pokémon, all of your opponent's Baby Pokémon Powers stop working and your opponent's Baby Pokémon can't attack. This power stops working while Dark Feraligatr is Asleep, Confused, or Paralyzed.",
+      "text": "As long as Dark Feraligatr is your Active Pokémon, all of your opponent’s Baby Pokémon Powers stop working and your opponent’s Baby Pokémon can’t attack. This power stops working while Dark Feraligatr is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "80",
@@ -336,7 +336,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If your opponent's Bench isn't full, look at his or her hand. If your opponent has any Baby Pokémon or Basic Pokémon there, choose 1 of them and put it on his or her Bench. Then, switch it with the Defending Pokémon."
+        "text": "If your opponent’s Bench isn’t full, look at his or her hand. If your opponent has any Baby Pokémon or Basic Pokémon there, choose 1 of them and put it on his or her Bench. Then, switch it with the Defending Pokémon."
       },
       {
         "name": "Dark Fire",
@@ -346,7 +346,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "If there are any Energy cards attached to Dark Houndoom, discard 1 of them and this attack does 30 damage plus 20 more damage (plus 10 more damage for the Energy you discarded). If there aren't any, this attack does 30 damage."
+        "text": "If there are any Energy cards attached to Dark Houndoom, discard 1 of them and this attack does 30 damage plus 20 more damage (plus 10 more damage for the Energy you discarded). If there aren’t any, this attack does 30 damage."
       }
     ],
     "weaknesses": [
@@ -368,7 +368,7 @@
     "evolvesFrom": "Porygon",
     "ability": {
       "name": "Spatial Distortion",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, choose a Stadium card from your discard pile and put it into play. (If there's already a Stadium card in play, discard it.) This power can't be used if Dark Porygon2 is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, choose a Stadium card from your discard pile and put it into play. (If there’s already a Stadium card in play, discard it.) This power can’t be used if Dark Porygon2 is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "60",
@@ -394,7 +394,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "Flip a coin. If heads, prevent all damage done by attacks to Dark Porygon2 during your opponent's next turn. (Any other effects of attacks still happen.)"
+        "text": "Flip a coin. If heads, prevent all damage done by attacks to Dark Porygon2 during your opponent’s next turn. (Any other effects of attacks still happen.)"
       }
     ],
     "weaknesses": [
@@ -446,7 +446,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, look at your opponent's hand. If he or she has any Trainer cards there, choose 1 of them. Your opponent shuffles that card into his or her deck."
+        "text": "Flip a coin. If heads, look at your opponent’s hand. If he or she has any Trainer cards there, choose 1 of them. Your opponent shuffles that card into his or her deck."
       },
       {
         "name": "Slash",
@@ -556,7 +556,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20×",
-        "text": "Flip a number of coins equal to the number of Energy cards attached to Dark Tyranitar. This attack does 20 damage times the number of heads. Then, for each heads, discard the top card from your opponent's deck."
+        "text": "Flip a number of coins equal to the number of Energy cards attached to Dark Tyranitar. This attack does 20 damage times the number of heads. Then, for each heads, discard the top card from your opponent’s deck."
       },
       {
         "name": "Fling Away",
@@ -568,7 +568,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "If your opponent has any Benched Pokémon, this attack does 30 damage instead of 50 and choose 1 of those Benched Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, this attack does 30 damage instead of 50 and choose 1 of those Benched Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -596,7 +596,7 @@
     "evolvesFrom": "Growlithe",
     "ability": {
       "name": "Drive Off",
-      "text": "As long as Light Arcanine is your Active Pokémon, once during your turn (before your attack), if your opponent has any Benched Pokémon, he or she chooses 1 of them and switches it with the Defending Pokémon. This power can't be used while Light Arcanine is Asleep, Confused, or Paralyzed.",
+      "text": "As long as Light Arcanine is your Active Pokémon, once during your turn (before your attack), if your opponent has any Benched Pokémon, he or she chooses 1 of them and switches it with the Defending Pokémon. This power can’t be used while Light Arcanine is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "100",
@@ -724,7 +724,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "During your opponent's next turn, prevent all effects of attacks that are not damage done to this Pokémon."
+        "text": "During your opponent’s next turn, prevent all effects of attacks that are not damage done to this Pokémon."
       }
     ],
     "resistances": [
@@ -796,7 +796,7 @@
     "set": "Neo Destiny",
     "setCode": "neo4",
     "text": [
-      "You can't have more than 1 Miracle Energy card in your deck. Attach Miracle Energy to one of your Shining or Light Pokémon. At the end of your turn, discard Miracle Energy. While in play, Miracle Energy counts as every type of Energy but provides only 2 Energy at a time."
+      "You can’t have more than 1 Miracle Energy card in your deck. Attach Miracle Energy to one of your Shining or Light Pokémon. At the end of your turn, discard Miracle Energy. While in play, Miracle Energy counts as every type of Energy but provides only 2 Energy at a time."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/neo4/16_hires.png"
   },
@@ -841,7 +841,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "The Defending Pokémon is now Poisoned. Flip a coin. If heads, the Defending Pokémon can't retreat until the end of your opponent's next turn and if the effect of an attack, Pokémon Power, or Trainer card would change that player's Active Pokémon, that part of the effect does nothing."
+        "text": "The Defending Pokémon is now Poisoned. Flip a coin. If heads, the Defending Pokémon can’t retreat until the end of your opponent’s next turn and if the effect of an attack, Pokémon Power, or Trainer card would change that player’s Active Pokémon, that part of the effect does nothing."
       }
     ],
     "weaknesses": [
@@ -863,7 +863,7 @@
     "evolvesFrom": "Slugma",
     "ability": {
       "name": "Hot Plate",
-      "text": "As long as Dark Magcargo is your Active Pokémon, whenever a player puts a Baby Pokémon or Basic Pokémon onto his or her Bench from his or her hand, this power does 10 damage to that Pokémon. (Don't apply Weakness and Resistance.) This power stops working if Dark Magcargo is Asleep, Confused, or Paralyzed.",
+      "text": "As long as Dark Magcargo is your Active Pokémon, whenever a player puts a Baby Pokémon or Basic Pokémon onto his or her Bench from his or her hand, this power does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance.) This power stops working if Dark Magcargo is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "60",
@@ -890,7 +890,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "You may discard a Energy card attached to Dark Magcargo when you use this attack. If you do and if your opponent has any Benched Pokémon, choose 1 of them and this attack does 20 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "You may discard a Energy card attached to Dark Magcargo when you use this attack. If you do and if your opponent has any Benched Pokémon, choose 1 of them and this attack does 20 damage to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -942,7 +942,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "During your opponent's next turn, the Defending Pokémon can't evolve except from effects of attacks or Pokémon Powers. (Benching that Pokémon ends this effect.)"
+        "text": "During your opponent’s next turn, the Defending Pokémon can’t evolve except from effects of attacks or Pokémon Powers. (Benching that Pokémon ends this effect.)"
       }
     ],
     "weaknesses": [
@@ -964,7 +964,7 @@
     "evolvesFrom": "Slowpoke",
     "ability": {
       "name": "Cunning",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, look at the top card of your opponent's deck. Then, you may have your opponent shuffle his or her deck. This power can't be used if Dark Slowking is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, look at the top card of your opponent’s deck. Then, you may have your opponent shuffle his or her deck. This power can’t be used if Dark Slowking is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "60",
@@ -990,7 +990,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Don't apply Weakness or Resistance for this attack."
+        "text": "Don’t apply Weakness or Resistance for this attack."
       }
     ],
     "weaknesses": [
@@ -1032,7 +1032,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at your opponent's hand. If he or she has any Baby Pokémon and/or Basic Pokémon there, you may put any number of them onto your opponent's Bench (as long as there's room). Then, your opponent looks at your hand. If you have any Baby Pokémon and/or Basic Pokémon there, your opponent may put any number of them onto your Bench (as long as there's room)."
+        "text": "Look at your opponent’s hand. If he or she has any Baby Pokémon and/or Basic Pokémon there, you may put any number of them onto your opponent’s Bench (as long as there’s room). Then, your opponent looks at your hand. If you have any Baby Pokémon and/or Basic Pokémon there, your opponent may put any number of them onto your Bench (as long as there’s room)."
       },
       {
         "name": "Battle Frenzy",
@@ -1042,7 +1042,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "For each Pokémon in play (yours and your opponent's), flip a coin. For each heads, this attack does 20 damage to that Pokémon. Don't apply Weakness and Resistance for this attack."
+        "text": "For each Pokémon in play (yours and your opponent’s), flip a coin. For each heads, this attack does 20 damage to that Pokémon. Don’t apply Weakness and Resistance for this attack."
       }
     ],
     "weaknesses": [
@@ -1102,7 +1102,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Light Dragonair."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Light Dragonair."
       }
     ],
     "resistances": [
@@ -1157,7 +1157,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1195,7 +1195,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If you have any Benched Pokémon, switch 1 of them with Light Ledian. As long as that Pokémon is your Active Pokémon, it can't become Asleep, Confused, Paralyzed, or Poisoned. (All other effects of attacks, Pokémon Powers, and Trainer cards still happen.)"
+        "text": "If you have any Benched Pokémon, switch 1 of them with Light Ledian. As long as that Pokémon is your Active Pokémon, it can’t become Asleep, Confused, Paralyzed, or Poisoned. (All other effects of attacks, Pokémon Powers, and Trainer cards still happen.)"
       },
       {
         "name": "Comet Punch",
@@ -1595,7 +1595,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn. If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing. (Benching either Pokémon ends this effect.)"
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn. If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing. (Benching either Pokémon ends this effect.)"
       }
     ],
     "weaknesses": [
@@ -1650,7 +1650,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20×",
-        "text": "Flip a number of coins equal to the number of Energy cards attached to your opponent's Pokémon. This attack does 20 damage times the number of heads."
+        "text": "Flip a number of coins equal to the number of Energy cards attached to your opponent’s Pokémon. This attack does 20 damage times the number of heads."
       }
     ],
     "weaknesses": [
@@ -1691,7 +1691,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, your opponent can't play Trainer cards during his or her next turn."
+        "text": "Flip a coin. If heads, your opponent can’t play Trainer cards during his or her next turn."
       },
       {
         "name": "Stun Wave",
@@ -1794,7 +1794,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put a Baby Pokémon or Basic Pokémon card from your opponent's discard pile onto his or her Bench. Put 1 damage counter on that Pokémon. (You can't use this attack if your Bench is full.)"
+        "text": "Put a Baby Pokémon or Basic Pokémon card from your opponent’s discard pile onto his or her Bench. Put 1 damage counter on that Pokémon. (You can’t use this attack if your Bench is full.)"
       },
       {
         "name": "Surround",
@@ -1804,7 +1804,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, the Defending Pokémon is now Asleep. If tails, the Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon is now Asleep. If tails, the Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "resistances": [
@@ -1847,7 +1847,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage for each Energy card attached to Dark Omanyte. Don't apply Weakness and Resistance. You can't do more than 30 damage in this way."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage for each Energy card attached to Dark Omanyte. Don’t apply Weakness and Resistance. You can’t do more than 30 damage in this way."
       }
     ],
     "weaknesses": [
@@ -1892,7 +1892,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Dark Pupitar does 10 damage to itself. Dark Pupitar can't use this attack during your next turn."
+        "text": "Dark Pupitar does 10 damage to itself. Dark Pupitar can’t use this attack during your next turn."
       },
       {
         "name": "Explosive Evolution",
@@ -1903,7 +1903,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Pokémon. Don't apply Weakness and Resistance. Then, search your deck for an Evolution card named Dark Tyranitar and put it on Dark Pupitar. (This counts as evolving Dark Pupitar.) Shuffle your deck afterward."
+        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent’s Pokémon. Don’t apply Weakness and Resistance. Then, search your deck for an Evolution card named Dark Tyranitar and put it on Dark Pupitar. (This counts as evolving Dark Pupitar.) Shuffle your deck afterward."
       }
     ],
     "weaknesses": [
@@ -1953,7 +1953,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Show the top card of your opponent's deck to all players. If it's a Trainer card, discard it."
+        "text": "Show the top card of your opponent’s deck to all players. If it’s a Trainer card, discard it."
       },
       {
         "name": "Rushing Magma",
@@ -2171,7 +2171,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Lunge",
@@ -2225,7 +2225,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "All damage done to Jigglypuff during your opponent's next turn is reduced by 10 (after applying Weakness and Resistance)."
+        "text": "All damage done to Jigglypuff during your opponent’s next turn is reduced by 10 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -2288,7 +2288,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Until the end of your opponent's next turn, as long as Light Dewgong is your Active Pokémon, prevent all damage done by attacks to your Benched Pokémon. (Any other effects of attacks still happen.)"
+        "text": "Until the end of your opponent’s next turn, as long as Light Dewgong is your Active Pokémon, prevent all damage done by attacks to your Benched Pokémon. (Any other effects of attacks still happen.)"
       }
     ],
     "weaknesses": [
@@ -2430,7 +2430,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, whenever 30 or more damage is done to Light Jolteon (after applying Weakness and Resistance), prevent that damage. (Any other effects of attacks still happen.)"
+        "text": "During your opponent’s next turn, whenever 30 or more damage is done to Light Jolteon (after applying Weakness and Resistance), prevent that damage. (Any other effects of attacks still happen.)"
       },
       {
         "name": "Thunder Needle",
@@ -2537,7 +2537,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put a Baby Pokémon or a Basic Pokémon card from your discard pile onto your Bench. (You can't use this attack if your Bench is full.)"
+        "text": "Put a Baby Pokémon or a Basic Pokémon card from your discard pile onto your Bench. (You can’t use this attack if your Bench is full.)"
       },
       {
         "name": "Fire Blast",
@@ -2652,7 +2652,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "The Defending Pokémon is now Asleep. Remove 1 damage counter from each Benched Pokémon (yours and your opponent's) with any damage counters on it."
+        "text": "The Defending Pokémon is now Asleep. Remove 1 damage counter from each Benched Pokémon (yours and your opponent’s) with any damage counters on it."
       }
     ],
     "weaknesses": [
@@ -2805,7 +2805,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Scyther."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Scyther."
       },
       {
         "name": "Sharp Sickle",
@@ -2865,7 +2865,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the Defending Pokémon attacks during your opponent's next turn, any damage it does is reduced by 10 (before applying Weakness and Resistance)."
+        "text": "If the Defending Pokémon attacks during your opponent’s next turn, any damage it does is reduced by 10 (before applying Weakness and Resistance)."
       },
       {
         "name": "Spike Ball Tackle",
@@ -2899,7 +2899,7 @@
     "level": "11",
     "ability": {
       "name": "[Chase]",
-      "text": "As long as Unown C is your Active Pokémon, whenever your opponent's Active Pokémon tries to retreat, flip a coin. If heads, put 1 damage counter on that Pokémon. Apply Weakness and Resistance.",
+      "text": "As long as Unown C is your Active Pokémon, whenever your opponent’s Active Pokémon tries to retreat, flip a coin. If heads, put 1 damage counter on that Pokémon. Apply Weakness and Resistance.",
       "type": "Pokémon Power"
     },
     "hp": "40",
@@ -2984,7 +2984,7 @@
     "level": "12",
     "ability": {
       "name": "[Quicken]",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, prevent all effects of attacks, including damage, done to any of your Pokémon with Unown in its name during your opponent's next turn. If you have more than 1 Unown Q in play, use only 1 [Quicken] each turn. This power can be used even if Unown Q is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, prevent all effects of attacks, including damage, done to any of your Pokémon with Unown in its name during your opponent’s next turn. If you have more than 1 Unown Q in play, use only 1 [Quicken] each turn. This power can be used even if Unown Q is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "40",
@@ -3093,7 +3093,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -3138,7 +3138,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20+",
-        "text": "This attack does 20 damage plus 10 more damage for each Energy attached to Dark Octillery but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "This attack does 20 damage plus 10 more damage for each Energy attached to Dark Octillery but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       },
       {
         "name": "Tentacle Wrap",
@@ -3148,7 +3148,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, the Defending Pokémon is now Paralyzed. If tails, during your opponent's next turn, your opponent pays more to retreat the Defending Pokémon."
+        "text": "Flip a coin. If heads, the Defending Pokémon is now Paralyzed. If tails, during your opponent’s next turn, your opponent pays more to retreat the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -3468,7 +3468,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If Hitmonchan would be damaged by an attack during your opponent's next turn, flip a coin. If heads, prevent that attack's damage done to Hitmonchan. (Any other effects of attacks still happen.)"
+        "text": "If Hitmonchan would be damaged by an attack during your opponent’s next turn, flip a coin. If heads, prevent that attack’s damage done to Hitmonchan. (Any other effects of attacks still happen.)"
       },
       {
         "name": "Supersonic Jab",
@@ -3519,7 +3519,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack during your opponent's next turn. (Benching or evolving either Pokémon ends this effect.)"
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack during your opponent’s next turn. (Benching or evolving either Pokémon ends this effect.)"
       },
       {
         "name": "Rock Throw",
@@ -3576,7 +3576,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Pokémon Powers, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Pokémon Powers, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -3733,7 +3733,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Mantine can't attack during your next turn."
+        "text": "Mantine can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -4252,7 +4252,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "Does 10 damage plus 10 more damage for each Energy attached to Totodile but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "Does 10 damage plus 10 more damage for each Energy attached to Totodile but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       }
     ],
     "weaknesses": [
@@ -4367,7 +4367,7 @@
     "level": "12",
     "ability": {
       "name": "[Tell]",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, look at your opponent's hand and show your hand to your opponent. This power can be used even if Unown T is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, look at your opponent’s hand and show your hand to your opponent. This power can be used even if Unown T is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "40",
@@ -4576,13 +4576,13 @@
     "set": "Neo Destiny",
     "setCode": "neo4",
     "text": [
-      "During your opponent's turn, if your Active Pokémon would be Knocked Out by your opponent's attack, you may take 1 of the basic Energy cards attached to your Active Pokémon and attach it to the Pokémon with EXP.ALL attached to it. If you do, discard EXP.ALL."
+      "During your opponent’s turn, if your Active Pokémon would be Knocked Out by your opponent’s attack, you may take 1 of the basic Energy cards attached to your Active Pokémon and attach it to the Pokémon with EXP.ALL attached to it. If you do, discard EXP.ALL."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/neo4/93_hires.png"
   },
   {
     "id": "neo4-94",
-    "name": "Impostor Professor Oak's Invention",
+    "name": "Impostor Professor Oak’s Invention",
     "imageUrl": "https://images.pokemontcg.io/neo4/94.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -4593,7 +4593,7 @@
     "set": "Neo Destiny",
     "setCode": "neo4",
     "text": [
-      "Look at your opponent's Prize cards. You may have your opponent shuffle them into his or her deck. If you do, your opponent takes that many cards from the top of his or her deck and sets them aside as his or her new Prize cards (without looking at them)."
+      "Look at your opponent’s Prize cards. You may have your opponent shuffle them into his or her deck. If you do, your opponent takes that many cards from the top of his or her deck and sets them aside as his or her new Prize cards (without looking at them)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/neo4/94_hires.png"
   },
@@ -4610,13 +4610,13 @@
     "set": "Neo Destiny",
     "setCode": "neo4",
     "text": [
-      "Once during each player's turn (before attacking), that player may look at the top 2 cards of his or her deck and put them back in the same order."
+      "Once during each player’s turn (before attacking), that player may look at the top 2 cards of his or her deck and put them back in the same order."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/neo4/95_hires.png"
   },
   {
     "id": "neo4-96",
-    "name": "Thought Wave Machine (Rocket's Secret Machine)",
+    "name": "Thought Wave Machine (Rocket’s Secret Machine)",
     "imageUrl": "https://images.pokemontcg.io/neo4/96.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -4627,7 +4627,7 @@
     "set": "Neo Destiny",
     "setCode": "neo4",
     "text": [
-      "Flip a coin until you get tails. For each heads, return an Energy card attached to your opponent's Active Pokémon to your opponent's hand. If the Pokémon has fewer attached Energy cards than that, return all of them to your opponent's hand. Your turn is over now (you don't get to attack)."
+      "Flip a coin until you get tails. For each heads, return an Energy card attached to your opponent’s Active Pokémon to your opponent’s hand. If the Pokémon has fewer attached Energy cards than that, return all of them to your opponent’s hand. Your turn is over now (you don’t get to attack)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/neo4/96_hires.png"
   },
@@ -4644,7 +4644,7 @@
     "set": "Neo Destiny",
     "setCode": "neo4",
     "text": [
-      "During your opponent's turn, if the Pokémon Counterattack Claws is attached to is your Active Pokémon and an opponent's attack damages it (even if it is Knocked Out), flip a coin. If heads, put 2 damage counters on the Defending Pokémon. Then, discard Counterattack Claws."
+      "During your opponent’s turn, if the Pokémon Counterattack Claws is attached to is your Active Pokémon and an opponent’s attack damages it (even if it is Knocked Out), flip a coin. If heads, put 2 damage counters on the Defending Pokémon. Then, discard Counterattack Claws."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/neo4/97_hires.png"
   },
@@ -4678,7 +4678,7 @@
     "set": "Neo Destiny",
     "setCode": "neo4",
     "text": [
-      "Once during each player's turn (before attacking), that player may flip a coin. If heads, that player puts a basic Energy card from his or her discard pile into his or her hand."
+      "Once during each player’s turn (before attacking), that player may flip a coin. If heads, that player puts a basic Energy card from his or her discard pile into his or her hand."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/neo4/99_hires.png"
   },
@@ -4695,7 +4695,7 @@
     "set": "Neo Destiny",
     "setCode": "neo4",
     "text": [
-      "Once during each player's turn (before attacking), that player may flip a coin. If heads, that player draws a card."
+      "Once during each player’s turn (before attacking), that player may flip a coin. If heads, that player draws a card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/neo4/100_hires.png"
   },
@@ -4712,7 +4712,7 @@
     "set": "Neo Destiny",
     "setCode": "neo4",
     "text": [
-      "Attach Magnifier to 1 of your Pokémon. At the end of your turn, discard Magnifier. If the Pokémon Magnifier is attached to attacks, don't apply Resistance for that attack."
+      "Attach Magnifier to 1 of your Pokémon. At the end of your turn, discard Magnifier. If the Pokémon Magnifier is attached to attacks, don’t apply Resistance for that attack."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/neo4/101_hires.png"
   },
@@ -4735,7 +4735,7 @@
   },
   {
     "id": "neo4-103",
-    "name": "Team Rocket's Evil Deeds",
+    "name": "Team Rocket’s Evil Deeds",
     "imageUrl": "https://images.pokemontcg.io/neo4/103.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -4746,7 +4746,7 @@
     "set": "Neo Destiny",
     "setCode": "neo4",
     "text": [
-      "Look at your opponent's hand and choose a card there. Your opponent shuffles that card into his or her deck. Then, your opponent may draw up to 2 cards."
+      "Look at your opponent’s hand and choose a card there. Your opponent shuffles that card into his or her deck. Then, your opponent may draw up to 2 cards."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/neo4/103_hires.png"
   },
@@ -4780,7 +4780,7 @@
     "set": "Neo Destiny",
     "setCode": "neo4",
     "text": [
-      "You can't play this card if you have 5 or more cards in your hand (including this one). Draw cards until you have exactly 4 cards in your hand."
+      "You can’t play this card if you have 5 or more cards in your hand (including this one). Draw cards until you have exactly 4 cards in your hand."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/neo4/105_hires.png"
   },
@@ -4917,7 +4917,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
-        "text": "Flip a coin. If heads, this attack does 30 damage plus 10 more damage and does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) If tails, this attack does 30 damage and Shining Kabutops does 10 damage to itself."
+        "text": "Flip a coin. If heads, this attack does 30 damage plus 10 more damage and does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) If tails, this attack does 30 damage and Shining Kabutops does 10 damage to itself."
       },
       {
         "name": "Water Slash",
@@ -4929,7 +4929,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "50+",
-        "text": "Does 50 damage plus 10 more damage for each Energy attached to Shining Kabutops but not used to pay for this attack's Energy cost. Don't apply Resistance."
+        "text": "Does 50 damage plus 10 more damage for each Energy attached to Shining Kabutops but not used to pay for this attack’s Energy cost. Don’t apply Resistance."
       }
     ],
     "weaknesses": [
@@ -4971,7 +4971,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "If an attack does damage to Shining Mewtwo during your opponent's next turn (even if Shining Mewtwo is Knocked Out), flip a coin. If heads, prevent all damage done to Shining Mewtwo from that attack (any other effects of attacks still happen) and do 20 damage to the attacking Pokémon."
+        "text": "If an attack does damage to Shining Mewtwo during your opponent’s next turn (even if Shining Mewtwo is Knocked Out), flip a coin. If heads, prevent all damage done to Shining Mewtwo from that attack (any other effects of attacks still happen) and do 20 damage to the attacking Pokémon."
       },
       {
         "name": "Psyburst",
@@ -5073,7 +5073,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to that Pokémon for each Energy attached to Shining Raichu. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to that Pokémon for each Energy attached to Shining Raichu. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -5119,7 +5119,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Flip a coin. If heads, this attack does 10 damage to each Benched Pokémon (yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.) If tails, this attack does nothing. Either way, Shining Steelix can't attack during your next turn."
+        "text": "Flip a coin. If heads, this attack does 10 damage to each Benched Pokémon (yours and your opponent’s). (Don’t apply Weakness and Resistance for Benched Pokémon.) If tails, this attack does nothing. Either way, Shining Steelix can’t attack during your next turn."
       }
     ],
     "weaknesses": [

--- a/json/cards/Neo Discovery.json
+++ b/json/cards/Neo Discovery.json
@@ -59,7 +59,7 @@
     "evolvesFrom": "Pineco",
     "ability": {
       "name": "Spikes",
-      "text": "During your opponent's turn, whenever 1 of your opponent's Benched Pokémon becomes his or her Active Pokémon, Forretress does 10 damage to it. (Don't apply Weakness and Resistance.) This power stops working if Forretress is Asleep, Confused, or Paralyzed.",
+      "text": "During your opponent’s turn, whenever 1 of your opponent’s Benched Pokémon becomes his or her Active Pokémon, Forretress does 10 damage to it. (Don’t apply Weakness and Resistance.) This power stops working if Forretress is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "80",
@@ -133,7 +133,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Hitmontop."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Hitmontop."
       },
       {
         "name": "Triple Kick",
@@ -302,7 +302,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a number of coins equal to the number of Energy cards attached to Kabutops. This attack does 40 times the number of heads. You can't flips more than 3 coins in this way."
+        "text": "Flip a number of coins equal to the number of Energy cards attached to Kabutops. This attack does 40 times the number of heads. You can’t flips more than 3 coins in this way."
       }
     ],
     "weaknesses": [
@@ -342,7 +342,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, treat any tails flipped when using Magnemite's Electric Bolt attack on the Defending Pokémon as if they were heads. (Benching or evolving either Pokémon ends this effect.)"
+        "text": "During your next turn, treat any tails flipped when using Magnemite’s Electric Bolt attack on the Defending Pokémon as if they were heads. (Benching or evolving either Pokémon ends this effect.)"
       },
       {
         "name": "Electric Bolt",
@@ -383,7 +383,7 @@
     "evolvesFrom": "Poliwhirl",
     "ability": {
       "name": "Frog Song",
-      "text": "Whenever Politoed's attack damages the Defending Pokémon (after applying Weakness and Resistance), if there are more than 3 Poliwags, Poliwhirls, Poliwraths, and/or Politoeds in play (including your opponent's), that attack does 40 more damage (no matter how many heads you get). This power stops working while Politoed is Asleep, Confused, or Paralyzed.",
+      "text": "Whenever Politoed’s attack damages the Defending Pokémon (after applying Weakness and Resistance), if there are more than 3 Poliwags, Poliwhirls, Poliwraths, and/or Politoeds in play (including your opponent’s), that attack does 40 more damage (no matter how many heads you get). This power stops working while Politoed is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "100",
@@ -509,7 +509,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Does damage equal to half the Defending Pokémon's remaining HP (rounded down to the nearest 10)."
+        "text": "Does damage equal to half the Defending Pokémon’s remaining HP (rounded down to the nearest 10)."
       },
       {
         "name": "Double Claw",
@@ -630,7 +630,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
-        "text": "For each Benched Pokémon in play (yours and your opponent's), flip a coin. If heads, this attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "For each Benched Pokémon in play (yours and your opponent’s), flip a coin. If heads, this attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "resistances": [
@@ -683,7 +683,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Pokémon Powers or any other effects on the Defending Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Pokémon Powers or any other effects on the Defending Pokémon."
       }
     ],
     "resistances": [
@@ -832,7 +832,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If an attack damages Wobbuffet during your opponent's next turn (even if Wobbuffet is knocked out), flip a coin. If heads, Wobbuffet attacks the Defending Pokémon for an equal amount of damage."
+        "text": "If an attack damages Wobbuffet during your opponent’s next turn (even if Wobbuffet is knocked out), flip a coin. If heads, Wobbuffet attacks the Defending Pokémon for an equal amount of damage."
       }
     ],
     "weaknesses": [
@@ -869,7 +869,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Pokémon. Don't apply Weakness and Resistance. Then, if your opponent has any Benched Pokémon, he or she chooses 1 of them and switches it with the Defending Pokémon."
+        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent’s Pokémon. Don’t apply Weakness and Resistance. Then, if your opponent has any Benched Pokémon, he or she chooses 1 of them and switches it with the Defending Pokémon."
       },
       {
         "name": "Swift",
@@ -880,7 +880,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Pokémon Powers, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Pokémon Powers, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -927,7 +927,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon is now Poisoned. Your opponent now puts 3 damage counters instead of 1 after each player's turn (even if it was already Poisoned)."
+        "text": "Flip a coin. If heads, the Defending Pokémon is now Poisoned. Your opponent now puts 3 damage counters instead of 1 after each player’s turn (even if it was already Poisoned)."
       },
       {
         "name": "Pin Missile",
@@ -1078,7 +1078,7 @@
     "evolvesFrom": "Pineco",
     "ability": {
       "name": "Spikes",
-      "text": "During your opponent's turn, whenever 1 of your opponent's Benched Pokémon becomes his or her Active Pokémon, Forretress does 10 damage to it. (Don't apply Weakness and Resistance.) This power stops working if Forretress is Asleep, Confused, or Paralyzed.",
+      "text": "During your opponent’s turn, whenever 1 of your opponent’s Benched Pokémon becomes his or her Active Pokémon, Forretress does 10 damage to it. (Don’t apply Weakness and Resistance.) This power stops working if Forretress is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "80",
@@ -1152,7 +1152,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Hitmontop."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Hitmontop."
       },
       {
         "name": "Triple Kick",
@@ -1321,7 +1321,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a number of coins equal to the number of Energy cards attached to Kabutops. This attack does 40 times the number of heads. You can't flips more than 3 coins in this way."
+        "text": "Flip a number of coins equal to the number of Energy cards attached to Kabutops. This attack does 40 times the number of heads. You can’t flips more than 3 coins in this way."
       }
     ],
     "weaknesses": [
@@ -1361,7 +1361,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, reat any tails flipped when using Magnemite's Electric Bolt attack on the Defending Pokémon as if they were heads. (Benching or evolving either Pokémon ends this effect.)"
+        "text": "During your next turn, reat any tails flipped when using Magnemite’s Electric Bolt attack on the Defending Pokémon as if they were heads. (Benching or evolving either Pokémon ends this effect.)"
       },
       {
         "name": "Electric Bolt",
@@ -1402,7 +1402,7 @@
     "evolvesFrom": "Poliwhirl",
     "ability": {
       "name": "Frog Song",
-      "text": "Whenever Politoed's attack damages the Defending Pokémon (after applying Weakness and Resistance), if there are more than 3 Poliwags, Poliwhirls, Poliwraths, and/or Politoeds in play (including your opponent's), that attack does 40 more damage (no matter how many heads you get). This power stops working while Politoed is Asleep, Confused, or Paralyzed.",
+      "text": "Whenever Politoed’s attack damages the Defending Pokémon (after applying Weakness and Resistance), if there are more than 3 Poliwags, Poliwhirls, Poliwraths, and/or Politoeds in play (including your opponent’s), that attack does 40 more damage (no matter how many heads you get). This power stops working while Politoed is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "100",
@@ -1528,7 +1528,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Does damage equal to half the Defending Pokémon's remaining HP (rounded down to the nearest 10)."
+        "text": "Does damage equal to half the Defending Pokémon’s remaining HP (rounded down to the nearest 10)."
       },
       {
         "name": "Double Claw",
@@ -1649,7 +1649,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
-        "text": "For each Benched Pokémon in play (yours and your opponent's), flip a coin. If heads, this attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "For each Benched Pokémon in play (yours and your opponent’s), flip a coin. If heads, this attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "resistances": [
@@ -1702,7 +1702,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "During your opponent's next turn, if the Defending Pokémon tries to retreat, do 10 damage to it. (Don't apply Weakness and Resistance.)"
+        "text": "During your opponent’s next turn, if the Defending Pokémon tries to retreat, do 10 damage to it. (Don’t apply Weakness and Resistance.)"
       }
     ],
     "resistances": [
@@ -1851,7 +1851,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If an attack damages Wobbuffet during your opponent's next turn (even if Wobbuffet is knocked out), flip a coin. If heads, Wobbuffet attacks the Defending Pokémon for an equal amount of damage."
+        "text": "If an attack damages Wobbuffet during your opponent’s next turn (even if Wobbuffet is knocked out), flip a coin. If heads, Wobbuffet attacks the Defending Pokémon for an equal amount of damage."
       }
     ],
     "weaknesses": [
@@ -1888,7 +1888,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Pokémon. Don't apply Weakness and Resistance. Then, if your opponent has any Benched Pokémon, he or she chooses 1 of them and switches it with the Defending Pokémon."
+        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent’s Pokémon. Don’t apply Weakness and Resistance. Then, if your opponent has any Benched Pokémon, he or she chooses 1 of them and switches it with the Defending Pokémon."
       },
       {
         "name": "Swift",
@@ -1899,7 +1899,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Pokémon Powers, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Pokémon Powers, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -1979,7 +1979,7 @@
     "level": "14",
     "ability": {
       "name": "Energy Evolution",
-      "text": "Whenever you attach an Energy card to Eevee, flip a coin. If heads, search your deck for that evolves from Eevee that is the same type as the Energy card you attached to Eevee. Shuffle your deck afterward. This power can't be used if Eevee is Asleep, Confused, or Paralyzed.",
+      "text": "Whenever you attach an Energy card to Eevee, flip a coin. If heads, search your deck for that evolves from Eevee that is the same type as the Energy card you attached to Eevee. Shuffle your deck afterward. This power can’t be used if Eevee is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "50",
@@ -2093,7 +2093,7 @@
     "level": "6",
     "ability": {
       "name": "Gaze",
-      "text": "Once during your turn (before you attack), choose 1 of your opponent's Benched Pokémon that has a Pokémon Power. That power stops working until the end of this turn. This effect ends if that Pokémon leaves the Bench. (Pokémon Power)",
+      "text": "Once during your turn (before you attack), choose 1 of your opponent’s Benched Pokémon that has a Pokémon Power. That power stops working until the end of this turn. This effect ends if that Pokémon leaves the Bench. (Pokémon Power)",
       "type": "Pokémon Power"
     },
     "hp": "30",
@@ -2107,7 +2107,7 @@
       "Colorless"
     ],
     "text": [
-      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent's turn ends without an attack."
+      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent’s turn ends without an attack."
     ],
     "nationalPokedexNumber": 174,
     "imageUrlHiRes": "https://images.pokemontcg.io/neo2/40_hires.png",
@@ -2146,7 +2146,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "During your opponent's next turn, whenever your opponent's attack damages Kakuna (even if Kakuna is knocked out), your opponent's Active Pokémon is now Poisoned and Kakuna does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "During your opponent’s next turn, whenever your opponent’s attack damages Kakuna (even if Kakuna is knocked out), your opponent’s Active Pokémon is now Poisoned and Kakuna does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2192,7 +2192,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "During your opponent's next turn, whenever 20 or less damage is done to Metapod (after applying Weakness and Resistance), prevent that damage. (Any other effects of attacks still happen.)"
+        "text": "During your opponent’s next turn, whenever 20 or less damage is done to Metapod (after applying Weakness and Resistance), prevent that damage. (Any other effects of attacks still happen.)"
       },
       {
         "name": "Hatch",
@@ -2299,7 +2299,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 3 damage counters on Poliwhirl. If this doesn't knock out Poliwhirl, search your deck for up to 2 Basic Energy cards and attach them to Poliwhirl. Shuffle your deck afterward."
+        "text": "Put 3 damage counters on Poliwhirl. If this doesn’t knock out Poliwhirl, search your deck for up to 2 Basic Energy cards and attach them to Poliwhirl. Shuffle your deck afterward."
       },
       {
         "name": "Water Gun",
@@ -2310,7 +2310,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
-        "text": "Does 30 damage plus 10 more damage for each W Energy attached to Poliwhirl but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "Does 30 damage plus 10 more damage for each W Energy attached to Poliwhirl but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       }
     ],
     "weaknesses": [
@@ -2366,7 +2366,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Does 10 damage to each non- Pokémon in play. Don't apply Weakness and Resistance."
+        "text": "Does 10 damage to each non- Pokémon in play. Don’t apply Weakness and Resistance."
       }
     ],
     "weaknesses": [
@@ -2681,7 +2681,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, choose 1 Energy card attached to the Defending Pokémon and 1 of your opponent's Benched Pokémon. Attach that Energy card to that Pokémon."
+        "text": "Flip a coin. If heads, choose 1 Energy card attached to the Defending Pokémon and 1 of your opponent’s Benched Pokémon. Attach that Energy card to that Pokémon."
       },
       {
         "name": "Super Psy",
@@ -2851,7 +2851,7 @@
     "level": "21",
     "ability": {
       "name": "Revive Friends",
-      "text": "Once during your turn (before you attack), you may flip a coin. If heads, search your deck for a card named Kabuto and put it on your Bench. Shuffle your deck afterward. Treat the new Kabuto as a Basic Pokémon. This power can't be used if Kabuto is Asleep, Confused, or Paralyzed (or if your Bench is full).",
+      "text": "Once during your turn (before you attack), you may flip a coin. If heads, search your deck for a card named Kabuto and put it on your Bench. Shuffle your deck afterward. Treat the new Kabuto as a Basic Pokémon. This power can’t be used if Kabuto is Asleep, Confused, or Paralyzed (or if your Bench is full).",
       "type": "Pokémon Power"
     },
     "hp": "50",
@@ -3042,7 +3042,7 @@
     "level": "21",
     "ability": {
       "name": "Fossil",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, search your deck for a card that evolves from Mysterious Fossil and put it on your Bench. Shuffle your deck afterward. Treat that card as a Basic Pokémon. This power can't be used if Omanyte is Asleep, Confused, or Paralyzed (or if your Bench is full).",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, search your deck for a card that evolves from Mysterious Fossil and put it on your Bench. Shuffle your deck afterward. Treat that card as a Basic Pokémon. This power can’t be used if Omanyte is Asleep, Confused, or Paralyzed (or if your Bench is full).",
       "type": "Pokémon Power"
     },
     "hp": "50",
@@ -3110,7 +3110,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, Pineco does 40 damage to itself and 10 damage to each Pokémon on each player's Bench. (Don't apply Weakness and Resistance for Benched Pokémon.) Flip a coin. If tails, this attack does nothing (not even damage)."
+        "text": "Flip a coin. If heads, Pineco does 40 damage to itself and 10 damage to each Pokémon on each player’s Bench. (Don’t apply Weakness and Resistance for Benched Pokémon.) Flip a coin. If tails, this attack does nothing (not even damage)."
       }
     ],
     "weaknesses": [
@@ -3205,7 +3205,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at your opponent's hand."
+        "text": "Look at your opponent’s hand."
       },
       {
         "name": "Tackle",
@@ -3368,7 +3368,7 @@
       }
     ],
     "text": [
-      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent's turn ends without an attack."
+      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent’s turn ends without an attack."
     ],
     "nationalPokedexNumber": 236,
     "imageUrlHiRes": "https://images.pokemontcg.io/neo2/66_hires.png",
@@ -3472,7 +3472,7 @@
     "level": "14",
     "ability": {
       "name": "Observe",
-      "text": "Once during your turn (before you attack), you may look at 5 cards from the top of your opponent's deck and put them back in the same order.",
+      "text": "Once during your turn (before you attack), you may look at 5 cards from the top of your opponent’s deck and put them back in the same order.",
       "type": "Pokémon Power"
     },
     "hp": "40",
@@ -3579,7 +3579,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If an attack would do damage to Wooper during your opponent's next turn, your opponent flips a coin. If tails, prevent all damage done to Wooper from that attack. (Any other effects of that attack happen.)"
+        "text": "If an attack would do damage to Wooper during your opponent’s next turn, your opponent flips a coin. If tails, prevent all damage done to Wooper from that attack. (Any other effects of that attack happen.)"
       },
       {
         "name": "Tail Slap",
@@ -3623,7 +3623,7 @@
     "set": "Neo Discovery",
     "setCode": "neo2",
     "text": [
-      "Flip a coin. If heads, either search your deck for a card that evolves from Mysterious Fossil and put it on your Bench or put a card that evolves from Mysterious Fossil from your hand onto your Bench. Either way, treat the new card as a Basic Pokémon. If you searched your deck, shuffle it. (You can't play this card if your Bench is full.)"
+      "Flip a coin. If heads, either search your deck for a card that evolves from Mysterious Fossil and put it on your Bench or put a card that evolves from Mysterious Fossil from your hand onto your Bench. Either way, treat the new card as a Basic Pokémon. If you searched your deck, shuffle it. (You can’t play this card if your Bench is full.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/neo2/72_hires.png"
   },
@@ -3640,7 +3640,7 @@
     "set": "Neo Discovery",
     "setCode": "neo2",
     "text": [
-      "Choose 1 of your Evolved Pokémon. Take the highest stage Evolution card from that Pokémon and put it into your hand. (You can't evolve a Pokémon the turn you devolve it.)"
+      "Choose 1 of your Evolved Pokémon. Take the highest stage Evolution card from that Pokémon and put it into your hand. (You can’t evolve a Pokémon the turn you devolve it.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/neo2/73_hires.png"
   },
@@ -3657,7 +3657,7 @@
     "set": "Neo Discovery",
     "setCode": "neo2",
     "text": [
-      "Search your deck for a card with Unown in its name and put it onto your Bench. Shuffle your deck afterward. (You can't play this card if your Bench is full.)"
+      "Search your deck for a card with Unown in its name and put it onto your Bench. Shuffle your deck afterward. (You can’t play this card if your Bench is full.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/neo2/74_hires.png"
   },

--- a/json/cards/Neo Genesis.json
+++ b/json/cards/Neo Genesis.json
@@ -31,7 +31,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Flip a coin. If heads, the Defending Pokémon is now Paralyzed and this attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, the Defending Pokémon is now Paralyzed and this attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -84,7 +84,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Flip a coin. If heads, the Defending Pokémon is now Paralyzed and this attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, the Defending Pokémon is now Paralyzed and this attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -159,7 +159,7 @@
     "evolvesFrom": "Croconaw",
     "ability": {
       "name": "Berserk",
-      "text": "When you play Feraligatr from your hand, flip a coin. If heads, discard the top 5 cards from your opponent's deck. If tails, discard the top 5 cards from your deck.",
+      "text": "When you play Feraligatr from your hand, flip a coin. If heads, discard the top 5 cards from your opponent’s deck. If tails, discard the top 5 cards from your deck.",
       "type": "Pokémon Power"
     },
     "hp": "100",
@@ -254,7 +254,7 @@
     "level": "28",
     "ability": {
       "name": "Final Blow",
-      "text": "If Heracross's remaining HP are 20 or less, you may make its Megahorn attack's base damage 120 instead of 60. This power can't be used if Heracross is Asleep, Confused, or Paralyzed.",
+      "text": "If Heracross’s remaining HP are 20 or less, you may make its Megahorn attack’s base damage 120 instead of 60. This power can’t be used if Heracross is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "60",
@@ -378,7 +378,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Kingdra."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Kingdra."
       },
       {
         "name": "Dragon Tornado",
@@ -390,7 +390,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
-        "text": "If this attack doesn't Knock Out the Defending Pokémon, and if there are any Pokémon on your opponent's Bench, choose 1 of them and switch it with the Defending Pokémon."
+        "text": "If this attack doesn’t Knock Out the Defending Pokémon, and if there are any Pokémon on your opponent’s Bench, choose 1 of them and switch it with the Defending Pokémon."
       }
     ],
     "nationalPokedexNumber": 230,
@@ -572,11 +572,11 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Does 20 damage to each Pokémon in play that has a Pokémon Power. Don't apply Weakness and Resistance."
+        "text": "Does 20 damage to each Pokémon in play that has a Pokémon Power. Don’t apply Weakness and Resistance."
       }
     ],
     "text": [
-      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent's turn ends without an attack."
+      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent’s turn ends without an attack."
     ],
     "nationalPokedexNumber": 172,
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/12_hires.png",
@@ -624,7 +624,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Flip a coin. If heads, all damage done by attacks to Skarmory during your opponent's next turn is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "Flip a coin. If heads, all damage done by attacks to Skarmory during your opponent’s next turn is reduced by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -652,7 +652,7 @@
     "evolvesFrom": "Slowpoke",
     "ability": {
       "name": "Mind Games",
-      "text": "Whenever your opponent plays a Trainer card, you may flip a coin. If heads, that card does nothing. Put it on top of your opponent's deck. This power can't be used if Slowking is Asleep, Confused, or Paralyzed.",
+      "text": "Whenever your opponent plays a Trainer card, you may flip a coin. If heads, that card does nothing. Put it on top of your opponent’s deck. This power can’t be used if Slowking is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "80",
@@ -780,7 +780,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, choose an attack of 1 of your opponent's Pokémon. Super Metronome copies that attack except for its Energy cost. (You must still do anything else in order to use that attack.) (No matter what type the Defending Pokémon is, Togetic's type is still .) Togetic performs that attack. (Togetic can make that attack even if it does not have the appropriate number or type of Energy attached to it necessary to make the attack.)"
+        "text": "Flip a coin. If heads, choose an attack of 1 of your opponent’s Pokémon. Super Metronome copies that attack except for its Energy cost. (You must still do anything else in order to use that attack.) (No matter what type the Defending Pokémon is, Togetic’s type is still .) Togetic performs that attack. (Togetic can make that attack even if it does not have the appropriate number or type of Energy attached to it necessary to make the attack.)"
       },
       {
         "name": "Fly",
@@ -791,7 +791,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Togetic; if tails, this attack does nothing (not even damage)."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Togetic; if tails, this attack does nothing (not even damage)."
       }
     ],
     "resistances": [
@@ -816,7 +816,7 @@
     "evolvesFrom": "Quilava",
     "ability": {
       "name": "Fire Recharge",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, attach a Fire Energy card from your discard pile to 1 of your Fire Pokémon. This power can't be used if Typhlosion is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, attach a Fire Energy card from your discard pile to 1 of your Fire Pokémon. This power can’t be used if Typhlosion is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "100",
@@ -894,7 +894,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "Discard 3 Energy cards attached to Typhlosion in order to use this attack. Do 20 damage to each Benched Pokémon (yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard 3 Energy cards attached to Typhlosion in order to use this attack. Do 20 damage to each Benched Pokémon (yours and your opponent’s). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -919,7 +919,7 @@
     "set": "Neo Genesis",
     "setCode": "neo1",
     "text": [
-      "Damage done to Pokémon Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). If the Pokémon Metal Energy is attached to isn't , whenever it damages a Pokémon, reduce that damage by 10 (before applying Weakness and Resistance). Metal Energy provides Energy. (Doesn't count as a basic Energy card.)"
+      "Damage done to Pokémon Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). If the Pokémon Metal Energy is attached to isn’t , whenever it damages a Pokémon, reduce that damage by 10 (before applying Weakness and Resistance). Metal Energy provides Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/19_hires.png"
   },
@@ -952,7 +952,7 @@
       }
     ],
     "text": [
-      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent's turn ends without an attack."
+      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent’s turn ends without an attack."
     ],
     "nationalPokedexNumber": 173,
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/20_hires.png",
@@ -1038,7 +1038,7 @@
       "Lightning"
     ],
     "text": [
-      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent's turn ends without an attack."
+      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent’s turn ends without an attack."
     ],
     "nationalPokedexNumber": 239,
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/22_hires.png",
@@ -1047,7 +1047,7 @@
     ],
     "ability": {
       "name": "Playful Punch",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, do 20 damage to your opponent's Active Pokémon. (Apply Weakness and Resistance.) Either way, this ends your turn. This power can't be used if Elekid is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, do 20 damage to your opponent’s Active Pokémon. (Apply Weakness and Resistance.) Either way, this ends your turn. This power can’t be used if Elekid is Asleep, Confused, or Paralyzed.",
       "type": "Poké-Power"
     }
   },
@@ -1080,7 +1080,7 @@
       }
     ],
     "text": [
-      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent's turn ends without an attack."
+      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent’s turn ends without an attack."
     ],
     "nationalPokedexNumber": 240,
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/23_hires.png",
@@ -1113,7 +1113,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "The Defending Pokémon can't retreat as long as Murkrow remains your Active Pokémon. (Benching or evolving either Pokémon ends this effect.)"
+        "text": "The Defending Pokémon can’t retreat as long as Murkrow remains your Active Pokémon. (Benching or evolving either Pokémon ends this effect.)"
       },
       {
         "name": "Feint Attack",
@@ -1123,7 +1123,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Pokémon Powers, or any other effects on the Defending Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Pokémon Powers, or any other effects on the Defending Pokémon."
       }
     ],
     "resistances": [
@@ -1272,7 +1272,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't retreat. (Benching or evolving that Pokémon ends this effect.)"
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t retreat. (Benching or evolving that Pokémon ends this effect.)"
       },
       {
         "name": "Poison Bite",
@@ -1333,7 +1333,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "During your opponent's next turn, Bayleef can't become Asleep, Confused, Paralyzed, or Poisoned. (All other effects of attacks, Pokémon Powers, and Trainer cards still happen.)"
+        "text": "During your opponent’s next turn, Bayleef can’t become Asleep, Confused, Paralyzed, or Poisoned. (All other effects of attacks, Pokémon Powers, and Trainer cards still happen.)"
       }
     ],
     "weaknesses": [
@@ -1378,7 +1378,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads and if any of your Pokémon have any damage counters on them, then remove 2 damage counters from 1 of them (or 1 if it only has 1). If tails and if any of your opponent's Pokémon have any damage counters on them, choose 1 of them and remove 2 damage counters from it (or 1 if it only has 1)."
+        "text": "Flip a coin. If heads and if any of your Pokémon have any damage counters on them, then remove 2 damage counters from 1 of them (or 1 if it only has 1). If tails and if any of your opponent’s Pokémon have any damage counters on them, choose 1 of them and remove 2 damage counters from it (or 1 if it only has 1)."
       },
       {
         "name": "Double Razor Leaf",
@@ -1506,7 +1506,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Until the end of your opponent's next turn, as long as Croconaw is your Active Pokémon, the Defending Pokémon can't retreat, and if the effect of an attack, Pokémon Power, or Trainer card would change that player's Active Pokémon, that part of the effect does nothing."
+        "text": "Until the end of your opponent’s next turn, as long as Croconaw is your Active Pokémon, the Defending Pokémon can’t retreat, and if the effect of an attack, Pokémon Power, or Trainer card would change that player’s Active Pokémon, that part of the effect does nothing."
       }
     ],
     "weaknesses": [
@@ -1618,7 +1618,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Pokémon Powers, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Pokémon Powers, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -1787,7 +1787,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20+",
-        "text": "Flip a coin. If heads, this attack does 20 damage plus 10 more damage and, until the end of your opponent's next turn, as long as Gloom is your Active Pokémon, the Defending Pokémon can't retreat, and if the effect of an attack, Pokémon Power, or Trainer card would change that player's Active Pokémon, that part of the effect does nothing. If tails, this attack does 20 damage."
+        "text": "Flip a coin. If heads, this attack does 20 damage plus 10 more damage and, until the end of your opponent’s next turn, as long as Gloom is your Active Pokémon, the Defending Pokémon can’t retreat, and if the effect of an attack, Pokémon Power, or Trainer card would change that player’s Active Pokémon, that part of the effect does nothing. If tails, this attack does 20 damage."
       }
     ],
     "weaknesses": [
@@ -1872,7 +1872,7 @@
     "level": "26",
     "ability": {
       "name": "Hydroelectric Power",
-      "text": "You may make Floodlight do 10 more damage for each Water Energy attached to Lanturn but not used to pay for Floodlight's Energy cost. This power can't be used if Lanturn is Asleep, Confused, or Paralyzed.",
+      "text": "You may make Floodlight do 10 more damage for each Water Energy attached to Lanturn but not used to pay for Floodlight’s Energy cost. This power can’t be used if Lanturn is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "70",
@@ -2079,7 +2079,7 @@
     "evolvesFrom": "Hoothoot",
     "ability": {
       "name": "Glaring Gaze",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, look at your opponent's hand. If your opponent has any Trainer cards there, choose 1 of them. Your opponent shuffles that card into his or her deck. This power can't be used if Noctowl is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, look at your opponent’s hand. If your opponent has any Trainer cards there, choose 1 of them. Your opponent shuffles that card into his or her deck. This power can’t be used if Noctowl is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "60",
@@ -2157,7 +2157,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, then if, during your opponent's next turn, Phanpy would be Knocked Out by an attack, Phanpy isn't Knocked Out and its remaining HP become 10 instead."
+        "text": "Flip a coin. If heads, then if, during your opponent’s next turn, Phanpy would be Knocked Out by an attack, Phanpy isn’t Knocked Out and its remaining HP become 10 instead."
       }
     ],
     "weaknesses": [
@@ -2210,7 +2210,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack. (Benching or evolving the Defending Pokémon ends this effect.)"
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack. (Benching or evolving the Defending Pokémon ends this effect.)"
       },
       {
         "name": "Blizzard",
@@ -2221,7 +2221,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Benched Pokémon. If tails, this attack does 10 damage to each of your own Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent’s Benched Pokémon. If tails, this attack does 10 damage to each of your own Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2285,7 +2285,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "Does 10 damage to each of your own Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your own Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2343,7 +2343,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If your opponent has any Benched Pokémon, choose 1 of them. Flip 2 coins. For each heads, this attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance.)"
+        "text": "If your opponent has any Benched Pokémon, choose 1 of them. Flip 2 coins. For each heads, this attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance.)"
       }
     ],
     "weaknesses": [
@@ -2388,7 +2388,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Char",
@@ -2399,7 +2399,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "If the Defending Pokémon doesn't have a Char counter on it, flip a coin. If heads, put a Char counter on it. A Char counter requires your opponent to flip a coin after every turn. If tails, put 2 damage counters on the Pokémon with that Char counter. (Char counters stay on the Pokémon as long as it's in play.)"
+        "text": "If the Defending Pokémon doesn’t have a Char counter on it, flip a coin. If heads, put a Char counter on it. A Char counter requires your opponent to flip a coin after every turn. If tails, put 2 damage counters on the Pokémon with that Char counter. (Char counters stay on the Pokémon as long as it’s in play.)"
       }
     ],
     "weaknesses": [
@@ -2453,7 +2453,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "If your opponent has any Benched Pokémon, choose 1 of them and flip a coin. If heads, this attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, choose 1 of them and flip a coin. If heads, this attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2637,7 +2637,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at the top 3 cards of either player's deck and rearrange them as you like."
+        "text": "Look at the top 3 cards of either player’s deck and rearrange them as you like."
       },
       {
         "name": "Confuse Ray",
@@ -2703,7 +2703,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, whenever Chikorita takes damage, divide that damage in half (rounded down to the nearest 10). (Any other effects still happen.)"
+        "text": "During your opponent’s next turn, whenever Chikorita takes damage, divide that damage in half (rounded down to the nearest 10). (Any other effects still happen.)"
       }
     ],
     "weaknesses": [
@@ -2746,7 +2746,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the Defending Pokémon attacks Chikorita during your opponent's next turn, any damage done to Chikorita is reduced by 10 (before applying Weakness and Resistance). (Benching or evolving either Pokémon ends this effect.)"
+        "text": "If the Defending Pokémon attacks Chikorita during your opponent’s next turn, any damage done to Chikorita is reduced by 10 (before applying Weakness and Resistance). (Benching or evolving either Pokémon ends this effect.)"
       },
       {
         "name": "Razor Leaf",
@@ -2851,7 +2851,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack Cyndaquil during your opponent's next turn. (Benching or evolving either Pokémon ends this effect.)"
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack Cyndaquil during your opponent’s next turn. (Benching or evolving either Pokémon ends this effect.)"
       },
       {
         "name": "Swift",
@@ -2861,7 +2861,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Pokémon Powers, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Pokémon Powers, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -2955,7 +2955,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Girafarig."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Girafarig."
       },
       {
         "name": "Psybeam",
@@ -3120,7 +3120,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Search your deck for a Basic Pokémon named Hoppip and put it onto your Bench. Shuffle your deck afterward. (You can't use this attack if your Bench is full.)"
+        "text": "Search your deck for a Basic Pokémon named Hoppip and put it onto your Bench. Shuffle your deck afterward. (You can’t use this attack if your Bench is full.)"
       }
     ],
     "weaknesses": [
@@ -3167,7 +3167,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "If an attack damaged Horsea during your opponent's last turn, this attack does 20 damage plus 10 more damage. If not, this attack does 20 damage."
+        "text": "If an attack damaged Horsea during your opponent’s last turn, this attack does 20 damage plus 10 more damage. If not, this attack does 20 damage."
       }
     ],
     "weaknesses": [
@@ -3267,7 +3267,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Mantine."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Mantine."
       }
     ],
     "weaknesses": [
@@ -3366,7 +3366,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to Marill during your opponent's next turn. (Any other effects of attacks still happen.)"
+        "text": "Flip a coin. If heads, prevent all damage done to Marill during your opponent’s next turn. (Any other effects of attacks still happen.)"
       },
       {
         "name": "Bubble Bomb",
@@ -3426,7 +3426,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. Don't apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. Don’t apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
       }
     ],
     "weaknesses": [
@@ -3475,7 +3475,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Oddish."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Oddish."
       },
       {
         "name": "Absorb",
@@ -3593,7 +3593,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Pikachu."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Pikachu."
       }
     ],
     "weaknesses": [
@@ -3685,7 +3685,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to Shuckle during your opponent's next turn. (Any other effects of attacks still happen.)"
+        "text": "Flip a coin. If heads, prevent all damage done to Shuckle during your opponent’s next turn. (Any other effects of attacks still happen.)"
       },
       {
         "name": "Wrap",
@@ -3744,7 +3744,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "Does 10 damage plus 10 more damage for each Energy attached to Slowpoke but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "Does 10 damage plus 10 more damage for each Energy attached to Slowpoke but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       }
     ],
     "weaknesses": [
@@ -3847,7 +3847,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, until the end of your opponent's next turn the Defending Pokémon can't attack or retreat."
+        "text": "Flip a coin. If heads, until the end of your opponent’s next turn the Defending Pokémon can’t attack or retreat."
       },
       {
         "name": "String Shot",
@@ -4167,7 +4167,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack Totodile during your opponent's next turn. (Benching or evolving either Pokémon ends this effect.)"
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack Totodile during your opponent’s next turn. (Benching or evolving either Pokémon ends this effect.)"
       },
       {
         "name": "Fury Swipes",
@@ -4219,7 +4219,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Slam",
@@ -4280,7 +4280,7 @@
     "set": "Neo Genesis",
     "setCode": "neo1",
     "text": [
-      "Whenever an attack, Pokémon Power, or Trainer card discards another player's non- Energy card from a Pokémon, return that Energy card to its owner's hand. (Energy cards that are discarded when that Pokémon is Knocked Out don't count.)"
+      "Whenever an attack, Pokémon Power, or Trainer card discards another player’s non- Energy card from a Pokémon, return that Energy card to its owner’s hand. (Energy cards that are discarded when that Pokémon is Knocked Out don’t count.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/84_hires.png"
   },
@@ -4314,7 +4314,7 @@
     "set": "Neo Genesis",
     "setCode": "neo1",
     "text": [
-      "If the Pokémon Focus Band is attached to would be Knocked Out by your opponent's attack, flip a coin. If heads, that Pokémon is not Knocked Out and its remaining HP become 10 instead. Then, discard Focus Band."
+      "If the Pokémon Focus Band is attached to would be Knocked Out by your opponent’s attack, flip a coin. If heads, that Pokémon is not Knocked Out and its remaining HP become 10 instead. Then, discard Focus Band."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/86_hires.png"
   },
@@ -4348,7 +4348,7 @@
     "set": "Neo Genesis",
     "setCode": "neo1",
     "text": [
-      "Look at the top 7 cards of your deck. If any of them are Trainer cards, you may show 1 of them to your opponent and put it into your hand. Shuffle your deck afterward. You can't play any more Trainer cards this turn."
+      "Look at the top 7 cards of your deck. If any of them are Trainer cards, you may show 1 of them to your opponent and put it into your hand. Shuffle your deck afterward. You can’t play any more Trainer cards this turn."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/88_hires.png"
   },
@@ -4382,13 +4382,13 @@
     "set": "Neo Genesis",
     "setCode": "neo1",
     "text": [
-      "Your opponent may choose 5 Basic Pokémon, Evolution, and/or basic Energy cards in his or her discard pile. (If your opponent doesn't have that many, he or she chooses all or none of them.) If your opponent chooses any cards, he or she shuffles them into his or her deck. Either way, you may do the same, and you can't play any more Trainer cards this turn."
+      "Your opponent may choose 5 Basic Pokémon, Evolution, and/or basic Energy cards in his or her discard pile. (If your opponent doesn’t have that many, he or she chooses all or none of them.) If your opponent chooses any cards, he or she shuffles them into his or her deck. Either way, you may do the same, and you can’t play any more Trainer cards this turn."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/90_hires.png"
   },
   {
     "id": "neo1-91",
-    "name": "Bill's Teleporter",
+    "name": "Bill’s Teleporter",
     "imageUrl": "https://images.pokemontcg.io/neo1/91.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -4416,7 +4416,7 @@
     "set": "Neo Genesis",
     "setCode": "neo1",
     "text": [
-      "Choose 1 of your opponent's face-down Prizes. Guess whether it is an Energy card, a Trainer card, or a Pokémon (Basic or Evolution) card. Flip the card face up (and leave it face up). If you guessed right, draw 2 cards."
+      "Choose 1 of your opponent’s face-down Prizes. Guess whether it is an Energy card, a Trainer card, or a Pokémon (Basic or Evolution) card. Flip the card face up (and leave it face up). If you guessed right, draw 2 cards."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/92_hires.png"
   },
@@ -4484,7 +4484,7 @@
     "set": "Neo Genesis",
     "setCode": "neo1",
     "text": [
-      "Shuffle your hand into your deck. Then, draw 7 cards. You can't play any more Trainer cards this turn."
+      "Shuffle your hand into your deck. Then, draw 7 cards. You can’t play any more Trainer cards this turn."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/96_hires.png"
   },
@@ -4501,7 +4501,7 @@
     "set": "Neo Genesis",
     "setCode": "neo1",
     "text": [
-      "All damage done by Pokémon's attacks is reduced by 30 (after applying Weakness and Resistance)."
+      "All damage done by Pokémon’s attacks is reduced by 30 (after applying Weakness and Resistance)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/97_hires.png"
   },
@@ -4586,7 +4586,7 @@
     "set": "Neo Genesis",
     "setCode": "neo1",
     "text": [
-      "Your opponent may search his or her deck for 1 Basic Pokémon card and put it onto his or her Bench. Then, you may search your deck for 1 Basic Pokémon card and put it onto your Bench. Then, each player shuffles his or her deck. (A player can't do any of this if his or her Bench is full.)"
+      "Your opponent may search his or her deck for 1 Basic Pokémon card and put it onto his or her Bench. Then, you may search your deck for 1 Basic Pokémon card and put it onto your Bench. Then, each player shuffles his or her deck. (A player can’t do any of this if his or her Bench is full.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/102_hires.png"
   },
@@ -4620,7 +4620,7 @@
     "set": "Neo Genesis",
     "setCode": "neo1",
     "text": [
-      "If the Pokémon Darkness Energy is attached to damages the Defending Pokémon (after applying Weakness and Resistance), the attack does 10 more damage to the Defending Pokémon. At the end of every turn, put 1 damage counter on the Pokémon Darkness Energy is attached to, unless it's or has Dark in its name. Darkness Energy provides Energy. (Doesn't count as a basic Energy card.)"
+      "If the Pokémon Darkness Energy is attached to damages the Defending Pokémon (after applying Weakness and Resistance), the attack does 10 more damage to the Defending Pokémon. At the end of every turn, put 1 damage counter on the Pokémon Darkness Energy is attached to, unless it’s or has Dark in its name. Darkness Energy provides Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/104_hires.png"
   },
@@ -4637,7 +4637,7 @@
     "set": "Neo Genesis",
     "setCode": "neo1",
     "text": [
-      "Recycle Energy provides 1 Energy. (Doesn't count as a basic Energy card.) If this card is put into your discard pile from play, return it to your hand."
+      "Recycle Energy provides 1 Energy. (Doesn’t count as a basic Energy card.) If this card is put into your discard pile from play, return it to your hand."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/105_hires.png"
   },

--- a/json/cards/Neo Revelation.json
+++ b/json/cards/Neo Revelation.json
@@ -119,7 +119,7 @@
     "level": "16",
     "ability": {
       "name": "Time Travel",
-      "text": "If an opponent's attack would Knock Out Celebi, flip a coin. If heads, Celebi is not Knocked Out and you shuffle it and all cards attached to it into your deck. This power doesn't work if Celebi is already Asleep, Confused, or Paralyzed.",
+      "text": "If an opponent’s attack would Knock Out Celebi, flip a coin. If heads, Celebi is not Knocked Out and you shuffle it and all cards attached to it into your deck. This power doesn’t work if Celebi is already Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "50",
@@ -344,7 +344,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Flip a coin. If heads, choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. Don't apply Weakness and Resistance."
+        "text": "Flip a coin. If heads, choose 1 of your opponent’s Pokémon. This attack does 40 damage to that Pokémon. Don’t apply Weakness and Resistance."
       },
       {
         "name": "Dive Bomb",
@@ -490,7 +490,7 @@
     "evolvesFrom": "Magnemite",
     "ability": {
       "name": "Electromagnetic Power",
-      "text": "As often as you like during your turn (before your attack), you may take 1 Energy card attached to 1 of your Magnemites, Magnetons, or Dark Magnetons and attach it to a different 1 of your Magnemites, Magnetons, or Dark Magnetons. This power can't be used if Magneton is Asleep, Confused, or Paralyzed.",
+      "text": "As often as you like during your turn (before your attack), you may take 1 Energy card attached to 1 of your Magnemites, Magnetons, or Dark Magnetons and attach it to a different 1 of your Magnemites, Magnetons, or Dark Magnetons. This power can’t be used if Magneton is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "80",
@@ -602,7 +602,7 @@
     "evolvesFrom": "Porygon",
     "ability": {
       "name": "Energy Converter",
-      "text": "Once during your turn (before your attack), you may choose 1 Basic Energy card attached to 1 of your Pokémon and choose an Energy type. Treat that Energy card as that type until the end is your turn. This power can't be used if Porygon2 is Asleep, Confused, or Paralyzed. If Porygon2 becomes Asleep, Confused, or Paralyzed, the Energy card goes back to its original type.",
+      "text": "Once during your turn (before your attack), you may choose 1 Basic Energy card attached to 1 of your Pokémon and choose an Energy type. Treat that Energy card as that type until the end is your turn. This power can’t be used if Porygon2 is Asleep, Confused, or Paralyzed. If Porygon2 becomes Asleep, Confused, or Paralyzed, the Energy card goes back to its original type.",
       "type": "Pokémon Power"
     },
     "hp": "70",
@@ -705,7 +705,7 @@
     "level": "33",
     "ability": {
       "name": "Crystal Body",
-      "text": "Prevent all effects of your opponent's attacks, other than damage, done to Suicune. This power stops working while Suicune is Asleep, Confused, or Paralyzed.",
+      "text": "Prevent all effects of your opponent’s attacks, other than damage, done to Suicune. This power stops working while Suicune is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "70",
@@ -752,7 +752,7 @@
     "level": "27",
     "ability": {
       "name": "Prehistoric Memory",
-      "text": "Whenever an Evolved Pokémon attacks (even if it's your opponent's), it can use any attack from its Basic card or any Evolution card attached to it. It still has to pay for that attack's Energy cost. This power stops working while Aerodactyl is Asleep, Confused, or Paralyzed.",
+      "text": "Whenever an Evolved Pokémon attacks (even if it’s your opponent’s), it can use any attack from its Basic card or any Evolution card attached to it. It still has to pay for that attack’s Energy cost. This power stops working while Aerodactyl is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "60",
@@ -779,7 +779,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Aerodactyl. If tails, this attack does nothing (not even damage)."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Aerodactyl. If tails, this attack does nothing (not even damage)."
       }
     ],
     "weaknesses": [
@@ -847,7 +847,7 @@
     "level": "24",
     "ability": {
       "name": "Legendary Body",
-      "text": "As long as Entei is your Active Pokémon, Entei and Energy cards attached to it aren't affected by effects from Trainer cards other than Trainer cards other than Stadium cards. As long as this power is active, discard all Trainer cards attached to Entei. (This power works even if Entei is Asleep, Confused, or Paralyzed.)",
+      "text": "As long as Entei is your Active Pokémon, Entei and Energy cards attached to it aren’t affected by effects from Trainer cards other than Trainer cards other than Stadium cards. As long as this power is active, discard all Trainer cards attached to Entei. (This power works even if Entei is Asleep, Confused, or Paralyzed.)",
       "type": "Pokémon Power"
     },
     "hp": "60",
@@ -962,7 +962,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Use any attack from Kingdra's Basic Pokémon card or Evolution card. (Kingdra doesn't have to pay for that attack's Energy cost.)"
+        "text": "Use any attack from Kingdra’s Basic Pokémon card or Evolution card. (Kingdra doesn’t have to pay for that attack’s Energy cost.)"
       },
       {
         "name": "Twister",
@@ -1092,7 +1092,7 @@
     "level": "26",
     "ability": {
       "name": "Legendary Body",
-      "text": "As long as Raikou is your Active Pokémon, Raikou and Energy cards attached to it aren't affected by effects from Trainer cards other than Trainer cards other than Stadium cards. As long as this power is active, discard all Trainer cards attached to Raikou. (This power works even if Raikou is Asleep, Confused, or Paralyzed.)",
+      "text": "As long as Raikou is your Active Pokémon, Raikou and Energy cards attached to it aren’t affected by effects from Trainer cards other than Trainer cards other than Stadium cards. As long as this power is active, discard all Trainer cards attached to Raikou. (This power works even if Raikou is Asleep, Confused, or Paralyzed.)",
       "type": "Pokémon Power"
     },
     "hp": "60",
@@ -1115,7 +1115,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "If your opponent has any Benched Pokémon, flip a coin. If heads, choose 1 of them and this attack does 20 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, flip a coin. If heads, choose 1 of them and this attack does 20 damage to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1167,7 +1167,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Skarmory."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Skarmory."
       }
     ],
     "weaknesses": [
@@ -1210,7 +1210,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, discard all Trainer cards attached to your opponent's Pokémon."
+        "text": "Flip a coin. If heads, discard all Trainer cards attached to your opponent’s Pokémon."
       },
       {
         "name": "Quick Attack",
@@ -1275,7 +1275,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "Choose an Energy type other than . This attack does 20 damage to each of your opponent's Pokémon with any Energy cards of that type attached to it. Don't apply Weakness and Resistance."
+        "text": "Choose an Energy type other than . This attack does 20 damage to each of your opponent’s Pokémon with any Energy cards of that type attached to it. Don’t apply Weakness and Resistance."
       }
     ],
     "weaknesses": [
@@ -1296,7 +1296,7 @@
     "level": "27",
     "ability": {
       "name": "Mimic",
-      "text": "As long as Sudowoodo is your Active Pokémon, it copies all of the Defending Pokémon's attacks, including their costs. This power can't be used if Sudowoodo is Asleep, Confused, or Paralyzed.",
+      "text": "As long as Sudowoodo is your Active Pokémon, it copies all of the Defending Pokémon’s attacks, including their costs. This power can’t be used if Sudowoodo is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "60",
@@ -1344,7 +1344,7 @@
     "level": "25",
     "ability": {
       "name": "Legendary Body",
-      "text": "As long as Suicune is your Active Pokémon, Suicune and Energy cards attached to it aren't affected by effects from Trainer cards other than Trainer cards other than Stadium cards. As long as this power is active, discard all Trainer cards attached to Suicune. (This power works even if Suicune is Asleep, Confused, or Paralyzed.)",
+      "text": "As long as Suicune is your Active Pokémon, Suicune and Energy cards attached to it aren’t affected by effects from Trainer cards other than Trainer cards other than Stadium cards. As long as this power is active, discard all Trainer cards attached to Suicune. (This power works even if Suicune is Asleep, Confused, or Paralyzed.)",
       "type": "Pokémon Power"
     },
     "hp": "60",
@@ -1419,7 +1419,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1522,7 +1522,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Does 10 damage to each of your own Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your own Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Rock Tumble",
@@ -1533,7 +1533,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Don't apply Resistance."
+        "text": "Don’t apply Resistance."
       }
     ],
     "weaknesses": [
@@ -1610,7 +1610,7 @@
     "evolvesFrom": "Chinchou",
     "ability": {
       "name": "Submerge",
-      "text": "Once during your turn (before your attack), you may change Lanturn's type to Water until the end of your turn. This power can't be used if Lanturn is Asleep, Confused, or Paralyzed. If Lanturn becomes Asleep, Confused, or Paralyzed after you have used this power, its type changes back to Lightning.",
+      "text": "Once during your turn (before your attack), you may change Lanturn’s type to Water until the end of your turn. This power can’t be used if Lanturn is Asleep, Confused, or Paralyzed. If Lanturn becomes Asleep, Confused, or Paralyzed after you have used this power, its type changes back to Lightning.",
       "type": "Pokémon Power"
     },
     "hp": "80",
@@ -1659,7 +1659,7 @@
     "evolvesFrom": "Slugma",
     "ability": {
       "name": "Magma Pool",
-      "text": "If Magcargo is your Active Pokémon and moves to the Bench, remove 1 Fire Energy card attached to Magcargo, if any, and attach it to the new Active Pokémon. (You can't use an Energy card that you used to pay for the Retreat Cost.)",
+      "text": "If Magcargo is your Active Pokémon and moves to the Bench, remove 1 Fire Energy card attached to Magcargo, if any, and attach it to the new Active Pokémon. (You can’t use an Energy card that you used to pay for the Retreat Cost.)",
       "type": "Pokémon Power"
     },
     "hp": "80",
@@ -1839,7 +1839,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "Piloswine does 30 damage to itself. Piloswine can't use this attack during your next turn."
+        "text": "Piloswine does 30 damage to itself. Piloswine can’t use this attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -1939,7 +1939,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the Defending Pokémon is a Basic, choose 1 of its attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "If the Defending Pokémon is a Basic, choose 1 of its attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Overhead Toss",
@@ -1950,7 +1950,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "If you have any Benched Pokémon, flip a coin. If tails, this attack does 10 damage to 1 of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If you have any Benched Pokémon, flip a coin. If tails, this attack does 10 damage to 1 of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1977,7 +1977,7 @@
     "level": "19",
     "ability": {
       "name": "[Bear]",
-      "text": "Once during your turn (before your attack), you may move 1 damage counter from 1 of your Pokémon with Unown in its name to Unown . This power can't be used if Unown has 10 HP left. This power can be used even if Unown is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may move 1 damage counter from 1 of your Pokémon with Unown in its name to Unown . This power can’t be used if Unown has 10 HP left. This power can be used even if Unown is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "50",
@@ -2083,7 +2083,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose a Trainer card attached to 1 of your opponent's Pokémon. Your opponent shuffles that card into his or her deck."
+        "text": "Choose a Trainer card attached to 1 of your opponent’s Pokémon. Your opponent shuffles that card into his or her deck."
       },
       {
         "name": "Tail Punch",
@@ -2151,7 +2151,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If the Defending Pokémon attacks Chinchou during your opponent's next turn, any damage done to Chinchou is reduced by 10 (before applying Weakness and Resistance). (Benching either Pokémon ends this effect.)"
+        "text": "If the Defending Pokémon attacks Chinchou during your opponent’s next turn, any damage done to Chinchou is reduced by 10 (before applying Weakness and Resistance). (Benching either Pokémon ends this effect.)"
       }
     ],
     "weaknesses": [
@@ -2205,7 +2205,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "This attack can't be used during your next turn. (Benching Farfetch'd ends this effect.)"
+        "text": "This attack can’t be used during your next turn. (Benching Farfetch'd ends this effect.)"
       }
     ],
     "weaknesses": [
@@ -2331,7 +2331,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Search your deck for a card named Murkrow and put it onto your Bench. Shuffle your deck afterward. (You can't use this attack if your Bench is full.)"
+        "text": "Search your deck for a card named Murkrow and put it onto your Bench. Shuffle your deck afterward. (You can’t use this attack if your Bench is full.)"
       },
       {
         "name": "Flock Attack",
@@ -2545,7 +2545,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. Don't apply Weakness and Resistance."
+        "text": "Flip a coin. If heads, choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. Don’t apply Weakness and Resistance."
       }
     ],
     "weaknesses": [
@@ -2594,7 +2594,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon is now Poisoned. It now takes 20 Poison damage after each player's turn (even if it was already Poisoned)."
+        "text": "Flip a coin. If heads, the Defending Pokémon is now Poisoned. It now takes 20 Poison damage after each player’s turn (even if it was already Poisoned)."
       }
     ],
     "weaknesses": [
@@ -2705,7 +2705,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2745,11 +2745,11 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, choose a Special Energy card attached to 1 of your opponent's Pokémon. Your opponent shuffles that card into his or her deck."
+        "text": "Flip a coin. If heads, choose a Special Energy card attached to 1 of your opponent’s Pokémon. Your opponent shuffles that card into his or her deck."
       }
     ],
     "text": [
-      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent's turn ends without an attack."
+      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent’s turn ends without an attack."
     ],
     "nationalPokedexNumber": 238,
     "imageUrlHiRes": "https://images.pokemontcg.io/neo3/54_hires.png",
@@ -2936,7 +2936,7 @@
     "level": "14",
     "ability": {
       "name": "[Keep]",
-      "text": "Your opponent's attacks, Pokémon Powers, and Trainer cards can't discard Energy cards from your Pokémon with Unown in their names. (Any other effects of attacks still happen.)",
+      "text": "Your opponent’s attacks, Pokémon Powers, and Trainer cards can’t discard Energy cards from your Pokémon with Unown in their names. (Any other effects of attacks still happen.)",
       "type": "Pokémon Power"
     },
     "hp": "40",
@@ -3057,7 +3057,7 @@
     "set": "Neo Revelation",
     "setCode": "neo3",
     "text": [
-      "Once during each player's turn, he or she may flip a coin. If heads, that player removes 2 damage counters from his or her Active Pokémon (1 if it only has 1)."
+      "Once during each player’s turn, he or she may flip a coin. If heads, that player removes 2 damage counters from his or her Active Pokémon (1 if it only has 1)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/neo3/61_hires.png"
   },
@@ -3080,7 +3080,7 @@
   },
   {
     "id": "neo3-63",
-    "name": "Rocket's Hideout",
+    "name": "Rocket’s Hideout",
     "imageUrl": "https://images.pokemontcg.io/neo3/63.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -3091,7 +3091,7 @@
     "set": "Neo Revelation",
     "setCode": "neo3",
     "text": [
-      "Each Pokémon in play with Dark in its name (even your opponent's) gets +20 HP."
+      "Each Pokémon in play with Dark in its name (even your opponent’s) gets +20 HP."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/neo3/63_hires.png"
   },
@@ -3156,7 +3156,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
-        "text": "Discard 2 Energy cards attached to Shining Gyarados or this attack does nothing. This attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Then, flip a coin. If heads, choose 1 Energy card attached to each of your opponent's Pokémon that has any Energy cards attached to it and discard those Energy cards."
+        "text": "Discard 2 Energy cards attached to Shining Gyarados or this attack does nothing. This attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) Then, flip a coin. If heads, choose 1 Energy card attached to each of your opponent’s Pokémon that has any Energy cards attached to it and discard those Energy cards."
       }
     ],
     "weaknesses": [

--- a/json/cards/Next Destinies.json
+++ b/json/cards/Next Destinies.json
@@ -39,7 +39,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -432,7 +432,7 @@
     "evolvesFrom": "Foongus",
     "ability": {
       "name": "Sporprise",
-      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may use this Ability. If you do, your opponent's Active Pokémon is now Confused and Poisoned.",
+      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may use this Ability. If you do, your opponent’s Active Pokémon is now Confused and Poisoned.",
       "type": "Ability"
     },
     "hp": "90",
@@ -583,7 +583,7 @@
     "evolvesFrom": "Growlithe",
     "ability": {
       "name": "Blazing Mane",
-      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out),the Attacking Pokémon is now Burned.",
+      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack (even if this Pokémon is Knocked Out),the Attacking Pokémon is now Burned.",
       "type": "Ability"
     },
     "hp": "130",
@@ -990,7 +990,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Does 30 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 30 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Inferno",
@@ -1207,7 +1207,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "50",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -1298,7 +1298,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "This attack does 20 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Surf",
@@ -1665,7 +1665,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "Does 10 more damage for each Colorless in the Defending Pokémon's Retreat Cost."
+        "text": "Does 10 more damage for each Colorless in the Defending Pokémon’s Retreat Cost."
       }
     ],
     "weaknesses": [
@@ -1759,7 +1759,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If this Pokémon was damaged by an attack during your opponent's last turn, this attack does the same amount of damage to the Defending Pokémon."
+        "text": "If this Pokémon was damaged by an attack during your opponent’s last turn, this attack does the same amount of damage to the Defending Pokémon."
       },
       {
         "name": "Absorb Life",
@@ -1811,7 +1811,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, this Pokémon's Belt attack's base damage is 40."
+        "text": "During your next turn, this Pokémon’s Belt attack’s base damage is 40."
       },
       {
         "name": "Belt",
@@ -1867,7 +1867,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
       },
       {
         "name": "Ambush",
@@ -1936,7 +1936,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "This Pokémon can't use Hail Blizzard during your next turn."
+        "text": "This Pokémon can’t use Hail Blizzard during your next turn."
       }
     ],
     "weaknesses": [
@@ -2081,7 +2081,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 50 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 50 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Thundering Hurricane",
@@ -2337,7 +2337,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "60",
-        "text": "Does 20 damage to 1 of your Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Crunch",
@@ -2429,7 +2429,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Your opponent can't play any Item cards from his or her hand during his or her next turn."
+        "text": "Your opponent can’t play any Item cards from his or her hand during his or her next turn."
       },
       {
         "name": "Lightning Crash",
@@ -2440,7 +2440,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Discard all Lightning Energy attached to this Pokémon. This attack does 80 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard all Lightning Energy attached to this Pokémon. This attack does 80 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2678,7 +2678,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Toxic Secretion",
@@ -2875,7 +2875,7 @@
     "evolvesFrom": "Kirlia",
     "ability": {
       "name": "Psychic Mirage",
-      "text": "Each basic Psychic Energy attached to your Psychic Pokémon provides PsychicPsychic Energy. You can't apply more than 1 Psychic Mirage Ability at a time.",
+      "text": "Each basic Psychic Energy attached to your Psychic Pokémon provides PsychicPsychic Energy. You can’t apply more than 1 Psychic Mirage Ability at a time.",
       "type": "Ability"
     },
     "hp": "110",
@@ -2903,7 +2903,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "This attack's damage isn't affected by Weakness or Resistance."
+        "text": "This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -3037,7 +3037,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Shuffle your hand into your deck. Then, draw a number of cards equal to the number of cards in your opponent's hand."
+        "text": "Shuffle your hand into your deck. Then, draw a number of cards equal to the number of cards in your opponent’s hand."
       },
       {
         "name": "DarMAXitan",
@@ -3129,7 +3129,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent reveals his or her hand. Choose a card from there and put it on the bottom of your opponent's deck."
+        "text": "Your opponent reveals his or her hand. Choose a card from there and put it on the bottom of your opponent’s deck."
       },
       {
         "name": "Psybeam",
@@ -3213,7 +3213,7 @@
     "evolvesFrom": "Riolu",
     "ability": {
       "name": "Reflexive Retaliation",
-      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), put 2 damage counters on the Attacking Pokémon.",
+      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack (even if this Pokémon is Knocked Out), put 2 damage counters on the Attacking Pokémon.",
       "type": "Ability"
     },
     "hp": "100",
@@ -3238,7 +3238,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3280,7 +3280,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Bite",
@@ -3357,7 +3357,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "90",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -3494,7 +3494,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Scratch",
@@ -3611,7 +3611,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Move an Energy attached to the Defending Pokémon to 1 of your opponent's Benched Pokémon."
+        "text": "Move an Energy attached to the Defending Pokémon to 1 of your opponent’s Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -3641,7 +3641,7 @@
     "evolvesFrom": "Nuzleaf",
     "ability": {
       "name": "Giant Fan",
-      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may flip a coin. If heads, choose 1 of your opponent's Pokémon. Your opponent shuffles that Pokémon and all cards attached to it into his or her deck.",
+      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may flip a coin. If heads, choose 1 of your opponent’s Pokémon. Your opponent shuffles that Pokémon and all cards attached to it into his or her deck.",
       "type": "Ability"
     },
     "hp": "130",
@@ -3773,7 +3773,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Hammer Kick",
@@ -3873,7 +3873,7 @@
     "evolvesFrom": "Bronzor",
     "ability": {
       "name": "Heal Block",
-      "text": "Damage can't be healed from any Pokémon (both yours and your opponent's). (Damage counters can still be moved.)",
+      "text": "Damage can’t be healed from any Pokémon (both yours and your opponent’s). (Damage counters can still be moved.)",
       "type": "Ability"
     },
     "hp": "110",
@@ -3902,7 +3902,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
-        "text": "Does 10 more damage for each card in your opponent's hand."
+        "text": "Does 10 more damage for each card in your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -4167,7 +4167,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, discard a random card from your opponent's hand."
+        "text": "Flip a coin. If heads, discard a random card from your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -4383,7 +4383,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "During your next turn, this Pokémon's Echoed Voice attack does 50 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s Echoed Voice attack does 50 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -4425,7 +4425,7 @@
     "set": "Next Destinies",
     "setCode": "bw4",
     "text": [
-      "When your Active Pokémon is Knocked Out by damage from an opponent's attack, you may move 1 basic Energy card that was attached to that Pokémon to the Pokémon this card is attached to."
+      "When your Active Pokémon is Knocked Out by damage from an opponent’s attack, you may move 1 basic Energy card that was attached to that Pokémon to the Pokémon this card is attached to."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw4/87_hires.png"
   },
@@ -4476,8 +4476,8 @@
     "set": "Next Destinies",
     "setCode": "bw4",
     "text": [
-      "Once during each player's turn, that player may heal 20 damage from 1 of his or her Benched Pokémon.",
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card."
+      "Once during each player’s turn, that player may heal 20 damage from 1 of his or her Benched Pokémon.",
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw4/90_hires.png"
   },
@@ -4694,7 +4694,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "This Pokémon can't use Hail Blizzard during your next turn."
+        "text": "This Pokémon can’t use Hail Blizzard during your next turn."
       }
     ],
     "weaknesses": [

--- a/json/cards/Noble Victories.json
+++ b/json/cards/Noble Victories.json
@@ -285,7 +285,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent’s next turn."
       },
       {
         "name": "Slash",
@@ -608,7 +608,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "60",
-        "text": "This Pokémon can't use Slashing Strike during your next turn."
+        "text": "This Pokémon can’t use Slashing Strike during your next turn."
       }
     ],
     "weaknesses": [
@@ -657,7 +657,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "During your next turn, this Pokémon's Leaf Wallop attack does 40 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s Leaf Wallop attack does 40 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -683,7 +683,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Victory Star",
-      "text": "Once during your turn, after you flip any coins for an attack, you may ignore all effects of those coin flips and begin flipping those coins again. You can't use more than 1 Victory Star Ability each turn.",
+      "text": "Once during your turn, after you flip any coins for an attack, you may ignore all effects of those coin flips and begin flipping those coins again. You can’t use more than 1 Victory Star Ability each turn.",
       "type": "Ability"
     },
     "hp": "60",
@@ -1527,7 +1527,7 @@
     "evolvesFrom": "Frillish",
     "ability": {
       "name": "Cursed Body",
-      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Confused.",
+      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Confused.",
       "type": "Ability"
     },
     "hp": "110",
@@ -1642,7 +1642,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon."
+        "text": "Switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon."
       },
       {
         "name": "Frost Vanish",
@@ -1704,7 +1704,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 30 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1743,7 +1743,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2011,7 +2011,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Wild Charge",
@@ -2393,7 +2393,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Gunk Shot",
@@ -2734,7 +2734,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Does 20 damage to each of your opponent's Benched Pokémon that shares a type with the Defending Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to each of your opponent’s Benched Pokémon that shares a type with the Defending Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Psyshot",
@@ -2869,7 +2869,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon."
+        "text": "Switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon."
       },
       {
         "name": "Will-O-Wisp",
@@ -2903,7 +2903,7 @@
     "evolvesFrom": "Lampent",
     "ability": {
       "name": "Cursed Shadow",
-      "text": "Once during your turn (before your attack), if this Pokémon is your Active Pokémon, you may put 3 damage counters on your opponent's Pokémon in any way you like.",
+      "text": "Once during your turn (before your attack), if this Pokémon is your Active Pokémon, you may put 3 damage counters on your opponent’s Pokémon in any way you like.",
       "type": "Ability"
     },
     "hp": "130",
@@ -2973,7 +2973,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 20 damage to 1 of your opponent's Pokémon for each Fighting Energy attached to this Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 1 of your opponent’s Pokémon for each Fighting Energy attached to this Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Power Gem",
@@ -3136,7 +3136,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "Flip a coin until you get tails. For each heads, discard the top card of your opponent's deck."
+        "text": "Flip a coin until you get tails. For each heads, discard the top card of your opponent’s deck."
       }
     ],
     "weaknesses": [
@@ -3178,7 +3178,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "40",
-        "text": "This attack's damage isn't affected by any effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by any effects on the Defending Pokémon."
       },
       {
         "name": "Swing Around",
@@ -3265,7 +3265,7 @@
     "evolvesFrom": "Archen",
     "ability": {
       "name": "Ancient Power",
-      "text": "Each player can't play any Pokémon from his or her hand to evolve his or her Pokémon.",
+      "text": "Each player can’t play any Pokémon from his or her hand to evolve his or her Pokémon.",
       "type": "Ability"
     },
     "hp": "130",
@@ -3292,7 +3292,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Does 10 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3441,7 +3441,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       },
       {
         "name": "High Jump Kick",
@@ -3547,7 +3547,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Discard the top card of your opponent's deck."
+        "text": "Discard the top card of your opponent’s deck."
       },
       {
         "name": "Hurricane Punch",
@@ -3608,7 +3608,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "If any of your Pokémon were Knocked Out by damage from an opponent's attack during his or her last turn, this attack does 60 more damage."
+        "text": "If any of your Pokémon were Knocked Out by damage from an opponent’s attack during his or her last turn, this attack does 60 more damage."
       },
       {
         "name": "Land Crush",
@@ -3669,7 +3669,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent’s). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3949,7 +3949,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "Does 40 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 40 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3998,7 +3998,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Twineedle",
@@ -4170,7 +4170,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "For each of your Durant in play, discard the top card of your opponent's deck."
+        "text": "For each of your Durant in play, discard the top card of your opponent’s deck."
       },
       {
         "name": "Vice Grip",
@@ -4238,7 +4238,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "The Defending Pokémon can't attack during your opponent's next turn."
+        "text": "The Defending Pokémon can’t attack during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -4422,7 +4422,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "This Pokémon can't attack during your next turn."
+        "text": "This Pokémon can’t attack during your next turn."
       }
     ],
     "nationalPokedexNumber": 612,
@@ -4436,7 +4436,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Rough Skin",
-      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), put 2 damage counters on the Attacking Pokémon.",
+      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack (even if this Pokémon is Knocked Out), put 2 damage counters on the Attacking Pokémon.",
       "type": "Ability"
     },
     "hp": "100",
@@ -4463,7 +4463,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "nationalPokedexNumber": 621,
@@ -4500,7 +4500,7 @@
     "setCode": "bw3",
     "text": [
       "If the Pokémon this card is attached to is a Basic Pokémon, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance).",
-      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw3/91_hires.png"
   },
@@ -4551,7 +4551,7 @@
     "set": "Noble Victories",
     "setCode": "bw3",
     "text": [
-      "If the Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent's attack (even if that Pokémon is Knocked Out), put 2 damage counters on the Attacking Pokémon."
+      "If the Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent’s attack (even if that Pokémon is Knocked Out), put 2 damage counters on the Attacking Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw3/94_hires.png"
   },
@@ -4626,7 +4626,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "During your next turn, this Pokémon's Leaf Wallop attack does 40 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s Leaf Wallop attack does 40 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -4652,7 +4652,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Victory Star",
-      "text": "Once during your turn, after you flip any coins for an attack, you may ignore all effects of those coin flips and begin flipping those coins again. You can't use more than 1 Victory Star Ability each turn.",
+      "text": "Once during your turn, after you flip any coins for an attack, you may ignore all effects of those coin flips and begin flipping those coins again. You can’t use more than 1 Victory Star Ability each turn.",
       "type": "Ability"
     },
     "hp": "60",
@@ -4720,7 +4720,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "If any of your Pokémon were Knocked Out by damage from an opponent's attack during his or her last turn, this attack does 60 more damage."
+        "text": "If any of your Pokémon were Knocked Out by damage from an opponent’s attack during his or her last turn, this attack does 60 more damage."
       },
       {
         "name": "Land Crush",
@@ -4783,7 +4783,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "The Defending Pokémon can't attack during your opponent's next turn."
+        "text": "The Defending Pokémon can’t attack during your opponent’s next turn."
       }
     ],
     "weaknesses": [

--- a/json/cards/POP Series 2.json
+++ b/json/cards/POP Series 2.json
@@ -59,7 +59,7 @@
     "evolvesFrom": "Pidgeotto",
     "ability": {
       "name": "Beating Wings",
-      "text": "Once during your turn (before your attack), If Pidgeot is your Active Pokémon, you may shuffle 1 of your Benched Pokémon and all cards attached to it in your deck. This power can't be used if Pidgeot is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), If Pidgeot is your Active Pokémon, you may shuffle 1 of your Benched Pokémon and all cards attached to it in your deck. This power can’t be used if Pidgeot is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -158,7 +158,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Mirror Coat",
-      "text": "If Suicune is Burned or Poisoned by an opponent's attack (even if Suicune is Knocked Out), the Attacking Pokémon is now affected by the same Special Conditions (1 if there is only 1).",
+      "text": "If Suicune is Burned or Poisoned by an opponent’s attack (even if Suicune is Knocked Out), the Attacking Pokémon is now affected by the same Special Conditions (1 if there is only 1).",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -278,7 +278,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "Does 20 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Hard Plant",
@@ -290,7 +290,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "Venusaur can't use Hard Plant during your next turn."
+        "text": "Venusaur can’t use Hard Plant during your next turn."
       }
     ],
     "weaknesses": [
@@ -358,7 +358,7 @@
   },
   {
     "id": "pop2-8",
-    "name": "Mr. Briney's Compassion",
+    "name": "Mr. Briney’s Compassion",
     "imageUrl": "https://images.pokemontcg.io/pop2/8.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -403,7 +403,7 @@
     "set": "POP Series 2",
     "setCode": "pop2",
     "text": [
-      "Once during each player's turn, when that player attaches an Energy card from his or her hand to 1 of his or her Benched Pokémon, he or she removes 1 damage counter from that Pokémon."
+      "Once during each player’s turn, when that player attaches an Energy card from his or her hand to 1 of his or her Benched Pokémon, he or she removes 1 damage counter from that Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pop2/10_hires.png"
   },
@@ -503,7 +503,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -704,7 +704,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Prevent all effects of attacks, including damage, done to Celebi ex by your opponent's Pokémon"
+        "text": "Prevent all effects of attacks, including damage, done to Celebi ex by your opponent’s Pokémon"
       }
     ],
     "weaknesses": [

--- a/json/cards/POP Series 3.json
+++ b/json/cards/POP Series 3.json
@@ -41,7 +41,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "Blastoise does 10 damage to itself. Flip a coin. If heads, prevent all damage done to Blastoise by attacks during your opponent's next turn."
+        "text": "Blastoise does 10 damage to itself. Flip a coin. If heads, prevent all damage done to Blastoise by attacks during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -197,7 +197,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 10 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 10 (before applying Weakness and Resistance)."
       },
       {
         "name": "Power Bolt",
@@ -207,7 +207,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Choose 1 of your opponent's Pokémon that has any Poké-Powers. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon that has any Poké-Powers. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -272,7 +272,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Choose 1 of your opponent's Pokémon that has any Poké-bodies. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon that has any Poké-bodies. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -328,7 +328,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "Does 30 damage plus 20 more damage for each Energy attached to Vaporeon but not used to pay for this attack's Energy cost. You can't add more than 40 damage in this way."
+        "text": "Does 30 damage plus 20 more damage for each Energy attached to Vaporeon but not used to pay for this attack’s Energy cost. You can’t add more than 40 damage in this way."
       }
     ],
     "weaknesses": [
@@ -786,7 +786,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Golden Wing",
-      "text": "If Ho-oh ex would be Knocked Out by damage from an opponent's attack, you may move 2 Energy attached to Ho-oh ex to your Pokémon in any way you like.",
+      "text": "If Ho-oh ex would be Knocked Out by damage from an opponent’s attack, you may move 2 Energy attached to Ho-oh ex to your Pokémon in any way you like.",
       "type": "Poké-Power"
     },
     "hp": "110",

--- a/json/cards/POP Series 4.json
+++ b/json/cards/POP Series 4.json
@@ -36,7 +36,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Weakness or Resistance."
+        "text": "This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -56,7 +56,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Form Change",
-      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys and switch it with Deoxys. (Any cards attached to Deoxys, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys on top of your deck. Shuffle your deck afterward. You can't use more than 1 Form Change Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys and switch it with Deoxys. (Any cards attached to Deoxys, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Form Change Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -81,7 +81,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "During your next turn, Deoxys's attacks do 40 more damage to the Defending Pokémon (before applying Weakness and Resistance)."
+        "text": "During your next turn, Deoxys’s attacks do 40 more damage to the Defending Pokémon (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -140,7 +140,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "70",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -160,7 +160,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Reactive Barrier",
-      "text": "As long as Mew has any React Energy cards attached to it, prevent all effects, excluding damage, done to Mew by attacks from your opponent's Pokémon.",
+      "text": "As long as Mew has any React Energy cards attached to it, prevent all effects, excluding damage, done to Mew by attacks from your opponent’s Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -206,7 +206,7 @@
     "evolvesFrom": "Grovyle",
     "ability": {
       "name": "Energy Trans",
-      "text": "As often as you like during your turn (before your attack), move a Grass Energy card attached to 1 of your Pokémon to another of your Pokémon. This power can't be used if Sceptile is affected by a Special Condition.",
+      "text": "As often as you like during your turn (before your attack), move a Grass Energy card attached to 1 of your Pokémon to another of your Pokémon. This power can’t be used if Sceptile is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -280,7 +280,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Sky Uppercut",
@@ -291,7 +291,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -412,7 +412,7 @@
     "set": "POP Series 4",
     "setCode": "pop4",
     "text": [
-      "Scramble Energy can be attached only to an Evolved Pokémon (excluding Pokémon-ex). Scramble Energy provides Energy. While in play, if you have more Prize cards left than your opponent, Scramble Energy provides every type of Energy but provides only 3 in any combination at a time. If the Pokémon Scramble Energy is attached to isn't an Evolved Pokémon (or evolves into Pokémon-ex), discard Scramble Energy."
+      "Scramble Energy can be attached only to an Evolved Pokémon (excluding Pokémon-ex). Scramble Energy provides Energy. While in play, if you have more Prize cards left than your opponent, Scramble Energy provides every type of Energy but provides only 3 in any combination at a time. If the Pokémon Scramble Energy is attached to isn’t an Evolved Pokémon (or evolves into Pokémon-ex), discard Scramble Energy."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pop4/10_hires.png"
   },
@@ -536,7 +536,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -559,7 +559,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shell Retreat",
-      "text": "As long as Squirtle has any Energy cards attached to it, damage done to Squirtle by an opponent's attack is reduced by 10 (after applying Weakness and Resistance).",
+      "text": "As long as Squirtle has any Energy cards attached to it, damage done to Squirtle by an opponent’s attack is reduced by 10 (after applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "50",
@@ -693,7 +693,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "During your opponent's next turn, any damage done to Wobbuffet is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Wobbuffet is reduced by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -713,7 +713,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Form Change",
-      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys ex and switch it with Deoxys ex. (Any cards attached to Deoxys ex, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys ex on top of your deck. Shuffle your deck afterward. You can't use more than 1 Form Change Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Deoxys ex and switch it with Deoxys ex. (Any cards attached to Deoxys ex, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Deoxys ex on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Form Change Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -739,7 +739,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "This attack's damage isn't affected by Resistance, Poké-Powers. Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Resistance, Poké-Powers. Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [

--- a/json/cards/POP Series 5.json
+++ b/json/cards/POP Series 5.json
@@ -131,7 +131,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. Copy copies that attack. This attack does nothing if Mew doesn't have the Energy necessary to use that attack. (You must still do anything else required for that attack.) Mew performs that attack."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. Copy copies that attack. This attack does nothing if Mew doesn’t have the Energy necessary to use that attack. (You must still do anything else required for that attack.) Mew performs that attack."
       },
       {
         "name": "Extra Draw",
@@ -165,7 +165,7 @@
     "set": "POP Series 5",
     "setCode": "pop5",
     "text": [
-      "Double Rainbow Energy can be attached only to an Evolved Pokémon (excluding Pokémon-ex). While in play, Double Rainbow Energy provides every type of Energy but provides 2 Energy at a time. (Has no effect other than providing Energy.) Damage done to your opponent's Pokémon by the Pokémon Double Rainbow Energy is attached to is reduced by 10 (before applying Weakness and Resistance). When the Pokémon Double Rainbow Energy is attached to is no longer an Evolved Pokémon, discard Double Rainbow Energy. (Major text change in Emerald. Using earlier versions requires reference.)"
+      "Double Rainbow Energy can be attached only to an Evolved Pokémon (excluding Pokémon-ex). While in play, Double Rainbow Energy provides every type of Energy but provides 2 Energy at a time. (Has no effect other than providing Energy.) Damage done to your opponent’s Pokémon by the Pokémon Double Rainbow Energy is attached to is reduced by 10 (before applying Weakness and Resistance). When the Pokémon Double Rainbow Energy is attached to is no longer an Evolved Pokémon, discard Double Rainbow Energy. (Major text change in Emerald. Using earlier versions requires reference.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pop5/4_hires.png"
   },
@@ -226,7 +226,7 @@
   },
   {
     "id": "pop5-6",
-    "name": "Bill's Maintenance",
+    "name": "Bill’s Maintenance",
     "imageUrl": "https://images.pokemontcg.io/pop5/6.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -271,7 +271,7 @@
     "set": "POP Series 5",
     "setCode": "pop5",
     "text": [
-      "Boost Energy can be attached only to an Evolved Pokémon. Discard Boost Energy at the end of the turn it was attached. Boost Energy provides Energy. The Pokémon Boost Energy is attached to can't retreat. If the Pokémon Boost Energy is attached to isn't an Evolved Pokémon, discard Boost Energy."
+      "Boost Energy can be attached only to an Evolved Pokémon. Discard Boost Energy at the end of the turn it was attached. Boost Energy provides Energy. The Pokémon Boost Energy is attached to can’t retreat. If the Pokémon Boost Energy is attached to isn’t an Evolved Pokémon, discard Boost Energy."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pop5/8_hires.png"
   },
@@ -371,7 +371,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
       }
     ],
     "weaknesses": [
@@ -500,7 +500,7 @@
     "evolvesFrom": "Wingull",
     "ability": {
       "name": "Mist",
-      "text": "Any damage done to Pelipper by attacks from Stage 2 Evolved Pokémon (both yours and your opponent's) is reduced by 30 (after applying Weakness and Resistance).",
+      "text": "Any damage done to Pelipper by attacks from Stage 2 Evolved Pokémon (both yours and your opponent’s) is reduced by 30 (after applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -523,7 +523,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Does 10 damage to 1 of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -568,7 +568,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Zangoose during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Zangoose during your opponent’s next turn."
       },
       {
         "name": "Metal Claw",
@@ -599,7 +599,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Purple Ray",
-      "text": "Once during your turn, when you put Espeon * from your hand onto your Bench, you may use this power. Each Active Pokémon (both yours and your opponent's) is now Confused.",
+      "text": "Once during your turn, when you put Espeon * from your hand onto your Bench, you may use this power. Each Active Pokémon (both yours and your opponent’s) is now Confused.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -645,7 +645,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Dark Ray",
-      "text": "Once during your turn, when you put Umbreon * from your hand onto your Bench, you may choose 1 card from your opponent's hand without looking and discard it.",
+      "text": "Once during your turn, when you put Umbreon * from your hand onto your Bench, you may choose 1 card from your opponent’s hand without looking and discard it.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -670,7 +670,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poké"
       }
     ],
     "weaknesses": [

--- a/json/cards/POP Series 6.json
+++ b/json/cards/POP Series 6.json
@@ -9,7 +9,7 @@
     "evolvesFrom": "Shieldon",
     "ability": {
       "name": "Protective Wall",
-      "text": "Prevent all damage done to your Benched Pokémon by your opponent's attacks.",
+      "text": "Prevent all damage done to your Benched Pokémon by your opponent’s attacks.",
       "type": "Poké-Body"
     },
     "hp": "130",
@@ -37,7 +37,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "If Bastiodon was damaged by an attack during your opponent's last turn, this attack does 40 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If Bastiodon was damaged by an attack during your opponent’s last turn, this attack does 40 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -84,7 +84,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       },
       {
         "name": "Aura Sphere",
@@ -94,7 +94,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -241,7 +241,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "As long as the Defending Pokémon's remaining HP is 60 or less, this attack's base damage is 60 instead of 30."
+        "text": "As long as the Defending Pokémon’s remaining HP is 60 or less, this attack’s base damage is 60 instead of 30."
       },
       {
         "name": "Hasty Headbutt",
@@ -252,7 +252,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "Rampardos does 20 damage to itself. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies. or any other effects on the Defending Pokémon."
+        "text": "Rampardos does 20 damage to itself. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies. or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -302,7 +302,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Flip a coin. If heads, the Defending Pokémon is now Confused and can't retreat during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon is now Confused and can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -439,7 +439,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Does 10 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -497,7 +497,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -546,7 +546,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Scavenge",
@@ -608,7 +608,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [

--- a/json/cards/POP Series 7.json
+++ b/json/cards/POP Series 7.json
@@ -9,7 +9,7 @@
     "evolvesFrom": "Flaaffy",
     "ability": {
       "name": "Jamming",
-      "text": "After your opponent plays a Supporter card from his or her hand, put 1 damage counter on each of your opponent's Pokémon. You can't use more than 1 Jamming Poké-Body each turn.",
+      "text": "After your opponent plays a Supporter card from his or her hand, put 1 damage counter on each of your opponent’s Pokémon. You can’t use more than 1 Jamming Poké-Body each turn.",
       "type": "Poké-Body"
     },
     "hp": "130",
@@ -37,7 +37,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "You may discard all Energy attached to Ampharos. If you do, this attack does 20 damage to each of your opponent's Benched Pokémon that has any Energy cards attached to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "You may discard all Energy attached to Ampharos. If you do, this attack does 20 damage to each of your opponent’s Benched Pokémon that has any Energy cards attached to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -426,7 +426,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 40 damage to that Pokémon. This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -477,7 +477,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If the Defending Pokémon isn't an Evolved Pokémon, that Pokémon is now Confused."
+        "text": "If the Defending Pokémon isn’t an Evolved Pokémon, that Pokémon is now Confused."
       }
     ],
     "weaknesses": [

--- a/json/cards/POP Series 8.json
+++ b/json/cards/POP Series 8.json
@@ -42,7 +42,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "90",
-        "text": "Discard 2 basic Energy cards attached to Heatran. (If you can't discard cards, this attack does nothing.)"
+        "text": "Discard 2 basic Energy cards attached to Heatran. (If you can’t discard cards, this attack does nothing.)"
       }
     ],
     "weaknesses": [
@@ -84,7 +84,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "During your opponent's next turn, any damage done to Lucario by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Lucario by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Striking Kick",
@@ -95,7 +95,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "This attack's damage isn't affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects of the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects of the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -117,7 +117,7 @@
     "evolvesFrom": "Luxio",
     "ability": {
       "name": "Intimidating Fang",
-      "text": "As long as Luxray is your Active Pokémon, any damage done by an opponent's attack is reduced by 10 (before applying Weakness and Resistance).",
+      "text": "As long as Luxray is your Active Pokémon, any damage done by an opponent’s attack is reduced by 10 (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -194,7 +194,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Does 10 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Triple Nose",
@@ -366,7 +366,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Before doing damage, count the remaining HP of the Defending Pokémon and Carnivine. If the Defending Pokémon has fewer remaining HP than Carnivine's, this attack does 60 damage instead."
+        "text": "Before doing damage, count the remaining HP of the Defending Pokémon and Carnivine. If the Defending Pokémon has fewer remaining HP than Carnivine’s, this attack does 60 damage instead."
       },
       {
         "name": "Wring Out",
@@ -487,7 +487,7 @@
   },
   {
     "id": "pop8-11",
-    "name": "Roseanne's Research",
+    "name": "Roseanne’s Research",
     "imageUrl": "https://images.pokemontcg.io/pop8/11.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -580,7 +580,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent can't play any Supporter cards from his or her hand during his or her next turn."
+        "text": "Flip a coin. If heads, your opponent can’t play any Supporter cards from his or her hand during his or her next turn."
       },
       {
         "name": "Finger Poke",
@@ -709,7 +709,7 @@
     "level": "6",
     "ability": {
       "name": "Inner Focus",
-      "text": "Riolu can't be Paralyzed.",
+      "text": "Riolu can’t be Paralyzed.",
       "type": "Poké-Body"
     },
     "hp": "50",

--- a/json/cards/POP Series 9.json
+++ b/json/cards/POP Series 9.json
@@ -36,7 +36,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "Discard 2 Energy attached to Garchomp and this attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard 2 Energy attached to Garchomp and this attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -85,7 +85,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Then, remove from Manaphy the number of damage counters equal to the damage you did to that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) Then, remove from Manaphy the number of damage counters equal to the damage you did to that Pokémon."
       }
     ],
     "weaknesses": [
@@ -138,7 +138,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "If Raichu evolved from Pikachu during this turn, this attack's base damage is 100 instead of 60."
+        "text": "If Raichu evolved from Pikachu during this turn, this attack’s base damage is 100 instead of 60."
       }
     ],
     "weaknesses": [
@@ -222,7 +222,7 @@
     "level": "46",
     "ability": {
       "name": "Type Shift",
-      "text": "Once during your turn (before your attack), you may use this power. Rotom's type is Psychic until the end of your turn",
+      "text": "Once during your turn (before your attack), you may use this power. Rotom’s type is Psychic until the end of your turn",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -247,7 +247,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "Look at your opponent's hand. This attack does 30 damage plus 10 more damage for each Trainer, Supporter, and Stadium card in your opponent's hand."
+        "text": "Look at your opponent’s hand. This attack does 30 damage plus 10 more damage for each Trainer, Supporter, and Stadium card in your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -303,7 +303,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "If you have Pachirisu in play, flip a coin. If heads, prevent all effects of an attack, including damage, done to Buizel during your opponent's next turn."
+        "text": "If you have Pachirisu in play, flip a coin. If heads, prevent all effects of an attack, including damage, done to Buizel during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -347,7 +347,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, choose 1 card from your opponent's hand without looking and discard it."
+        "text": "Flip a coin. If heads, choose 1 card from your opponent’s hand without looking and discard it."
       },
       {
         "name": "Nimble",
@@ -401,7 +401,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to Gabite by attacks during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all damage done to Gabite by attacks during your opponent’s next turn."
       },
       {
         "name": "Distorted Wave",
@@ -457,7 +457,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Jazzed",
@@ -625,7 +625,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to Buneary by attacks during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all damage done to Buneary by attacks during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -765,7 +765,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
       },
       {
         "name": "Numb",
@@ -836,7 +836,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "If you have Buizel in play, this attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If you have Buizel in play, this attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [

--- a/json/cards/Phantom Forces.json
+++ b/json/cards/Phantom Forces.json
@@ -27,7 +27,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -81,7 +81,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Your opponent's Active Pokémon is now Confused and Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Confused and Poisoned."
       }
     ],
     "weaknesses": [
@@ -276,7 +276,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       },
       {
         "name": "Corkscrew Punch",
@@ -504,7 +504,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is increased by 40 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is increased by 40 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -584,7 +584,7 @@
     "evolvesFrom": "Litleo",
     "ability": {
       "name": "Flare Command",
-      "text": "Once during your turn (before your attack), you may discard a Fire Energy attached to this Pokémon. If you do, switch 1 of your opponent's Benched Pokémon with his or her Active Pokémon.",
+      "text": "Once during your turn (before your attack), you may discard a Fire Energy attached to this Pokémon. If you do, switch 1 of your opponent’s Benched Pokémon with his or her Active Pokémon.",
       "type": "Ability"
     },
     "hp": "110",
@@ -708,7 +708,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Crabhammer",
@@ -815,7 +815,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -862,7 +862,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Flip a coin until you get tails. For each heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin until you get tails. For each heads, discard an Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Second Strike",
@@ -874,7 +874,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80+",
-        "text": "If your opponent's Active Pokémon already has any damage counters on it, this attack does 80 more damage."
+        "text": "If your opponent’s Active Pokémon already has any damage counters on it, this attack does 80 more damage."
       }
     ],
     "weaknesses": [
@@ -966,7 +966,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       }
     ],
     "weaknesses": [
@@ -1006,7 +1006,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -1051,7 +1051,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Attach 3 Energy cards from your opponent's discard pile to his or her Pokémon in any way you like."
+        "text": "Attach 3 Energy cards from your opponent’s discard pile to his or her Pokémon in any way you like."
       },
       {
         "name": "Ensnaring Spray",
@@ -1062,7 +1062,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50+",
-        "text": "This attack does 10 more damage for each Energy attached to your opponent's Active Pokémon."
+        "text": "This attack does 10 more damage for each Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -1154,7 +1154,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "This attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Assault Laser",
@@ -1164,7 +1164,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "60+",
-        "text": "If your opponent's Active Pokémon has a Pokémon Tool card attached to it, this attack does 60 more damage."
+        "text": "If your opponent’s Active Pokémon has a Pokémon Tool card attached to it, this attack does 60 more damage."
       }
     ],
     "weaknesses": [
@@ -1412,7 +1412,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with your opponent's Active Pokémon. The new Active Pokémon is now Confused."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with your opponent’s Active Pokémon. The new Active Pokémon is now Confused."
       },
       {
         "name": "Electroweb",
@@ -1423,7 +1423,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1632,7 +1632,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 10 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1662,7 +1662,7 @@
     "evolvesFrom": "Zubat",
     "ability": {
       "name": "Sneaky Bite",
-      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may put 2 damage counters on 1 of your opponent's Pokémon.",
+      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may put 2 damage counters on 1 of your opponent’s Pokémon.",
       "type": "Ability"
     },
     "hp": "70",
@@ -1683,7 +1683,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1713,7 +1713,7 @@
     "evolvesFrom": "Golbat",
     "ability": {
       "name": "Surprise Bite",
-      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may put 3 damage counters on 1 of your opponent's Pokémon.",
+      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may put 3 damage counters on 1 of your opponent’s Pokémon.",
       "type": "Ability"
     },
     "hp": "130",
@@ -1734,7 +1734,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 30 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1780,7 +1780,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 3 damage counters on 1 of your opponent's Pokémon."
+        "text": "Put 3 damage counters on 1 of your opponent’s Pokémon."
       },
       {
         "name": "Dark Corridor",
@@ -1791,7 +1791,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Your opponent's Active Pokémon is now Poisoned. Switch this Pokémon with 1 of your Benched Pokémon."
+        "text": "Your opponent’s Active Pokémon is now Poisoned. Switch this Pokémon with 1 of your Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -1843,7 +1843,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon's attacks and use it as this attack."
+        "text": "Choose 1 of your opponent’s Pokémon’s attacks and use it as this attack."
       }
     ],
     "weaknesses": [
@@ -1869,7 +1869,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Bide Barricade",
-      "text": "As long as this Pokémon is your Active Pokémon, each Pokémon in play, in each player's hand, and in each player's discard pile has no Abilities (except for Psychic Pokémon).",
+      "text": "As long as this Pokémon is your Active Pokémon, each Pokémon in play, in each player’s hand, and in each player’s discard pile has no Abilities (except for Psychic Pokémon).",
       "type": "Ability"
     },
     "hp": "110",
@@ -1895,7 +1895,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10+",
-        "text": "This attack does 10 more damage for each damage counter on your opponent's Active Pokémon."
+        "text": "This attack does 10 more damage for each damage counter on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -1935,7 +1935,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Poisoned."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Poisoned."
       },
       {
         "name": "Sludge Bomb",
@@ -1992,7 +1992,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       },
       {
         "name": "Swallow Up",
@@ -2003,7 +2003,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50+",
-        "text": "If, before doing damage, your opponent's Active Pokémon has fewer remaining HP than this Pokémon, this attack does 50 more damage."
+        "text": "If, before doing damage, your opponent’s Active Pokémon has fewer remaining HP than this Pokémon, this attack does 50 more damage."
       }
     ],
     "weaknesses": [
@@ -2196,7 +2196,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 3 damage counters on your opponent's Pokémon in any way you like."
+        "text": "Put 3 damage counters on your opponent’s Pokémon in any way you like."
       },
       {
         "name": "Night March",
@@ -2237,7 +2237,7 @@
     "evolvesFrom": "Lampent",
     "ability": {
       "name": "Fainting Spell",
-      "text": "If this Pokémon is Knocked Out by damage from an opponent's attack, flip a coin. If heads, the Attacking Pokémon is Knocked Out.",
+      "text": "If this Pokémon is Knocked Out by damage from an opponent’s attack, flip a coin. If heads, the Attacking Pokémon is Knocked Out.",
       "type": "Ability"
     },
     "hp": "130",
@@ -2264,7 +2264,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Put 6 damage counters on your opponent's Pokémon in any way you like."
+        "text": "Put 6 damage counters on your opponent’s Pokémon in any way you like."
       }
     ],
     "weaknesses": [
@@ -2468,7 +2468,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Your opponent can't attach Energy from his or her hand to the Defending Pokémon during his or her next turn."
+        "text": "Your opponent can’t attach Energy from his or her hand to the Defending Pokémon during his or her next turn."
       },
       {
         "name": "Poison Jab",
@@ -2479,7 +2479,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Poisoned."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Poisoned."
       }
     ],
     "weaknesses": [
@@ -2601,7 +2601,7 @@
     "evolvesFrom": "Boldore",
     "ability": {
       "name": "High Density Armor",
-      "text": "If this Pokémon has full HP, any damage done to this Pokémon by an opponent's attack is reduced by 50 (after applying Weakness and Resistance).",
+      "text": "If this Pokémon has full HP, any damage done to this Pokémon by an opponent’s attack is reduced by 50 (after applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "140",
@@ -2630,7 +2630,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60+",
-        "text": "During your next turn, this Pokémon's Overdrive Smash attack does 40 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s Overdrive Smash attack does 40 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -2729,7 +2729,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Nightmare Mambo",
@@ -2740,7 +2740,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "If your opponent's Active Pokémon is Asleep, this attack does 60 more damage."
+        "text": "If your opponent’s Active Pokémon is Asleep, this attack does 60 more damage."
       }
     ],
     "weaknesses": [
@@ -2845,7 +2845,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Darkness Fang",
@@ -2901,7 +2901,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Your opponent can't play any Pokémon from his or her hand to evolve the Defending Pokémon during his or her next turn."
+        "text": "Your opponent can’t play any Pokémon from his or her hand to evolve the Defending Pokémon during his or her next turn."
       },
       {
         "name": "Confuse Ray",
@@ -2911,7 +2911,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Confused."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Confused."
       }
     ],
     "nationalPokedexNumber": 442,
@@ -2944,7 +2944,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -2993,7 +2993,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 60 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 60 (before applying Weakness and Resistance)."
       },
       {
         "name": "Mach Claw",
@@ -3003,7 +3003,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -3029,7 +3029,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Hyper Hypnosis",
-      "text": "When you attach an Energy from your hand to this Pokémon, you may use this Ability. Your opponent's Active Pokémon is now Asleep.",
+      "text": "When you attach an Energy from your hand to this Pokémon, you may use this Ability. Your opponent’s Active Pokémon is now Asleep.",
       "type": "Ability"
     },
     "hp": "170",
@@ -3263,7 +3263,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "If the Defending Pokémon is a Pokémon-EX, it can't attack during your opponent's next turn."
+        "text": "If the Defending Pokémon is a Pokémon-EX, it can’t attack during your opponent’s next turn."
       },
       {
         "name": "Full Metal Impact",
@@ -3384,7 +3384,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Discard a random card from your opponent's hand."
+        "text": "Discard a random card from your opponent’s hand."
       },
       {
         "name": "Spiral Rush",
@@ -3421,7 +3421,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Mighty Shield",
-      "text": "Prevent all damage done to this Pokémon by attacks from each of your opponent's Pokémon that has Special Energy attached to it.",
+      "text": "Prevent all damage done to this Pokémon by attacks from each of your opponent’s Pokémon that has Special Energy attached to it.",
       "type": "Ability"
     },
     "hp": "170",
@@ -3475,7 +3475,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Mighty Shield",
-      "text": "Prevent all damage done to this Pokémon by attacks from each of your opponent's Pokémon that has Special Energy attached to it.",
+      "text": "Prevent all damage done to this Pokémon by attacks from each of your opponent’s Pokémon that has Special Energy attached to it.",
       "type": "Ability"
     },
     "hp": "170",
@@ -3558,7 +3558,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -3725,7 +3725,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Prevent all effects of your opponent's attacks, except damage, done to this Pokémon during your opponent's next turn."
+        "text": "Prevent all effects of your opponent’s attacks, except damage, done to this Pokémon during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3770,7 +3770,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Spiral Drain",
@@ -3826,7 +3826,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Diamond Storm",
@@ -4111,7 +4111,7 @@
     "evolvesFrom": "Sliggoo",
     "ability": {
       "name": "Slip Trip",
-      "text": "Each player can't attach any Pokémon Tool cards from his or her hand to any of his or her Pokémon.",
+      "text": "Each player can’t attach any Pokémon Tool cards from his or her hand to any of his or her Pokémon.",
       "type": "Ability"
     },
     "hp": "140",
@@ -4229,7 +4229,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       },
       {
         "name": "Drill Peck",
@@ -4298,7 +4298,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "If you don't have exactly 7 cards in your hand, this attack does nothing."
+        "text": "If you don’t have exactly 7 cards in your hand, this attack does nothing."
       }
     ],
     "weaknesses": [
@@ -4503,7 +4503,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
-        "text": "This attack does 30 more damage for each Energy attached to your opponent's Active Pokémon."
+        "text": "This attack does 30 more damage for each Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -4549,7 +4549,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "This attack does 20 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Hyper Voice",
@@ -4605,7 +4605,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 40 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 40 (before applying Weakness and Resistance)."
       },
       {
         "name": "Heavy Impact",
@@ -4712,7 +4712,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Earthquake",
@@ -4723,7 +4723,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4821,7 +4821,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Sharp Fang",
@@ -4891,7 +4891,7 @@
     "set": "Phantom Forces",
     "setCode": "xy4",
     "text": [
-      "Each Psychic Pokémon's attacks (both yours and your opponent's) cost Colorless less."
+      "Each Psychic Pokémon’s attacks (both yours and your opponent’s) cost Colorless less."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/93_hires.png"
   },
@@ -4908,7 +4908,7 @@
     "set": "Phantom Forces",
     "setCode": "xy4",
     "text": [
-      "Discard a Special Energy attached to 1 of your opponent's Pokémon."
+      "Discard a Special Energy attached to 1 of your opponent’s Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/94_hires.png"
   },
@@ -4959,7 +4959,7 @@
     "set": "Phantom Forces",
     "setCode": "xy4",
     "text": [
-      "The attacks of the Pokémon this card is attached to cost Colorless more. When this card is removed from a Pokémon for any reason, put this card in its owner's discard pile."
+      "The attacks of the Pokémon this card is attached to cost Colorless more. When this card is removed from a Pokémon for any reason, put this card in its owner’s discard pile."
     ],
     "attacks": [
       {
@@ -4967,7 +4967,7 @@
         "cost": [],
         "convertedEnergyCost": 0,
         "damage": "",
-        "text": "Attach this Pokémon Tool to 1 of your opponent's Pokémon-EX that doesn't already have a Pokémon Tool attached to it."
+        "text": "Attach this Pokémon Tool to 1 of your opponent’s Pokémon-EX that doesn’t already have a Pokémon Tool attached to it."
       }
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/97_hires.png"
@@ -4985,13 +4985,13 @@
     "set": "Phantom Forces",
     "setCode": "xy4",
     "text": [
-      "The attacks of the Pokémon this card is attached to do 20 less damage to all Defending Pokémon (before applying Weakness and Resistance). (Don’t apply Weakness and Resistance for Benched Pokémon.) When this card is removed from a Pokémon for any reason, put this card in its owner's discard pile."
+      "The attacks of the Pokémon this card is attached to do 20 less damage to all Defending Pokémon (before applying Weakness and Resistance). (Don’t apply Weakness and Resistance for Benched Pokémon.) When this card is removed from a Pokémon for any reason, put this card in its owner’s discard pile."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/98_hires.png"
   },
   {
     "id": "xy4-99",
-    "name": "Lysandre's Trump Card",
+    "name": "Lysandre’s Trump Card",
     "imageUrl": "https://images.pokemontcg.io/xy4/99.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -5002,7 +5002,7 @@
     "set": "Phantom Forces",
     "setCode": "xy4",
     "text": [
-      "Each player shuffles all cards in his or her discard pile into his or her deck (except for Lysandre's Trump Card)."
+      "Each player shuffles all cards in his or her discard pile into his or her deck (except for Lysandre’s Trump Card)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/99_hires.png"
   },
@@ -5053,7 +5053,7 @@
     "set": "Phantom Forces",
     "setCode": "xy4",
     "text": [
-      "Play this card as if it were a 30 HP Colorless Basic Pokémon. At any time during your turn (before your attack), you may discard this card from play. This card can't retreat. If this card is Knocked Out, your opponent can't take any Prize cards for it."
+      "Play this card as if it were a 30 HP Colorless Basic Pokémon. At any time during your turn (before your attack), you may discard this card from play. This card can’t retreat. If this card is Knocked Out, your opponent can’t take any Prize cards for it."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/102_hires.png"
   },
@@ -5104,7 +5104,7 @@
     "set": "Phantom Forces",
     "setCode": "xy4",
     "text": [
-      "Each Metal Pokémon (both yours and your opponent's) can't be affected by any Special Conditions. (Remove any Special Conditions affecting those Pokémon.)"
+      "Each Metal Pokémon (both yours and your opponent’s) can’t be affected by any Special Conditions. (Remove any Special Conditions affecting those Pokémon.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/105_hires.png"
   },
@@ -5121,7 +5121,7 @@
     "set": "Phantom Forces",
     "setCode": "xy4",
     "text": [
-      "Put a Basic Pokémon from your opponent's discard pile onto his or her Bench."
+      "Put a Basic Pokémon from your opponent’s discard pile onto his or her Bench."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/106_hires.png"
   },
@@ -5189,7 +5189,7 @@
     "set": "Phantom Forces",
     "setCode": "xy4",
     "text": [
-      "Choose a Pokémon Tool or Special Energy card attached to a Pokémon in play (yours or your opponent's) and discard it."
+      "Choose a Pokémon Tool or Special Energy card attached to a Pokémon in play (yours or your opponent’s) and discard it."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/110_hires.png"
   },
@@ -5254,7 +5254,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "This attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Assault Laser",
@@ -5264,7 +5264,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "60+",
-        "text": "If your opponent's Active Pokémon has a Pokémon Tool card attached to it, this attack does 60 more damage."
+        "text": "If your opponent’s Active Pokémon has a Pokémon Tool card attached to it, this attack does 60 more damage."
       }
     ],
     "weaknesses": [
@@ -5311,7 +5311,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 3 damage counters on 1 of your opponent's Pokémon."
+        "text": "Put 3 damage counters on 1 of your opponent’s Pokémon."
       },
       {
         "name": "Dark Corridor",
@@ -5322,7 +5322,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Your opponent's Active Pokémon is now Poisoned. Switch this Pokémon with 1 of your Benched Pokémon."
+        "text": "Your opponent’s Active Pokémon is now Poisoned. Switch this Pokémon with 1 of your Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -5349,7 +5349,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Hyper Hypnosis",
-      "text": "When you attach an Energy from your hand to this Pokémon, you may use this Ability. Your opponent's Active Pokémon is now Asleep.",
+      "text": "When you attach an Energy from your hand to this Pokémon, you may use this Ability. Your opponent’s Active Pokémon is now Asleep.",
       "type": "Ability"
     },
     "hp": "170",
@@ -5468,7 +5468,7 @@
   },
   {
     "id": "xy4-118",
-    "name": "Lysandre's Trump Card",
+    "name": "Lysandre’s Trump Card",
     "imageUrl": "https://images.pokemontcg.io/xy4/118.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -5479,7 +5479,7 @@
     "set": "Phantom Forces",
     "setCode": "xy4",
     "text": [
-      "Each player shuffles all cards in his or her discard pile into his or her deck (except for Lysandre's Trump Card)."
+      "Each player shuffles all cards in his or her discard pile into his or her deck (except for Lysandre’s Trump Card)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/118_hires.png"
   },
@@ -5496,7 +5496,7 @@
     "set": "Phantom Forces",
     "setCode": "xy4",
     "text": [
-      "Choose a Pokémon Tool or Special Energy card attached to a Pokémon in play (yours or your opponent's) and discard it."
+      "Choose a Pokémon Tool or Special Energy card attached to a Pokémon in play (yours or your opponent’s) and discard it."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/119_hires.png"
   }

--- a/json/cards/Plasma Blast.json
+++ b/json/cards/Plasma Blast.json
@@ -381,7 +381,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "If an Escavalier you had in play was Knocked Out by damage from an opponent's attack during his or her last turn, put all Energy attached to the Defending Pokémon into your opponent's hand."
+        "text": "If an Escavalier you had in play was Knocked Out by damage from an opponent’s attack during his or her last turn, put all Energy attached to the Defending Pokémon into your opponent’s hand."
       },
       {
         "name": "Signal Beam",
@@ -411,7 +411,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Verdant Wind",
-      "text": "Each of your Pokémon that has any Grass Energy attached to it can't be affected by any Special Conditions. (Remove any Special Conditions affecting those Pokémon.)",
+      "text": "Each of your Pokémon that has any Grass Energy attached to it can’t be affected by any Special Conditions. (Remove any Special Conditions affecting those Pokémon.)",
       "type": "Ability"
     },
     "hp": "170",
@@ -515,7 +515,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Red Signal",
-      "text": "When you attach a Plasma Energy from your hand to this Pokémon, you may switch 1 of your opponent's Benched Pokémon with his or her Active Pokémon.",
+      "text": "When you attach a Plasma Energy from your hand to this Pokémon, you may switch 1 of your opponent’s Benched Pokémon with his or her Active Pokémon.",
       "type": "Ability"
     },
     "hp": "170",
@@ -544,7 +544,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -943,7 +943,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 30 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Bubble Beam",
@@ -1128,7 +1128,7 @@
     "evolvesFrom": "Snorunt",
     "ability": {
       "name": "Cursed Glare",
-      "text": "As long as this Pokémon is your Active Pokémon, your opponent can't attach any Special Energy cards from his or her hand to his or her Pokémon.",
+      "text": "As long as this Pokémon is your Active Pokémon, your opponent can’t attach any Special Energy cards from his or her hand to his or her Pokémon.",
       "type": "Ability"
     },
     "hp": "90",
@@ -1153,7 +1153,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1461,7 +1461,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "This attack does 20 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1728,7 +1728,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 40 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 40 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1752,7 +1752,7 @@
     "evolvesFrom": "Drifloon",
     "ability": {
       "name": "Drifting Balloon",
-      "text": "This Pokémon's attacks cost Colorless less for each of your opponent's Team Plasma Pokémon in play.",
+      "text": "This Pokémon’s attacks cost Colorless less for each of your opponent’s Team Plasma Pokémon in play.",
       "type": "Ability"
     },
     "hp": "100",
@@ -1814,7 +1814,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 3 damage counters on your opponent's Pokémon in any way you like."
+        "text": "Put 3 damage counters on your opponent’s Pokémon in any way you like."
       }
     ],
     "weaknesses": [
@@ -1910,7 +1910,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Move as many Special Energy attached to your opponent's Pokémon to your opponent's other Pokémon in any way you like."
+        "text": "Move as many Special Energy attached to your opponent’s Pokémon to your opponent’s other Pokémon in any way you like."
       }
     ],
     "weaknesses": [
@@ -2106,7 +2106,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2194,7 +2194,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 30 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 30 (after applying Weakness and Resistance)."
       },
       {
         "name": "Telekinesis of Nobility",
@@ -2316,7 +2316,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -2403,7 +2403,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20+",
-        "text": "If this Pokémon's remaining HP is 10, this attack does 70 more damage."
+        "text": "If this Pokémon’s remaining HP is 10, this attack does 70 more damage."
       },
       {
         "name": "Seismic Toss",
@@ -2438,7 +2438,7 @@
     "evolvesFrom": "Machoke",
     "ability": {
       "name": "Badge of Discipline",
-      "text": "The damage of each of your Fighting Pokémon's attacks isn't affected by Resistance.",
+      "text": "The damage of each of your Fighting Pokémon’s attacks isn’t affected by Resistance.",
       "type": "Ability"
     },
     "hp": "150",
@@ -2467,7 +2467,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "Flip a coin. If tails, during your opponent's next turn, any damage done to this Pokémon by attacks is increased by 30 (after applying Weakness and Resistance)."
+        "text": "Flip a coin. If tails, during your opponent’s next turn, any damage done to this Pokémon by attacks is increased by 30 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -2511,7 +2511,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Discard a random card from your opponent's hand."
+        "text": "Discard a random card from your opponent’s hand."
       },
       {
         "name": "Reinforced Lariat",
@@ -2576,7 +2576,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80-",
-        "text": "Does 80 damage minus 20 damage for each Colorless in the Defending Pokémon's Retreat Cost."
+        "text": "Does 80 damage minus 20 damage for each Colorless in the Defending Pokémon’s Retreat Cost."
       }
     ],
     "weaknesses": [
@@ -2724,7 +2724,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "100",
-        "text": "If this Pokémon's remaining HP is 50 or less, this attack's base damage is 50."
+        "text": "If this Pokémon’s remaining HP is 50 or less, this attack’s base damage is 50."
       }
     ],
     "weaknesses": [
@@ -2823,7 +2823,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Blazing Claws",
@@ -3019,7 +3019,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "Does 20 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to each Benched Pokémon (both yours and your opponent’s). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3123,7 +3123,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Slashing Strike",
@@ -3134,7 +3134,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "This Pokémon can't use Slashing Strike during your next turn."
+        "text": "This Pokémon can’t use Slashing Strike during your next turn."
       }
     ],
     "weaknesses": [
@@ -3269,7 +3269,7 @@
     "evolvesFrom": "Shelgon",
     "ability": {
       "name": "Breakwing",
-      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may discard all Pokémon Tool cards attached to each of your opponent's Pokémon.",
+      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may discard all Pokémon Tool cards attached to each of your opponent’s Pokémon.",
       "type": "Ability"
     },
     "hp": "150",
@@ -3356,7 +3356,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "90",
-        "text": "For each Plasma Energy attached to this Pokémon, discard the top card of your opponent's deck."
+        "text": "For each Plasma Energy attached to this Pokémon, discard the top card of your opponent’s deck."
       }
     ],
     "weaknesses": [
@@ -3620,7 +3620,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "This attack's damage isn't affected by any effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by any effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -3891,7 +3891,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "During your next turn, each of this Pokémon's attacks does 50 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, each of this Pokémon’s attacks does 50 more damage (before applying Weakness and Resistance)."
       },
       {
         "name": "Strength",
@@ -3942,7 +3942,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Discard all Pokémon Tool cards attached to each of your opponent's Pokémon."
+        "text": "Discard all Pokémon Tool cards attached to each of your opponent’s Pokémon."
       },
       {
         "name": "Tone-Deaf",
@@ -4034,7 +4034,7 @@
     "set": "Plasma Blast",
     "setCode": "bw10",
     "text": [
-      "During this turn, your Pokémon's attacks do 10 more damage to the Active Pokémon for each Prize card your opponent has taken (before applying Weakness and Resistance)."
+      "During this turn, your Pokémon’s attacks do 10 more damage to the Active Pokémon for each Prize card your opponent has taken (before applying Weakness and Resistance)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw10/81_hires.png"
   },
@@ -4068,7 +4068,7 @@
     "set": "Plasma Blast",
     "setCode": "bw10",
     "text": [
-      "Switch your opponent's Active Pokémon with 1 of his or her Benched Pokémon."
+      "Switch your opponent’s Active Pokémon with 1 of his or her Benched Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw10/83_hires.png"
   },
@@ -4102,7 +4102,7 @@
     "set": "Plasma Blast",
     "setCode": "bw10",
     "text": [
-      "Choose 1 of your Basic Pokémon in play. If you have a Stage 2 card in your hand that evolves from that Pokémon, put that card on the Basic Pokémon. (This counts as evolving that Pokémon.) You can't use this card during your first turn or on a Basic Pokémon that was put into play this turn."
+      "Choose 1 of your Basic Pokémon in play. If you have a Stage 2 card in your hand that evolves from that Pokémon, put that card on the Basic Pokémon. (This counts as evolving that Pokémon.) You can’t use this card during your first turn or on a Basic Pokémon that was put into play this turn."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw10/85_hires.png"
   },
@@ -4119,7 +4119,7 @@
     "set": "Plasma Blast",
     "setCode": "bw10",
     "text": [
-      "When the Team Plasma Pokémon this card is attached to is Knocked Out by damage from an opponent's attack, search your deck for a card and put it into your hand. Shuffle your deck afterward."
+      "When the Team Plasma Pokémon this card is attached to is Knocked Out by damage from an opponent’s attack, search your deck for a card and put it into your hand. Shuffle your deck afterward."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw10/86_hires.png"
   },
@@ -4170,7 +4170,7 @@
     "set": "Plasma Blast",
     "setCode": "bw10",
     "text": [
-      "Prevent all effects of attacks, including damage, done to the Pokémon this card is attached to (excluding Pokémon-EX) by your opponent's Team Plasma Pokémon."
+      "Prevent all effects of attacks, including damage, done to the Pokémon this card is attached to (excluding Pokémon-EX) by your opponent’s Team Plasma Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw10/89_hires.png"
   },
@@ -4187,7 +4187,7 @@
     "set": "Plasma Blast",
     "setCode": "bw10",
     "text": [
-      "Discard 2 cards from your hand. (If you can't discard 2 cards, you can't play this card.) Search your deck for a Pokémon, reveal it, and put it into your hand. Shuffle your deck afterward."
+      "Discard 2 cards from your hand. (If you can’t discard 2 cards, you can’t play this card.) Search your deck for a Pokémon, reveal it, and put it into your hand. Shuffle your deck afterward."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw10/90_hires.png"
   },
@@ -4284,7 +4284,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Verdant Wind",
-      "text": "Each of your Pokémon that has any Grass Energy attached to it can't be affected by any Special Conditions. (Remove any Special Conditions affecting those Pokémon.)",
+      "text": "Each of your Pokémon that has any Grass Energy attached to it can’t be affected by any Special Conditions. (Remove any Special Conditions affecting those Pokémon.)",
       "type": "Ability"
     },
     "hp": "170",
@@ -4338,7 +4338,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Red Signal",
-      "text": "When you attach a Plasma Energy from your hand to this Pokémon, you may switch 1 of your opponent's Benched Pokémon with his or her Active Pokémon.",
+      "text": "When you attach a Plasma Energy from your hand to this Pokémon, you may switch 1 of your opponent’s Benched Pokémon with his or her Active Pokémon.",
       "type": "Ability"
     },
     "hp": "170",
@@ -4367,7 +4367,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4479,7 +4479,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "90",
-        "text": "For each Plasma Energy attached to this Pokémon, discard the top card of your opponent's deck."
+        "text": "For each Plasma Energy attached to this Pokémon, discard the top card of your opponent’s deck."
       }
     ],
     "weaknesses": [
@@ -4561,7 +4561,7 @@
     "set": "Plasma Blast",
     "setCode": "bw10",
     "text": [
-      "During this turn, your Pokémon's attacks do 10 more damage to the Active Pokémon for each Prize card your opponent has taken (before applying Weakness and Resistance)."
+      "During this turn, your Pokémon’s attacks do 10 more damage to the Active Pokémon for each Prize card your opponent has taken (before applying Weakness and Resistance)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw10/101_hires.png"
   },
@@ -4656,7 +4656,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "During your next turn, this Pokémon's Leaf Wallop attack does 40 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s Leaf Wallop attack does 40 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -4683,7 +4683,7 @@
     "evolvesFrom": "Dusclops",
     "ability": {
       "name": "Sinister Hand",
-      "text": "As often as you like during your turn (before your attack), you may move 1 damage counter from 1 of your opponent's Pokémon to another of your opponent's Pokémon.",
+      "text": "As often as you like during your turn (before your attack), you may move 1 damage counter from 1 of your opponent’s Pokémon to another of your opponent’s Pokémon.",
       "type": "Ability"
     },
     "hp": "130",
@@ -4712,7 +4712,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -4737,7 +4737,7 @@
     "set": "Plasma Blast",
     "setCode": "bw10",
     "text": [
-      "Choose 1 of your Basic Pokémon in play. If you have a Stage 2 card in your hand that evolves from that Pokémon, put that card on the Basic Pokémon. (This counts as evolving that Pokémon.) You can't use this card during your first turn or on a Basic Pokémon that was put into play this turn."
+      "Choose 1 of your Basic Pokémon in play. If you have a Stage 2 card in your hand that evolves from that Pokémon, put that card on the Basic Pokémon. (This counts as evolving that Pokémon.) You can’t use this card during your first turn or on a Basic Pokémon that was put into play this turn."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw10/105_hires.png"
   }

--- a/json/cards/Plasma Freeze.json
+++ b/json/cards/Plasma Freeze.json
@@ -70,7 +70,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -216,7 +216,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Your opponent can't play any Supporter cards from his or her hand during his or her next turn."
+        "text": "Your opponent can’t play any Supporter cards from his or her hand during his or her next turn."
       },
       {
         "name": "Stomp",
@@ -498,7 +498,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "60",
-        "text": "Does 30 damage to 1 of your Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 30 damage to 1 of your Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Payback",
@@ -555,7 +555,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20x",
-        "text": "Does 20 damage times the amount of Energy attached to all of your opponent's Pokémon."
+        "text": "Does 20 damage times the amount of Energy attached to all of your opponent’s Pokémon."
       },
       {
         "name": "Leaf Blade",
@@ -974,7 +974,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -1310,7 +1310,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Does 30 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 30 damage to each Benched Pokémon (both yours and your opponent’s). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Splashing Turn",
@@ -1507,7 +1507,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Discard an Energy attached to this Pokémon. The Defending Pokémon can't attack during your opponent's next turn."
+        "text": "Discard an Energy attached to this Pokémon. The Defending Pokémon can’t attack during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1549,7 +1549,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Blizzard Burn",
@@ -1560,7 +1560,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "This Pokémon can't attack during your next turn."
+        "text": "This Pokémon can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -1700,7 +1700,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "If the Defending Pokémon is a Pokémon-EX, that Pokémon can't attack during your opponent's next turn."
+        "text": "If the Defending Pokémon is a Pokémon-EX, that Pokémon can’t attack during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1940,7 +1940,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       },
       {
         "name": "Fusion Bolt",
@@ -2245,7 +2245,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, switch 1 of your opponent's Benched Pokémon with the Defending Pokémon. The new Defending Pokémon is now Poisoned."
+        "text": "Flip a coin. If heads, switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon. The new Defending Pokémon is now Poisoned."
       },
       {
         "name": "Sludge Toss",
@@ -2409,7 +2409,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 40 damage to 1 of your opponent's Pokémon. Also apply Weakness and Resistance for Benched Pokémon."
+        "text": "This attack does 40 damage to 1 of your opponent’s Pokémon. Also apply Weakness and Resistance for Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -2458,7 +2458,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "nationalPokedexNumber": 302,
@@ -2628,7 +2628,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Power Connect",
-      "text": "Your Team Plasma Pokémon's attacks (excluding Deoxys-EX) do 10 more damage to the Active Pokémon (before applying Weakness and Resistance).",
+      "text": "Your Team Plasma Pokémon’s attacks (excluding Deoxys-EX) do 10 more damage to the Active Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "170",
@@ -2697,7 +2697,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Move 1 damage counter from any of your Pokémon to any of your opponent's Pokémon."
+        "text": "Move 1 damage counter from any of your Pokémon to any of your opponent’s Pokémon."
       }
     ],
     "weaknesses": [
@@ -2774,7 +2774,7 @@
     "evolvesFrom": "Yamask",
     "ability": {
       "name": "Six Feet Under",
-      "text": "Once during your turn (before your attack), you may Knock Out this Pokémon. If you do, put 3 damage counters on your opponent's Pokémon in any way you like.",
+      "text": "Once during your turn (before your attack), you may Knock Out this Pokémon. If you do, put 3 damage counters on your opponent’s Pokémon in any way you like.",
       "type": "Ability"
     },
     "hp": "100",
@@ -2842,7 +2842,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 30 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Crazy Slap",
@@ -3175,7 +3175,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is increased by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is increased by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -3317,7 +3317,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Vilify",
@@ -3373,7 +3373,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "Does 20 more damage for each of your opponent's Benched Pokémon."
+        "text": "Does 20 more damage for each of your opponent’s Benched Pokémon."
       },
       {
         "name": "Fearsome Shadow",
@@ -3543,7 +3543,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Move an Energy attached to the Defending Pokémon to 1 of your opponent's Benched Pokémon."
+        "text": "Move an Energy attached to the Defending Pokémon to 1 of your opponent’s Benched Pokémon."
       },
       {
         "name": "Hammer In",
@@ -3989,7 +3989,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with the Defending Pokémon. This attack does 40 damage to the new Defending Pokémon."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon. This attack does 40 damage to the new Defending Pokémon."
       },
       {
         "name": "Obsidian Fang",
@@ -4052,7 +4052,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "During your opponent's next turn, this Pokémon has no Weakness."
+        "text": "During your opponent’s next turn, this Pokémon has no Weakness."
       },
       {
         "name": "Heavy Impact",
@@ -4110,7 +4110,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, choose a random card from your opponent's hand. Your opponent reveals that card and shuffles it into his or her deck."
+        "text": "Flip a coin. If heads, choose a random card from your opponent’s hand. Your opponent reveals that card and shuffles it into his or her deck."
       },
       {
         "name": "Big Ol' Bite",
@@ -4121,7 +4121,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Heal 30 damage from this Pokémon. The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "Heal 30 damage from this Pokémon. The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -4277,7 +4277,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Your opponent can't play any Item cards from his or her hand during his or her next turn."
+        "text": "Your opponent can’t play any Item cards from his or her hand during his or her next turn."
       },
       {
         "name": "Healwing",
@@ -4338,7 +4338,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 30 damage to 3 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 3 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4358,7 +4358,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Bright Down",
-      "text": "Prevent all effects of attacks, including damage, done to this Pokémon by your opponent's Pokémon with Abilities.",
+      "text": "Prevent all effects of attacks, including damage, done to this Pokémon by your opponent’s Pokémon with Abilities.",
       "type": "Ability"
     },
     "hp": "160",
@@ -4387,7 +4387,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -4431,7 +4431,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Luster Purge",
@@ -4572,7 +4572,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
       },
       {
         "name": "Quick Attack",
@@ -4741,7 +4741,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10x",
-        "text": "Does 10 damage times the number of cards in your opponent's hand."
+        "text": "Does 10 damage times the number of cards in your opponent’s hand."
       },
       {
         "name": "Fly",
@@ -4752,7 +4752,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -4830,7 +4830,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Color Change",
-      "text": "As long as this Pokémon is your Active Pokémon, this Pokémon is the same type as your opponent's Active Pokémon.",
+      "text": "As long as this Pokémon is your Active Pokémon, this Pokémon is the same type as your opponent’s Active Pokémon.",
       "type": "Ability"
     },
     "hp": "70",
@@ -4854,7 +4854,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. If this Pokémon has the necessary Energy to use that attack, use it as this attack."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. If this Pokémon has the necessary Energy to use that attack, use it as this attack."
       }
     ],
     "weaknesses": [
@@ -5166,7 +5166,7 @@
     "set": "Plasma Freeze",
     "setCode": "bw9",
     "text": [
-      "Discard 2 cards from your hand. (If you can't discard 2 cards, you can't play this card.) Put 4 basic Energy cards from your discard pile into your hand. (You can't choose a card you discarded with the effect of this card.)"
+      "Discard 2 cards from your hand. (If you can’t discard 2 cards, you can’t play this card.) Put 4 basic Energy cards from your discard pile into your hand. (You can’t choose a card you discarded with the effect of this card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw9/103_hires.png"
   },
@@ -5251,7 +5251,7 @@
     "set": "Plasma Freeze",
     "setCode": "bw9",
     "text": [
-      "If the Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent's attack (even if that Pokémon is Knocked Out), put 6 damage counters on the Attacking Pokémon."
+      "If the Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent’s attack (even if that Pokémon is Knocked Out), put 6 damage counters on the Attacking Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw9/108_hires.png"
   },
@@ -5375,7 +5375,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Power Connect",
-      "text": "Your Team Plasma Pokémon's attacks (excluding Deoxys-EX) do 10 more damage to the Active Pokémon (before applying Weakness and Resistance).",
+      "text": "Your Team Plasma Pokémon’s attacks (excluding Deoxys-EX) do 10 more damage to the Active Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "170",
@@ -5424,7 +5424,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Bright Down",
-      "text": "Prevent all effects of attacks, including damage, done to this Pokémon by your opponent's Pokémon with Abilities.",
+      "text": "Prevent all effects of attacks, including damage, done to this Pokémon by your opponent’s Pokémon with Abilities.",
       "type": "Ability"
     },
     "hp": "160",
@@ -5453,7 +5453,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -5497,7 +5497,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Luster Purge",
@@ -5650,7 +5650,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10x",
-        "text": "Does 10 damage times the number of Pokémon in play (both yours and your opponent's)."
+        "text": "Does 10 damage times the number of Pokémon in play (both yours and your opponent’s)."
       }
     ],
     "weaknesses": [
@@ -5717,7 +5717,7 @@
     "evolvesFrom": "Trubbish",
     "ability": {
       "name": "Garbotoxin",
-      "text": "If this Pokémon has a Pokémon Tool card attached to it, each Pokémon in play, in each player's hand, and in each player's discard pile has no Abilities (except for Garbotoxin).",
+      "text": "If this Pokémon has a Pokémon Tool card attached to it, each Pokémon in play, in each player’s hand, and in each player’s discard pile has no Abilities (except for Garbotoxin).",
       "type": "Ability"
     },
     "hp": "100",
@@ -5837,7 +5837,7 @@
     "set": "Plasma Freeze",
     "setCode": "bw9",
     "text": [
-      "Discard 2 cards from your hand. (If you can't discard 2 cards, you can't play this card.) Search your deck for a Pokémon, reveal it, and put it into your hand. Shuffle your deck afterward."
+      "Discard 2 cards from your hand. (If you can’t discard 2 cards, you can’t play this card.) Search your deck for a Pokémon, reveal it, and put it into your hand. Shuffle your deck afterward."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw9/122_hires.png"
   }

--- a/json/cards/Plasma Storm.json
+++ b/json/cards/Plasma Storm.json
@@ -145,7 +145,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Rumble Stomp",
@@ -438,7 +438,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 40 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 40 (after applying Weakness and Resistance)."
       },
       {
         "name": "Surprise Attack",
@@ -598,7 +598,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, choose a random card from your opponent's hand. Your opponent reveals that card and shuffles it into his or her deck."
+        "text": "Flip a coin. If heads, choose a random card from your opponent’s hand. Your opponent reveals that card and shuffles it into his or her deck."
       }
     ],
     "weaknesses": [
@@ -648,7 +648,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, choose 3 random cards from your opponent's hand. Your opponent reveals those cards and shuffles them into his or her deck."
+        "text": "Flip a coin. If heads, choose 3 random cards from your opponent’s hand. Your opponent reveals those cards and shuffles them into his or her deck."
       },
       {
         "name": "Miracle Powder",
@@ -857,7 +857,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Malevolent Fire",
@@ -1157,7 +1157,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with the Defending Pokémon. The new Defending Pokémon is now Burned."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon. The new Defending Pokémon is now Burned."
       },
       {
         "name": "Fiery Licks",
@@ -1254,7 +1254,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Frost Prison",
@@ -1643,7 +1643,7 @@
     "evolvesFrom": "Carvanha",
     "ability": {
       "name": "Rough Skin",
-      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), put 2 damage counters on the Attacking Pokémon.",
+      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack (even if this Pokémon is Knocked Out), put 2 damage counters on the Attacking Pokémon.",
       "type": "Ability"
     },
     "hp": "90",
@@ -1685,7 +1685,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Final Wish",
-      "text": "When this Pokémon is Knocked Out by damage from an opponent's attack, search your deck for a card and put it into your hand. Shuffle your deck afterward.",
+      "text": "When this Pokémon is Knocked Out by damage from an opponent’s attack, search your deck for a card and put it into your hand. Shuffle your deck afterward.",
       "type": "Ability"
     },
     "hp": "70",
@@ -1748,7 +1748,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -1846,7 +1846,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "Does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1911,7 +1911,7 @@
     "evolvesFrom": "Frillish",
     "ability": {
       "name": "Spiteful Spirit",
-      "text": "If this Pokémon is your Active Pokémon and is Knocked Out by damage from an opponent's attack, the Attacking Pokémon is now Confused and Poisoned.",
+      "text": "If this Pokémon is your Active Pokémon and is Knocked Out by damage from an opponent’s attack, the Attacking Pokémon is now Confused and Poisoned.",
       "type": "Ability"
     },
     "hp": "100",
@@ -1937,7 +1937,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1977,7 +1977,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Icy Snow",
@@ -2046,7 +2046,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": "Discard the top card of your opponent's deck."
+        "text": "Discard the top card of your opponent’s deck."
       }
     ],
     "weaknesses": [
@@ -2383,7 +2383,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       },
       {
         "name": "Powervolt",
@@ -2450,7 +2450,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20x",
-        "text": "Your opponent reveals his or her hand. This attack does 20 damage times the number of Trainer cards in your opponent's hand."
+        "text": "Your opponent reveals his or her hand. This attack does 20 damage times the number of Trainer cards in your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -2834,7 +2834,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -2858,7 +2858,7 @@
     "evolvesFrom": "Koffing",
     "ability": {
       "name": "Aftermath",
-      "text": "When this Pokémon is Knocked Out by damage from an opponent's attack, discard the top 3 cards of your opponent's deck.",
+      "text": "When this Pokémon is Knocked Out by damage from an opponent’s attack, discard the top 3 cards of your opponent’s deck.",
       "type": "Ability"
     },
     "hp": "100",
@@ -2884,7 +2884,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "This attack does 20 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3078,7 +3078,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "90",
-        "text": "Discard a random card from your opponent's hand."
+        "text": "Discard a random card from your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -3224,7 +3224,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20x",
-        "text": "Does 20 damage for each Pokémon Tool card attached to Pokémon in play (both yours and your opponent's)."
+        "text": "Does 20 damage for each Pokémon Tool card attached to Pokémon in play (both yours and your opponent’s)."
       }
     ],
     "weaknesses": [
@@ -3323,7 +3323,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20x",
-        "text": "Does 20 damage times the number of Colorless in the Defending Pokémon's Retreat Cost."
+        "text": "Does 20 damage times the number of Colorless in the Defending Pokémon’s Retreat Cost."
       },
       {
         "name": "Double Ducts",
@@ -3417,7 +3417,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Smash Punch",
@@ -3470,7 +3470,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Damakinesis",
@@ -3805,7 +3805,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -4417,7 +4417,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -4463,7 +4463,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Vice Grip",
@@ -4564,7 +4564,7 @@
     "evolvesFrom": "Klang",
     "ability": {
       "name": "Plasma Steel",
-      "text": "Prevent all damage done to your Metal Pokémon by attacks from your opponent's Pokémon-EX.",
+      "text": "Prevent all damage done to your Metal Pokémon by attacks from your opponent’s Pokémon-EX.",
       "type": "Ability"
     },
     "hp": "140",
@@ -4592,7 +4592,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "Flip a coin. If heads, this attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4704,7 +4704,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -4764,7 +4764,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -4810,7 +4810,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Dragon Claw",
@@ -5163,7 +5163,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Block",
-      "text": "As long as this Pokémon is your Active Pokémon, your opponent's Active Pokémon can't retreat.",
+      "text": "As long as this Pokémon is your Active Pokémon, your opponent’s Active Pokémon can’t retreat.",
       "type": "Ability"
     },
     "hp": "130",
@@ -5376,7 +5376,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, discard a random card from your opponent's hand."
+        "text": "Flip a coin. If heads, discard a random card from your opponent’s hand."
       },
       {
         "name": "Hyper Voice",
@@ -5523,7 +5523,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Overflow",
-      "text": "If your opponent's Pokémon is Knocked Out by damage from an attack of this Pokémon, take 1 more Prize card.",
+      "text": "If your opponent’s Pokémon is Knocked Out by damage from an attack of this Pokémon, take 1 more Prize card.",
       "type": "Ability"
     },
     "hp": "180",
@@ -5554,7 +5554,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "Discard a Plasma Energy attached to this Pokémon. If you can't discard a Plasma Energy, this attack does nothing."
+        "text": "Discard a Plasma Energy attached to this Pokémon. If you can’t discard a Plasma Energy, this attack does nothing."
       }
     ],
     "weaknesses": [
@@ -5737,7 +5737,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Discard a random card from your opponent's hand."
+        "text": "Discard a random card from your opponent’s hand."
       },
       {
         "name": "Biting Fang",
@@ -5996,7 +5996,7 @@
     "set": "Plasma Storm",
     "setCode": "bw8",
     "text": [
-      "Shuffle your hand into your deck. Then, draw a number of cards equal to the number of Benched Pokémon (both yours and your opponent's)."
+      "Shuffle your hand into your deck. Then, draw a number of cards equal to the number of Benched Pokémon (both yours and your opponent’s)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw8/118_hires.png"
   },
@@ -6030,7 +6030,7 @@
     "set": "Plasma Storm",
     "setCode": "bw8",
     "text": [
-      "Each player switches his or her Active Pokémon with 1 of his or her Benched Pokémon. (Your opponent switches first. If a player does not have a Benched Pokémon, he or she doesn't switch Pokémon.)"
+      "Each player switches his or her Active Pokémon with 1 of his or her Benched Pokémon. (Your opponent switches first. If a player does not have a Benched Pokémon, he or she doesn’t switch Pokémon.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw8/120_hires.png"
   },
@@ -6081,7 +6081,7 @@
     "set": "Plasma Storm",
     "setCode": "bw8",
     "text": [
-      "Your opponent's Active Pokémon is now Poisoned. Flip a coin. If heads, your opponent's Active Pokémon is also Asleep."
+      "Your opponent’s Active Pokémon is now Poisoned. Flip a coin. If heads, your opponent’s Active Pokémon is also Asleep."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw8/123_hires.png"
   },
@@ -6098,7 +6098,7 @@
     "set": "Plasma Storm",
     "setCode": "bw8",
     "text": [
-      "Each Pokémon that has any Plasma Energy attached to it (both yours and your opponent's) has no Weakness."
+      "Each Pokémon that has any Plasma Energy attached to it (both yours and your opponent’s) has no Weakness."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw8/124_hires.png"
   },
@@ -6115,7 +6115,7 @@
     "set": "Plasma Storm",
     "setCode": "bw8",
     "text": [
-      "Discard a Team Plasma card from your hand. (If you can't discard a Team Plasma card, you can't play this card.) Draw 4 cards."
+      "Discard a Team Plasma card from your hand. (If you can’t discard a Team Plasma card, you can’t play this card.) Draw 4 cards."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw8/125_hires.png"
   },
@@ -6132,7 +6132,7 @@
     "set": "Plasma Storm",
     "setCode": "bw8",
     "text": [
-      "Put 2 more damage counters on Poisoned Pokémon (both yours and your opponent's) between turns."
+      "Put 2 more damage counters on Poisoned Pokémon (both yours and your opponent’s) between turns."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw8/126_hires.png"
   },
@@ -6166,7 +6166,7 @@
     "set": "Plasma Storm",
     "setCode": "bw8",
     "text": [
-      "Discard 2 cards from your hand. (If you can't discard 2 cards, you can't play this card.) Put a Trainer card from your discard pile into your hand."
+      "Discard 2 cards from your hand. (If you can’t discard 2 cards, you can’t play this card.) Put a Trainer card from your discard pile into your hand."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw8/128_hires.png"
   },
@@ -6289,7 +6289,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Frost Prison",
@@ -6361,7 +6361,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -6387,7 +6387,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Overflow",
-      "text": "If your opponent's Pokémon is Knocked Out by damage from an attack of this Pokémon, take 1 more Prize card.",
+      "text": "If your opponent’s Pokémon is Knocked Out by damage from an attack of this Pokémon, take 1 more Prize card.",
       "type": "Ability"
     },
     "hp": "180",
@@ -6418,7 +6418,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "Discard a Plasma Energy attached to this Pokémon. If you can't discard a Plasma Energy, this attack does nothing."
+        "text": "Discard a Plasma Energy attached to this Pokémon. If you can’t discard a Plasma Energy, this attack does nothing."
       }
     ],
     "weaknesses": [
@@ -6449,7 +6449,7 @@
     "set": "Plasma Storm",
     "setCode": "bw8",
     "text": [
-      "Shuffle your hand into your deck. Then, draw a number of cards equal to the number of Benched Pokémon (both yours and your opponent's)."
+      "Shuffle your hand into your deck. Then, draw a number of cards equal to the number of Benched Pokémon (both yours and your opponent’s)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/bw8/135_hires.png"
   },
@@ -6485,7 +6485,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 40 damage to 2 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 40 damage to 2 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Scorching Fire",

--- a/json/cards/Platinum.json
+++ b/json/cards/Platinum.json
@@ -9,7 +9,7 @@
     "evolvesFrom": "Flaaffy",
     "ability": {
       "name": "Damage Bind",
-      "text": "Each Pokémon that has any damage counters on it (both yours and your opponent's) can't use any Poké-Powers.",
+      "text": "Each Pokémon that has any damage counters on it (both yours and your opponent’s) can’t use any Poké-Powers.",
       "type": "Poké-Body"
     },
     "hp": "130",
@@ -74,7 +74,7 @@
     "evolvesFrom": "Wartortle",
     "ability": {
       "name": "Dig Well",
-      "text": "Once during your turn (before your attack), you may look at the top 3 cards of your deck, choose as many Water Energy cards as you like, and attach them to your Pokémon in any way you like. Discard the other cards. This power can't be used if Blastoise is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may look at the top 3 cards of your deck, choose as many Water Energy cards as you like, and attach them to your Pokémon in any way you like. Discard the other cards. This power can’t be used if Blastoise is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "130",
@@ -100,7 +100,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "Does 20 damage plus 10 more damage for each Water Energy attached to all Pokémon (both yours and your opponent's)."
+        "text": "Does 20 damage plus 10 more damage for each Water Energy attached to all Pokémon (both yours and your opponent’s)."
       },
       {
         "name": "Double Launcher",
@@ -112,7 +112,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Discard 2 Water Energy attached to Blastoise. Choose 2 of your opponent's Benched Pokémon. This attack does 60 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.) Blastoise can't use Double Launcher during your next turn."
+        "text": "Discard 2 Water Energy attached to Blastoise. Choose 2 of your opponent’s Benched Pokémon. This attack does 60 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.) Blastoise can’t use Double Launcher during your next turn."
       }
     ],
     "weaknesses": [
@@ -134,7 +134,7 @@
     "evolvesFrom": "Combusken",
     "ability": {
       "name": "Fire Breath",
-      "text": "Once during your turn (before your attack), you may choose 1 of the Defending Pokémon. That Pokémon is now Burned. This power can't be used if Blaziken is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may choose 1 of the Defending Pokémon. That Pokémon is now Burned. This power can’t be used if Blaziken is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "130",
@@ -159,7 +159,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Fire Spin",
@@ -192,7 +192,7 @@
     "evolvesFrom": "Skitty",
     "ability": {
       "name": "Power Circulation",
-      "text": "Once during your turn (before your attack), you may search your discard pile for up to 2 basic Energy cards, show them to your opponent, and put them on top of your deck in any order. If you do, put 2 damage counters on Delcatty. This power can't be used if Delcatty is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may search your discard pile for up to 2 basic Energy cards, show them to your opponent, and put them on top of your deck in any order. If you do, put 2 damage counters on Delcatty. This power can’t be used if Delcatty is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -303,7 +303,7 @@
     "level": "70",
     "ability": {
       "name": "Time Aura",
-      "text": "As long as Dialga is your Active Pokémon, your opponent can't play any Pokémon from his or her hand to evolve his or her Active Pokémon.",
+      "text": "As long as Dialga is your Active Pokémon, your opponent can’t play any Pokémon from his or her hand to evolve his or her Active Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -379,7 +379,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Your opponent can't play any Trainer cards or Stadium cards from his or her hand during your opponent's next turn."
+        "text": "Your opponent can’t play any Trainer cards or Stadium cards from his or her hand during your opponent’s next turn."
       },
       {
         "name": "Second Strike",
@@ -418,7 +418,7 @@
     "evolvesFrom": "Kirlia",
     "ability": {
       "name": "Psychic Connect",
-      "text": "As often as you like during your turn (before your attack), you may move a Psychic Energy attached to 1 of your Benched Pokémon to your Active Pokémon. This power can't be used if Gardevoir is affected by a Special Condition.",
+      "text": "As often as you like during your turn (before your attack), you may move a Psychic Energy attached to 1 of your Benched Pokémon to your Active Pokémon. This power can’t be used if Gardevoir is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -453,7 +453,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Gardevoir has no Weakness during your opponent's next turn."
+        "text": "Gardevoir has no Weakness during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -502,7 +502,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Flip 2 coins. This attack does 10 damage times the number of heads to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip 2 coins. This attack does 10 damage times the number of heads to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -551,7 +551,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "This attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Dark Wing Flaps",
@@ -561,7 +561,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Choose 1 card from your opponent's hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
+        "text": "Choose 1 card from your opponent’s hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
       },
       {
         "name": "Wrack Down",
@@ -621,7 +621,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 30 damage to each Pokémon that has any Poké-Powers (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to each Pokémon that has any Poké-Powers (both yours and your opponent’s). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Attract Current",
@@ -690,7 +690,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -712,7 +712,7 @@
     "evolvesFrom": "Cranidos",
     "ability": {
       "name": "Iron Skull",
-      "text": "Rampardos's attack's damage isn't affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon.",
+      "text": "Rampardos’s attack’s damage isn’t affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "130",
@@ -880,7 +880,7 @@
     "evolvesFrom": "Vigoroth",
     "ability": {
       "name": "Lazy Paunch",
-      "text": "If Slaking used any attacks during your last turn, Slaking can't attack.",
+      "text": "If Slaking used any attacks during your last turn, Slaking can’t attack.",
       "type": "Poké-Body"
     },
     "hp": "150",
@@ -910,7 +910,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "150",
-        "text": "During your opponent's next turn, any damage done to Slaking by attacks is increased by 50 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Slaking by attacks is increased by 50 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -1053,7 +1053,7 @@
     "evolvesFrom": "Shuppet",
     "ability": {
       "name": "Temper Tantrum",
-      "text": "Once during your turn (before your attack), you may discard as many cards as you like from your hand. If you do, put that many damage counters on Banette. This power can't be used if Banette is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may discard as many cards as you like from your hand. If you do, put that many damage counters on Banette. This power can’t be used if Banette is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -1087,7 +1087,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "You may show your hand to your opponent. If you do and if you don't have any Pokémon in your hand, this attack does 30 damage plus 30 more damage."
+        "text": "You may show your hand to your opponent. If you do and if you don’t have any Pokémon in your hand, this attack does 30 damage plus 30 more damage."
       }
     ],
     "weaknesses": [
@@ -1144,7 +1144,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Bastiodon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Bastiodon during your opponent’s next turn."
       },
       {
         "name": "Iron Tackle",
@@ -1209,7 +1209,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "If the Defending Pokémon has any Resistance, this attack's base damage is 60 instead of 30."
+        "text": "If the Defending Pokémon has any Resistance, this attack’s base damage is 60 instead of 30."
       }
     ],
     "weaknesses": [
@@ -1237,7 +1237,7 @@
     "evolvesFrom": "Chansey",
     "ability": {
       "name": "Nurse Call",
-      "text": "Once during your turn (before your attack), you may discard a card from your hand. If you do, remove 2 damage counters from 1 of your Pokémon. You can't use more than 1 Nurse Call Poké-Power each turn. This power can't be used if Blissey is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may discard a card from your hand. If you do, remove 2 damage counters from 1 of your Pokémon. You can’t use more than 1 Nurse Call Poké-Power each turn. This power can’t be used if Blissey is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -1329,7 +1329,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "Dialga can't attack during your next turn."
+        "text": "Dialga can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -1357,7 +1357,7 @@
     "evolvesFrom": "Diglett",
     "ability": {
       "name": "Sinkhole",
-      "text": "If your opponent's Active Pokémon retreats, put 2 damage counters on that Pokémon.",
+      "text": "If your opponent’s Active Pokémon retreats, put 2 damage counters on that Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -1390,7 +1390,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent’s). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1418,7 +1418,7 @@
     "evolvesFrom": "Cascoon",
     "ability": {
       "name": "Camouflage Pattern",
-      "text": "Prevent all effects of attacks, including damage, done to Dustox by your opponent's Pokémon that is affected by 2 or more Special Conditions.",
+      "text": "Prevent all effects of attacks, including damage, done to Dustox by your opponent’s Pokémon that is affected by 2 or more Special Conditions.",
       "type": "Poké-Body"
     },
     "hp": "130",
@@ -1440,7 +1440,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "The Defending Pokémon is now Poisoned. If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "The Defending Pokémon is now Poisoned. If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Chemical Scale",
@@ -1494,7 +1494,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Choose 1 card from your opponent's hand without looking and discard it."
+        "text": "Choose 1 card from your opponent’s hand without looking and discard it."
       },
       {
         "name": "Jet Smash",
@@ -1505,7 +1505,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 70 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Empoleon can't use Jet Smash during your next turn."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 70 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) Empoleon can’t use Jet Smash during your next turn."
       }
     ],
     "weaknesses": [
@@ -1662,7 +1662,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "If your opponent has any Water Energy attached to any of his or her Pokémon, you may do 30 damage to any 1 Benched Pokémon instead. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Water Energy attached to any of his or her Pokémon, you may do 30 damage to any 1 Benched Pokémon instead. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Water Slide",
@@ -1716,7 +1716,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Flip a coin for each of your opponent's Pokémon. If that coin flip is heads, this attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin for each of your opponent’s Pokémon. If that coin flip is heads, this attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Dwindling Wave",
@@ -1874,7 +1874,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Before doing damage, discard all Trainer cards attached to that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 40 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) Before doing damage, discard all Trainer cards attached to that Pokémon."
       },
       {
         "name": "Body Press",
@@ -1908,7 +1908,7 @@
     "evolvesFrom": "Lombre",
     "ability": {
       "name": "Cheerful Voice",
-      "text": "Once during your turn (before your attack), you may use this power. If you do, your turn ends. During your next turn, each of Ludicolo's attacks does 60 more damage to the Defending Pokémon (before applying Weakness and Resistance). This power can't be used if Ludicolo is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may use this power. If you do, your turn ends. During your next turn, each of Ludicolo’s attacks does 60 more damage to the Defending Pokémon (before applying Weakness and Resistance). This power can’t be used if Ludicolo is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -1945,7 +1945,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "After doing damage, remove from Ludicolo the number of damage counters equal to the damage you did to the Defending Pokémon. Ludicolo can't use Best Dance during your next turn."
+        "text": "After doing damage, remove from Ludicolo the number of damage counters equal to the damage you did to the Defending Pokémon. Ludicolo can’t use Best Dance during your next turn."
       }
     ],
     "weaknesses": [
@@ -1985,7 +1985,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. Search your deck for a Pokémon that is the same type as the Pokémon you chose, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
+        "text": "Choose 1 of your opponent’s Pokémon. Search your deck for a Pokémon that is the same type as the Pokémon you chose, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
       },
       {
         "name": "Sweet Kiss",
@@ -2084,7 +2084,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Water Pulse",
@@ -2278,7 +2278,7 @@
     "level": "58",
     "ability": {
       "name": "Galactic Switch",
-      "text": "Once during your turn (before your attack), you may move an Energy card attached to 1 of your Pokémon SP to another of your Pokémon. Then, put 2 damage counters on Bronzong . This power can't be used if Bronzong is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may move an Energy card attached to 1 of your Pokémon SP to another of your Pokémon. Then, put 2 damage counters on Bronzong . This power can’t be used if Bronzong is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -2306,7 +2306,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Does 10 damage to each of your opponent's Benched Pokémon that has any damage counters on it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Benched Pokémon that has any damage counters on it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2355,7 +2355,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon that has any damage counters on it. This attack does 50 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon that has any damage counters on it. This attack does 50 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Poison Experiment",
@@ -2406,7 +2406,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 2 of your opponent's Benched Pokémon. This attack does 10 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 2 of your opponent’s Benched Pokémon. This attack does 10 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Absorb",
@@ -2618,7 +2618,7 @@
     "level": "44",
     "ability": {
       "name": "Flash Bite",
-      "text": "Once during your turn, when you put Crobat from your hand onto your Bench, you may put 1 damage counter on 1 of your opponent's Pokémon.",
+      "text": "Once during your turn, when you put Crobat from your hand onto your Bench, you may put 1 damage counter on 1 of your opponent’s Pokémon.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -2687,7 +2687,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Does 10 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Tail Code",
@@ -2697,7 +2697,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Move an Energy card attached to the Defending Pokémon to another of your opponent's Pokémon."
+        "text": "Move an Energy card attached to the Defending Pokémon to another of your opponent’s Pokémon."
       }
     ],
     "weaknesses": [
@@ -2811,7 +2811,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat or use any Poké-Powers during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat or use any Poké-Powers during your opponent’s next turn."
       },
       {
         "name": "Dark Slash",
@@ -2927,7 +2927,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, look at your opponent's hand and choose 1 card, then have your opponent shuffle that card into his or her deck."
+        "text": "Flip a coin. If heads, look at your opponent’s hand and choose 1 card, then have your opponent shuffle that card into his or her deck."
       },
       {
         "name": "Gentle Slap",
@@ -2979,7 +2979,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Do the Wave",
@@ -3011,7 +3011,7 @@
     "evolvesFrom": "Poochyena",
     "ability": {
       "name": "Cold Feet",
-      "text": "If Mightyena is affected by a Special Condition, ignore all Energy necessary to use Mightyena's attacks.",
+      "text": "If Mightyena is affected by a Special Condition, ignore all Energy necessary to use Mightyena’s attacks.",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -3091,7 +3091,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Psybeam",
@@ -3271,7 +3271,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Any time the Defending Pokémon tries to attack, your opponent flips a coin. If tails, the attack does nothing. (If the Defending Pokémon is no longer your opponent's Active Pokémon, this effect ends.)"
+        "text": "Any time the Defending Pokémon tries to attack, your opponent flips a coin. If tails, the attack does nothing. (If the Defending Pokémon is no longer your opponent’s Active Pokémon, this effect ends.)"
       }
     ],
     "weaknesses": [
@@ -3370,7 +3370,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Hyper Beam",
@@ -3482,7 +3482,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, during your opponent's next turn, if Shieldon would be Knocked Out by damage from an attack, Shieldon is not Knocked Out and its remaining HP becomes 10 instead."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, if Shieldon would be Knocked Out by damage from an attack, Shieldon is not Knocked Out and its remaining HP becomes 10 instead."
       },
       {
         "name": "Rock Slide",
@@ -3492,7 +3492,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Does 10 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3662,7 +3662,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Wartortle does 10 damage to itself. Flip a coin. If heads, prevent all damage done to Wartortle by attacks during your opponent's next turn."
+        "text": "Wartortle does 10 damage to itself. Flip a coin. If heads, prevent all damage done to Wartortle by attacks during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3686,7 +3686,7 @@
     "level": "29",
     "ability": {
       "name": "Thick Skin",
-      "text": "Zangoose can't be affected by any Special Conditions.",
+      "text": "Zangoose can’t be affected by any Special Conditions.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -3710,7 +3710,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon. This attack does 20 damage to the new Defending Pokémon."
+        "text": "Switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon. This attack does 20 damage to the new Defending Pokémon."
       },
       {
         "name": "Chop Up",
@@ -3721,7 +3721,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Does 10 damage to each of your opponent's Benched Pokémon that has any damage counters on it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Benched Pokémon that has any damage counters on it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3770,7 +3770,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip 2 coins. For each heads, choose 1 of your opponent's Pokémon and this attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can choose the same Pokémon more than once, but you can't do more than 10 damage to that Pokémon in this way.)"
+        "text": "Flip 2 coins. For each heads, choose 1 of your opponent’s Pokémon and this attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) (You can choose the same Pokémon more than once, but you can’t do more than 10 damage to that Pokémon in this way.)"
       }
     ],
     "weaknesses": [
@@ -3887,7 +3887,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "If the Defending Pokémon already has any damage counters on it, this attack's base damage is 10 instead of 40."
+        "text": "If the Defending Pokémon already has any damage counters on it, this attack’s base damage is 10 instead of 40."
       }
     ],
     "weaknesses": [
@@ -3993,7 +3993,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4042,7 +4042,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. This attack’s damage isn’t affected by Weakness or Resistance."
       },
       {
         "name": "Trip Over",
@@ -4110,7 +4110,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4264,7 +4264,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon. Remove 2 damage counters from the new Defending Pokémon."
+        "text": "Switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon. Remove 2 damage counters from the new Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -4301,13 +4301,13 @@
     ],
     "attacks": [
       {
-        "name": "Honcho's Command",
+        "name": "Honcho’s Command",
         "cost": [
           "Free"
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Search your deck for up to 2 in any combination of Stadium cards or Trainer cards that has Team Galactic's Invention in its name, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
+        "text": "Search your deck for up to 2 in any combination of Stadium cards or Trainer cards that has Team Galactic’s Invention in its name, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
       },
       {
         "name": "Target Attack",
@@ -4317,7 +4317,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. If that Pokémon already has any damage counters on it, this attack does 20 damage plus 20 more damage. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. If that Pokémon already has any damage counters on it, this attack does 20 damage plus 20 more damage. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4470,7 +4470,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. This attack’s damage isn’t affected by Weakness or Resistance."
       },
       {
         "name": "Knock Off",
@@ -4481,7 +4481,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Choose 1 card from your opponent's hand without looking and discard it."
+        "text": "Choose 1 card from your opponent’s hand without looking and discard it."
       }
     ],
     "weaknesses": [
@@ -4524,7 +4524,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "Does 10 damage plus 10 more damage for each Energy attached to Lotad but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "Does 10 damage plus 10 more damage for each Energy attached to Lotad but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       },
       {
         "name": "Synthesis",
@@ -4585,7 +4585,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "During your opponent's next turn, any damage done to Mareep by attacks is reduced by 10 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Mareep by attacks is reduced by 10 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -4692,7 +4692,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon."
+        "text": "Switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon."
       },
       {
         "name": "Rollout",
@@ -4745,7 +4745,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Pound",
@@ -4857,7 +4857,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent can't play any Trainer, Supporter, or Stadium cards from his or her hand during his or her next turn."
+        "text": "Flip a coin. If heads, your opponent can’t play any Trainer, Supporter, or Stadium cards from his or her hand during his or her next turn."
       },
       {
         "name": "Latent Power",
@@ -4963,7 +4963,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at the top 5 cards of either player's deck and put them back on top of that player's deck in any order."
+        "text": "Look at the top 5 cards of either player’s deck and put them back on top of that player’s deck in any order."
       },
       {
         "name": "Hypnoblast",
@@ -5130,7 +5130,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Return Shuppet and all cards attached to it to your hand. (If you don't have any Benched Pokémon, this attack does nothing.)"
+        "text": "Return Shuppet and all cards attached to it to your hand. (If you don’t have any Benched Pokémon, this attack does nothing.)"
       }
     ],
     "weaknesses": [
@@ -5212,7 +5212,7 @@
     "level": "46",
     "ability": {
       "name": "Poison Structure",
-      "text": "Once during your turn (before your attack), if you have a Stadium card in play, you may use this power. Each Active Pokémon (both yours and your opponent's) (excluding Pokémon SP) is now Poisoned. This power can't be used if Skuntank is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if you have a Stadium card in play, you may use this power. Each Active Pokémon (both yours and your opponent’s) (excluding Pokémon SP) is now Poisoned. This power can’t be used if Skuntank is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -5238,7 +5238,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -5288,7 +5288,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Remove all damage counters from Slakoth. Slakoth can't attack during your next turn."
+        "text": "Remove all damage counters from Slakoth. Slakoth can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -5488,7 +5488,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, Torchic's Fire Shard attack's base damage is 80."
+        "text": "During your next turn, Torchic’s Fire Shard attack’s base damage is 80."
       },
       {
         "name": "Fire Shard",
@@ -5745,13 +5745,13 @@
     "setCode": "pl1",
     "text": [
       "Each player may evolve a Pokémon that he or she just played or evolved during that turn.",
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card."
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/104_hires.png"
   },
   {
     "id": "pl1-105",
-    "name": "Cyrus's Conspiracy",
+    "name": "Cyrus’s Conspiracy",
     "imageUrl": "https://images.pokemontcg.io/pl1/105.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -5764,7 +5764,7 @@
     "setCode": "pl1",
     "text": [
       "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.",
-      "Search your deck for a Supporter card, a basic Energy card, and a Trainer card that has Team Galactic's Invention in its name, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
+      "Search your deck for a Supporter card, a basic Energy card, and a Trainer card that has Team Galactic’s Invention in its name, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/105_hires.png"
   },
@@ -5782,7 +5782,7 @@
     "setCode": "pl1",
     "text": [
       "Whenever any player plays any Pokémon from his or her hand to evolve his or her Pokémon, put 2 damage counters on that Pokémon.",
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card."
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/106_hires.png"
   },
@@ -5824,7 +5824,7 @@
   },
   {
     "id": "pl1-109",
-    "name": "Looker's Investigation",
+    "name": "Looker’s Investigation",
     "imageUrl": "https://images.pokemontcg.io/pl1/109.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -5837,7 +5837,7 @@
     "setCode": "pl1",
     "text": [
       "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.",
-      "Look at your opponent's hand, then choose you or your opponent. That player shuffles his or her hand into his or her deck and draws up to 5 cards."
+      "Look at your opponent’s hand, then choose you or your opponent. That player shuffles his or her hand into his or her deck and draws up to 5 cards."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/109_hires.png"
   },
@@ -5855,8 +5855,8 @@
     "set": "Platinum",
     "setCode": "pl1",
     "text": [
-      "Attach Memory Berry to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
-      "The Pokémon this card is attached to can use any attack from its Basic Pokémon or its Stage 1 Evolution card. (You still have to pay for that attack's Energy cost.)"
+      "Attach Memory Berry to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
+      "The Pokémon this card is attached to can use any attack from its Basic Pokémon or its Stage 1 Evolution card. (You still have to pay for that attack’s Energy cost.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/110_hires.png"
   },
@@ -5873,7 +5873,7 @@
     "set": "Platinum",
     "setCode": "pl1",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
       "Whenever any player puts a Basic Pokémon (excluding Grass or Psychic Pokémon) from his or her hand onto his or her Bench, put 2 damage counters on that Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/111_hires.png"
@@ -5952,7 +5952,7 @@
   },
   {
     "id": "pl1-116",
-    "name": "Team Galactic's Invention G-101 Energy Gain",
+    "name": "Team Galactic’s Invention G-101 Energy Gain",
     "imageUrl": "https://images.pokemontcg.io/pl1/116.png",
     "subtype": "Pokémon Tool",
     "supertype": "Trainer",
@@ -5964,14 +5964,14 @@
     "set": "Platinum",
     "setCode": "pl1",
     "text": [
-      "Attach Team Galactic's Invention G-101 Energy Gain to 1 of your Pokémon SP that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card. When the Pokémon this card is attached to is no longer a Pokémon SP, discard this card.",
-      "As long as Team Galactic's Invention G-101 Energy Gain is attached to a Pokémon, the attack cost of that Pokémon's attacks is Colorless less."
+      "Attach Team Galactic’s Invention G-101 Energy Gain to 1 of your Pokémon SP that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card. When the Pokémon this card is attached to is no longer a Pokémon SP, discard this card.",
+      "As long as Team Galactic’s Invention G-101 Energy Gain is attached to a Pokémon, the attack cost of that Pokémon’s attacks is Colorless less."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/116_hires.png"
   },
   {
     "id": "pl1-117",
-    "name": "Team Galactic's Invention G-103 Power Spray",
+    "name": "Team Galactic’s Invention G-103 Power Spray",
     "imageUrl": "https://images.pokemontcg.io/pl1/117.png",
     "subtype": "Item",
     "supertype": "Trainer",
@@ -5983,13 +5983,13 @@
     "set": "Platinum",
     "setCode": "pl1",
     "text": [
-      "You may play this card during your opponent's turn when your opponent's Pokémon uses any Poké-Power. Prevent all effects of that Poké-Power. (This counts as that Pokémon using its Poké-Power.) If you have 2 or less Pokémon SP in play, you can't play this card."
+      "You may play this card during your opponent’s turn when your opponent’s Pokémon uses any Poké-Power. Prevent all effects of that Poké-Power. (This counts as that Pokémon using its Poké-Power.) If you have 2 or less Pokémon SP in play, you can’t play this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/117_hires.png"
   },
   {
     "id": "pl1-118",
-    "name": "Team Galactic's Invention G-105 Poké Turn",
+    "name": "Team Galactic’s Invention G-105 Poké Turn",
     "imageUrl": "https://images.pokemontcg.io/pl1/118.png",
     "subtype": "Item",
     "supertype": "Trainer",
@@ -6019,8 +6019,8 @@
     "set": "Platinum",
     "setCode": "pl1",
     "text": [
-      "Play Armor Fossil as if it were a Colorless Basic Pokémon. (Armor Fossil counts as a Trainer card as well, but if Armor Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Armor Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Armor Fossil from play. (This doesn't count as a Knocked Out Pokémon.)",
-      "Whenever Armor Fossil would be damaged by your opponent's attack, flip a coin until you get tails. For each heads, reduce that damage by 10."
+      "Play Armor Fossil as if it were a Colorless Basic Pokémon. (Armor Fossil counts as a Trainer card as well, but if Armor Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Armor Fossil can’t be affected by any Special Conditions and can’t retreat. At any time during your turn before your attack, you may discard Armor Fossil from play. (This doesn’t count as a Knocked Out Pokémon.)",
+      "Whenever Armor Fossil would be damaged by your opponent’s attack, flip a coin until you get tails. For each heads, reduce that damage by 10."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/119_hires.png"
   },
@@ -6038,8 +6038,8 @@
     "set": "Platinum",
     "setCode": "pl1",
     "text": [
-      "Play Skull Fossil as if it were a Colorless Basic Pokémon. (Skull Fossil counts as a Trainer card as well, but if Skull Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Skull Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Skull Fossil from play. (This doesn't count as a Knocked Out Pokémon.)",
-      "During your opponent's turn, if Skull Fossil would be Knocked Out by damage from an opponent's attack, flip a coin until you get tails. For each heads, put 1 damage counter on the Attacking Pokémon."
+      "Play Skull Fossil as if it were a Colorless Basic Pokémon. (Skull Fossil counts as a Trainer card as well, but if Skull Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Skull Fossil can’t be affected by any Special Conditions and can’t retreat. At any time during your turn before your attack, you may discard Skull Fossil from play. (This doesn’t count as a Knocked Out Pokémon.)",
+      "During your opponent’s turn, if Skull Fossil would be Knocked Out by damage from an opponent’s attack, flip a coin until you get tails. For each heads, put 1 damage counter on the Attacking Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/120_hires.png"
   },
@@ -6069,7 +6069,7 @@
     "level": "X",
     "ability": {
       "name": "Time Crystal",
-      "text": "Each Pokémon (both yours and your opponent's) (excluding Pokémon SP) can't use any Poké-Bodies.",
+      "text": "Each Pokémon (both yours and your opponent’s) (excluding Pokémon SP) can’t use any Poké-Bodies.",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -6127,7 +6127,7 @@
     "level": "X",
     "ability": {
       "name": "Tri-Poison",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, choose 1 of the Defending Pokémon. That Pokémon is now Poisoned. Put 3 damage counters instead of 1 on that Pokémon between turns. This power can't be used if Drapion is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, choose 1 of the Defending Pokémon. That Pokémon is now Poisoned. Put 3 damage counters instead of 1 on that Pokémon between turns. This power can’t be used if Drapion is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "130",
@@ -6159,7 +6159,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "40",
-        "text": "Does 40 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "Does 40 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -6180,7 +6180,7 @@
     "level": "X",
     "ability": {
       "name": "Invisible Tentacles",
-      "text": "Whenever your opponent's Pokémon tries to attack, your opponent discards 1 card from his or her hand. (If your opponent can’t discard 1 card, your opponent's Pokémon can't attack.) You can't use more than 1 Invisible Tentacles Poké-Body each turn.",
+      "text": "Whenever your opponent’s Pokémon tries to attack, your opponent discards 1 card from his or her hand. (If your opponent can’t discard 1 card, your opponent’s Pokémon can’t attack.) You can’t use more than 1 Invisible Tentacles Poké-Body each turn.",
       "type": "Poké-Body"
     },
     "hp": "130",
@@ -6212,7 +6212,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "This attack does 30 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) If any of your opponent's Pokémon would be Knocked Out by damage from this attack, put that Pokémon and all cards attached to it in the Lost Zone instead of discarding it."
+        "text": "This attack does 30 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) If any of your opponent’s Pokémon would be Knocked Out by damage from this attack, put that Pokémon and all cards attached to it in the Lost Zone instead of discarding it."
       }
     ],
     "weaknesses": [
@@ -6239,7 +6239,7 @@
     "level": "X",
     "ability": {
       "name": "Lost Cyclone",
-      "text": "Once during your turn (before your attack), you may use this power. Any player who has 4 or more Benched Pokémon chooses 3 of his or her Benched Pokémon. Put the other Benched Pokémon and all cards attached to them in the Lost Zone. (You choose your Pokémon first.) This power can't be used if Palkia is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may use this power. Any player who has 4 or more Benched Pokémon chooses 3 of his or her Benched Pokémon. Put the other Benched Pokémon and all cards attached to them in the Lost Zone. (You choose your Pokémon first.) This power can’t be used if Palkia is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -6270,7 +6270,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Discard 2 Energy attached to Palkia . Choose 1 of your opponent's Pokémon. This attack does 80 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard 2 Energy attached to Palkia . Choose 1 of your opponent’s Pokémon. This attack does 80 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -6291,7 +6291,7 @@
     "level": "X",
     "ability": {
       "name": "Thankfulness",
-      "text": "Each of your Grass Pokémon (excluding any Shaymin) gets +40 HP. You can't use more than 1 Thankfulness Poké-Body each turn.",
+      "text": "Each of your Grass Pokémon (excluding any Shaymin) gets +40 HP. You can’t use more than 1 Thankfulness Poké-Body each turn.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -6347,7 +6347,7 @@
     "level": "X",
     "ability": {
       "name": "Revenge Seed",
-      "text": "If any of your Grass Pokémon were Knocked Out by damage from an opponent's attack during his or her last turn, each of Shaymin's attacks does 60 more damage to the Active Pokémon (before applying Weakness and Resistance).",
+      "text": "If any of your Grass Pokémon were Knocked Out by damage from an opponent’s attack during his or her last turn, each of Shaymin’s attacks does 60 more damage to the Active Pokémon (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "110",
@@ -6521,7 +6521,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, Scyther's Slash attack's base damage is 60."
+        "text": "During your next turn, Scyther’s Slash attack’s base damage is 60."
       },
       {
         "name": "Slash",
@@ -6562,7 +6562,7 @@
     "level": "14",
     "ability": {
       "name": "Swift Swim",
-      "text": "If Lotad has any Water Energy attached to it, Lotad's Retreat Cost is 0.",
+      "text": "If Lotad has any Water Energy attached to it, Lotad’s Retreat Cost is 0.",
       "type": "Poké-Body"
     },
     "hp": "50",
@@ -6639,7 +6639,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Remove 4 damage counters from Swablu. Swablu can't retreat during your next turn."
+        "text": "Remove 4 damage counters from Swablu. Swablu can’t retreat during your next turn."
       },
       {
         "name": "Mirror Move",
@@ -6648,7 +6648,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If Swablu was damaged by an attack during your opponent's last turn, this attack does the same amount of damage done to Swablu to the Defending Pokémon."
+        "text": "If Swablu was damaged by an attack during your opponent’s last turn, this attack does the same amount of damage done to Swablu to the Defending Pokémon."
       },
       {
         "name": "Fury Attack",
@@ -6715,7 +6715,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Does 10 damage to each of your opponent's Benched Grass Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Benched Grass Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Inflame",
@@ -6725,7 +6725,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Discard a Fire Energy card from your hand. (If you can't discard a card from your hand, this attack does nothing.)"
+        "text": "Discard a Fire Energy card from your hand. (If you can’t discard a card from your hand, this attack does nothing.)"
       }
     ],
     "weaknesses": [

--- a/json/cards/Power Keepers.json
+++ b/json/cards/Power Keepers.json
@@ -8,7 +8,7 @@
     "evolvesFrom": "Lairon",
     "ability": {
       "name": "Terraforming",
-      "text": "Once during your turn (before your attack), you may look at the top 5 cards from your deck and put them back on top of your deck in any order. This power can't be used if Aggron is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may look at the top 5 cards from your deck and put them back on top of your deck in any order. This power can’t be used if Aggron is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -76,7 +76,7 @@
     "evolvesFrom": "Swablu",
     "ability": {
       "name": "Synergy Effect",
-      "text": "If Drake's Stadium is in play, remove 1 damage counter from Altaria between turns.",
+      "text": "If Drake’s Stadium is in play, remove 1 damage counter from Altaria between turns.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -101,7 +101,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Choose 1 card from your opponent's hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
+        "text": "Choose 1 card from your opponent’s hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
       },
       {
         "name": "Gust",
@@ -164,7 +164,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Discard up to 5 Fighting Energy cards attached to Armaldo. For each Energy card you discarded, choose an opponent's Pokémon in play and this attack does 20 damage to those Pokémon. (You may choose the same Pokémon more than once.) This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Discard up to 5 Fighting Energy cards attached to Armaldo. For each Energy card you discarded, choose an opponent’s Pokémon in play and this attack does 20 damage to those Pokémon. (You may choose the same Pokémon more than once.) This attack’s damage isn’t affected by Weakness or Resistance."
       },
       {
         "name": "Mach Claw",
@@ -175,7 +175,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -227,7 +227,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40x",
-        "text": "Your opponent flips a number of coins equal to the number of his or her Benched Pokémon. This attack does 40 damage times the number of tails. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Your opponent flips a number of coins equal to the number of his or her Benched Pokémon. This attack does 40 damage times the number of tails. This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -254,7 +254,7 @@
     "evolvesFrom": "Combusken",
     "ability": {
       "name": "Firestarter",
-      "text": "Once during your turn (before your attack), you may attach a Fire Energy card from your discard pile to 1 of your Benched Pokémon. This power can't be used if Blaziken is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may attach a Fire Energy card from your discard pile to 1 of your Benched Pokémon. This power can’t be used if Blaziken is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -281,7 +281,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Discard a Fire Energy card attached to Blaziken. This attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard a Fire Energy card attached to Blaziken. This attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -382,7 +382,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "The Defending Pokémon is now Poisoned. The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon is now Poisoned. The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -403,7 +403,7 @@
     "evolvesFrom": "Skitty",
     "ability": {
       "name": "Energy Draw",
-      "text": "Once during your turn (before your attack), you may discard 1 Energy card from your hand. Then draw up to 3 cards from your deck. This power can't be used if Delcatty is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may discard 1 Energy card from your hand. Then draw up to 3 cards from your deck. This power can’t be used if Delcatty is affected by a Special Condition.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -448,7 +448,7 @@
     "evolvesFrom": "Kirlia",
     "ability": {
       "name": "Psy Shadow",
-      "text": "Once during your turn (before your attack), you may search your deck for a Psychic Energy card and attach it to 1 of your Pokémon. Put 2 damage counters on that Pokémon. Shuffle your deck afterward. This power can't be used if Gardevoir is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may search your deck for a Psychic Energy card and attach it to 1 of your Pokémon. Put 2 damage counters on that Pokémon. Shuffle your deck afterward. This power can’t be used if Gardevoir is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -494,7 +494,7 @@
     "evolvesFrom": "Kabuto",
     "ability": {
       "name": "Primal Stare",
-      "text": "As long as Kabutops is your Active Pokémon, your opponent can't play any Basic Pokémon or Evolution cards from his or her hand to evolve his or her Active Pokémon.",
+      "text": "As long as Kabutops is your Active Pokémon, your opponent can’t play any Basic Pokémon or Evolution cards from his or her hand to evolve his or her Active Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "110",
@@ -520,7 +520,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Before doing damage, you may choose 1 of your opponent's Benched Pokémon and switch it with 1 of the Defending Pokémon. If you do, this attack does 20 damage to the new Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
+        "text": "Before doing damage, you may choose 1 of your opponent’s Benched Pokémon and switch it with 1 of the Defending Pokémon. If you do, this attack does 20 damage to the new Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
       },
       {
         "name": "Blinding Scythe",
@@ -552,7 +552,7 @@
     "evolvesFrom": "Machoke",
     "ability": {
       "name": "Overzealous",
-      "text": "If your opponent has any Pokémon-ex in play, each of Machamp's attacks does 30 more damage to the Defending Pokémon.",
+      "text": "If your opponent has any Pokémon-ex in play, each of Machamp’s attacks does 30 more damage to the Defending Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -578,7 +578,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "This attack's damage isn't affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       },
       {
         "name": "Cross Chop",
@@ -662,7 +662,7 @@
     "evolvesFrom": "Vigoroth",
     "ability": {
       "name": "Lazy",
-      "text": "As long as Slaking is your Active Pokémon, your opponent's Pokémon can't use any Poké-Powers.",
+      "text": "As long as Slaking is your Active Pokémon, your opponent’s Pokémon can’t use any Poké-Powers.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -691,7 +691,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "Discard a basic Energy card attached to Slaking or this attack does nothing. Slaking can't attack during your next turn."
+        "text": "Discard a basic Energy card attached to Slaking or this attack does nothing. Slaking can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -733,7 +733,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Mysterious Light",
@@ -744,7 +744,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "If Phoebe's Stadium is in play, the Defending Pokémon is now Confused."
+        "text": "If Phoebe’s Stadium is in play, the Defending Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -774,7 +774,7 @@
     "evolvesFrom": "Chinchou",
     "ability": {
       "name": "Energy Grounding",
-      "text": "Once during your opponent's turn, when any of your Pokémon is Knocked Out by your opponent's attacks, you may use this power. Choose a basic Energy card discarded from the Knocked Out Pokémon and attach it to Lanturn. You can't use more than 1 Energy Grounding Poké-Power each turn.",
+      "text": "Once during your opponent’s turn, when any of your Pokémon is Knocked Out by your opponent’s attacks, you may use this power. Choose a basic Energy card discarded from the Knocked Out Pokémon and attach it to Lanturn. You can’t use more than 1 Energy Grounding Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -801,7 +801,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "You may discard all Lightning Energy attached to Lanturn. If you do, this attack's base damage is 90 instead of 50."
+        "text": "You may discard all Lightning Energy attached to Lanturn. If you do, this attack’s base damage is 90 instead of 50."
       }
     ],
     "weaknesses": [
@@ -822,7 +822,7 @@
     "evolvesFrom": "Magnemite",
     "ability": {
       "name": "Magnetic Field",
-      "text": "Once during your turn (before your attack), if you have basic Energy cards in your discard pile, you may discard any 1 card from your hand. Then search for up to 2 basic Energy cards from your discard pile, show them to your opponent, and put them into your hand. You can't return the card you first discarded to your hand in this way. This power can't be used if Magneton is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if you have basic Energy cards in your discard pile, you may discard any 1 card from your hand. Then search for up to 2 basic Energy cards from your discard pile, show them to your opponent, and put them into your hand. You can’t return the card you first discarded to your hand in this way. This power can’t be used if Magneton is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -960,7 +960,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50+",
-        "text": "If Sidney's Stadium is in play, this attack does 50 damage plus 20 more damage."
+        "text": "If Sidney’s Stadium is in play, this attack does 50 damage plus 20 more damage."
       }
     ],
     "weaknesses": [
@@ -987,7 +987,7 @@
     "evolvesFrom": "Vulpix",
     "ability": {
       "name": "Safeguard",
-      "text": "Prevent all effects of attacks, including damage, done to Ninetales by your opponent's Pokémon-ex.",
+      "text": "Prevent all effects of attacks, including damage, done to Ninetales by your opponent’s Pokémon-ex.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -1074,7 +1074,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "Does 30 damage plus 20 more damage for each Water Energy attached to Omastar but not used to pay for this attack's Energy cost. You can't add more than 40 damage in this way."
+        "text": "Does 30 damage plus 20 more damage for each Water Energy attached to Omastar but not used to pay for this attack’s Energy cost. You can’t add more than 40 damage in this way."
       }
     ],
     "weaknesses": [
@@ -1141,7 +1141,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Synergy Effect",
-      "text": "If Phoebe's Stadium is in play, prevent all damage done to Sableye by attacks from your opponent's Pokémon-ex.",
+      "text": "If Phoebe’s Stadium is in play, prevent all damage done to Sableye by attacks from your opponent’s Pokémon-ex.",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -1175,7 +1175,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
       }
     ],
     "resistances": [
@@ -1245,7 +1245,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Safeguard",
-      "text": "Prevent all effects of attacks, including damage, done to Wobbuffet by your opponent's Pokémon-ex.",
+      "text": "Prevent all effects of attacks, including damage, done to Wobbuffet by your opponent’s Pokémon-ex.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -1272,7 +1272,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Wobbuffet does 10 damage to itself, and don't apply Weakness and Resistance to this damage."
+        "text": "Wobbuffet does 10 damage to itself, and don’t apply Weakness and Resistance to this damage."
       }
     ],
     "weaknesses": [
@@ -1292,7 +1292,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Thick Skin",
-      "text": "Zangoose can't be affected by any Special Conditions.",
+      "text": "Zangoose can’t be affected by any Special Conditions.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -1396,7 +1396,7 @@
     "evolvesFrom": "Cacnea",
     "ability": {
       "name": "Poison Structure",
-      "text": "Once during your turn (before your attack), if Sidney's Stadium is in play, you may choose 1 of the Defending Pokémon. That Pokémon is now Poisoned. This power can't be used if Cacturne is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Sidney’s Stadium is in play, you may choose 1 of the Defending Pokémon. That Pokémon is now Poisoned. This power can’t be used if Cacturne is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -1468,7 +1468,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack or retreat during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack or retreat during your opponent’s next turn."
       },
       {
         "name": "Flame Tail",
@@ -1552,7 +1552,7 @@
     "evolvesFrom": "Snorunt",
     "ability": {
       "name": "Synergy Effect",
-      "text": "If Glacia's Stadium is in play, any damage done to Glalie by attacks from your opponent's Pokémon is reduced by 30 (after applying Weakness and Resistance).",
+      "text": "If Glacia’s Stadium is in play, any damage done to Glalie by attacks from your opponent’s Pokémon is reduced by 30 (after applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -1684,7 +1684,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "During your opponent's next turn, any damage done to Lairon by attacks is reduced by 10 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Lairon by attacks is reduced by 10 (after applying Weakness and Resistance)."
       },
       {
         "name": "Stomp",
@@ -1779,7 +1779,7 @@
     "evolvesFrom": "Meditite",
     "ability": {
       "name": "Vigorous Aura",
-      "text": "As long as Medicham is your Active Pokémon, attacks by each player's Active Pokémon do 10 more damage to any Active Pokémon (before applying Weakness and Resistance).",
+      "text": "As long as Medicham is your Active Pokémon, attacks by each player’s Active Pokémon do 10 more damage to any Active Pokémon (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -1836,7 +1836,7 @@
     "evolvesFrom": "Beldum",
     "ability": {
       "name": "Clear Body",
-      "text": "Metang can't be affected by any Special Conditions.",
+      "text": "Metang can’t be affected by any Special Conditions.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -2182,7 +2182,7 @@
     "evolvesFrom": "Slakoth",
     "ability": {
       "name": "Strikes Back",
-      "text": "If Vigoroth is your Active Pokémon and is damaged by an opponent's attack (even if Vigoroth is Knocked Out), put 1 damage counter on the Attacking Pokémon.",
+      "text": "If Vigoroth is your Active Pokémon and is damaged by an opponent’s attack (even if Vigoroth is Knocked Out), put 1 damage counter on the Attacking Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -2413,7 +2413,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, move a basic Energy card from the Defending Pokémon to another of your opponent's Pokémon. (Ignore this effect if your opponent has only 1 Pokémon.)"
+        "text": "Flip a coin. If heads, move a basic Energy card from the Defending Pokémon to another of your opponent’s Pokémon. (Ignore this effect if your opponent has only 1 Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2461,7 +2461,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
       }
     ],
     "weaknesses": [
@@ -2484,7 +2484,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Rough Skin",
-      "text": "If Carvanha is your Active Pokémon and is damaged by an opponent's attack (even if Carvanha is Knocked Out), put 1 damage counter on the Attacking Pokémon.",
+      "text": "If Carvanha is your Active Pokémon and is damaged by an opponent’s attack (even if Carvanha is Knocked Out), put 1 damage counter on the Attacking Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "40",
@@ -2557,7 +2557,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -2609,7 +2609,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 10 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 10 (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -2757,7 +2757,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Choose 1 card from your opponent's hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
+        "text": "Choose 1 card from your opponent’s hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
       },
       {
         "name": "Acid",
@@ -2768,7 +2768,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2872,7 +2872,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3276,7 +3276,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack during your opponent’s next turn."
       },
       {
         "name": "Tackle",
@@ -3328,7 +3328,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Scratch",
@@ -3379,7 +3379,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Benched Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Benched Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Double Headbutt",
@@ -3432,7 +3432,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to Spheal during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all damage done to Spheal during your opponent’s next turn."
       },
       {
         "name": "Aurora Beam",
@@ -3702,14 +3702,14 @@
     "set": "Power Keepers",
     "setCode": "ex16",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "Each player's Colorless Evolved Pokémon, Darkness Evolved Pokémon, and Metal Evolved Pokémon can't use any Poké-Powers or Poké-Bodies."
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
+      "Each player’s Colorless Evolved Pokémon, Darkness Evolved Pokémon, and Metal Evolved Pokémon can’t use any Poké-Powers or Poké-Bodies."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/71_hires.png"
   },
   {
     "id": "ex16-72",
-    "name": "Drake's Stadium",
+    "name": "Drake’s Stadium",
     "imageUrl": "https://images.pokemontcg.io/ex16/72.png",
     "subtype": "Stadium",
     "supertype": "Trainer",
@@ -3721,8 +3721,8 @@
     "set": "Power Keepers",
     "setCode": "ex16",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "Any damage done to Colorless Active Pokémon (both yours and your opponent's) by an opponent's attack is reduced by 10 (after applying Weakness and Resistance)."
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
+      "Any damage done to Colorless Active Pokémon (both yours and your opponent’s) by an opponent’s attack is reduced by 10 (after applying Weakness and Resistance)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/72_hires.png"
   },
@@ -3758,7 +3758,7 @@
     "set": "Power Keepers",
     "setCode": "ex16",
     "text": [
-      "Flip a coin. If heads, choose 1 Energy card attached to 1 of your opponent's Pokémon and discard it."
+      "Flip a coin. If heads, choose 1 Energy card attached to 1 of your opponent’s Pokémon and discard it."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/74_hires.png"
   },
@@ -3782,7 +3782,7 @@
   },
   {
     "id": "ex16-76",
-    "name": "Glacia's Stadium",
+    "name": "Glacia’s Stadium",
     "imageUrl": "https://images.pokemontcg.io/ex16/76.png",
     "subtype": "Stadium",
     "supertype": "Trainer",
@@ -3794,8 +3794,8 @@
     "set": "Power Keepers",
     "setCode": "ex16",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "Each player's Water Pokémon (excluding Pokémon-ex) has no Weakness."
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
+      "Each player’s Water Pokémon (excluding Pokémon-ex) has no Weakness."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/76_hires.png"
   },
@@ -3837,7 +3837,7 @@
   },
   {
     "id": "ex16-79",
-    "name": "Phoebe's Stadium",
+    "name": "Phoebe’s Stadium",
     "imageUrl": "https://images.pokemontcg.io/ex16/79.png",
     "subtype": "Stadium",
     "supertype": "Trainer",
@@ -3849,7 +3849,7 @@
     "set": "Power Keepers",
     "setCode": "ex16",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
       "Each player pays Colorless Colorless less to retreat his or her Psychic Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/79_hires.png"
@@ -3894,7 +3894,7 @@
   },
   {
     "id": "ex16-82",
-    "name": "Sidney's Stadium",
+    "name": "Sidney’s Stadium",
     "imageUrl": "https://images.pokemontcg.io/ex16/82.png",
     "subtype": "Stadium",
     "supertype": "Trainer",
@@ -3906,14 +3906,14 @@
     "set": "Power Keepers",
     "setCode": "ex16",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "Each player's Darkness Pokémon can't be Asleep, Confused, or Paralyzed."
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
+      "Each player’s Darkness Pokémon can’t be Asleep, Confused, or Paralyzed."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/82_hires.png"
   },
   {
     "id": "ex16-83",
-    "name": "Steven's Advice",
+    "name": "Steven’s Advice",
     "imageUrl": "https://images.pokemontcg.io/ex16/83.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -3926,7 +3926,7 @@
     "setCode": "ex16",
     "text": [
       "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.",
-      "Draw a number of cards up to the number of your opponent's Pokémon in play. If you have 7 or more cards (including this one) in your hand, you can't play this card."
+      "Draw a number of cards up to the number of your opponent’s Pokémon in play. If you have 7 or more cards (including this one) in your hand, you can’t play this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/83_hires.png"
   },
@@ -3944,8 +3944,8 @@
     "set": "Power Keepers",
     "setCode": "ex16",
     "text": [
-      "Play Claw Fossil as if it were a Basic Pokémon. While in play, Claw Fossil counts as a Colorless Pokémon (as well as a Trainer card). Claw Fossil has no attacks of its own, can't retreat, and can't be affected by any Special Conditions. If Claw Fossil is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Claw Fossil from play.",
-      "If Claw Fossil is your Active Pokémon and is damaged by an opponent's attack (even if Claw Fossil is Knocked Out), put 1 damage counter on the Attacking Pokémon."
+      "Play Claw Fossil as if it were a Basic Pokémon. While in play, Claw Fossil counts as a Colorless Pokémon (as well as a Trainer card). Claw Fossil has no attacks of its own, can’t retreat, and can’t be affected by any Special Conditions. If Claw Fossil is Knocked Out, it doesn’t count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Claw Fossil from play.",
+      "If Claw Fossil is your Active Pokémon and is damaged by an opponent’s attack (even if Claw Fossil is Knocked Out), put 1 damage counter on the Attacking Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/84_hires.png"
   },
@@ -3963,7 +3963,7 @@
     "set": "Power Keepers",
     "setCode": "ex16",
     "text": [
-      "Play Mysterious Fossil as if it were a Basic Pokémon. While in play, Mysterious Fossil counts as a Colorless Pokémon (as well as a Trainer card). Mysterious Fossil has no attacks of its own, can't retreat, and can't be affected by any Special Conditions. If Mysterious Fossil is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Mysterious Fossil from play."
+      "Play Mysterious Fossil as if it were a Basic Pokémon. While in play, Mysterious Fossil counts as a Colorless Pokémon (as well as a Trainer card). Mysterious Fossil has no attacks of its own, can’t retreat, and can’t be affected by any Special Conditions. If Mysterious Fossil is Knocked Out, it doesn’t count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Mysterious Fossil from play."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/85_hires.png"
   },
@@ -3981,7 +3981,7 @@
     "set": "Power Keepers",
     "setCode": "ex16",
     "text": [
-      "Play Root Fossil as if it were a Basic Pokémon. While in play, Root Fossil counts as a Colorless Pokémon (as well as a Trainer card). Root Fossil has no attacks of its own, can't retreat, and can't be affected by any Special Conditions. If Root Fossil is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Root Fossil from play.",
+      "Play Root Fossil as if it were a Basic Pokémon. While in play, Root Fossil counts as a Colorless Pokémon (as well as a Trainer card). Root Fossil has no attacks of its own, can’t retreat, and can’t be affected by any Special Conditions. If Root Fossil is Knocked Out, it doesn’t count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Root Fossil from play.",
       "At any time between turns, remove 1 damage counter from Root Fossil."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/86_hires.png"
@@ -3999,7 +3999,7 @@
     "set": "Power Keepers",
     "setCode": "ex16",
     "text": [
-      "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect unless the Attacking Pokémon is Darkness or has Dark in its name. Darkness Energy provides Darkness Energy. (Doesn't count as a basic Energy card.)"
+      "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect unless the Attacking Pokémon is Darkness or has Dark in its name. Darkness Energy provides Darkness Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/87_hires.png"
   },
@@ -4016,7 +4016,7 @@
     "set": "Power Keepers",
     "setCode": "ex16",
     "text": [
-      "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn't Metal. Metal Energy provides Metal Energy. (Doesn't count as a basic Energy card.)"
+      "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn’t Metal. Metal Energy provides Metal Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/88_hires.png"
   },
@@ -4050,7 +4050,7 @@
     "set": "Power Keepers",
     "setCode": "ex16",
     "text": [
-      "Cyclone Energy provides Colorless Energy. When you attach this card from your hand to your Active Pokémon, switch 1 of the Defending Pokémon with 1 of your opponent's Benched Pokémon. Your opponent chooses the Benched Pokémon to switch."
+      "Cyclone Energy provides Colorless Energy. When you attach this card from your hand to your Active Pokémon, switch 1 of the Defending Pokémon with 1 of your opponent’s Benched Pokémon. Your opponent chooses the Benched Pokémon to switch."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/90_hires.png"
   },
@@ -4080,7 +4080,7 @@
     "level": "ex",
     "ability": {
       "name": "Cursed Eyes",
-      "text": "Once during your turn, when you put Absol ex from your hand onto your Bench, you may move 3 damage counters from 1 of your opponent's Pokémon to another of his or her Pokémon.",
+      "text": "Once during your turn, when you put Absol ex from your hand onto your Bench, you may move 3 damage counters from 1 of your opponent’s Pokémon to another of his or her Pokémon.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -4108,7 +4108,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Does 10 damage to each of your opponent's Benched Pokémon that has any damage counters on it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Benched Pokémon that has any damage counters on it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4136,7 +4136,7 @@
     "evolvesFrom": "Baltoy",
     "ability": {
       "name": "Type Shift",
-      "text": "Once during your turn (before your attack), you may use this power. Claydol ex's type is Fighting until the end of your turn.",
+      "text": "Once during your turn (before your attack), you may use this power. Claydol ex’s type is Fighting until the end of your turn.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -4198,7 +4198,7 @@
     "evolvesFrom": "Vibrava",
     "ability": {
       "name": "Psychic Protector",
-      "text": "If Flygon ex is damaged by an opponent's attack, you may discard up to 4 cards from your hand. If you do, any damage done to Flygon ex is reduced by 10 for each card you discarded.",
+      "text": "If Flygon ex is damaged by an opponent’s attack, you may discard up to 4 cards from your hand. If you do, any damage done to Flygon ex is reduced by 10 for each card you discarded.",
       "type": "Poké-Body"
     },
     "hp": "150",
@@ -4224,7 +4224,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "Flip a coin. If tails, Flygon ex can't use Slashing Strike during your next turn."
+        "text": "Flip a coin. If tails, Flygon ex can’t use Slashing Strike during your next turn."
       }
     ],
     "weaknesses": [
@@ -4256,7 +4256,7 @@
     "evolvesFrom": "Metang",
     "ability": {
       "name": "Magnetic Redraw",
-      "text": "Once during your turn (before your attack), if Metagross ex is your Active Pokémon, you may use this power. Each player shuffles his or her hand into his or her deck. Then, each player draws 4 cards. This power can't be used if Metagross ex is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Metagross ex is your Active Pokémon, you may use this power. Each player shuffles his or her hand into his or her deck. Then, each player draws 4 cards. This power can’t be used if Metagross ex is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "150",
@@ -4288,7 +4288,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "Does 70 damage to each of your opponent's Benched Pokémon that has the same name as the Defending Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 70 damage to each of your opponent’s Benched Pokémon that has the same name as the Defending Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4354,7 +4354,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Discard all Water Energy attached to Salamence ex. This attack does 30 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard all Water Energy attached to Salamence ex. This attack does 30 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4408,7 +4408,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at your opponent's hand and choose a Basic Pokémon or Evolution card you find there. Choose 1 of that Pokémon's attacks. Skill Hack copies that attack except for its Energy cost. (You must still do anything else required for that attack.) (No matter what type that Pokémon is, Shiftry ex's type is still Darkness.) Shiftry ex performs that attack."
+        "text": "Look at your opponent’s hand and choose a Basic Pokémon or Evolution card you find there. Choose 1 of that Pokémon’s attacks. Skill Hack copies that attack except for its Energy cost. (You must still do anything else required for that attack.) (No matter what type that Pokémon is, Shiftry ex’s type is still Darkness.) Shiftry ex performs that attack."
       },
       {
         "name": "Dirge",
@@ -4419,7 +4419,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Does 60 damage to each of your opponent's Benched Pokémon that has the same name as the Defending Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 60 damage to each of your opponent’s Benched Pokémon that has the same name as the Defending Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4446,7 +4446,7 @@
     "level": "ex",
     "ability": {
       "name": "Metal Gravity",
-      "text": "If your opponent's Active Pokémon retreats and has 40 or more remaining HP, put 3 damage counters on that Pokémon. You can't use more than 1 Metal Gravity Poké-Body each turn.",
+      "text": "If your opponent’s Active Pokémon retreats and has 40 or more remaining HP, put 3 damage counters on that Pokémon. You can’t use more than 1 Metal Gravity Poké-Body each turn.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -4513,7 +4513,7 @@
     "evolvesFrom": "Sealeo",
     "ability": {
       "name": "Chilling Breath",
-      "text": "Once during your turn, when you play Walrein ex from your hand to evolve 1 of your Pokémon, you may use this power. Your opponent can't play any Trainer cards from his or her hand during your opponent's next turn.",
+      "text": "Once during your turn, when you play Walrein ex from your hand to evolve 1 of your Pokémon, you may use this power. Your opponent can’t play any Trainer cards from his or her hand during your opponent’s next turn.",
       "type": "Poké-Power"
     },
     "hp": "150",
@@ -4564,7 +4564,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Crimson Ray",
-      "text": "Once during your turn, when you put Flareon Star from your hand onto your Bench, you may use this power. Each Active Pokémon (both yours and your opponent's) is now Burned.",
+      "text": "Once during your turn, when you put Flareon Star from your hand onto your Bench, you may use this power. Each Active Pokémon (both yours and your opponent’s) is now Burned.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -4578,7 +4578,7 @@
     "set": "Power Keepers",
     "setCode": "ex16",
     "text": [
-      "You can't have more than 1 Pokémon Star in your deck."
+      "You can’t have more than 1 Pokémon Star in your deck."
     ],
     "types": [
       "Fire"
@@ -4613,7 +4613,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Yellow Ray",
-      "text": "Once during your turn, when you put Jolteon Star from your hand onto your Bench, you may put 1 damage counter on each Active Pokémon (both yours and your opponent's).",
+      "text": "Once during your turn, when you put Jolteon Star from your hand onto your Bench, you may put 1 damage counter on each Active Pokémon (both yours and your opponent’s).",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -4627,7 +4627,7 @@
     "set": "Power Keepers",
     "setCode": "ex16",
     "text": [
-      "You can't have more than 1 Pokémon Star in your deck."
+      "You can’t have more than 1 Pokémon Star in your deck."
     ],
     "types": [
       "Lightning"
@@ -4642,7 +4642,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Jolteon Star during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Jolteon Star during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -4668,7 +4668,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Blue Ray",
-      "text": "Once during your turn, when you put Vaporeon Star from your hand onto your Bench, you may remove all Special Conditions and 3 damage counters from each Active Pokémon (both yours and your opponent's).",
+      "text": "Once during your turn, when you put Vaporeon Star from your hand onto your Bench, you may remove all Special Conditions and 3 damage counters from each Active Pokémon (both yours and your opponent’s).",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -4682,7 +4682,7 @@
     "set": "Power Keepers",
     "setCode": "ex16",
     "text": [
-      "You can't have more than 1 Pokémon Star in your deck."
+      "You can’t have more than 1 Pokémon Star in your deck."
     ],
     "types": [
       "Water"

--- a/json/cards/Primal Clash.json
+++ b/json/cards/Primal Clash.json
@@ -233,7 +233,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80+",
-        "text": "This attack does 10 more damage for each Colorless in your opponent's Active Pokémon's Retreat Cost."
+        "text": "This attack does 10 more damage for each Colorless in your opponent’s Active Pokémon’s Retreat Cost."
       }
     ],
     "weaknesses": [
@@ -326,7 +326,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -433,7 +433,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "Discard 1 Energy attached to this Pokémon. Your opponent's Active Pokémon is now Poisoned."
+        "text": "Discard 1 Energy attached to this Pokémon. Your opponent’s Active Pokémon is now Poisoned."
       }
     ],
     "weaknesses": [
@@ -551,7 +551,7 @@
     "evolvesFrom": "Lombre",
     "ability": {
       "name": "Captivating Rhythm",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, switch 1 of your opponent's Benched Pokémon with his or her Active Pokémon.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, switch 1 of your opponent’s Benched Pokémon with his or her Active Pokémon.",
       "type": "Ability"
     },
     "hp": "130",
@@ -660,7 +660,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Confused. Switch this Pokémon with 1 of your Benched Pokémon."
+        "text": "Your opponent’s Active Pokémon is now Confused. Switch this Pokémon with 1 of your Benched Pokémon."
       },
       {
         "name": "Air Slash",
@@ -709,7 +709,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       }
     ],
     "weaknesses": [
@@ -754,7 +754,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40+",
-        "text": "Flip a coin. If heads, this attack does 20 more damage and your opponent's Active Pokémon is now Confused."
+        "text": "Flip a coin. If heads, this attack does 20 more damage and your opponent’s Active Pokémon is now Confused."
       },
       {
         "name": "Mega Kick",
@@ -814,7 +814,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "If your opponent's Active Pokémon is affected by a Special Condition, this attack does 30 more damage."
+        "text": "If your opponent’s Active Pokémon is affected by a Special Condition, this attack does 30 more damage."
       }
     ],
     "weaknesses": [
@@ -862,7 +862,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -906,7 +906,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Wood Blast",
@@ -989,7 +989,7 @@
     "evolvesFrom": "Vulpix",
     "ability": {
       "name": "Barrier Shrine",
-      "text": "Each player can't play any Stadium cards from his or her hand.",
+      "text": "Each player can’t play any Stadium cards from his or her hand.",
       "type": "Ability"
     },
     "hp": "90",
@@ -1015,7 +1015,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       }
     ],
     "weaknesses": [
@@ -1056,7 +1056,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Discard a Grass Energy attached to your opponent's Active Pokémon."
+        "text": "Discard a Grass Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Ram",
@@ -1113,7 +1113,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "This attack does 20 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Flamethrower",
@@ -1182,7 +1182,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "If your opponent's Active Pokémon is a Pokémon-EX, this attack does 60 more damage."
+        "text": "If your opponent’s Active Pokémon is a Pokémon-EX, this attack does 60 more damage."
       }
     ],
     "weaknesses": [
@@ -1244,7 +1244,7 @@
     "supertype": "Pokémon",
     "ancientTrait": {
       "name": "Ω Barrage",
-      "text": "This Pokémon may attack twice a turn. (If the first attack Knocks Out your opponent's Active Pokémon, you may attack again after your opponent chooses a new Active Pokémon.)"
+      "text": "This Pokémon may attack twice a turn. (If the first attack Knocks Out your opponent’s Active Pokémon, you may attack again after your opponent chooses a new Active Pokémon.)"
     },
     "hp": "50",
     "retreatCost": [
@@ -1479,7 +1479,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -1730,7 +1730,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 60 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 60 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Waterfall",
@@ -1840,7 +1840,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Choose a random card from your opponent's hand. Your opponent reveals that card and shuffles it into his or her deck."
+        "text": "Choose a random card from your opponent’s hand. Your opponent reveals that card and shuffles it into his or her deck."
       },
       {
         "name": "Splash Dance",
@@ -1851,7 +1851,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "During your next turn, this Pokémon's Splash Dance attack does 60 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s Splash Dance attack does 60 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -1991,7 +1991,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Choose 1 of your opponent's Active Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of your opponent’s Active Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Rising Lunge",
@@ -2063,7 +2063,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "This attack does 20 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2112,7 +2112,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Discard a random card from your opponent's hand."
+        "text": "Discard a random card from your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -2336,7 +2336,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Aurora Beam",
@@ -2406,7 +2406,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "70+",
-        "text": "If your opponent's Active Pokémon is a Fighting Pokémon, this attack does 70 more damage."
+        "text": "If your opponent’s Active Pokémon is a Fighting Pokémon, this attack does 70 more damage."
       }
     ],
     "weaknesses": [
@@ -2446,7 +2446,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, if this Pokémon would be damaged by an attack, prevent that attack's damage done to this Pokémon if that damage is 50 or less."
+        "text": "During your opponent’s next turn, if this Pokémon would be damaged by an attack, prevent that attack’s damage done to this Pokémon if that damage is 50 or less."
       }
     ],
     "weaknesses": [
@@ -2501,7 +2501,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -2538,7 +2538,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with his or her Active Pokémon."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with his or her Active Pokémon."
       },
       {
         "name": "Psychic",
@@ -2548,7 +2548,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "This attack does 10 more damage for each Energy attached to your opponent's Active Pokémon."
+        "text": "This attack does 10 more damage for each Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -2593,7 +2593,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -2648,7 +2648,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "This attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2694,7 +2694,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Giant Whirlpool",
@@ -2760,7 +2760,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "150",
-        "text": "Move 2 Energy from this Pokémon to 1 of your Benched Pokémon. This attack does 30 damage to each of your opponent's Benched Pokémon-EX. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Move 2 Energy from this Pokémon to 1 of your Benched Pokémon. This attack does 30 damage to each of your opponent’s Benched Pokémon-EX. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2900,7 +2900,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       },
       {
         "name": "Take Down",
@@ -3018,7 +3018,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -3079,7 +3079,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "Discard all Lightning Energy attached to this Pokémon. Your opponent's Active Pokémon is now Paralyzed."
+        "text": "Discard all Lightning Energy attached to this Pokémon. Your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -3468,7 +3468,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Your opponent's Active Pokémon is now Poisoned. Put 2 damage counters instead of 1 on that Pokémon between turns."
+        "text": "Your opponent’s Active Pokémon is now Poisoned. Put 2 damage counters instead of 1 on that Pokémon between turns."
       }
     ],
     "weaknesses": [
@@ -3489,7 +3489,7 @@
     "evolvesFrom": "Nidorina",
     "ancientTrait": {
       "name": "Ω Barrage",
-      "text": "This Pokémon may attack twice a turn. (If the first attack Knocks Out your opponent's Active Pokémon, you may attack again after your opponent chooses a new Active Pokémon.)"
+      "text": "This Pokémon may attack twice a turn. (If the first attack Knocks Out your opponent’s Active Pokémon, you may attack again after your opponent chooses a new Active Pokémon.)"
     },
     "hp": "140",
     "retreatCost": [
@@ -3513,7 +3513,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       },
       {
         "name": "Dynamite Punch",
@@ -3524,7 +3524,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "This Pokémon does 20 damage to itself. Don't apply Weakness to this damage."
+        "text": "This Pokémon does 20 damage to itself. Don’t apply Weakness to this damage."
       }
     ],
     "weaknesses": [
@@ -3655,7 +3655,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Confused and Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Confused and Poisoned."
       },
       {
         "name": "Stick and Absorb",
@@ -3665,7 +3665,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Heal 30 damage from this Pokémon. The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "Heal 30 damage from this Pokémon. The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3702,7 +3702,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "If this Pokémon and your opponent's Active Pokémon have the same amount of Energy attached to them, this attack does 60 more damage."
+        "text": "If this Pokémon and your opponent’s Active Pokémon have the same amount of Energy attached to them, this attack does 60 more damage."
       }
     ],
     "weaknesses": [
@@ -3852,7 +3852,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Flip 3 coins. This attack does 20 damage times the number of heads to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip 3 coins. This attack does 20 damage times the number of heads to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Stone Edge",
@@ -3885,7 +3885,7 @@
     "evolvesFrom": "Rhydon",
     "ability": {
       "name": "Rock Wall",
-      "text": "Any damage done to your Pokémon by an opponent's attack is reduced by 10 (after applying Weakness and Resistance).",
+      "text": "Any damage done to your Pokémon by an opponent’s attack is reduced by 10 (after applying Weakness and Resistance).",
       "type": "Ability"
     },
     "ancientTrait": {
@@ -3919,7 +3919,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "Discard the top card of your opponent's deck."
+        "text": "Discard the top card of your opponent’s deck."
       }
     ],
     "weaknesses": [
@@ -3961,7 +3961,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 40 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 40 (after applying Weakness and Resistance)."
       },
       {
         "name": "Ram",
@@ -4058,7 +4058,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 4 damage counters on your opponent's Pokémon in any way you like."
+        "text": "Put 4 damage counters on your opponent’s Pokémon in any way you like."
       },
       {
         "name": "Windmill Kick",
@@ -4068,7 +4068,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "60",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -4089,7 +4089,7 @@
     "evolvesFrom": "Meditite",
     "ancientTrait": {
       "name": "Ω Barrage",
-      "text": "This Pokémon may attack twice a turn. (If the first attack Knocks Out your opponent's Active Pokémon, you may attack again after your opponent chooses a new Active Pokémon.)"
+      "text": "This Pokémon may attack twice a turn. (If the first attack Knocks Out your opponent’s Active Pokémon, you may attack again after your opponent chooses a new Active Pokémon.)"
     },
     "hp": "90",
     "retreatCost": [
@@ -4122,7 +4122,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Weakness or Resistance."
+        "text": "This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -4278,7 +4278,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4324,7 +4324,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Massive Rend",
@@ -4491,7 +4491,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "During your opponent's next turn, prevent all effects of attacks, including damage, done to this Pokémon by Pokémon-EX."
+        "text": "During your opponent’s next turn, prevent all effects of attacks, including damage, done to this Pokémon by Pokémon-EX."
       },
       {
         "name": "Double-Edge",
@@ -4588,7 +4588,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin until you get tails. For each heads, discard the top card of your opponent's deck."
+        "text": "Flip a coin until you get tails. For each heads, discard the top card of your opponent’s deck."
       },
       {
         "name": "Hammer In",
@@ -4642,7 +4642,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with his or her Active Pokémon. This attack does 30 damage to the new Active Pokémon."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with his or her Active Pokémon. This attack does 30 damage to the new Active Pokémon."
       },
       {
         "name": "Jagged Fang",
@@ -4653,7 +4653,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "Discard an Energy attached to this Pokémon. Then, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Discard an Energy attached to this Pokémon. Then, discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -4674,7 +4674,7 @@
     "evolvesFrom": "Corphish",
     "ability": {
       "name": "Unruly Claw",
-      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may discard an Energy attached to your opponent's Active Pokémon.",
+      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may discard an Energy attached to your opponent’s Active Pokémon.",
       "type": "Ability"
     },
     "hp": "90",
@@ -4823,7 +4823,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120+",
-        "text": "You may flip a coin. If heads, this attack does 120 more damage. If tails, this attack does 20 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "You may flip a coin. If heads, this attack does 120 more damage. If tails, this attack does 20 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4929,7 +4929,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Straight Claw",
@@ -4967,7 +4967,7 @@
     "evolvesFrom": "Drilbur",
     "ancientTrait": {
       "name": "Ω Barrage",
-      "text": "This Pokémon may attack twice a turn. (If the first attack Knocks Out your opponent's Active Pokémon, you may attack again after your opponent chooses a new Active Pokémon.)"
+      "text": "This Pokémon may attack twice a turn. (If the first attack Knocks Out your opponent’s Active Pokémon, you may attack again after your opponent chooses a new Active Pokémon.)"
     },
     "hp": "110",
     "retreatCost": [
@@ -5003,7 +5003,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -5049,7 +5049,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -5100,7 +5100,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, put damage counters on your opponent's Active Pokémon until its remaining HP is 10."
+        "text": "Flip a coin. If heads, put damage counters on your opponent’s Active Pokémon until its remaining HP is 10."
       },
       {
         "name": "Slash",
@@ -5169,7 +5169,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -5215,7 +5215,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Move a Pokémon Tool card attached to 1 of either player's Pokémon to another of that player's Pokémon that doesn't already have a Pokémon Tool attached to it. If there is no Pokémon to move the Pokémon Tool card to, this attack does nothing."
+        "text": "Move a Pokémon Tool card attached to 1 of either player’s Pokémon to another of that player’s Pokémon that doesn’t already have a Pokémon Tool attached to it. If there is no Pokémon to move the Pokémon Tool card to, this attack does nothing."
       },
       {
         "name": "Lock Up",
@@ -5225,7 +5225,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -5332,7 +5332,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Superpower",
@@ -5455,7 +5455,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Heal from this Pokémon the same amount of damage you did to your opponent's Active Pokémon."
+        "text": "Heal from this Pokémon the same amount of damage you did to your opponent’s Active Pokémon."
       },
       {
         "name": "Shining Wind",
@@ -5466,7 +5466,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "During your opponent's next turn, this Pokémon has no Weakness."
+        "text": "During your opponent’s next turn, this Pokémon has no Weakness."
       }
     ],
     "weaknesses": [
@@ -5566,7 +5566,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "This attack's damage isn't affected by any effects on your opponent's Active Pokémon."
+        "text": "This attack’s damage isn’t affected by any effects on your opponent’s Active Pokémon."
       },
       {
         "name": "Twister",
@@ -5576,7 +5576,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "70",
-        "text": "Flip 2 coins. For each heads, discard an Energy attached to your opponent's Active Pokémon. If both of them are tails, this attack does nothing."
+        "text": "Flip 2 coins. For each heads, discard an Energy attached to your opponent’s Active Pokémon. If both of them are tails, this attack does nothing."
       }
     ],
     "weaknesses": [
@@ -5671,7 +5671,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Super Vibration",
@@ -5732,7 +5732,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -5771,7 +5771,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Headbutt",
@@ -5835,7 +5835,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -5874,7 +5874,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
       },
       {
         "name": "Tail Smack",
@@ -5976,7 +5976,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Confused. If tails, this Pokémon is now Confused."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Confused. If tails, this Pokémon is now Confused."
       },
       {
         "name": "Uproar",
@@ -5985,7 +5985,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -6035,7 +6035,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -6128,7 +6128,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Continuous Headbutt",
@@ -6159,7 +6159,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Sap Sipper",
-      "text": "This Pokémon's attacks do 40 more damage to your opponent's Grass Pokémon (before applying Weakness and Resistance).",
+      "text": "This Pokémon’s attacks do 40 more damage to your opponent’s Grass Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "110",
@@ -6186,7 +6186,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "Discard a Special Energy attached to your opponent's Active Pokémon."
+        "text": "Discard a Special Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -6250,7 +6250,7 @@
     "supertype": "Pokémon",
     "ancientTrait": {
       "name": "Ω Barrage",
-      "text": "This Pokémon may attack twice a turn. (If the first attack Knocks Out your opponent's Active Pokémon, you may attack again after your opponent chooses a new Active Pokémon.)"
+      "text": "This Pokémon may attack twice a turn. (If the first attack Knocks Out your opponent’s Active Pokémon, you may attack again after your opponent chooses a new Active Pokémon.)"
     },
     "hp": "60",
     "retreatCost": [
@@ -6274,7 +6274,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Discard the top card of your opponent's deck."
+        "text": "Discard the top card of your opponent’s deck."
       },
       {
         "name": "Rototiller",
@@ -6334,7 +6334,7 @@
   },
   {
     "id": "xy5-124",
-    "name": "Archie's Ace in the Hole",
+    "name": "Archie’s Ace in the Hole",
     "imageUrl": "https://images.pokemontcg.io/xy5/124.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -6396,7 +6396,7 @@
     "set": "Primal Clash",
     "setCode": "xy5",
     "text": [
-      "Each player switches his or her Active Pokémon with 1 of his or her Benched Pokémon. (Your opponent switches first. If a player does not have a Benched Pokémon, he or she doesn't switch Pokémon.)"
+      "Each player switches his or her Active Pokémon with 1 of his or her Benched Pokémon. (Your opponent switches first. If a player does not have a Benched Pokémon, he or she doesn’t switch Pokémon.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/127_hires.png"
   },
@@ -6413,7 +6413,7 @@
     "set": "Primal Clash",
     "setCode": "xy5",
     "text": [
-      "When your Active Pokémon is Knocked Out by damage from an opponent's attack, you may move 1 basic Energy card that was attached to that Pokémon to the Pokémon this card is attached to."
+      "When your Active Pokémon is Knocked Out by damage from an opponent’s attack, you may move 1 basic Energy card that was attached to that Pokémon to the Pokémon this card is attached to."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/128_hires.png"
   },
@@ -6487,7 +6487,7 @@
   },
   {
     "id": "xy5-133",
-    "name": "Maxie's Hidden Ball Trick",
+    "name": "Maxie’s Hidden Ball Trick",
     "imageUrl": "https://images.pokemontcg.io/xy5/133.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -6504,7 +6504,7 @@
   },
   {
     "id": "xy5-134",
-    "name": "Professor Birch's Observations",
+    "name": "Professor Birch’s Observations",
     "imageUrl": "https://images.pokemontcg.io/xy5/134.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -6532,7 +6532,7 @@
     "set": "Primal Clash",
     "setCode": "xy5",
     "text": [
-      "Choose 1 of your Basic Pokémon in play. If you have a Stage 2 card in your hand that evolves from that Pokémon, put that card on the Basic Pokémon. (This counts as evolving that Pokémon.) You can't use this card during your first turn or on a Basic Pokémon that was put into play this turn."
+      "Choose 1 of your Basic Pokémon in play. If you have a Stage 2 card in your hand that evolves from that Pokémon, put that card on the Basic Pokémon. (This counts as evolving that Pokémon.) You can’t use this card during your first turn or on a Basic Pokémon that was put into play this turn."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/135_hires.png"
   },
@@ -6566,7 +6566,7 @@
     "set": "Primal Clash",
     "setCode": "xy5",
     "text": [
-      "Once during each player's turn, that player may heal 30 damage from each of his or her Water Pokémon and Lightning Pokémon."
+      "Once during each player’s turn, that player may heal 30 damage from each of his or her Water Pokémon and Lightning Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/137_hires.png"
   },
@@ -6583,7 +6583,7 @@
     "set": "Primal Clash",
     "setCode": "xy5",
     "text": [
-      "Once during each player's turn, that player may discard a Fire or Fighting Energy card from his or her hand. If that player does so, he or she draws 2 cards."
+      "Once during each player’s turn, that player may discard a Fire or Fighting Energy card from his or her hand. If that player does so, he or she draws 2 cards."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/138_hires.png"
   },
@@ -6600,7 +6600,7 @@
     "set": "Primal Clash",
     "setCode": "xy5",
     "text": [
-      "Each player's evolved Pokémon can use any attack from its previous Evolutions. (That player still needs the necessary Energy to use each attack.)"
+      "Each player’s evolved Pokémon can use any attack from its previous Evolutions. (That player still needs the necessary Energy to use each attack.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/139_hires.png"
   },
@@ -6617,7 +6617,7 @@
     "set": "Primal Clash",
     "setCode": "xy5",
     "text": [
-      "Each Basic Pokémon in play, in each player's hand, and in each player's discard pile has no Abilities."
+      "Each Basic Pokémon in play, in each player’s hand, and in each player’s discard pile has no Abilities."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/140_hires.png"
   },
@@ -6634,7 +6634,7 @@
     "set": "Primal Clash",
     "setCode": "xy5",
     "text": [
-      "You can play this card only if 1 of your Pokémon was Knocked Out during your opponent's last turn. Search your deck for up to 2 cards and put them into your hand. Shuffle your deck afterward."
+      "You can play this card only if 1 of your Pokémon was Knocked Out during your opponent’s last turn. Search your deck for up to 2 cards and put them into your hand. Shuffle your deck afterward."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/141_hires.png"
   },
@@ -6668,7 +6668,7 @@
     "set": "Primal Clash",
     "setCode": "xy5",
     "text": [
-      "This card can only be attached to Metal Pokémon. This card provides Metal Energy only while this card is attached to a Metal Pokémon. The attacks of your opponent's Pokémon do 10 less damage to the Metal Pokémon this card is attached to (before applying Weakness and Resistance). (If this card is attached to anything other than a Metal Pokémon, discard this card.)"
+      "This card can only be attached to Metal Pokémon. This card provides Metal Energy only while this card is attached to a Metal Pokémon. The attacks of your opponent’s Pokémon do 10 less damage to the Metal Pokémon this card is attached to (before applying Weakness and Resistance). (If this card is attached to anything other than a Metal Pokémon, discard this card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/143_hires.png"
   },
@@ -6685,7 +6685,7 @@
     "set": "Primal Clash",
     "setCode": "xy5",
     "text": [
-      "This card can only be attached to Fairy Pokémon. This card provides Fairy Energy only while this card is attached to a Fairy Pokémon. Prevent all effects of your opponent's attacks, except damage, done to the Fairy Pokémon this card is attached to. (Existing effects are not removed.) (If this card is attached to anything other than a Fairy Pokémon, discard this card.)"
+      "This card can only be attached to Fairy Pokémon. This card provides Fairy Energy only while this card is attached to a Fairy Pokémon. Prevent all effects of your opponent’s attacks, except damage, done to the Fairy Pokémon this card is attached to. (Existing effects are not removed.) (If this card is attached to anything other than a Fairy Pokémon, discard this card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/144_hires.png"
   },
@@ -6721,7 +6721,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Wood Blast",
@@ -6890,7 +6890,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Giant Whirlpool",
@@ -6956,7 +6956,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "150",
-        "text": "Move 2 Energy from this Pokémon to 1 of your Benched Pokémon. This attack does 30 damage to each of your opponent's Benched Pokémon-EX. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Move 2 Energy from this Pokémon to 1 of your Benched Pokémon. This attack does 30 damage to each of your opponent’s Benched Pokémon-EX. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -7002,7 +7002,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Massive Rend",
@@ -7111,7 +7111,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with his or her Active Pokémon. This attack does 30 damage to the new Active Pokémon."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with his or her Active Pokémon. This attack does 30 damage to the new Active Pokémon."
       },
       {
         "name": "Jagged Fang",
@@ -7122,7 +7122,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "Discard an Energy attached to this Pokémon. Then, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Discard an Energy attached to this Pokémon. Then, discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -7238,7 +7238,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120+",
-        "text": "You may flip a coin. If heads, this attack does 120 more damage. If tails, this attack does 20 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "You may flip a coin. If heads, this attack does 120 more damage. If tails, this attack does 20 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -7287,7 +7287,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Heal from this Pokémon the same amount of damage you did to your opponent's Active Pokémon."
+        "text": "Heal from this Pokémon the same amount of damage you did to your opponent’s Active Pokémon."
       },
       {
         "name": "Shining Wind",
@@ -7298,7 +7298,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "During your opponent's next turn, this Pokémon has no Weakness."
+        "text": "During your opponent’s next turn, this Pokémon has no Weakness."
       }
     ],
     "weaknesses": [
@@ -7372,7 +7372,7 @@
   },
   {
     "id": "xy5-157",
-    "name": "Archie's Ace in the Hole",
+    "name": "Archie’s Ace in the Hole",
     "imageUrl": "https://images.pokemontcg.io/xy5/157.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -7389,7 +7389,7 @@
   },
   {
     "id": "xy5-158",
-    "name": "Maxie's Hidden Ball Trick",
+    "name": "Maxie’s Hidden Ball Trick",
     "imageUrl": "https://images.pokemontcg.io/xy5/158.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -7406,7 +7406,7 @@
   },
   {
     "id": "xy5-159",
-    "name": "Professor Birch's Observations",
+    "name": "Professor Birch’s Observations",
     "imageUrl": "https://images.pokemontcg.io/xy5/159.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -7434,7 +7434,7 @@
     "set": "Primal Clash",
     "setCode": "xy5",
     "text": [
-      "You can play this card only if 1 of your Pokémon was Knocked Out during your opponent's last turn. Search your deck for up to 2 cards and put them into your hand. Shuffle your deck afterward."
+      "You can play this card only if 1 of your Pokémon was Knocked Out during your opponent’s last turn. Search your deck for up to 2 cards and put them into your hand. Shuffle your deck afterward."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/160_hires.png"
   }

--- a/json/cards/Rising Rivals.json
+++ b/json/cards/Rising Rivals.json
@@ -129,7 +129,7 @@
     "level": "58",
     "ability": {
       "name": "Eerie Aura",
-      "text": "Put 1 damage counter on each of your opponent's Pokémon that remains Asleep between turns.",
+      "text": "Put 1 damage counter on each of your opponent’s Pokémon that remains Asleep between turns.",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -212,7 +212,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "Floatzel can't use Giant Wave during your next turn."
+        "text": "Floatzel can’t use Giant Wave during your next turn."
       }
     ],
     "weaknesses": [
@@ -256,7 +256,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Discard a Stadium card your opponent has in play. If you do, prevent all effects of an attack, including damage, done to Flygon during your opponent's next turn."
+        "text": "Discard a Stadium card your opponent has in play. If you do, prevent all effects of an attack, including damage, done to Flygon during your opponent’s next turn."
       },
       {
         "name": "Power Swing",
@@ -313,7 +313,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon. The new Defending Pokémon is now Asleep."
+        "text": "Switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon. The new Defending Pokémon is now Asleep."
       },
       {
         "name": "Wake-Up Slap",
@@ -344,7 +344,7 @@
     "level": "39",
     "ability": {
       "name": "Final Wish",
-      "text": "Once during your opponent's turn, if Jirachi would be Knocked Out by damage from an attack, you may search your deck for any 1 card and put it into your hand. Shuffle your deck afterward.",
+      "text": "Once during your opponent’s turn, if Jirachi would be Knocked Out by damage from an attack, you may search your deck for any 1 card and put it into your hand. Shuffle your deck afterward.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -374,7 +374,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -401,7 +401,7 @@
     "level": "32",
     "ability": {
       "name": "Boundary Aura",
-      "text": "Apply Weakness for each Pokémon (both yours and your opponent's) as x2 instead.",
+      "text": "Apply Weakness for each Pokémon (both yours and your opponent’s) as x2 instead.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -479,7 +479,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "Discard an Energy card from your hand. (If you can't discard a card from your hand, this attack does nothing.)"
+        "text": "Discard an Energy card from your hand. (If you can’t discard a card from your hand, this attack does nothing.)"
       }
     ],
     "weaknesses": [
@@ -582,7 +582,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin for each Benched Pokémon (both yours and your opponent's). If that coin flip is heads, this attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin for each Benched Pokémon (both yours and your opponent’s). If that coin flip is heads, this attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Rend",
@@ -633,7 +633,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "The Defending Pokémon is now Poisoned and can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon is now Poisoned and can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Long Whip",
@@ -643,7 +643,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "If the Defending Pokémon is affected by any Special Conditions, you may do 30 damage to any 1 Benched Pokémon instead. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If the Defending Pokémon is affected by any Special Conditions, you may do 30 damage to any 1 Benched Pokémon instead. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -701,7 +701,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "The Defending Pokémon can't use any Poké-Powers or Poké-Bodies during your opponent's next turn."
+        "text": "The Defending Pokémon can’t use any Poké-Powers or Poké-Bodies during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -751,7 +751,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "If Aggron was damaged by an attack during your opponent's last turn, this attack does the same amount of damage done to Aggron to the Defending Pokémon."
+        "text": "If Aggron was damaged by an attack during your opponent’s last turn, this attack does the same amount of damage done to Aggron to the Defending Pokémon."
       },
       {
         "name": "Metal Fang",
@@ -802,7 +802,7 @@
     "evolvesFrom": "Kakuna",
     "ability": {
       "name": "Flutter Wings",
-      "text": "Once during your turn (before your attack), you may search your deck for a Grass Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward. This power can't be used if Beedrill is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may search your deck for a Grass Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward. This power can’t be used if Beedrill is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -1019,7 +1019,7 @@
     "evolvesFrom": "Eevee",
     "ability": {
       "name": "Undevelop",
-      "text": "Once during your turn (before your attack), you may devolve Flareon and put Flareon into your hand. This power can't be used if Flareon is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may devolve Flareon and put Flareon into your hand. This power can’t be used if Flareon is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -1094,7 +1094,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Does 10 damage to each of your opponent's Benched Pokémon that has any damage counters on it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Benched Pokémon that has any damage counters on it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Feint",
@@ -1105,7 +1105,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -1223,7 +1223,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon and 10 damage to each of your opponent's other Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon and 10 damage to each of your opponent’s other Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Raging Sea",
@@ -1345,7 +1345,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, Heracross 's Megahorn attack's base damage is 100."
+        "text": "During your next turn, Heracross ’s Megahorn attack’s base damage is 100."
       },
       {
         "name": "Megahorn",
@@ -1377,7 +1377,7 @@
     "evolvesFrom": "Hippopotas",
     "ability": {
       "name": "Sand Cover",
-      "text": "As long as Hippowdon is your Active Pokémon, put 1 damage counter on each of your opponent's Pokémon LV.X between turns.",
+      "text": "As long as Hippowdon is your Active Pokémon, put 1 damage counter on each of your opponent’s Pokémon LV.X between turns.",
       "type": "Poké-Body"
     },
     "hp": "110",
@@ -1416,7 +1416,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "Does 10 damage to each Benched Pokémon that isn't an Evolved Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each Benched Pokémon that isn’t an Evolved Pokémon (both yours and your opponent’s). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1444,7 +1444,7 @@
     "evolvesFrom": "Eevee",
     "ability": {
       "name": "Undevelop",
-      "text": "Once during your turn (before your attack), you may devolve Jolteon and put Jolteon into your hand. This power can't be used if Jolteon is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may devolve Jolteon and put Jolteon into your hand. This power can’t be used if Jolteon is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -1475,7 +1475,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "If Jolteon evolved from Eevee during this turn, this attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If Jolteon evolved from Eevee during this turn, this attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1502,7 +1502,7 @@
     "level": "61",
     "ability": {
       "name": "Icy Aura",
-      "text": "As long as Mamoswine is your Active Pokémon, put 1 damage counter on each Active Pokémon (excluding Water Pokémon) (both yours and your opponent's) between turns.",
+      "text": "As long as Mamoswine is your Active Pokémon, put 1 damage counter on each Active Pokémon (excluding Water Pokémon) (both yours and your opponent’s) between turns.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -1532,7 +1532,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1588,7 +1588,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "During your opponent's next turn, any damage done to Mr.Mime by attacks is reduced by 10 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Mr.Mime by attacks is reduced by 10 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -1610,7 +1610,7 @@
     "evolvesFrom": "Nidorino",
     "ability": {
       "name": "Territoriality",
-      "text": "If your Active Pokémon is damaged by an opponent's attack (even if that Pokémon is Knocked Out), put 2 damage counters on the Attacking Pokémon. You can't put more than 2 damage counters in this way.",
+      "text": "If your Active Pokémon is damaged by an opponent’s attack (even if that Pokémon is Knocked Out), put 2 damage counters on the Attacking Pokémon. You can’t put more than 2 damage counters in this way.",
       "type": "Poké-Body"
     },
     "hp": "130",
@@ -1637,7 +1637,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "If your opponent has any Benched Pokémon, this attack's base damage is 30 instead of 60 and this attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, this attack’s base damage is 30 instead of 60 and this attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Giga Horn",
@@ -1677,7 +1677,7 @@
     "evolvesFrom": "Nidorina",
     "ability": {
       "name": "Maternal Comfort",
-      "text": "At any time between turns, remove 1 damage counter from each of your Pokémon. You can't use more than 1 Maternal Comfort Poké-Body between turns.",
+      "text": "At any time between turns, remove 1 damage counter from each of your Pokémon. You can’t use more than 1 Maternal Comfort Poké-Body between turns.",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -1714,7 +1714,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50+",
-        "text": "Does 50 damage plus 10 more damage for each of your opponent's Benched Pokémon."
+        "text": "Does 50 damage plus 10 more damage for each of your opponent’s Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -1757,7 +1757,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 2 of your opponent's Benched Pokémon. This attack does 10 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 2 of your opponent’s Benched Pokémon. This attack does 10 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Repeat Lightning",
@@ -1767,7 +1767,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "Does 30 damage plus 10 more damage for each of your opponent's Benched Pokémon that has any damage counters on it."
+        "text": "Does 30 damage plus 10 more damage for each of your opponent’s Benched Pokémon that has any damage counters on it."
       }
     ],
     "weaknesses": [
@@ -1828,7 +1828,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -1911,7 +1911,7 @@
     "evolvesFrom": "Eevee",
     "ability": {
       "name": "Undevelop",
-      "text": "Once during your turn (before your attack), you may devolve Vaporeon and put Vaporeon into your hand. This power can't be used if Vaporeon is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may devolve Vaporeon and put Vaporeon into your hand. This power can’t be used if Vaporeon is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -1936,7 +1936,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Evolving Aqua",
@@ -1946,7 +1946,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon that has any damage counters on it. This attack does 40 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) If Vaporeon evolved from Eevee during this turn, this attack does 60 damage instead."
+        "text": "Choose 1 of your opponent’s Pokémon that has any damage counters on it. This attack does 40 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) If Vaporeon evolved from Eevee during this turn, this attack does 60 damage instead."
       }
     ],
     "weaknesses": [
@@ -2091,7 +2091,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Whirlwind",
@@ -2199,7 +2199,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 20 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Electrode does 100 damage to itself."
+        "text": "This attack does 20 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) Electrode does 100 damage to itself."
       },
       {
         "name": "Reflect Energy",
@@ -2266,7 +2266,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Put 3 damage counters on 1 of your opponent's Pokémon. You may shuffle Gengar and all cards attached to it back into your deck."
+        "text": "Put 3 damage counters on 1 of your opponent’s Pokémon. You may shuffle Gengar and all cards attached to it back into your deck."
       }
     ],
     "weaknesses": [
@@ -2294,7 +2294,7 @@
     "evolvesFrom": "Eevee",
     "ability": {
       "name": "Frost Wind",
-      "text": "As long as Glaceon is your Active Pokémon, any damage done to your Pokémon by your opponent's attacks is reduced by 10 (after applying Weakness and Resistance).",
+      "text": "As long as Glaceon is your Active Pokémon, any damage done to your Pokémon by your opponent’s attacks is reduced by 10 (after applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -2319,7 +2319,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Ice Bind",
@@ -2330,7 +2330,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "If your opponent doesn't discard a card from his or her hand, the Defending Pokémon is now Paralyzed."
+        "text": "If your opponent doesn’t discard a card from his or her hand, the Defending Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -2425,7 +2425,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 2 of your opponent's Pokémon. This attack does 20 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 2 of your opponent’s Pokémon. This attack does 20 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "High Jump Kick",
@@ -2490,7 +2490,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "During your opponent's next turn, any damage done to Lairon by attacks is reduced by 10 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Lairon by attacks is reduced by 10 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -2620,7 +2620,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Put the Defending Pokémon and all cards attached to it on top of your opponent's deck. Your opponent shuffles his or her deck afterward. (If your opponent doesn't have any Benched Pokémon, this attack does nothing.)"
+        "text": "Put the Defending Pokémon and all cards attached to it on top of your opponent’s deck. Your opponent shuffles his or her deck afterward. (If your opponent doesn’t have any Benched Pokémon, this attack does nothing.)"
       }
     ],
     "weaknesses": [
@@ -2739,7 +2739,7 @@
     "evolvesFrom": "Carvanha",
     "ability": {
       "name": "Energy Shark",
-      "text": "If Sharpedo is your Active Pokémon and is damaged by an opponent's attack (even if Sharpedo is Knocked Out), flip a coin. If heads, discard an Energy card attached to the Attacking Pokémon.",
+      "text": "If Sharpedo is your Active Pokémon and is damaged by an opponent’s attack (even if Sharpedo is Knocked Out), flip a coin. If heads, discard an Energy card attached to the Attacking Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -2800,7 +2800,7 @@
     "evolvesFrom": "Staryu",
     "ability": {
       "name": "Aqua Recycle",
-      "text": "Once during your turn (before your attack), you may search your discard pile for a Water Energy card, show it to your opponent, and put it into your hand. This power can't be used if Starmie is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may search your discard pile for a Water Energy card, show it to your opponent, and put it into your hand. This power can’t be used if Starmie is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -2830,7 +2830,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "40",
-        "text": "Starmie can't attack during your next turn."
+        "text": "Starmie can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -2933,7 +2933,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of an attack, including damage, done to Tropius during your opponent's next turn."
+        "text": "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of an attack, including damage, done to Tropius during your opponent’s next turn."
       },
       {
         "name": "Blessed Fruit",
@@ -3002,7 +3002,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20×",
-        "text": "Does 20 damage times the number of Energy cards in your opponent's discard pile. Then, put those Energy cards on top of your opponent's deck. Your opponent shuffles his or her deck afterward."
+        "text": "Does 20 damage times the number of Energy cards in your opponent’s discard pile. Then, put those Energy cards on top of your opponent’s deck. Your opponent shuffles his or her deck afterward."
       },
       {
         "name": "Quick Attack",
@@ -3072,7 +3072,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3125,7 +3125,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent can't play any Pokémon from his or her hand to evolve or to Level-Up the Defending Pokémon during his or her next turn."
+        "text": "Your opponent can’t play any Pokémon from his or her hand to evolve or to Level-Up the Defending Pokémon during his or her next turn."
       }
     ],
     "weaknesses": [
@@ -3171,7 +3171,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Move an Energy card attached to the Defending Pokémon to another of your opponent's Pokémon."
+        "text": "Move an Energy card attached to the Defending Pokémon to another of your opponent’s Pokémon."
       },
       {
         "name": "Snap Attack",
@@ -3181,7 +3181,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "60",
-        "text": "If the Defending Pokémon has any Energy cards attached to it, this attack's base damage is 20 instead of 60."
+        "text": "If the Defending Pokémon has any Energy cards attached to it, this attack’s base damage is 20 instead of 60."
       }
     ],
     "weaknesses": [
@@ -3280,7 +3280,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack or retreat during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack or retreat during your opponent’s next turn."
       },
       {
         "name": "Whirlpool",
@@ -3448,7 +3448,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Forretress can't use Shell Scatter during your next turn."
+        "text": "This attack does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) Forretress can’t use Shell Scatter during your next turn."
       },
       {
         "name": "Bomb Risk",
@@ -3459,7 +3459,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.) Flip a coin. If tails, Forretress does 80 damage to itself."
+        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent’s). (Don’t apply Weakness and Resistance for Benched Pokémon.) Flip a coin. If tails, Forretress does 80 damage to itself."
       }
     ],
     "weaknesses": [
@@ -3678,7 +3678,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Fire Fang",
@@ -3766,7 +3766,7 @@
     "level": "34",
     "ability": {
       "name": "Colorful Body",
-      "text": "Kecleon's type is Grass Fire Water Lightning Psychic Fighting Darkness Metal Colorless.",
+      "text": "Kecleon’s type is Grass Fire Water Lightning Psychic Fighting Darkness Metal Colorless.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -3842,7 +3842,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Koffing does 30 damage to itself, and don't apply Weakness and Resistance to this damage."
+        "text": "Koffing does 30 damage to itself, and don’t apply Weakness and Resistance to this damage."
       }
     ],
     "weaknesses": [
@@ -4038,7 +4038,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack during your opponent’s next turn."
       },
       {
         "name": "Horn Hazard",
@@ -4093,7 +4093,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Nidorina does 10 damage to itself, and don't apply Weakness and Resistance to this damage."
+        "text": "Nidorina does 10 damage to itself, and don’t apply Weakness and Resistance to this damage."
       },
       {
         "name": "Stress Poison",
@@ -4160,7 +4160,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon that doesn't have any damage counters on it. This attack does 40 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon that doesn’t have any damage counters on it. This attack does 40 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4204,7 +4204,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Feint Attack",
@@ -4214,7 +4214,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
       }
     ],
     "weaknesses": [
@@ -4244,7 +4244,7 @@
     "level": "34",
     "ability": {
       "name": "Submerge",
-      "text": "As long as Quagsire is on your Bench, prevent all damage done to Quagsire by attacks (both yours and your opponent's).",
+      "text": "As long as Quagsire is on your Bench, prevent all damage done to Quagsire by attacks (both yours and your opponent’s).",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -4329,7 +4329,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -4372,7 +4372,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, if Seedot would be damaged by an attack, prevent that attack's damage done to Seedot if that damage is 40 or less."
+        "text": "During your opponent’s next turn, if Seedot would be damaged by an attack, prevent that attack’s damage done to Seedot if that damage is 40 or less."
       },
       {
         "name": "Astonish",
@@ -4381,7 +4381,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Choose 1 card from your opponent's hand without looking. Look at that card you chose, then have your opponent shuffle that card into his or her deck."
+        "text": "Choose 1 card from your opponent’s hand without looking. Look at that card you chose, then have your opponent shuffle that card into his or her deck."
       }
     ],
     "weaknesses": [
@@ -4430,7 +4430,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, put 1 damage counter on each of your opponent's Pokémon."
+        "text": "Flip a coin. If heads, put 1 damage counter on each of your opponent’s Pokémon."
       },
       {
         "name": "Brine",
@@ -4439,7 +4439,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon that has any damage counters on it. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon that has any damage counters on it. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4517,7 +4517,7 @@
     "level": "40",
     "ability": {
       "name": "Bad Sleeping Habits",
-      "text": "As long as Snorlax is Asleep, your opponent's Active Pokémon can't retreat.",
+      "text": "As long as Snorlax is Asleep, your opponent’s Active Pokémon can’t retreat.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -4660,7 +4660,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -4738,7 +4738,7 @@
     "level": "20",
     "ability": {
       "name": "Overgrow",
-      "text": "As long as Turtwig 's remaining HP is 60 or less, each of Turtwig 's attacks does 30 more damage to the Active Pokémon (before applying Weakness and Resistance).",
+      "text": "As long as Turtwig ’s remaining HP is 60 or less, each of Turtwig ’s attacks does 30 more damage to the Active Pokémon (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -4849,7 +4849,7 @@
     "evolvesFrom": "Koffing",
     "ability": {
       "name": "Camouflage Gas",
-      "text": "If Weezing is Confused and is Knocked Out, your opponent can't take a Prize card.",
+      "text": "If Weezing is Confused and is Knocked Out, your opponent can’t take a Prize card.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -4897,7 +4897,7 @@
   },
   {
     "id": "pl2-88",
-    "name": "Aaron's Collection",
+    "name": "Aaron’s Collection",
     "imageUrl": "https://images.pokemontcg.io/pl2/88.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4916,7 +4916,7 @@
   },
   {
     "id": "pl2-89",
-    "name": "Bebe's Search",
+    "name": "Bebe’s Search",
     "imageUrl": "https://images.pokemontcg.io/pl2/89.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4929,13 +4929,13 @@
     "setCode": "pl2",
     "text": [
       "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.",
-      "Choose a card from your hand and put it on top of your deck. Search your deck for a Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward. (If this is the only card in your hand, you can't play this card.)"
+      "Choose a card from your hand and put it on top of your deck. Search your deck for a Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward. (If this is the only card in your hand, you can’t play this card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl2/89_hires.png"
   },
   {
     "id": "pl2-90",
-    "name": "Bertha's Warmth",
+    "name": "Bertha’s Warmth",
     "imageUrl": "https://images.pokemontcg.io/pl2/90.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4954,7 +4954,7 @@
   },
   {
     "id": "pl2-91",
-    "name": "Flint's Willpower",
+    "name": "Flint’s Willpower",
     "imageUrl": "https://images.pokemontcg.io/pl2/91.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4973,7 +4973,7 @@
   },
   {
     "id": "pl2-92",
-    "name": "Lucian's Assignment",
+    "name": "Lucian’s Assignment",
     "imageUrl": "https://images.pokemontcg.io/pl2/92.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -5003,7 +5003,7 @@
     "set": "Rising Rivals",
     "setCode": "pl2",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
       "Once during each player’s turn, if that player’s Bench isn’t full, the player may flip a coin. If heads, that player searches his or her deck for a Basic Pokémon and puts it onto his or her Bench. If the player does, he or she may search his or her deck for a Pokémon Tool card and attach it to that Pokémon. If that player searched his or her deck, the player shuffles his or her deck afterward."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl2/93_hires.png"
@@ -5021,14 +5021,14 @@
     "set": "Rising Rivals",
     "setCode": "pl2",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "Any damage done by attacks from Lightning Pokémon (both yours and your opponent's) to the Defending Pokémon isn't affected by Resistance. Each Lightning Pokémon in play (both yours and your opponent's) has no Weakness."
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
+      "Any damage done by attacks from Lightning Pokémon (both yours and your opponent’s) to the Defending Pokémon isn’t affected by Resistance. Each Lightning Pokémon in play (both yours and your opponent’s) has no Weakness."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl2/94_hires.png"
   },
   {
     "id": "pl2-95",
-    "name": "Team Galactic's Invention G-107 Technical Machine",
+    "name": "Team Galactic’s Invention G-107 Technical Machine",
     "imageUrl": "https://images.pokemontcg.io/pl2/95.png",
     "subtype": "Technical Machine",
     "supertype": "Trainer",
@@ -5039,13 +5039,13 @@
     "set": "Rising Rivals",
     "setCode": "pl2",
     "text": [
-      "Attach this card to 1 of your Pokémon SP in play. That Pokémon may use this card's attack instead of its own. When the Pokémon this card is attached to is no longer a Pokémon SP, discard this card."
+      "Attach this card to 1 of your Pokémon SP in play. That Pokémon may use this card’s attack instead of its own. When the Pokémon this card is attached to is no longer a Pokémon SP, discard this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl2/95_hires.png"
   },
   {
     "id": "pl2-96",
-    "name": "Team Galactic's Invention G-109 SP Radar",
+    "name": "Team Galactic’s Invention G-109 SP Radar",
     "imageUrl": "https://images.pokemontcg.io/pl2/96.png",
     "subtype": "Item",
     "supertype": "Trainer",
@@ -5057,7 +5057,7 @@
     "set": "Rising Rivals",
     "setCode": "pl2",
     "text": [
-      "Choose a card from your hand and put it on top of your deck. Search your deck for a Pokémon SP, show it to your opponent, and put it into your hand. Shuffle your deck afterward. (If this is the only card in your hand, you can't play this card.)"
+      "Choose a card from your hand and put it on top of your deck. Search your deck for a Pokémon SP, show it to your opponent, and put it into your hand. Shuffle your deck afterward. (If this is the only card in your hand, you can’t play this card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl2/96_hires.png"
   },
@@ -5082,7 +5082,7 @@
   },
   {
     "id": "pl2-98",
-    "name": "Volkner's Philosophy",
+    "name": "Volkner’s Philosophy",
     "imageUrl": "https://images.pokemontcg.io/pl2/98.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -5095,7 +5095,7 @@
     "setCode": "pl2",
     "text": [
       "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.",
-      "You may discard a card from your hand. Then, draw cards until you have 6 cards in your hand. (If you can't draw any cards, you can't play this card.)"
+      "You may discard a card from your hand. Then, draw cards until you have 6 cards in your hand. (If you can’t draw any cards, you can’t play this card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl2/98_hires.png"
   },
@@ -5112,7 +5112,7 @@
     "set": "Rising Rivals",
     "setCode": "pl2",
     "text": [
-      "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect if the Pokémon that Darkness Energy is attached to isn't Darkness. Darkness Energy provides Darkness Energy. (Doesn't count as a basic Energy card.)"
+      "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect if the Pokémon that Darkness Energy is attached to isn’t Darkness. Darkness Energy provides Darkness Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl2/99_hires.png"
   },
@@ -5129,7 +5129,7 @@
     "set": "Rising Rivals",
     "setCode": "pl2",
     "text": [
-      "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn't Metal. Metal Energy provides Metal Energy. (Doesn't count as a basic Energy card.)"
+      "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn’t Metal. Metal Energy provides Metal Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl2/100_hires.png"
   },
@@ -5176,7 +5176,7 @@
     "level": "X",
     "ability": {
       "name": "Damage Switch",
-      "text": "As often as you like during your turn (before your attack), you may move 1 damage counter from 1 of your Pokémon SP to another of your Pokémon SP. This power can't be used if Alakazam is affected by a Special Condition.",
+      "text": "As often as you like during your turn (before your attack), you may move 1 damage counter from 1 of your Pokémon SP to another of your Pokémon SP. This power can’t be used if Alakazam is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -5206,7 +5206,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "This attack's damage isn't affected by Weakness or Resistance."
+        "text": "This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -5273,7 +5273,7 @@
     "level": "X",
     "ability": {
       "name": "Wind Erosion",
-      "text": "As long as Flygon is your Active Pokémon, discard the top card from your opponent's deck between turns.",
+      "text": "As long as Flygon is your Active Pokémon, discard the top card from your opponent’s deck between turns.",
       "type": "Poké-Body"
     },
     "hp": "140",
@@ -5299,7 +5299,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon LV.X. This attack does 150 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon LV.X. This attack does 150 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -5326,7 +5326,7 @@
     "level": "X",
     "ability": {
       "name": "Blade Storm",
-      "text": "Once during your turn (before your attack), when you put Gallade LV.X from your hand onto your Active Gallade , you may put 1 damage counter on each of your opponent's Pokémon.",
+      "text": "Once during your turn (before your attack), when you put Gallade LV.X from your hand onto your Active Gallade , you may put 1 damage counter on each of your opponent’s Pokémon.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -5376,7 +5376,7 @@
     "level": "X",
     "ability": {
       "name": "Sand Reset",
-      "text": "Once during a game on your turn (before your attack), each player shuffles all cards in play (excluding Pokémon and Supporter cards) into his or her deck. You can't use more than 1 Sand Reset Poké-Power each game.",
+      "text": "Once during a game on your turn (before your attack), each player shuffles all cards in play (excluding Pokémon and Supporter cards) into his or her deck. You can’t use more than 1 Sand Reset Poké-Power each game.",
       "type": "Poké-Power"
     },
     "hp": "130",
@@ -5409,7 +5409,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Discard 2 Fighting Energy attached to Hippowdon and choose 2 of your opponent's Benched Pokémon. This attack does 40 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard 2 Fighting Energy attached to Hippowdon and choose 2 of your opponent’s Benched Pokémon. This attack does 40 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -5436,7 +5436,7 @@
     "level": "X",
     "ability": {
       "name": "Intimidating Roar",
-      "text": "Once during your turn (before your attack), you may have your opponent switch his or her Active Pokémon with 1 of his or her Benched Pokémon. This power can't be used if Infernape is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may have your opponent switch his or her Active Pokémon with 1 of his or her Benched Pokémon. This power can’t be used if Infernape is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -5483,7 +5483,7 @@
     "level": "X",
     "ability": {
       "name": "Bright Look",
-      "text": "Once during your turn (before your attack), when you put Luxray LV.X from your hand onto your Active Luxray , you may switch the Defending Pokémon with 1 of your opponent's Benched Pokémon.",
+      "text": "Once during your turn (before your attack), when you put Luxray LV.X from your hand onto your Active Luxray , you may switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -5508,7 +5508,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "60",
-        "text": "Does 30 damage to 1 of your Pokémon, and don't apply Weakness and Resistance to this damage."
+        "text": "Does 30 damage to 1 of your Pokémon, and don’t apply Weakness and Resistance to this damage."
       }
     ],
     "weaknesses": [
@@ -5535,7 +5535,7 @@
     "level": "X",
     "ability": {
       "name": "Magical Return",
-      "text": "As often as you like during your turn (before your attack), you may return a Pokémon Tool card or Technical Machine card attached to your Pokémon to your hand. This power can't be used if Mismagius is affected by a Special Condition.",
+      "text": "As often as you like during your turn (before your attack), you may return a Pokémon Tool card or Technical Machine card attached to your Pokémon to your hand. This power can’t be used if Mismagius is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -5564,7 +5564,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Count the number of cards in your hand. Put that many damage counters on the Defending Pokémon. You can't put more than 8 damage counters in this way."
+        "text": "Count the number of cards in your hand. Put that many damage counters on the Defending Pokémon. You can’t put more than 8 damage counters in this way."
       }
     ],
     "weaknesses": [
@@ -5591,7 +5591,7 @@
     "level": "X",
     "ability": {
       "name": "Big Appetite",
-      "text": "Once during your turn (before your attack), if Snorlax is your Active Pokémon, you may draw cards until you have 6 cards in your hand. If you do, Snorlax is now Asleep. This power can't be used if Snorlax is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Snorlax is your Active Pokémon, you may draw cards until you have 6 cards in your hand. If you do, Snorlax is now Asleep. This power can’t be used if Snorlax is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "130",
@@ -5728,7 +5728,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of an attack, including damage, done to Flying Pikachu during your opponent's next turn."
+        "text": "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of an attack, including damage, done to Flying Pikachu during your opponent’s next turn."
       }
     ],
     "resistances": [
@@ -5796,7 +5796,7 @@
     "level": "46",
     "ability": {
       "name": "Fan Shift",
-      "text": "Once during your turn (before your attack), you may use this power. Fan Rotom's type is Colorless until the end of your turn.",
+      "text": "Once during your turn (before your attack), you may use this power. Fan Rotom’s type is Colorless until the end of your turn.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -5856,7 +5856,7 @@
     "level": "46",
     "ability": {
       "name": "Frost Shift",
-      "text": "Once during your turn (before your attack), you may use this power. Frost Rotom's type is Water until the end of your turn.",
+      "text": "Once during your turn (before your attack), you may use this power. Frost Rotom’s type is Water until the end of your turn.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -5883,7 +5883,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "This attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Crushing Ice",
@@ -5894,7 +5894,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40+",
-        "text": "Does 40 damage plus 10 more damage for each Colorless Energy in the Defending Pokémon's Retreat Cost (after applying effects to the Retreat Cost)."
+        "text": "Does 40 damage plus 10 more damage for each Colorless Energy in the Defending Pokémon’s Retreat Cost (after applying effects to the Retreat Cost)."
       }
     ],
     "weaknesses": [
@@ -5921,7 +5921,7 @@
     "level": "46",
     "ability": {
       "name": "Heat Shift",
-      "text": "Once during your turn (before your attack), you may use this power. Heat Rotom's type is Fire until the end of your turn.",
+      "text": "Once during your turn (before your attack), you may use this power. Heat Rotom’s type is Fire until the end of your turn.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -5983,7 +5983,7 @@
     "level": "46",
     "ability": {
       "name": "Mow Shift",
-      "text": "Once during your turn (before your attack), you may use this power. Mow Rotom's type is Grass until the end of your turn.",
+      "text": "Once during your turn (before your attack), you may use this power. Mow Rotom’s type is Grass until the end of your turn.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -6020,7 +6020,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Flip a coin. If heads, discard an Energy card attached to each of your opponent's Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy card attached to each of your opponent’s Pokémon."
       }
     ],
     "weaknesses": [
@@ -6047,7 +6047,7 @@
     "level": "46",
     "ability": {
       "name": "Wash Shift",
-      "text": "Once during your turn (before your attack), you may use this power. Wash Rotom's type is Water until the end of your turn.",
+      "text": "Once during your turn (before your attack), you may use this power. Wash Rotom’s type is Water until the end of your turn.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -6082,7 +6082,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin until you get tails. For each heads, choose 1 card from your opponent's hand without looking and discard it."
+        "text": "Flip a coin until you get tails. For each heads, choose 1 card from your opponent’s hand without looking and discard it."
       }
     ],
     "weaknesses": [
@@ -6102,7 +6102,7 @@
   },
   {
     "id": "pl2-RT6",
-    "name": "Charon's Choice",
+    "name": "Charon’s Choice",
     "imageUrl": "https://images.pokemontcg.io/pl2/RT6.png",
     "subtype": "Supporter",
     "supertype": "Trainer",

--- a/json/cards/Roaring Skies.json
+++ b/json/cards/Roaring Skies.json
@@ -186,7 +186,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -210,7 +210,7 @@
     "evolvesFrom": "Silcoon",
     "ability": {
       "name": "Miraculous Scales",
-      "text": "Prevent all damage done to this Pokémon by attacks from your opponent's Pokémon-EX.",
+      "text": "Prevent all damage done to this Pokémon by attacks from your opponent’s Pokémon-EX.",
       "type": "Ability"
     },
     "hp": "130",
@@ -275,7 +275,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       },
       {
         "name": "Iron Defense",
@@ -285,7 +285,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -330,7 +330,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       },
       {
         "name": "Twilight Poison",
@@ -342,7 +342,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "Your opponent's Active Pokémon is now Asleep and Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Asleep and Poisoned."
       }
     ],
     "weaknesses": [
@@ -363,7 +363,7 @@
     "evolvesFrom": "Cascoon",
     "ancientTrait": {
       "name": "Δ Plus",
-      "text": "If your opponent's Pokémon is Knocked Out by damage from an attack of this Pokémon, take 1 more Prize card."
+      "text": "If your opponent’s Pokémon is Knocked Out by damage from an attack of this Pokémon, take 1 more Prize card."
     },
     "hp": "130",
     "retreatCost": [
@@ -397,7 +397,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 50 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 50 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -460,7 +460,7 @@
     "evolvesFrom": "Nincada",
     "ability": {
       "name": "Wing Buzz",
-      "text": "Once during your turn (before your attack), if this Pokémon is your Active Pokémon, you may discard a card from your hand. If you do, discard the top card of your opponent's deck.",
+      "text": "Once during your turn (before your attack), if this Pokémon is your Active Pokémon, you may discard a card from your hand. If you do, discard the top card of your opponent’s deck.",
       "type": "Ability"
     },
     "hp": "70",
@@ -525,7 +525,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 1 damage counter on each of your opponent's Pokémon. Switch this Pokémon with 1 of your Benched Pokémon."
+        "text": "Put 1 damage counter on each of your opponent’s Pokémon. Switch this Pokémon with 1 of your Benched Pokémon."
       },
       {
         "name": "Hopeless Scream",
@@ -631,7 +631,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -668,7 +668,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Before doing damage, discard all Pokémon Tool cards attached to your opponent's Active Pokémon."
+        "text": "Before doing damage, discard all Pokémon Tool cards attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -795,7 +795,7 @@
     "supertype": "Pokémon",
     "ancientTrait": {
       "name": "Δ Plus",
-      "text": "If your opponent's Pokémon is Knocked Out by damage from an attack of this Pokémon, take 1 more Prize card."
+      "text": "If your opponent’s Pokémon is Knocked Out by damage from an attack of this Pokémon, take 1 more Prize card."
     },
     "hp": "120",
     "retreatCost": [
@@ -819,7 +819,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Tri Edge",
@@ -926,7 +926,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Heal from this Pokémon the same amount of damage you did to your opponent's Active Pokémon."
+        "text": "Heal from this Pokémon the same amount of damage you did to your opponent’s Active Pokémon."
       },
       {
         "name": "Water Pulse",
@@ -938,7 +938,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "70",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       }
     ],
     "weaknesses": [
@@ -983,7 +983,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack during your opponent’s next turn."
       },
       {
         "name": "Electro Ball",
@@ -1041,7 +1041,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Big Explosion",
@@ -1168,7 +1168,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "This attack does 40 damage to 1 of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 40 damage to 1 of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1262,7 +1262,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 30 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Bite",
@@ -1322,7 +1322,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "Flip a coin. If heads, this attack does 30 more damage. If tails, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, this attack does 30 more damage. If tails, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Voltage Rush",
@@ -1401,7 +1401,7 @@
     "supertype": "Pokémon",
     "ancientTrait": {
       "name": "Δ Plus",
-      "text": "If your opponent's Pokémon is Knocked Out by damage from an attack of this Pokémon, take 1 more Prize card."
+      "text": "If your opponent’s Pokémon is Knocked Out by damage from an attack of this Pokémon, take 1 more Prize card."
     },
     "hp": "40",
     "retreatCost": [
@@ -1425,7 +1425,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10×",
-        "text": "This attack does 10 damage times the amount of Energy attached to your opponent's Active Pokémon."
+        "text": "This attack does 10 damage times the amount of Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -1468,7 +1468,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at the top 5 cards of either player's deck and put them back on top of that player's deck in any order."
+        "text": "Look at the top 5 cards of either player’s deck and put them back on top of that player’s deck in any order."
       },
       {
         "name": "Stressful Eye",
@@ -1517,7 +1517,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Discard a Special Energy attached to 1 of your opponent's Pokémon."
+        "text": "Discard a Special Energy attached to 1 of your opponent’s Pokémon."
       }
     ],
     "weaknesses": [
@@ -1623,7 +1623,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Your opponent can't play any Pokémon from his or her hand to evolve his or her Pokémon during his or her next turn."
+        "text": "Your opponent can’t play any Pokémon from his or her hand to evolve his or her Pokémon during his or her next turn."
       },
       {
         "name": "Curse Deeply",
@@ -1633,7 +1633,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Put 5 damage counters on your opponent's Active Pokémon."
+        "text": "Put 5 damage counters on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -1688,7 +1688,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "During your next turn, this Pokémon's Overdrive Smash attack does 60 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s Overdrive Smash attack does 60 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -1791,7 +1791,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "110",
-        "text": "This attack does 30 damage to each of your opponent's Benched Pokémon that has any damage counters on it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to each of your opponent’s Benched Pokémon that has any damage counters on it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1830,7 +1830,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed and Poisoned."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed and Poisoned."
       }
     ],
     "weaknesses": [
@@ -1873,7 +1873,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "This attack does 20 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Slash",
@@ -1923,7 +1923,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Mud-Slap",
@@ -2013,7 +2013,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Cursed Eyes",
-      "text": "When you play this Pokémon from your hand onto your Bench, you may move 3 damage counters from 1 of your opponent's Pokémon to another of his or her Pokémon.",
+      "text": "When you play this Pokémon from your hand onto your Bench, you may move 3 damage counters from 1 of your opponent’s Pokémon to another of his or her Pokémon.",
       "type": "Ability"
     },
     "hp": "100",
@@ -2038,7 +2038,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -2083,7 +2083,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose a random card from your opponent's hand. Your opponent reveals that card and shuffles it into his or her deck."
+        "text": "Choose a random card from your opponent’s hand. Your opponent reveals that card and shuffles it into his or her deck."
       },
       {
         "name": "Psybeam",
@@ -2093,7 +2093,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Confused."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -2151,7 +2151,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Discard all Energy attached to this Pokémon. The Defending Pokémon is Knocked Out at the end of your opponent's next turn."
+        "text": "Discard all Energy attached to this Pokémon. The Defending Pokémon is Knocked Out at the end of your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2317,7 +2317,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "This attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2400,7 +2400,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Jewel Armor",
-      "text": "As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's).",
+      "text": "As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent’s).",
       "type": "Ability"
     },
     "hp": "70",
@@ -2644,7 +2644,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "Flip 2 coins. If both of them are heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip 2 coins. If both of them are heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -2665,7 +2665,7 @@
     "evolvesFrom": "Dragonair",
     "ancientTrait": {
       "name": "Δ Plus",
-      "text": "If your opponent's Pokémon is Knocked Out by damage from an attack of this Pokémon, take 1 more Prize card."
+      "text": "If your opponent’s Pokémon is Knocked Out by damage from an attack of this Pokémon, take 1 more Prize card."
     },
     "hp": "160",
     "retreatCost": [
@@ -2744,7 +2744,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Shuffle your hand into your deck. Then, draw a number of cards equal to the number of Benched Pokémon (both yours and your opponent's)."
+        "text": "Shuffle your hand into your deck. Then, draw a number of cards equal to the number of Benched Pokémon (both yours and your opponent’s)."
       },
       {
         "name": "Midnight Eyes",
@@ -2754,7 +2754,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       }
     ],
     "weaknesses": [
@@ -2836,7 +2836,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Almost Flight",
@@ -2955,7 +2955,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20×",
-        "text": "This attack does 20 damage times the number of cards in your opponent's hand."
+        "text": "This attack does 20 damage times the number of cards in your opponent’s hand."
       },
       {
         "name": "Steam Blast",
@@ -3022,7 +3022,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "110",
-        "text": "Prevent all effects of your opponent's attacks, except damage, done to this Pokémon during your opponent's next turn."
+        "text": "Prevent all effects of your opponent’s attacks, except damage, done to this Pokémon during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3066,7 +3066,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Discard 2 Energy attached to this Pokémon. This attack does 120 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard 2 Energy attached to this Pokémon. This attack does 120 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3122,7 +3122,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "130",
-        "text": "Flip a coin. If tails, this Pokémon can't use Dragon Strike during your next turn."
+        "text": "Flip a coin. If tails, this Pokémon can’t use Dragon Strike during your next turn."
       }
     ],
     "weaknesses": [
@@ -3144,7 +3144,7 @@
     "evolvesFrom": "Rayquaza-EX",
     "ancientTrait": {
       "name": "Δ Wild",
-      "text": "Any damage done to this Pokémon by attacks from your opponent's Grass, Fire, Water, or Lightning Pokémon is reduced by 20 (after applying Weakness and Resistance)."
+      "text": "Any damage done to this Pokémon by attacks from your opponent’s Grass, Fire, Water, or Lightning Pokémon is reduced by 20 (after applying Weakness and Resistance)."
     },
     "hp": "230",
     "retreatCost": [
@@ -3227,7 +3227,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "This attack's damage isn't affected by any effects on your opponent's Active Pokémon."
+        "text": "This attack’s damage isn’t affected by any effects on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -3428,7 +3428,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "70",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -3523,7 +3523,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Discard the top card of your opponent's deck."
+        "text": "Discard the top card of your opponent’s deck."
       },
       {
         "name": "Rollout",
@@ -3675,7 +3675,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Aerial Ace",
@@ -3713,7 +3713,7 @@
     "evolvesFrom": "Taillow",
     "ancientTrait": {
       "name": "Δ Plus",
-      "text": "If your opponent's Pokémon is Knocked Out by damage from an attack of this Pokémon, take 1 more Prize card."
+      "text": "If your opponent’s Pokémon is Knocked Out by damage from an attack of this Pokémon, take 1 more Prize card."
     },
     "hp": "90",
     "retreatCost": [
@@ -3901,7 +3901,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "If your opponent's Active Pokémon is a Pokémon-EX, this attack does 50 more damage."
+        "text": "If your opponent’s Active Pokémon is a Pokémon-EX, this attack does 50 more damage."
       },
       {
         "name": "Dragon Pulse",
@@ -4182,7 +4182,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -4242,7 +4242,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Shuffle all cards attached to each player's Pokémon into that player's deck."
+        "text": "Shuffle all cards attached to each player’s Pokémon into that player’s deck."
       }
     ],
     "weaknesses": [
@@ -4290,7 +4290,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "During your next turn, each of this Pokémon's attacks does 80 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, each of this Pokémon’s attacks does 80 more damage (before applying Weakness and Resistance)."
       },
       {
         "name": "Sky Attack",
@@ -4567,7 +4567,7 @@
     "set": "Roaring Skies",
     "setCode": "xy6",
     "text": [
-      "Discard 2 cards from your hand. (If you can't discard 2 cards, you can't play this card.) Search your deck for a Pokémon, reveal it, and put it into your hand. Shuffle your deck afterward."
+      "Discard 2 cards from your hand. (If you can’t discard 2 cards, you can’t play this card.) Search your deck for a Pokémon, reveal it, and put it into your hand. Shuffle your deck afterward."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy6/93_hires.png"
   },
@@ -4601,7 +4601,7 @@
     "set": "Roaring Skies",
     "setCode": "xy6",
     "text": [
-      "Damage from the attacks of the Pokémon this card is attached to is affected by Weakness and Resistance for your opponent's Benched Pokémon."
+      "Damage from the attacks of the Pokémon this card is attached to is affected by Weakness and Resistance for your opponent’s Benched Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy6/95_hires.png"
   },
@@ -4671,7 +4671,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "Flip a coin. If heads, this attack does 30 more damage. If tails, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, this attack does 30 more damage. If tails, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Voltage Rush",
@@ -4791,7 +4791,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "110",
-        "text": "This attack does 30 damage to each of your opponent's Benched Pokémon that has any damage counters on it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to each of your opponent’s Benched Pokémon that has any damage counters on it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4846,7 +4846,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "110",
-        "text": "Prevent all effects of your opponent's attacks, except damage, done to this Pokémon during your opponent's next turn."
+        "text": "Prevent all effects of your opponent’s attacks, except damage, done to this Pokémon during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -4890,7 +4890,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Discard 2 Energy attached to this Pokémon. This attack does 120 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard 2 Energy attached to this Pokémon. This attack does 120 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4941,7 +4941,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "This attack's damage isn't affected by any effects on your opponent's Active Pokémon."
+        "text": "This attack’s damage isn’t affected by any effects on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -4984,7 +4984,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "If your opponent's Active Pokémon is a Pokémon-EX, this attack does 50 more damage."
+        "text": "If your opponent’s Active Pokémon is a Pokémon-EX, this attack does 50 more damage."
       },
       {
         "name": "Dragon Pulse",

--- a/json/cards/Ruby & Sapphire.json
+++ b/json/cards/Ruby & Sapphire.json
@@ -134,7 +134,7 @@
     "evolvesFrom": "Combusken",
     "ability": {
       "name": "Firestarter",
-      "text": "Once during your turn (before your attack), you may attach a Fire Energy card from your discard pile to 1 of your Benched Pokémon. This power can't be used if Blaziken is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may attach a Fire Energy card from your discard pile to 1 of your Benched Pokémon. This power can’t be used if Blaziken is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -161,7 +161,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Discard a Fire Energy card attached to Blaziken. If you do, this attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard a Fire Energy card attached to Blaziken. If you do, this attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -204,7 +204,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Choose 1 of your opponent's Benched Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Benched Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Fire Spin",
@@ -237,7 +237,7 @@
     "evolvesFrom": "Skitty",
     "ability": {
       "name": "Energy Draw",
-      "text": "Once during your turn (before your attack), you may discard 1 Energy card from your hand. Then draw up to 3 cards from your deck. This power can't be used if Delcatty is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may discard 1 Energy card from your hand. Then draw up to 3 cards from your deck. This power can’t be used if Delcatty is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -336,7 +336,7 @@
     "evolvesFrom": "Kirlia",
     "ability": {
       "name": "Psy Shadow",
-      "text": "Once during your turn (before your attack), you may search your deck for a Psychic Energy card and attach it to 1 of your Pokémon. Put 2 damage counters on that Pokémon. Shuffle your deck afterward. This power can't be used if Gardevoir is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may search your deck for a Psychic Energy card and attach it to 1 of your Pokémon. Put 2 damage counters on that Pokémon. Shuffle your deck afterward. This power can’t be used if Gardevoir is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -491,7 +491,7 @@
     "evolvesFrom": "Poochyena",
     "ability": {
       "name": "Intimidating Fang",
-      "text": "As long as Mightyena is your Active Pokémon, any damage done to your Pokémon done by an opponent's attack is reduced by 10 (before applying Weakness and Resistance).",
+      "text": "As long as Mightyena is your Active Pokémon, any damage done to your Pokémon done by an opponent’s attack is reduced by 10 (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -517,7 +517,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Flip a coin. If heads, choose 1 card from your opponent's hand without looking and discard it."
+        "text": "Flip a coin. If heads, choose 1 card from your opponent’s hand without looking and discard it."
       }
     ],
     "weaknesses": [
@@ -605,7 +605,7 @@
     "evolvesFrom": "Vigoroth",
     "ability": {
       "name": "Lazy",
-      "text": "As long as Slaking is your Active Pokémon, your opponent's Pokémon can't use any Poké-Powers.",
+      "text": "As long as Slaking is your Active Pokémon, your opponent’s Pokémon can’t use any Poké-Powers.",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -634,7 +634,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "Discard a basic Energy card attached to Slaking or this attack does nothing. Slaking can't attack during your next turn."
+        "text": "Discard a basic Energy card attached to Slaking or this attack does nothing. Slaking can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -655,7 +655,7 @@
     "evolvesFrom": "Marshtomp",
     "ability": {
       "name": "Water Call",
-      "text": "Once during your turn (before your attack), you may attach a Water Energy card from your hand to your Active Pokémon. This power can't be used if Swampert is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may attach a Water Energy card from your hand to your Active Pokémon. This power can’t be used if Swampert is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -784,7 +784,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat until the end of your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat until the end of your opponent’s next turn."
       },
       {
         "name": "Flamethrower",
@@ -940,7 +940,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If any of your opponent's Active Pokémon are Evolved Pokémon, search your deck for any 1 card and put it into your hand. Shuffle your deck afterward."
+        "text": "If any of your opponent’s Active Pokémon are Evolved Pokémon, search your deck for any 1 card and put it into your hand. Shuffle your deck afterward."
       },
       {
         "name": "Repulsion",
@@ -950,7 +950,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent returns the Defending Pokémon and all cards attached to it to his or her hand. (If your opponent doesn't have any Benched Pokémon or other Active Pokémon, this attack does nothing.)"
+        "text": "Flip a coin. If heads, your opponent returns the Defending Pokémon and all cards attached to it to his or her hand. (If your opponent doesn’t have any Benched Pokémon or other Active Pokémon, this attack does nothing.)"
       }
     ],
     "weaknesses": [
@@ -993,7 +993,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, Spit Up's base damage is 70 instead of 30, and Swallow's base damage is 60 instead of 20."
+        "text": "During your next turn, Spit Up’s base damage is 70 instead of 30, and Swallow’s base damage is 60 instead of 20."
       },
       {
         "name": "Spit Up",
@@ -1041,7 +1041,7 @@
     "evolvesFrom": "Grovyle",
     "ability": {
       "name": "Energy Trans",
-      "text": "As often as you like during your turn (before your attack), move a Grass Energy card attached to 1 of your Pokémon to another of your Pokémon. This power can't be used if Sceptile is affected by a Special Condition.",
+      "text": "As often as you like during your turn (before your attack), move a Grass Energy card attached to 1 of your Pokémon to another of your Pokémon. This power can’t be used if Sceptile is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -1112,7 +1112,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Fast Stream",
@@ -1143,7 +1143,7 @@
     "evolvesFrom": "Carvanha",
     "ability": {
       "name": "Rough Skin",
-      "text": "If Sharpedo is your Active Pokémon and is damaged by an opponent's attack (even if Sharpedo is Knocked Out), put 2 damage counters on the Attacking Pokémon.",
+      "text": "If Sharpedo is your Active Pokémon and is damaged by an opponent’s attack (even if Sharpedo is Knocked Out), put 2 damage counters on the Attacking Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -1215,7 +1215,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Waterfall",
@@ -1277,7 +1277,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Each Defending Pokémon is now Poisoned. Does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Each Defending Pokémon is now Poisoned. Does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1356,7 +1356,7 @@
     "evolvesFrom": "Wurmple",
     "ability": {
       "name": "Hard Cocoon",
-      "text": "During your opponent's turn, if Cascoon would be damaged by an opponent's attack (after applying Weakness and Resistance), flip a coin. If heads, reduce that damage by 30.",
+      "text": "During your opponent’s turn, if Cascoon would be damaged by an opponent’s attack (after applying Weakness and Resistance), flip a coin. If heads, reduce that damage by 30.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -1537,7 +1537,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "Does 30 damage plus 10 more damage for each Energy attached to Delcatty but not used to pay for this attack's Energy cost."
+        "text": "Does 30 damage plus 10 more damage for each Energy attached to Delcatty but not used to pay for this attack’s Energy cost."
       }
     ],
     "weaknesses": [
@@ -1647,7 +1647,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -1974,7 +1974,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each Benched Pokémon (both yours and your opponent’s). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "One-Two Strike",
@@ -2097,7 +2097,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Does 10 damage to 2 of your opponent's Benched Pokémon (1 if there is only 1). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 2 of your opponent’s Benched Pokémon (1 if there is only 1). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2203,7 +2203,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "This attack's damage is not affected by Resistance."
+        "text": "This attack’s damage is not affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -2285,7 +2285,7 @@
     "evolvesFrom": "Wurmple",
     "ability": {
       "name": "Hard Cocoon",
-      "text": "During your opponent's turn, if Silcoon would be damaged by an opponent's attack (after applying Weakness and Resistance), flip a coin. If heads, reduce that damage by 30.",
+      "text": "During your opponent’s turn, if Silcoon would be damaged by an opponent’s attack (after applying Weakness and Resistance), flip a coin. If heads, reduce that damage by 30.",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -2310,7 +2310,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "The Defending Pokémon can't retreat until the end of your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat until the end of your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2413,7 +2413,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Remove all damage counters from Slakoth. Slakoth can't attack during your next turn."
+        "text": "Remove all damage counters from Slakoth. Slakoth can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -2437,7 +2437,7 @@
     "evolvesFrom": "Taillow",
     "ability": {
       "name": "Drive Off",
-      "text": "Once during your turn (before your attack), if Swellow is your Active Pokémon, you may switch 1 of the Defending Pokémon with 1 of your opponent's Benched Pokémon. Your opponent picks the Benched Pokémon to switch. This power can't be used if Swellow is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Swellow is your Active Pokémon, you may switch 1 of the Defending Pokémon with 1 of your opponent’s Benched Pokémon. Your opponent picks the Benched Pokémon to switch. This power can’t be used if Swellow is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -2572,7 +2572,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "This attack does 20 damage plus 10 more damage for each Water Energy attached to Wailmer but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "This attack does 20 damage plus 10 more damage for each Water Energy attached to Wailmer but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       }
     ],
     "weaknesses": [
@@ -2614,7 +2614,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done to Aron by attacks is reduced by 10."
+        "text": "During your opponent’s next turn, any damage done to Aron by attacks is reduced by 10."
       },
       {
         "name": "Ram",
@@ -2702,7 +2702,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Rough Skin",
-      "text": "If Carvanha is your Active Pokémon and is damaged by an opponent's attack (even if Carvanha is Knocked Out), put 1 damage counter on the Attacking Pokémon.",
+      "text": "If Carvanha is your Active Pokémon and is damaged by an opponent’s attack (even if Carvanha is Knocked Out), put 1 damage counter on the Attacking Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "40",
@@ -2726,7 +2726,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "The Defending Pokémon can't retreat until the end of your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat until the end of your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3360,7 +3360,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, choose 1 card from your opponent's hand without looking and discard it."
+        "text": "Flip a coin. If heads, choose 1 card from your opponent’s hand without looking and discard it."
       },
       {
         "name": "Rear Kick",
@@ -3418,7 +3418,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "The Defending Pokémon can't retreat until the end of your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat until the end of your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3570,7 +3570,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "If Ralts and the Defending Pokémon have a different amount of Energy attached to them, this attack's base damage is 10 instead of 40."
+        "text": "If Ralts and the Defending Pokémon have a different amount of Energy attached to them, this attack’s base damage is 10 instead of 40."
       }
     ],
     "weaknesses": [
@@ -4150,7 +4150,7 @@
     "set": "Ruby & Sapphire",
     "setCode": "ex1",
     "text": [
-      "Flip a coin. If heads, choose 1 Energy card attached to 1 of your opponent's Pokémon and discard it."
+      "Flip a coin. If heads, choose 1 Energy card attached to 1 of your opponent’s Pokémon and discard it."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/80_hires.png"
   },
@@ -4168,7 +4168,7 @@
     "set": "Ruby & Sapphire",
     "setCode": "ex1",
     "text": [
-      "Flip 3 coins. For each heads, put a basic Energy card from your discard pile into your hand. If you don't have that many basic Energy cards in your discard pile, put all of them into your hand."
+      "Flip 3 coins. For each heads, put a basic Energy card from your discard pile into your hand. If you don’t have that many basic Energy cards in your discard pile, put all of them into your hand."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/81_hires.png"
   },
@@ -4224,7 +4224,7 @@
     "setCode": "ex1",
     "text": [
       "At any time between turns, if the Pokémon this card is attached to is affected by any Special Conditions, remove all of them. Then discard Lum Berry.",
-      "Attach Lum Berry to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card."
+      "Attach Lum Berry to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/84_hires.png"
   },
@@ -4243,7 +4243,7 @@
     "setCode": "ex1",
     "text": [
       "At any time between turns, if the Pokémon this card is attached to has at least 2 damage counters on it, remove 2 damage counters from it. Then, discard Oran Berry.",
-      "Attach Oran Berry to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card."
+      "Attach Oran Berry to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/85_hires.png"
   },
@@ -4387,7 +4387,7 @@
     "set": "Ruby & Sapphire",
     "setCode": "ex1",
     "text": [
-      "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect unless the Attacking Pokémon is Darkness or has Dark in its name. Darkness Energy provides Darkness Energy. (Doesn't count as a basic Energy card.)\""
+      "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect unless the Attacking Pokémon is Darkness or has Dark in its name. Darkness Energy provides Darkness Energy. (Doesn’t count as a basic Energy card.)\""
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/93_hires.png"
   },
@@ -4404,7 +4404,7 @@
     "set": "Ruby & Sapphire",
     "setCode": "ex1",
     "text": [
-      "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn't Metal. Metal Energy provides Metal. (Doesn't count as a basic Energy card)\""
+      "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn’t Metal. Metal Energy provides Metal. (Doesn’t count as a basic Energy card)\""
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/94_hires.png"
   },
@@ -4421,7 +4421,7 @@
     "set": "Ruby & Sapphire",
     "setCode": "ex1",
     "text": [
-      "Attach Rainbow Energy to 1 of your Pokémon. While in play, Rainbow Energy provides every type of Energy but provides only 1 Energy at a time. (Doesn't count as a basic Energy card when not in play.) When you attach this card from your hand to 1 of your Pokémon, put 1 damage counter on that Pokémon."
+      "Attach Rainbow Energy to 1 of your Pokémon. While in play, Rainbow Energy provides every type of Energy but provides only 1 Energy at a time. (Doesn’t count as a basic Energy card when not in play.) When you attach this card from your hand to 1 of your Pokémon, put 1 damage counter on that Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/95_hires.png"
   },
@@ -4592,7 +4592,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "The attack's damage is not affected by Resistance."
+        "text": "The attack’s damage is not affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -4637,7 +4637,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "Does 10 damage plus 10 more damage for each Energy attached to Lapras ex but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "Does 10 damage plus 10 more damage for each Energy attached to Lapras ex but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       },
       {
         "name": "Confuse Ray",
@@ -4692,7 +4692,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Super Singe",
@@ -4805,7 +4805,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Scyther ex during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Scyther ex during your opponent’s next turn."
       },
       {
         "name": "Slash",

--- a/json/cards/Sandstorm.json
+++ b/json/cards/Sandstorm.json
@@ -8,7 +8,7 @@
     "evolvesFrom": "Anorith",
     "ability": {
       "name": "Primal Veil",
-      "text": "As long as Armaldo is your Active Pokémon, each player can't play any Supporter cards.",
+      "text": "As long as Armaldo is your Active Pokémon, each player can’t play any Supporter cards.",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -57,7 +57,7 @@
     "evolvesFrom": "Cacnea",
     "ability": {
       "name": "Poison Payback",
-      "text": "If Cacturne is your Active Pokémon and is damaged by an opponent's attack (even if Cacturne is Knocked Out), the Attacking Pokémon is now Poisoned.",
+      "text": "If Cacturne is your Active Pokémon and is damaged by an opponent’s attack (even if Cacturne is Knocked Out), the Attacking Pokémon is now Poisoned.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -83,7 +83,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poke-Powers, Poke-Bodies or any other effects on that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 40 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poke-Powers, Poke-Bodies or any other effects on that Pokémon."
       }
     ],
     "weaknesses": [
@@ -104,7 +104,7 @@
     "evolvesFrom": "Lileep",
     "ability": {
       "name": "Super Suction Cups",
-      "text": "As long as Cradily is your Active Pokémon, your opponent's Pokémon can't retreat.",
+      "text": "As long as Cradily is your Active Pokémon, your opponent’s Pokémon can’t retreat.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -129,7 +129,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Before using this effect, you may switch the Defending Pokémon with 1 of your opponent's Benched Pokémon, if any. The Defending Pokémon is now Poisoned."
+        "text": "Before using this effect, you may switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon, if any. The Defending Pokémon is now Poisoned."
       },
       {
         "name": "Spiral Drain",
@@ -307,7 +307,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "You may discard all Lightning Energy cards attached to Jolteon. If you do, this attack's base damage is 70 instead of 40."
+        "text": "You may discard all Lightning Energy cards attached to Jolteon. If you do, this attack’s base damage is 70 instead of 40."
       }
     ],
     "weaknesses": [
@@ -361,7 +361,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50+",
-        "text": "Does 50 damage plus 10 more damage for each Water Energy attached to Ludicolo but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "Does 50 damage plus 10 more damage for each Water Energy attached to Ludicolo but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       }
     ],
     "weaknesses": [
@@ -381,7 +381,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Lunar Eclipse",
-      "text": "Once during your turn (before your attack), if Solrock is in play, you may use this power. Until the end of your turn, Lunatone's type is Darkness. This power can't be used if Lunatone is affected by a Special Condition.\"",
+      "text": "Once during your turn (before your attack), if Solrock is in play, you may use this power. Until the end of your turn, Lunatone’s type is Darkness. This power can’t be used if Lunatone is affected by a Special Condition.\"",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -454,7 +454,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at your opponent's hand. You may have your opponent shuffle a Supporter card you find there into his or her deck. If you do, your opponent draws a card."
+        "text": "Look at your opponent’s hand. You may have your opponent shuffle a Supporter card you find there into his or her deck. If you do, your opponent draws a card."
       },
       {
         "name": "Metal Hook",
@@ -464,7 +464,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Before doing damage, you may switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. If you do, this attack does 20 damage to the new Defending Pokémon."
+        "text": "Before doing damage, you may switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon. If you do, this attack does 20 damage to the new Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -503,7 +503,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at your opponent's hand. You may use the effect of a Supporter card you find there as the effect of this attack. (The Supporter card remains in your opponent's hand.)"
+        "text": "Look at your opponent’s hand. You may use the effect of a Supporter card you find there as the effect of this attack. (The Supporter card remains in your opponent’s hand.)"
       },
       {
         "name": "Dark Bind",
@@ -584,7 +584,7 @@
     "evolvesFrom": "Nuzleaf",
     "ability": {
       "name": "Fan Away",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, return 1 Energy card attached to the Defending Pokémon to your opponent's hand. This power can't be used if Shiftry is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, return 1 Energy card attached to the Defending Pokémon to your opponent’s hand. This power can’t be used if Shiftry is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -632,7 +632,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Solar Eclipse",
-      "text": "Once during your turn (before your attack), if Lunatone is in play, you may use this power. Until the end of your turn, Solrock's type is Fire. This power can't be used if Solrock is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Lunatone is in play, you may use this power. Until the end of your turn, Solrock’s type is Fire. This power can’t be used if Solrock is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -687,7 +687,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Poison Resistance",
-      "text": "Zangoose can't be Poisoned.",
+      "text": "Zangoose can’t be Poisoned.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -743,7 +743,7 @@
     "evolvesFrom": "Growlithe",
     "ability": {
       "name": "Fire Veil",
-      "text": "If Arcanine is your Active Pokémon and is damaged by an opponent's attack (even if Arcanine is Knocked Out), the Attacking Pokémon is now Burned.",
+      "text": "If Arcanine is your Active Pokémon and is damaged by an opponent’s attack (even if Arcanine is Knocked Out), the Attacking Pokémon is now Burned.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -820,7 +820,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20+",
-        "text": "Does 20 damage plus 10 more damage for each Energy attached to all of your opponent's Pokémon."
+        "text": "Does 20 damage plus 10 more damage for each Energy attached to all of your opponent’s Pokémon."
       }
     ],
     "weaknesses": [
@@ -841,7 +841,7 @@
     "evolvesFrom": "Psyduck",
     "ability": {
       "name": "Chaos Flash",
-      "text": "Once during your turn (before your attack), if Golduck is your Active Pokémon, you may flip a coin. If heads, the Defending Pokémon (choose 1 if there are 2) is now Confused. This power can't be used if Golduck is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Golduck is your Active Pokémon, you may flip a coin. If heads, the Defending Pokémon (choose 1 if there are 2) is now Confused. This power can’t be used if Golduck is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -886,7 +886,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Energy Variation",
-      "text": "Kecleon's type is the same as every type of basic Energy card attached to Kecleon.",
+      "text": "Kecleon’s type is the same as every type of basic Energy card attached to Kecleon.",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -962,7 +962,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "Does 30 damage plus 20 more damage for each Water Energy attached to Omastar but not used to pay for this attack's Energy cost. You can't add more than 40 damage in this way."
+        "text": "Does 30 damage plus 20 more damage for each Water Energy attached to Omastar but not used to pay for this attack’s Energy cost. You can’t add more than 40 damage in this way."
       }
     ],
     "weaknesses": [
@@ -1047,7 +1047,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Does 20 damage to each Defending Pokémon. The Defending Pokémon can't retreat until the end of your opponent's next turn."
+        "text": "Does 20 damage to each Defending Pokémon. The Defending Pokémon can’t retreat until the end of your opponent’s next turn."
       },
       {
         "name": "Earthquake",
@@ -1058,7 +1058,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1101,7 +1101,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poke-Powers, Poke-Bodies, or any other effects on that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 40 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poke-Powers, Poke-Bodies, or any other effects on that Pokémon."
       },
       {
         "name": "Slash",
@@ -1170,7 +1170,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Does 20 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1285,7 +1285,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "This attack's damage is not affected by Resistance."
+        "text": "This attack’s damage is not affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -1305,7 +1305,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Safeguard",
-      "text": "Prevent all effects of attacks, including damage, done to Wobbuffet by your opponent's Pokémon-ex.",
+      "text": "Prevent all effects of attacks, including damage, done to Wobbuffet by your opponent’s Pokémon-ex.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -1332,7 +1332,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Wobbuffet does 10 damage to itself, and don't apply Weakness and Resistance to this damage."
+        "text": "Wobbuffet does 10 damage to itself, and don’t apply Weakness and Resistance to this damage."
       }
     ],
     "weaknesses": [
@@ -1461,7 +1461,7 @@
     "evolvesFrom": "Ekans",
     "ability": {
       "name": "Intimidating Fang",
-      "text": "As long as Arbok is your Active Pokémon, any damage to your Pokémon done by an opponent's attack is reduced by 10 (before applying Weakness and Resistance).",
+      "text": "As long as Arbok is your Active Pokémon, any damage to your Pokémon done by an opponent’s attack is reduced by 10 (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -1677,7 +1677,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "This attack's damage is not affected by Resistance."
+        "text": "This attack’s damage is not affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -1729,7 +1729,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "10x",
-        "text": "Does 10 damage times the amount of basic Energy attached to all of the Active Pokémon (both yours and your opponent's)."
+        "text": "Does 10 damage times the amount of basic Energy attached to all of the Active Pokémon (both yours and your opponent’s)."
       }
     ],
     "weaknesses": [
@@ -1779,7 +1779,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 40 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1910,7 +1910,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Glowing Screen",
-      "text": "As long as Volbeat is in play, any damage done to Illumise by attacks from Fire Pokémon and Dark Pokémon is reduced by 30. You can't reduce more than 30 damage even if there is more than 1 Volbeat in play.",
+      "text": "As long as Volbeat is in play, any damage done to Illumise by attacks from Fire Pokémon and Dark Pokémon is reduced by 30. You can’t reduce more than 30 damage even if there is more than 1 Volbeat in play.",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -2055,7 +2055,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "If Kirlia and the Defending Pokémon have a different amount of Energy attached to them, this attack's base damage is 30 instead of 60."
+        "text": "If Kirlia and the Defending Pokémon have a different amount of Energy attached to them, this attack’s base damage is 30 instead of 60."
       }
     ],
     "weaknesses": [
@@ -2100,7 +2100,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Lairon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Lairon during your opponent’s next turn."
       },
       {
         "name": "Headbutt",
@@ -2216,7 +2216,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Headbutt",
@@ -2365,7 +2365,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Choose 1 card from your opponent's hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
+        "text": "Choose 1 card from your opponent’s hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
       },
       {
         "name": "Fury Swipes",
@@ -2417,7 +2417,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 card from your opponent's hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
+        "text": "Choose 1 card from your opponent’s hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
       },
       {
         "name": "Dark Mind",
@@ -2427,7 +2427,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2584,7 +2584,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "Does 30 damage plus 10 more damage for each Water Energy attached to Pelipper but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "Does 30 damage plus 10 more damage for each Water Energy attached to Pelipper but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       }
     ],
     "weaknesses": [
@@ -2686,7 +2686,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, base damage of Vigoroth's slash attack is 90 instead of 40."
+        "text": "During your next turn, base damage of Vigoroth’s slash attack is 90 instead of 40."
       },
       {
         "name": "Slash",
@@ -2720,7 +2720,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Uplifting Glow",
-      "text": "As long as Illumise is in play, Volbeat's Retreat Cost is 0.",
+      "text": "As long as Illumise is in play, Volbeat’s Retreat Cost is 0.",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -2822,7 +2822,7 @@
     "evolvesFrom": "Natu",
     "ability": {
       "name": "Healing Wind",
-      "text": "Once during your turn (before your attack), you may remove 1 damage counter from each of your Active Pokémon. This power can't be used if Xatu is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may remove 1 damage counter from each of your Active Pokémon. This power can’t be used if Xatu is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -2844,7 +2844,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Put 1 damage counter on each of your opponent's Pokémon."
+        "text": "Put 1 damage counter on each of your opponent’s Pokémon."
       }
     ],
     "weaknesses": [
@@ -2919,7 +2919,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Poison Payback",
-      "text": "If Cacnea is your Active Pokémon and is damaged by an opponent's attack (even if Cacnea is Knocked Out), the Attacking Pokémon is now Poisoned.",
+      "text": "If Cacnea is your Active Pokémon and is damaged by an opponent’s attack (even if Cacnea is Knocked Out), the Attacking Pokémon is now Poisoned.",
       "type": "Poké-Body"
     },
     "hp": "50",
@@ -3126,7 +3126,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 card from your opponent's hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
+        "text": "Choose 1 card from your opponent’s hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
       },
       {
         "name": "Confuse Ray",
@@ -3193,7 +3193,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3322,7 +3322,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Fire Veil",
-      "text": "If Growlithe is your Active Pokémon and is damaged by an opponent's attack (even if Growlithe is Knocked Out), the Attacking Pokémon is now Burned.",
+      "text": "If Growlithe is your Active Pokémon and is damaged by an opponent’s attack (even if Growlithe is Knocked Out), the Attacking Pokémon is now Burned.",
       "type": "Poké-Body"
     },
     "hp": "50",
@@ -4073,7 +4073,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Slakoth can't attack during your next turn."
+        "text": "Slakoth can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -4115,7 +4115,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Spearow during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Spearow during your opponent’s next turn."
       },
       {
         "name": "Peck",
@@ -4172,7 +4172,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "The Defending Pokémon can't retreat until the end of your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat until the end of your opponent’s next turn."
       },
       {
         "name": "Irongrip",
@@ -4373,7 +4373,7 @@
   },
   {
     "id": "ex2-87",
-    "name": "Lanette's Net Search",
+    "name": "Lanette’s Net Search",
     "imageUrl": "https://images.pokemontcg.io/ex2/87.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4410,7 +4410,7 @@
   },
   {
     "id": "ex2-89",
-    "name": "Wally's Training",
+    "name": "Wally’s Training",
     "imageUrl": "https://images.pokemontcg.io/ex2/89.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4441,8 +4441,8 @@
     "set": "Sandstorm",
     "setCode": "ex2",
     "text": [
-      "Play Claw Fossil as if it were a Basic Pokémon. While in play, Claw Fossil counts as a Colorless Pokémon (instead of a Trainer card). Claw Fossil has no attacks of its own can't retreat and can't be affected by any Special Conditions. If Claw Fossil is Knocked Out it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack you may discard Claw Fossil from play.\"",
-      "If Claw Fossil is your Active Pokémon and is damaged by an opponent's attack (even if Claw Fossil is Knocked Out), put 1 damage counter on the Attacking Pokémon."
+      "Play Claw Fossil as if it were a Basic Pokémon. While in play, Claw Fossil counts as a Colorless Pokémon (instead of a Trainer card). Claw Fossil has no attacks of its own can’t retreat and can’t be affected by any Special Conditions. If Claw Fossil is Knocked Out it doesn’t count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack you may discard Claw Fossil from play.\"",
+      "If Claw Fossil is your Active Pokémon and is damaged by an opponent’s attack (even if Claw Fossil is Knocked Out), put 1 damage counter on the Attacking Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex2/90_hires.png"
   },
@@ -4460,7 +4460,7 @@
     "set": "Sandstorm",
     "setCode": "ex2",
     "text": [
-      "Play Mysterious Fossil as if it were a Basic Pokémon. While in play, Mysterious Fossil counts as a Colorless Pokémon (instead of a Trainer card). Mysterious Fossil has no attacks of its own can't retreat and can't be affected by any Special Conditions. If Mysterious Fossil is Knocked Out it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack you may discard Mysterious Fossil from play.\""
+      "Play Mysterious Fossil as if it were a Basic Pokémon. While in play, Mysterious Fossil counts as a Colorless Pokémon (instead of a Trainer card). Mysterious Fossil has no attacks of its own can’t retreat and can’t be affected by any Special Conditions. If Mysterious Fossil is Knocked Out it doesn’t count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack you may discard Mysterious Fossil from play.\""
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex2/91_hires.png"
   },
@@ -4478,7 +4478,7 @@
     "set": "Sandstorm",
     "setCode": "ex2",
     "text": [
-      "Play Root Fossil as if it were a Basic Pokémon. While in play, Root Fossil counts as a Colorless Pokémon (instead of a Trainer card). Root Fossil has no attacks of its own can't retreat and can't be affected by any Special Conditions. If Root Fossil is Knocked Out it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack you may discard Root Fossil from play.\"",
+      "Play Root Fossil as if it were a Basic Pokémon. While in play, Root Fossil counts as a Colorless Pokémon (instead of a Trainer card). Root Fossil has no attacks of its own can’t retreat and can’t be affected by any Special Conditions. If Root Fossil is Knocked Out it doesn’t count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack you may discard Root Fossil from play.\"",
       "At any time between turns, remove 1 damage counter from Root Fossil."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex2/92_hires.png"
@@ -4496,7 +4496,7 @@
     "set": "Sandstorm",
     "setCode": "ex2",
     "text": [
-      "Attach Multi Energy to 1 of your Pokémon. While in play, Multi Energy provides every type of Energy but provides only 1 Energy at a time. (Doesn't count as a basic Energy card when not in play.) Multi Energy provides Colorless Energy when attached to a Pokémon that already has Special Energy cards attached to it.\""
+      "Attach Multi Energy to 1 of your Pokémon. While in play, Multi Energy provides every type of Energy but provides only 1 Energy at a time. (Doesn’t count as a basic Energy card when not in play.) Multi Energy provides Colorless Energy when attached to a Pokémon that already has Special Energy cards attached to it.\""
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex2/93_hires.png"
   },
@@ -4510,7 +4510,7 @@
     "evolvesFrom": "Mysterious Fossil",
     "ability": {
       "name": "Primal Lock",
-      "text": "As long as Aerodactyl ex is in play, your opponent can't play Pokémon Tool cards. Remove any Pokémon Tool cards attached to your opponent's Pokémon and put them into his or her discard pile.",
+      "text": "As long as Aerodactyl ex is in play, your opponent can’t play Pokémon Tool cards. Remove any Pokémon Tool cards attached to your opponent’s Pokémon and put them into his or her discard pile.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -4616,7 +4616,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "50",
-        "text": "Does 20 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4672,7 +4672,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Count the number of cards in your opponent's hand. Put that many damage counters on the Defending Pokémon."
+        "text": "Count the number of cards in your opponent’s hand. Put that many damage counters on the Defending Pokémon."
       },
       {
         "name": "Psystorm",
@@ -4733,7 +4733,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "40x",
-        "text": "Flip a number of coins equal to the amount of Energy attached to Kabutops ex. This attack does 40 damage times the number of heads. You can't flip more than 3 coins in this way."
+        "text": "Flip a number of coins equal to the amount of Energy attached to Kabutops ex. This attack does 40 damage times the number of heads. You can’t flip more than 3 coins in this way."
       },
       {
         "name": "Spiral Drain",
@@ -4851,7 +4851,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "The Defending Pokémon is now Burned, and can't retreat until the end of your opponent's next turn."
+        "text": "The Defending Pokémon is now Burned, and can’t retreat until the end of your opponent’s next turn."
       },
       {
         "name": "Split Blast",
@@ -4916,7 +4916,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If you don't have any Benched Pokémon, this attack does nothing. Remove 3 damage counters from Wailord ex. Switch Wailord ex with 1 of your Benched Pokémon."
+        "text": "If you don’t have any Benched Pokémon, this attack does nothing. Remove 3 damage counters from Wailord ex. Switch Wailord ex with 1 of your Benched Pokémon."
       },
       {
         "name": "Dwindling Wave",

--- a/json/cards/Secret Wonders.json
+++ b/json/cards/Secret Wonders.json
@@ -9,7 +9,7 @@
     "evolvesFrom": "Flaaffy",
     "ability": {
       "name": "Jamming",
-      "text": "After your opponent plays a Supporter card from his or her hand, put 1 damage counter on each of your opponent's Pokémon. You can't use more than 1 Jamming Poké-Body each turn.",
+      "text": "After your opponent plays a Supporter card from his or her hand, put 1 damage counter on each of your opponent’s Pokémon. You can’t use more than 1 Jamming Poké-Body each turn.",
       "type": "Poké-Body"
     },
     "hp": "130",
@@ -37,7 +37,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "You may discard all Lightning Energy attached to Ampharos. If you do, this attack does 20 damage to each of your opponent's Benched Pokémon that has any Energy cards attached to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "You may discard all Lightning Energy attached to Ampharos. If you do, this attack does 20 damage to each of your opponent’s Benched Pokémon that has any Energy cards attached to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -65,7 +65,7 @@
     "evolvesFrom": "Wartortle",
     "ability": {
       "name": "Waterlog",
-      "text": "Once during your turn (before your attack), you may attach as many basic Water Energy cards from your hand to any of your Pokémon in any way you like. If you do, your turn ends. This power can't be used if Blastoise is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may attach as many basic Water Energy cards from your hand to any of your Pokémon in any way you like. If you do, your turn ends. This power can’t be used if Blastoise is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -92,7 +92,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50+",
-        "text": "Does 50 damage plus 20 more damage for each Water Energy attached to Blastoise but not used to pay for this attack's Energy cost. You can't add more than 40 damage in this way."
+        "text": "Does 50 damage plus 20 more damage for each Water Energy attached to Blastoise but not used to pay for this attack’s Energy cost. You can’t add more than 40 damage in this way."
       }
     ],
     "weaknesses": [
@@ -114,7 +114,7 @@
     "evolvesFrom": "Charmeleon",
     "ability": {
       "name": "Fury Blaze",
-      "text": "If your opponent has 3 or less Prize cards left, each of Charizard's attacks does 50 more damage to the Active Pokémon (before applying Weakness and Resistance).",
+      "text": "If your opponent has 3 or less Prize cards left, each of Charizard’s attacks does 50 more damage to the Active Pokémon (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "130",
@@ -143,7 +143,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "Flip a coin. If heads, discard 2 Energy cards attached to Charizard. If tails, discard 4 Energy cards attached to Charizard. (If you can't, this attack does nothing.)"
+        "text": "Flip a coin. If heads, discard 2 Energy cards attached to Charizard. If tails, discard 4 Energy cards attached to Charizard. (If you can’t, this attack does nothing.)"
       }
     ],
     "weaknesses": [
@@ -170,7 +170,7 @@
     "level": "43",
     "ability": {
       "name": "Burning Coat",
-      "text": "Whenever 1 of your opponent's Pokémon is Knocked Out by damage from Entei's attacks, discard the top 3 cards from your opponent's deck.",
+      "text": "Whenever 1 of your opponent’s Pokémon is Knocked Out by damage from Entei’s attacks, discard the top 3 cards from your opponent’s deck.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -197,7 +197,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Flip a coin. If tails, discard 2 Fire Energy attached to Entei."
+        "text": "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) Flip a coin. If tails, discard 2 Fire Energy attached to Entei."
       }
     ],
     "weaknesses": [
@@ -219,7 +219,7 @@
     "evolvesFrom": "Vibrava",
     "ability": {
       "name": "Irritating Buzz",
-      "text": "As long as Flygon is your Active Pokémon, put 1 damage counter on each of your opponent's Active Pokémon between turns, excluding Fighting Pokémon.",
+      "text": "As long as Flygon is your Active Pokémon, put 1 damage counter on each of your opponent’s Active Pokémon between turns, excluding Fighting Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -327,7 +327,7 @@
     "evolvesFrom": "Kirlia",
     "ability": {
       "name": "Telepass",
-      "text": "Once during your turn (before your attack), you may search your opponent's discard pile for a Supporter card and use the effect of that card as the effect of this power. (The Supporter card remains in your opponent's discard pile.)  You can't use more than 1 Telepass Poké-Power each turn. This power can't be used if Gardevoir is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may search your opponent’s discard pile for a Supporter card and use the effect of that card as the effect of this power. (The Supporter card remains in your opponent’s discard pile.)  You can’t use more than 1 Telepass Poké-Power each turn. This power can’t be used if Gardevoir is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -354,7 +354,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "During your opponent's next turn, your opponent can't use any Poké-Powers on his or her Pokémon."
+        "text": "During your opponent’s next turn, your opponent can’t use any Poké-Powers on his or her Pokémon."
       }
     ],
     "weaknesses": [
@@ -468,7 +468,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "Put 1 damage counter on each Benched Pokémon (both yours and your opponent's)."
+        "text": "Put 1 damage counter on each Benched Pokémon (both yours and your opponent’s)."
       }
     ],
     "weaknesses": [
@@ -495,7 +495,7 @@
     "level": "45",
     "ability": {
       "name": "Phoenix Turn",
-      "text": "Once during your opponent's turn, if Ho-Oh would be Knocked Out by damage from an attack, you may flip a coin. If heads, Ho-Oh isn't discarded. Instead, remove all damage counters, Special Conditions, and other effects from Ho-Oh. Then, discard all cards attached to Ho-Oh (except for Energy cards). This counts as Ho-Oh being Knocked Out and your opponent takes a Prize card.",
+      "text": "Once during your opponent’s turn, if Ho-Oh would be Knocked Out by damage from an attack, you may flip a coin. If heads, Ho-Oh isn’t discarded. Instead, remove all damage counters, Special Conditions, and other effects from Ho-Oh. Then, discard all cards attached to Ho-Oh (except for Energy cards). This counts as Ho-Oh being Knocked Out and your opponent takes a Prize card.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -551,7 +551,7 @@
     "evolvesFrom": "Skiploom",
     "ability": {
       "name": "Cotton Spore",
-      "text": "Whenever Jumpluff would be damaged by your opponent's attack, flip a coin. If heads, prevent all damage done to Jumpluff by that attack.",
+      "text": "Whenever Jumpluff would be damaged by your opponent’s attack, flip a coin. If heads, prevent all damage done to Jumpluff by that attack.",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -573,7 +573,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip 2 coins. Choose 1 of your opponent's Pokémon. For each heads, this attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip 2 coins. Choose 1 of your opponent’s Pokémon. For each heads, this attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -624,7 +624,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. If you choose a Benched Pokémon, switch the Defending Pokémon with that Pokémon. This attack does 20 damage to the Pokémon you chose. Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
+        "text": "Choose 1 of your opponent’s Pokémon. If you choose a Benched Pokémon, switch the Defending Pokémon with that Pokémon. This attack does 20 damage to the Pokémon you chose. Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
       },
       {
         "name": "Boundless Power",
@@ -636,7 +636,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "During your next turn, Lickilicky can't attack."
+        "text": "During your next turn, Lickilicky can’t attack."
       }
     ],
     "weaknesses": [
@@ -726,7 +726,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Flip a coin. If heads, choose an Energy card attached to the Defending Pokémon and return it to your opponent's hand."
+        "text": "Flip a coin. If heads, choose an Energy card attached to the Defending Pokémon and return it to your opponent’s hand."
       },
       {
         "name": "Psychic Destruction",
@@ -737,7 +737,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "If the Defending Pokémon has any Energy cards attached to it, this attack's base damage is 40 instead of 120."
+        "text": "If the Defending Pokémon has any Energy cards attached to it, this attack’s base damage is 40 instead of 120."
       }
     ],
     "weaknesses": [
@@ -794,7 +794,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose an attack on 1 of your opponent's Pokémon in his or her discard pile. Re-creation copies that attack except for its Energy cost. (You must still do anything else required for that attack.) Mew performs that attack."
+        "text": "Choose an attack on 1 of your opponent’s Pokémon in his or her discard pile. Re-creation copies that attack except for its Energy cost. (You must still do anything else required for that attack.) Mew performs that attack."
       }
     ],
     "weaknesses": [
@@ -815,7 +815,7 @@
     "level": "42",
     "ability": {
       "name": "Thunder Rumble",
-      "text": "Once during your turn (before your attack), when you attach a Lightning Energy card from your hand to Raikou, you may put 1 damage counter on 1 of your opponent's Benched Pokémon.",
+      "text": "Once during your turn (before your attack), when you attach a Lightning Energy card from your hand to Raikou, you may put 1 damage counter on 1 of your opponent’s Benched Pokémon.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -944,7 +944,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       },
       {
         "name": "Dragon Finish",
@@ -956,7 +956,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Discard 2 basic Fire Energy cards or 2 basic Water Energy cards attached to Salamence. If you discarded 2 basic Fire Energy cards, this attack does 100 damage to the Defending Pokémon. If you discarded 2 basic Water Energy cards, this attack does 100 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (If you can't discard cards, this attack does nothing.)"
+        "text": "Discard 2 basic Fire Energy cards or 2 basic Water Energy cards attached to Salamence. If you discarded 2 basic Fire Energy cards, this attack does 100 damage to the Defending Pokémon. If you discarded 2 basic Water Energy cards, this attack does 100 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) (If you can’t discard cards, this attack does nothing.)"
       }
     ],
     "weaknesses": [
@@ -1009,7 +1009,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -1031,7 +1031,7 @@
     "evolvesFrom": "Ivysaur",
     "ability": {
       "name": "Miracle Aroma",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, choose either Asleep, Burned, or Poisoned. The Defending Pokémon is now affected by that Special Condition. This power can't be used if Venusaur is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, choose either Asleep, Burned, or Poisoned. The Defending Pokémon is now affected by that Special Condition. This power can’t be used if Venusaur is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "130",
@@ -1099,7 +1099,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose a card from your opponent's hand without looking and discard it. If you discarded a Trainer, Supporter, or Stadium card, choose 1 more card from your opponent's hand without looking and discard it."
+        "text": "Choose a card from your opponent’s hand without looking and discard it. If you discarded a Trainer, Supporter, or Stadium card, choose 1 more card from your opponent’s hand without looking and discard it."
       },
       {
         "name": "Dark Raid",
@@ -1108,7 +1108,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If you played Absol from your hand during this turn, this attack's base damage is 40 instead of 10."
+        "text": "If you played Absol from your hand during this turn, this attack’s base damage is 40 instead of 10."
       }
     ],
     "weaknesses": [
@@ -1205,7 +1205,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put as many damage counters as you like on Banette. (You can't put more than Banette's remaining HP.) Put that many damage counters on the Defending Pokémon."
+        "text": "Put as many damage counters as you like on Banette. (You can’t put more than Banette’s remaining HP.) Put that many damage counters on the Defending Pokémon."
       },
       {
         "name": "Spiteful Pain",
@@ -1260,7 +1260,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of an attack, including damage, done to Dugtrio during your opponent's next turn. If Dugtrio is your Active Pokémon at the end of your opponent's next turn, put 6 damage counters on 1 of your opponent's Benched Pokémon."
+        "text": "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of an attack, including damage, done to Dugtrio during your opponent’s next turn. If Dugtrio is your Active Pokémon at the end of your opponent’s next turn, put 6 damage counters on 1 of your opponent’s Benched Pokémon."
       },
       {
         "name": "Pit Trap",
@@ -1299,7 +1299,7 @@
     "evolvesFrom": "Electabuzz",
     "ability": {
       "name": "Motor Drive",
-      "text": "Once during your turn (before your attack), you may search your discard pile for a Lightning Energy card and attach it to Electivire. This power can't be used if Electivire is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may search your discard pile for a Lightning Energy card and attach it to Electivire. This power can’t be used if Electivire is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -1355,7 +1355,7 @@
     "evolvesFrom": "Voltorb",
     "ability": {
       "name": "Energy Shift",
-      "text": "Once during your turn, if Electrode would be Knocked Out by damage from an attack, you may use this power. Electrode isn't discarded. Instead, attach it as an Energy card to 1 of your Pokémon. While attached, this card is a Special Energy card and provides every type of Energy but provides only 1 Energy at a time. (Has no effect other than providing Energy.)",
+      "text": "Once during your turn, if Electrode would be Knocked Out by damage from an attack, you may use this power. Electrode isn’t discarded. Instead, attach it as an Energy card to 1 of your Pokémon. While attached, this card is a Special Energy card and provides every type of Energy but provides only 1 Energy at a time. (Has no effect other than providing Energy.)",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -1475,7 +1475,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can use only that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can use only that attack during your opponent’s next turn."
       },
       {
         "name": "Break Beam",
@@ -1531,7 +1531,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 2 of your opponent's Pokémon. This attack does 30 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 2 of your opponent’s Pokémon. This attack does 30 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Megaton Rock",
@@ -1543,7 +1543,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "You may do 40 damage instead of 80 to the Defending Pokémon. If you do, during your opponent's next turn, any damage done to Golem by attacks is reduced by 40 (after applying Weakness and Resistance)."
+        "text": "You may do 40 damage instead of 80 to the Defending Pokémon. If you do, during your opponent’s next turn, any damage done to Golem by attacks is reduced by 40 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -1591,7 +1591,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "If Jynx was damaged by an attack during your opponent's last turn, the Defending Pokémon is now Paralyzed."
+        "text": "If Jynx was damaged by an attack during your opponent’s last turn, the Defending Pokémon is now Paralyzed."
       },
       {
         "name": "Lovely Kiss",
@@ -1660,7 +1660,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Does 20 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1681,7 +1681,7 @@
     "level": "30",
     "ability": {
       "name": "Minus Charge",
-      "text": "Once during your turn (before your attack), if any of your Pokémon were Knocked Out during your opponent's last turn, you may draw 2 cards. You can't use more than 1 Minus Charge Poké-Power each turn. This power can't be used if Minun is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if any of your Pokémon were Knocked Out during your opponent’s last turn, you may draw 2 cards. You can’t use more than 1 Minus Charge Poké-Power each turn. This power can’t be used if Minun is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -1811,7 +1811,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "The Defending Pokémon is now Poisoned. Before doing damage, you may switch 1 of the Defending Pokémon with 1 of your opponent's Benched Pokémon. The new Defending Pokémon is now Poisoned."
+        "text": "The Defending Pokémon is now Poisoned. Before doing damage, you may switch 1 of the Defending Pokémon with 1 of your opponent’s Benched Pokémon. The new Defending Pokémon is now Poisoned."
       },
       {
         "name": "Pride Attack",
@@ -1862,7 +1862,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "If Pidgeot was damaged by an attack during your opponent's last turn, this attack does the same amount of damage done to Pidgeot to the Defending Pokémon."
+        "text": "If Pidgeot was damaged by an attack during your opponent’s last turn, this attack does the same amount of damage done to Pidgeot to the Defending Pokémon."
       },
       {
         "name": "Whirlwind",
@@ -1899,7 +1899,7 @@
     "level": "30",
     "ability": {
       "name": "Plus Charge",
-      "text": "Once during your turn (before your attack), if any of your Pokémon were Knocked Out during your opponent's last turn, you may search your discard pile for up to 2 basic Energy cards, show them to your opponent, and put them into your hand. You can't use more than 1 Plus Charge Poké-Power each turn. This power can't be used if Plusle is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if any of your Pokémon were Knocked Out during your opponent’s last turn, you may search your discard pile for up to 2 basic Energy cards, show them to your opponent, and put them into your hand. You can’t use more than 1 Plus Charge Poké-Power each turn. This power can’t be used if Plusle is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -1923,7 +1923,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "If you have Minun on your Bench, you may do 20 damage to any 1 Benched Pokémon instead. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If you have Minun on your Bench, you may do 20 damage to any 1 Benched Pokémon instead. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1951,7 +1951,7 @@
     "evolvesFrom": "Carvanha",
     "ability": {
       "name": "Rough Skin",
-      "text": "If Sharpedo is your Active Pokémon and is damaged by an opponent's attack (even if Sharpedo is Knocked Out), put 2 damage counters on the Attacking Pokémon.",
+      "text": "If Sharpedo is your Active Pokémon and is damaged by an opponent’s attack (even if Sharpedo is Knocked Out), put 2 damage counters on the Attacking Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -1974,7 +1974,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "If the Defending Pokémon has 2 or more damage counters on it, this attack does 60 damage plus 20 more damage. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
+        "text": "If the Defending Pokémon has 2 or more damage counters on it, this attack does 60 damage plus 20 more damage. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
       }
     ],
     "weaknesses": [
@@ -2002,7 +2002,7 @@
     "evolvesFrom": "Sunkern",
     "ability": {
       "name": "Grass Whistle",
-      "text": "Once during your turn (before your attack), you may remove 1 damage counter from each of your Grass Pokémon. You can't use more than 1 Grass Whistle Poké-Power each turn. This power can't be used if Sunflora is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may remove 1 damage counter from each of your Grass Pokémon. You can’t use more than 1 Grass Whistle Poké-Power each turn. This power can’t be used if Sunflora is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -2101,7 +2101,7 @@
     "evolvesFrom": "Sneasel",
     "ability": {
       "name": "Dark Engage",
-      "text": "Once during your turn (before your attack), you may use this power. Each of your Active Pokémon's type is Darkness until the end of your turn. If that Pokémon is no longer your Active Pokémon, this effect ends.",
+      "text": "Once during your turn (before your attack), you may use this power. Each of your Active Pokémon’s type is Darkness until the end of your turn. If that Pokémon is no longer your Active Pokémon, this effect ends.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -2344,7 +2344,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon plus 10 more damage for each Energy attached to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon plus 10 more damage for each Energy attached to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2404,7 +2404,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "If the Defending Pokémon's Retreat Cost is 0, this attack does 60 damage plus 60 more damage."
+        "text": "If the Defending Pokémon’s Retreat Cost is 0, this attack does 60 damage plus 60 more damage."
       }
     ],
     "weaknesses": [
@@ -2501,7 +2501,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to Cloyster by attacks during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all damage done to Cloyster by attacks during your opponent’s next turn."
       },
       {
         "name": "Spine Missile",
@@ -2511,7 +2511,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip 4 coins. For each heads, choose an opponent's Pokémon in play and this attack does 20 damage to those Pokémon. (You may choose the same Pokémon more than once.) (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip 4 coins. For each heads, choose an opponent’s Pokémon in play and this attack does 20 damage to those Pokémon. (You may choose the same Pokémon more than once.) (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2613,7 +2613,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, Farfetch'd's Leek Slap attack's base damage is 60."
+        "text": "During your next turn, Farfetch'd’s Leek Slap attack’s base damage is 60."
       },
       {
         "name": "Leek Slap",
@@ -2622,7 +2622,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "During your next turn, Farfetch'd can't use Leek Slap."
+        "text": "During your next turn, Farfetch'd can’t use Leek Slap."
       }
     ],
     "weaknesses": [
@@ -2767,7 +2767,7 @@
     "level": "28",
     "ability": {
       "name": "Camouflage",
-      "text": "If any basic Energy card attached to Kecleon is the same type as the Attacking Pokémon's type, any damage done by attacks from that Pokémon to Kecleon is reduced by 40 (after applying Weakness and Resistance).",
+      "text": "If any basic Energy card attached to Kecleon is the same type as the Attacking Pokémon’s type, any damage done by attacks from that Pokémon to Kecleon is reduced by 40 (after applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -2792,7 +2792,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "60",
-        "text": "Flip a coin. If tails, this attack does no damage to the Defending Pokémon. Instead, this attack does 20 damage to 1 of your Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If tails, this attack does no damage to the Defending Pokémon. Instead, this attack does 20 damage to 1 of your Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2844,7 +2844,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 40 damage to that Pokémon. This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -2890,7 +2890,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent can't play any Supporter cards from his or her hand during his or her next turn."
+        "text": "Flip a coin. If heads, your opponent can’t play any Supporter cards from his or her hand during his or her next turn."
       },
       {
         "name": "Absorb",
@@ -2976,7 +2976,7 @@
     "evolvesFrom": "Grimer",
     "ability": {
       "name": "Toxic Sludge",
-      "text": "At the end of each player's turn, each of your opponent's Active Pokémon that has any Grass Energy attached to it is now Poisoned. If that Pokémon is already Poisoned, Toxic Sludge Poké-Body does nothing to that Pokémon.",
+      "text": "At the end of each player’s turn, each of your opponent’s Active Pokémon that has any Grass Energy attached to it is now Poisoned. If that Pokémon is already Poisoned, Toxic Sludge Poké-Body does nothing to that Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -3003,7 +3003,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "The Defending Pokémon is now Confused and can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon is now Confused and can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3045,7 +3045,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "During your next turn, each of Nidorino's attacks does 20 more damage to the Defending Pokémon (before applying Weakness and Resistance)."
+        "text": "During your next turn, each of Nidorino’s attacks does 20 more damage to the Defending Pokémon (before applying Weakness and Resistance)."
       },
       {
         "name": "Poison Horn",
@@ -3156,7 +3156,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Power Guillotine",
@@ -3167,7 +3167,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "Flip 2 coins. If either of them is tails, this attack's base damage is 10 instead of 100."
+        "text": "Flip 2 coins. If either of them is tails, this attack’s base damage is 10 instead of 100."
       }
     ],
     "weaknesses": [
@@ -3217,7 +3217,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3414,7 +3414,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, Shelgon's Protect Charge attack's base damage is 80."
+        "text": "During your next turn, Shelgon’s Protect Charge attack’s base damage is 80."
       },
       {
         "name": "Protect Charge",
@@ -3425,7 +3425,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "During your opponent's next turn, any damage done to Shelgon by attacks is reduced by 30 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Shelgon by attacks is reduced by 30 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -3456,7 +3456,7 @@
     "evolvesFrom": "Hoppip",
     "ability": {
       "name": "Cotton Balloon",
-      "text": "If Skiploom has any Grass Energy attached to it, any damage done to Skiploom by attacks from your opponent's Evolved Pokémon is reduced by 20 (after applying Weakness and Resistance).",
+      "text": "If Skiploom has any Grass Energy attached to it, any damage done to Skiploom by attacks from your opponent’s Evolved Pokémon is reduced by 20 (after applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -3535,7 +3535,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, choose an attack on 1 of your opponent's Benched Pokémon. Trace copies that attack except for its Energy cost. (You must still do anything else required for that attack.) Smeargle performs that attack."
+        "text": "Flip a coin. If heads, choose an attack on 1 of your opponent’s Benched Pokémon. Trace copies that attack except for its Energy cost. (You must still do anything else required for that attack.) Smeargle performs that attack."
       }
     ],
     "weaknesses": [
@@ -3580,7 +3580,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, choose a Special Energy card attached to 1 of your opponent's Pokémon and have your opponent shuffle that card into his or her deck."
+        "text": "Flip a coin. If heads, choose a Special Energy card attached to 1 of your opponent’s Pokémon and have your opponent shuffle that card into his or her deck."
       }
     ],
     "weaknesses": [
@@ -3649,7 +3649,7 @@
     "level": "16",
     "ability": {
       "name": "NOD",
-      "text": "Once during your turn (before your attack), if you have Unown N, Unown O, and Unown D on your Bench, you may ask your opponent to take a Prize card. If he or she does, you take a Prize card. If he or she doesn't, draw a card.",
+      "text": "Once during your turn (before your attack), if you have Unown N, Unown O, and Unown D on your Bench, you may ask your opponent to take a Prize card. If he or she does, you take a Prize card. If he or she doesn’t, draw a card.",
       "type": "Poké-Power"
     },
     "hp": "50",
@@ -3739,7 +3739,7 @@
     "level": "11",
     "ability": {
       "name": "X-RAY",
-      "text": "Once during your turn (before your attack), if you have Unown X on your Bench, you may look at the top card of your opponent's deck and put it back on top of his or her deck.",
+      "text": "Once during your turn (before your attack), if you have Unown X on your Bench, you may look at the top card of your opponent’s deck and put it back on top of his or her deck.",
       "type": "Poké-Power"
     },
     "hp": "50",
@@ -3831,7 +3831,7 @@
     "evolvesFrom": "Venonat",
     "ability": {
       "name": "Dangerous Scales",
-      "text": "If Venomoth is your Active Pokémon and is damaged by an opponent's attack (even if Venomoth is Knocked Out), the Attacking Pokémon is now Asleep and Poisoned.",
+      "text": "If Venomoth is your Active Pokémon and is damaged by an opponent’s attack (even if Venomoth is Knocked Out), the Attacking Pokémon is now Asleep and Poisoned.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -3856,7 +3856,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "Prevent all effects of an attack, excluding damage, done to Venomoth during your opponent's next turn."
+        "text": "Prevent all effects of an attack, excluding damage, done to Venomoth during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3903,7 +3903,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Hyper Beam",
@@ -3965,7 +3965,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Wartortle can't use Giant Wave during your next turn."
+        "text": "Wartortle can’t use Giant Wave during your next turn."
       },
       {
         "name": "Shell Attack",
@@ -4285,7 +4285,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, choose a card from your opponent's hand without looking and discard it."
+        "text": "Flip a coin. If heads, choose a card from your opponent’s hand without looking and discard it."
       }
     ],
     "weaknesses": [
@@ -4344,7 +4344,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4545,7 +4545,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, choose 1 card from your opponent's hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
+        "text": "Flip a coin. If heads, choose 1 card from your opponent’s hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
       }
     ],
     "weaknesses": [
@@ -4665,7 +4665,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -5041,7 +5041,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
       }
     ],
     "weaknesses": [
@@ -5099,7 +5099,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at the top 5 cards of either player's deck and put them back on top of that player's deck in any order."
+        "text": "Look at the top 5 cards of either player’s deck and put them back on top of that player’s deck in any order."
       }
     ],
     "weaknesses": [
@@ -5259,7 +5259,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
       },
       {
         "name": "Peck",
@@ -5351,7 +5351,7 @@
     "level": "31",
     "ability": {
       "name": "Balloon Sting",
-      "text": "Once during your opponent's turn, if Qwilfish is your Active Pokémon and is damaged by an attack (even if Qwilfish is Knocked Out), you may flip a coin. If heads, the Attacking Pokémon is now Poisoned. Put 2 damage counters instead of 1 on that Pokémon between turns.",
+      "text": "Once during your opponent’s turn, if Qwilfish is your Active Pokémon and is damaged by an attack (even if Qwilfish is Knocked Out), you may flip a coin. If heads, the Attacking Pokémon is now Poisoned. Put 2 damage counters instead of 1 on that Pokémon between turns.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -5465,7 +5465,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack during your opponent’s next turn."
       },
       {
         "name": "Bite",
@@ -5767,7 +5767,7 @@
     "level": "25",
     "ability": {
       "name": "Pot Shell",
-      "text": "Prevent all effects of attacks, including damage, done to Shuckle by your opponent's Pokémon that has any Special Energy cards attached to it.",
+      "text": "Prevent all effects of attacks, including damage, done to Shuckle by your opponent’s Pokémon that has any Special Energy cards attached to it.",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -5792,7 +5792,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "The Defending Pokémon is now Poisoned. As long as the Defending Pokémon remains Poisoned by this attack, it can't use any Poké-Body."
+        "text": "The Defending Pokémon is now Poisoned. As long as the Defending Pokémon remains Poisoned by this attack, it can’t use any Poké-Body."
       }
     ],
     "weaknesses": [
@@ -5832,7 +5832,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 1 damage counter on 1 of your opponent's Pokémon."
+        "text": "Put 1 damage counter on 1 of your opponent’s Pokémon."
       },
       {
         "name": "Hang Down",
@@ -6003,7 +6003,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If the Defending Pokémon isn't an Evolved Pokémon, that Pokémon is now Confused."
+        "text": "If the Defending Pokémon isn’t an Evolved Pokémon, that Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -6101,7 +6101,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon."
+        "text": "Switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon."
       },
       {
         "name": "Sand Tomb",
@@ -6110,7 +6110,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -6279,7 +6279,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -6302,7 +6302,7 @@
   },
   {
     "id": "dp3-119",
-    "name": "Bebe's Search",
+    "name": "Bebe’s Search",
     "imageUrl": "https://images.pokemontcg.io/dp3/119.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -6314,7 +6314,7 @@
     "set": "Secret Wonders",
     "setCode": "dp3",
     "text": [
-      "Choose a card from your hand and put it on top of your deck. Search your deck for a Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward. (If this is the only card in your hand, you can't play this card.)",
+      "Choose a card from your hand and put it on top of your deck. Search your deck for a Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward. (If this is the only card in your hand, you can’t play this card.)",
       "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp3/119_hires.png"
@@ -6357,7 +6357,7 @@
   },
   {
     "id": "dp3-122",
-    "name": "Professor Oak's Visit",
+    "name": "Professor Oak’s Visit",
     "imageUrl": "https://images.pokemontcg.io/dp3/122.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -6388,7 +6388,7 @@
     "set": "Secret Wonders",
     "setCode": "dp3",
     "text": [
-      "Choose 1 card in your hand and shuffle the rest of your cards into your deck. Then, draw 4 cards. (If this is the only card in your hand, you can't play this card.)",
+      "Choose 1 card in your hand and shuffle the rest of your cards into your deck. Then, draw 4 cards. (If this is the only card in your hand, you can’t play this card.)",
       "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp3/123_hires.png"
@@ -6414,7 +6414,7 @@
   },
   {
     "id": "dp3-125",
-    "name": "Roseanne's Research",
+    "name": "Roseanne’s Research",
     "imageUrl": "https://images.pokemontcg.io/dp3/125.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -6433,7 +6433,7 @@
   },
   {
     "id": "dp3-126",
-    "name": "Team Galactic's Mars",
+    "name": "Team Galactic’s Mars",
     "imageUrl": "https://images.pokemontcg.io/dp3/126.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -6445,7 +6445,7 @@
     "set": "Secret Wonders",
     "setCode": "dp3",
     "text": [
-      "Draw 2 cards. Then, choose a card from your opponent's hand without looking and put it on the bottom of his or her deck.",
+      "Draw 2 cards. Then, choose a card from your opponent’s hand without looking and put it on the bottom of his or her deck.",
       "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp3/126_hires.png"
@@ -6499,7 +6499,7 @@
     "set": "Secret Wonders",
     "setCode": "dp3",
     "text": [
-      "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect if the Pokémon that Darkness Energy is attached to isn't Darkness. Darkness Energy provides Darkness Energy. (Doesn't count as a basic Energy card.)"
+      "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect if the Pokémon that Darkness Energy is attached to isn’t Darkness. Darkness Energy provides Darkness Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp3/129_hires.png"
   },
@@ -6516,7 +6516,7 @@
     "set": "Secret Wonders",
     "setCode": "dp3",
     "text": [
-      "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn't Metal. Metal Energy provides Metal Energy. (Doesn't count as a basic Energy card.)"
+      "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn’t Metal. Metal Energy provides Metal Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp3/130_hires.png"
   },
@@ -6529,7 +6529,7 @@
     "level": "X",
     "ability": {
       "name": "Teleportation",
-      "text": "Once during your turn (before your attack), choose 1 of your Active Pokémon or 1 of your Benched Pokémon and switch Gardevoir with that Pokémon. This power can't be used if Gardevoir is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), choose 1 of your Active Pokémon or 1 of your Benched Pokémon and switch Gardevoir with that Pokémon. This power can’t be used if Gardevoir is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "130",
@@ -6558,7 +6558,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 Pokémon (yours or your opponent's) with the fewest remaining HP (excluding Gardevoir) and that Pokémon is now Knocked Out."
+        "text": "Choose 1 Pokémon (yours or your opponent’s) with the fewest remaining HP (excluding Gardevoir) and that Pokémon is now Knocked Out."
       }
     ],
     "weaknesses": [
@@ -6599,7 +6599,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 40 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
       },
       {
         "name": "Darkness Wing",

--- a/json/cards/Shining Legends.json
+++ b/json/cards/Shining Legends.json
@@ -87,7 +87,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
-        "text": "Your opponent's Active Pokémon is now Confused and Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Confused and Poisoned."
       }
     ],
     "weaknesses": [
@@ -111,7 +111,7 @@
     "evolvesFrom": "Ivysaur",
     "ability": {
       "name": "Jungle Totem",
-      "text": "Each basic Grass Energy attached to your Pokémon provides GrassGrass Energy. You can't apply more than 1 Jungle Totem Ability at a time.",
+      "text": "Each basic Grass Energy attached to your Pokémon provides GrassGrass Energy. You can’t apply more than 1 Jungle Totem Ability at a time.",
       "type": "Ability"
     },
     "hp": "160",
@@ -225,7 +225,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Asleep. Your opponent flips 2 coins instead of 1 between turns. If either of them is tails, that Pokémon is still Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep. Your opponent flips 2 coins instead of 1 between turns. If either of them is tails, that Pokémon is still Asleep."
       },
       {
         "name": "Magnum Punch",
@@ -276,7 +276,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. The new Active Pokémon is now Poisoned."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with their Active Pokémon. The new Active Pokémon is now Poisoned."
       },
       {
         "name": "Crunch",
@@ -286,7 +286,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Discard an Energy from your opponent's Active Pokémon."
+        "text": "Discard an Energy from your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -335,7 +335,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "If any of your Pokémon were Knocked Out by damage from an opponent's attack during their last turn, this attack does 90 more damage."
+        "text": "If any of your Pokémon were Knocked Out by damage from an opponent’s attack during their last turn, this attack does 90 more damage."
       }
     ],
     "weaknesses": [
@@ -385,7 +385,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -488,7 +488,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "Your opponent's Active Pokémon is now Burned."
+        "text": "Your opponent’s Active Pokémon is now Burned."
       },
       {
         "name": "Brave Burn-GX",
@@ -499,7 +499,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 150 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 150 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -541,7 +541,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "During your next turn, this Pokémon's High-Pressure Heat attack does 50 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s High-Pressure Heat attack does 50 more damage (before applying Weakness and Resistance)."
       },
       {
         "name": "Flamethrower",
@@ -696,7 +696,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "130",
-        "text": "This Pokémon can't attack during your next turn."
+        "text": "This Pokémon can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -778,7 +778,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, discard an Energy from your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy from your opponent’s Active Pokémon."
       },
       {
         "name": "Fire Claws",
@@ -992,7 +992,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "Discard an Energy from your opponent's Active Pokémon."
+        "text": "Discard an Energy from your opponent’s Active Pokémon."
       },
       {
         "name": "Hydro Splash",
@@ -1043,7 +1043,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       },
       {
         "name": "Shocking Sting",
@@ -1053,7 +1053,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "If your opponent's Active Pokémon is affected by a Special Condition, this attack does 50 more damage."
+        "text": "If your opponent’s Active Pokémon is affected by a Special Condition, this attack does 50 more damage."
       }
     ],
     "weaknesses": [
@@ -1304,7 +1304,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "This attack does 20 more damage for each of your opponent's Benched Pokémon."
+        "text": "This attack does 20 more damage for each of your opponent’s Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -1347,7 +1347,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 50 damage to 2 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 50 damage to 2 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Quad Smash",
@@ -1474,7 +1474,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "Your opponent's Active Pokémon is now Paralyzed. (You can't use more than 1 GX attack in a game.)"
+        "text": "Your opponent’s Active Pokémon is now Paralyzed. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -1565,7 +1565,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "60",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, or any other effects on your opponent's Active Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, or any other effects on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -1721,7 +1721,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "This attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1826,7 +1826,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Poisoned."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Poisoned."
       }
     ],
     "weaknesses": [
@@ -1850,7 +1850,7 @@
     "evolvesFrom": "Ekans",
     "ability": {
       "name": "Intimidating Pattern",
-      "text": "As long as this Pokémon is your Active Pokémon, your opponent's Active Pokémon's attacks do 30 less damage (before applying Weakness and Resistance).",
+      "text": "As long as this Pokémon is your Active Pokémon, your opponent’s Active Pokémon’s attacks do 30 less damage (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "120",
@@ -1878,7 +1878,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       }
     ],
     "weaknesses": [
@@ -1917,7 +1917,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose a random card from your opponent's hand. Your opponent reveals that card and shuffles it into their deck."
+        "text": "Choose a random card from your opponent’s hand. Your opponent reveals that card and shuffles it into their deck."
       },
       {
         "name": "Feverish Kiss",
@@ -1927,7 +1927,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -1992,7 +1992,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "200",
-        "text": "This attack's damage isn't affected by any effects on your opponent's Active Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack’s damage isn’t affected by any effects on your opponent’s Active Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -2077,7 +2077,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Lagoon Flight",
@@ -2127,7 +2127,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If your opponent’s Active Pokémon is an evolved Pokémon, devolve it by putting all of the Evolution cards on it into your opponent's hand."
+        "text": "If your opponent’s Active Pokémon is an evolved Pokémon, devolve it by putting all of the Evolution cards on it into your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -2287,7 +2287,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -2335,7 +2335,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Head Bolt",
@@ -2366,7 +2366,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Cursed Whirlpool",
-      "text": "As long as this Pokémon is your Active Pokémon, your opponent's Active Pokémon can't retreat.",
+      "text": "As long as this Pokémon is your Active Pokémon, your opponent’s Active Pokémon can’t retreat.",
       "type": "Ability"
     },
     "hp": "60",
@@ -2392,7 +2392,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Put 3 damage counters on your opponent's Pokémon in any way you like."
+        "text": "Put 3 damage counters on your opponent’s Pokémon in any way you like."
       }
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm35/47_hires.png",
@@ -2484,7 +2484,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Choose 1 of your opponent's Active Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of your opponent’s Active Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Slash",
@@ -2600,7 +2600,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "If your opponent's Active Pokémon is a Basic Pokémon, this attack does 50 more damage."
+        "text": "If your opponent’s Active Pokémon is a Basic Pokémon, this attack does 50 more damage."
       },
       {
         "name": "Hammer In",
@@ -2736,7 +2736,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon's attacks and use it as this attack. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Choose 1 of your opponent’s Pokémon’s attacks and use it as this attack. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -2820,7 +2820,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Scoundrel Guard",
-      "text": "Prevent all effects of attacks, including damage, done to this Pokémon by your opponent's Pokémon-GX or Pokémon-EX.",
+      "text": "Prevent all effects of attacks, including damage, done to this Pokémon by your opponent’s Pokémon-GX or Pokémon-EX.",
       "type": "Ability"
     },
     "hp": "120",
@@ -2953,7 +2953,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "This attack does 30 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3046,7 +3046,7 @@
     "set": "Shining Legends",
     "setCode": "sm35",
     "text": [
-      "Draw cards until you have 6 cards in your hand. If it's your first turn, draw cards until you have 8 cards in your hand."
+      "Draw cards until you have 6 cards in your hand. If it’s your first turn, draw cards until you have 8 cards in your hand."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm35/62_hires.png"
   },
@@ -3063,7 +3063,7 @@
     "set": "Shining Legends",
     "setCode": "sm35",
     "text": [
-      "Draw 2 cards and heal 20 damage from your Active Pokémon. If you have no cards in your deck, you can't play this card."
+      "Draw 2 cards and heal 20 damage from your Active Pokémon. If you have no cards in your deck, you can’t play this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm35/63_hires.png"
   },
@@ -3080,7 +3080,7 @@
     "set": "Shining Legends",
     "setCode": "sm35",
     "text": [
-      "Flip a coin. If heads, switch 1 of your opponent's Benched Pokémon with their Active Pokémon."
+      "Flip a coin. If heads, switch 1 of your opponent’s Benched Pokémon with their Active Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm35/64_hires.png"
   },
@@ -3230,7 +3230,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "Your opponent's Active Pokémon is now Burned."
+        "text": "Your opponent’s Active Pokémon is now Burned."
       },
       {
         "name": "Brave Burn-GX",
@@ -3241,7 +3241,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 150 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 150 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -3306,7 +3306,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "200",
-        "text": "This attack's damage isn't affected by any effects on your opponent's Active Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack’s damage isn’t affected by any effects on your opponent’s Active Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -3331,7 +3331,7 @@
     "set": "Shining Legends",
     "setCode": "sm35",
     "text": [
-      "Draw 2 cards and heal 20 damage from your Active Pokémon. If you have no cards in your deck, you can't play this card."
+      "Draw 2 cards and heal 20 damage from your Active Pokémon. If you have no cards in your deck, you can’t play this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm35/73_hires.png"
   },
@@ -3379,7 +3379,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "Your opponent's Active Pokémon is now Burned."
+        "text": "Your opponent’s Active Pokémon is now Burned."
       },
       {
         "name": "Brave Burn-GX",
@@ -3390,7 +3390,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 150 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 150 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -3457,7 +3457,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "Your opponent's Active Pokémon is now Paralyzed. (You can't use more than 1 GX attack in a game.)"
+        "text": "Your opponent’s Active Pokémon is now Paralyzed. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -3528,7 +3528,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "200",
-        "text": "This attack's damage isn't affected by any effects on your opponent's Active Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack’s damage isn’t affected by any effects on your opponent’s Active Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -3589,7 +3589,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon's attacks and use it as this attack. (You can’t use more than 1 GX attack in a game.)"
+        "text": "Choose 1 of your opponent’s Pokémon’s attacks and use it as this attack. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -3660,7 +3660,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "200",
-        "text": "This attack's damage isn't affected by any effects on your opponent's Active Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack’s damage isn’t affected by any effects on your opponent’s Active Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [

--- a/json/cards/Skyridge.json
+++ b/json/cards/Skyridge.json
@@ -8,7 +8,7 @@
     "evolvesFrom": "Kadabra",
     "ability": {
       "name": "Energy Jump",
-      "text": "Once during your turn (before you attack) you may move an energy card from 1 of your Pokémon to another of your Pokémon. This power can't be used if Alakazam is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack) you may move an energy card from 1 of your Pokémon to another of your Pokémon. This power can’t be used if Alakazam is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -55,7 +55,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Ancient Wind",
-      "text": "Once during your turn (before you attack) if Aerodactyl is your Active Pokémon, you may ignore all Poké-Bodies until the end of your turn. This power can't be used if Aerodactyl is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack) if Aerodactyl is your Active Pokémon, you may ignore all Poké-Bodies until the end of your turn. This power can’t be used if Aerodactyl is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -159,7 +159,7 @@
     "evolvesFrom": "Kadabra",
     "ability": {
       "name": "Energy Jump",
-      "text": "Once during your turn (before you attack) you may move an energy card from 1 of your Pokémon to another of your Pokémon. This power can't be used if Alakazam is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack) you may move an energy card from 1 of your Pokémon to another of your Pokémon. This power can’t be used if Alakazam is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -206,7 +206,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Water Immunity",
-      "text": "You can't attach Water Energy cards from your hand to Articuno.",
+      "text": "You can’t attach Water Energy cards from your hand to Articuno.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -243,7 +243,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
-        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Benched Pokémon. If tails, this attack does 10 damage to each of your Pokémon in play. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent’s Benched Pokémon. If tails, this attack does 10 damage to each of your Pokémon in play. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -369,7 +369,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Water Immunity",
-      "text": "You can't attach Water Energy cards from your hand to Articuno.",
+      "text": "You can’t attach Water Energy cards from your hand to Articuno.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -406,7 +406,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
-        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Benched Pokémon. If tails, this attack does 10 damage to each of your Pokémon in play. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent’s Benched Pokémon. If tails, this attack does 10 damage to each of your Pokémon in play. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -476,7 +476,7 @@
     "evolvesFrom": "Golbat",
     "ability": {
       "name": "Carry Off",
-      "text": "Once during your turn (before you attack) you may flip a coin. If heads, look at your opponent's hand. If your opponent has and Baby Pokémon, Basic Pokémon, of Evolution cards there, choose 1 of them. Your opponent shuffles that card into his or her deck. This power can't be used if Crobat is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack) you may flip a coin. If heads, look at your opponent’s hand. If your opponent has and Baby Pokémon, Basic Pokémon, of Evolution cards there, choose 1 of them. Your opponent shuffles that card into his or her deck. This power can’t be used if Crobat is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -520,7 +520,7 @@
     "evolvesFrom": "Golbat",
     "ability": {
       "name": "Carry Off",
-      "text": "Once during your turn (before you attack) you may flip a coin. If heads, look at your opponent's hand. If your opponent has and Baby Pokémon, Basic Pokémon, of Evolution cards there, choose 1 of them. Your opponent shuffles that card into his or her deck. This power can't be used if Crobat is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack) you may flip a coin. If heads, look at your opponent’s hand. If your opponent has and Baby Pokémon, Basic Pokémon, of Evolution cards there, choose 1 of them. Your opponent shuffles that card into his or her deck. This power can’t be used if Crobat is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -585,7 +585,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent can't attach Energy cards from his or her hand to his or her Active Pokémon during his or her next turn."
+        "text": "Flip a coin. If heads, your opponent can’t attach Energy cards from his or her hand to his or her Active Pokémon during his or her next turn."
       },
       {
         "name": "Crushing Ice",
@@ -597,7 +597,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "40+",
-        "text": "This attack does 40 damage plus 10 more damage for each Energy in the Defending Pokémon's Retreat Cost. Damage is calculated using the Defending Pokémon's Retreat Cost after applying effects to the Retreat Cost."
+        "text": "This attack does 40 damage plus 10 more damage for each Energy in the Defending Pokémon’s Retreat Cost. Damage is calculated using the Defending Pokémon’s Retreat Cost after applying effects to the Retreat Cost."
       }
     ],
     "weaknesses": [
@@ -639,7 +639,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent can't attach Energy cards from his or her hand to his or her Active Pokémon during his or her next turn."
+        "text": "Flip a coin. If heads, your opponent can’t attach Energy cards from his or her hand to his or her Active Pokémon during his or her next turn."
       },
       {
         "name": "Crushing Ice",
@@ -651,7 +651,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "40+",
-        "text": "This attack does 40 damage plus 10 more damage for each Energy in the Defending Pokémon's Retreat Cost. Damage is calculated using the Defending Pokémon's Retreat Cost after applying effects to the Retreat Cost."
+        "text": "This attack does 40 damage plus 10 more damage for each Energy in the Defending Pokémon’s Retreat Cost. Damage is calculated using the Defending Pokémon’s Retreat Cost after applying effects to the Retreat Cost."
       }
     ],
     "weaknesses": [
@@ -816,7 +816,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Flip 2 coins. For each heads, do 10 damage to each of your opponent's Benched Pokémon. For each tails, do 10 damage to each of your own Benched Pokémon. (Don't apply Weakness or Resistance for Benched Pokémon.)"
+        "text": "Flip 2 coins. For each heads, do 10 damage to each of your opponent’s Benched Pokémon. For each tails, do 10 damage to each of your own Benched Pokémon. (Don’t apply Weakness or Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -930,7 +930,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Flip 2 coins. For each heads, do 10 damage to each of your opponent's Benched Pokémon. For each tails, do 10 damage to each of your own Benched Pokémon. (Don't apply Weakness or Resistance for Benched Pokémon.)"
+        "text": "Flip 2 coins. For each heads, do 10 damage to each of your opponent’s Benched Pokémon. For each tails, do 10 damage to each of your own Benched Pokémon. (Don’t apply Weakness or Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1031,7 +1031,7 @@
     ],
     "attacks": [
       {
-        "name": "Dragon's Vengeance",
+        "name": "Dragon’s Vengeance",
         "cost": [
           "Colorless",
           "Colorless",
@@ -1040,7 +1040,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "If Gyarados has 7 or more damage counters on it, this attack's base damage is 100."
+        "text": "If Gyarados has 7 or more damage counters on it, this attack’s base damage is 100."
       }
     ],
     "weaknesses": [
@@ -1092,7 +1092,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
-        "text": "This attack does 30 damage plus 20 damage times the number of your opponent's Benched Pokémon minus the number of your Benched Pokémon. (For example, if your opponent has 3 Benched Pokémon and you have 1, this attack will do 30 damage plus 40 more damage."
+        "text": "This attack does 30 damage plus 20 damage times the number of your opponent’s Benched Pokémon minus the number of your Benched Pokémon. (For example, if your opponent has 3 Benched Pokémon and you have 1, this attack will do 30 damage plus 40 more damage."
       }
     ],
     "weaknesses": [
@@ -1138,7 +1138,7 @@
     ],
     "attacks": [
       {
-        "name": "Dragon's Vengeance",
+        "name": "Dragon’s Vengeance",
         "cost": [
           "Colorless",
           "Colorless",
@@ -1147,7 +1147,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "If Gyarados has 7 or more damage counters on it, this attack's base damage is 100."
+        "text": "If Gyarados has 7 or more damage counters on it, this attack’s base damage is 100."
       }
     ],
     "weaknesses": [
@@ -1200,7 +1200,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "This attack does 10 damage to each Benched Pokémon with at least 1 Energy card attached to it (yours and your opponent's)."
+        "text": "This attack does 10 damage to each Benched Pokémon with at least 1 Energy card attached to it (yours and your opponent’s)."
       }
     ],
     "weaknesses": [
@@ -1252,7 +1252,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
-        "text": "This attack does 30 damage plus 20 damage times the number of your opponent's Benched Pokémon minus the number of your Benched Pokémon. (For example, if your opponent has 3 Benched Pokémon and you have 1, this attack will do 30 damage plus 40 more damage."
+        "text": "This attack does 30 damage plus 20 damage times the number of your opponent’s Benched Pokémon minus the number of your Benched Pokémon. (For example, if your opponent has 3 Benched Pokémon and you have 1, this attack will do 30 damage plus 40 more damage."
       }
     ],
     "weaknesses": [
@@ -1359,7 +1359,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "This attack does 10 damage to each Benched Pokémon with at least 1 Energy card attached to it (yours and your opponent's)."
+        "text": "This attack does 10 damage to each Benched Pokémon with at least 1 Energy card attached to it (yours and your opponent’s)."
       }
     ],
     "weaknesses": [
@@ -1444,7 +1444,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "During your opponent's next turn, Ledian can't become affected by a Special Condition. (Any other effect of attacks, Poké"
+        "text": "During your opponent’s next turn, Ledian can’t become affected by a Special Condition. (Any other effect of attacks, Poké"
       },
       {
         "name": "Swift",
@@ -1455,7 +1455,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -1476,7 +1476,7 @@
     "evolvesFrom": "Machoke",
     "ability": {
       "name": "Immunity",
-      "text": "Prevent all effects of your opponent's attacks done to Machamp.",
+      "text": "Prevent all effects of your opponent’s attacks done to Machamp.",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -1551,7 +1551,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "During your opponent's next turn, Ledian can't become affected by a Special Condition. (Any other effect of attacks, Poké"
+        "text": "During your opponent’s next turn, Ledian can’t become affected by a Special Condition. (Any other effect of attacks, Poké"
       },
       {
         "name": "Swift",
@@ -1562,7 +1562,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Power, Poké-Bodies, or any other effects on the Defending POkemon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Power, Poké-Bodies, or any other effects on the Defending POkemon."
       }
     ],
     "weaknesses": [
@@ -1583,7 +1583,7 @@
     "evolvesFrom": "Machoke",
     "ability": {
       "name": "Immunity",
-      "text": "Prevent all effects of your opponent's attacks done to Machamp.",
+      "text": "Prevent all effects of your opponent’s attacks done to Machamp.",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -1676,7 +1676,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "Discard a Energy card attached to Magcargo in order to use this attack. If your opponent has any Benched Pokémon, this attack does 10 damage to each of them. (Don't apply Weakness or Resistance for Benched Pokémon.)"
+        "text": "Discard a Energy card attached to Magcargo in order to use this attack. If your opponent has any Benched Pokémon, this attack does 10 damage to each of them. (Don’t apply Weakness or Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1780,7 +1780,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "Discard a Energy card attached to Magcargo in order to use this attack. If your opponent has any Benched Pokémon, this attack does 10 damage to each of them. (Don't apply Weakness or Resistance for Benched Pokémon.)"
+        "text": "Discard a Energy card attached to Magcargo in order to use this attack. If your opponent has any Benched Pokémon, this attack does 10 damage to each of them. (Don’t apply Weakness or Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1876,7 +1876,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "You may discard all Energy cards attached to Magneton when you use this attack. If you do, put damage counters equal to the amount of Energy cards removed in this way on any number of your opponent's Benched Pokémon in the way you like. (For example, if you discard 3 Energy cards, you can put 1 damage counter on 1 of your opponent's Benched Pokémon and 2 on another.)"
+        "text": "You may discard all Energy cards attached to Magneton when you use this attack. If you do, put damage counters equal to the amount of Energy cards removed in this way on any number of your opponent’s Benched Pokémon in the way you like. (For example, if you discard 3 Energy cards, you can put 1 damage counter on 1 of your opponent’s Benched Pokémon and 2 on another.)"
       }
     ],
     "weaknesses": [
@@ -1926,7 +1926,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "You may discard all Energy cards attached to Magneton when you use this attack. If you do, put damage counters equal to the amount of Energy cards removed in this way on any number of your opponent's Benched Pokémon in the way you like. (For example, if you discard 3 Energy cards, you can put 1 damage counter on 1 of your opponent's Benched Pokémon and 2 on another.)"
+        "text": "You may discard all Energy cards attached to Magneton when you use this attack. If you do, put damage counters equal to the amount of Energy cards removed in this way on any number of your opponent’s Benched Pokémon in the way you like. (For example, if you discard 3 Energy cards, you can put 1 damage counter on 1 of your opponent’s Benched Pokémon and 2 on another.)"
       }
     ],
     "weaknesses": [
@@ -1970,7 +1970,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If Magneton and the Defending Pokémon don't have the same number of Energy cards attached to them, the player controlling the Active Pokémon with the fewest number of Energy cards attached to it switches 1 of his or her Benched Pokémon with his or her Active Pokémon."
+        "text": "If Magneton and the Defending Pokémon don’t have the same number of Energy cards attached to them, the player controlling the Active Pokémon with the fewest number of Energy cards attached to it switches 1 of his or her Benched Pokémon with his or her Active Pokémon."
       },
       {
         "name": "Magnetic Wave",
@@ -1981,7 +1981,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
-        "text": "This attack does 30 damage plus 10 more damage times the number of your Benched Pokémon minus the number of your opponent's Benched Pokémon. (For example, if your opponent has 1 Benched Pokémon and you have 3, this attack will do 30 damage plus 20 more damage.)"
+        "text": "This attack does 30 damage plus 10 more damage times the number of your Benched Pokémon minus the number of your opponent’s Benched Pokémon. (For example, if your opponent has 1 Benched Pokémon and you have 3, this attack will do 30 damage plus 20 more damage.)"
       }
     ],
     "weaknesses": [
@@ -2032,7 +2032,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If Magneton and the Defending Pokémon don't have the same number of Energy cards attached to them, the player controlling the Active Pokémon with the fewest number of Energy cards attached to it switches 1 of his or her Benched Pokémon with his or her Active Pokémon."
+        "text": "If Magneton and the Defending Pokémon don’t have the same number of Energy cards attached to them, the player controlling the Active Pokémon with the fewest number of Energy cards attached to it switches 1 of his or her Benched Pokémon with his or her Active Pokémon."
       },
       {
         "name": "Magnetic Wave",
@@ -2043,7 +2043,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
-        "text": "This attack does 30 damage plus 10 more damage times the number of your Benched Pokémon minus the number of your opponent's Benched Pokémon. (For example, if your opponent has 1 Benched Pokémon and you have 3, this attack will do 30 damage plus 20 more damage.)"
+        "text": "This attack does 30 damage plus 10 more damage times the number of your Benched Pokémon minus the number of your opponent’s Benched Pokémon. (For example, if your opponent has 1 Benched Pokémon and you have 3, this attack will do 30 damage plus 20 more damage.)"
       }
     ],
     "weaknesses": [
@@ -2072,7 +2072,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Fire Immunity",
-      "text": "You can't attach R Energy cards from your hand to Moltres.",
+      "text": "You can’t attach R Energy cards from your hand to Moltres.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -2135,7 +2135,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Fire Immunity",
-      "text": "You can't attach Fire Energy cards from your hand to Moltres.",
+      "text": "You can’t attach Fire Energy cards from your hand to Moltres.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -2332,7 +2332,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "40",
-        "text": "For each Benched Pokémon (yours and your opponent's), flip a coin. If heads, this attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "For each Benched Pokémon (yours and your opponent’s), flip a coin. If heads, this attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2421,7 +2421,7 @@
     "evolvesFrom": "Omanyte",
     "ability": {
       "name": "Primal Stare",
-      "text": "As long as Omastar is your Active Pokémon, your opponent can't play Basic Pokémon or Evolution cards from his or her hand to evolve his or her Active Pokémon.",
+      "text": "As long as Omastar is your Active Pokémon, your opponent can’t play Basic Pokémon or Evolution cards from his or her hand to evolve his or her Active Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -2448,7 +2448,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2504,7 +2504,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "40",
-        "text": "For each Benched Pokémon (yours and your opponent's), flip a coin. If heads, this attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "For each Benched Pokémon (yours and your opponent’s), flip a coin. If heads, this attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2528,7 +2528,7 @@
     "evolvesFrom": "Poliwhirl",
     "ability": {
       "name": "Strange Spiral",
-      "text": "Once during your turn (before you attack), if Poliwrath if your Active Pokémon, you may discard a basic Energy card attached to Poliwrath. If you do, the Defending Pokémon is now Confused. This power can't be used if Poliwrath is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack), if Poliwrath if your Active Pokémon, you may discard a basic Energy card attached to Poliwrath. If you do, the Defending Pokémon is now Confused. This power can’t be used if Poliwrath is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -2739,7 +2739,7 @@
     "evolvesFrom": "Poliwhirl",
     "ability": {
       "name": "Strange Spiral",
-      "text": "Once during your turn (before you attack), if Poliwrath if your Active Pokémon, you may discard a basic Energy card attached to Poliwrath. If you do, the Defending Pokémon is now Confused. This power can't be used if Poliwrath is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack), if Poliwrath if your Active Pokémon, you may discard a basic Energy card attached to Poliwrath. If you do, the Defending Pokémon is now Confused. This power can’t be used if Poliwrath is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -2872,7 +2872,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "This attack does 20 damage to each Pokémon with a Poké-Body or Poké-Power (yours and your opponent's). (Don't apply Weakness or Resistance.)"
+        "text": "This attack does 20 damage to each Pokémon with a Poké-Body or Poké-Power (yours and your opponent’s). (Don’t apply Weakness or Resistance.)"
       },
       {
         "name": "Lightning Storm",
@@ -3134,7 +3134,7 @@
     "evolvesFrom": "Eevee",
     "ability": {
       "name": "Dark Gaze",
-      "text": "As long as Umbreon is your Active Pokémon, Benched Pokémon (yours and your opponent's) can't use Poké-Powers.",
+      "text": "As long as Umbreon is your Active Pokémon, Benched Pokémon (yours and your opponent’s) can’t use Poké-Powers.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -3273,7 +3273,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "If the Defending Pokémon has any Energy cards attached to it, flip a coin. If heads, choose 1 of those Energy cards and move it to 1 of your opponent's Benched Pokémon. If your opponent has no Benched Pokémon, ignore this effect."
+        "text": "If the Defending Pokémon has any Energy cards attached to it, flip a coin. If heads, choose 1 of those Energy cards and move it to 1 of your opponent’s Benched Pokémon. If your opponent has no Benched Pokémon, ignore this effect."
       }
     ],
     "weaknesses": [
@@ -3362,7 +3362,7 @@
     "evolvesFrom": "Eevee",
     "ability": {
       "name": "Dark Gaze",
-      "text": "As long as Umbreon is your Active Pokémon, Benched Pokémon (yours and your opponent's) can't use Poké-Powers.",
+      "text": "As long as Umbreon is your Active Pokémon, Benched Pokémon (yours and your opponent’s) can’t use Poké-Powers.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -3497,7 +3497,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "If the Defending Pokémon has any Energy cards attached to it, flip a coin. If heads, choose 1 of those Energy cards and move it to 1 of your opponent's Benched Pokémon. If your opponent has no Benched Pokémon, ignore this effect."
+        "text": "If the Defending Pokémon has any Energy cards attached to it, flip a coin. If heads, choose 1 of those Energy cards and move it to 1 of your opponent’s Benched Pokémon. If your opponent has no Benched Pokémon, ignore this effect."
       }
     ],
     "weaknesses": [
@@ -3518,7 +3518,7 @@
     "evolvesFrom": "Jigglypuff",
     "ability": {
       "name": "Good Neighbor",
-      "text": "Once during your turn (before you attack), if Wigglytuff is on your bench, you may flip a coin. If heads, each player removes up to 2 damage counters from his or her Active Pokémon. This power can't be used if you have already used another Wigglytuff's Good Neighbor Poké-Power this turn.",
+      "text": "Once during your turn (before you attack), if Wigglytuff is on your bench, you may flip a coin. If heads, each player removes up to 2 damage counters from his or her Active Pokémon. This power can’t be used if you have already used another Wigglytuff’s Good Neighbor Poké-Power this turn.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -3644,7 +3644,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "This attack does 20 damage to each Pokémon on each player's bench. (Don't apply Weakness and Resistance for Benched Pokémon) Electrode does 100 damage to itself."
+        "text": "This attack does 20 damage to each Pokémon on each player’s bench. (Don’t apply Weakness and Resistance for Benched Pokémon) Electrode does 100 damage to itself."
       }
     ],
     "weaknesses": [
@@ -3732,7 +3732,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, Machoke's Mega Punch attack's base damage is 80."
+        "text": "During your next turn, Machoke’s Mega Punch attack’s base damage is 80."
       },
       {
         "name": "Mega Punch",
@@ -3825,7 +3825,7 @@
     "evolvesFrom": "Hoothoot",
     "ability": {
       "name": "Investigate",
-      "text": "Once during your turn (before you attack) you may look at the top 2 cards of any player's deck or at to up 2 of any player's Prizes. Put any cards you looked at back in the same order. This power can't be used if Noctowl is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack) you may look at the top 2 cards of any player’s deck or at to up 2 of any player’s Prizes. Put any cards you looked at back in the same order. This power can’t be used if Noctowl is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -3899,7 +3899,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Before doing damage, you may choose 1 of your opponent's Benched Pokémon and switch it with the Defending Pokémon."
+        "text": "Before doing damage, you may choose 1 of your opponent’s Benched Pokémon and switch it with the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -3946,7 +3946,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads look at your opponent's hand. If he or she has any Trainer cards there, choose 1 of them. Your opponent shuffles that card into his or her deck."
+        "text": "Flip a coin. If heads look at your opponent’s hand. If he or she has any Trainer cards there, choose 1 of them. Your opponent shuffles that card into his or her deck."
       },
       {
         "name": "Lunge",
@@ -4061,7 +4061,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "This attack does 10 damage plus 20 more damage for each Energy attached to Starmie but not used to pay for this attack's energy cost. You can't add more than 40 damage in this way."
+        "text": "This attack does 10 damage plus 20 more damage for each Energy attached to Starmie but not used to pay for this attack’s energy cost. You can’t add more than 40 damage in this way."
       },
       {
         "name": "Core Blast",
@@ -4092,7 +4092,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Mirror Coat",
-      "text": "If Wobbuffet becomes Poisoned or Burned by the Defending Pokémon's attack during your opponent's turn, the Defending Pokémon becomes affected by the same Special Condition.",
+      "text": "If Wobbuffet becomes Poisoned or Burned by the Defending Pokémon’s attack during your opponent’s turn, the Defending Pokémon becomes affected by the same Special Condition.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -4227,7 +4227,7 @@
       }
     ],
     "text": [
-      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent's turn ends without an attack."
+      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent’s turn ends without an attack."
     ],
     "nationalPokedexNumber": 173,
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/48_hires.png",
@@ -4311,7 +4311,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, prevent all damage done by attacks to Diglett during your opponent's next turn. (Any other effects of attack still happen.)"
+        "text": "Flip a coin. If heads, prevent all damage done by attacks to Diglett during your opponent’s next turn. (Any other effects of attack still happen.)"
       }
     ],
     "weaknesses": [
@@ -4364,7 +4364,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. Copy copies that attack. This attack does nothing if Ditto doesn't have the Energy necessary to use that attack. (You must still do anything else required in order to use that attack.)"
+        "text": "Choose 1 of the Defending Pokémon’s attacks. Copy copies that attack. This attack does nothing if Ditto doesn’t have the Energy necessary to use that attack. (You must still do anything else required in order to use that attack.)"
       }
     ],
     "weaknesses": [
@@ -4405,7 +4405,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, prevent all damage done by attacks to Dugtrio during your opponent's next turn. (any other effects of attacks still happen.)"
+        "text": "Flip a coin. If heads, prevent all damage done by attacks to Dugtrio during your opponent’s next turn. (any other effects of attacks still happen.)"
       },
       {
         "name": "Dig Under",
@@ -4416,7 +4416,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. Don't apply Weakness or Resistance. (any other effects that would happen after applying Weakness and Resistance still happen.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. Don’t apply Weakness or Resistance. (any other effects that would happen after applying Weakness and Resistance still happen.)"
       }
     ],
     "weaknesses": [
@@ -4442,7 +4442,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Slippery Skin",
-      "text": "As long as the Defending Pokémon is an Evolved Pokémon, Dunsparce's Retreat Cost is 0.",
+      "text": "As long as the Defending Pokémon is an Evolved Pokémon, Dunsparce’s Retreat Cost is 0.",
       "type": "Poké-Body"
     },
     "hp": "40",
@@ -4626,7 +4626,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "This attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Double Spin",
@@ -4734,7 +4734,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "If Girafarig and the Defending Pokémon don't have the same number of Energy cards attached to them, this attack's base damage is 10 instead of 40."
+        "text": "If Girafarig and the Defending Pokémon don’t have the same number of Energy cards attached to them, this attack’s base damage is 10 instead of 40."
       }
     ],
     "weaknesses": [
@@ -5058,7 +5058,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "If there are 4 or more damage counters on Heracross, this attack's base damage is 50 instead of 30."
+        "text": "If there are 4 or more damage counters on Heracross, this attack’s base damage is 50 instead of 30."
       }
     ],
     "weaknesses": [
@@ -5209,7 +5209,7 @@
       }
     ],
     "text": [
-      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent's turn ends without an attack."
+      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent’s turn ends without an attack."
     ],
     "nationalPokedexNumber": 174,
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/67_hires.png",
@@ -5308,7 +5308,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Don't apply Weakness and Resistance."
+        "text": "Don’t apply Weakness and Resistance."
       }
     ],
     "weaknesses": [
@@ -5451,7 +5451,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done to Ledyba is reduced by 20."
+        "text": "During your opponent’s next turn, any damage done to Ledyba is reduced by 20."
       },
       {
         "name": "Quick Turn",
@@ -5672,7 +5672,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If the Defending Pokémon has any basic Energy cards attached to it, flip a coin. If heads, choose 1 of those Energy cards and move it to 1 of your opponent's Benched Pokémon. If your opponent has no Benched Pokémon, ignore this effect."
+        "text": "If the Defending Pokémon has any basic Energy cards attached to it, flip a coin. If heads, choose 1 of those Energy cards and move it to 1 of your opponent’s Benched Pokémon. If your opponent has no Benched Pokémon, ignore this effect."
       }
     ],
     "weaknesses": [
@@ -5726,7 +5726,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Don't apply Weakness and Resistance."
+        "text": "Don’t apply Weakness and Resistance."
       }
     ],
     "weaknesses": [
@@ -5771,7 +5771,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, look at your opponent's hand. If he or she has any Energy cards there, choose 1 of them. Your opponent shuffles that card into his or her deck."
+        "text": "Flip a coin. If heads, look at your opponent’s hand. If he or she has any Energy cards there, choose 1 of them. Your opponent shuffles that card into his or her deck."
       }
     ],
     "weaknesses": [
@@ -5813,7 +5813,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Choose 1 of your opponent's Pokémon. Put a damage counter on that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. Put a damage counter on that Pokémon."
       },
       {
         "name": "Blindside",
@@ -5823,7 +5823,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon that has a damage counter on it. This attack does 20 damage to that Pokémon. Don't apply Weakness and Resistance."
+        "text": "Choose 1 of your opponent’s Pokémon that has a damage counter on it. This attack does 20 damage to that Pokémon. Don’t apply Weakness and Resistance."
       }
     ],
     "weaknesses": [
@@ -5871,7 +5871,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at the top 3 cards of either player's deck and rearrange them as you like."
+        "text": "Look at the top 3 cards of either player’s deck and rearrange them as you like."
       },
       {
         "name": "Removal Beam",
@@ -5923,7 +5923,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Search your deck for a Basic Pokémon card named Nidoran M or Nidoran F and put it onto your Bench. Shuffle your deck afterward. (You can't use this attack if your bench is full.)"
+        "text": "Search your deck for a Basic Pokémon card named Nidoran M or Nidoran F and put it onto your Bench. Shuffle your deck afterward. (You can’t use this attack if your bench is full.)"
       },
       {
         "name": "Scratch",
@@ -6352,7 +6352,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Search your deck for a Baby Pokémon or Basic Pokémon and put it onto your bench. Shuffle your deck afterward. (You can't use this attack it your bench is full.)"
+        "text": "Search your deck for a Baby Pokémon or Basic Pokémon and put it onto your bench. Shuffle your deck afterward. (You can’t use this attack it your bench is full.)"
       },
       {
         "name": "Body Slam",
@@ -6471,7 +6471,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. Don't apply Weakness and Resistance. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. Don’t apply Weakness and Resistance. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
       }
     ],
     "weaknesses": [
@@ -6521,7 +6521,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "If your opponent has any Benched Pokémon, choose up to 2 of them. This attack does 10 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, choose up to 2 of them. This attack does 10 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Poison Needle Rush",
@@ -6851,7 +6851,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Lolling About",
-      "text": "Once during your turn (before you attack) if Snorlax is your Active Pokémon, you may remove 1 damage counter from Snorlax. Snorlax is now Asleep. This power can't be used if Snorlax is affected by a Special Condition.",
+      "text": "Once during your turn (before you attack) if Snorlax is your Active Pokémon, you may remove 1 damage counter from Snorlax. Snorlax is now Asleep. This power can’t be used if Snorlax is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -6918,7 +6918,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, until the end of your opponent's next turn the Defending Pokémon can't Retreat."
+        "text": "Flip a coin. If heads, until the end of your opponent’s next turn the Defending Pokémon can’t Retreat."
       },
       {
         "name": "Bite",
@@ -6970,7 +6970,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, look at your opponent's hand. If he or she has any Trainer cards there, choose 1 of them. Your opponent shuffles that card back into his or her deck."
+        "text": "Flip a coin. If heads, look at your opponent’s hand. If he or she has any Trainer cards there, choose 1 of them. Your opponent shuffles that card back into his or her deck."
       },
       {
         "name": "Antler Swipe",
@@ -6980,7 +6980,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, this attack does 20 damage to the Defending Pokémon (Don't apply Weakness and Resistance) If tails, your and opponent has any Benched Pokémon, choose 1 of them and this attack does 20 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 20 damage to the Defending Pokémon (Don’t apply Weakness and Resistance) If tails, your and opponent has any Benched Pokémon, choose 1 of them and this attack does 20 damage to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -7298,7 +7298,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "If your opponent has nay Benched Pokémon, flip a coin. If heads, choose 1 of them and this attack does 10 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has nay Benched Pokémon, flip a coin. If heads, choose 1 of them and this attack does 10 damage to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -7402,7 +7402,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "The Defending Pokémon can't Retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t Retreat during your opponent’s next turn."
       },
       {
         "name": "Rend",
@@ -7700,7 +7700,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Flip a coin. If heads, during your opponent's next turn prevent all effects of attacks, including damage, done to Yanma."
+        "text": "Flip a coin. If heads, during your opponent’s next turn prevent all effects of attacks, including damage, done to Yanma."
       },
       {
         "name": "Triple Smash",
@@ -7768,7 +7768,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. Don't apply Weakness and Resistance. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. Don’t apply Weakness and Resistance. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
       }
     ],
     "weaknesses": [
@@ -7854,7 +7854,7 @@
     "set": "Skyridge",
     "setCode": "ecard3",
     "text": [
-      "Once during each player's turn (before he or she attacks), if he or she has not played a Supporter card, that player may reveal his or her hand to his or her opponent. If that player reveals his or her hand and there is no Supporter card there, that player draws a card."
+      "Once during each player’s turn (before he or she attacks), if he or she has not played a Supporter card, that player may reveal his or her hand to his or her opponent. If that player reveals his or her hand and there is no Supporter card there, that player draws a card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/119_hires.png"
   },
@@ -7905,7 +7905,7 @@
     "set": "Skyridge",
     "setCode": "ecard3",
     "text": [
-      "As long as this card is attached to a Pokémon, that Pokémon's type (color) is . If that Pokémon attacks, discard this card at the end of the turn."
+      "As long as this card is attached to a Pokémon, that Pokémon’s type (color) is . If that Pokémon attacks, discard this card at the end of the turn."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/122_hires.png"
   },
@@ -7939,7 +7939,7 @@
     "set": "Skyridge",
     "setCode": "ecard3",
     "text": [
-      "Reveal cards from your deck until you reveal an Evolution card. Show that card to your opponent and put it into your hand. Shuffle the other revealed cards into your deck. (If you don't reveal an Evolution card, shuffle all the revealed cards back into your deck.)"
+      "Reveal cards from your deck until you reveal an Evolution card. Show that card to your opponent and put it into your hand. Shuffle the other revealed cards into your deck. (If you don’t reveal an Evolution card, shuffle all the revealed cards back into your deck.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/124_hires.png"
   },
@@ -7973,7 +7973,7 @@
     "set": "Skyridge",
     "setCode": "ecard3",
     "text": [
-      "Choose 1 of your opponent's Pokémon. Search your deck for a Baby Pokémon, Basic Pokémon, of Evolution card of the same type (color), show it to your opponent, and put it into your hand. Shuffle your deck afterward."
+      "Choose 1 of your opponent’s Pokémon. Search your deck for a Baby Pokémon, Basic Pokémon, of Evolution card of the same type (color), show it to your opponent, and put it into your hand. Shuffle your deck afterward."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/126_hires.png"
   },
@@ -8058,7 +8058,7 @@
     "set": "Skyridge",
     "setCode": "ecard3",
     "text": [
-      "If the Pokémon using this attack has and basic Energy cards attached to it, the Defending Pokémon is now Asleep and Poisoned. If the Pokémon using this attack has and basic Energy cards attached to it, this attack does 30 damage plus 10 more damage and lets you put 1 damage counter on each of your opponent's Benched Pokémon."
+      "If the Pokémon using this attack has and basic Energy cards attached to it, the Defending Pokémon is now Asleep and Poisoned. If the Pokémon using this attack has and basic Energy cards attached to it, this attack does 30 damage plus 10 more damage and lets you put 1 damage counter on each of your opponent’s Benched Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/131_hires.png"
   },
@@ -8075,7 +8075,7 @@
     "set": "Skyridge",
     "setCode": "ecard3",
     "text": [
-      "Whenever a player tries to Retreat a Pokémon during his or her turn, that player flips a coin. If heads, that player retreats that Pokémon (and discards Energy normally). If tails, that Pokémon can't Retreat this turn (the player doesn't discard any Energy)."
+      "Whenever a player tries to Retreat a Pokémon during his or her turn, that player flips a coin. If heads, that player retreats that Pokémon (and discards Energy normally). If tails, that Pokémon can’t Retreat this turn (the player doesn’t discard any Energy)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/132_hires.png"
   },
@@ -8126,7 +8126,7 @@
     "set": "Skyridge",
     "setCode": "ecard3",
     "text": [
-      "If your opponent has 5 or more Prizes, shuffle your hand into your deck and then draw 6 cards. If your opponent has exactly 2 Prizes, choose 1 of your opponent's Evolved Pokémon. Your opponent puts the top card on that Evolved Pokémon on the bottom of his or her deck. (This counts as devolving that Pokémon.)"
+      "If your opponent has 5 or more Prizes, shuffle your hand into your deck and then draw 6 cards. If your opponent has exactly 2 Prizes, choose 1 of your opponent’s Evolved Pokémon. Your opponent puts the top card on that Evolved Pokémon on the bottom of his or her deck. (This counts as devolving that Pokémon.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/135_hires.png"
   },
@@ -8160,7 +8160,7 @@
     "set": "Skyridge",
     "setCode": "ecard3",
     "text": [
-      "Once during each player's turn (before he or she attacks), if that player has an Evolution card in his or her hand, he or she may search his or her deck for a basic Energy card, show it to his or her opponent, and put it into his or her hand. Then that player chooses an Evolution card from his or her hand, shows it to his or her opponent, and puts it into his or her deck. That player shuffles his or her deck afterward."
+      "Once during each player’s turn (before he or she attacks), if that player has an Evolution card in his or her hand, he or she may search his or her deck for a basic Energy card, show it to his or her opponent, and put it into his or her hand. Then that player chooses an Evolution card from his or her hand, shows it to his or her opponent, and puts it into his or her deck. That player shuffles his or her deck afterward."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/137_hires.png"
   },
@@ -8228,7 +8228,7 @@
     "set": "Skyridge",
     "setCode": "ecard3",
     "text": [
-      "Once during each player's turn, that player may put an Omanyte or Kabuto card from his or her discard pile onto his or her Bench. (Cards put on the Bench in this way are considered Basic Pokémon.)"
+      "Once during each player’s turn, that player may put an Omanyte or Kabuto card from his or her discard pile onto his or her Bench. (Cards put on the Bench in this way are considered Basic Pokémon.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/141_hires.png"
   },
@@ -8291,7 +8291,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Crystal Type",
-      "text": "Whenever you attach a Grass, Water, or Psychic basic Energy card from your hand to Celebi, Celebi's type (color) becomes the same as that type of energy until the end of the turn.",
+      "text": "Whenever you attach a Grass, Water, or Psychic basic Energy card from your hand to Celebi, Celebi’s type (color) becomes the same as that type of energy until the end of the turn.",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -8316,7 +8316,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Remove 2 damage counters from Celebi and each Pokémon that's the same type (color) as Celebi."
+        "text": "Remove 2 damage counters from Celebi and each Pokémon that’s the same type (color) as Celebi."
       },
       {
         "name": "Mind Bend",
@@ -8348,7 +8348,7 @@
     "evolvesFrom": "Charmeleon",
     "ability": {
       "name": "Crystal Type",
-      "text": "Whenever you attach a Fire, Lightning, or Fighting basic Energy card from your hand to Charizard, Charizard's type (color) becomes the same as that type of energy until the end of the turn.",
+      "text": "Whenever you attach a Fire, Lightning, or Fighting basic Energy card from your hand to Charizard, Charizard’s type (color) becomes the same as that type of energy until the end of the turn.",
       "type": "Poké-Body"
     },
     "hp": "110",
@@ -8410,7 +8410,7 @@
     "evolvesFrom": "Golbat",
     "ability": {
       "name": "Crystal Type",
-      "text": "Whenever you attach a Grass, Fire, or Psychic basic Energy card from your hand to Crobat, Crobat's type (color) becomes the same as that type of energy until the end of the turn.",
+      "text": "Whenever you attach a Grass, Fire, or Psychic basic Energy card from your hand to Crobat, Crobat’s type (color) becomes the same as that type of energy until the end of the turn.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -8465,7 +8465,7 @@
     "evolvesFrom": "Graveler",
     "ability": {
       "name": "Crystal Type",
-      "text": "Whenever you attach a Grass, Fire, or Fighting basic Energy card from your hand to Golem, Golem's type (color) becomes the same as that type of energy until the end of the turn.",
+      "text": "Whenever you attach a Grass, Fire, or Fighting basic Energy card from your hand to Golem, Golem’s type (color) becomes the same as that type of energy until the end of the turn.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -8506,7 +8506,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
-        "text": "Golem does 20 damage to itself. This attack also does 10 damage to each Benched Pokémon (yours and your opponents). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Golem does 20 damage to itself. This attack also does 10 damage to each Benched Pokémon (yours and your opponents). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -8526,7 +8526,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Crystal Type",
-      "text": "Whenever you attach a Fire, Water, or Lightning basic Energy card from your hand to Ho-oh, Ho-oh's type (color) becomes the same as that type of energy until the end of the turn.",
+      "text": "Whenever you attach a Fire, Water, or Lightning basic Energy card from your hand to Ho-oh, Ho-oh’s type (color) becomes the same as that type of energy until the end of the turn.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -8586,7 +8586,7 @@
     "evolvesFrom": "Kabuto",
     "ability": {
       "name": "Crystal Type",
-      "text": "Whenever you attach a Water, Lightning, or Fighting basic Energy card from your hand to Kabutops, Kabutop's type (color) becomes the same as that type of energy until the end of the turn.",
+      "text": "Whenever you attach a Water, Lightning, or Fighting basic Energy card from your hand to Kabutops, Kabutop’s type (color) becomes the same as that type of energy until the end of the turn.",
       "type": "Poké-Body"
     },
     "hp": "90",

--- a/json/cards/Steam Siege.json
+++ b/json/cards/Steam Siege.json
@@ -225,7 +225,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with his or her Active Pokémon."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with his or her Active Pokémon."
       },
       {
         "name": "Solar Step",
@@ -337,7 +337,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50+",
-        "text": "If your opponent's Active Pokémon has a Pokémon Tool card attached to it, this attack does 70 more damage."
+        "text": "If your opponent’s Active Pokémon has a Pokémon Tool card attached to it, this attack does 70 more damage."
       }
     ],
     "weaknesses": [
@@ -385,7 +385,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, or any other effects on your opponent's Active Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, or any other effects on your opponent’s Active Pokémon."
       }
     ],
     "nationalPokedexNumber": 469,
@@ -418,7 +418,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, if this Pokémon would be Knocked Out by damage from an attack during your opponent's next turn, it is not Knocked Out and its remaining HP becomes 10 instead."
+        "text": "Flip a coin. If heads, if this Pokémon would be Knocked Out by damage from an attack during your opponent’s next turn, it is not Knocked Out and its remaining HP becomes 10 instead."
       }
     ],
     "weaknesses": [
@@ -461,7 +461,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, if this Pokémon would be damaged by an attack, prevent that attack's damage done to this Pokémon if that damage is 60 or less."
+        "text": "During your opponent’s next turn, if this Pokémon would be damaged by an attack, prevent that attack’s damage done to this Pokémon if that damage is 60 or less."
       },
       {
         "name": "Razor Leaf",
@@ -512,7 +512,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "40",
-        "text": "Until the end of your opponent's next turn, each Stadium or Pokémon Tool card in play has no effect. (This includes cards that come into play on that turn.)"
+        "text": "Until the end of your opponent’s next turn, each Stadium or Pokémon Tool card in play has no effect. (This includes cards that come into play on that turn.)"
       },
       {
         "name": "Extrasensory",
@@ -614,7 +614,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Confused and Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Confused and Poisoned."
       },
       {
         "name": "Strange Reaction",
@@ -624,7 +624,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "If your opponent's Active Pokémon is Confused, it is now Paralyzed."
+        "text": "If your opponent’s Active Pokémon is Confused, it is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -705,7 +705,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Confused. If tails, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Confused. If tails, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Power Hurricane",
@@ -1108,7 +1108,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": "Before doing damage, discard all Pokémon Tool cards attached to your opponent's Active Pokémon."
+        "text": "Before doing damage, discard all Pokémon Tool cards attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -1215,7 +1215,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Steam Up",
-      "text": "Once during your turn (before your attack), you may discard a Fire Energy card from your hand. If you do, during this turn, your Basic Fire Pokémon's attacks do 30 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
+      "text": "Once during your turn (before your attack), you may discard a Fire Energy card from your hand. If you do, during this turn, your Basic Fire Pokémon’s attacks do 30 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "180",
@@ -1243,7 +1243,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "130",
-        "text": "This Pokémon can't attack during your next turn."
+        "text": "This Pokémon can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -1387,7 +1387,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "During your opponent's next turn, the Defending Pokémon's attacks cost Colorless more, and its Retreat Cost is Colorless more."
+        "text": "During your opponent’s next turn, the Defending Pokémon’s attacks cost Colorless more, and its Retreat Cost is Colorless more."
       },
       {
         "name": "Water Pulse",
@@ -1398,7 +1398,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       }
     ],
     "weaknesses": [
@@ -1528,7 +1528,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "If the damage from this attack reduces your opponent's Active Pokémon's HP to 60 or less, that Pokémon is Knocked Out."
+        "text": "If the damage from this attack reduces your opponent’s Active Pokémon’s HP to 60 or less, that Pokémon is Knocked Out."
       },
       {
         "name": "Pike",
@@ -1539,7 +1539,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1669,7 +1669,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn. During your next turn, any damage done to that Pokémon by attacks is increased by 120 (after applying Weakness and Resistance)."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn. During your next turn, any damage done to that Pokémon by attacks is increased by 120 (after applying Weakness and Resistance)."
       }
     ],
     "nationalPokedexNumber": 693,
@@ -1760,7 +1760,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Melting Floe",
@@ -1771,7 +1771,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Discard the top 3 cards of your deck. For each Water Energy card you discarded in this way, discard the top 3 cards of your opponent's deck."
+        "text": "Discard the top 3 cards of your deck. For each Water Energy card you discarded in this way, discard the top 3 cards of your opponent’s deck."
       }
     ],
     "weaknesses": [
@@ -1810,7 +1810,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Tackle",
@@ -1881,7 +1881,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -1911,7 +1911,7 @@
     "evolvesFrom": "Flaaffy",
     "ability": {
       "name": "Shocking Light",
-      "text": "Once during your turn (before your attack), you may put 3 damage counters on 1 of your opponent's Pokémon-EX.",
+      "text": "Once during your turn (before your attack), you may put 3 damage counters on 1 of your opponent’s Pokémon-EX.",
       "type": "Ability"
     },
     "hp": "140",
@@ -1938,7 +1938,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80+",
-        "text": "Flip a coin. If heads, this attack does 40 more damage. If tails, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, this attack does 40 more damage. If tails, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -2026,7 +2026,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 30 damage to 2 of your opponent's Pokémon. Also apply Weakness and Resistance for Benched Pokémon."
+        "text": "This attack does 30 damage to 2 of your opponent’s Pokémon. Also apply Weakness and Resistance for Benched Pokémon."
       },
       {
         "name": "Electroweb",
@@ -2035,7 +2035,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2173,8 +2173,8 @@
     "supertype": "Pokémon",
     "evolvesFrom": "Nidorino",
     "ability": {
-      "name": "King's Palace",
-      "text": "Your Nidoqueen's attacks do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
+      "name": "King’s Palace",
+      "text": "Your Nidoqueen’s attacks do 20 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "150",
@@ -2242,7 +2242,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Move 1 damage counter from 1 of your Pokémon to 1 of your opponent's Pokémon."
+        "text": "Move 1 damage counter from 1 of your Pokémon to 1 of your opponent’s Pokémon."
       }
     ],
     "weaknesses": [
@@ -2292,7 +2292,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       },
       {
         "name": "Burst Curse",
@@ -2302,7 +2302,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Discard 2 Energy attached to this Pokémon. Put 8 damage counters on your opponent's Pokémon in any way you like."
+        "text": "Discard 2 Energy attached to this Pokémon. Put 8 damage counters on your opponent’s Pokémon in any way you like."
       }
     ],
     "weaknesses": [
@@ -2406,7 +2406,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       }
     ],
     "weaknesses": [
@@ -2508,7 +2508,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 20 damage to 2 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 2 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Portal Strike",
@@ -2519,7 +2519,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "130",
-        "text": "This Pokémon can't use Portal Strike during your next turn."
+        "text": "This Pokémon can’t use Portal Strike during your next turn."
       }
     ],
     "weaknesses": [
@@ -2558,7 +2558,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, this Pokémon's Flop attack's base damage is 50."
+        "text": "During your next turn, this Pokémon’s Flop attack’s base damage is 50."
       },
       {
         "name": "Flop",
@@ -2610,7 +2610,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Spirited Throw",
@@ -2620,7 +2620,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "If, before doing damage, your opponent's Active Pokémon has more remaining HP than this Pokémon, this attack does 60 more damage."
+        "text": "If, before doing damage, your opponent’s Active Pokémon has more remaining HP than this Pokémon, this attack does 60 more damage."
       }
     ],
     "weaknesses": [
@@ -2660,7 +2660,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Rolling Tackle",
@@ -2728,7 +2728,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2819,7 +2819,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "40",
-        "text": "Move an Energy from your opponent's Active Pokémon to 1 of his or her Benched Pokémon."
+        "text": "Move an Energy from your opponent’s Active Pokémon to 1 of his or her Benched Pokémon."
       },
       {
         "name": "Guard Claw",
@@ -2830,7 +2830,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 30 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 30 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -2893,7 +2893,7 @@
     "evolvesFrom": "Croagunk",
     "ability": {
       "name": "Poison Enzyme",
-      "text": "Prevent all damage done to this Pokémon by attacks from your opponent's Poisoned Pokémon.",
+      "text": "Prevent all damage done to this Pokémon by attacks from your opponent’s Poisoned Pokémon.",
       "type": "Ability"
     },
     "hp": "90",
@@ -2919,7 +2919,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Poisoned."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Poisoned."
       }
     ],
     "weaknesses": [
@@ -2958,7 +2958,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3058,7 +3058,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Damage Play",
@@ -3068,7 +3068,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Move as many damage counters on your opponent's Benched Pokémon as you like to any of your opponent's other Pokémon in any way you like."
+        "text": "Move as many damage counters on your opponent’s Benched Pokémon as you like to any of your opponent’s other Pokémon in any way you like."
       }
     ],
     "nationalPokedexNumber": 442,
@@ -3148,7 +3148,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30+",
-        "text": "If any of your Pokémon were Knocked Out by damage from an opponent's attack during his or her last turn, this attack does 60 more damage."
+        "text": "If any of your Pokémon were Knocked Out by damage from an opponent’s attack during his or her last turn, this attack does 60 more damage."
       },
       {
         "name": "Mach Claw",
@@ -3158,7 +3158,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "60",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -3219,7 +3219,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "Flip a coin. If tails, this Pokémon can't attack during your next turn."
+        "text": "Flip a coin. If tails, this Pokémon can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -3267,7 +3267,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "This attack does 30 damage to each of your opponent's Benched Pokémon that has any damage counters on it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to each of your opponent’s Benched Pokémon that has any damage counters on it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "nationalPokedexNumber": 717,
@@ -3377,7 +3377,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "160",
-        "text": "This attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3431,7 +3431,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Hammer In",
@@ -3495,7 +3495,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "During your opponent's next turn, if this Pokémon is damaged by an attack (even if this Pokémon is Knocked Out), put damage counters on the Attacking Pokémon equal to the damage done to this Pokémon."
+        "text": "During your opponent’s next turn, if this Pokémon is damaged by an attack (even if this Pokémon is Knocked Out), put damage counters on the Attacking Pokémon equal to the damage done to this Pokémon."
       },
       {
         "name": "Fortress of Rage",
@@ -3645,7 +3645,7 @@
     "evolvesFrom": "Klang",
     "ability": {
       "name": "Heavy Bumper",
-      "text": "Any damage done to this Pokémon by an opponent's attack is reduced by 10 for each Colorless in your opponent's Active Pokémon's Retreat Cost (after applying Weakness and Resistance).",
+      "text": "Any damage done to this Pokémon by an opponent’s attack is reduced by 10 for each Colorless in your opponent’s Active Pokémon’s Retreat Cost (after applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "140",
@@ -3673,7 +3673,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "During your next turn, this Pokémon's Gear Spinner attack does 70 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s Gear Spinner attack does 70 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -3719,7 +3719,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Prevent all damage done to this Pokémon by attacks from Basic Pokémon during your opponent's next turn. This Pokémon can't use Quick Guard during your next turn."
+        "text": "Prevent all damage done to this Pokémon by attacks from Basic Pokémon during your opponent’s next turn. This Pokémon can’t use Quick Guard during your next turn."
       },
       {
         "name": "Revenge Blast",
@@ -3755,7 +3755,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Mystic Heart",
-      "text": "Prevent all effects of your opponent's attacks, except damage, done to each of your Pokémon that has any Metal Energy attached to it. (Existing effects are not removed.)",
+      "text": "Prevent all effects of your opponent’s attacks, except damage, done to each of your Pokémon that has any Metal Energy attached to it. (Existing effects are not removed.)",
       "type": "Ability"
     },
     "hp": "160",
@@ -3784,7 +3784,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "During your next turn, this Pokémon's Soul Blaster attack's base damage is 60."
+        "text": "During your next turn, this Pokémon’s Soul Blaster attack’s base damage is 60."
       }
     ],
     "weaknesses": [
@@ -3942,7 +3942,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "If this Pokémon and your opponent's Active Pokémon have the same amount of Energy attached to them, this attack does 70 more damage."
+        "text": "If this Pokémon and your opponent’s Active Pokémon have the same amount of Energy attached to them, this attack does 70 more damage."
       },
       {
         "name": "Luminous Blade",
@@ -4033,7 +4033,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Wonder Lock",
-      "text": "Once during your turn (before your attack), if this Pokémon is on your Bench, you may discard all cards attached to this Pokémon and attach it to 1 of your Pokémon as a Pokémon Tool card. Prevent any damage done to the Pokémon this card is attached to by attacks from your opponent's Mega Evolution Pokémon. If this card is attached to a Pokémon, discard this card at the end of your opponent's turn.",
+      "text": "Once during your turn (before your attack), if this Pokémon is on your Bench, you may discard all cards attached to this Pokémon and attach it to 1 of your Pokémon as a Pokémon Tool card. Prevent any damage done to the Pokémon this card is attached to by attacks from your opponent’s Mega Evolution Pokémon. If this card is attached to a Pokémon, discard this card at the end of your opponent’s turn.",
       "type": "Ability"
     },
     "hp": "70",
@@ -4360,7 +4360,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 40 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 40 (before applying Weakness and Resistance)."
       },
       {
         "name": "Dark Burn",
@@ -4414,7 +4414,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "150",
-        "text": "Discard 3 Energy attached to this Pokémon. This attack does 50 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard 3 Energy attached to this Pokémon. This attack does 50 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4453,7 +4453,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "You can use this attack only if you go second, and only on your first turn. Discard an Energy attached to 1 of your opponent's Pokémon."
+        "text": "You can use this attack only if you go second, and only on your first turn. Discard an Energy attached to 1 of your opponent’s Pokémon."
       },
       {
         "name": "Scratch",
@@ -4555,7 +4555,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at the top 3 cards of your opponent's deck and put them back in any order."
+        "text": "Look at the top 3 cards of your opponent’s deck and put them back in any order."
       },
       {
         "name": "Tail Jab",
@@ -4608,7 +4608,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20+",
-        "text": "Discard the top card of your opponent's deck. If that card is an Energy card, this attack does 60 more damage."
+        "text": "Discard the top card of your opponent’s deck. If that card is an Energy card, this attack does 60 more damage."
       },
       {
         "name": "Double Hit",
@@ -4720,7 +4720,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120−",
-        "text": "This attack does 120 damage minus 20 damage for each Colorless in your opponent's Active Pokémon's Retreat Cost."
+        "text": "This attack does 120 damage minus 20 damage for each Colorless in your opponent’s Active Pokémon’s Retreat Cost."
       }
     ],
     "weaknesses": [
@@ -4964,7 +4964,7 @@
     "set": "Steam Siege",
     "setCode": "xy11",
     "text": [
-      "Your opponent reveals his or her hand. Put any number of Basic Pokémon you find there onto your opponent's Bench."
+      "Your opponent reveals his or her hand. Put any number of Basic Pokémon you find there onto your opponent’s Bench."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy11/99_hires.png"
   },
@@ -5095,7 +5095,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Steam Up",
-      "text": "Once during your turn (before your attack), you may discard a Fire Energy card from your hand. If you do, during this turn, your Basic Fire Pokémon's attacks do 30 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
+      "text": "Once during your turn (before your attack), you may discard a Fire Energy card from your hand. If you do, during this turn, your Basic Fire Pokémon’s attacks do 30 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "180",
@@ -5123,7 +5123,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "130",
-        "text": "This Pokémon can't attack during your next turn."
+        "text": "This Pokémon can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -5243,7 +5243,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "160",
-        "text": "This attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -5273,7 +5273,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Mystic Heart",
-      "text": "Prevent all effects of your opponent's attacks, except damage, done to each of your Pokémon that has any Metal Energy attached to it. (Existing effects are not removed.)",
+      "text": "Prevent all effects of your opponent’s attacks, except damage, done to each of your Pokémon that has any Metal Energy attached to it. (Existing effects are not removed.)",
       "type": "Ability"
     },
     "hp": "160",
@@ -5302,7 +5302,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "During your next turn, this Pokémon's Soul Blaster attack's base damage is 60."
+        "text": "During your next turn, this Pokémon’s Soul Blaster attack’s base damage is 60."
       }
     ],
     "weaknesses": [
@@ -5352,7 +5352,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "If this Pokémon and your opponent's Active Pokémon have the same amount of Energy attached to them, this attack does 70 more damage."
+        "text": "If this Pokémon and your opponent’s Active Pokémon have the same amount of Energy attached to them, this attack does 70 more damage."
       },
       {
         "name": "Luminous Blade",
@@ -5477,7 +5477,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Steam Up",
-      "text": "Once during your turn (before your attack), you may discard a Fire Energy card from your hand. If you do, during this turn, your Basic Fire Pokémon's attacks do 30 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
+      "text": "Once during your turn (before your attack), you may discard a Fire Energy card from your hand. If you do, during this turn, your Basic Fire Pokémon’s attacks do 30 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "180",
@@ -5505,7 +5505,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "130",
-        "text": "This Pokémon can't attack during your next turn."
+        "text": "This Pokémon can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -5553,7 +5553,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "If this Pokémon and your opponent's Active Pokémon have the same amount of Energy attached to them, this attack does 70 more damage."
+        "text": "If this Pokémon and your opponent’s Active Pokémon have the same amount of Energy attached to them, this attack does 70 more damage."
       },
       {
         "name": "Luminous Blade",

--- a/json/cards/Stormfront.json
+++ b/json/cards/Stormfront.json
@@ -9,7 +9,7 @@
     "evolvesFrom": "Dusclops",
     "ability": {
       "name": "Shadow Command",
-      "text": "Once during your turn (before your attack), you may draw 2 cards. If you have 7 or more cards in your hand, discard a number of cards until you have 6 cards in your hand. Then, put 2 damage counters on Dusknoir. This power can't be used if Dusknoir is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may draw 2 cards. If you have 7 or more cards in your hand, discard a number of cards until you have 6 cards in your hand. Then, put 2 damage counters on Dusknoir. This power can’t be used if Dusknoir is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -36,7 +36,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Count the number of damage counters on Dusknoir. Put that many damage counters on 1 of your opponent's Pokémon."
+        "text": "Count the number of damage counters on Dusknoir. Put that many damage counters on 1 of your opponent’s Pokémon."
       },
       {
         "name": "Night Spin",
@@ -47,7 +47,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Prevent all effects of an attack, including damage, done to Dusknoir by your opponent's Pokémon that has 2 or less Energy attached to it during your opponent's next turn."
+        "text": "Prevent all effects of an attack, including damage, done to Dusknoir by your opponent’s Pokémon that has 2 or less Energy attached to it during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -75,7 +75,7 @@
     "evolvesFrom": "Prinplup",
     "ability": {
       "name": "Emperor Aura",
-      "text": "Once during your turn (before your attack), when you play Empoleon from your hand to evolve 1 of your Active Pokémon, you may use this power. Your opponent can't attach any Energy cards from his or her hand to his or her Pokémon during your opponent's next turn.",
+      "text": "Once during your turn (before your attack), when you play Empoleon from your hand to evolve 1 of your Active Pokémon, you may use this power. Your opponent can’t attach any Energy cards from his or her hand to his or her Pokémon during your opponent’s next turn.",
       "type": "Poké-Power"
     },
     "hp": "130",
@@ -101,7 +101,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "During your opponent's next turn, any damage done to Empoleon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Empoleon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Whirlpool",
@@ -156,7 +156,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "60",
-        "text": "During your opponent's next turn, any damage done to Infernape by attacks is increased by 30 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Infernape by attacks is increased by 30 (after applying Weakness and Resistance)."
       },
       {
         "name": "Spreading Fire",
@@ -168,7 +168,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "Discard 2 Fire Energy attached to Infernape and this attack does 20 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard 2 Fire Energy attached to Infernape and this attack does 20 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -190,7 +190,7 @@
     "evolvesFrom": "Finneon",
     "ability": {
       "name": "Fin Luster",
-      "text": "Once during your turn (before your attack), if Lumineon is your Active Pokémon, you may look at your opponent's hand. If your opponent's Bench isn't full, choose 1 Basic Pokémon from your opponent's hand, and put it onto his or her Bench. Then, switch it with the Defending Pokémon. This power can't be used if Lumineon is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Lumineon is your Active Pokémon, you may look at your opponent’s hand. If your opponent’s Bench isn’t full, choose 1 Basic Pokémon from your opponent’s hand, and put it onto his or her Bench. Then, switch it with the Defending Pokémon. This power can’t be used if Lumineon is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -211,7 +211,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. This attack’s damage isn’t affected by Weakness or Resistance."
       },
       {
         "name": "Elegant Swim",
@@ -242,7 +242,7 @@
     "evolvesFrom": "Magneton",
     "ability": {
       "name": "Magnetic Search",
-      "text": "Once during your turn (before your attack), you may search your deck for a Lightning or Metal Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward. This power can't be used if Magnezone is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may search your deck for a Lightning or Metal Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward. This power can’t be used if Magnezone is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -268,7 +268,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
       },
       {
         "name": "Crush Volt",
@@ -307,7 +307,7 @@
     "evolvesFrom": "Magneton",
     "ability": {
       "name": "Super Connectivity",
-      "text": "Once during your turn (before your attack), you may search your discard pile for a Lightning or Metal Energy card and attach it to your Active Pokémon. Then, put 1 damage counter on that Pokémon. This power can't be used if Magnezone is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may search your discard pile for a Lightning or Metal Energy card and attach it to your Active Pokémon. Then, put 1 damage counter on that Pokémon. This power can’t be used if Magnezone is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -382,7 +382,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20x",
-        "text": "Choose up to 4 in any combination of Pokémon Tool cards and Technical Machine cards in play (both yours and your opponent's) and discard them. This attack does 20 damage times the number of cards discarded in this way."
+        "text": "Choose up to 4 in any combination of Pokémon Tool cards and Technical Machine cards in play (both yours and your opponent’s) and discard them. This attack does 20 damage times the number of cards discarded in this way."
       },
       {
         "name": "Horror Chant",
@@ -392,7 +392,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "If your opponent has 4 or more Benched Pokémon, choose 1 of them and return that Pokémon and all cards attached to it to your opponent's hand."
+        "text": "If your opponent has 4 or more Benched Pokémon, choose 1 of them and return that Pokémon and all cards attached to it to your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -436,7 +436,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Raichu can't use Slice during your next turn."
+        "text": "Raichu can’t use Slice during your next turn."
       },
       {
         "name": "Split Ball",
@@ -485,7 +485,7 @@
     "level": "47",
     "ability": {
       "name": "Regi Form",
-      "text": "If you have Regirock, Regice, and Registeel in play, the attack cost of Regigigas's attacks is Colorless less.",
+      "text": "If you have Regirock, Regice, and Registeel in play, the attack cost of Regigigas’s attacks is Colorless less.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -547,7 +547,7 @@
     "evolvesFrom": "Grovyle",
     "ability": {
       "name": "Energy Trans",
-      "text": "As often as you like during your turn (before your attack), move a Grass Energy card attached to 1 of your Pokémon to another of your Pokémon. This power can't be used if Sceptile is affected by a Special Condition.",
+      "text": "As often as you like during your turn (before your attack), move a Grass Energy card attached to 1 of your Pokémon to another of your Pokémon. This power can’t be used if Sceptile is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -652,7 +652,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "During your opponent's next turn, when your opponent puts a Basic Pokémon from his or her hand onto his or her Bench, put 2 damage counters on that Pokémon."
+        "text": "During your opponent’s next turn, when your opponent puts a Basic Pokémon from his or her hand onto his or her Bench, put 2 damage counters on that Pokémon."
       }
     ],
     "weaknesses": [
@@ -680,7 +680,7 @@
     "evolvesFrom": "Snover",
     "ability": {
       "name": "Snow Veil",
-      "text": "As long as Abomasnow is your Active Pokémon, any damage done to your Pokémon by an opponent's attack is reduced by 20 (after applying Weakness and Resistance).",
+      "text": "As long as Abomasnow is your Active Pokémon, any damage done to your Pokémon by an opponent’s attack is reduced by 20 (after applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -707,7 +707,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Does 20 damage to each of your opponent's Benched Pokémon, excluding Grass Pokémon and Water Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to each of your opponent’s Benched Pokémon, excluding Grass Pokémon and Water Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Below Zero",
@@ -740,7 +740,7 @@
     "evolvesFrom": "Bronzor",
     "ability": {
       "name": "Cycler",
-      "text": "Once during your turn (before your attack), you may choose a card from your hand and put it on top of your deck. Then, search your deck for up to 2 basic Energy cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward. This power can't be used if Bronzong is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may choose a card from your hand and put it on top of your deck. Then, search your deck for up to 2 basic Energy cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward. This power can’t be used if Bronzong is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -778,7 +778,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Put a number of damage counters on each of your opponent's Pokémon equal to the number of Colorless Energy in that Pokémon's Retreat Cost (after applying effects to the Retreat Cost)."
+        "text": "Put a number of damage counters on each of your opponent’s Pokémon equal to the number of Colorless Energy in that Pokémon’s Retreat Cost (after applying effects to the Retreat Cost)."
       }
     ],
     "weaknesses": [
@@ -806,7 +806,7 @@
     "evolvesFrom": "Cherubi",
     "ability": {
       "name": "Sunny Day",
-      "text": "Each of your Grass Pokémon and Fire Pokémon's attacks does 10 more damage to the Defending Pokémon (before applying Weakness and Resistance).",
+      "text": "Each of your Grass Pokémon and Fire Pokémon’s attacks does 10 more damage to the Defending Pokémon (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -890,7 +890,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, the Defending Pokémon is now Paralyzed. If tails, the Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon is now Paralyzed. If tails, the Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Cross Poison",
@@ -968,7 +968,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Flip a coin. If heads, the Defending Pokémon is now Confused and can't retreat during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon is now Confused and can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -996,7 +996,7 @@
     "evolvesFrom": "Dusclops",
     "ability": {
       "name": "Spirit Pulse",
-      "text": "As long as Dusknoir is your Active Pokémon, put 1 damage counter on each of your opponent's Pokémon that has any Energy attached to it between turns.",
+      "text": "As long as Dusknoir is your Active Pokémon, put 1 damage counter on each of your opponent’s Pokémon that has any Energy attached to it between turns.",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -1051,7 +1051,7 @@
     "evolvesFrom": "Haunter",
     "ability": {
       "name": "Fainting Spell",
-      "text": "Once during your opponent's turn, if Gengar would be Knocked Out by damage from an attack, you may flip a coin. If heads, the Defending Pokémon is Knocked Out.",
+      "text": "Once during your opponent’s turn, if Gengar would be Knocked Out by damage from an attack, you may flip a coin. If heads, the Defending Pokémon is Knocked Out.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -1072,7 +1072,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 3 damage counters on 1 of your opponent's Pokémon. If that Pokémon has any Poké-Powers, put 6 damage counters on that Pokémon instead."
+        "text": "Put 3 damage counters on 1 of your opponent’s Pokémon. If that Pokémon has any Poké-Powers, put 6 damage counters on that Pokémon instead."
       },
       {
         "name": "Poltergeist",
@@ -1082,7 +1082,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30x",
-        "text": "Look at your opponent's hand. This attack does 30 damage times the number of Trainer, Supporter, and Stadium cards in your opponent's hand."
+        "text": "Look at your opponent’s hand. This attack does 30 damage times the number of Trainer, Supporter, and Stadium cards in your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -1141,7 +1141,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Flip a coin until you get tails. For each heads, discard the top card from your opponent's deck."
+        "text": "Flip a coin until you get tails. For each heads, discard the top card from your opponent’s deck."
       },
       {
         "name": "Dragon Beat",
@@ -1154,7 +1154,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "100",
-        "text": "Flip a coin. If heads, discard an Energy card from each of your opponent's Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy card from each of your opponent’s Pokémon."
       }
     ],
     "weaknesses": [
@@ -1202,7 +1202,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "40",
-        "text": "If the Defending Pokémon isn't an Evolved Pokémon, that Pokémon is Knocked Out instead of damaged by this attack."
+        "text": "If the Defending Pokémon isn’t an Evolved Pokémon, that Pokémon is Knocked Out instead of damaged by this attack."
       },
       {
         "name": "Hurricane Punch",
@@ -1271,7 +1271,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30x",
-        "text": "Flip a coin until you get tails. This attack does 30 damage times the number of heads or you may start again. Each time you start again, put 2 damage counters on Mamoswine. (If Mamoswine would be Knocked Out, you can't start again.)"
+        "text": "Flip a coin until you get tails. This attack does 30 damage times the number of heads or you may start again. Each time you start again, put 2 damage counters on Mamoswine. (If Mamoswine would be Knocked Out, you can’t start again.)"
       },
       {
         "name": "Parade",
@@ -1311,7 +1311,7 @@
     "evolvesFrom": "Ponyta",
     "ability": {
       "name": "Burning Mane",
-      "text": "If Rapidash is your Active Pokémon and is damaged by an opponent's attack (even if Rapidash is Knocked Out), the Attacking Pokémon is now Burned.",
+      "text": "If Rapidash is your Active Pokémon and is damaged by an opponent’s attack (even if Rapidash is Knocked Out), the Attacking Pokémon is now Burned.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -1343,7 +1343,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Discard 2 Fire Energy attached to Rapidash and choose 1 of your opponent's Pokémon. This attack does 60 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard 2 Fire Energy attached to Rapidash and choose 1 of your opponent’s Pokémon. This attack does 60 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1365,7 +1365,7 @@
     "evolvesFrom": "Roselia",
     "ability": {
       "name": "Hidden Poison",
-      "text": "If Roserade is your Active Pokémon and is damaged by an opponent's attack (even if Roserade is Knocked Out), the Defending Pokémon is now Poisoned.",
+      "text": "If Roserade is your Active Pokémon and is damaged by an opponent’s attack (even if Roserade is Knocked Out), the Defending Pokémon is now Poisoned.",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -1390,7 +1390,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Flip a coin. If heads, discard an Energy card attached to that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) Flip a coin. If heads, discard an Energy card attached to that Pokémon."
       },
       {
         "name": "Deep Poison",
@@ -1423,7 +1423,7 @@
     "evolvesFrom": "Shelgon",
     "ability": {
       "name": "Battle Rush",
-      "text": "If your opponent has any Pokémon in play that has maximum HP of 120 or more, ignore all Colorless Energy necessary to use Salamence's attacks.",
+      "text": "If your opponent has any Pokémon in play that has maximum HP of 120 or more, ignore all Colorless Energy necessary to use Salamence’s attacks.",
       "type": "Poké-Body"
     },
     "hp": "140",
@@ -1515,7 +1515,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "If the Defending Pokémon is Knocked Out by this attack, prevent all effects of an attack, including damage, done to Scizor during your opponent's next turn."
+        "text": "If the Defending Pokémon is Knocked Out by this attack, prevent all effects of an attack, including damage, done to Scizor during your opponent’s next turn."
       },
       {
         "name": "Pound Down",
@@ -1525,7 +1525,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40+",
-        "text": "If you don't have any Pokémon with any Poké-Powers in play, this attack does 40 damage plus 30 more damage."
+        "text": "If you don’t have any Pokémon with any Poké-Powers in play, this attack does 40 damage plus 30 more damage."
       }
     ],
     "weaknesses": [
@@ -1612,7 +1612,7 @@
     "evolvesFrom": "Staravia",
     "ability": {
       "name": "Protect Wing",
-      "text": "As long as Staraptor is your Active Pokémon, any damage done by attacks from your opponent's Stage 2 Evolved Pokémon is reduced by 20 (after applying Weakness and Resistance).",
+      "text": "As long as Staraptor is your Active Pokémon, any damage done by attacks from your opponent’s Stage 2 Evolved Pokémon is reduced by 20 (after applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -1633,7 +1633,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, put 1 of your opponent's Benched Pokémon and all cards attached to it on top of your opponent's deck. Your opponent shuffles his or her deck afterward."
+        "text": "Flip a coin. If heads, put 1 of your opponent’s Benched Pokémon and all cards attached to it on top of your opponent’s deck. Your opponent shuffles his or her deck afterward."
       },
       {
         "name": "Clutch",
@@ -1644,7 +1644,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -1694,7 +1694,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose a number of your opponent's Pokémon up to the amount of Energy attached to Steelix. This attack does 20 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose a number of your opponent’s Pokémon up to the amount of Energy attached to Steelix. This attack does 20 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Iron Tail",
@@ -1773,7 +1773,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "Does 20 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1801,7 +1801,7 @@
     "evolvesFrom": "Pupitar",
     "ability": {
       "name": "Darkness Drive",
-      "text": "After your opponent's Pokémon uses a Poké-Power, you may search your discard pile for a basic Darkness Energy card and attach it to Tyranitar.",
+      "text": "After your opponent’s Pokémon uses a Poké-Power, you may search your discard pile for a basic Darkness Energy card and attach it to Tyranitar.",
       "type": "Poké-Body"
     },
     "hp": "140",
@@ -1842,7 +1842,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "",
-        "text": "This attack does 30 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1870,7 +1870,7 @@
     "evolvesFrom": "Combee",
     "ability": {
       "name": "Green Dignity",
-      "text": "As long as you have more Prize cards left than your opponent, Vespiquen's attacks do 10 more damage for each Grass Pokémon on your Bench to the Active Pokémon (before applying Weakness and Resistance).",
+      "text": "As long as you have more Prize cards left than your opponent, Vespiquen’s attacks do 10 more damage for each Grass Pokémon on your Bench to the Active Pokémon (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -1959,7 +1959,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Surf",
@@ -1990,7 +1990,7 @@
     "level": "8",
     "ability": {
       "name": "Poison Enzyme",
-      "text": "Prevent all effects of attacks, including damage, done to Budew by your opponent's Poisoned Pokémon.",
+      "text": "Prevent all effects of attacks, including damage, done to Budew by your opponent’s Poisoned Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "40",
@@ -2162,7 +2162,7 @@
     "evolvesFrom": "Voltorb",
     "ability": {
       "name": "Radiance",
-      "text": "If Electrode is your Active Pokémon and is damaged by an opponent's attack (even if Electrode is Knocked Out), put 1 damage counter on each of your opponent's Pokémon.",
+      "text": "If Electrode is your Active Pokémon and is damaged by an opponent’s attack (even if Electrode is Knocked Out), put 1 damage counter on each of your opponent’s Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -2183,7 +2183,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "If Electrode was damaged by an attack during your opponent's last turn, the Defending Pokémon is now Paralyzed."
+        "text": "If Electrode was damaged by an attack during your opponent’s last turn, the Defending Pokémon is now Paralyzed."
       },
       {
         "name": "Swift",
@@ -2194,7 +2194,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -2238,7 +2238,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "If the Defending Pokemon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokemon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Electro Diffusion",
@@ -2420,7 +2420,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "You may search your opponent's discard pile for up to 3 in any combination of Trainer, Supporter, or Stadium cards and put them into your opponent's hand."
+        "text": "You may search your opponent’s discard pile for up to 3 in any combination of Trainer, Supporter, or Stadium cards and put them into your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -2481,7 +2481,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -2526,7 +2526,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If you have a Stadium card in play, this attack does 20 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If you have a Stadium card in play, this attack does 20 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Magnetic Release",
@@ -2777,7 +2777,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2808,7 +2808,7 @@
     "evolvesFrom": "Larvitar",
     "ability": {
       "name": "Energy Protection",
-      "text": "Any damage done to Pupitar by attacks is reduced by 10 for each Energy attached to Pupitar (after applying Weakness and Resistance). You can't reduce more than 30 damage in this way.",
+      "text": "Any damage done to Pupitar by attacks is reduced by 10 for each Energy attached to Pupitar (after applying Weakness and Resistance). You can’t reduce more than 30 damage in this way.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -2863,7 +2863,7 @@
     "level": "31",
     "ability": {
       "name": "Overeager",
-      "text": "If Sableye is your Active Pokémon at the beginning of the game, you go first. (If each player's Active Pokémon has the Overeager Poké-Body, this power does nothing.)",
+      "text": "If Sableye is your Active Pokémon at the beginning of the game, you go first. (If each player’s Active Pokémon has the Overeager Poké-Body, this power does nothing.)",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -2896,7 +2896,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If the Defending Pokémon has fewer remaining HP than Sableye, this attack's base damage is 40."
+        "text": "If the Defending Pokémon has fewer remaining HP than Sableye, this attack’s base damage is 40."
       }
     ],
     "resistances": [
@@ -2933,7 +2933,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, Scyther's Slashing Strike attack's base damage is 60."
+        "text": "During your next turn, Scyther’s Slashing Strike attack’s base damage is 60."
       },
       {
         "name": "Slashing Strike",
@@ -2943,7 +2943,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "During your next turn, Scyther can't use Slashing Strike."
+        "text": "During your next turn, Scyther can’t use Slashing Strike."
       }
     ],
     "weaknesses": [
@@ -3066,7 +3066,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Flip a coin. If heads, this attack does 50 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 50 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3122,7 +3122,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "Does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3171,7 +3171,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack or retreat during your opponent's next turn."
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack or retreat during your opponent’s next turn."
       },
       {
         "name": "Headbutt",
@@ -3284,7 +3284,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put a number of damage counters on the Defending Pokémon equal to the number of Colorless Energy in Bronzor's Retreat Cost (after applying effects to the Retreat Cost)."
+        "text": "Put a number of damage counters on the Defending Pokémon equal to the number of Colorless Energy in Bronzor’s Retreat Cost (after applying effects to the Retreat Cost)."
       },
       {
         "name": "Psyshock",
@@ -3459,7 +3459,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3626,7 +3626,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Benched Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Benched Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Mouth Pump",
@@ -3678,7 +3678,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "You opponent can't play any Trainer cards from his or her hand during your opponent's next turn."
+        "text": "You opponent can’t play any Trainer cards from his or her hand during your opponent’s next turn."
       },
       {
         "name": "Trick Gas",
@@ -3746,7 +3746,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Does 10 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3960,7 +3960,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4069,7 +4069,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, if Onix would be damaged by an attack, prevent that attack's damage done to Onix if that damage is 40 or less."
+        "text": "During your opponent’s next turn, if Onix would be damaged by an attack, prevent that attack’s damage done to Onix if that damage is 40 or less."
       },
       {
         "name": "Bind",
@@ -4136,7 +4136,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "If Pikachu evolved from Pichu during this turn, prevent all effects of an attack, including damage, done to Pikachu during your opponent's next turn."
+        "text": "If Pikachu evolved from Pichu during this turn, prevent all effects of an attack, including damage, done to Pikachu during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -4292,7 +4292,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Dangerous Claw",
@@ -4345,7 +4345,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Snover during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Snover during your opponent’s next turn."
       },
       {
         "name": "Powder Snow",
@@ -4397,7 +4397,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Double Stab",
@@ -4572,7 +4572,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If tails, this attack does nothing. If heads, search your deck for a Grass Energy card and attach it to Tangela. Shuffle your deck afterward. If you do, prevent all effects of an attack, including damage, done to Tangela during your opponent's next turn."
+        "text": "Flip a coin. If tails, this attack does nothing. If heads, search your deck for a Grass Energy card and attach it to Tangela. Shuffle your deck afterward. If you do, prevent all effects of an attack, including damage, done to Tangela during your opponent’s next turn."
       },
       {
         "name": "Tickle",
@@ -4790,8 +4790,8 @@
     "set": "Stormfront",
     "setCode": "dp7",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "Once during each player's turn, the player may flip a coin. If heads, that player searches his or her discard pile for a Lightning or Metal Energy card, shows it to the opponent, and puts it into his or her hand."
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
+      "Once during each player’s turn, the player may flip a coin. If heads, that player searches his or her discard pile for a Lightning or Metal Energy card, shows it to the opponent, and puts it into his or her hand."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp7/82_hires.png"
   },
@@ -4810,7 +4810,7 @@
     "setCode": "dp7",
     "text": [
       "As long as Energy Link is attached to a Pokémon, you may move an Energy card attached to that Pokémon to another of your Pokémon that has Energy Link attached to it. You may use this effect as often as you like during your turn.",
-      "Attach Energy Link to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card."
+      "Attach Energy Link to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp7/83_hires.png"
   },
@@ -4864,13 +4864,13 @@
     "set": "Stormfront",
     "setCode": "dp7",
     "text": [
-      "Search your deck for a Pokémon (excluding Pokémon LV.X), show it to your opponent, and put it into your hand. Shuffle your deck afterward. If any Luxury Ball is in your discard pile, you can't play this card."
+      "Search your deck for a Pokémon (excluding Pokémon LV.X), show it to your opponent, and put it into your hand. Shuffle your deck afterward. If any Luxury Ball is in your discard pile, you can’t play this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp7/86_hires.png"
   },
   {
     "id": "dp7-87",
-    "name": "Marley's Request",
+    "name": "Marley’s Request",
     "imageUrl": "https://images.pokemontcg.io/dp7/87.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4901,7 +4901,7 @@
     "set": "Stormfront",
     "setCode": "dp7",
     "text": [
-      "You may play 2 Poké Blower + at the same time. If you play 1 Poké Blower +, flip a coin. If heads, put 1 damage counter on 1 of your opponent's Pokémon. If you play 2 Poké Blower +, choose 1 of your opponent's Benched Pokémon and switch it with 1 of your opponent's Active Pokémon."
+      "You may play 2 Poké Blower + at the same time. If you play 1 Poké Blower +, flip a coin. If heads, put 1 damage counter on 1 of your opponent’s Pokémon. If you play 2 Poké Blower +, choose 1 of your opponent’s Benched Pokémon and switch it with 1 of your opponent’s Active Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp7/88_hires.png"
   },
@@ -5008,7 +5008,7 @@
     "set": "Stormfront",
     "setCode": "dp7",
     "text": [
-      "Cyclone Energy provides Colorless Energy. When you attach this card from your hand to your Active Pokémon, switch 1 of the Defending Pokémon with 1 of your opponent's Benched Pokémon. Your opponent chooses the Benched Pokémon to switch."
+      "Cyclone Energy provides Colorless Energy. When you attach this card from your hand to your Active Pokémon, switch 1 of the Defending Pokémon with 1 of your opponent’s Benched Pokémon. Your opponent chooses the Benched Pokémon to switch."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/dp7/94_hires.png"
   },
@@ -5038,7 +5038,7 @@
     "level": "X",
     "ability": {
       "name": "Ectoplasm",
-      "text": "If Dusknoir is your Active Pokémon and would be Knocked Out by damage from your opponent's attack, you may discard all cards attached to Dusknoir LV.X and put Dusknoir LV.X as a Stadium card into play instead of discarding it. This counts as Dusknoir being Knocked Out and your opponent takes a Prize card. As long as you have Dusknoir LV.X as a Stadium card in play, put 1 damage counter on each of your opponent's Pokémon between turns. If another Stadium card comes into play or Dusknoir LV.X is discarded by the effect of any attacks, Poké-Powers, Poké-Bodies, Trainer, or Supporter cards, return Dusknoir LV.X to your hand.",
+      "text": "If Dusknoir is your Active Pokémon and would be Knocked Out by damage from your opponent’s attack, you may discard all cards attached to Dusknoir LV.X and put Dusknoir LV.X as a Stadium card into play instead of discarding it. This counts as Dusknoir being Knocked Out and your opponent takes a Prize card. As long as you have Dusknoir LV.X as a Stadium card in play, put 1 damage counter on each of your opponent’s Pokémon between turns. If another Stadium card comes into play or Dusknoir LV.X is discarded by the effect of any attacks, Poké-Powers, Poké-Bodies, Trainer, or Supporter cards, return Dusknoir LV.X to your hand.",
       "type": "Poké-Power"
     },
     "hp": "140",
@@ -5083,7 +5083,7 @@
     "level": "X",
     "ability": {
       "name": "Heat Metal",
-      "text": "Your opponent can't remove the Special Condition Burned by evolving or devolving his or her Burned Pokémon. (This also includes putting a Pokémon Level-Up card onto the Burned Pokémon.) Whenever your opponent flips a coin for the Special Condition Burned between turns, treat it as tails.",
+      "text": "Your opponent can’t remove the Special Condition Burned by evolving or devolving his or her Burned Pokémon. (This also includes putting a Pokémon Level-Up card onto the Burned Pokémon.) Whenever your opponent flips a coin for the Special Condition Burned between turns, treat it as tails.",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -5123,7 +5123,7 @@
     "level": "X",
     "ability": {
       "name": "No Guard",
-      "text": "As long as Machamp is your Active Pokémon, each of Machamp's attacks does 60 more damage to the Active Pokémon (before applying Weakness and Resistance) and any damage done to Machamp by your opponent's Pokémon is increased by 60 (after applying Weakness and Resistance).",
+      "text": "As long as Machamp is your Active Pokémon, each of Machamp’s attacks does 60 more damage to the Active Pokémon (before applying Weakness and Resistance) and any damage done to Machamp by your opponent’s Pokémon is increased by 60 (after applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "150",
@@ -5154,7 +5154,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "During your opponent's next turn, if Machamp would be Knocked Out by damage from an attack, flip a coin. If heads, Machamp is not Knocked Out and its remaining HP becomes 10 instead."
+        "text": "During your opponent’s next turn, if Machamp would be Knocked Out by damage from an attack, flip a coin. If heads, Machamp is not Knocked Out and its remaining HP becomes 10 instead."
       }
     ],
     "weaknesses": [
@@ -5175,7 +5175,7 @@
     "level": "X",
     "ability": {
       "name": "Link Lightning",
-      "text": "Once during your turn, when you put Raichu LV.X onto Raichu and use Voltage Shoot, you may use another attack of Raichu afterward. This power can't be used if Raichu is affected by a Special Condition.",
+      "text": "Once during your turn, when you put Raichu LV.X onto Raichu and use Voltage Shoot, you may use another attack of Raichu afterward. This power can’t be used if Raichu is affected by a Special Condition.",
       "type": "Poké-Body"
     },
     "hp": "110",
@@ -5201,7 +5201,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Discard 2 Lightning Energy cards from your hand and choose 1 of your opponent's Pokémon. This attack does 80 to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard 2 Lightning Energy cards from your hand and choose 1 of your opponent’s Pokémon. This attack does 80 to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -5228,7 +5228,7 @@
     "level": "X",
     "ability": {
       "name": "Sacrifice",
-      "text": "Once during your turn (before your attack), you may choose 1 of your Pokémon in play and that Pokémon is Knocked Out. Then, search your discard pile for up to 2 basic Energy cards, attach them to Regigigas, and remove 8 damage counters from Regigigas. This power can't be used if Regigigas is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may choose 1 of your Pokémon in play and that Pokémon is Knocked Out. Then, search your discard pile for up to 2 basic Energy cards, attach them to Regigigas, and remove 8 damage counters from Regigigas. This power can’t be used if Regigigas is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "150",
@@ -5261,7 +5261,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "Discard the top card from your opponent's deck. Then, choose 1 card from your opponent's hand without looking and discard it. Regigigas can't use Giga Blaster during your next turn."
+        "text": "Discard the top card from your opponent’s deck. Then, choose 1 card from your opponent’s hand without looking and discard it. Regigigas can’t use Giga Blaster during your next turn."
       }
     ],
     "weaknesses": [
@@ -5449,7 +5449,7 @@
     "level": "16",
     "ability": {
       "name": "Unburden",
-      "text": "If Drifloon has a Pokémon Tool card attached to it, Drifloon's Retreat Cost is colorless colorless more.",
+      "text": "If Drifloon has a Pokémon Tool card attached to it, Drifloon’s Retreat Cost is colorless colorless more.",
       "type": "Poké-Body"
     },
     "hp": "50",
@@ -5549,7 +5549,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin.  If heads, your opponent can't attach any Energy cards from his or her hand to the Active Pokémon during his or her next turn."
+        "text": "Flip a coin.  If heads, your opponent can’t attach any Energy cards from his or her hand to the Active Pokémon during his or her next turn."
       }
     ],
     "weaknesses": [
@@ -5598,7 +5598,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon.  Flip a coin.  If heads, this attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon.  Flip a coin.  If heads, this attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Charge Beam",

--- a/json/cards/Sun & Moon Black Star Promos.json
+++ b/json/cards/Sun & Moon Black Star Promos.json
@@ -246,7 +246,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "210",
-        "text": "This Pokémon is now Asleep. (You can't use more than 1 GX attack in a game.)"
+        "text": "This Pokémon is now Asleep. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -438,7 +438,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent’s next turn."
       },
       {
         "name": "Discharge",
@@ -500,7 +500,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       }
     ],
     "weaknesses": [
@@ -551,7 +551,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": "This attack's damage isn't affected by any effects on your opponent's Active Pokémon."
+        "text": "This attack’s damage isn’t affected by any effects on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -590,7 +590,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Team Play",
@@ -647,7 +647,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "This attack does 20 more damage times the amount of Energy attached to your opponent's Active Pokémon."
+        "text": "This attack does 20 more damage times the amount of Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -691,7 +691,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Discard an Energy from your opponent's Active Pokémon."
+        "text": "Discard an Energy from your opponent’s Active Pokémon."
       },
       {
         "name": "Accelerock",
@@ -713,7 +713,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "200",
-        "text": "Discard 2 Energy from this Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "Discard 2 Energy from this Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -759,7 +759,7 @@
         "text": ""
       },
       {
-        "name": "Land's Wrath",
+        "name": "Land’s Wrath",
         "cost": [
           "Fighting",
           "Fighting",
@@ -855,7 +855,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "For each Pokémon in your opponent’s discard pile, put 1 damage counter on your opponent's Pokémon in any way you like."
+        "text": "For each Pokémon in your opponent’s discard pile, put 1 damage counter on your opponent’s Pokémon in any way you like."
       },
       {
         "name": "Revelation Dance",
@@ -1155,7 +1155,7 @@
     "evolvesFrom": "Fomantis",
     "ability": {
       "name": "Sunny Day",
-      "text": "The attacks of your Grass Pokémon and Fire Pokémon do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
+      "text": "The attacks of your Grass Pokémon and Fire Pokémon do 20 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "100",
@@ -1378,7 +1378,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 1 damage counter on your opponent's Active Pokémon."
+        "text": "Put 1 damage counter on your opponent’s Active Pokémon."
       },
       {
         "name": "Astonish",
@@ -1388,7 +1388,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose a random card from your opponent's hand. Your opponent reveals that card and shuffles it into their deck."
+        "text": "Choose a random card from your opponent’s hand. Your opponent reveals that card and shuffles it into their deck."
       }
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/smp/SM29_hires.png",
@@ -1419,7 +1419,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "This attack does 20 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Electric Ball",
@@ -1472,7 +1472,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "This attack does 20 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Electric Ball",
@@ -1555,7 +1555,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "150",
-        "text": "Heal all damage from this Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "Heal all damage from this Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/smp/SM32_hires.png"
@@ -1610,7 +1610,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50×",
-        "text": "This attack does 50 damage times the amount of Energy attached to all of your opponent's Pokémon. (You can’t use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage times the amount of Energy attached to all of your opponent’s Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/smp/SM33_hires.png"
@@ -1651,7 +1651,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Double Impact",
@@ -1675,7 +1675,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Discard your opponent's Active Pokémon and all cards attached to it. (You can't use more than 1 GX attack in a game.)"
+        "text": "Discard your opponent’s Active Pokémon and all cards attached to it. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -1697,7 +1697,7 @@
     "evolvesFrom": "Dartrix",
     "ability": {
       "name": "Feather Arrow",
-      "text": "Once during your turn (before your attack), you may put 2 damage counters on 1 of your opponent's Pokémon.",
+      "text": "Once during your turn (before your attack), you may put 2 damage counters on 1 of your opponent’s Pokémon.",
       "type": "Ability"
     },
     "hp": "240",
@@ -1804,7 +1804,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "200",
-        "text": "Your opponent's Active Pokémon is now Burned. (You can't use more than 1 GX attack in a game.)"
+        "text": "Your opponent’s Active Pokémon is now Burned. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -1862,7 +1862,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "Discard an Energy from your opponent's Active Pokémon."
+        "text": "Discard an Energy from your opponent’s Active Pokémon."
       },
       {
         "name": "Grand Echo-GX",
@@ -1872,7 +1872,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Heal all damage from all of your Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "Heal all damage from all of your Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -1911,7 +1911,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Rollout",
@@ -1948,7 +1948,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "More Poison",
-      "text": "Put 1 more damage counter on your opponent's Poisoned Pokémon between turns.",
+      "text": "Put 1 more damage counter on your opponent’s Poisoned Pokémon between turns.",
       "type": "Ability"
     },
     "hp": "100",
@@ -1975,7 +1975,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       }
     ],
     "weaknesses": [
@@ -2137,7 +2137,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "60",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       },
       {
         "name": "Beauty-GX",
@@ -2194,7 +2194,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
-        "text": "This attack does 30 more damage for each Colorless Energy in your opponent's Active Pokémon's Retreat Cost."
+        "text": "This attack does 30 more damage for each Colorless Energy in your opponent’s Active Pokémon’s Retreat Cost."
       },
       {
         "name": "Moon Press",
@@ -2269,7 +2269,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "Discard the top card of your opponent's deck."
+        "text": "Discard the top card of your opponent’s deck."
       },
       {
         "name": "Lighting-GX",
@@ -2283,7 +2283,7 @@
     ],
     "ability": {
       "name": "Flashing Head",
-      "text": "Prevent all damage done to this Pokémon by attacks from your opponent's Pokémon that have any Special Energy attached to them.",
+      "text": "Prevent all damage done to this Pokémon by attacks from your opponent’s Pokémon that have any Special Energy attached to them.",
       "type": "Ability"
     },
     "weaknesses": [
@@ -2333,7 +2333,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Knuckle Impact",
@@ -2344,7 +2344,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "160",
-        "text": "This Pokémon can't attack during your next turn."
+        "text": "This Pokémon can’t attack during your next turn."
       },
       {
         "name": "Absorption-GX",
@@ -2355,7 +2355,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40×",
-        "text": "This attack does 40 damage for each of your remaining Prize cards. (You can't use more than 1 GX attack in a game.)"
+        "text": "This attack does 40 damage for each of your remaining Prize cards. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -2408,7 +2408,7 @@
           "Darkness"
         ],
         "name": "Trickster-GX",
-        "text": "Choose 1 of your opponent's Pokémon's attacks and use it as this attack. (You can’t use more than 1 GX attack in a game.)",
+        "text": "Choose 1 of your opponent’s Pokémon’s attacks and use it as this attack. (You can’t use more than 1 GX attack in a game.)",
         "damage": "",
         "convertedEnergyCost": 2
       }

--- a/json/cards/Sun & Moon.json
+++ b/json/cards/Sun & Moon.json
@@ -81,7 +81,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent’s next turn."
       },
       {
         "name": "Bug Bite",
@@ -135,7 +135,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Whirlwind",
@@ -284,7 +284,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, put your opponent's Active Pokémon and all cards attached to it into your opponent's hand."
+        "text": "Flip a coin. If heads, put your opponent’s Active Pokémon and all cards attached to it into your opponent’s hand."
       },
       {
         "name": "Guillotine",
@@ -373,7 +373,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Move an Energy from your opponent's Active Pokémon to 1 of their Benched Pokémon."
+        "text": "Move an Energy from your opponent’s Active Pokémon to 1 of their Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -465,7 +465,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 20 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Leaf Blade",
@@ -552,7 +552,7 @@
     "evolvesFrom": "Dartrix",
     "ability": {
       "name": "Feather Arrow",
-      "text": "Once during your turn (before your attack), you may put 2 damage counters on 1 of your opponent's Pokémon.",
+      "text": "Once during your turn (before your attack), you may put 2 damage counters on 1 of your opponent’s Pokémon.",
       "type": "Ability"
     },
     "hp": "240",
@@ -752,7 +752,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "50×",
-        "text": "This attack does 50 damage times the amount of Grass Energy attached to this Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage times the amount of Grass Energy attached to this Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -791,7 +791,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Ram",
@@ -850,7 +850,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       }
     ],
     "weaknesses": [
@@ -1091,7 +1091,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Your opponent's Active Pokémon is now Burned."
+        "text": "Your opponent’s Active Pokémon is now Burned."
       },
       {
         "name": "Firestorm",
@@ -1144,7 +1144,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Burned."
+        "text": "Your opponent’s Active Pokémon is now Burned."
       },
       {
         "name": "Body Slam",
@@ -1154,7 +1154,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -1304,7 +1304,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Burned."
+        "text": "Your opponent’s Active Pokémon is now Burned."
       },
       {
         "name": "Darkest Lariat",
@@ -1383,7 +1383,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "200",
-        "text": "Your opponent's Active Pokémon is now Burned. (You can't use more than 1 GX attack in a game.)"
+        "text": "Your opponent’s Active Pokémon is now Burned. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -1624,7 +1624,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       },
       {
         "name": "Wake-Up Slap",
@@ -1635,7 +1635,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80+",
-        "text": "If your opponent's Active Pokémon is affected by a Special Condition, this attack does 80 more damage. Then, remove all Special Conditions from that Pokémon."
+        "text": "If your opponent’s Active Pokémon is affected by a Special Condition, this attack does 80 more damage. Then, remove all Special Conditions from that Pokémon."
       }
     ],
     "weaknesses": [
@@ -1721,7 +1721,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "Flip a coin. If heads, this attack does 30 more damage. If tails, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, this attack does 30 more damage. If tails, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Guard Press",
@@ -1732,7 +1732,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "During your opponent's next turn, this Pokémon takes 20 less damage from attacks (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, this Pokémon takes 20 less damage from attacks (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -1787,7 +1787,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "160",
-        "text": "This Pokémon can't attack during your next turn."
+        "text": "This Pokémon can’t attack during your next turn."
       },
       {
         "name": "Ice Beam-GX",
@@ -1798,7 +1798,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "Your opponent's Active Pokémon is now Paralyzed. (You can't use more than 1 GX attack in a game.)"
+        "text": "Your opponent’s Active Pokémon is now Paralyzed. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -1887,7 +1887,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Heal 30 damage from this Pokémon. It can't retreat during your next turn."
+        "text": "Heal 30 damage from this Pokémon. It can’t retreat during your next turn."
       }
     ],
     "weaknesses": [
@@ -1948,7 +1948,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2059,7 +2059,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -2104,7 +2104,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       },
       {
         "name": "Sparkling Aria",
@@ -2173,7 +2173,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "Discard an Energy from your opponent's Active Pokémon."
+        "text": "Discard an Energy from your opponent’s Active Pokémon."
       },
       {
         "name": "Grand Echo-GX",
@@ -2183,7 +2183,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Heal all damage from all of your Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "Heal all damage from all of your Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -2228,7 +2228,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "This attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Ice Hammer",
@@ -2260,7 +2260,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Cowardice",
-      "text": "Once during your turn (before your attack), you may discard all cards attached to this Pokémon and return it to your hand. You can't use this Ability during your first turn or on the turn this Pokémon was put into play.",
+      "text": "Once during your turn (before your attack), you may discard all cards attached to this Pokémon and return it to your hand. You can’t use this Ability during your first turn or on the turn this Pokémon was put into play.",
       "type": "Ability"
     },
     "hp": "30",
@@ -2323,7 +2323,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -2347,7 +2347,7 @@
     "evolvesFrom": "Dewpider",
     "ability": {
       "name": "Water Bubble",
-      "text": "Prevent all damage done to this Pokémon by attacks from your opponent's Fire Pokémon.",
+      "text": "Prevent all damage done to this Pokémon by attacks from your opponent’s Fire Pokémon.",
       "type": "Ability"
     },
     "hp": "100",
@@ -2394,7 +2394,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Innards Out",
-      "text": "If this Pokémon is your Active Pokémon and is Knocked Out by damage from an opponent's attack, put 6 damage counters on the Attacking Pokémon.",
+      "text": "If this Pokémon is your Active Pokémon and is Knocked Out by damage from an opponent’s attack, put 6 damage counters on the Attacking Pokémon.",
       "type": "Ability"
     },
     "hp": "60",
@@ -2469,7 +2469,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": "This attack's damage isn't affected by any effects on your opponent's Active Pokémon."
+        "text": "This attack’s damage isn’t affected by any effects on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -2569,7 +2569,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       },
       {
         "name": "Aqua Spark",
@@ -2629,7 +2629,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Electric Ball",
@@ -2744,7 +2744,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent’s next turn."
       },
       {
         "name": "Discharge",
@@ -2798,7 +2798,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose a random card from your opponent's hand. Your opponent reveals that card and shuffles it into their deck."
+        "text": "Choose a random card from your opponent’s hand. Your opponent reveals that card and shuffles it into their deck."
       }
     ],
     "weaknesses": [
@@ -2844,7 +2844,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       },
       {
         "name": "Acrobatics",
@@ -2900,7 +2900,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Poisoned. Put 3 damage counters instead of 1 on that Pokémon between turns."
+        "text": "Your opponent’s Active Pokémon is now Poisoned. Put 3 damage counters instead of 1 on that Pokémon between turns."
       },
       {
         "name": "Surprise Strike",
@@ -2958,7 +2958,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Poisoned."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Poisoned."
       },
       {
         "name": "Pound",
@@ -2993,7 +2993,7 @@
     "evolvesFrom": "Alolan Grimer",
     "ability": {
       "name": "Power of Alchemy",
-      "text": "Each Basic Pokémon in play, in each player's hand, and in each player's discard pile has no Abilities.",
+      "text": "Each Basic Pokémon in play, in each player’s hand, and in each player’s discard pile has no Abilities.",
       "type": "Ability"
     },
     "hp": "120",
@@ -3023,7 +3023,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "90",
-        "text": "Flip a coin. If heads, discard an Energy from your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy from your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -3063,7 +3063,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10×",
-        "text": "This attack does 10 damage times the amount of Energy attached to your opponent's Active Pokémon."
+        "text": "This attack does 10 damage times the amount of Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Headbutt",
@@ -3118,7 +3118,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "This attack does 10 more damage for each damage counter on your opponent's Active Pokémon."
+        "text": "This attack does 10 more damage for each damage counter on your opponent’s Active Pokémon."
       },
       {
         "name": "Hypnoblast",
@@ -3129,7 +3129,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       }
     ],
     "weaknesses": [
@@ -3173,7 +3173,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       },
       {
         "name": "Psychic",
@@ -3184,7 +3184,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "This attack does 30 more damage times the amount of Energy attached to your opponent's Active Pokémon."
+        "text": "This attack does 30 more damage times the amount of Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Divide-GX",
@@ -3195,7 +3195,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Put 10 damage counters on your opponent's Pokémon in any way you like. (You can't use more than 1 GX attack in a game.)"
+        "text": "Put 10 damage counters on your opponent’s Pokémon in any way you like. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -3234,7 +3234,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       }
     ],
     "weaknesses": [
@@ -3258,7 +3258,7 @@
     "evolvesFrom": "Mareanie",
     "ability": {
       "name": "Toxic Spikes",
-      "text": "Whenever your opponent's Active Pokémon retreats, their new Active Pokémon is Poisoned.",
+      "text": "Whenever your opponent’s Active Pokémon retreats, their new Active Pokémon is Poisoned.",
       "type": "Ability"
     },
     "hp": "110",
@@ -3286,7 +3286,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50+",
-        "text": "If your opponent's Active Pokémon is Poisoned, this attack does 50 more damage."
+        "text": "If your opponent’s Active Pokémon is Poisoned, this attack does 50 more damage."
       }
     ],
     "weaknesses": [
@@ -3427,7 +3427,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "The Defending Pokémon can't be healed during your opponent's next turn."
+        "text": "The Defending Pokémon can’t be healed during your opponent’s next turn."
       },
       {
         "name": "Lunar Fall-GX",
@@ -3438,7 +3438,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Knock Out 1 of your opponent's Basic Pokémon that isn't a Pokémon-GX. (You can't use more than 1 GX attack in a game.)"
+        "text": "Knock Out 1 of your opponent’s Basic Pokémon that isn’t a Pokémon-GX. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -3596,7 +3596,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "If your opponent's Active Pokémon has Fighting Resistance, this attack does 50 more damage."
+        "text": "If your opponent’s Active Pokémon has Fighting Resistance, this attack does 50 more damage."
       }
     ],
     "weaknesses": [
@@ -3654,7 +3654,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -3713,7 +3713,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -3807,7 +3807,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Team Play",
@@ -3869,7 +3869,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3923,7 +3923,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
-        "text": "Heal from this Pokémon the same amount of damage you did to your opponent's Active Pokémon."
+        "text": "Heal from this Pokémon the same amount of damage you did to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -4116,7 +4116,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with their Active Pokémon."
       },
       {
         "name": "Claw Rend",
@@ -4125,7 +4125,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30+",
-        "text": "If your opponent's Active Pokémon already has any damage counters on it, this attack does 30 more damage."
+        "text": "If your opponent’s Active Pokémon already has any damage counters on it, this attack does 30 more damage."
       }
     ],
     "weaknesses": [
@@ -4187,7 +4187,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Dark Call-GX",
@@ -4197,7 +4197,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Discard 2 Energy from your opponent's Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "Discard 2 Energy from your opponent’s Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -4242,7 +4242,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Discard all Pokémon Tool cards from your opponent's Active Pokémon."
+        "text": "Discard all Pokémon Tool cards from your opponent’s Active Pokémon."
       },
       {
         "name": "Bite",
@@ -4282,7 +4282,7 @@
     "evolvesFrom": "Carvanha",
     "ability": {
       "name": "Rough Skin",
-      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), put 3 damage counters on the Attacking Pokémon.",
+      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack (even if this Pokémon is Knocked Out), put 3 damage counters on the Attacking Pokémon.",
       "type": "Ability"
     },
     "hp": "110",
@@ -4305,7 +4305,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "This attack does 20 more damage for each Colorless in your opponent's Active Pokémon's Retreat Cost."
+        "text": "This attack does 20 more damage for each Colorless in your opponent’s Active Pokémon’s Retreat Cost."
       }
     ],
     "weaknesses": [
@@ -4363,7 +4363,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Flip a coin. If heads, discard an Energy from your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy from your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -4414,7 +4414,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Discard a random card from your opponent's hand."
+        "text": "Discard a random card from your opponent’s hand."
       },
       {
         "name": "Darkness Fang",
@@ -4477,7 +4477,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "This attack does 20 more damage for each card in your opponent's hand."
+        "text": "This attack does 20 more damage for each card in your opponent’s hand."
       },
       {
         "name": "Obsidian Fang",
@@ -4488,7 +4488,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "Before doing damage, discard all Pokémon Tool cards from your opponent's Active Pokémon."
+        "text": "Before doing damage, discard all Pokémon Tool cards from your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -4572,7 +4572,7 @@
     "evolvesFrom": "Alolan Diglett",
     "ability": {
       "name": "Tangling Hair",
-      "text": "Your opponent's Active Pokémon's Retreat Cost is Colorless more.",
+      "text": "Your opponent’s Active Pokémon’s Retreat Cost is Colorless more.",
       "type": "Ability"
     },
     "hp": "100",
@@ -4599,7 +4599,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "This attack does 50 damage to 1 of your opponent's Pokémon. This damage isn't affected by Weakness or Resistance."
+        "text": "This attack does 50 damage to 1 of your opponent’s Pokémon. This damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -4724,7 +4724,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Search your deck for up to 5 Energy cards and attach them to your Pokémon in any way you like. Then, shuffle your deck. (You can't use more than 1 GX attack in a game.)"
+        "text": "Search your deck for up to 5 Energy cards and attach them to your Pokémon in any way you like. Then, shuffle your deck. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -4819,7 +4819,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Fight Back",
@@ -4875,7 +4875,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If any damage is done to this Pokémon by attacks during your opponent's next turn, flip a coin. If heads, prevent that damage."
+        "text": "If any damage is done to this Pokémon by attacks during your opponent’s next turn, flip a coin. If heads, prevent that damage."
       }
     ],
     "weaknesses": [
@@ -5022,7 +5022,7 @@
     ],
     "attacks": [
       {
-        "name": "Dragon's Wish",
+        "name": "Dragon’s Wish",
         "cost": [
           "Colorless"
         ],
@@ -5138,7 +5138,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "If your opponent's Active Pokémon is a Grass Pokémon, this attack does 30 more damage."
+        "text": "If your opponent’s Active Pokémon is a Grass Pokémon, this attack does 30 more damage."
       }
     ],
     "weaknesses": [
@@ -5196,7 +5196,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "60",
-        "text": "This Pokémon can't use Slashing Strike during your next turn."
+        "text": "This Pokémon can’t use Slashing Strike during your next turn."
       }
     ],
     "weaknesses": [
@@ -5243,7 +5243,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30+",
-        "text": "If your opponent's Active Pokémon is an Evolution Pokémon, this attack does 30 more damage."
+        "text": "If your opponent’s Active Pokémon is an Evolution Pokémon, this attack does 30 more damage."
       },
       {
         "name": "Hurricane Punch",
@@ -5321,7 +5321,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30×",
-        "text": "This attack does 30 damage for each damage counter on this Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "This attack does 30 damage for each damage counter on this Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -5415,7 +5415,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -5454,7 +5454,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, this Pokémon's attacks do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s attacks do 20 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance)."
       },
       {
         "name": "Bite",
@@ -5561,7 +5561,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "During your opponent's next turn, the Defending Pokémon's attacks do 50 less damage (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, the Defending Pokémon’s attacks do 50 less damage (before applying Weakness and Resistance)."
       },
       {
         "name": "Hammer In",
@@ -5712,7 +5712,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "60",
-        "text": "During your next turn, this Pokémon's Echoed Voice attack does 60 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s Echoed Voice attack does 60 more damage (before applying Weakness and Resistance)."
       },
       {
         "name": "Beak Blast",
@@ -5723,7 +5723,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Burned."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Burned."
       }
     ],
     "weaknesses": [
@@ -5842,7 +5842,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "This attack does 50 more damage times the amount of Energy attached to your opponent's Active Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 more damage times the amount of Energy attached to your opponent’s Active Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -5929,7 +5929,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Superpower",
@@ -5987,7 +5987,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "This attack does 20 more damage times the amount of Energy attached to your opponent's Active Pokémon."
+        "text": "This attack does 20 more damage times the amount of Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -6029,7 +6029,7 @@
     "set": "Sun & Moon",
     "setCode": "sm1",
     "text": [
-      "Flip a coin. If heads, discard an Energy from 1 of your opponent's Pokémon."
+      "Flip a coin. If heads, discard an Energy from 1 of your opponent’s Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/115_hires.png"
   },
@@ -6080,7 +6080,7 @@
     "set": "Sun & Moon",
     "setCode": "sm1",
     "text": [
-      "When your Active Pokémon is Knocked Out by damage from an opponent's attack, you may move 1 basic Energy card from that Pokémon to the Pokémon this card is attached to."
+      "When your Active Pokémon is Knocked Out by damage from an opponent’s attack, you may move 1 basic Energy card from that Pokémon to the Pokémon this card is attached to."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/118_hires.png"
   },
@@ -6148,7 +6148,7 @@
     "set": "Sun & Moon",
     "setCode": "sm1",
     "text": [
-      "Draw cards until you have 6 cards in your hand. If it's your first turn, draw cards until you have 8 cards in your hand."
+      "Draw cards until you have 6 cards in your hand. If it’s your first turn, draw cards until you have 8 cards in your hand."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/122_hires.png"
   },
@@ -6182,7 +6182,7 @@
     "set": "Sun & Moon",
     "setCode": "sm1",
     "text": [
-      "If the Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Poisoned."
+      "If the Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent’s attack (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Poisoned."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/124_hires.png"
   },
@@ -6216,7 +6216,7 @@
     "set": "Sun & Moon",
     "setCode": "sm1",
     "text": [
-      "Flip a coin. If heads, switch 1 of your opponent's Benched Pokémon with their Active Pokémon."
+      "Flip a coin. If heads, switch 1 of your opponent’s Benched Pokémon with their Active Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/126_hires.png"
   },
@@ -6250,7 +6250,7 @@
     "set": "Sun & Moon",
     "setCode": "sm1",
     "text": [
-      "Draw 2 cards. During this turn, your Pokémon's attacks do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance)."
+      "Draw 2 cards. During this turn, your Pokémon’s attacks do 20 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/128_hires.png"
   },
@@ -6267,7 +6267,7 @@
     "set": "Sun & Moon",
     "setCode": "sm1",
     "text": [
-      "Choose 1 of your Basic Pokémon in play. If you have a Stage 2 card in your hand that evolves from that Pokémon, put that card onto the Basic Pokémon to evolve it. You can't use this card during your first turn or on a Basic Pokémon that was put into play this turn."
+      "Choose 1 of your Basic Pokémon in play. If you have a Stage 2 card in your hand that evolves from that Pokémon, put that card onto the Basic Pokémon to evolve it. You can’t use this card during your first turn or on a Basic Pokémon that was put into play this turn."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/129_hires.png"
   },
@@ -6460,7 +6460,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "50×",
-        "text": "This attack does 50 damage times the amount of Grass Energy attached to this Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage times the amount of Grass Energy attached to this Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6515,7 +6515,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "160",
-        "text": "This Pokémon can't attack during your next turn."
+        "text": "This Pokémon can’t attack during your next turn."
       },
       {
         "name": "Ice Beam-GX",
@@ -6526,7 +6526,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "Your opponent's Active Pokémon is now Paralyzed. (You can't use more than 1 GX attack in a game.)"
+        "text": "Your opponent’s Active Pokémon is now Paralyzed. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6570,7 +6570,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       },
       {
         "name": "Psychic",
@@ -6581,7 +6581,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "This attack does 30 more damage times the amount of Energy attached to your opponent's Active Pokémon."
+        "text": "This attack does 30 more damage times the amount of Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Divide-GX",
@@ -6592,7 +6592,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Put 10 damage counters on your opponent's Pokémon in any way you like. (You can't use more than 1 GX attack in a game.)"
+        "text": "Put 10 damage counters on your opponent’s Pokémon in any way you like. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6645,7 +6645,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "The Defending Pokémon can't be healed during your opponent's next turn."
+        "text": "The Defending Pokémon can’t be healed during your opponent’s next turn."
       },
       {
         "name": "Lunar Fall-GX",
@@ -6656,7 +6656,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Knock Out 1 of your opponent's Basic Pokémon that isn't a Pokémon-GX. (You can't use more than 1 GX attack in a game.)"
+        "text": "Knock Out 1 of your opponent’s Basic Pokémon that isn’t a Pokémon-GX. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6718,7 +6718,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Dark Call-GX",
@@ -6728,7 +6728,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Discard 2 Energy from your opponent's Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "Discard 2 Energy from your opponent’s Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6796,7 +6796,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Search your deck for up to 5 Energy cards and attach them to your Pokémon in any way you like. Then, shuffle your deck. (You can't use more than 1 GX attack in a game.)"
+        "text": "Search your deck for up to 5 Energy cards and attach them to your Pokémon in any way you like. Then, shuffle your deck. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6868,7 +6868,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30×",
-        "text": "This attack does 30 damage for each damage counter on this Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "This attack does 30 damage for each damage counter on this Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6929,7 +6929,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "This attack does 50 more damage times the amount of Energy attached to your opponent's Active Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 more damage times the amount of Energy attached to your opponent’s Active Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -6971,7 +6971,7 @@
     "set": "Sun & Moon",
     "setCode": "sm1",
     "text": [
-      "Draw cards until you have 6 cards in your hand. If it's your first turn, draw cards until you have 8 cards in your hand."
+      "Draw cards until you have 6 cards in your hand. If it’s your first turn, draw cards until you have 8 cards in your hand."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/147_hires.png"
   },
@@ -6988,7 +6988,7 @@
     "set": "Sun & Moon",
     "setCode": "sm1",
     "text": [
-      "Draw 2 cards. During this turn, your Pokémon's attacks do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance)."
+      "Draw 2 cards. During this turn, your Pokémon’s attacks do 20 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/148_hires.png"
   },
@@ -7062,7 +7062,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "50×",
-        "text": "This attack does 50 damage times the amount of Grass Energy attached to this Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 damage times the amount of Grass Energy attached to this Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7117,7 +7117,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "160",
-        "text": "This Pokémon can't attack during your next turn."
+        "text": "This Pokémon can’t attack during your next turn."
       },
       {
         "name": "Ice Beam-GX",
@@ -7128,7 +7128,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "Your opponent's Active Pokémon is now Paralyzed. (You can't use more than 1 GX attack in a game.)"
+        "text": "Your opponent’s Active Pokémon is now Paralyzed. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7172,7 +7172,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       },
       {
         "name": "Psychic",
@@ -7183,7 +7183,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "This attack does 30 more damage times the amount of Energy attached to your opponent's Active Pokémon."
+        "text": "This attack does 30 more damage times the amount of Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Divide-GX",
@@ -7194,7 +7194,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Put 10 damage counters on your opponent's Pokémon in any way you like. (You can't use more than 1 GX attack in a game.)"
+        "text": "Put 10 damage counters on your opponent’s Pokémon in any way you like. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7247,7 +7247,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "The Defending Pokémon can't be healed during your opponent's next turn."
+        "text": "The Defending Pokémon can’t be healed during your opponent’s next turn."
       },
       {
         "name": "Lunar Fall-GX",
@@ -7258,7 +7258,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Knock Out 1 of your opponent's Basic Pokémon that isn't a Pokémon-GX. (You can't use more than 1 GX attack in a game.)"
+        "text": "Knock Out 1 of your opponent’s Basic Pokémon that isn’t a Pokémon-GX. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7320,7 +7320,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Dark Call-GX",
@@ -7330,7 +7330,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Discard 2 Energy from your opponent's Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "Discard 2 Energy from your opponent’s Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7398,7 +7398,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Search your deck for up to 5 Energy cards and attach them to your Pokémon in any way you like. Then, shuffle your deck. (You can't use more than 1 GX attack in a game.)"
+        "text": "Search your deck for up to 5 Energy cards and attach them to your Pokémon in any way you like. Then, shuffle your deck. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7470,7 +7470,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30×",
-        "text": "This attack does 30 damage for each damage counter on this Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "This attack does 30 damage for each damage counter on this Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [
@@ -7531,7 +7531,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "This attack does 50 more damage times the amount of Energy attached to your opponent's Active Pokémon. (You can't use more than 1 GX attack in a game.)"
+        "text": "This attack does 50 more damage times the amount of Energy attached to your opponent’s Active Pokémon. (You can’t use more than 1 GX attack in a game.)"
       }
     ],
     "weaknesses": [

--- a/json/cards/Supreme Victors.json
+++ b/json/cards/Supreme Victors.json
@@ -27,7 +27,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
       },
       {
         "name": "Doom News",
@@ -38,7 +38,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Return all Energy cards attached to Absol to your hand. The Defending Pokémon is Knocked Out at the end of your opponent's next turn."
+        "text": "Return all Energy cards attached to Absol to your hand. The Defending Pokémon is Knocked Out at the end of your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -84,7 +84,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon. The new Defending Pokémon is now Burned."
+        "text": "Switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon. The new Defending Pokémon is now Burned."
       },
       {
         "name": "Vapor Kick",
@@ -142,7 +142,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Benched Pokémon. This attack does 40 damage to that Pokémon. Apply Weakness and Resistance."
+        "text": "Choose 1 of your opponent’s Benched Pokémon. This attack does 40 damage to that Pokémon. Apply Weakness and Resistance."
       }
     ],
     "weaknesses": [
@@ -229,7 +229,7 @@
     "evolvesFrom": "Gabite",
     "ability": {
       "name": "Dragon Intimidation",
-      "text": "If Garchomp is your Active Pokémon and is damaged by an opponent's attack (even if Garchomp is Knocked Out), choose an Energy card attached to the Attacking Pokémon and put it into your opponent's hand.",
+      "text": "If Garchomp is your Active Pokémon and is damaged by an opponent’s attack (even if Garchomp is Knocked Out), choose an Energy card attached to the Attacking Pokémon and put it into your opponent’s hand.",
       "type": "Poké-Body"
     },
     "hp": "130",
@@ -251,7 +251,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "During your opponent's next turn, any damage done to Garchomp by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Garchomp by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Speed Impact",
@@ -284,7 +284,7 @@
     "evolvesFrom": "Magmar",
     "ability": {
       "name": "Evolutionary Flame",
-      "text": "Once during your turn, when you play Magmortar from your hand to evolve 1 of your Pokémon, you may use this power. Your opponent's Active Pokémon is now Burned and Confused.",
+      "text": "Once during your turn, when you play Magmortar from your hand to evolve 1 of your Pokémon, you may use this power. Your opponent’s Active Pokémon is now Burned and Confused.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -310,7 +310,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Flame Ball",
@@ -343,7 +343,7 @@
     "evolvesFrom": "Metang",
     "ability": {
       "name": "Gravitation",
-      "text": "Each Pokémon in play (both yours and your opponent's) gets -20 HP. No more than 20 HP can be reduced by all Gravitation Poké-Bodies.",
+      "text": "Each Pokémon in play (both yours and your opponent’s) gets -20 HP. No more than 20 HP can be reduced by all Gravitation Poké-Bodies.",
       "type": "Poké-Body"
     },
     "hp": "130",
@@ -371,7 +371,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "If you have a Stadium card in play, this attack does 20 damage to each of your opponent's Benched Pokémon that is the same type as the Defending Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If you have a Stadium card in play, this attack does 20 damage to each of your opponent’s Benched Pokémon that is the same type as the Defending Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -551,7 +551,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "If the Defending Pokémon would be Knocked Out by this attack, discard the top 3 cards from your opponent's deck."
+        "text": "If the Defending Pokémon would be Knocked Out by this attack, discard the top 3 cards from your opponent’s deck."
       }
     ],
     "weaknesses": [
@@ -636,7 +636,7 @@
     "evolvesFrom": "Marshtomp",
     "ability": {
       "name": "Root Protector",
-      "text": "Any damage done to Swampert by attacks from your opponent's Pokémon that isn't an Evolved Pokémon is reduced by 20 (after applying Weakness and Resistance).",
+      "text": "Any damage done to Swampert by attacks from your opponent’s Pokémon that isn’t an Evolved Pokémon is reduced by 20 (after applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "130",
@@ -663,7 +663,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Before doing damage, you may switch your opponent's Active Pokémon with 1 of his or her Benched Pokémon."
+        "text": "Before doing damage, you may switch your opponent’s Active Pokémon with 1 of his or her Benched Pokémon."
       },
       {
         "name": "Push Over",
@@ -697,7 +697,7 @@
     "evolvesFrom": "Ivysaur",
     "ability": {
       "name": "Green Aroma",
-      "text": "Remove all Special Conditions from each of your Grass Pokémon. Each of your Grass Pokémon can't be affected by any Special Conditions.",
+      "text": "Remove all Special Conditions from each of your Grass Pokémon. Each of your Grass Pokémon can’t be affected by any Special Conditions.",
       "type": "Poké-Body"
     },
     "hp": "140",
@@ -758,7 +758,7 @@
     "evolvesFrom": "Yanma",
     "ability": {
       "name": "Speed Boost",
-      "text": "Once during your turn (before your attack), if Yanmega is your Active Pokémon, you may search your discard pile for a Grass Energy card and attach it to Yanmega. This power can't be used if Yanmega is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Yanmega is your Active Pokémon, you may search your discard pile for a Grass Energy card and attach it to Yanmega. This power can’t be used if Yanmega is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -819,7 +819,7 @@
     "level": "60",
     "ability": {
       "name": "Extreme Speed",
-      "text": "Arcanine 's Retreat Cost is Colorless less for each Fire Energy attached to Arcanine .",
+      "text": "Arcanine ’s Retreat Cost is Colorless less for each Fire Energy attached to Arcanine .",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -846,7 +846,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -928,7 +928,7 @@
     "level": "50",
     "ability": {
       "name": "Compound Eyes",
-      "text": "If your opponent's Active Pokémon has any Poké-Bodies, each of Butterfree 's attacks does 30 more damage to the Active Pokémon (before applying Weakness and Resistance).",
+      "text": "If your opponent’s Active Pokémon has any Poké-Bodies, each of Butterfree ’s attacks does 30 more damage to the Active Pokémon (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -1072,7 +1072,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "Flip 2 coins. This attack does 10 damage times the number of heads to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip 2 coins. This attack does 10 damage times the number of heads to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1115,7 +1115,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, this attack does 40 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 40 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Heat Blast",
@@ -1181,7 +1181,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. Count the amount of Energy attached to that Pokémon. Put that many damage counters on the Pokémon."
+        "text": "Choose 1 of your opponent’s Pokémon. Count the amount of Energy attached to that Pokémon. Put that many damage counters on the Pokémon."
       }
     ],
     "weaknesses": [
@@ -1223,7 +1223,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Put 3 damage counters on any Pokémon (both yours and your opponent's) in any way you like."
+        "text": "Put 3 damage counters on any Pokémon (both yours and your opponent’s) in any way you like."
       },
       {
         "name": "Synchro Attack",
@@ -1233,7 +1233,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "If the Defending Pokémon has the same remaining HP as Claydol, this attack's base damage is 90 instead of 30."
+        "text": "If the Defending Pokémon has the same remaining HP as Claydol, this attack’s base damage is 90 instead of 30."
       }
     ],
     "weaknesses": [
@@ -1333,7 +1333,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "If the Defending Pokémon is a Fighting Pokémon, this attack's base damage is 80 instead of 30."
+        "text": "If the Defending Pokémon is a Fighting Pokémon, this attack’s base damage is 80 instead of 30."
       },
       {
         "name": "Aurora Beam",
@@ -1367,7 +1367,7 @@
     "evolvesFrom": "Doduo",
     "ability": {
       "name": "Echo Draw",
-      "text": "Once during your turn (before your attack), you may draw a card. This power can't be used if Dodrio is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may draw a card. This power can’t be used if Dodrio is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -1497,7 +1497,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Move an Energy card attached to the Defending Pokémon to another of your opponent's Pokémon."
+        "text": "Move an Energy card attached to the Defending Pokémon to another of your opponent’s Pokémon."
       },
       {
         "name": "Escort",
@@ -1589,7 +1589,7 @@
     "evolvesFrom": "Murkrow",
     "ability": {
       "name": "Darkness Restore",
-      "text": "Once during your turn (before your attack), if Honchkrow is your Active Pokémon and your opponent's Bench isn't full, you may use this power. Search your opponent's discard pile for a Basic Pokémon and put it onto his or her Bench. This power can't be used if Honchkrow is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Honchkrow is your Active Pokémon and your opponent’s Bench isn’t full, you may use this power. Search your opponent’s discard pile for a Basic Pokémon and put it onto his or her Bench. This power can’t be used if Honchkrow is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -1615,7 +1615,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30+",
-        "text": "Does 30 damage plus 10 more damage for each Pokémon that isn't an Evolved Pokémon in play (both yours and your opponent's)."
+        "text": "Does 30 damage plus 10 more damage for each Pokémon that isn’t an Evolved Pokémon in play (both yours and your opponent’s)."
       }
     ],
     "weaknesses": [
@@ -1746,7 +1746,7 @@
     "level": "38",
     "ability": {
       "name": "Marvel Eyes",
-      "text": "If you have Solrock in play, prevent all effects of attacks, including damage, done to any of your Lunatone or Solrock by your opponent's Pokémon LV.X.",
+      "text": "If you have Solrock in play, prevent all effects of attacks, including damage, done to any of your Lunatone or Solrock by your opponent’s Pokémon LV.X.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -1768,7 +1768,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Does 30 damage to each of your opponent's Benched Pokémon that doesn't have a Retreat Cost. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 30 damage to each of your opponent’s Benched Pokémon that doesn’t have a Retreat Cost. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1808,7 +1808,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, any damage done by Mawile's Swallow or Bite to your opponent's Active Pokémon is increased by 40 (before applying Weakness and Resistance)."
+        "text": "During your next turn, any damage done by Mawile’s Swallow or Bite to your opponent’s Active Pokémon is increased by 40 (before applying Weakness and Resistance)."
       },
       {
         "name": "Swallow",
@@ -1887,7 +1887,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "10+",
-        "text": "Does 10 damage plus 10 more damage for each card in your opponent's hand."
+        "text": "Does 10 damage plus 10 more damage for each card in your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -2132,7 +2132,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Discard the top card from your opponent's deck. If you discarded a Pokémon, this attack does damage equal to the HP of that Pokémon."
+        "text": "Discard the top card from your opponent’s deck. If you discarded a Pokémon, this attack does damage equal to the HP of that Pokémon."
       },
       {
         "name": "Brick Break",
@@ -2142,7 +2142,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "This attack's damage isn't affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -2240,7 +2240,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Choose 1 card from your opponent's hand without looking. Look at that card you chose, then have your opponent shuffle that card into his or her deck."
+        "text": "Choose 1 card from your opponent’s hand without looking. Look at that card you chose, then have your opponent shuffle that card into his or her deck."
       }
     ],
     "resistances": [
@@ -2262,7 +2262,7 @@
     "evolvesFrom": "Sandshrew",
     "ability": {
       "name": "Dig Down",
-      "text": "Once during your turn (before your attack), you may look at the top 5 cards of your deck. Choose as many Fighting Energy cards as you like, show them to your opponent, and put them into your hand. Put the other cards back on top of your deck. Shuffle your deck afterward. This power can't be used if Sandslash is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may look at the top 5 cards of your deck. Choose as many Fighting Energy cards as you like, show them to your opponent, and put them into your hand. Put the other cards back on top of your deck. Shuffle your deck afterward. This power can’t be used if Sandslash is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -2344,7 +2344,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Flip a coin. If heads, during your opponent's next turn, if Seaking would be Knocked Out by damage from an attack, Seaking is not Knocked Out and its remaining HP becomes 10 instead."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, if Seaking would be Knocked Out by damage from an attack, Seaking is not Knocked Out and its remaining HP becomes 10 instead."
       }
     ],
     "weaknesses": [
@@ -2366,7 +2366,7 @@
     "evolvesFrom": "Nincada",
     "ability": {
       "name": "Marvel Shell",
-      "text": "Prevent all effects of attacks, including damage, done to Shedinja by your opponent's Pokémon that has any Poké-Powers or Poké-Bodies.",
+      "text": "Prevent all effects of attacks, including damage, done to Shedinja by your opponent’s Pokémon that has any Poké-Powers or Poké-Bodies.",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -2390,7 +2390,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon that has any damage counters on it. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon that has any damage counters on it. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2411,7 +2411,7 @@
     "level": "41",
     "ability": {
       "name": "Sunshine Fate",
-      "text": "Once during your turn (before your attack), if you have Lunatone in play, you may look at the top 3 cards of your deck and put them back on top of your deck in any order. This power can't be used if Solrock is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if you have Lunatone in play, you may look at the top 3 cards of your deck and put them back on top of your deck in any order. This power can’t be used if Solrock is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -2485,7 +2485,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "If the Defending Pokémon already has any damage counters on it, this attack's base damage is 10 instead of 30."
+        "text": "If the Defending Pokémon already has any damage counters on it, this attack’s base damage is 10 instead of 30."
       }
     ],
     "weaknesses": [
@@ -2543,7 +2543,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "100",
-        "text": "Wailord can't use Giant Wave during your next turn."
+        "text": "Wailord can’t use Giant Wave during your next turn."
       }
     ],
     "weaknesses": [
@@ -2655,7 +2655,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -2705,7 +2705,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Combustion",
@@ -2903,7 +2903,7 @@
     "level": "49",
     "ability": {
       "name": "Disrupting Spy",
-      "text": "Once during your turn, when you put Chatot from your hand onto your Bench, you may look at the top 4 cards of your opponent's deck. Put them back on top of your opponent's deck in any order.",
+      "text": "Once during your turn, when you put Chatot from your hand onto your Bench, you may look at the top 4 cards of your opponent’s deck. Put them back on top of your opponent’s deck in any order.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -3033,7 +3033,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "If the Defending Pokémon is a Pokémon SP, this attack's base damage is 80 instead of 20."
+        "text": "If the Defending Pokémon is a Pokémon SP, this attack’s base damage is 80 instead of 20."
       },
       {
         "name": "Giant Tail",
@@ -3214,7 +3214,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3269,7 +3269,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3347,7 +3347,7 @@
     "evolvesFrom": "Bulbasaur",
     "ability": {
       "name": "Evolutionary Pollen",
-      "text": "Once during your turn, when you play Ivysaur from your hand to evolve 1 of your Pokémon, you may use this power. Your opponent's Active Pokémon is now Asleep.",
+      "text": "Once during your turn, when you play Ivysaur from your hand to evolve 1 of your Pokémon, you may use this power. Your opponent’s Active Pokémon is now Asleep.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -3483,7 +3483,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Discard the top card from your opponent's deck."
+        "text": "Discard the top card from your opponent’s deck."
       }
     ],
     "weaknesses": [
@@ -3526,7 +3526,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Fireworks",
@@ -3668,7 +3668,7 @@
     "evolvesFrom": "Surskit",
     "ability": {
       "name": "Intimidating Pattern",
-      "text": "As long as Masquerain is your Active Pokémon, any damage done by an opponent's attack is reduced by 20 (before applying Weakness and Resistance).",
+      "text": "As long as Masquerain is your Active Pokémon, any damage done by an opponent’s attack is reduced by 20 (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -3901,7 +3901,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Move a Pokémon Tool card attached to 1 of your opponent's Pokémon to another of your opponent's Pokémon (excluding Pokémon that already has a Pokémon Tool attached to it). (If an effect of this attack is prevented, this attack does nothing.)"
+        "text": "Move a Pokémon Tool card attached to 1 of your opponent’s Pokémon to another of your opponent’s Pokémon (excluding Pokémon that already has a Pokémon Tool attached to it). (If an effect of this attack is prevented, this attack does nothing.)"
       },
       {
         "name": "Flap",
@@ -3958,7 +3958,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Switch Ninjask with 1 of your Benched Pokémon."
+        "text": "This attack does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) Switch Ninjask with 1 of your Benched Pokémon."
       },
       {
         "name": "Parallel Drain",
@@ -4188,7 +4188,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Does 10 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4280,7 +4280,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon for each Pokémon Tool card and Stadium card your opponent has in play. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon for each Pokémon Tool card and Stadium card your opponent has in play. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Amnesia",
@@ -4290,7 +4290,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -4344,7 +4344,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -4456,7 +4456,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "This attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4502,7 +4502,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "During your opponent's next turn, when your opponent puts a Basic Pokémon from his or her hand onto his or her Bench, put 2 damage counters on that Pokémon."
+        "text": "During your opponent’s next turn, when your opponent puts a Basic Pokémon from his or her hand onto his or her Bench, put 2 damage counters on that Pokémon."
       },
       {
         "name": "Metal Max",
@@ -4558,7 +4558,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Lock Up",
@@ -4568,7 +4568,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "resistances": [
@@ -4726,7 +4726,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "Does 20 damage plus 10 more damage for each Water Energy attached to Wailmer but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "Does 20 damage plus 10 more damage for each Water Energy attached to Wailmer but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       },
       {
         "name": "Take Down",
@@ -5325,7 +5325,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Search your opponent's discard pile for a Supporter card and use the effect of that card as the effect of this attack. (The Supporter card remains in your opponent's discard pile.)"
+        "text": "Search your opponent’s discard pile for a Supporter card and use the effect of that card as the effect of this attack. (The Supporter card remains in your opponent’s discard pile.)"
       }
     ],
     "weaknesses": [
@@ -5645,7 +5645,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Draw a card for each of your opponent's Pokémon that isn't an Evolved Pokémon."
+        "text": "Draw a card for each of your opponent’s Pokémon that isn’t an Evolved Pokémon."
       }
     ],
     "weaknesses": [
@@ -5742,7 +5742,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Bite",
@@ -6210,7 +6210,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can use only that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can use only that attack during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -6312,7 +6312,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Benched Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Benched Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -7198,14 +7198,14 @@
     "set": "Supreme Victors",
     "setCode": "pl3",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
       "Whenever any player plays any Pokémon from his or her hand to Level-Up 1 of his or her Pokémon, remove 4 damage counters from that Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl3/134_hires.png"
   },
   {
     "id": "pl3-135",
-    "name": "Champion's Room",
+    "name": "Champion’s Room",
     "imageUrl": "https://images.pokemontcg.io/pl3/135.png",
     "subtype": "Stadium",
     "supertype": "Trainer",
@@ -7216,14 +7216,14 @@
     "set": "Supreme Victors",
     "setCode": "pl3",
     "text": [
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "The Retreat Cost for each Pokémon SP (both yours and your opponent's) is Colorless less."
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.",
+      "The Retreat Cost for each Pokémon SP (both yours and your opponent’s) is Colorless less."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl3/135_hires.png"
   },
   {
     "id": "pl3-136",
-    "name": "Cynthia's Guidance",
+    "name": "Cynthia’s Guidance",
     "imageUrl": "https://images.pokemontcg.io/pl3/136.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -7242,7 +7242,7 @@
   },
   {
     "id": "pl3-137",
-    "name": "Cyrus's Initiative",
+    "name": "Cyrus’s Initiative",
     "imageUrl": "https://images.pokemontcg.io/pl3/137.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -7255,7 +7255,7 @@
     "setCode": "pl3",
     "text": [
       "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.",
-      "Flip 2 coins. If either of them is heads, look at your opponent's hand. For each heads, choose 1 card from your opponent's hand and put it on the bottom of your opponent's deck in any order."
+      "Flip 2 coins. If either of them is heads, look at your opponent’s hand. For each heads, choose 1 card from your opponent’s hand and put it on the bottom of your opponent’s deck in any order."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/pl3/137_hires.png"
   },
@@ -7279,7 +7279,7 @@
   },
   {
     "id": "pl3-139",
-    "name": "Palmer's Contribution",
+    "name": "Palmer’s Contribution",
     "imageUrl": "https://images.pokemontcg.io/pl3/139.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -7323,7 +7323,7 @@
     "level": "X",
     "ability": {
       "name": "Darkness Send",
-      "text": "Once during your turn (before your attack), when you put Absol LV.X from your hand onto your Active Absol , you may flip 3 coins. For each heads, put the top card from your opponent's deck in the Lost Zone.",
+      "text": "Once during your turn (before your attack), when you put Absol LV.X from your hand onto your Active Absol , you may flip 3 coins. For each heads, put the top card from your opponent’s deck in the Lost Zone.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -7378,7 +7378,7 @@
     "level": "X",
     "ability": {
       "name": "Burning Spirit",
-      "text": "Any damage done by attacks to a Burned Pokémon (both yours and your opponent's) is increased by 40 (after applying Weakness and Resistance). No more than 40 damage can be added by all Burning Spirit Poké-Bodies.",
+      "text": "Any damage done by attacks to a Burned Pokémon (both yours and your opponent’s) is increased by 40 (after applying Weakness and Resistance). No more than 40 damage can be added by all Burning Spirit Poké-Bodies.",
       "type": "Poké-Body"
     },
     "hp": "110",
@@ -7406,7 +7406,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "80",
-        "text": "During your opponent's next turn, any damage done to Blaziken by attacks is increased by 40 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Blaziken by attacks is increased by 40 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -7427,7 +7427,7 @@
     "level": "X",
     "ability": {
       "name": "Call for Power",
-      "text": "As often as you like during your turn (before your attack), you may move an Energy attached to 1 of your Pokémon to Charizard . This power can't be used if Charizard is affected by a Special Condition.",
+      "text": "As often as you like during your turn (before your attack), you may move an Energy attached to 1 of your Pokémon to Charizard . This power can’t be used if Charizard is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -7487,7 +7487,7 @@
     "level": "X",
     "ability": {
       "name": "Energy Recycle",
-      "text": "Once during your turn (before your attack), you may use this power. If you do, your turn ends. Search your discard pile for up to 3 Energy cards and attach them to your Pokémon in any way you like. This power can't be used if Electivire is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may use this power. If you do, your turn ends. Search your discard pile for up to 3 Energy cards and attach them to your Pokémon in any way you like. This power can’t be used if Electivire is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -7571,7 +7571,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Discard 2 Energy attached to Garchomp . Choose 1 of your opponent's Pokémon. This attack does 80 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Garchomp can't use Dragon Rush during your next turn."
+        "text": "Discard 2 Energy attached to Garchomp . Choose 1 of your opponent’s Pokémon. This attack does 80 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) Garchomp can’t use Dragon Rush during your next turn."
       }
     ],
     "weaknesses": [
@@ -7592,7 +7592,7 @@
     "level": "X",
     "ability": {
       "name": "Dragon Spirit",
-      "text": "If Rayquaza is your Active Pokémon and is damaged but not Knocked Out by an opponent's attack, you may search your discard pile for an Energy card and attach it to Rayquaza .",
+      "text": "If Rayquaza is your Active Pokémon and is damaged but not Knocked Out by an opponent’s attack, you may search your discard pile for an Energy card and attach it to Rayquaza .",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -7651,7 +7651,7 @@
     "level": "X",
     "ability": {
       "name": "Fast Call",
-      "text": "Once during your turn (before your attack), you may search your deck for a Supporter card, show it to your opponent, and put it into your hand. Shuffle your deck afterward. This power can't be used if Staraptor is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may search your deck for a Supporter card, show it to your opponent, and put it into your hand. Shuffle your deck afterward. This power can’t be used if Staraptor is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -7677,7 +7677,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Before doing damage, you may discard any Stadium card in play. If you do, this attack's base damage is 70 instead of 40."
+        "text": "Before doing damage, you may discard any Stadium card in play. If you do, this attack’s base damage is 70 instead of 40."
       }
     ],
     "weaknesses": [
@@ -7725,7 +7725,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "Flip a coin. If heads, the Defending Pokémon is now Paralyzed and this attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, the Defending Pokémon is now Paralyzed and this attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "resistances": [
@@ -7809,7 +7809,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Flip a coin. If heads, this attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) If tails, Zapdos does 30 damage to itself."
+        "text": "Flip a coin. If heads, this attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) If tails, Zapdos does 30 damage to itself."
       }
     ],
     "resistances": [
@@ -7831,7 +7831,7 @@
     "evolvesFrom": "Feebas",
     "ability": {
       "name": "Aqua Mirage",
-      "text": "If you have no cards in your hand, prevent all damage done to Milotic by attacks from your opponent's Pokémon.",
+      "text": "If you have no cards in your hand, prevent all damage done to Milotic by attacks from your opponent’s Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -7898,7 +7898,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "During your opponent's next turn, the Defending Pokémon's Retreat Cost is Colorless Colorless more."
+        "text": "During your opponent’s next turn, the Defending Pokémon’s Retreat Cost is Colorless Colorless more."
       },
       {
         "name": "Aqua Wave",
@@ -7949,7 +7949,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "This attack's damage isn't affected by Weakness or Resistance."
+        "text": "This attack’s damage isn’t affected by Weakness or Resistance."
       },
       {
         "name": "Baton Pass",

--- a/json/cards/Team Magma vs Team Aqua.json
+++ b/json/cards/Team Magma vs Team Aqua.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "ex4-1",
-    "name": "Team Aqua's Cacturne",
+    "name": "Team Aqua’s Cacturne",
     "imageUrl": "https://images.pokemontcg.io/ex4/1.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -28,7 +28,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "You may discard a Darkness Energy card attached to Team Aqua's Cacturne. If you do, the Defending Pokémon is now Paralyzed.\""
+        "text": "You may discard a Darkness Energy card attached to Team Aqua’s Cacturne. If you do, the Defending Pokémon is now Paralyzed.\""
       },
       {
         "name": "Poison Barb",
@@ -53,7 +53,7 @@
   },
   {
     "id": "ex4-2",
-    "name": "Team Aqua's Crawdaunt",
+    "name": "Team Aqua’s Crawdaunt",
     "imageUrl": "https://images.pokemontcg.io/ex4/2.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -80,7 +80,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Before doing damage, you may choose 1 of your opponent's Benched Pokémon that has Team Magma in its name and switch it with 1 of the Defending Pokémon. Your opponent chooses which Defending Pokémon to switch."
+        "text": "Before doing damage, you may choose 1 of your opponent’s Benched Pokémon that has Team Magma in its name and switch it with 1 of the Defending Pokémon. Your opponent chooses which Defending Pokémon to switch."
       },
       {
         "name": "Deep Impact",
@@ -105,13 +105,13 @@
   },
   {
     "id": "ex4-3",
-    "name": "Team Aqua's Kyogre",
+    "name": "Team Aqua’s Kyogre",
     "imageUrl": "https://images.pokemontcg.io/ex4/3.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
     "ability": {
       "name": "Power Saver",
-      "text": "As long as the number of Pokémon in play (both yours and your opponent's) that has Team Aqua in its name is 3 or less, Team Aqua's Kyogre can't attack.",
+      "text": "As long as the number of Pokémon in play (both yours and your opponent’s) that has Team Aqua in its name is 3 or less, Team Aqua’s Kyogre can’t attack.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -164,13 +164,13 @@
   },
   {
     "id": "ex4-4",
-    "name": "Team Aqua's Manectric",
+    "name": "Team Aqua’s Manectric",
     "imageUrl": "https://images.pokemontcg.io/ex4/4.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
     "ability": {
       "name": "Power Shift",
-      "text": "Once during your turn (before your attack), you may move any number of basic Energy cards attached to 1 of your Pokémon with Team Aqua in its name to another of your Pokémon. This power can't be used if Team Aqua's Manectric is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may move any number of basic Energy cards attached to 1 of your Pokémon with Team Aqua in its name to another of your Pokémon. This power can’t be used if Team Aqua’s Manectric is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -197,7 +197,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Does 10 damage to each Benched Pokémon (yours and your opponent's) that has Energy cards attached to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each Benched Pokémon (yours and your opponent’s) that has Energy cards attached to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -217,7 +217,7 @@
   },
   {
     "id": "ex4-5",
-    "name": "Team Aqua's Sharpedo",
+    "name": "Team Aqua’s Sharpedo",
     "imageUrl": "https://images.pokemontcg.io/ex4/5.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -241,7 +241,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10+",
-        "text": "Does 10 damage plus 10 more damage for each damage counter on Team Aqua's Sharpedo."
+        "text": "Does 10 damage plus 10 more damage for each damage counter on Team Aqua’s Sharpedo."
       },
       {
         "name": "Aqua Slash",
@@ -252,7 +252,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Team Aqua's Sharpedo can't attack during your next turn."
+        "text": "Team Aqua’s Sharpedo can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -266,7 +266,7 @@
   },
   {
     "id": "ex4-6",
-    "name": "Team Aqua's Walrein",
+    "name": "Team Aqua’s Walrein",
     "imageUrl": "https://images.pokemontcg.io/ex4/6.png",
     "subtype": "Stage 2",
     "supertype": "Pokémon",
@@ -293,7 +293,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "Does 10 damage plus 10 more damage for each Energy attached to Team Aqua's Walrein."
+        "text": "Does 10 damage plus 10 more damage for each Energy attached to Team Aqua’s Walrein."
       },
       {
         "name": "Hydro Reverse",
@@ -323,7 +323,7 @@
   },
   {
     "id": "ex4-7",
-    "name": "Team Magma's Aggron",
+    "name": "Team Magma’s Aggron",
     "imageUrl": "https://images.pokemontcg.io/ex4/7.png",
     "subtype": "Stage 2",
     "supertype": "Pokémon",
@@ -350,7 +350,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30x",
-        "text": "Flip a coin for each Energy attached to Team Magma's Aggron. This attack does 30 damage times the number of heads."
+        "text": "Flip a coin for each Energy attached to Team Magma’s Aggron. This attack does 30 damage times the number of heads."
       },
       {
         "name": "Land Stream",
@@ -362,7 +362,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "50+",
-        "text": "You may discard any number of basic Energy cards attached to Team Magma's Aggron. If you do, this attack does 50 damage plus 20 more damage for each basic Energy card you discarded."
+        "text": "You may discard any number of basic Energy cards attached to Team Magma’s Aggron. If you do, this attack does 50 damage plus 20 more damage for each basic Energy card you discarded."
       }
     ],
     "weaknesses": [
@@ -380,13 +380,13 @@
   },
   {
     "id": "ex4-8",
-    "name": "Team Magma's Claydol",
+    "name": "Team Magma’s Claydol",
     "imageUrl": "https://images.pokemontcg.io/ex4/8.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
     "ability": {
       "name": "Magma Switch",
-      "text": "Once during your turn (before your attack), you may move an Energy card attached to your Pokémon with Team Magma in its name to another of your Pokémon. This power can't be used if Team Magma's Claydol is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may move an Energy card attached to your Pokémon with Team Magma in its name to another of your Pokémon. This power can’t be used if Team Magma’s Claydol is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -428,13 +428,13 @@
   },
   {
     "id": "ex4-9",
-    "name": "Team Magma's Groudon",
+    "name": "Team Magma’s Groudon",
     "imageUrl": "https://images.pokemontcg.io/ex4/9.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
     "ability": {
       "name": "Power Saver",
-      "text": "As long as the number of Pokémon in play (both yours and your opponent's) that has Team Magma in its name is 3 or less, Team Magma's Groudon can't attack.",
+      "text": "As long as the number of Pokémon in play (both yours and your opponent’s) that has Team Magma in its name is 3 or less, Team Magma’s Groudon can’t attack.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -462,7 +462,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Pulverize",
@@ -487,7 +487,7 @@
   },
   {
     "id": "ex4-10",
-    "name": "Team Magma's Houndoom",
+    "name": "Team Magma’s Houndoom",
     "imageUrl": "https://images.pokemontcg.io/ex4/10.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -539,7 +539,7 @@
   },
   {
     "id": "ex4-11",
-    "name": "Team Magma's Rhydon",
+    "name": "Team Magma’s Rhydon",
     "imageUrl": "https://images.pokemontcg.io/ex4/11.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -567,7 +567,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "This attack's damage is not affected by Resistance."
+        "text": "This attack’s damage is not affected by Resistance."
       },
       {
         "name": "Shoot Down",
@@ -595,7 +595,7 @@
   },
   {
     "id": "ex4-12",
-    "name": "Team Magma's Torkoal",
+    "name": "Team Magma’s Torkoal",
     "imageUrl": "https://images.pokemontcg.io/ex4/12.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -622,7 +622,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Discard the top card from your opponent's deck, and flip a coin. If tails, discard a Fire Energy attached to Team Magma's Torkoal."
+        "text": "Discard the top card from your opponent’s deck, and flip a coin. If tails, discard a Fire Energy attached to Team Magma’s Torkoal."
       },
       {
         "name": "Hot Air",
@@ -632,7 +632,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Discard a Fire Energy attached to Team Magma's Torkoal, and your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon, if any."
+        "text": "Discard a Fire Energy attached to Team Magma’s Torkoal, and your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon, if any."
       }
     ],
     "weaknesses": [
@@ -672,7 +672,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Does 10 damage to 2 of your opponent's Benched Pokémon (1 if there is only 1). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 2 of your opponent’s Benched Pokémon (1 if there is only 1). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Kerzap",
@@ -697,7 +697,7 @@
   },
   {
     "id": "ex4-14",
-    "name": "Team Aqua's Crawdaunt",
+    "name": "Team Aqua’s Crawdaunt",
     "imageUrl": "https://images.pokemontcg.io/ex4/14.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -748,7 +748,7 @@
   },
   {
     "id": "ex4-15",
-    "name": "Team Aqua's Mightyena",
+    "name": "Team Aqua’s Mightyena",
     "imageUrl": "https://images.pokemontcg.io/ex4/15.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -805,7 +805,7 @@
   },
   {
     "id": "ex4-16",
-    "name": "Team Aqua's Sealeo",
+    "name": "Team Aqua’s Sealeo",
     "imageUrl": "https://images.pokemontcg.io/ex4/16.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -830,7 +830,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "At the end of your opponent's next turn, the Defending Pokémon is now Asleep."
+        "text": "At the end of your opponent’s next turn, the Defending Pokémon is now Asleep."
       },
       {
         "name": "Super Hypnoblast",
@@ -857,7 +857,7 @@
   },
   {
     "id": "ex4-17",
-    "name": "Team Aqua's Seviper",
+    "name": "Team Aqua’s Seviper",
     "imageUrl": "https://images.pokemontcg.io/ex4/17.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -908,7 +908,7 @@
   },
   {
     "id": "ex4-18",
-    "name": "Team Aqua's Sharpedo",
+    "name": "Team Aqua’s Sharpedo",
     "imageUrl": "https://images.pokemontcg.io/ex4/18.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -931,7 +931,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "At the end of your opponent's next turn, the Defending Pokémon is now Poisoned."
+        "text": "At the end of your opponent’s next turn, the Defending Pokémon is now Poisoned."
       },
       {
         "name": "Aqua Smash",
@@ -956,13 +956,13 @@
   },
   {
     "id": "ex4-19",
-    "name": "Team Magma's Camerupt",
+    "name": "Team Magma’s Camerupt",
     "imageUrl": "https://images.pokemontcg.io/ex4/19.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
     "ability": {
       "name": "Overheat",
-      "text": "Once during your turn (before your attack), you may search your discard pile for a basic Energy card and attach it to Team Magma's Camerupt. Put 2 damage counters on Team Mamga's Camerupt. This power can't be used if Team Magma's Camerupt is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may search your discard pile for a basic Energy card and attach it to Team Magma’s Camerupt. Put 2 damage counters on Team Mamga’s Camerupt. This power can’t be used if Team Magma’s Camerupt is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -989,7 +989,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "You may move a Fire Energy card attached to Team Magma's Camerupt to 1 of your Benched Pokémon."
+        "text": "You may move a Fire Energy card attached to Team Magma’s Camerupt to 1 of your Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -1003,7 +1003,7 @@
   },
   {
     "id": "ex4-20",
-    "name": "Team Magma's Lairon",
+    "name": "Team Magma’s Lairon",
     "imageUrl": "https://images.pokemontcg.io/ex4/20.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -1057,7 +1057,7 @@
   },
   {
     "id": "ex4-21",
-    "name": "Team Magma's Mightyena",
+    "name": "Team Magma’s Mightyena",
     "imageUrl": "https://images.pokemontcg.io/ex4/21.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -1082,7 +1082,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Choose 1 of your opponent's Benched Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Benched Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Bite Off",
@@ -1113,7 +1113,7 @@
   },
   {
     "id": "ex4-22",
-    "name": "Team Magma's Rhydon",
+    "name": "Team Magma’s Rhydon",
     "imageUrl": "https://images.pokemontcg.io/ex4/22.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -1151,7 +1151,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Flip a coin. If tails, discard an Energy card attached to Team Magma's Rhydon."
+        "text": "Flip a coin. If tails, discard an Energy card attached to Team Magma’s Rhydon."
       }
     ],
     "weaknesses": [
@@ -1168,7 +1168,7 @@
   },
   {
     "id": "ex4-23",
-    "name": "Team Magma's Zangoose",
+    "name": "Team Magma’s Zangoose",
     "imageUrl": "https://images.pokemontcg.io/ex4/23.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -1218,7 +1218,7 @@
   },
   {
     "id": "ex4-24",
-    "name": "Team Aqua's Cacnea",
+    "name": "Team Aqua’s Cacnea",
     "imageUrl": "https://images.pokemontcg.io/ex4/24.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -1271,13 +1271,13 @@
   },
   {
     "id": "ex4-25",
-    "name": "Team Aqua's Carvanha",
+    "name": "Team Aqua’s Carvanha",
     "imageUrl": "https://images.pokemontcg.io/ex4/25.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
     "ability": {
       "name": "Dark Lift",
-      "text": "If Team Aqua's Carvanha has any Darkness Energy attached to it, the Retreat Cost for Team Aqua's Carvanha is 0.\"",
+      "text": "If Team Aqua’s Carvanha has any Darkness Energy attached to it, the Retreat Cost for Team Aqua’s Carvanha is 0.\"",
       "type": "Poké-Body"
     },
     "hp": "50",
@@ -1302,7 +1302,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "At the end of your opponent's next turn, the Defending Pokémon is now Poisoned."
+        "text": "At the end of your opponent’s next turn, the Defending Pokémon is now Poisoned."
       }
     ],
     "weaknesses": [
@@ -1319,7 +1319,7 @@
   },
   {
     "id": "ex4-26",
-    "name": "Team Aqua's Corphish",
+    "name": "Team Aqua’s Corphish",
     "imageUrl": "https://images.pokemontcg.io/ex4/26.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -1354,7 +1354,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Discard a basic Energy card attached to Team Aqua's Corphish or this attack does nothing. The Defending Pokémon is now Poisoned."
+        "text": "Discard a basic Energy card attached to Team Aqua’s Corphish or this attack does nothing. The Defending Pokémon is now Poisoned."
       }
     ],
     "weaknesses": [
@@ -1371,7 +1371,7 @@
   },
   {
     "id": "ex4-27",
-    "name": "Team Aqua's Electrike",
+    "name": "Team Aqua’s Electrike",
     "imageUrl": "https://images.pokemontcg.io/ex4/27.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -1396,7 +1396,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Plasma",
@@ -1406,7 +1406,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Flip a coin. If heads, search your discard pile for a Lightning Energy card and attach it to Team Aqua's Electrike."
+        "text": "Flip a coin. If heads, search your discard pile for a Lightning Energy card and attach it to Team Aqua’s Electrike."
       }
     ],
     "weaknesses": [
@@ -1429,13 +1429,13 @@
   },
   {
     "id": "ex4-28",
-    "name": "Team Aqua's Lanturn",
+    "name": "Team Aqua’s Lanturn",
     "imageUrl": "https://images.pokemontcg.io/ex4/28.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
     "ability": {
       "name": "Auxiliary Light",
-      "text": "Once during your turn (before your attack), you may attach a basic Energy card from your hand to Team Aqua's Lanturn. Put 2 damage counters on Team Aqua's Lanturn. This power can't be used if Team Aqua's Lanturn is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may attach a basic Energy card from your hand to Team Aqua’s Lanturn. Put 2 damage counters on Team Aqua’s Lanturn. This power can’t be used if Team Aqua’s Lanturn is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -1481,7 +1481,7 @@
   },
   {
     "id": "ex4-29",
-    "name": "Team Aqua's Manectric",
+    "name": "Team Aqua’s Manectric",
     "imageUrl": "https://images.pokemontcg.io/ex4/29.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -1507,7 +1507,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If the Defending Pokémon has Team Magma's in its name, the Defending Pokémon is now Confused."
+        "text": "If the Defending Pokémon has Team Magma’s in its name, the Defending Pokémon is now Confused."
       },
       {
         "name": "Chaos Crush",
@@ -1538,7 +1538,7 @@
   },
   {
     "id": "ex4-30",
-    "name": "Team Aqua's Mightyena",
+    "name": "Team Aqua’s Mightyena",
     "imageUrl": "https://images.pokemontcg.io/ex4/30.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -1593,7 +1593,7 @@
   },
   {
     "id": "ex4-31",
-    "name": "Team Aqua's Sealeo",
+    "name": "Team Aqua’s Sealeo",
     "imageUrl": "https://images.pokemontcg.io/ex4/31.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -1648,7 +1648,7 @@
   },
   {
     "id": "ex4-32",
-    "name": "Team Magma's Baltoy",
+    "name": "Team Magma’s Baltoy",
     "imageUrl": "https://images.pokemontcg.io/ex4/32.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -1673,7 +1673,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip 2 coins. For each heads, choose 1 of your opponent's Pokémon and put 1 damage counter on that Pokémon."
+        "text": "Flip 2 coins. For each heads, choose 1 of your opponent’s Pokémon and put 1 damage counter on that Pokémon."
       },
       {
         "name": "Pain Amplifier",
@@ -1683,7 +1683,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Put 1 damage counter on each of your opponent's Pokémon that already has damage counters on it."
+        "text": "Put 1 damage counter on each of your opponent’s Pokémon that already has damage counters on it."
       }
     ],
     "weaknesses": [
@@ -1700,7 +1700,7 @@
   },
   {
     "id": "ex4-33",
-    "name": "Team Magma's Claydol",
+    "name": "Team Magma’s Claydol",
     "imageUrl": "https://images.pokemontcg.io/ex4/33.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -1726,7 +1726,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Put 2 damage counters on your opponent's Pokémon in any way you like."
+        "text": "Put 2 damage counters on your opponent’s Pokémon in any way you like."
       },
       {
         "name": "Clay Pulse",
@@ -1737,7 +1737,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Does 10 damage to each of your opponent's Benched Pokémon that has any damage counters on it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Benched Pokémon that has any damage counters on it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1751,7 +1751,7 @@
   },
   {
     "id": "ex4-34",
-    "name": "Team Magma's Houndoom",
+    "name": "Team Magma’s Houndoom",
     "imageUrl": "https://images.pokemontcg.io/ex4/34.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -1802,7 +1802,7 @@
   },
   {
     "id": "ex4-35",
-    "name": "Team Magma's Houndour",
+    "name": "Team Magma’s Houndour",
     "imageUrl": "https://images.pokemontcg.io/ex4/35.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -1854,7 +1854,7 @@
   },
   {
     "id": "ex4-36",
-    "name": "Team Magma's Lairon",
+    "name": "Team Magma’s Lairon",
     "imageUrl": "https://images.pokemontcg.io/ex4/36.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
@@ -1907,13 +1907,13 @@
   },
   {
     "id": "ex4-37",
-    "name": "Team Magma's Mightyena",
+    "name": "Team Magma’s Mightyena",
     "imageUrl": "https://images.pokemontcg.io/ex4/37.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
     "ability": {
       "name": "Call for Help",
-      "text": "Once during your turn (before your attack), if Team Magma's Mightyena is your Active Pokémon, you may search your deck for a Pokémon with Team Magma in its name, show it to your opponent, and put it into your hand. Shuffle your deck afterward. This power can't be used if Team Magma's Mightyena is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Team Magma’s Mightyena is your Active Pokémon, you may search your deck for a Pokémon with Team Magma in its name, show it to your opponent, and put it into your hand. Shuffle your deck afterward. This power can’t be used if Team Magma’s Mightyena is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -1958,7 +1958,7 @@
   },
   {
     "id": "ex4-38",
-    "name": "Team Magma's Rhyhorn",
+    "name": "Team Magma’s Rhyhorn",
     "imageUrl": "https://images.pokemontcg.io/ex4/38.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2233,7 +2233,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Pikachu during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Pikachu during your opponent’s next turn."
       },
       {
         "name": "Thundershock",
@@ -2336,7 +2336,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Tail Strike",
@@ -2370,7 +2370,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shell Retreat",
-      "text": "As long as Squirtle has any Energy cards attached to it, damage done to Squirtle by an opponent's attack is reduced by 10 (after applying Weakness and Resistance).",
+      "text": "As long as Squirtle has any Energy cards attached to it, damage done to Squirtle by an opponent’s attack is reduced by 10 (after applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "50",
@@ -2411,7 +2411,7 @@
   },
   {
     "id": "ex4-47",
-    "name": "Team Aqua's Carvanha",
+    "name": "Team Aqua’s Carvanha",
     "imageUrl": "https://images.pokemontcg.io/ex4/47.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2463,7 +2463,7 @@
   },
   {
     "id": "ex4-48",
-    "name": "Team Aqua's Carvanha",
+    "name": "Team Aqua’s Carvanha",
     "imageUrl": "https://images.pokemontcg.io/ex4/48.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2515,7 +2515,7 @@
   },
   {
     "id": "ex4-49",
-    "name": "Team Aqua's Chinchou",
+    "name": "Team Aqua’s Chinchou",
     "imageUrl": "https://images.pokemontcg.io/ex4/49.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2573,7 +2573,7 @@
   },
   {
     "id": "ex4-50",
-    "name": "Team Aqua's Corphish",
+    "name": "Team Aqua’s Corphish",
     "imageUrl": "https://images.pokemontcg.io/ex4/50.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2615,7 +2615,7 @@
   },
   {
     "id": "ex4-51",
-    "name": "Team Aqua's Corphish",
+    "name": "Team Aqua’s Corphish",
     "imageUrl": "https://images.pokemontcg.io/ex4/51.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2650,7 +2650,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "At the end of your opponent's next turn, the Defending Pokémon is now Poisoned."
+        "text": "At the end of your opponent’s next turn, the Defending Pokémon is now Poisoned."
       }
     ],
     "weaknesses": [
@@ -2667,7 +2667,7 @@
   },
   {
     "id": "ex4-52",
-    "name": "Team Aqua's Electrike",
+    "name": "Team Aqua’s Electrike",
     "imageUrl": "https://images.pokemontcg.io/ex4/52.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2725,7 +2725,7 @@
   },
   {
     "id": "ex4-53",
-    "name": "Team Aqua's Electrike",
+    "name": "Team Aqua’s Electrike",
     "imageUrl": "https://images.pokemontcg.io/ex4/53.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2750,7 +2750,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Attach an Energy card from your hand to Team Aqua's Electrike."
+        "text": "Attach an Energy card from your hand to Team Aqua’s Electrike."
       },
       {
         "name": "Tackle",
@@ -2783,7 +2783,7 @@
   },
   {
     "id": "ex4-54",
-    "name": "Team Aqua's Poochyena",
+    "name": "Team Aqua’s Poochyena",
     "imageUrl": "https://images.pokemontcg.io/ex4/54.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2841,7 +2841,7 @@
   },
   {
     "id": "ex4-55",
-    "name": "Team Aqua's Poochyena",
+    "name": "Team Aqua’s Poochyena",
     "imageUrl": "https://images.pokemontcg.io/ex4/55.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2899,7 +2899,7 @@
   },
   {
     "id": "ex4-56",
-    "name": "Team Aqua's Spheal",
+    "name": "Team Aqua’s Spheal",
     "imageUrl": "https://images.pokemontcg.io/ex4/56.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2941,7 +2941,7 @@
   },
   {
     "id": "ex4-57",
-    "name": "Team Aqua's Spheal",
+    "name": "Team Aqua’s Spheal",
     "imageUrl": "https://images.pokemontcg.io/ex4/57.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2976,7 +2976,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "At the end of your opponent's next turn, the Defending Pokémon is now Asleep."
+        "text": "At the end of your opponent’s next turn, the Defending Pokémon is now Asleep."
       }
     ],
     "weaknesses": [
@@ -2993,7 +2993,7 @@
   },
   {
     "id": "ex4-58",
-    "name": "Team Magma's Aron",
+    "name": "Team Magma’s Aron",
     "imageUrl": "https://images.pokemontcg.io/ex4/58.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3045,7 +3045,7 @@
   },
   {
     "id": "ex4-59",
-    "name": "Team Magma's Aron",
+    "name": "Team Magma’s Aron",
     "imageUrl": "https://images.pokemontcg.io/ex4/59.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3070,7 +3070,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -3087,7 +3087,7 @@
   },
   {
     "id": "ex4-60",
-    "name": "Team Magma's Baltoy",
+    "name": "Team Magma’s Baltoy",
     "imageUrl": "https://images.pokemontcg.io/ex4/60.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3139,7 +3139,7 @@
   },
   {
     "id": "ex4-61",
-    "name": "Team Magma's Baltoy",
+    "name": "Team Magma’s Baltoy",
     "imageUrl": "https://images.pokemontcg.io/ex4/61.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3164,7 +3164,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 1 damage counter on 1 of your opponent's Pokémon."
+        "text": "Put 1 damage counter on 1 of your opponent’s Pokémon."
       },
       {
         "name": "Spinning Attack",
@@ -3191,7 +3191,7 @@
   },
   {
     "id": "ex4-62",
-    "name": "Team Magma's Houndour",
+    "name": "Team Magma’s Houndour",
     "imageUrl": "https://images.pokemontcg.io/ex4/62.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3243,7 +3243,7 @@
   },
   {
     "id": "ex4-63",
-    "name": "Team Magma's Houndour",
+    "name": "Team Magma’s Houndour",
     "imageUrl": "https://images.pokemontcg.io/ex4/63.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3295,7 +3295,7 @@
   },
   {
     "id": "ex4-64",
-    "name": "Team Magma's Numel",
+    "name": "Team Magma’s Numel",
     "imageUrl": "https://images.pokemontcg.io/ex4/64.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3347,7 +3347,7 @@
   },
   {
     "id": "ex4-65",
-    "name": "Team Magma's Poochyena",
+    "name": "Team Magma’s Poochyena",
     "imageUrl": "https://images.pokemontcg.io/ex4/65.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3395,7 +3395,7 @@
   },
   {
     "id": "ex4-66",
-    "name": "Team Magma's Poochyena",
+    "name": "Team Magma’s Poochyena",
     "imageUrl": "https://images.pokemontcg.io/ex4/66.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3453,7 +3453,7 @@
   },
   {
     "id": "ex4-67",
-    "name": "Team Magma's Rhyhorn",
+    "name": "Team Magma’s Rhyhorn",
     "imageUrl": "https://images.pokemontcg.io/ex4/67.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3505,7 +3505,7 @@
   },
   {
     "id": "ex4-68",
-    "name": "Team Magma's Rhyhorn",
+    "name": "Team Magma’s Rhyhorn",
     "imageUrl": "https://images.pokemontcg.io/ex4/68.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -3665,7 +3665,7 @@
     "setCode": "ex4",
     "text": [
       "Whenever an attack from the Pokémon that Strength Charm is attached to does damage to the Active Pokémon (after applying Weakness and Resistance), the attack does 10 more damage. At the end of the turn in which this happens, discard Strength Charm.",
-      "Attach Strength Charm to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card."
+      "Attach Strength Charm to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/74_hires.png"
   },
@@ -3702,7 +3702,7 @@
     "setCode": "ex4",
     "text": [
       "At any time between turns, if the Pokémon Team Aqua Belt is attached to is your Active Pokémon, search your deck for a card that evolves from that Pokémon and put it on that Pokémon. (This counts as evolving that Pokémon.) Shuffle your deck afterward, then discard Team Aqua Belt.",
-      "Attach Team Aqua Belt to 1 of your Pokémon with Team Aqua in its name that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card."
+      "Attach Team Aqua Belt to 1 of your Pokémon with Team Aqua in its name that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/76_hires.png"
   },
@@ -3746,7 +3746,7 @@
   },
   {
     "id": "ex4-79",
-    "name": "Team Aqua's Technical Machine 01",
+    "name": "Team Aqua’s Technical Machine 01",
     "imageUrl": "https://images.pokemontcg.io/ex4/79.png",
     "subtype": "Item",
     "supertype": "Trainer",
@@ -3758,7 +3758,7 @@
     "set": "Team Magma vs Team Aqua",
     "setCode": "ex4",
     "text": [
-      "Attach this card to 1 of your Pokémon that has Team Aqua in its name. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Team Aqua Technical Machine 01."
+      "Attach this card to 1 of your Pokémon that has Team Aqua in its name. That Pokémon may use this card’s attack instead of its own. At the end of your turn, discard Team Aqua Technical Machine 01."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/79_hires.png"
   },
@@ -3795,7 +3795,7 @@
     "setCode": "ex4",
     "text": [
       "At any time between turns, if the Pokémon Team Magma Belt is attached to is your Active Pokémon, search your deck for a card that evolves from that Pokémon and put it on that Pokémon. (This counts as evolving that Pokémon.) Shuffle your deck afterward, then discard Team Magma Belt.",
-      "Attach Team Magma Belt to 1 of your Pokémon with Team Magma in its name that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card."
+      "Attach Team Magma Belt to 1 of your Pokémon with Team Magma in its name that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/81_hires.png"
   },
@@ -3832,14 +3832,14 @@
     "set": "Team Magma vs Team Aqua",
     "setCode": "ex4",
     "text": [
-      "Whenever any player plays a Basic Pokémon that doesn't have Team Magma in its name from his or her hand, that player puts 1 damage counter on that Pokémon.",
+      "Whenever any player plays a Basic Pokémon that doesn’t have Team Magma in its name from his or her hand, that player puts 1 damage counter on that Pokémon.",
       "This card stays in play when you play it. Discard this card if another Stadium card comes into play."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/83_hires.png"
   },
   {
     "id": "ex4-84",
-    "name": "Team Magma's Technical Machine 01",
+    "name": "Team Magma’s Technical Machine 01",
     "imageUrl": "https://images.pokemontcg.io/ex4/84.png",
     "subtype": "Item",
     "supertype": "Trainer",
@@ -3851,7 +3851,7 @@
     "set": "Team Magma vs Team Aqua",
     "setCode": "ex4",
     "text": [
-      "Attach this card to 1 of your Pokémon that has Team Magma in its name. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Team Magma Technical Machine 01."
+      "Attach this card to 1 of your Pokémon that has Team Magma in its name. That Pokémon may use this card’s attack instead of its own. At the end of your turn, discard Team Magma Technical Machine 01."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/84_hires.png"
   },
@@ -3886,7 +3886,7 @@
     "set": "Team Magma vs Team Aqua",
     "setCode": "ex4",
     "text": [
-      "Aqua Energy can be attached only to a Pokémon with Team Aqua in its name. Aqua Energy provides Water and Darkness Energy but provides 2 Energy at a time. (Doesn't count as a basic Energy card when not in play and has no effect other than providing Energy.) At the end of your turn, discard Aqua Energy.\""
+      "Aqua Energy can be attached only to a Pokémon with Team Aqua in its name. Aqua Energy provides Water and Darkness Energy but provides 2 Energy at a time. (Doesn’t count as a basic Energy card when not in play and has no effect other than providing Energy.) At the end of your turn, discard Aqua Energy.\""
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/86_hires.png"
   },
@@ -3903,7 +3903,7 @@
     "set": "Team Magma vs Team Aqua",
     "setCode": "ex4",
     "text": [
-      "Magma Energy can be attached only to a Pokémon with Team Magma in its name. Magma Energy provides Fighting and /or Darkness Energy but provides 2 Energy at a time. (Doesn't count as a basic Energy card when not in play and has no effect other than providing Energy.) At the end of your turn, discard Magma Energy.\""
+      "Magma Energy can be attached only to a Pokémon with Team Magma in its name. Magma Energy provides Fighting and /or Darkness Energy but provides 2 Energy at a time. (Doesn’t count as a basic Energy card when not in play and has no effect other than providing Energy.) At the end of your turn, discard Magma Energy.\""
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/87_hires.png"
   },
@@ -3920,7 +3920,7 @@
     "set": "Team Magma vs Team Aqua",
     "setCode": "ex4",
     "text": [
-      "Double Rainbow Energy can be attached only to an Evolved Pokémon (excluding Pokémon-ex). While in play, Double Rainbow Energy provides every type of Energy but provides 2 Energy at a time. (Doesn't count as a basic Energy when not in play and has no effect other than providing Energy.) Damage done to your opponent's Pokémon by the Pokémon Double Rainbow Energy is attached to is reduced by 10 (after applying Weakness and Resistance). When the Pokémon Double Rainbow Energy is attached to is no longer an Evolved Pokémon, discard Double Rainbow Energy."
+      "Double Rainbow Energy can be attached only to an Evolved Pokémon (excluding Pokémon-ex). While in play, Double Rainbow Energy provides every type of Energy but provides 2 Energy at a time. (Doesn’t count as a basic Energy when not in play and has no effect other than providing Energy.) Damage done to your opponent’s Pokémon by the Pokémon Double Rainbow Energy is attached to is reduced by 10 (after applying Weakness and Resistance). When the Pokémon Double Rainbow Energy is attached to is no longer an Evolved Pokémon, discard Double Rainbow Energy."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/88_hires.png"
   },
@@ -3969,7 +3969,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Discard 2 Fire Energy attached to Blaziken ex and then choose 1 of your opponent's Pokémon. This attack does 100 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard 2 Fire Energy attached to Blaziken ex and then choose 1 of your opponent’s Pokémon. This attack does 100 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3994,7 +3994,7 @@
     "level": "ex",
     "ability": {
       "name": "Primal Vibes",
-      "text": "As long as Cradily ex is your Active Pokémon, your opponent can't play a Pokémon from his or her hand to evolve his or her Active Pokémon.",
+      "text": "As long as Cradily ex is your Active Pokémon, your opponent can’t play a Pokémon from his or her hand to evolve his or her Active Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "150",
@@ -4204,7 +4204,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "The Defending Pokémon is now Poisoned. The Defending Pokémon can't retreat until the end of your opponent's next turn."
+        "text": "The Defending Pokémon is now Poisoned. The Defending Pokémon can’t retreat until the end of your opponent’s next turn."
       },
       {
         "name": "Slashing Strike",
@@ -4217,7 +4217,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "100",
-        "text": "Sceptile ex can't use Slashing Strike during your next turn."
+        "text": "Sceptile ex can’t use Slashing Strike during your next turn."
       }
     ],
     "weaknesses": [
@@ -4271,7 +4271,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Benched Pokémon. This attack does 10 damage to that Pokémon. You may move an Energy card attached to that Pokémon to another of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Benched Pokémon. This attack does 10 damage to that Pokémon. You may move an Energy card attached to that Pokémon to another of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Reverse Stream",
@@ -4327,7 +4327,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20+",
-        "text": "Does 20 damage plus 20 more damage for each basic Energy attached to Swampert ex but not used to pay for this attack's Energy cost. You can't add more than 80 damage in this way."
+        "text": "Does 20 damage plus 20 more damage for each basic Energy attached to Swampert ex but not used to pay for this attack’s Energy cost. You can’t add more than 80 damage in this way."
       },
       {
         "name": "Crushing Wave",
@@ -4338,7 +4338,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. After doing damage, flip a coin. If heads, your opponent discards an Energy card, if any, attached to that Pokémon. (Don't apply Weakness and Resistance to Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 40 damage to that Pokémon. After doing damage, flip a coin. If heads, your opponent discards an Energy card, if any, attached to that Pokémon. (Don’t apply Weakness and Resistance to Benched Pokémon.)"
       }
     ],
     "weaknesses": [

--- a/json/cards/Team Rocket Returns.json
+++ b/json/cards/Team Rocket Returns.json
@@ -54,7 +54,7 @@
     "evolvesFrom": "Dark Flaaffy",
     "ability": {
       "name": "Darkest Impulse",
-      "text": "As long as Dark Ampharos is in play, whenever your opponent plays an Evolution card from his or her hand to evolve 1 of his or her Pokémon, put 2 damage counters on that Pokémon. You can't use more than 1 Darkest Impulse Poké-Body each turn.",
+      "text": "As long as Dark Ampharos is in play, whenever your opponent plays an Evolution card from his or her hand to evolve 1 of his or her Pokémon, put 2 damage counters on that Pokémon. You can’t use more than 1 Darkest Impulse Poké-Body each turn.",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -113,7 +113,7 @@
     "evolvesFrom": "Dark Golbat",
     "ability": {
       "name": "Black Beam",
-      "text": "Once during your turn (before your attack), if Dark Crobat is your Active Pokémon, you may choose 1 of the Defending Pokémon. That Pokémon is now Poisoned. This power can't be used if Dark Crobat is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Dark Crobat is your Active Pokémon, you may choose 1 of the Defending Pokémon. That Pokémon is now Poisoned. This power can’t be used if Dark Crobat is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -139,7 +139,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Remove from Dark Crobat a number of damage counters equal to the number of your opponent's Pokémon in play."
+        "text": "Does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) Remove from Dark Crobat a number of damage counters equal to the number of your opponent’s Pokémon in play."
       },
       {
         "name": "Skill Dive",
@@ -149,7 +149,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Does 30 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 30 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -176,7 +176,7 @@
     "evolvesFrom": "Voltorb",
     "ability": {
       "name": "Darkness Navigation",
-      "text": "Once during your turn (before your attack), if Dark Electrode has no Energy attached to it, you may search your deck for a Darkness or Dark Metal Energy and attach it to Dark Electrode. Shuffle your deck afterward. This power can't be used if Dark Electrode is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Dark Electrode has no Energy attached to it, you may search your deck for a Darkness or Dark Metal Energy and attach it to Dark Electrode. Shuffle your deck afterward. This power can’t be used if Dark Electrode is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -243,7 +243,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Choose a card from your opponent's hand without looking and discard it."
+        "text": "Choose a card from your opponent’s hand without looking and discard it."
       },
       {
         "name": "Dark Fire",
@@ -309,7 +309,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, choose an attack on 1 of your Pokémon in play that has Dark in its name (excluding this one). Dark Link copies that attack except for its Energy cost. (You must still do anything else required for that attack.) (No matter what type that Pokémon is, Dark Hypno's type is still PsychicDarkness.) Dark Hypno performs that attack.\""
+        "text": "Flip a coin. If heads, choose an attack on 1 of your Pokémon in play that has Dark in its name (excluding this one). Dark Link copies that attack except for its Energy cost. (You must still do anything else required for that attack.) (No matter what type that Pokémon is, Dark Hypno’s type is still PsychicDarkness.) Dark Hypno performs that attack.\""
       },
       {
         "name": "Black Magic",
@@ -319,7 +319,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20x",
-        "text": "Does 20 damage times the number of your opponent's Benched Pokémon."
+        "text": "Does 20 damage times the number of your opponent’s Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -361,7 +361,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       },
       {
         "name": "Hard Bone",
@@ -423,7 +423,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "Does 30 damage plus 10 more damage for each Energy attached to Dark Octillery but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "Does 30 damage plus 10 more damage for each Energy attached to Dark Octillery but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       }
     ],
     "weaknesses": [
@@ -444,7 +444,7 @@
     "evolvesFrom": "Slowpoke",
     "ability": {
       "name": "Cunning",
-      "text": "Once during your turn (before your attack), you may look at the top card of your opponent's deck. Then, you may shuffle his or her deck. This power can't be used if Dark Slowking is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may look at the top card of your opponent’s deck. Then, you may shuffle his or her deck. This power can’t be used if Dark Slowking is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -470,7 +470,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "You may discard a combination of up to 2 Pokémon Tool cards and Rocket's Secret Machine cards from your hand, and then do 20 damage plus 30 more damage for each card you discarded."
+        "text": "You may discard a combination of up to 2 Pokémon Tool cards and Rocket’s Secret Machine cards from your hand, and then do 20 damage plus 30 more damage for each card you discarded."
       }
     ],
     "weaknesses": [
@@ -554,7 +554,7 @@
     "evolvesFrom": "Skiploom",
     "ability": {
       "name": "Buffer",
-      "text": "If Jumpluff would be Knocked Out by an opponent's attack, flip a coin. If heads, Jumpluff is not Knocked Out and its remaining HP becomes 10 instead.",
+      "text": "If Jumpluff would be Knocked Out by an opponent’s attack, flip a coin. If heads, Jumpluff is not Knocked Out and its remaining HP becomes 10 instead.",
       "type": "Poké-Body"
     },
     "hp": "90",
@@ -575,7 +575,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "Does 10 damage plus 10 more damage for each Energy attached to all of your opponent's Pokémon."
+        "text": "Does 10 damage plus 10 more damage for each Energy attached to all of your opponent’s Pokémon."
       }
     ],
     "weaknesses": [
@@ -639,7 +639,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "This attack's damage is not affected by Resistance."
+        "text": "This attack’s damage is not affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -681,7 +681,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, each Defending Pokémon can't attack during your opponent's next turn."
+        "text": "Flip a coin. If heads, each Defending Pokémon can’t attack during your opponent’s next turn."
       },
       {
         "name": "Tonnage",
@@ -717,7 +717,7 @@
     "evolvesFrom": "Togepi",
     "ability": {
       "name": "Holy Shield",
-      "text": "Prevent all effects of attacks, including damage, done to Togetic by your opponent's Pokémon that has Dark in its name.",
+      "text": "Prevent all effects of attacks, including damage, done to Togetic by your opponent’s Pokémon that has Dark in its name.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -753,7 +753,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Benched Pokémon's attacks. Rainbow Moves copies that attack except for its Energy cost. (You must still do anything else required for that attack.) (No matter what type that Pokémon is, Togetic's type is still Colorless. Togetic performs that attack."
+        "text": "Choose 1 of your opponent’s Benched Pokémon’s attacks. Rainbow Moves copies that attack except for its Energy cost. (You must still do anything else required for that attack.) (No matter what type that Pokémon is, Togetic’s type is still Colorless. Togetic performs that attack."
       }
     ],
     "weaknesses": [
@@ -783,7 +783,7 @@
     "evolvesFrom": "Dark Dragonair",
     "ability": {
       "name": "Dark Trance",
-      "text": "As often as you like during your turn (before your attack), you may move a Darkness Energy card attached to 1 of your Pokémon to another of your Pokémon. This power can't be used if Dark Dragonite is affected by a Special Condition.\"",
+      "text": "As often as you like during your turn (before your attack), you may move a Darkness Energy card attached to 1 of your Pokémon to another of your Pokémon. This power can’t be used if Dark Dragonite is affected by a Special Condition.\"",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -877,7 +877,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10x",
-        "text": "Does 10 damage times the number of Colorless Energy in the Defending Pokémon's Retreat Cost (after applying effects to the Retreat Cost).\""
+        "text": "Does 10 damage times the number of Colorless Energy in the Defending Pokémon’s Retreat Cost (after applying effects to the Retreat Cost).\""
       },
       {
         "name": "Acidic Poison",
@@ -924,7 +924,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn. Put 5 damage counters on the Defending Pokémon at the end of your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn. Put 5 damage counters on the Defending Pokémon at the end of your opponent’s next turn."
       },
       {
         "name": "Spread Poison",
@@ -934,7 +934,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "The Defending Pokémon is now Poisoned. This attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "The Defending Pokémon is now Poisoned. This attack does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -955,7 +955,7 @@
     "evolvesFrom": "Sandshrew",
     "ability": {
       "name": "Poison Payback",
-      "text": "If Dark Sandslash is your Active Pokémon and is damaged by an opponent's attack (even if Dark Sandslash is Knocked Out), the Attacking Pokémon is now Poisoned.",
+      "text": "If Dark Sandslash is your Active Pokémon and is damaged by an opponent’s attack (even if Dark Sandslash is Knocked Out), the Attacking Pokémon is now Poisoned.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -979,7 +979,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -1031,7 +1031,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Does 20 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Bite Off",
@@ -1071,7 +1071,7 @@
     "evolvesFrom": "Dark Pupitar",
     "ability": {
       "name": "Sand Damage",
-      "text": "As long as Dark Tyranitar is your Active Pokémon, put 1 damage counter on each of your opponent's Benched Basic Pokémon between turns. You can't use more than 1 Sand Damage Poké-Body between turns.",
+      "text": "As long as Dark Tyranitar is your Active Pokémon, put 1 damage counter on each of your opponent’s Benched Basic Pokémon between turns. You can’t use more than 1 Sand Damage Poké-Body between turns.",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -1120,7 +1120,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Gift Exchange",
-      "text": "Once during your turn (before your attack), if Delibird is your Active Pokémon, you may shuffle 1 card from your hand into your deck. Then, draw a card. This power can't be used if Delibird is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Delibird is your Active Pokémon, you may shuffle 1 card from your hand into your deck. Then, draw a card. This power can’t be used if Delibird is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -1319,7 +1319,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Dark Spell",
-      "text": "Once during your turn (before your attack), if Misdreavus is your Active Pokémon, you may flip a coin. If heads, put 1 damage counter on 1 of your opponent's Pokémon. This power can't be used if Misdreavus is affected by a Special Condition or if your other Active Pokémon is not Misdreavus.",
+      "text": "Once during your turn (before your attack), if Misdreavus is your Active Pokémon, you may flip a coin. If heads, put 1 damage counter on 1 of your opponent’s Pokémon. This power can’t be used if Misdreavus is affected by a Special Condition or if your other Active Pokémon is not Misdreavus.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -1399,7 +1399,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20+",
-        "text": "Does 20 damage plus 20 more damage for each basic Energy card attached to Quagsire but not used to pay for this attack's Energy cost. You can't add more than 60 damage in this way."
+        "text": "Does 20 damage plus 20 more damage for each basic Energy card attached to Quagsire but not used to pay for this attack’s Energy cost. You can’t add more than 60 damage in this way."
       }
     ],
     "weaknesses": [
@@ -1419,7 +1419,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Spiny",
-      "text": "If Qwilfish is your Active Pokémon and is damaged by an opponent's attack (even if Qwilfish is Knocked Out), flip a coin until you get tails. For each heads, put 1 damage counter on the Attacking Pokémon.",
+      "text": "If Qwilfish is your Active Pokémon and is damaged by an opponent’s attack (even if Qwilfish is Knocked Out), flip a coin until you get tails. For each heads, put 1 damage counter on the Attacking Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -1492,7 +1492,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -1542,7 +1542,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "Before doing damage, count the remaining HP of the Defending Pokémon and Dark Arbok. If the Defending Pokémon has fewer remaining HP than Dark Arbok's, this attack does 10 damage plus 30 more damage."
+        "text": "Before doing damage, count the remaining HP of the Defending Pokémon and Dark Arbok. If the Defending Pokémon has fewer remaining HP than Dark Arbok’s, this attack does 10 damage plus 30 more damage."
       },
       {
         "name": "Extra Poison",
@@ -1604,7 +1604,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage for each Colorless Energy in that Pokémon's Retreat Cost (after applying effects to the Retreat Cost). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage for each Colorless Energy in that Pokémon’s Retreat Cost (after applying effects to the Retreat Cost). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1625,7 +1625,7 @@
     "evolvesFrom": "Dratini",
     "ability": {
       "name": "Evolutionary Light",
-      "text": "Once during your turn (before your attack), if Dark Dragonair is your Active Pokémon, you may search your deck for an Evolution card. Show it to your opponent and put it into your hand. Shuffle your deck afterward. This power can't be used if Dark Dragonair is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Dark Dragonair is your Active Pokémon, you may search your deck for an Evolution card. Show it to your opponent and put it into your hand. Shuffle your deck afterward. This power can’t be used if Dark Dragonair is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -1774,7 +1774,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If the Defending Pokémon is a Basic Pokémon, the Defending Pokémon is now Paralyzed. Dark Flaaffy can't use Thunder Slash during your next turn."
+        "text": "If the Defending Pokémon is a Basic Pokémon, the Defending Pokémon is now Paralyzed. Dark Flaaffy can’t use Thunder Slash during your next turn."
       },
       {
         "name": "Headbutt",
@@ -1825,7 +1825,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Does 30 damage to 1 of your opponent's Pokémon. Dark Golbat can't attack during your next turn. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 30 damage to 1 of your opponent’s Pokémon. Dark Golbat can’t attack during your next turn. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1870,7 +1870,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to each of your Active Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to each of your Active Pokémon during your opponent’s next turn."
       },
       {
         "name": "Cold Crush",
@@ -1962,7 +1962,7 @@
     "evolvesFrom": "Houndour",
     "ability": {
       "name": "Fire Breath",
-      "text": "Once during your turn (before your attack), if Dark Houndoom is your Active Pokémon, you may flip a coin. If heads, the Defending Pokémon (choose 1 if there are 2) is now Burned. This power can't be used if Dark Houndoom is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), if Dark Houndoom is your Active Pokémon, you may flip a coin. If heads, the Defending Pokémon (choose 1 if there are 2) is now Burned. This power can’t be used if Dark Houndoom is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -2042,7 +2042,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 40 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2084,7 +2084,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If your opponent has at least 2 Pokémon in play, move a basic Energy card from the Defending Pokémon to another of your opponent's Pokémon."
+        "text": "If your opponent has at least 2 Pokémon in play, move a basic Energy card from the Defending Pokémon to another of your opponent’s Pokémon."
       },
       {
         "name": "Poison Pulse",
@@ -2139,7 +2139,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance.) Then, search your deck for a card that evolves from Dark Pupitar and put it on Dark Pupitar. (This counts as evolving Dark Pupitar.) Shuffle your deck afterward."
+        "text": "Flip a coin. If heads, this attack does 10 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance.) Then, search your deck for a card that evolves from Dark Pupitar and put it on Dark Pupitar. (This counts as evolving Dark Pupitar.) Shuffle your deck afterward."
       },
       {
         "name": "Double Tackle",
@@ -2206,7 +2206,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "This attack's damage is not affected by Resistance."
+        "text": "This attack’s damage is not affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -2287,7 +2287,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Crust",
-      "text": "Any damage done to Heracross by attacks from your opponent's Basic Pokémon is reduced by 20 (after applying Weakness and Resistance).",
+      "text": "Any damage done to Heracross by attacks from your opponent’s Basic Pokémon is reduced by 20 (after applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -2385,7 +2385,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Ripples",
-      "text": "Once during your turn (before your attack), you may remove 1 damage counter from 1 of your Pokémon (excluding Mantine). This power can't be used if Mantine is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may remove 1 damage counter from 1 of your Pokémon (excluding Mantine). This power can’t be used if Mantine is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -2410,7 +2410,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Mantine can't attack during your next turn."
+        "text": "Mantine can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -2424,7 +2424,7 @@
   },
   {
     "id": "ex7-46",
-    "name": "Rocket's Meowth",
+    "name": "Rocket’s Meowth",
     "imageUrl": "https://images.pokemontcg.io/ex7/46.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2449,7 +2449,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Search your deck for a Pokémon Tool card or Rocket's Secret Machine card, show it to your opponent, and put it into your hand. If you do, you may switch Rocket's Meowth with 1 of your Benched Pokémon. Shuffle your deck afterward."
+        "text": "Search your deck for a Pokémon Tool card or Rocket’s Secret Machine card, show it to your opponent, and put it into your hand. If you do, you may switch Rocket’s Meowth with 1 of your Benched Pokémon. Shuffle your deck afterward."
       },
       {
         "name": "Miraculous Comeback",
@@ -2459,7 +2459,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10x",
-        "text": "Flip a coin for each Pokémon in play (both yours and your opponent's). This attack does 10 damage times the number of heads. Rocket's Meowth does 10 damage times the number of tails to itself."
+        "text": "Flip a coin for each Pokémon in play (both yours and your opponent’s). This attack does 10 damage times the number of heads. Rocket’s Meowth does 10 damage times the number of tails to itself."
       }
     ],
     "weaknesses": [
@@ -2476,7 +2476,7 @@
   },
   {
     "id": "ex7-47",
-    "name": "Rocket's Wobbuffet",
+    "name": "Rocket’s Wobbuffet",
     "imageUrl": "https://images.pokemontcg.io/ex7/47.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -2501,7 +2501,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Search your discard pile for Pokémon Tool cards and Rocket's Secret Machine cards. You may either show 1 Pokémon Tool card or Rocket's Secret Machine card to your opponent and put it into your hand, or show a combination of 3 Pokémon Tool cards or Rocket's Secret Machine cards to your opponent and shuffle them into your deck."
+        "text": "Search your discard pile for Pokémon Tool cards and Rocket’s Secret Machine cards. You may either show 1 Pokémon Tool card or Rocket’s Secret Machine card to your opponent and put it into your hand, or show a combination of 3 Pokémon Tool cards or Rocket’s Secret Machine cards to your opponent and shuffle them into your deck."
       },
       {
         "name": "Amnesia",
@@ -2511,7 +2511,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2563,7 +2563,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "If your opponent has any Benched Pokemon, move 1 Energy card attached to the Defending Pokémon to 1 of your opponent's Benched Pokémon. If your opponent has no Benched Pokémon, this effect does nothing."
+        "text": "If your opponent has any Benched Pokemon, move 1 Energy card attached to the Defending Pokémon to 1 of your opponent’s Benched Pokémon. If your opponent has no Benched Pokémon, this effect does nothing."
       }
     ],
     "weaknesses": [
@@ -2587,7 +2587,7 @@
     "evolvesFrom": "Hoppip",
     "ability": {
       "name": "Buffer",
-      "text": "If Skiploom would be Knocked Out by an opponent's attack, flip a coin. If heads, Skiploom is not Knocked Out and its remaining HP becomes 10 instead.",
+      "text": "If Skiploom would be Knocked Out by an opponent’s attack, flip a coin. If heads, Skiploom is not Knocked Out and its remaining HP becomes 10 instead.",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -2666,7 +2666,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, choose 1 of the Defending Pokémon's attacks. Mini-Metronome copies that attack except for its Energy cost. (You must still do anything else required for that attack.) (No matter what type that Pokémon is, Togepi's type is still Colorless.) Togepi performs that attack.\""
+        "text": "Flip a coin. If heads, choose 1 of the Defending Pokémon’s attacks. Mini-Metronome copies that attack except for its Energy cost. (You must still do anything else required for that attack.) (No matter what type that Pokémon is, Togepi’s type is still Colorless.) Togepi performs that attack.\""
       }
     ],
     "weaknesses": [
@@ -2708,7 +2708,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Reveal cards from your deck until you reveal a Basic Pokémon. Show that card to your opponent and put it into your hand. Shuffle the other revealed cards into your deck. (If you don't reveal a Basic Pokémon, shuffle all the revealed cards back into your deck.)"
+        "text": "Reveal cards from your deck until you reveal a Basic Pokémon. Show that card to your opponent and put it into your hand. Shuffle the other revealed cards into your deck. (If you don’t reveal a Basic Pokémon, shuffle all the revealed cards back into your deck.)"
       },
       {
         "name": "Bonemerang",
@@ -2838,7 +2838,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Insomnia",
-      "text": "Drowzee can't be Asleep.",
+      "text": "Drowzee can’t be Asleep.",
       "type": "Poké-Body"
     },
     "hp": "50",
@@ -2943,7 +2943,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Benched Pokémon and switch it with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
+        "text": "Choose 1 of your opponent’s Benched Pokémon and switch it with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
       },
       {
         "name": "Spit Poison",
@@ -2979,7 +2979,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Buffer",
-      "text": "If Hoppip would be Knocked Out by an opponent's attack, flip a coin. If heads, Hoppip is not Knocked Out and its remaining HP becomes 10 instead.",
+      "text": "If Hoppip would be Knocked Out by an opponent’s attack, flip a coin. If heads, Hoppip is not Knocked Out and its remaining HP becomes 10 instead.",
       "type": "Poké-Body"
     },
     "hp": "30",
@@ -3061,7 +3061,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -3113,7 +3113,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -3183,7 +3183,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Knockout Gas",
-      "text": "If Koffing is your Active Pokémon and is Knocked Out by an opponent's attack, the Attacking Pokémon is now Confused and Poisoned.",
+      "text": "If Koffing is your Active Pokémon and is Knocked Out by an opponent’s attack, the Attacking Pokémon is now Confused and Poisoned.",
       "type": "Poké-Body"
     },
     "hp": "50",
@@ -3438,7 +3438,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "This attack's damage isn't affected by Weakness or Resistance."
+        "text": "This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -3586,7 +3586,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "During your opponent's next turn, any damage done to Onix by attacks is reduced by 10 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Onix by attacks is reduced by 10 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -3637,7 +3637,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent can't play a Trainer card from his or her hand until the end of your opponent's next turn."
+        "text": "Flip a coin. If heads, your opponent can’t play a Trainer card from his or her hand until the end of your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3838,7 +3838,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -3912,7 +3912,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Dense",
-      "text": "Any damage done to Slowpoke by attacks from your opponent's Evolved Pokémon is reduced by 10 (after applying Weakness and Resistance).",
+      "text": "Any damage done to Slowpoke by attacks from your opponent’s Evolved Pokémon is reduced by 10 (after applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "50",
@@ -4273,7 +4273,7 @@
     "set": "Team Rocket Returns",
     "setCode": "ex7",
     "text": [
-      "Shuffle your hand into your deck. Then, count the number of cards in your opponent's hand and draw that many cards.",
+      "Shuffle your hand into your deck. Then, count the number of cards in your opponent’s hand and draw that many cards.",
       "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex7/83_hires.png"
@@ -4282,7 +4282,7 @@
     "id": "ex7-84",
     "name": "Pokémon Retriever",
     "imageUrl": "https://images.pokemontcg.io/ex7/84.png",
-    "subtype": "Rocket's Secret Machine",
+    "subtype": "Rocket’s Secret Machine",
     "supertype": "Trainer",
     "number": "84",
     "artist": "Katsura Tabata",
@@ -4299,7 +4299,7 @@
     "id": "ex7-85",
     "name": "Pow! Hand Extension",
     "imageUrl": "https://images.pokemontcg.io/ex7/85.png",
-    "subtype": "Rocket's Secret Machine",
+    "subtype": "Rocket’s Secret Machine",
     "supertype": "Trainer",
     "number": "85",
     "artist": "Katsura Tabata",
@@ -4308,14 +4308,14 @@
     "set": "Team Rocket Returns",
     "setCode": "ex7",
     "text": [
-      "Move 1 Energy card attached to the Defending Pokémon to another of your opponent's Pokémon. Or, switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch.",
+      "Move 1 Energy card attached to the Defending Pokémon to another of your opponent’s Pokémon. Or, switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch.",
       "You may use this card only if you have more Prize cards left than your opponent."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex7/85_hires.png"
   },
   {
     "id": "ex7-86",
-    "name": "Rocket's Admin.",
+    "name": "Rocket’s Admin.",
     "imageUrl": "https://images.pokemontcg.io/ex7/86.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4334,7 +4334,7 @@
   },
   {
     "id": "ex7-87",
-    "name": "Rocket's Hideout",
+    "name": "Rocket’s Hideout",
     "imageUrl": "https://images.pokemontcg.io/ex7/87.png",
     "subtype": "Stadium",
     "supertype": "Trainer",
@@ -4346,14 +4346,14 @@
     "set": "Team Rocket Returns",
     "setCode": "ex7",
     "text": [
-      "Each Pokémon with Dark or Rocket's in its name (both yours and your opponent's) gets +20 HP.",
+      "Each Pokémon with Dark or Rocket’s in its name (both yours and your opponent’s) gets +20 HP.",
       "This card stays in play when you play it. Discard this card if another Stadium card comes into play."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex7/87_hires.png"
   },
   {
     "id": "ex7-88",
-    "name": "Rocket's Mission",
+    "name": "Rocket’s Mission",
     "imageUrl": "https://images.pokemontcg.io/ex7/88.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4365,14 +4365,14 @@
     "set": "Team Rocket Returns",
     "setCode": "ex7",
     "text": [
-      "Discard a card from your hand. Then, draw 3 cards. If you discarded a Pokémon that has Dark or Rocket's in its name, draw 4 cards instead.",
+      "Discard a card from your hand. Then, draw 3 cards. If you discarded a Pokémon that has Dark or Rocket’s in its name, draw 4 cards instead.",
       "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex7/88_hires.png"
   },
   {
     "id": "ex7-89",
-    "name": "Rocket's Poké Ball",
+    "name": "Rocket’s Poké Ball",
     "imageUrl": "https://images.pokemontcg.io/ex7/89.png",
     "subtype": "Item",
     "supertype": "Trainer",
@@ -4390,7 +4390,7 @@
   },
   {
     "id": "ex7-90",
-    "name": "Rocket's Tricky Gym",
+    "name": "Rocket’s Tricky Gym",
     "imageUrl": "https://images.pokemontcg.io/ex7/90.png",
     "subtype": "Stadium",
     "supertype": "Trainer",
@@ -4402,7 +4402,7 @@
     "set": "Team Rocket Returns",
     "setCode": "ex7",
     "text": [
-      "Each Pokémon with Dark or Rocket's in its name (both yours and your opponent's) can use attacks on this card instead of its own.",
+      "Each Pokémon with Dark or Rocket’s in its name (both yours and your opponent’s) can use attacks on this card instead of its own.",
       "This card stays in play when you play it. Discard this card if another Stadium card comes into play."
     ],
     "attacks": [
@@ -4413,7 +4413,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Does 20 damage to 1 of your opponent's Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
+        "text": "Does 20 damage to 1 of your opponent’s Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
       }
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex7/90_hires.png"
@@ -4422,7 +4422,7 @@
     "id": "ex7-91",
     "name": "Surprise! Time Machine",
     "imageUrl": "https://images.pokemontcg.io/ex7/91.png",
-    "subtype": "Rocket's Secret Machine",
+    "subtype": "Rocket’s Secret Machine",
     "supertype": "Trainer",
     "number": "91",
     "artist": "Katsura Tabata",
@@ -4439,7 +4439,7 @@
     "id": "ex7-92",
     "name": "Swoop! Teleporter",
     "imageUrl": "https://images.pokemontcg.io/ex7/92.png",
-    "subtype": "Rocket's Secret Machine",
+    "subtype": "Rocket’s Secret Machine",
     "supertype": "Trainer",
     "number": "92",
     "artist": "Katsura Tabata",
@@ -4456,7 +4456,7 @@
     "id": "ex7-93",
     "name": "Venture Bomb",
     "imageUrl": "https://images.pokemontcg.io/ex7/93.png",
-    "subtype": "Rocket's Secret Machine",
+    "subtype": "Rocket’s Secret Machine",
     "supertype": "Trainer",
     "number": "93",
     "artist": "Katsura Tabata",
@@ -4465,7 +4465,7 @@
     "set": "Team Rocket Returns",
     "setCode": "ex7",
     "text": [
-      "Flip a coin. If heads, put 1 damage counter on 1 of your opponent's Pokémon. If tails, put 1 damage counter on 1 of your Pokémon."
+      "Flip a coin. If heads, put 1 damage counter on 1 of your opponent’s Pokémon. If tails, put 1 damage counter on 1 of your Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex7/93_hires.png"
   },
@@ -4482,7 +4482,7 @@
     "set": "Team Rocket Returns",
     "setCode": "ex7",
     "text": [
-      "Attach Dark Metal Energy to 1 of your Pokémon. While in play, Dark Metal Energy provides Darkness Energy and Metal Energy, but provides only 1 Energy at a time. (Doesn't count as a basic Energy card when not in play and has no effect other than providing Energy.)\""
+      "Attach Dark Metal Energy to 1 of your Pokémon. While in play, Dark Metal Energy provides Darkness Energy and Metal Energy, but provides only 1 Energy at a time. (Doesn’t count as a basic Energy card when not in play and has no effect other than providing Energy.)\""
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex7/94_hires.png"
   },
@@ -4499,20 +4499,20 @@
     "set": "Team Rocket Returns",
     "setCode": "ex7",
     "text": [
-      "Attach R Energy to a Pokémon that has Dark or Rocket's in its name. While in play, R Energy provides 2 Darkness Energy. (Doesn't count as a basic Energy card.) If the Pokémon R Energy is attached to attacks the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). When your turn ends discard R Energy.\""
+      "Attach R Energy to a Pokémon that has Dark or Rocket’s in its name. While in play, R Energy provides 2 Darkness Energy. (Doesn’t count as a basic Energy card.) If the Pokémon R Energy is attached to attacks the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). When your turn ends discard R Energy.\""
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex7/95_hires.png"
   },
   {
     "id": "ex7-96",
-    "name": "Rocket's Articuno ex",
+    "name": "Rocket’s Articuno ex",
     "imageUrl": "https://images.pokemontcg.io/ex7/96.png",
     "subtype": "EX",
     "supertype": "Pokémon",
     "level": "ex",
     "ability": {
       "name": "Darkness Veil",
-      "text": "As long as Rocket's Articuno ex has any Darkness Energy attached to it prevent all effects except damage by an opponent's attack done to Rocket's Articuno ex.\"",
+      "text": "As long as Rocket’s Articuno ex has any Darkness Energy attached to it prevent all effects except damage by an opponent’s attack done to Rocket’s Articuno ex.\"",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -4536,7 +4536,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Search your discard pile for a Water Energy card and attach it to Rocket's Articuno ex.\""
+        "text": "Search your discard pile for a Water Energy card and attach it to Rocket’s Articuno ex.\""
       },
       {
         "name": "Ice Wing",
@@ -4561,14 +4561,14 @@
   },
   {
     "id": "ex7-97",
-    "name": "Rocket's Entei ex",
+    "name": "Rocket’s Entei ex",
     "imageUrl": "https://images.pokemontcg.io/ex7/97.png",
     "subtype": "EX",
     "supertype": "Pokémon",
     "level": "ex",
     "ability": {
       "name": "Dark Condition",
-      "text": "As long as Rocket's Entei ex has any Darkness Energy attached to it, Rocket's Entei ex has no Weakness.\"",
+      "text": "As long as Rocket’s Entei ex has any Darkness Energy attached to it, Rocket’s Entei ex has no Weakness.\"",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -4592,7 +4592,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Search your discard pile for an Energy card and attach it to Rocket's Entei ex."
+        "text": "Search your discard pile for an Energy card and attach it to Rocket’s Entei ex."
       },
       {
         "name": "Volcanic Ash",
@@ -4603,7 +4603,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Discard 2 Energy attached to Rocket's Entei ex and then choose 1 of your opponent's Pokémon. This attack does 60 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard 2 Energy attached to Rocket’s Entei ex and then choose 1 of your opponent’s Pokémon. This attack does 60 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4617,14 +4617,14 @@
   },
   {
     "id": "ex7-98",
-    "name": "Rocket's Hitmonchan ex",
+    "name": "Rocket’s Hitmonchan ex",
     "imageUrl": "https://images.pokemontcg.io/ex7/98.png",
     "subtype": "EX",
     "supertype": "Pokémon",
     "level": "ex",
     "ability": {
       "name": "Strikes Back",
-      "text": "If Rocket's Hitmonchan ex is your Active Pokémon and is damaged by an opponent's attack (even if Rocket's Hitmonchan ex is Knocked Out), put 2 damage counters on the Attacking Pokémon.",
+      "text": "If Rocket’s Hitmonchan ex is your Active Pokémon and is damaged by an opponent’s attack (even if Rocket’s Hitmonchan ex is Knocked Out), put 2 damage counters on the Attacking Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -4648,7 +4648,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Magnum Punch",
@@ -4673,7 +4673,7 @@
   },
   {
     "id": "ex7-99",
-    "name": "Rocket's Mewtwo ex",
+    "name": "Rocket’s Mewtwo ex",
     "imageUrl": "https://images.pokemontcg.io/ex7/99.png",
     "subtype": "EX",
     "supertype": "Pokémon",
@@ -4700,7 +4700,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Discard an Energy card attached to Rocket's Mewtwo ex, and then switch all damage counters on Rocket's Mewtwo ex with those on the Defending Pokémon. (If an effect of this attack is prevented, this attack does nothing.)"
+        "text": "Discard an Energy card attached to Rocket’s Mewtwo ex, and then switch all damage counters on Rocket’s Mewtwo ex with those on the Defending Pokémon. (If an effect of this attack is prevented, this attack does nothing.)"
       },
       {
         "name": "Hypnoblast",
@@ -4737,14 +4737,14 @@
   },
   {
     "id": "ex7-100",
-    "name": "Rocket's Moltres ex",
+    "name": "Rocket’s Moltres ex",
     "imageUrl": "https://images.pokemontcg.io/ex7/100.png",
     "subtype": "EX",
     "supertype": "Pokémon",
     "level": "ex",
     "ability": {
       "name": "Dark Lift",
-      "text": "If Rocket's Moltres ex has any Darkness Energy attached to it, the Retreat Cost for Rocket's Moltres ex is 0.\"",
+      "text": "If Rocket’s Moltres ex has any Darkness Energy attached to it, the Retreat Cost for Rocket’s Moltres ex is 0.\"",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -4795,15 +4795,15 @@
   },
   {
     "id": "ex7-101",
-    "name": "Rocket's Scizor ex",
+    "name": "Rocket’s Scizor ex",
     "imageUrl": "https://images.pokemontcg.io/ex7/101.png",
     "subtype": "EX",
     "supertype": "Pokémon",
     "level": "ex",
-    "evolvesFrom": "Rocket's Scyther ex",
+    "evolvesFrom": "Rocket’s Scyther ex",
     "ability": {
       "name": "Dual Armor",
-      "text": "As long as Rocket's Scizor ex has any Metal Energy attached to it, Rocket's Scizor ex is both Darkness and Metal type.\"",
+      "text": "As long as Rocket’s Scizor ex has any Metal Energy attached to it, Rocket’s Scizor ex is both Darkness and Metal type.\"",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -4829,7 +4829,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "You may discard an Energy card attached to Rocket's Scizor ex. If you do, search your discard pile for an Energy card (excluding the one you discarded) and attach it to Rocket's Scizor ex."
+        "text": "You may discard an Energy card attached to Rocket’s Scizor ex. If you do, search your discard pile for an Energy card (excluding the one you discarded) and attach it to Rocket’s Scizor ex."
       }
     ],
     "weaknesses": [
@@ -4849,14 +4849,14 @@
   },
   {
     "id": "ex7-102",
-    "name": "Rocket's Scyther ex",
+    "name": "Rocket’s Scyther ex",
     "imageUrl": "https://images.pokemontcg.io/ex7/102.png",
     "subtype": "EX",
     "supertype": "Pokémon",
     "level": "ex",
     "ability": {
       "name": "Dual Armor",
-      "text": "As long as Rocket's Scyther ex has any Grass Energy attached to it, Rocket's Scyther ex is both Grass and Darkness type.\"",
+      "text": "As long as Rocket’s Scyther ex has any Grass Energy attached to it, Rocket’s Scyther ex is both Grass and Darkness type.\"",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -4880,7 +4880,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "After your attack, you may switch Rocket's Scyther ex with 1 of your Benched Pokémon."
+        "text": "After your attack, you may switch Rocket’s Scyther ex with 1 of your Benched Pokémon."
       },
       {
         "name": "Slashing Strike",
@@ -4891,7 +4891,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Rocket's Scyther ex can't use Slashing Strike during your next turn."
+        "text": "Rocket’s Scyther ex can’t use Slashing Strike during your next turn."
       }
     ],
     "weaknesses": [
@@ -4914,7 +4914,7 @@
   },
   {
     "id": "ex7-103",
-    "name": "Rocket's Sneasel ex",
+    "name": "Rocket’s Sneasel ex",
     "imageUrl": "https://images.pokemontcg.io/ex7/103.png",
     "subtype": "EX",
     "supertype": "Pokémon",
@@ -4940,7 +4940,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Before doing damage, you may switch 1 of your opponent's Benched Pokémon with the Defending Pokémon. If you do, this attack does 10 damage to the new Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
+        "text": "Before doing damage, you may switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon. If you do, this attack does 10 damage to the new Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
       },
       {
         "name": "Dark Ring",
@@ -4974,14 +4974,14 @@
   },
   {
     "id": "ex7-104",
-    "name": "Rocket's Snorlax ex",
+    "name": "Rocket’s Snorlax ex",
     "imageUrl": "https://images.pokemontcg.io/ex7/104.png",
     "subtype": "EX",
     "supertype": "Pokémon",
     "level": "ex",
     "ability": {
       "name": "Dark Healer",
-      "text": "As long as Rocket's Snorlax ex has any Darkness Energy attached to it, remove 1 damage counter from Rocket's Snorlax ex between turns.\"",
+      "text": "As long as Rocket’s Snorlax ex has any Darkness Energy attached to it, remove 1 damage counter from Rocket’s Snorlax ex between turns.\"",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -5020,7 +5020,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "60",
-        "text": "Rocket's Snorlax ex is now Asleep."
+        "text": "Rocket’s Snorlax ex is now Asleep."
       }
     ],
     "weaknesses": [
@@ -5034,14 +5034,14 @@
   },
   {
     "id": "ex7-105",
-    "name": "Rocket's Suicune ex",
+    "name": "Rocket’s Suicune ex",
     "imageUrl": "https://images.pokemontcg.io/ex7/105.png",
     "subtype": "EX",
     "supertype": "Pokémon",
     "level": "ex",
     "ability": {
       "name": "Dark and Clear",
-      "text": "As long as Rocket's Suicune ex has any Darkness Energy attached to it, Rocket's Suicune ex can't be affected by any Special Conditions.\"",
+      "text": "As long as Rocket’s Suicune ex has any Darkness Energy attached to it, Rocket’s Suicune ex can’t be affected by any Special Conditions.\"",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -5090,14 +5090,14 @@
   },
   {
     "id": "ex7-106",
-    "name": "Rocket's Zapdos ex",
+    "name": "Rocket’s Zapdos ex",
     "imageUrl": "https://images.pokemontcg.io/ex7/106.png",
     "subtype": "EX",
     "supertype": "Pokémon",
     "level": "ex",
     "ability": {
       "name": "Darkness Guard",
-      "text": "As long as Rocket's Zapdos ex has any Darkness Energy attached to it, damage done to Rocket's Zapdos ex by an opponent's attack is reduced by 10 (after applying Weakness and Resistance).\"",
+      "text": "As long as Rocket’s Zapdos ex has any Darkness Energy attached to it, damage done to Rocket’s Zapdos ex by an opponent’s attack is reduced by 10 (after applying Weakness and Resistance).\"",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -5121,7 +5121,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Search your discard pile for a Lightning Energy card and attach it to Rocket's Zapdos ex.\""
+        "text": "Search your discard pile for a Lightning Energy card and attach it to Rocket’s Zapdos ex.\""
       },
       {
         "name": "Raging Thunder",

--- a/json/cards/Team Rocket.json
+++ b/json/cards/Team Rocket.json
@@ -43,7 +43,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Don't apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
+        "text": "Don’t apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
       }
     ],
     "weaknesses": [
@@ -86,7 +86,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. Don't apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.) If that Pokémon has a Pokémon Power, that power stops working until the end of your opponent's next turn."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. Don’t apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.) If that Pokémon has a Pokémon Power, that power stops working until the end of your opponent’s next turn."
       },
       {
         "name": "Poison Vapor",
@@ -97,7 +97,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "The Defending Pokémon is now Poisoned. This attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "The Defending Pokémon is now Poisoned. This attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -140,7 +140,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "Does 30 damage plus 20 more damage for each Energy attached to Dark Blastoise but not used to pay for this attack. You can't add more than 40 damage in this way."
+        "text": "Does 30 damage plus 20 more damage for each Energy attached to Dark Blastoise but not used to pay for this attack. You can’t add more than 40 damage in this way."
       },
       {
         "name": "Rocket Tackle",
@@ -151,7 +151,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Dark Blastoise does 10 damage to itself. Flip a coin. If heads, prevent all damage done to Dark Blastoise during your opponent's next turn. (Any other effects of attacks still happen.)"
+        "text": "Dark Blastoise does 10 damage to itself. Flip a coin. If heads, prevent all damage done to Dark Blastoise during your opponent’s next turn. (Any other effects of attacks still happen.)"
       }
     ],
     "weaknesses": [
@@ -282,7 +282,7 @@
     "evolvesFrom": "Diglett",
     "ability": {
       "name": "Sinkhole",
-      "text": "Whenever your opponent's Active Pokémon retreats, your opponent flips a coin. If tails, this power does 20 damage to that Pokémon. (Don't apply Weakness and Resistance.) This power stops working while Dark Dugtrio is Asleep, Confused, or Paralyzed.",
+      "text": "Whenever your opponent’s Active Pokémon retreats, your opponent flips a coin. If tails, this power does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance.) This power stops working while Dark Dugtrio is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "50",
@@ -336,7 +336,7 @@
     "evolvesFrom": "Zubat",
     "ability": {
       "name": "Sneak Attack",
-      "text": "When you play Dark Golbat from your hand, you may choose 1 of your opponent's Pokémon. If you do, Dark Golbat does 10 damage to that Pokémon. Apply Weakness and Resistance.",
+      "text": "When you play Dark Golbat from your hand, you may choose 1 of your opponent’s Pokémon. If you do, Dark Golbat does 10 damage to that Pokémon. Apply Weakness and Resistance.",
       "type": "Pokémon Power"
     },
     "hp": "50",
@@ -358,7 +358,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. Don't apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. Don’t apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
       }
     ],
     "weaknesses": [
@@ -470,7 +470,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20×",
-        "text": "Your opponent flips a number of coins equal to the number of Pokémon on his or her Bench. This attack does 20 damage times the number of tails. Don't apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
+        "text": "Your opponent flips a number of coins equal to the number of Pokémon on his or her Bench. This attack does 20 damage times the number of tails. Don’t apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
       }
     ],
     "weaknesses": [
@@ -526,7 +526,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Your opponent shuffles his or her Active Pokémon and all cards attached to it into his or her deck. This attack can't be used if your opponent has no Benched Pokémon."
+        "text": "Your opponent shuffles his or her Active Pokémon and all cards attached to it into his or her deck. This attack can’t be used if your opponent has no Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -569,7 +569,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Don't apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
+        "text": "Don’t apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
       },
       {
         "name": "Magnetic Lines",
@@ -721,7 +721,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20×",
-        "text": "Does 20 damage times the total number of Koffings, Weezings, and Dark Weezings in play (Apply Weakness and Resistance.). Then, this attack does 20 damage to each Koffing, Weezing, and Dark Weezing (even your own). Don't apply Weakness and Resistance."
+        "text": "Does 20 damage times the total number of Koffings, Weezings, and Dark Weezings in play (Apply Weakness and Resistance.). Then, this attack does 20 damage to each Koffing, Weezing, and Dark Weezing (even your own). Don’t apply Weakness and Resistance."
       },
       {
         "name": "Stun Gas",
@@ -763,7 +763,7 @@
   },
   {
     "id": "base5-16",
-    "name": "Rocket's Sneak Attack",
+    "name": "Rocket’s Sneak Attack",
     "imageUrl": "https://images.pokemontcg.io/base5/16.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -774,7 +774,7 @@
     "set": "Team Rocket",
     "setCode": "base5",
     "text": [
-      "Look at your opponent's hand. If he or she has any Trainer cards, choose 1 of them. Your opponent shuffles that card into his or her deck."
+      "Look at your opponent’s hand. If he or she has any Trainer cards, choose 1 of them. Your opponent shuffles that card into his or her deck."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base5/16_hires.png"
   },
@@ -791,7 +791,7 @@
     "set": "Team Rocket",
     "setCode": "base5",
     "text": [
-      "Attach Rainbow Energy to 1 of your Pokémon. While in play, Rainbow Energy counts as every type of basic Energy but only provides 1 Energy at a time. (Doesn't count as a basic Energy card when not in play.) When you attach this card from your hand to 1 of your Pokémon, it does 10 damage to that Pokémon. (Don't apply Weakness and Resistance.) (Major text change in Ruby/Sapphire. Requires reference.)"
+      "Attach Rainbow Energy to 1 of your Pokémon. While in play, Rainbow Energy counts as every type of basic Energy but only provides 1 Energy at a time. (Doesn’t count as a basic Energy card when not in play.) When you attach this card from your hand to 1 of your Pokémon, it does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance.) (Major text change in Ruby/Sapphire. Requires reference.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base5/17_hires.png"
   },
@@ -839,7 +839,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Don't apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
+        "text": "Don’t apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
       }
     ],
     "weaknesses": [
@@ -882,7 +882,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. Don't apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.) If that Pokémon has a Pokémon Power, that power stops working until the end of your opponent's next turn."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. Don’t apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.) If that Pokémon has a Pokémon Power, that power stops working until the end of your opponent’s next turn."
       },
       {
         "name": "Poison Vapor",
@@ -893,7 +893,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "The Defending Pokémon is now Poisoned. This attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "The Defending Pokémon is now Poisoned. This attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -936,7 +936,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "Does 30 damage plus 20 more damage for each Energy attached to Dark Blastoise but not used to pay for this attack. You can't add more than 40 damage in this way."
+        "text": "Does 30 damage plus 20 more damage for each Energy attached to Dark Blastoise but not used to pay for this attack. You can’t add more than 40 damage in this way."
       },
       {
         "name": "Rocket Tackle",
@@ -947,7 +947,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Dark Blastoise does 10 damage to itself. Flip a coin. If heads, prevent all damage done to Dark Blastoise during your opponent's next turn. (Any other effects of attacks still happen.)"
+        "text": "Dark Blastoise does 10 damage to itself. Flip a coin. If heads, prevent all damage done to Dark Blastoise during your opponent’s next turn. (Any other effects of attacks still happen.)"
       }
     ],
     "weaknesses": [
@@ -1078,7 +1078,7 @@
     "evolvesFrom": "Diglett",
     "ability": {
       "name": "Sinkhole",
-      "text": "Whenever your opponent's Active Pokémon retreats, your opponent flips a coin. If tails, this power does 20 damage to that Pokémon. (Don't apply Weakness and Resistance.) This power stops working while Dark Dugtrio is Asleep, Confused, or Paralyzed.",
+      "text": "Whenever your opponent’s Active Pokémon retreats, your opponent flips a coin. If tails, this power does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance.) This power stops working while Dark Dugtrio is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "50",
@@ -1132,7 +1132,7 @@
     "evolvesFrom": "Weavile",
     "ability": {
       "name": "Sneak Attack",
-      "text": "When you play Dark Golbat from your hand, you may choose 1 of your opponent's Pokémon. If you do, Dark Golbat does 10 damage to that Pokémon. Apply Weakness and Resistance.",
+      "text": "When you play Dark Golbat from your hand, you may choose 1 of your opponent’s Pokémon. If you do, Dark Golbat does 10 damage to that Pokémon. Apply Weakness and Resistance.",
       "type": "Pokémon Power"
     },
     "hp": "50",
@@ -1154,7 +1154,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. Don't apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. Don’t apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
       }
     ],
     "weaknesses": [
@@ -1185,7 +1185,7 @@
     "evolvesFrom": "Magikarp",
     "ability": {
       "name": "Final Beam",
-      "text": "When Dark Gyarados is Knocked Out by an attack, flip a coin. If heads, this power does 20 damage for each Water Energy attached to Dark Gyarados to the Pokémon that Knocked Out Dark Gyarados. Apply Weakness and Resistance. This power doesn't work if Dark Gyarados is Asleep, Confused, or Paralyzed.",
+      "text": "When Dark Gyarados is Knocked Out by an attack, flip a coin. If heads, this power does 20 damage for each Water Energy attached to Dark Gyarados to the Pokémon that Knocked Out Dark Gyarados. Apply Weakness and Resistance. This power doesn’t work if Dark Gyarados is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "70",
@@ -1271,7 +1271,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20×",
-        "text": "Your opponent flips a number of coins equal to the number of Pokémon on his or her Bench. This attack does 20 damage times the number of tails. Don't apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
+        "text": "Your opponent flips a number of coins equal to the number of Pokémon on his or her Bench. This attack does 20 damage times the number of tails. Don’t apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
       }
     ],
     "weaknesses": [
@@ -1327,7 +1327,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Your opponent shuffles his or her Active Pokémon and all cards attached to it into his or her deck. This attack can't be used if your opponent has no Benched Pokémon."
+        "text": "Your opponent shuffles his or her Active Pokémon and all cards attached to it into his or her deck. This attack can’t be used if your opponent has no Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -1370,7 +1370,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Don't apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
+        "text": "Don’t apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
       },
       {
         "name": "Magnetic Lines",
@@ -1522,7 +1522,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20×",
-        "text": "Does 20 damage times the total number of Koffings, Weezings, and Dark Weezings in play (Apply Weakness and Resistance.). Then, this attack does 20 damage to each Koffing, Weezing, and Dark Weezing even your own). Don't apply Weakness and Resistance."
+        "text": "Does 20 damage times the total number of Koffings, Weezings, and Dark Weezings in play (Apply Weakness and Resistance.). Then, this attack does 20 damage to each Koffing, Weezing, and Dark Weezing even your own). Don’t apply Weakness and Resistance."
       },
       {
         "name": "Stun Gas",
@@ -1612,7 +1612,7 @@
     "evolvesFrom": "Dratini",
     "ability": {
       "name": "Evolutionary Light",
-      "text": "Once during your turn (before your attack), you may search your deck for an Evolution card. Show it to your opponent and put it into your hand. Shuffle your deck afterward. This power can't be used if Dark Dragonair is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may search your deck for an Evolution card. Show it to your opponent and put it into your hand. Shuffle your deck afterward. This power can’t be used if Dark Dragonair is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "60",
@@ -1766,7 +1766,7 @@
     "evolvesFrom": "Oddish",
     "ability": {
       "name": "Pollen Stench",
-      "text": "Once during your turn (before your attack), you may flip a coin. If heads, the Defending Pokémon is now Confused; if tails, your Active Pokémon is now Confused. This power can't be used if Dark Gloom is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may flip a coin. If heads, the Defending Pokémon is now Confused; if tails, your Active Pokémon is now Confused. This power can’t be used if Dark Gloom is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "50",
@@ -1890,7 +1890,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Thunder Attack",
@@ -1923,7 +1923,7 @@
     "evolvesFrom": "Abra",
     "ability": {
       "name": "Matter Exchange",
-      "text": "Once during your turn (before your attack), you may discard a card from your hand in order to draw a card. This power can't be used if Dark Kadabra is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may discard a card from your hand in order to draw a card. This power can’t be used if Dark Kadabra is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "50",
@@ -1949,7 +1949,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Don't apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
+        "text": "Don’t apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
       }
     ],
     "weaknesses": [
@@ -1996,7 +1996,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "Before doing damage, choose 1 of your opponent's Benched Pokémon and switch it with the Defending Pokémon. Do the damage to the new Defending Pokémon. This attack can't be used if your opponent has no Benched Pokémon."
+        "text": "Before doing damage, choose 1 of your opponent’s Benched Pokémon and switch it with the Defending Pokémon. Do the damage to the new Defending Pokémon. This attack can’t be used if your opponent has no Benched Pokémon."
       },
       {
         "name": "Knock Back",
@@ -2096,7 +2096,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, choose 1 of your opponent's Benched Pokémon and switch it with the Defending Pokémon. This attack can't be used if your opponent has no Benched Pokémon."
+        "text": "Flip a coin. If heads, choose 1 of your opponent’s Benched Pokémon and switch it with the Defending Pokémon. This attack can’t be used if your opponent has no Benched Pokémon."
       },
       {
         "name": "Poison Claws",
@@ -2134,7 +2134,7 @@
     "evolvesFrom": "Mankey",
     "ability": {
       "name": "Frenzy",
-      "text": "If Dark Primeape does any damage while it's Confused (even to itself), it does 30 more damage.",
+      "text": "If Dark Primeape does any damage while it’s Confused (even to itself), it does 30 more damage.",
       "type": "Pokémon Power"
     },
     "hp": "60",
@@ -2208,7 +2208,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "You may discard 1 Energy card attached to Dark Rapidash when you use this attack. If you do and if your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "You may discard 1 Energy card attached to Dark Rapidash when you use this attack. If you do and if your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2313,7 +2313,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "If an attack does damage to Dark Wartortle during your opponent's next turn (even if Dark Wartortle is Knocked Out), Dark Wartortle attacks the Defending Pokémon for an equal amount of damage."
+        "text": "If an attack does damage to Dark Wartortle during your opponent’s next turn (even if Dark Wartortle is Knocked Out), Dark Wartortle attacks the Defending Pokémon for an equal amount of damage."
       }
     ],
     "weaknesses": [
@@ -2505,7 +2505,7 @@
     "level": "9",
     "ability": {
       "name": "Gather Fire",
-      "text": "Once during your turn (before your attack), you may take 1 Fire Energy card attached to 1 of your other Pokémon and attach it to Charmander. This power can't be used if Charmander is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may take 1 Fire Energy card attached to 1 of your other Pokémon and attach it to Charmander. This power can’t be used if Charmander is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "40",
@@ -2628,7 +2628,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. Don't apply Weakness and Resistance for this attack. (Any other effects that would happen after Applying Weakness and Resistance still happen.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. Don’t apply Weakness and Resistance for this attack. (Any other effects that would happen after Applying Weakness and Resistance still happen.)"
       },
       {
         "name": "Scratch",
@@ -2712,7 +2712,7 @@
     "level": "10",
     "ability": {
       "name": "Long",
-      "text": "Distance Hypnosis - Once during your turn (before your attack), you may flip a coin. If heads, the Defending Pokémon is now Asleep; if tails, your Active Pokémon is now Asleep. The power can't be used if Drowzee is Asleep, Confused, or Paralyzed.",
+      "text": "Distance Hypnosis - Once during your turn (before your attack), you may flip a coin. If heads, the Defending Pokémon is now Asleep; if tails, your Active Pokémon is now Asleep. The power can’t be used if Drowzee is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "50",
@@ -2790,7 +2790,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       }
     ],
     "weaknesses": [
@@ -3111,7 +3111,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Shuffle your opponent's deck."
+        "text": "Shuffle your opponent’s deck."
       },
       {
         "name": "Anger",
@@ -3165,7 +3165,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon and flip a coin. If heads, this attack does 20 damage to that Pokémon. Don't apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
+        "text": "Choose 1 of your opponent’s Pokémon and flip a coin. If heads, this attack does 20 damage to that Pokémon. Don’t apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
       }
     ],
     "weaknesses": [
@@ -3320,7 +3320,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "Does 20 damage plus 10 more damage for each Energy attached to Psyduck but not used to pay for this attack. You can't add more than 20 damage in this way."
+        "text": "Does 20 damage plus 10 more damage for each Energy attached to Psyduck but not used to pay for this attack. You can’t add more than 20 damage in this way."
       }
     ],
     "weaknesses": [
@@ -3344,7 +3344,7 @@
     "level": "12",
     "ability": {
       "name": "Trickery",
-      "text": "Once during your turn (before your attack), you may switch 1 of your Prizes with the top card of your deck. This power can't be used if Rattata is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may switch 1 of your Prizes with the top card of your deck. This power can’t be used if Rattata is Asleep, Confused, or Paralyzed.",
       "type": "Pokémon Power"
     },
     "hp": "40",
@@ -3601,7 +3601,7 @@
   },
   {
     "id": "base5-72",
-    "name": "Rocket's Sneak Attack",
+    "name": "Rocket’s Sneak Attack",
     "imageUrl": "https://images.pokemontcg.io/base5/72.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -3612,13 +3612,13 @@
     "set": "Team Rocket",
     "setCode": "base5",
     "text": [
-      "Look at your opponent's hand. If he or she has any Trainer cards, choose 1 of them. Your opponent shuffles that card into his or her deck."
+      "Look at your opponent’s hand. If he or she has any Trainer cards, choose 1 of them. Your opponent shuffles that card into his or her deck."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base5/72_hires.png"
   },
   {
     "id": "base5-73",
-    "name": "The Boss's Way",
+    "name": "The Boss’s Way",
     "imageUrl": "https://images.pokemontcg.io/base5/73.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -3646,7 +3646,7 @@
     "set": "Team Rocket",
     "setCode": "base5",
     "text": [
-      "Ask your opponent if he or she accepts your challenge. If your opponent declines (or if both Benches are full), draw 2 cards. If your opponent accepts, each of you searches your decks for any number of Basic Pokémon cards and puts them face down onto your Benches. (A player can't do this if his or her Bench is full.) When you both have finished, shuffle your decks and turn those cards face up."
+      "Ask your opponent if he or she accepts your challenge. If your opponent declines (or if both Benches are full), draw 2 cards. If your opponent accepts, each of you searches your decks for any number of Basic Pokémon cards and puts them face down onto your Benches. (A player can’t do this if his or her Bench is full.) When you both have finished, shuffle your decks and turn those cards face up."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base5/74_hires.png"
   },
@@ -3669,7 +3669,7 @@
   },
   {
     "id": "base5-76",
-    "name": "Imposter Oak's Revenge",
+    "name": "Imposter Oak’s Revenge",
     "imageUrl": "https://images.pokemontcg.io/base5/76.png",
     "subtype": "",
     "supertype": "Trainer",
@@ -3714,7 +3714,7 @@
     "set": "Team Rocket",
     "setCode": "base5",
     "text": [
-      "All Pokémon Powers stop working until the end of your opponent's next turn."
+      "All Pokémon Powers stop working until the end of your opponent’s next turn."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base5/78_hires.png"
   },
@@ -3748,7 +3748,7 @@
     "set": "Team Rocket",
     "setCode": "base5",
     "text": [
-      "Attach Rainbow Energy to 1 of your Pokémon. While in play, Rainbow Energy counts as every type of basic Energy but only provides 1 Energy at a time. (Doesn't count as a basic Energy card when not in play.) When you attach this card from your hand to 1 of your Pokémon, it does 10 damage to that Pokémon. (Don't apply Weakness and Resistance.) (Major text change in Ruby/Sapphire. Requires reference.)"
+      "Attach Rainbow Energy to 1 of your Pokémon. While in play, Rainbow Energy counts as every type of basic Energy but only provides 1 Energy at a time. (Doesn’t count as a basic Energy card when not in play.) When you attach this card from your hand to 1 of your Pokémon, it does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance.) (Major text change in Ruby/Sapphire. Requires reference.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base5/80_hires.png"
   },
@@ -3765,7 +3765,7 @@
     "set": "Team Rocket",
     "setCode": "base5",
     "text": [
-      "If you play this card from your hand, the Pokémon you attach it to is no longer Asleep, Confused, Paralyzed, or Poisoned. Full Heal Energy Provides energy. (Doesn't count as a basic Energy card.)"
+      "If you play this card from your hand, the Pokémon you attach it to is no longer Asleep, Confused, Paralyzed, or Poisoned. Full Heal Energy Provides energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base5/81_hires.png"
   },
@@ -3782,7 +3782,7 @@
     "set": "Team Rocket",
     "setCode": "base5",
     "text": [
-      "If you play this card from your hand, remove 1 damage counter from the Pokémon you attach it to, if it has any. Potion Energy provides energy. (Doesn't count as a basic Energy card.)"
+      "If you play this card from your hand, remove 1 damage counter from the Pokémon you attach it to, if it has any. Potion Energy provides energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/base5/82_hires.png"
   },
@@ -3817,7 +3817,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Flip a coin. If heads, flip another coin. If the second coin is heads, this attack does 20 damage to each of your opponent's Benched Pokémon. If the second coin is tails, this attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon"
+        "text": "Flip a coin. If heads, flip another coin. If the second coin is heads, this attack does 20 damage to each of your opponent’s Benched Pokémon. If the second coin is tails, this attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon"
       }
     ],
     "weaknesses": [

--- a/json/cards/Unseen Forces.json
+++ b/json/cards/Unseen Forces.json
@@ -8,7 +8,7 @@
     "evolvesFrom": "Flaaffy",
     "ability": {
       "name": "Energy Connect",
-      "text": "As often as you like during your turn (before your attack), you may move a basic Energy card attached to 1 of your Benched Pokémon to your Active Pokémon. This power can't be used if Ampharos is affected by a Special Condition.",
+      "text": "As often as you like during your turn (before your attack), you may move a basic Energy card attached to 1 of your Benched Pokémon to your Active Pokémon. This power can’t be used if Ampharos is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "120",
@@ -168,7 +168,7 @@
     "evolvesFrom": "Croconaw",
     "ability": {
       "name": "Intimidating Fang",
-      "text": "As long as Feraligatr is your Active Pokémon, any damage done to your Pokémon by an opponent's attack is reduced by 10 (before applying Weakness and Resistance).",
+      "text": "As long as Feraligatr is your Active Pokémon, any damage done to your Pokémon by an opponent’s attack is reduced by 10 (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -297,7 +297,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Put 3 damage counters on the Defending Pokémon at the end of your opponent's next turn."
+        "text": "Put 3 damage counters on the Defending Pokémon at the end of your opponent’s next turn."
       },
       {
         "name": "Pop",
@@ -309,7 +309,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "Put 7 damage counters on Forretress. Move all Energy cards attached to Forretress to your Benched Pokémon in any way you like. (Ignore this effect if you don't have any Benched Pokémon.)"
+        "text": "Put 7 damage counters on Forretress. Move all Energy cards attached to Forretress to your Benched Pokémon in any way you like. (Ignore this effect if you don’t have any Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -336,7 +336,7 @@
     "evolvesFrom": "Houndour",
     "ability": {
       "name": "Lonesome",
-      "text": "As long as you have less Pokémon in play than your opponent, your opponent can't play any Trainer cards (except for Supporter cards) from his or her hand.",
+      "text": "As long as you have less Pokémon in play than your opponent, your opponent can’t play any Trainer cards (except for Supporter cards) from his or her hand.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -447,7 +447,7 @@
     "evolvesFrom": "Bayleef",
     "ability": {
       "name": "Healing Aroma",
-      "text": "As long as Meganium is your Active Pokémon, remove 1 damage counter from each Pokémon (excluding Pokémon-ex) (both yours and your opponent's) between turns.",
+      "text": "As long as Meganium is your Active Pokémon, remove 1 damage counter from each Pokémon (excluding Pokémon-ex) (both yours and your opponent’s) between turns.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -502,7 +502,7 @@
     "evolvesFrom": "Remoraid",
     "ability": {
       "name": "Super Suction Cups",
-      "text": "As long as Octillery is your Active Pokémon, your opponent's Pokémon can't retreat.",
+      "text": "As long as Octillery is your Active Pokémon, your opponent’s Pokémon can’t retreat.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -526,7 +526,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Discard an Energy card attached to Octillery. During your next turn, Octillery's Pulse Blast attack's base damage is 120."
+        "text": "Discard an Energy card attached to Octillery. During your next turn, Octillery’s Pulse Blast attack’s base damage is 120."
       },
       {
         "name": "Pulse Blast",
@@ -557,7 +557,7 @@
     "evolvesFrom": "Poliwhirl",
     "ability": {
       "name": "Spiral Swirl",
-      "text": "If Poliwrath is your Active Pokémon and is Knocked Out by damage from an opponent's attack, the Attacking Pokémon is now Confused.",
+      "text": "If Poliwrath is your Active Pokémon and is Knocked Out by damage from an opponent’s attack, the Attacking Pokémon is now Confused.",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -615,7 +615,7 @@
     "evolvesFrom": "Porygon",
     "ability": {
       "name": "3-D Reset",
-      "text": "As often as you like during your turn (before your attack), return a Pokémon Tool card attached to 1 of your Pokémon to your hand. This power can't be used if Porygon2 is affected by a Special Condition.",
+      "text": "As often as you like during your turn (before your attack), return a Pokémon Tool card attached to 1 of your Pokémon to your hand. This power can’t be used if Porygon2 is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -731,7 +731,7 @@
     "evolvesFrom": "Slowpoke",
     "ability": {
       "name": "Item Search",
-      "text": "Once during your turn (before your attack), you may search your deck for a Pokémon Tool card, show it to your opponent, and put it into your hand. Shuffle your deck afterward. This power can't be used if Slowking is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may search your deck for a Pokémon Tool card, show it to your opponent, and put it into your hand. Shuffle your deck afterward. This power can’t be used if Slowking is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "70",
@@ -756,7 +756,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "Does 20 damage plus 10 more damage for each Pokémon Tool card in your discard pile. You can't add more than 60 damage in this way."
+        "text": "Does 20 damage plus 10 more damage for each Pokémon Tool card in your discard pile. You can’t add more than 60 damage in this way."
       }
     ],
     "weaknesses": [
@@ -795,7 +795,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of the Defending Pokémon's attacks. Copy copies that attack. This attack does nothing if Sudowoodo doesn't have the Energy necessary to use that attack. (You must still do anything else required for that attack.) Sudowoodo performs that attack."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. Copy copies that attack. This attack does nothing if Sudowoodo doesn’t have the Energy necessary to use that attack. (You must still do anything else required for that attack.) Sudowoodo performs that attack."
       },
       {
         "name": "Karate Chop",
@@ -883,7 +883,7 @@
     "evolvesFrom": "Quilava",
     "ability": {
       "name": "Burning Aura",
-      "text": "As long as Typhlosion is your Active Pokémon, put 1 damage counter on each Active Pokémon (both yours and your opponent's) between turns.",
+      "text": "As long as Typhlosion is your Active Pokémon, put 1 damage counter on each Active Pokémon (both yours and your opponent’s) between turns.",
       "type": "Poké-Body"
     },
     "hp": "110",
@@ -939,7 +939,7 @@
     "evolvesFrom": "Teddiursa",
     "ability": {
       "name": "Intimidating Ring",
-      "text": "As long as Ursaring is your Active Pokémon, your opponent's Basic Pokémon can't attack or use any Poké-Powers.",
+      "text": "As long as Ursaring is your Active Pokémon, your opponent’s Basic Pokémon can’t attack or use any Poké-Powers.",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -965,7 +965,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Before doing damage, you may switch 1 of your opponent's Benched Pokémon with the Defending Pokémon. If you do, this attack does 20 damage to the new Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
+        "text": "Before doing damage, you may switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon. If you do, this attack does 20 damage to the new Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
       },
       {
         "name": "Rock Smash",
@@ -1147,7 +1147,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Stages of Evolution",
-      "text": "As long as Electabuzz is an Evolved Pokémon, damage done by attacks from your opponent's Pokémon that has any Special Energy cards attached to it is reduced by 40 (after applying Weakness and Resistance).",
+      "text": "As long as Electabuzz is an Evolved Pokémon, damage done by attacks from your opponent’s Pokémon that has any Special Energy cards attached to it is reduced by 40 (after applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -1279,7 +1279,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10×",
-        "text": "Does 10 damage times the number of your opponent's Benched Pokémon."
+        "text": "Does 10 damage times the number of your opponent’s Benched Pokémon."
       },
       {
         "name": "Speedy Uppercut",
@@ -1290,7 +1290,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -1310,7 +1310,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Stages of Evolution",
-      "text": "As long as Hitmonlee is an Evolved Pokémon, Hitmonlee's attacks do 20 more damage to your opponent's Pokémon (before applying Weakness and Resistance).",
+      "text": "As long as Hitmonlee is an Evolved Pokémon, Hitmonlee’s attacks do 20 more damage to your opponent’s Pokémon (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -1334,7 +1334,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Benched Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Benched Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Mega Kick",
@@ -1365,7 +1365,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Stages of Evolution",
-      "text": "As long as Hitmontop is an Evolved Pokémon, is your Active Pokémon, and is damaged by an opponent's attack (even if Hitmontop is Knocked Out), put 2 damage counters on the Attacking Pokémon.",
+      "text": "As long as Hitmontop is an Evolved Pokémon, is your Active Pokémon, and is damaged by an opponent’s attack (even if Hitmontop is Knocked Out), put 2 damage counters on the Attacking Pokémon.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -1455,7 +1455,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Flip a coin. If heads, choose 1 of your opponent's Pokémon. This attack does 60 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Flip a coin. If heads, choose 1 of your opponent’s Pokémon. This attack does 60 damage to that Pokémon. This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -1475,7 +1475,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Stages of Evolution",
-      "text": "As long as Jynx is an Evolved Pokémon, prevent all effects of opponent's attacks, except damage, done to Jynx, and Jynx has no Weakness.",
+      "text": "As long as Jynx is an Evolved Pokémon, prevent all effects of opponent’s attacks, except damage, done to Jynx, and Jynx has no Weakness.",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -1510,7 +1510,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Put 4 damage counters on your opponent's Pokémon in any way you like."
+        "text": "Put 4 damage counters on your opponent’s Pokémon in any way you like."
       }
     ],
     "weaknesses": [
@@ -1591,7 +1591,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. The new Defending Pokémon is now Asleep."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. The new Defending Pokémon is now Asleep."
       },
       {
         "name": "Plunder",
@@ -1654,7 +1654,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 1 damage counter on 1 of your opponent's Pokémon."
+        "text": "Put 1 damage counter on 1 of your opponent’s Pokémon."
       }
     ],
     "weaknesses": [
@@ -1706,7 +1706,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Look at your opponent's hand, choose a Trainer card you find there, and discard it."
+        "text": "Look at your opponent’s hand, choose a Trainer card you find there, and discard it."
       }
     ],
     "weaknesses": [
@@ -1775,7 +1775,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Snappy Move",
-      "text": "Once during your turn (before your attack), if Aipom is on your Bench, you may draw a card. Then, discard all cards attached to Aipom and put Aipom on the bottom of your deck. You can't use more than 1 Snappy Move Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), if Aipom is on your Bench, you may draw a card. Then, discard all cards attached to Aipom and put Aipom on the bottom of your deck. You can’t use more than 1 Snappy Move Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "50",
@@ -1799,7 +1799,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1960,7 +1960,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 2 of your opponent's Benched Pokémon. This attack does 10 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 2 of your opponent’s Benched Pokémon. This attack does 10 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2012,7 +2012,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -2036,7 +2036,7 @@
     "evolvesFrom": "Snubbull",
     "ability": {
       "name": "Intimidating Fang",
-      "text": "As long as Granbull is your Active Pokémon, any damage done to your Pokémon by an opponent's attack is reduced by 10 (before applying Weakness and Resistance).",
+      "text": "As long as Granbull is your Active Pokémon, any damage done to your Pokémon by an opponent’s attack is reduced by 10 (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "70",
@@ -2172,7 +2172,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Extra Flame",
@@ -2287,7 +2287,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Choose 1 card from your opponent's hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
+        "text": "Choose 1 card from your opponent’s hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck."
       }
     ],
     "weaknesses": [
@@ -2314,7 +2314,7 @@
     "evolvesFrom": "Wooper",
     "ability": {
       "name": "Dense",
-      "text": "Any damage done to Quagsire by attacks from your opponent's Evolved Pokémon is reduced by 20 (after applying Weakness and Resistance).",
+      "text": "Any damage done to Quagsire by attacks from your opponent’s Evolved Pokémon is reduced by 20 (after applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "80",
@@ -2350,7 +2350,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -2391,7 +2391,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Tackle",
@@ -2454,7 +2454,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Scyther during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Scyther during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2477,7 +2477,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Extra Tight",
-      "text": "Prevent all damage done to Shuckle by attacks from your opponent's Pokémon-ex.",
+      "text": "Prevent all damage done to Shuckle by attacks from your opponent’s Pokémon-ex.",
       "type": "Poké-Body"
     },
     "hp": "60",
@@ -2522,7 +2522,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Makeover",
-      "text": "Once during your turn (before your attack), you may discard a basic Energy card attached to 1 of your Pokémon (excluding Pokémon-ex). If you do, search your discard pile for a basic Energy card (excluding the one you discarded) and attach it to that Pokémon. This power can't be used if Smeargle is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may discard a basic Energy card attached to 1 of your Pokémon (excluding Pokémon-ex). If you do, search your discard pile for a basic Energy card (excluding the one you discarded) and attach it to that Pokémon. This power can’t be used if Smeargle is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "50",
@@ -2587,7 +2587,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. This attack’s damage isn’t affected by Weakness or Resistance."
       },
       {
         "name": "Psyshock",
@@ -2645,7 +2645,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, this attack does 20 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 20 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2881,7 +2881,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Energy Evolution",
-      "text": "Whenever you attach an Energy card from your hand to Eevee, you may search your deck for a card that evolves from Eevee that is the same type as the Energy card you attached to Eevee. Put that card onto Eevee. (This counts as evolving Eevee.) Shuffle your deck afterward. This power can't be used when you attach an Energy card to Eevee as part of an attack's effect.",
+      "text": "Whenever you attach an Energy card from your hand to Eevee, you may search your deck for a card that evolves from Eevee that is the same type as the Energy card you attached to Eevee. Put that card onto Eevee. (This counts as evolving Eevee.) Shuffle your deck afterward. This power can’t be used when you attach an Energy card to Eevee as part of an attack’s effect.",
       "type": "Poké-Body"
     },
     "hp": "40",
@@ -2995,7 +2995,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Free Flight",
-      "text": "If Gligar has no Energy attached to it, Gligar's Retreat Cost is 0.",
+      "text": "If Gligar has no Energy attached to it, Gligar’s Retreat Cost is 0.",
       "type": "Poké-Body"
     },
     "hp": "50",
@@ -3306,7 +3306,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -3539,7 +3539,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "Does 30 damage plus 10 more damage for each Energy attached to Poliwhirl but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "Does 30 damage plus 10 more damage for each Energy attached to Poliwhirl but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       }
     ],
     "weaknesses": [
@@ -3983,7 +3983,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, any damage done to Teddiursa by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Teddiursa by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Scratch",
@@ -4034,7 +4034,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -4115,8 +4115,8 @@
     "set": "Unseen Forces",
     "setCode": "ex10",
     "text": [
-      "Attach Curse Powder to 1 of your Evolved Pokémon (excluding Pokémon-ex) that doesn't already have a Pokémon Tool attached to it. If the Pokémon Curse Powder is attached to is a Basic Pokémon or Pokémon-ex, discard Curse Powder.",
-      "If the Pokémon that Curse Powder is attached to is your Active Pokémon and is Knocked Out by damage from an opponent's attack, put 3 damage counters on the Attacking Pokémon."
+      "Attach Curse Powder to 1 of your Evolved Pokémon (excluding Pokémon-ex) that doesn’t already have a Pokémon Tool attached to it. If the Pokémon Curse Powder is attached to is a Basic Pokémon or Pokémon-ex, discard Curse Powder.",
+      "If the Pokémon that Curse Powder is attached to is your Active Pokémon and is Knocked Out by damage from an opponent’s attack, put 3 damage counters on the Attacking Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/80_hires.png"
   },
@@ -4152,7 +4152,7 @@
     "set": "Unseen Forces",
     "setCode": "ex10",
     "text": [
-      "Flip a coin. If heads, choose 1 Energy card attached to 1 of your opponent's Pokémon and discard it."
+      "Flip a coin. If heads, choose 1 Energy card attached to 1 of your opponent’s Pokémon and discard it."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/82_hires.png"
   },
@@ -4170,8 +4170,8 @@
     "set": "Unseen Forces",
     "setCode": "ex10",
     "text": [
-      "Attach Energy Root to 1 of your Pokémon (excluding Pokémon-ex and Pokémon that has Dark or an owner in its name) that doesn't already have a Pokémon Tool attached to it. If the Pokémon Energy Root is attached to is Pokémon-ex or has Dark or an owner in its name, discard Energy Root.",
-      "As long as Energy Root is attached to a Pokémon, that Pokémon gets +20 HP and can't use any Poké-Powers or Poké-Bodies."
+      "Attach Energy Root to 1 of your Pokémon (excluding Pokémon-ex and Pokémon that has Dark or an owner in its name) that doesn’t already have a Pokémon Tool attached to it. If the Pokémon Energy Root is attached to is Pokémon-ex or has Dark or an owner in its name, discard Energy Root.",
+      "As long as Energy Root is attached to a Pokémon, that Pokémon gets +20 HP and can’t use any Poké-Powers or Poké-Bodies."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/83_hires.png"
   },
@@ -4207,14 +4207,14 @@
     "set": "Unseen Forces",
     "setCode": "ex10",
     "text": [
-      "Attach Fluffy Berry to 1 of your Pokémon (excluding Pokémon-ex and Pokémon that has Dark or an owner in its name) that doesn't already have a Pokémon Tool attached to it. If the Pokémon Fluffy Berry is attached to is Pokémon-ex or has Dark or an owner in its name, discard Fluffy Berry.",
-      "As long as Fluffy Berry is attached to a Pokémon, that Pokémon's Retreat Cost is 0."
+      "Attach Fluffy Berry to 1 of your Pokémon (excluding Pokémon-ex and Pokémon that has Dark or an owner in its name) that doesn’t already have a Pokémon Tool attached to it. If the Pokémon Fluffy Berry is attached to is Pokémon-ex or has Dark or an owner in its name, discard Fluffy Berry.",
+      "As long as Fluffy Berry is attached to a Pokémon, that Pokémon’s Retreat Cost is 0."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/85_hires.png"
   },
   {
     "id": "ex10-86",
-    "name": "Mary's Request",
+    "name": "Mary’s Request",
     "imageUrl": "https://images.pokemontcg.io/ex10/86.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4227,7 +4227,7 @@
     "setCode": "ex10",
     "text": [
       "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.",
-      "Draw a card. If you don't have any Stage 2 Evolved Pokémon in play, draw 2 more cards."
+      "Draw a card. If you don’t have any Stage 2 Evolved Pokémon in play, draw 2 more cards."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/86_hires.png"
   },
@@ -4263,13 +4263,13 @@
     "set": "Unseen Forces",
     "setCode": "ex10",
     "text": [
-      "Flip a coin. If heads, choose 1 of your opponent's Benched Pokémon and switch it with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
+      "Flip a coin. If heads, choose 1 of your opponent’s Benched Pokémon and switch it with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/88_hires.png"
   },
   {
     "id": "ex10-89",
-    "name": "Professor Elm's Training Method",
+    "name": "Professor Elm’s Training Method",
     "imageUrl": "https://images.pokemontcg.io/ex10/89.png",
     "subtype": "Supporter",
     "supertype": "Trainer",
@@ -4300,7 +4300,7 @@
     "set": "Unseen Forces",
     "setCode": "ex10",
     "text": [
-      "Attach Protective Orb to 1 of your Evolved Pokémon (excluding Pokémon-ex) that doesn't already have a Pokémon Tool attached to it. If the Pokémon Protective Orb is attached to is a Basic Pokémon or Pokémon-ex, discard Protective Orb.",
+      "Attach Protective Orb to 1 of your Evolved Pokémon (excluding Pokémon-ex) that doesn’t already have a Pokémon Tool attached to it. If the Pokémon Protective Orb is attached to is a Basic Pokémon or Pokémon-ex, discard Protective Orb.",
       "As long as Protective Orb is attached to a Pokémon, that Pokémon has no Weakness."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/90_hires.png"
@@ -4319,7 +4319,7 @@
     "set": "Unseen Forces",
     "setCode": "ex10",
     "text": [
-      "Attach Sitrus Berry to 1 of your Pokémon (excluding Pokémon-ex and Pokémon that has Dark or an owner in its name) that doesn't already have a Pokémon Tool attached to it. If the Pokémon Sitrus Berry is attached to is Pokémon-ex or has Dark or an owner in its name, discard Sitrus Berry.",
+      "Attach Sitrus Berry to 1 of your Pokémon (excluding Pokémon-ex and Pokémon that has Dark or an owner in its name) that doesn’t already have a Pokémon Tool attached to it. If the Pokémon Sitrus Berry is attached to is Pokémon-ex or has Dark or an owner in its name, discard Sitrus Berry.",
       "At any time between turns, if the Pokémon this card is attached to has at least 3 damage counters on it, remove 3 damage counters from it. Then, discard Sitrus Berry."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/91_hires.png"
@@ -4338,7 +4338,7 @@
     "set": "Unseen Forces",
     "setCode": "ex10",
     "text": [
-      "Attach Solid Rage to 1 of your Evolved Pokémon (excluding Pokémon-ex) that doesn't already have a Pokémon Tool attached to it. If the Pokémon Solid Rage is attached to is a Basic Pokémon or Pokémon-ex, discard Solid Rage.",
+      "Attach Solid Rage to 1 of your Evolved Pokémon (excluding Pokémon-ex) that doesn’t already have a Pokémon Tool attached to it. If the Pokémon Solid Rage is attached to is a Basic Pokémon or Pokémon-ex, discard Solid Rage.",
       "If you have more Prize cards left than your opponent, the Pokémon that Solid Rage is attached to does 20 more damage to the Active Pokémon (before applying Weakness and Resistance)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/92_hires.png"
@@ -4410,7 +4410,7 @@
     "set": "Unseen Forces",
     "setCode": "ex10",
     "text": [
-      "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect unless the Attacking Pokémon is Darkness or has Dark in its name. Darkness Energy provides Darkness Energy. (Doesn't count as a basic Energy card.)"
+      "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect unless the Attacking Pokémon is Darkness or has Dark in its name. Darkness Energy provides Darkness Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/96_hires.png"
   },
@@ -4427,7 +4427,7 @@
     "set": "Unseen Forces",
     "setCode": "ex10",
     "text": [
-      "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn't Metal. Metal Energy provides Metal Energy. (Doesn't count as a basic Energy card.)"
+      "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn’t Metal. Metal Energy provides Metal Energy. (Doesn’t count as a basic Energy card.)"
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/97_hires.png"
   },
@@ -4444,7 +4444,7 @@
     "set": "Unseen Forces",
     "setCode": "ex10",
     "text": [
-      "Boost Energy can be attached only to an Evolved Pokémon. Discard Boost Energy at the end of the turn it was attached. Boost Energy provides Colorless Colorless Colorless Energy. The Pokémon Boost Energy is attached to can't retreat. If the Pokémon Boost Energy is attached to isn't an Evolved Pokémon, discard Boost Energy."
+      "Boost Energy can be attached only to an Evolved Pokémon. Discard Boost Energy at the end of the turn it was attached. Boost Energy provides Colorless Colorless Colorless Energy. The Pokémon Boost Energy is attached to can’t retreat. If the Pokémon Boost Energy is attached to isn’t an Evolved Pokémon, discard Boost Energy."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/98_hires.png"
   },
@@ -4461,7 +4461,7 @@
     "set": "Unseen Forces",
     "setCode": "ex10",
     "text": [
-      "Cyclone Energy provides Colorless Energy. When you attach this card from your hand to your Active Pokémon, switch 1 of the Defending Pokémon with 1 of your opponent's Benched Pokémon. Your opponent chooses the Benched Pokémon to switch."
+      "Cyclone Energy provides Colorless Energy. When you attach this card from your hand to your Active Pokémon, switch 1 of the Defending Pokémon with 1 of your opponent’s Benched Pokémon. Your opponent chooses the Benched Pokémon to switch."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/99_hires.png"
   },
@@ -4553,7 +4553,7 @@
     "evolvesFrom": "Eevee",
     "ability": {
       "name": "Devo Flash",
-      "text": "Once during your turn, when you play Espeon ex from your hand to evolve 1 of your Pokémon, you may choose 1 Evolved Pokémon on your opponent's Bench, remove the highest Stage Evolution card from that Pokémon, and put it back into his or her hand.",
+      "text": "Once during your turn, when you play Espeon ex from your hand to evolve 1 of your Pokémon, you may choose 1 Evolved Pokémon on your opponent’s Bench, remove the highest Stage Evolution card from that Pokémon, and put it back into his or her hand.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -4578,7 +4578,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Psyloop",
@@ -4611,7 +4611,7 @@
     "evolvesFrom": "Croconaw",
     "ability": {
       "name": "Overpowering Fang",
-      "text": "As long as Feraligatr ex is your Active Pokémon, each player's Pokémon (excluding Pokémon-ex) can't use any Poké-Powers or Poké-Bodies.",
+      "text": "As long as Feraligatr ex is your Active Pokémon, each player’s Pokémon (excluding Pokémon-ex) can’t use any Poké-Powers or Poké-Bodies.",
       "type": "Poké-Body"
     },
     "hp": "150",
@@ -4641,7 +4641,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Sore Spot",
@@ -4674,7 +4674,7 @@
     "level": "ex",
     "ability": {
       "name": "Golden Wing",
-      "text": "If Ho-Oh ex would be Knocked Out by damage from an opponent's attack, you may move up to 2 Energy attached to Ho-Oh ex to your Pokémon in any way you like.",
+      "text": "If Ho-Oh ex would be Knocked Out by damage from an opponent’s attack, you may move up to 2 Energy attached to Ho-Oh ex to your Pokémon in any way you like.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -4722,7 +4722,7 @@
     "level": "ex",
     "ability": {
       "name": "Silver Sparkle",
-      "text": "If Lugia ex is your Active Pokémon and is damaged by an opponent's attack (even if Lugia ex is Knocked Out), flip a coin. If heads, choose an Energy card attached to the Attacking Pokémon and return it to your opponent's hand.",
+      "text": "If Lugia ex is your Active Pokémon and is damaged by an opponent’s attack (even if Lugia ex is Knocked Out), flip a coin. If heads, choose an Energy card attached to the Attacking Pokémon and return it to your opponent’s hand.",
       "type": "Poké-Body"
     },
     "hp": "100",
@@ -4779,7 +4779,7 @@
     "evolvesFrom": "Bayleef",
     "ability": {
       "name": "Nurture and Heal",
-      "text": "Once during your turn (before your attack), you may attach a Grass Energy card from your hand to 1 of your Pokémon. If you do, remove 1 damage counter from that Pokémon. This power can't be used if Meganium ex is affected by a Special Condition.",
+      "text": "Once during your turn (before your attack), you may attach a Grass Energy card from your hand to 1 of your Pokémon. If you do, remove 1 damage counter from that Pokémon. This power can’t be used if Meganium ex is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "150",
@@ -4879,7 +4879,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. If that Pokémon is a Stage 2 Evolved Pokémon, this attack does 50 damage instead. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. If that Pokémon is a Stage 2 Evolved Pokémon, this attack does 50 damage instead. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Punch and Run",
@@ -4902,7 +4902,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "70",
-        "text": "Before doing damage, count the remaining HP of the Defending Pokémon and Politoed ex. If the Defending Pokémon has fewer remaining HP than Politoed ex's, this attack does 120 damage instead."
+        "text": "Before doing damage, count the remaining HP of the Defending Pokémon and Politoed ex. If the Defending Pokémon has fewer remaining HP than Politoed ex’s, this attack does 120 damage instead."
       }
     ],
     "weaknesses": [
@@ -4924,7 +4924,7 @@
     "evolvesFrom": "Scyther",
     "ability": {
       "name": "Danger Perception",
-      "text": "As long as Scizor ex's remaining HP is 60 or less, Scizor ex does 40 more damage to the Defending Pokémon (before applying Weakness and Resistance).",
+      "text": "As long as Scizor ex’s remaining HP is 60 or less, Scizor ex does 40 more damage to the Defending Pokémon (before applying Weakness and Resistance).",
       "type": "Poké-Body"
     },
     "hp": "120",
@@ -4952,7 +4952,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "During your opponent's next turn, any damage done to Scizor ex by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to Scizor ex by attacks is reduced by 20 (after applying Weakness and Resistance)."
       },
       {
         "name": "Cross-Cut",
@@ -4991,7 +4991,7 @@
     "evolvesFrom": "Onix",
     "ability": {
       "name": "Poison Resistance",
-      "text": "Steelix ex can't be Poisoned.",
+      "text": "Steelix ex can’t be Poisoned.",
       "type": "Poké-Body"
     },
     "hp": "150",
@@ -5036,7 +5036,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Discard 2 Fighting Energy attached to Steelix ex and choose 1 of your opponent's Pokémon. This attack does 100 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard 2 Fighting Energy attached to Steelix ex and choose 1 of your opponent’s Pokémon. This attack does 100 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -5072,7 +5072,7 @@
     "evolvesFrom": "Quilava",
     "ability": {
       "name": "Bursting Up",
-      "text": "Once during your turn, when you play Typhlosion ex from your hand to evolve 1 of your Pokémon, count the number of your opponent's Benched Pokémon. You may search your deck for up to that number of Fire Energy cards and attach them to 1 of your Fire Pokémon. Shuffle your deck afterward.",
+      "text": "Once during your turn, when you play Typhlosion ex from your hand to evolve 1 of your Pokémon, count the number of your opponent’s Benched Pokémon. You may search your deck for up to that number of Fire Energy cards and attach them to 1 of your Fire Pokémon. Shuffle your deck afterward.",
       "type": "Poké-Power"
     },
     "hp": "150",
@@ -5216,7 +5216,7 @@
     "evolvesFrom": "Eevee",
     "ability": {
       "name": "Darker Ring",
-      "text": "Once during your turn (before your attack), when you play Umbreon ex from your hand to evolve 1 of your Pokémon, switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch.",
+      "text": "Once during your turn (before your attack), when you play Umbreon ex from your hand to evolve 1 of your Pokémon, switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch.",
       "type": "Poké-Power"
     },
     "hp": "110",
@@ -5243,7 +5243,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "The Defending Pokémon can't retreat or use any Poké-Powers during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat or use any Poké-Powers during your opponent’s next turn."
       },
       {
         "name": "Darkness Fang",
@@ -5289,7 +5289,7 @@
     "set": "Unseen Forces",
     "setCode": "ex10",
     "text": [
-      "You can't have more than 1 Pokémon Star in your deck."
+      "You can’t have more than 1 Pokémon Star in your deck."
     ],
     "types": [
       "Fire"
@@ -5343,7 +5343,7 @@
     "set": "Unseen Forces",
     "setCode": "ex10",
     "text": [
-      "You can't have more than 1 Pokémon Star in your deck."
+      "You can’t have more than 1 Pokémon Star in your deck."
     ],
     "types": [
       "Lightning"
@@ -5368,7 +5368,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "If you have less Prize cards left than your opponent, this attack does 40 damage to each of your Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If you have less Prize cards left than your opponent, this attack does 40 damage to each of your Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -5397,7 +5397,7 @@
     "set": "Unseen Forces",
     "setCode": "ex10",
     "text": [
-      "You can't have more than 1 Pokémon Star in your deck."
+      "You can’t have more than 1 Pokémon Star in your deck."
     ],
     "types": [
       "Water"
@@ -5436,15 +5436,15 @@
   },
   {
     "id": "ex10-116",
-    "name": "Rocket's Persian ex",
+    "name": "Rocket’s Persian ex",
     "imageUrl": "https://images.pokemontcg.io/ex10/116.png",
     "subtype": "Stage 1",
     "supertype": "Pokémon",
     "level": "ex",
-    "evolvesFrom": "Rocket's Meowth",
+    "evolvesFrom": "Rocket’s Meowth",
     "ability": {
       "name": "Night Cry",
-      "text": "Once during your turn, if Rocket's Persian ex is on your Bench, you may search your deck for a Pokémon with Dark or Rocket's in its name. Show it to your opponent and put it into your hand. Shuffle your deck afterward.",
+      "text": "Once during your turn, if Rocket’s Persian ex is on your Bench, you may search your deck for a Pokémon with Dark or Rocket’s in its name. Show it to your opponent and put it into your hand. Shuffle your deck afterward.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -5516,7 +5516,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, put 1 damage counter on each of your opponent's Pokemon. If tails, remove 1 damage country for each of your Pokémon."
+        "text": "Flip a coin. If heads, put 1 damage counter on each of your opponent’s Pokemon. If tails, remove 1 damage country for each of your Pokémon."
       },
       {
         "name": "Time Trap",
@@ -5526,7 +5526,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, look at the top 4 cards of your opponent's deck, and put them back on top of your opponent's deck in any order. If tails, look at the top 4 cards of your deck, and put them back on top of your deck in any order."
+        "text": "Flip a coin. If heads, look at the top 4 cards of your opponent’s deck, and put them back on top of your opponent’s deck in any order. If tails, look at the top 4 cards of your deck, and put them back on top of your deck in any order."
       }
     ],
     "weaknesses": [
@@ -5546,7 +5546,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -5590,7 +5590,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -5615,7 +5615,7 @@
           "Colorless"
         ],
         "convertedEnergyCost": 3,
-        "text": "Count the number of cards in your opponent's hand. Put that many damage counters on the Defending Pokémon."
+        "text": "Count the number of cards in your opponent’s hand. Put that many damage counters on the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -5635,7 +5635,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -5658,7 +5658,7 @@
           "Colorless"
         ],
         "convertedEnergyCost": 1,
-        "text": "Search your opponent's discard pile for a Supporter card and use the effect of that card as the effect of this attack. (The Supporter card remains in your opponent's discard pile.)"
+        "text": "Search your opponent’s discard pile for a Supporter card and use the effect of that card as the effect of this attack. (The Supporter card remains in your opponent’s discard pile.)"
       }
     ],
     "weaknesses": [
@@ -5678,7 +5678,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -5701,7 +5701,7 @@
           "Colorless"
         ],
         "convertedEnergyCost": 1,
-        "text": "Flip a coin. If heads, choose 1 of either player's Evolved Pokémon, remove the highest Stage Evolution card from that Pokémon, and put it into that player's hand."
+        "text": "Flip a coin. If heads, choose 1 of either player’s Evolved Pokémon, remove the highest Stage Evolution card from that Pokémon, and put it into that player’s hand."
       }
     ],
     "weaknesses": [
@@ -5721,7 +5721,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -5744,7 +5744,7 @@
           "Colorless"
         ],
         "convertedEnergyCost": 1,
-        "text": "If your opponent's Bench isn't full, look at his or her hand. Choose 1 Basic Pokémon you find there and put it onto your opponent's Bench. Then, switch it with the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
+        "text": "If your opponent’s Bench isn’t full, look at his or her hand. Choose 1 Basic Pokémon you find there and put it onto your opponent’s Bench. Then, switch it with the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
       }
     ],
     "weaknesses": [
@@ -5764,7 +5764,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -5809,7 +5809,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -5853,7 +5853,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -5896,7 +5896,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -5920,7 +5920,7 @@
           "Colorless"
         ],
         "convertedEnergyCost": 2,
-        "text": "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. The new Defending Pokémon is now Burned and Confused."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. The new Defending Pokémon is now Burned and Confused."
       }
     ],
     "weaknesses": [
@@ -5940,7 +5940,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -5983,7 +5983,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -6028,7 +6028,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -6072,7 +6072,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -6115,7 +6115,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -6158,7 +6158,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -6203,7 +6203,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -6227,7 +6227,7 @@
           "Colorless"
         ],
         "convertedEnergyCost": 2,
-        "text": "Put 1 damage counter on each of your opponent's Pokémon that already has damage counters on it."
+        "text": "Put 1 damage counter on each of your opponent’s Pokémon that already has damage counters on it."
       }
     ],
     "weaknesses": [
@@ -6247,7 +6247,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -6290,7 +6290,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -6314,7 +6314,7 @@
           "Colorless"
         ],
         "convertedEnergyCost": 2,
-        "text": "Flip a coin. If heads, your opponent returns the Defending Pokémon and all cards attached to it to his or her hand. (If your opponent doesn't have any Benched Pokémon or other Active Pokémon, this attack does nothing.)"
+        "text": "Flip a coin. If heads, your opponent returns the Defending Pokémon and all cards attached to it to his or her hand. (If your opponent doesn’t have any Benched Pokémon or other Active Pokémon, this attack does nothing.)"
       }
     ],
     "weaknesses": [
@@ -6334,7 +6334,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -6358,7 +6358,7 @@
           "Psychic"
         ],
         "convertedEnergyCost": 2,
-        "text": "If the Defending Pokémon has a Poké-Power or a Poké-Body, choose up to 2 basic Energy cards attached to 1 of your opponent's Pokémon and attach them to the Defending Pokémon."
+        "text": "If the Defending Pokémon has a Poké-Power or a Poké-Body, choose up to 2 basic Energy cards attached to 1 of your opponent’s Pokémon and attach them to the Defending Pokémon."
       }
     ],
     "weaknesses": [
@@ -6378,7 +6378,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -6402,7 +6402,7 @@
           "Colorless"
         ],
         "convertedEnergyCost": 2,
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. This attack’s damage isn’t affected by Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -6422,7 +6422,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -6447,7 +6447,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": 10,
-        "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of the Defending Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -6467,7 +6467,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -6493,7 +6493,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20+",
-        "text": "Does 20 damage plus 10 more damage for each Basic Pokémon and each Evolution card in your discard pile. You can't add more than 60 damage in this way."
+        "text": "Does 20 damage plus 10 more damage for each Basic Pokémon and each Evolution card in your discard pile. You can’t add more than 60 damage in this way."
       }
     ],
     "weaknesses": [
@@ -6513,7 +6513,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -6558,7 +6558,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -6603,7 +6603,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -6647,7 +6647,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -6670,7 +6670,7 @@
           "Psychic"
         ],
         "convertedEnergyCost": 1,
-        "text": "Does 20 damage to each Pokémon that has any Poké-Powers or Poké-Bodies (both yours and your opponent's). Don't apply Weakness or Resistance."
+        "text": "Does 20 damage to each Pokémon that has any Poké-Powers or Poké-Bodies (both yours and your opponent’s). Don’t apply Weakness or Resistance."
       }
     ],
     "weaknesses": [
@@ -6690,7 +6690,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",
@@ -6713,7 +6713,7 @@
           "Colorless"
         ],
         "convertedEnergyCost": 1,
-        "text": "Flip a coin. If heads, put 2 damage counters on 1 of your opponent's Pokémon. If tails, put 2 damage counters on 1 of your Pokémon."
+        "text": "Flip a coin. If heads, put 2 damage counters on 1 of your opponent’s Pokémon. If tails, put 2 damage counters on 1 of your Pokémon."
       }
     ],
     "weaknesses": [
@@ -6733,7 +6733,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Shuffle",
-      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn.",
+      "text": "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Shuffle Poké-Power each turn.",
       "type": "Poké-Power"
     },
     "hp": "60",

--- a/json/cards/Wizards Black Star Promos.json
+++ b/json/cards/Wizards Black Star Promos.json
@@ -26,7 +26,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the Defending Pokémon attacks Pikachu during your opponent's next turn, any damage done by the attack is reduced by 10 (after applying Weakness and Resistance). (Benching either Pokémon ends this effect.)"
+        "text": "If the Defending Pokémon attacks Pikachu during your opponent’s next turn, any damage done by the attack is reduced by 10 (after applying Weakness and Resistance). (Benching either Pokémon ends this effect.)"
       },
       {
         "name": "Thundershock",
@@ -79,7 +79,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Whenever an attack does damage to Electabuzz (after applying Weakness and Resistance) during your opponent's next turn, that attack only does half the damage to Electabuzz (rounded down to the nearest 10). (Any other effects still happen.)"
+        "text": "Whenever an attack does damage to Electabuzz (after applying Weakness and Resistance) during your opponent’s next turn, that attack only does half the damage to Electabuzz (rounded down to the nearest 10). (Any other effects still happen.)"
       },
       {
         "name": "Quick Attack",
@@ -218,7 +218,7 @@
     "evolvesFrom": "Dragonair",
     "ability": {
       "name": "Special Delivery",
-      "text": "Once during your turn (before your attack), you may draw a card. If you do, choose a card from your hand and put it on top of your deck. This power can't be used if Dragonite is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may draw a card. If you do, choose a card from your hand and put it on top of your deck. This power can’t be used if Dragonite is Asleep, Confused, or Paralyzed.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -403,7 +403,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose an Evolved Pokémon (your own or your opponent's). Return the highest Stage Evolution card on that Pokémon to its player's hand. That Pokémon is no longer Asleep, Confused, Paralyzed, Poisoned, or anything else that might be the result of an attack (just as if you had evolved it)."
+        "text": "Choose an Evolved Pokémon (your own or your opponent’s). Return the highest Stage Evolution card on that Pokémon to its player’s hand. That Pokémon is no longer Asleep, Confused, Paralyzed, Poisoned, or anything else that might be the result of an attack (just as if you had evolved it)."
       }
     ],
     "weaknesses": [
@@ -452,7 +452,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Choose an Evolved Pokémon (your own or your opponent's). Return the highest Stage Evolution card on that Pokémon to its player's hand. That Pokémon is no longer Asleep, Confused, Paralyzed, Poisoned, or anything else that might be the result of an attack (just as if you had evolved it)."
+        "text": "Choose an Evolved Pokémon (your own or your opponent’s). Return the highest Stage Evolution card on that Pokémon to its player’s hand. That Pokémon is no longer Asleep, Confused, Paralyzed, Poisoned, or anything else that might be the result of an attack (just as if you had evolved it)."
       }
     ],
     "weaknesses": [
@@ -492,7 +492,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, this attack does 20 damage. If tails and if your opponent has any Benched Pokémon, he or she chooses 1 of them and this attack does 20 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, this attack does 20 damage. If tails and if your opponent has any Benched Pokémon, he or she chooses 1 of them and this attack does 20 damage to it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -522,7 +522,7 @@
     "level": "7",
     "ability": {
       "name": "Chain Reaction",
-      "text": "This power can only be used when a Pokémon evolves. Search your deck for a card that evolves from Eevee and attach it to Eevee. This counts as evolving Eevee. Shuffle your deck afterward. This power can't be used if Eevee is Asleep, Confused, or Paralyzed.",
+      "text": "This power can only be used when a Pokémon evolves. Search your deck for a card that evolves from Eevee and attach it to Eevee. This counts as evolving Eevee. Shuffle your deck afterward. This power can’t be used if Eevee is Asleep, Confused, or Paralyzed.",
       "type": "Poké-Power"
     },
     "hp": "30",
@@ -597,7 +597,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, choose a basic Energy card attached to 1 of your opponent's Pokémon and attach it to another of your opponent's Pokémon of your choice."
+        "text": "Flip a coin. If heads, choose a basic Energy card attached to 1 of your opponent’s Pokémon and attach it to another of your opponent’s Pokémon of your choice."
       },
       {
         "name": "Telekinesis",
@@ -608,7 +608,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. Don't apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
+        "text": "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. Don’t apply Weakness and Resistance for this attack. (Any other effects that would happen after applying Weakness and Resistance still happen.)"
       }
     ],
     "weaknesses": [
@@ -630,7 +630,7 @@
     "evolvesFrom": "Ivysaur",
     "ability": {
       "name": "Solar Power",
-      "text": "Once during your turn (before your attack), you may use this power. Your Active Pokémon and the Defending Pokémon are no longer Asleep, Confused, Paralyzed, or Poisoned. This power can't be used if Venusaur is Asleep, Confused, or Paralyzed.",
+      "text": "Once during your turn (before your attack), you may use this power. Your Active Pokémon and the Defending Pokémon are no longer Asleep, Confused, Paralyzed, or Poisoned. This power can’t be used if Venusaur is Asleep, Confused, or Paralyzed.",
       "type": "Poké-Power"
     },
     "hp": "100",
@@ -748,7 +748,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "You may change Cool Porygon's Resistance to a type of your choice other than Colorless. If the Defending Pokémon has a Weakness, you may change it to a type of your choice other than Colorless. (Benching either Pokémon ends the effect on that Pokémon.)"
+        "text": "You may change Cool Porygon’s Resistance to a type of your choice other than Colorless. If the Defending Pokémon has a Weakness, you may change it to a type of your choice other than Colorless. (Benching either Pokémon ends the effect on that Pokémon.)"
       },
       {
         "name": "3-D Attack",
@@ -792,7 +792,7 @@
     "set": "Wizards Black Star Promos",
     "setCode": "basep",
     "text": [
-      "You may draw up to 5 cards, then your opponent may draw up to 5 cards. Your turn is over now (you don't get to attack)."
+      "You may draw up to 5 cards, then your opponent may draw up to 5 cards. Your turn is over now (you don’t get to attack)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/basep/16_hires.png"
   },
@@ -821,7 +821,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If your opponent has any Benched Pokémon, flip a coin. If heads, choose 1 of your opponent's Benched Pokémon and switch it with the Defending Pokémon."
+        "text": "If your opponent has any Benched Pokémon, flip a coin. If heads, choose 1 of your opponent’s Benched Pokémon and switch it with the Defending Pokémon."
       },
       {
         "name": "Poison Claws",
@@ -851,7 +851,7 @@
   },
   {
     "id": "basep-18",
-    "name": "Team Rocket's Meowth",
+    "name": "Team Rocket’s Meowth",
     "imageUrl": "https://images.pokemontcg.io/basep/18.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -877,7 +877,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10×",
-        "text": "Flip a number of coins equal to the total number of Pokémon in play. This attack does 10 damage times the number of heads. Then, Team Rocket's Meowth does 10 damage times the number of tails to itself."
+        "text": "Flip a number of coins equal to the total number of Pokémon in play. This attack does 10 damage times the number of heads. Then, Team Rocket’s Meowth does 10 damage times the number of tails to itself."
       }
     ],
     "weaknesses": [
@@ -900,7 +900,7 @@
   },
   {
     "id": "basep-19",
-    "name": "Sabrina's Abra",
+    "name": "Sabrina’s Abra",
     "imageUrl": "https://images.pokemontcg.io/basep/19.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -935,7 +935,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "This attack can't be used unless Sabrina's Abra and the Defending Pokémon have the same number of Energy cards attached to them."
+        "text": "This attack can’t be used unless Sabrina’s Abra and the Defending Pokémon have the same number of Energy cards attached to them."
       }
     ],
     "weaknesses": [
@@ -977,7 +977,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent can't play Trainer cards during his or her next turn."
+        "text": "Your opponent can’t play Trainer cards during his or her next turn."
       },
       {
         "name": "Fury Swipes",
@@ -1030,7 +1030,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Flip a coin. If heads, discard 1 Energy card attached to Moltres. If tails, discard all Energy cards attached to Moltres. If you can't discard Energy cards, this attack does nothing."
+        "text": "Flip a coin. If heads, discard 1 Energy card attached to Moltres. If tails, discard all Energy cards attached to Moltres. If you can’t discard Energy cards, this attack does nothing."
       }
     ],
     "resistances": [
@@ -1071,7 +1071,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "Flip a coin. If heads, the Defending Pokémon is now Paralyzed, and this attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip a coin. If heads, the Defending Pokémon is now Paralyzed, and this attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "resistances": [
@@ -1112,7 +1112,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Flip a coin. If heads, and if your opponent has any Benched Pokémon, choose 1 of them. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) If tails, Zapdos does 30 damage to itself."
+        "text": "Flip a coin. If heads, and if your opponent has any Benched Pokémon, choose 1 of them. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) If tails, Zapdos does 30 damage to itself."
       }
     ],
     "resistances": [
@@ -1126,7 +1126,7 @@
   },
   {
     "id": "basep-24",
-    "name": "___________'s Pikachu",
+    "name": "___________’s Pikachu",
     "imageUrl": "https://images.pokemontcg.io/basep/24.png",
     "subtype": "Basic",
     "supertype": "Pokémon",
@@ -1152,7 +1152,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "If it's not your birthday, this attack does 30 damage. If it is your birthday, flip a coin. If heads, this attack does 30 damage plus 50 more damage; if tails, this attack does 30 damage."
+        "text": "If it’s not your birthday, this attack does 30 damage. If it is your birthday, flip a coin. If heads, this attack does 30 damage plus 50 more damage; if tails, this attack does 30 damage."
       }
     ],
     "weaknesses": [
@@ -1205,7 +1205,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Flying Pikachu; if tails, this attack does nothing (not even damage)."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Flying Pikachu; if tails, this attack does nothing (not even damage)."
       }
     ],
     "resistances": [
@@ -1306,7 +1306,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Pikachu."
+        "text": "Flip a coin. If heads, during your opponent’s next turn, prevent all effects of attacks, including damage, done to Pikachu."
       }
     ],
     "weaknesses": [
@@ -1394,7 +1394,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20+",
-        "text": "Does 20 damage plus 10 more damage for each Energy attached to Marill but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+        "text": "Does 20 damage plus 10 more damage for each Energy attached to Marill but not used to pay for this attack’s Energy cost. You can’t add more than 20 damage in this way."
       }
     ],
     "weaknesses": [
@@ -1436,7 +1436,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "If the Defending Pokémon attacks Togepi during your opponent's next turn, any damage done to Togepi is reduced by 20 (before applying Weakness and Resistance). (Benching either Pokémon ends this effect.)"
+        "text": "If the Defending Pokémon attacks Togepi during your opponent’s next turn, any damage done to Togepi is reduced by 20 (before applying Weakness and Resistance). (Benching either Pokémon ends this effect.)"
       },
       {
         "name": "Mini-Metronome",
@@ -1446,7 +1446,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip a coin. If heads, choose 1 of the Defending Pokémon's attacks. Mini-Metronome copies that attack except for its Energy cost. (You must still do anything else in order to use that attack.) (No matter what type the Defending Pokémon is, Togepi's type is still .) Togepi performs that attack."
+        "text": "Flip a coin. If heads, choose 1 of the Defending Pokémon’s attacks. Mini-Metronome copies that attack except for its Energy cost. (You must still do anything else in order to use that attack.) (No matter what type the Defending Pokémon is, Togepi’s type is still .) Togepi performs that attack."
       }
     ],
     "resistances": [
@@ -1490,7 +1490,7 @@
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/basep/31_hires.png",
     "text": [
-      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent's turn ends without an attack."
+      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent’s turn ends without an attack."
     ],
     "nationalPokedexNumber": 173,
     "evolvesTo": [
@@ -1568,7 +1568,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, the Defending Pokémon can't attack Scizor during your opponent's next turn. (Benching either Pokémon ends this effect.)"
+        "text": "Flip a coin. If heads, the Defending Pokémon can’t attack Scizor during your opponent’s next turn. (Benching either Pokémon ends this effect.)"
       },
       {
         "name": "Metal Pincer",
@@ -1606,7 +1606,7 @@
     "level": "37",
     "ability": {
       "name": "Bolt",
-      "text": "Whenever your opponent's attack damages Entei, unless that attack Knocks Out Entei, flip a coin. If heads, shuffle Entei and all cards attached to it into your deck. This power can't be used if Entei is already Asleep, Confused, or Paralyzed when it is damaged.",
+      "text": "Whenever your opponent’s attack damages Entei, unless that attack Knocks Out Entei, flip a coin. If heads, shuffle Entei and all cards attached to it into your deck. This power can’t be used if Entei is already Asleep, Confused, or Paralyzed when it is damaged.",
       "type": "Poké-Power"
     },
     "hp": "80",
@@ -1631,7 +1631,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "During your opponent's next turn, prevent all effects of attacks, including damage, done to your Benched Pokémon."
+        "text": "During your opponent’s next turn, prevent all effects of attacks, including damage, done to your Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -1661,18 +1661,18 @@
     ],
     "attacks": [
       {
-        "name": "Let's Play!",
+        "name": "Let’s Play!",
         "cost": [
           "Colorless"
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Search your deck for a Baby Pokémon card and put it onto your Bench. Shuffle your deck afterward. (You can't use this attack if your Bench is full.)"
+        "text": "Search your deck for a Baby Pokémon card and put it onto your Bench. Shuffle your deck afterward. (You can’t use this attack if your Bench is full.)"
       }
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/basep/35_hires.png",
     "text": [
-      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent's turn ends without an attack."
+      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent’s turn ends without an attack."
     ],
     "nationalPokedexNumber": 172,
     "evolvesTo": [
@@ -1708,7 +1708,7 @@
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/basep/36_hires.png",
     "text": [
-      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent's turn ends without an attack."
+      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything else required in order to use that attack). If tails, your opponent’s turn ends without an attack."
     ],
     "nationalPokedexNumber": 174,
     "evolvesTo": [
@@ -1890,7 +1890,7 @@
     "set": "Wizards Black Star Promos",
     "setCode": "basep",
     "text": [
-      "Once during each player's turn (before attacking), the player may flip a coin. If heads, that player draws a card."
+      "Once during each player’s turn (before attacking), the player may flip a coin. If heads, that player draws a card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/basep/41_hires.png"
   },
@@ -1906,7 +1906,7 @@
     "set": "Wizards Black Star Promos",
     "setCode": "basep",
     "text": [
-      "If the effect of a Pokémon Power, attack, Energy card, or Trainer card would put a card in a discard pile into its owner's hand, that card stays in that discard pile instead."
+      "If the effect of a Pokémon Power, attack, Energy card, or Trainer card would put a card in a discard pile into its owner’s hand, that card stays in that discard pile instead."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/basep/42_hires.png"
   },
@@ -2047,7 +2047,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "This attack can't be used during your next turn. (Benching Scyther ends this effect.)"
+        "text": "This attack can’t be used during your next turn. (Benching Scyther ends this effect.)"
       }
     ],
     "weaknesses": [
@@ -2095,7 +2095,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose 1 of your opponent's Pokémon and put a Lightning Rod marker on it. (A Pokémon can have only 1 Lightning Rod marker on it at a time.)"
+        "text": "Choose 1 of your opponent’s Pokémon and put a Lightning Rod marker on it. (A Pokémon can have only 1 Lightning Rod marker on it at a time.)"
       },
       {
         "name": "Lightning Bolt",
@@ -2221,7 +2221,7 @@
     "level": "35",
     "ability": {
       "name": "Guard",
-      "text": "As long as Snorlax is your Active Pokémon, the Defending Pokémon can't retreat. This power stops working when Snorlax is affected by a Special Condition.",
+      "text": "As long as Snorlax is your Active Pokémon, the Defending Pokémon can’t retreat. This power stops working when Snorlax is affected by a Special Condition.",
       "type": "Poké-Power"
     },
     "hp": "90",
@@ -2332,7 +2332,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "If you opponent has any Benched Pokémon, choose 1 of them. Flip a coin. If heads, this attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If you opponent has any Benched Pokémon, choose 1 of them. Flip a coin. If heads, this attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Super Singe",
@@ -2385,7 +2385,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Flip a coin. If tails, this attack's base damage is 20 instead of 60."
+        "text": "Flip a coin. If tails, this attack’s base damage is 20 instead of 60."
       }
     ],
     "weaknesses": [
@@ -2411,7 +2411,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Pure Body",
-      "text": "Whenever you attach a Water Energy card to Suicune from your hand, you must discard 1 other Energy card attached to Suicune. (If you can't discard Energy cards, you can't attach the Water Energy card.)",
+      "text": "Whenever you attach a Water Energy card to Suicune from your hand, you must discard 1 other Energy card attached to Suicune. (If you can’t discard Energy cards, you can’t attach the Water Energy card.)",
       "type": "Poké-Body"
     },
     "hp": "70",

--- a/json/cards/XY Black Star Promos.json
+++ b/json/cards/XY Black Star Promos.json
@@ -183,7 +183,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       },
       {
         "name": "Fairy Wind",
@@ -308,7 +308,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "Flip a coin. If tails, this Pokémon can't attack during your next turn."
+        "text": "Flip a coin. If tails, this Pokémon can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -359,7 +359,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "X Blast",
@@ -371,7 +371,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "140",
-        "text": "This Pokémon can't use X Blast during your next turn."
+        "text": "This Pokémon can’t use X Blast during your next turn."
       }
     ],
     "weaknesses": [
@@ -515,7 +515,7 @@
     "evolvesFrom": "Skrelp",
     "ability": {
       "name": "Poison Barrier",
-      "text": "Your opponent's Poisoned Pokémon can't retreat.",
+      "text": "Your opponent’s Poisoned Pokémon can’t retreat.",
       "type": "Ability"
     },
     "hp": "100",
@@ -541,7 +541,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Poisoned."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Poisoned."
       }
     ],
     "weaknesses": [
@@ -625,7 +625,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your next turn, this Pokémon's Slash attack's base damage is 40."
+        "text": "During your next turn, this Pokémon’s Slash attack’s base damage is 40."
       },
       {
         "name": "Slash",
@@ -665,7 +665,7 @@
     "evolvesFrom": "Machoke",
     "ability": {
       "name": "Fighting Fury",
-      "text": "Each of your Fighting Pokémon's attacks do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
+      "text": "Each of your Fighting Pokémon’s attacks do 20 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "150",
@@ -692,7 +692,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 40 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 40 (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -734,7 +734,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       },
       {
         "name": "Wood Hammer",
@@ -793,7 +793,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 30 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 30 (after applying Weakness and Resistance)."
       },
       {
         "name": "Sleepy Ball",
@@ -804,7 +804,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       }
     ],
     "weaknesses": [
@@ -1024,7 +1024,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Confused."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Confused."
       },
       {
         "name": "Wonder Flare",
@@ -1036,7 +1036,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80＋",
-        "text": "Your opponent reveals his or her hand. This attack does 40 more damage for each Energy card in your opponent's hand."
+        "text": "Your opponent reveals his or her hand. This attack does 40 more damage for each Energy card in your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -1078,7 +1078,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 30 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Aqua Blast",
@@ -1184,7 +1184,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Deep Wind",
@@ -1195,7 +1195,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60＋",
-        "text": "If your opponent's Active Pokémon is Asleep, this attack does 60 more damage and heal 30 damage from this Pokémon."
+        "text": "If your opponent’s Active Pokémon is Asleep, this attack does 60 more damage and heal 30 damage from this Pokémon."
       }
     ],
     "weaknesses": [
@@ -1242,7 +1242,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30＋",
-        "text": "Your opponent reveals his or her hand. Choose a Pokémon you find there and put it on the bottom of your opponent's deck. If you do, this attack does 30 more damage."
+        "text": "Your opponent reveals his or her hand. Choose a Pokémon you find there and put it on the bottom of your opponent’s deck. If you do, this attack does 30 more damage."
       },
       {
         "name": "Spirit Dance",
@@ -1274,7 +1274,7 @@
     "evolvesFrom": "Frogadier",
     "ability": {
       "name": "Mist Concealment",
-      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may prevent all effects of attacks, including damage, done to this Pokémon by your opponent's Pokémon during your opponent’s next turn.",
+      "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may prevent all effects of attacks, including damage, done to this Pokémon by your opponent’s Pokémon during your opponent’s next turn.",
       "type": "Ability"
     },
     "hp": "130",
@@ -1299,7 +1299,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "60",
-        "text": "This attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1351,7 +1351,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40+",
-        "text": "This attack does 10 more damage for each damage counter on your opponent's Active Pokémon."
+        "text": "This attack does 10 more damage for each damage counter on your opponent’s Active Pokémon."
       },
       {
         "name": "Megaton Fang",
@@ -1363,7 +1363,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "130",
-        "text": "Discard a card from your hand. If you can't discard a card, this attack does nothing."
+        "text": "Discard a card from your hand. If you can’t discard a card, this attack does nothing."
       }
     ],
     "weaknesses": [
@@ -1411,7 +1411,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Royal Flare",
@@ -1448,8 +1448,8 @@
     "set": "XY Black Star Promos",
     "setCode": "xyp",
     "text": [
-      "Once during each player's turn, if that player has 6 Pokémon in play, he or she may heal 10 damage from each of his or her Pokémon.",
-      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card."
+      "Once during each player’s turn, if that player has 6 Pokémon in play, he or she may heal 10 damage from each of his or her Pokémon.",
+      "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xyp/XY27_hires.png"
   },
@@ -1488,7 +1488,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       },
       {
         "name": "Jungle Hammer",
@@ -1656,7 +1656,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "During your opponent's next turn, this Pokémon has no Weakness."
+        "text": "During your opponent’s next turn, this Pokémon has no Weakness."
       },
       {
         "name": "Light of Life",
@@ -1716,7 +1716,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Wings of Destruction",
@@ -2078,7 +2078,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Metamorphosis Gene",
-      "text": "If this Pokémon is your Active Pokémon, it can use the attacks of your opponent's Active Pokémon. (You still need the necessary Energy to use each attack.)",
+      "text": "If this Pokémon is your Active Pokémon, it can use the attacks of your opponent’s Active Pokémon. (You still need the necessary Energy to use each attack.)",
       "type": "Ability"
     },
     "hp": "70",
@@ -2149,7 +2149,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Giant Whirlpool",
@@ -2207,7 +2207,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Massive Rend",
@@ -2263,7 +2263,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
       },
       {
         "name": "Luminous Swirl",
@@ -2328,7 +2328,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "During your opponent's next turn, prevent all damage done to each of your Pokémon by attacks from your opponent's Pokémon-EX. (If this Pokémon is no longer your Active Pokémon, this effect ends.)"
+        "text": "During your opponent’s next turn, prevent all damage done to each of your Pokémon by attacks from your opponent’s Pokémon-EX. (If this Pokémon is no longer your Active Pokémon, this effect ends.)"
       }
     ],
     "weaknesses": [
@@ -2379,7 +2379,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40+",
-        "text": "If your opponent's Active Pokémon has no Energy attached to it, this attack does 40 more damage."
+        "text": "If your opponent’s Active Pokémon has no Energy attached to it, this attack does 40 more damage."
       },
       {
         "name": "Cross Slash",
@@ -2391,7 +2391,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "130",
-        "text": "This Pokémon can't use Cross Slash during your next turn."
+        "text": "This Pokémon can’t use Cross Slash during your next turn."
       }
     ],
     "weaknesses": [
@@ -2465,7 +2465,7 @@
     "evolvesFrom": "Helioptile",
     "ability": {
       "name": "Dry Skin",
-      "text": "Any damage done to this Pokémon by attacks from your opponent's Water Pokémon is reduced by 30 (after applying Weakness and Resistance).",
+      "text": "Any damage done to this Pokémon by attacks from your opponent’s Water Pokémon is reduced by 30 (after applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "90",
@@ -2491,7 +2491,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -2518,7 +2518,7 @@
     "evolvesFrom": "Espurr",
     "ability": {
       "name": "Mysterious Ears",
-      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Confused.",
+      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Confused.",
       "type": "Ability"
     },
     "hp": "90",
@@ -2544,7 +2544,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -2701,7 +2701,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "This attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2756,7 +2756,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2798,7 +2798,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       },
       {
         "name": "Strong Slash",
@@ -2809,7 +2809,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "130",
-        "text": "This Pokémon can't use Strong Slash during your next turn."
+        "text": "This Pokémon can’t use Strong Slash during your next turn."
       }
     ],
     "weaknesses": [
@@ -2971,7 +2971,7 @@
         "text": "Flip 2 coins. This attack does 40 damage times the number of heads."
       },
       {
-        "name": "Nurse's Egg",
+        "name": "Nurse’s Egg",
         "cost": [
           "Colorless",
           "Colorless",
@@ -3085,7 +3085,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "If you have the same number of cards in your hand as your opponent, your opponent's Active Pokémon is now Confused."
+        "text": "If you have the same number of cards in your hand as your opponent, your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -3293,7 +3293,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Flip a coin. If heads, discard a random card from your opponent's hand."
+        "text": "Flip a coin. If heads, discard a random card from your opponent’s hand."
       },
       {
         "name": "Dark Edge",
@@ -3304,7 +3304,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -3357,7 +3357,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "80＋",
-        "text": "Discard the top card of your opponent's deck. If that card is a Trainer card, this attack does 80 more damage."
+        "text": "Discard the top card of your opponent’s deck. If that card is a Trainer card, this attack does 80 more damage."
       }
     ],
     "weaknesses": [
@@ -3383,7 +3383,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Ozone Wall",
-      "text": "As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's).",
+      "text": "As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent’s).",
       "type": "Ability"
     },
     "hp": "120",
@@ -3566,7 +3566,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Discard a Special Energy attached to your opponent's Active Pokémon. If you do, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Discard a Special Energy attached to your opponent’s Active Pokémon. If you do, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       },
       {
         "name": "Dream Dance",
@@ -3621,7 +3621,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "Discard a Special Energy attached to your opponent's Active Pokémon. If you do, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Discard a Special Energy attached to your opponent’s Active Pokémon. If you do, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       },
       {
         "name": "Dream Dance",
@@ -3682,7 +3682,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "If your opponent's Active Pokémon already has any damage counters on it, this attack does 60 more damage."
+        "text": "If your opponent’s Active Pokémon already has any damage counters on it, this attack does 60 more damage."
       },
       {
         "name": "Adamantine Press",
@@ -3694,7 +3694,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -3777,7 +3777,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Despotic Fang",
-      "text": "Damage from this Pokémon's attacks isn't affected by any effects on your opponent's Active Pokémon.",
+      "text": "Damage from this Pokémon’s attacks isn’t affected by any effects on your opponent’s Active Pokémon.",
       "type": "Ability"
     },
     "hp": "180",
@@ -3859,7 +3859,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Discard 2 Energy attached to this Pokémon. This attack does 100 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard 2 Energy attached to this Pokémon. This attack does 100 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -3914,7 +3914,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "110",
-        "text": "Prevent all effects of your opponent's attacks, except damage, done to this Pokémon during your opponent's next turn."
+        "text": "Prevent all effects of your opponent’s attacks, except damage, done to this Pokémon during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -3971,7 +3971,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "130",
-        "text": "Flip a coin. If tails, this Pokémon can't use Dragon Strike during your next turn."
+        "text": "Flip a coin. If tails, this Pokémon can’t use Dragon Strike during your next turn."
       }
     ],
     "weaknesses": [
@@ -4078,7 +4078,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "Your opponent can't attach Energy from his or her hand to the Defending Pokémon during his or her next turn."
+        "text": "Your opponent can’t attach Energy from his or her hand to the Defending Pokémon during his or her next turn."
       }
     ],
     "weaknesses": [
@@ -4131,7 +4131,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "90",
-        "text": "This attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -4190,7 +4190,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "Your opponent can't play any Pokémon from his or her hand to evolve the Defending Pokémon during his or her next turn."
+        "text": "Your opponent can’t play any Pokémon from his or her hand to evolve the Defending Pokémon during his or her next turn."
       }
     ],
     "weaknesses": [
@@ -4340,7 +4340,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Frozen Slice",
@@ -4395,7 +4395,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Flare Blizzard",
@@ -4407,7 +4407,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "This Pokémon can't use Flare Blizzard during your next turn."
+        "text": "This Pokémon can’t use Flare Blizzard during your next turn."
       }
     ],
     "weaknesses": [
@@ -4672,7 +4672,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "During your next turn, this Pokémon's Moonsault Blaze attack does 100 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s Moonsault Blaze attack does 100 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -4721,7 +4721,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "130+",
-        "text": "You may do 30 more damage. If you do, discard the top 3 cards of each player's deck."
+        "text": "You may do 30 more damage. If you do, discard the top 3 cards of each player’s deck."
       }
     ],
     "weaknesses": [
@@ -4804,7 +4804,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Electric Ring",
@@ -4899,7 +4899,7 @@
     "set": "XY Black Star Promos",
     "setCode": "xyp",
     "text": [
-      "Once during each player's turn, if that player has 6 Pokémon in play, he or she may heal 10 damage from each of his or her Pokémon."
+      "Once during each player’s turn, if that player has 6 Pokémon in play, he or she may heal 10 damage from each of his or her Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xyp/XY91_hires.png"
   },
@@ -4955,7 +4955,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Leap Through Time",
-      "text": "When this Pokémon is Knocked Out, flip a coin. If heads, your opponent can't take a Prize card. Shuffle this Pokémon and all cards attached to it into your deck.",
+      "text": "When this Pokémon is Knocked Out, flip a coin. If heads, your opponent can’t take a Prize card. Shuffle this Pokémon and all cards attached to it into your deck.",
       "type": "Ability"
     },
     "hp": "70",
@@ -4979,7 +4979,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 1 damage counter on each of your opponent's Pokémon."
+        "text": "Put 1 damage counter on each of your opponent’s Pokémon."
       }
     ],
     "weaknesses": [
@@ -5000,7 +5000,7 @@
     "evolvesFrom": "Phantump",
     "ability": {
       "name": "Nervous Seed",
-      "text": "As long as this Pokémon is your Active Pokémon, your opponent's Basic Pokémon's attacks cost Colorless more.",
+      "text": "As long as this Pokémon is your Active Pokémon, your opponent’s Basic Pokémon’s attacks cost Colorless more.",
       "type": "Ability"
     },
     "hp": "110",
@@ -5057,7 +5057,7 @@
         "cost": [
           "Colorless"
         ],
-        "name": "Let's Eat Together",
+        "name": "Let’s Eat Together",
         "text": "Heal 30 damage from both Active Pokémon.",
         "damage": "",
         "convertedEnergyCost": 1
@@ -5121,7 +5121,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -5234,7 +5234,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "110",
-        "text": "This attack does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each Benched Pokémon (both yours and your opponent’s). (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -5298,7 +5298,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -5339,7 +5339,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -5359,7 +5359,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Frozen Charm",
-      "text": "Each of your Pokémon that has any Water Energy attached to it can't be Paralyzed. (If any of those Pokémon are Paralyzed, remove that Special Condition.)",
+      "text": "Each of your Pokémon that has any Water Energy attached to it can’t be Paralyzed. (If any of those Pokémon are Paralyzed, remove that Special Condition.)",
       "type": "Ability"
     },
     "hp": "180",
@@ -5397,7 +5397,7 @@
           "Colorless"
         ],
         "name": "Crystal Breath",
-        "text": "This Pokémon can't attack during your next turn",
+        "text": "This Pokémon can’t attack during your next turn",
         "damage": "160",
         "convertedEnergyCost": 4
       }
@@ -5445,7 +5445,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -5499,7 +5499,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "130",
-        "text": "Flip 2 coins. For each heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip 2 coins. For each heads, discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -5937,7 +5937,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "Your opponent's Active Pokémon is now Asleep. Your opponent flips 2 coins instead of 1 between turns. If either of them is tails, that Pokémon is still Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep. Your opponent flips 2 coins instead of 1 between turns. If either of them is tails, that Pokémon is still Asleep."
       }
     ],
     "weaknesses": [
@@ -6115,7 +6115,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Justified",
-      "text": "This Pokémon's attacks do 50 more damage to your opponent's Darkness Pokémon (before applying Weakness and Resistance).",
+      "text": "This Pokémon’s attacks do 50 more damage to your opponent’s Darkness Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "90",
@@ -6141,7 +6141,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "This Pokémon can't use Sacred Sword during your next turn."
+        "text": "This Pokémon can’t use Sacred Sword during your next turn."
       }
     ],
     "weaknesses": [
@@ -6182,7 +6182,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "This attack does 30 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Destructor Beam",
@@ -6193,7 +6193,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -6238,7 +6238,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip 3 coins. This attack does 10 damage times the number of heads to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip 3 coins. This attack does 10 damage times the number of heads to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Entrancing Melody",
@@ -6248,7 +6248,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -6396,7 +6396,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       },
       {
         "name": "Jungle Hammer",
@@ -6515,7 +6515,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 30 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 30 (before applying Weakness and Resistance)."
       },
       {
         "name": "Psyburn",
@@ -6548,7 +6548,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Versatile",
-      "text": "This Pokémon can use the attacks of any Pokémon in play (both yours and your opponent's). (You still need the necessary Energy to use each attack.)",
+      "text": "This Pokémon can use the attacks of any Pokémon in play (both yours and your opponent’s). (You still need the necessary Energy to use each attack.)",
       "type": "Ability"
     },
     "hp": "120",
@@ -6928,7 +6928,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip 3 coins. This attack does 20 damage times the number of heads to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip 3 coins. This attack does 20 damage times the number of heads to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Ninja Blade",
@@ -6939,7 +6939,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "130",
-        "text": "This Pokémon can't use Ninja Blade during your next turn."
+        "text": "This Pokémon can’t use Ninja Blade during your next turn."
       }
     ],
     "weaknesses": [
@@ -7248,7 +7248,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -7340,7 +7340,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 2 damage counters on each of your opponent's Pokémon that has any damage counters on it."
+        "text": "Put 2 damage counters on each of your opponent’s Pokémon that has any damage counters on it."
       },
       {
         "name": "Mind Bend",
@@ -7351,7 +7351,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -7437,7 +7437,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50+",
-        "text": "If your opponent's Active Pokémon has a Pokémon Tool card attached to it, this attack does 70 more damage."
+        "text": "If your opponent’s Active Pokémon has a Pokémon Tool card attached to it, this attack does 70 more damage."
       }
     ],
     "weaknesses": [
@@ -7582,7 +7582,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 20 damage to 2 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 2 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Pitfall",
@@ -7593,7 +7593,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "130",
-        "text": "This Pokémon can't use Pitfall during your next turn."
+        "text": "This Pokémon can’t use Pitfall during your next turn."
       }
     ],
     "weaknesses": [
@@ -7688,7 +7688,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "X Blast",
@@ -7700,7 +7700,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "140",
-        "text": "This Pokémon can't use X Blast during your next turn."
+        "text": "This Pokémon can’t use X Blast during your next turn."
       }
     ],
     "weaknesses": [
@@ -7866,7 +7866,7 @@
     ],
     "attacks": [
       {
-        "name": "Land's Pulse",
+        "name": "Land’s Pulse",
         "cost": [
           "Fighting"
         ],
@@ -7885,7 +7885,7 @@
         "text": "Heal 30 damage from this Pokémon."
       },
       {
-        "name": "Land's Wrath",
+        "name": "Land’s Wrath",
         "cost": [
           "Fighting",
           "Fighting",
@@ -7934,7 +7934,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Geostrike",
@@ -7945,7 +7945,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -8047,7 +8047,7 @@
         ],
         "convertedEnergyCost": 5,
         "damage": "160",
-        "text": "This Pokémon can't use Shining Flame during your next turn."
+        "text": "This Pokémon can’t use Shining Flame during your next turn."
       }
     ],
     "nationalPokedexNumber": 250,
@@ -8082,7 +8082,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Discard all Energy attached to this Pokémon. During your opponent's next turn, if this Pokémon is damaged by an attack (even if this Pokémon is Knocked Out), put damage counters on the Attacking Pokémon equal to the damage done to this Pokémon."
+        "text": "Discard all Energy attached to this Pokémon. During your opponent’s next turn, if this Pokémon is damaged by an attack (even if this Pokémon is Knocked Out), put damage counters on the Attacking Pokémon equal to the damage done to this Pokémon."
       }
     ],
     "weaknesses": [
@@ -8183,7 +8183,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Discard up to 2 Pokémon Tool cards attached to your opponent's Pokémon."
+        "text": "Discard up to 2 Pokémon Tool cards attached to your opponent’s Pokémon."
       },
       {
         "name": "Pin Missile",
@@ -8236,7 +8236,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "Discard all Energy attached to this Pokémon. Your opponent's Active Pokémon is now Paralyzed and Poisoned. Put 4 damage counters instead of 1 on that Pokémon between turns."
+        "text": "Discard all Energy attached to this Pokémon. Your opponent’s Active Pokémon is now Paralyzed and Poisoned. Put 4 damage counters instead of 1 on that Pokémon between turns."
       }
     ],
     "weaknesses": [
@@ -8308,7 +8308,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "If this Pokémon has any Lightning Energy attached to it, this attack does 20 damage to each of your opponent's Benched Pokémon. (Don't apply weakness and Resistance for Benched Pokémon.)"
+        "text": "If this Pokémon has any Lightning Energy attached to it, this attack does 20 damage to each of your opponent’s Benched Pokémon. (Don’t apply weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -8346,7 +8346,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Crackling Ribbon",
@@ -8457,7 +8457,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20×",
-        "text": "This attack does 20 damage times the number of different types of Pokémon on your opponent's Bench."
+        "text": "This attack does 20 damage times the number of different types of Pokémon on your opponent’s Bench."
       }
     ],
     "weaknesses": [
@@ -8506,7 +8506,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "This attack's damage isn't affected by any effects on your opponent's Active Pokémon."
+        "text": "This attack’s damage isn’t affected by any effects on your opponent’s Active Pokémon."
       },
       {
         "name": "Hyper Beam",
@@ -8518,7 +8518,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -8625,7 +8625,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "10+",
-        "text": "This attack does 50 more damage for each of your opponent's Pokémon-EX."
+        "text": "This attack does 50 more damage for each of your opponent’s Pokémon-EX."
       },
       {
         "name": "Dragon Strike",
@@ -8637,7 +8637,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "130",
-        "text": "This Pokémon can't use Dragon Strike during your next turn."
+        "text": "This Pokémon can’t use Dragon Strike during your next turn."
       }
     ],
     "weaknesses": [
@@ -8722,7 +8722,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Steam Up",
-      "text": "Once during your turn (before your attack), you may discard a Fire Energy card from your hand. If you do, during this turn, your Basic Fire Pokémon's attacks do 30 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
+      "text": "Once during your turn (before your attack), you may discard a Fire Energy card from your hand. If you do, during this turn, your Basic Fire Pokémon’s attacks do 30 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance).",
       "type": "Ability"
     },
     "hp": "180",
@@ -8750,7 +8750,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "130",
-        "text": "This Pokémon can't attack during your next turn."
+        "text": "This Pokémon can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -8793,7 +8793,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Mega Thunderbolt",
@@ -8833,7 +8833,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Mystic Heart",
-      "text": "Prevent all effects of your opponent's attacks, except damage, done to each of your Pokémon that has any Metal Energy attached to it. (Existing effects are not removed.)",
+      "text": "Prevent all effects of your opponent’s attacks, except damage, done to each of your Pokémon that has any Metal Energy attached to it. (Existing effects are not removed.)",
       "type": "Ability"
     },
     "hp": "160",
@@ -8862,7 +8862,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "During your next turn, this Pokémon's Soul Blaster attack's base damage is 60."
+        "text": "During your next turn, this Pokémon’s Soul Blaster attack’s base damage is 60."
       }
     ],
     "weaknesses": [
@@ -8893,7 +8893,7 @@
     "set": "XY Black Star Promos",
     "setCode": "xyp",
     "text": [
-      "Once during each player's turn, if that player has 6 Pokémon in play, he or she may heal 10 damage from each of his or her Pokémon."
+      "Once during each player’s turn, if that player has 6 Pokémon in play, he or she may heal 10 damage from each of his or her Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xyp/XY176_hires.png"
   },
@@ -8939,7 +8939,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Lamentation",
-      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), discard a random card from your opponent's hand.",
+      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack (even if this Pokémon is Knocked Out), discard a random card from your opponent’s hand.",
       "type": "Ability"
     },
     "hp": "100",
@@ -8965,7 +8965,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -9019,7 +9019,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "110",
-        "text": "Discard a random card from your opponent's hand."
+        "text": "Discard a random card from your opponent’s hand."
       }
     ],
     "weaknesses": [
@@ -9067,7 +9067,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "You may leave your opponent's Active Pokémon Paralyzed. If you do, shuffle this Pokémon and all cards attached to it into your deck."
+        "text": "You may leave your opponent’s Active Pokémon Paralyzed. If you do, shuffle this Pokémon and all cards attached to it into your deck."
       }
     ],
     "nationalPokedexNumber": 169,
@@ -9103,7 +9103,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 30 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 30 (before applying Weakness and Resistance)."
       },
       {
         "name": "Psyburn",

--- a/json/cards/XY.json
+++ b/json/cards/XY.json
@@ -34,7 +34,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       },
       {
         "name": "Jungle Hammer",
@@ -92,7 +92,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "Your opponent's Active Pokémon is now Paralyzed and Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Paralyzed and Poisoned."
       }
     ],
     "weaknesses": [
@@ -135,7 +135,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
-        "text": "If your opponent's Active Pokémon is a Grass Pokémon, this attack does 20 more damage."
+        "text": "If your opponent’s Active Pokémon is a Grass Pokémon, this attack does 20 more damage."
       }
     ],
     "weaknesses": [
@@ -179,7 +179,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, if this Pokémon would be damaged by an attack, prevent that attack's damage done to this Pokémon if that damage is 60 or less."
+        "text": "During your opponent’s next turn, if this Pokémon would be damaged by an attack, prevent that attack’s damage done to this Pokémon if that damage is 60 or less."
       }
     ],
     "weaknesses": [
@@ -222,7 +222,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       },
       {
         "name": "Flash Needle",
@@ -232,7 +232,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40x",
-        "text": "Flip 3 coins. This attack does 40 damage times the number of heads. If all of them are heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip 3 coins. This attack does 40 damage times the number of heads. If all of them are heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -325,7 +325,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "This attack does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -364,7 +364,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Switch 1 of your opponent's Benched Pokémon with your opponent's Active Pokémon."
+        "text": "Switch 1 of your opponent’s Benched Pokémon with your opponent’s Active Pokémon."
       },
       {
         "name": "Signal Beam",
@@ -374,7 +374,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -515,7 +515,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "Choose 1 of your opponent's Active Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+        "text": "Choose 1 of your opponent’s Active Pokémon’s attacks. That Pokémon can’t use that attack during your opponent’s next turn."
       },
       {
         "name": "Solar Beam",
@@ -611,7 +611,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent’s next turn."
       },
       {
         "name": "Wood Hammer",
@@ -646,7 +646,7 @@
     "evolvesFrom": "Quilladin",
     "ability": {
       "name": "Spiky Shield",
-      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), put 3 damage counters on the Attacking Pokémon.",
+      "text": "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack (even if this Pokémon is Knocked Out), put 3 damage counters on the Attacking Pokémon.",
       "type": "Ability"
     },
     "hp": "160",
@@ -771,7 +771,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -814,7 +814,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose either Asleep or Poisoned. Your opponent's Active Pokémon is now affected by that Special Condition."
+        "text": "Choose either Asleep or Poisoned. Your opponent’s Active Pokémon is now affected by that Special Condition."
       },
       {
         "name": "Colorful Wind",
@@ -1122,7 +1122,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Asleep."
+        "text": "Your opponent’s Active Pokémon is now Asleep."
       },
       {
         "name": "Flamethrower",
@@ -1488,7 +1488,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": "This attack does 30 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1578,7 +1578,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed and discard an Energy attached to that Pokémon."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed and discard an Energy attached to that Pokémon."
       },
       {
         "name": "Spike Cannon",
@@ -1968,7 +1968,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -1992,7 +1992,7 @@
     "evolvesFrom": "Frogadier",
     "ability": {
       "name": "Water Shuriken",
-      "text": "Once during your turn (before your attack), you may discard a Water Energy card from your hand. If you do, put 3 damage counters on 1 of your opponent's Pokémon.",
+      "text": "Once during your turn (before your attack), you may discard a Water Energy card from your hand. If you do, put 3 damage counters on 1 of your opponent’s Pokémon.",
       "type": "Ability"
     },
     "hp": "130",
@@ -2016,7 +2016,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "50",
-        "text": "This attack's damage isn't affected by Weakness, Resistance, or any other effects on your opponent's Active Pokémon."
+        "text": "This attack’s damage isn’t affected by Weakness, Resistance, or any other effects on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -2055,7 +2055,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Quick Attack",
@@ -2149,7 +2149,7 @@
     "supertype": "Pokémon",
     "ability": {
       "name": "Destiny Burst",
-      "text": "If this Pokémon is your Active Pokémon and is Knocked Out by damage from an opponent's attack, flip a coin. If heads, put 5 damage counters on the Attacking Pokémon.",
+      "text": "If this Pokémon is your Active Pokémon and is Knocked Out by damage from an opponent’s attack, flip a coin. If heads, put 5 damage counters on the Attacking Pokémon.",
       "type": "Ability"
     },
     "hp": "50",
@@ -2216,7 +2216,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, discard an Energy attached to 1 of your opponent's Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to 1 of your opponent’s Pokémon."
       },
       {
         "name": "Rollout",
@@ -2377,7 +2377,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       }
     ],
     "weaknesses": [
@@ -2461,7 +2461,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "You may move an Energy attached to your opponent's Active Pokémon to 1 of your opponent's Benched Pokémon."
+        "text": "You may move an Energy attached to your opponent’s Active Pokémon to 1 of your opponent’s Benched Pokémon."
       },
       {
         "name": "Psybeam",
@@ -2472,7 +2472,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -2514,7 +2514,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       }
     ],
     "weaknesses": [
@@ -2617,7 +2617,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "70",
-        "text": "Your opponent's Active Pokémon is now Poisoned. That Pokémon can't retreat during your opponent's next turn."
+        "text": "Your opponent’s Active Pokémon is now Poisoned. That Pokémon can’t retreat during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -2657,7 +2657,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Choose a random card from your opponent's hand. Your opponent reveals that card and shuffles it into his or her deck."
+        "text": "Choose a random card from your opponent’s hand. Your opponent reveals that card and shuffles it into his or her deck."
       },
       {
         "name": "Hook",
@@ -2697,8 +2697,8 @@
     "supertype": "Pokémon",
     "evolvesFrom": "Phantump",
     "ability": {
-      "name": "Forest's Curse",
-      "text": "As long as this Pokémon is your Active Pokémon, your opponent can't play any Item cards from his or her hand.",
+      "name": "Forest’s Curse",
+      "text": "As long as this Pokémon is your Active Pokémon, your opponent can’t play any Item cards from his or her hand.",
       "type": "Ability"
     },
     "hp": "110",
@@ -2726,7 +2726,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "This attack does 20 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -2772,7 +2772,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -2822,7 +2822,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Put 2 damage counters on each of your opponent's Pokémon."
+        "text": "Put 2 damage counters on each of your opponent’s Pokémon."
       },
       {
         "name": "Spirit Scream",
@@ -2877,7 +2877,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Look at the top card of your opponent's deck. Then, you may have your opponent shuffle his or her deck."
+        "text": "Look at the top card of your opponent’s deck. Then, you may have your opponent shuffle his or her deck."
       },
       {
         "name": "Mud-Slap",
@@ -2930,7 +2930,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "60",
-        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 10 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Rock Tumble",
@@ -2941,7 +2941,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -3052,7 +3052,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "",
-        "text": "Flip 2 coins. If both are heads, discard the top card of your opponent's deck for each damage counter on this Pokémon."
+        "text": "Flip 2 coins. If both are heads, discard the top card of your opponent’s deck for each damage counter on this Pokémon."
       }
     ],
     "weaknesses": [
@@ -3110,7 +3110,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "130",
-        "text": "This attack's damage isn't affected by Weakness or Resistance. This Pokémon can't attack during your next turn."
+        "text": "This attack’s damage isn’t affected by Weakness or Resistance. This Pokémon can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -3159,7 +3159,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
+        "text": "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -3308,7 +3308,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Discard the top card of your opponent's deck."
+        "text": "Discard the top card of your opponent’s deck."
       }
     ],
     "weaknesses": [
@@ -3353,7 +3353,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30+",
-        "text": "If your opponent's Active Pokémon is affected by a Special Condition, this attack does 60 more damage. Then, remove all Special Conditions from that Pokémon."
+        "text": "If your opponent’s Active Pokémon is affected by a Special Condition, this attack does 60 more damage. Then, remove all Special Conditions from that Pokémon."
       },
       {
         "name": "Dynamic Punch",
@@ -3364,7 +3364,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "Flip a coin. If heads, this attack does 40 more damage and your opponent's Active Pokémon is now Confused."
+        "text": "Flip a coin. If heads, this attack does 40 more damage and your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -3413,7 +3413,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "nationalPokedexNumber": 302,
@@ -3512,7 +3512,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Darkness Fang",
@@ -3576,7 +3576,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Flip a coin. If heads, your opponent can't play any Supporter cards from his or her hand during his or her next turn."
+        "text": "Flip a coin. If heads, your opponent can’t play any Supporter cards from his or her hand during his or her next turn."
       },
       {
         "name": "Knock Back",
@@ -3692,7 +3692,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+        "text": "The Defending Pokémon can’t retreat during your opponent’s next turn."
       },
       {
         "name": "Night Claw",
@@ -3811,7 +3811,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -3871,7 +3871,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Asleep. If tails, your opponent's Active Pokémon is now Confused."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Asleep. If tails, your opponent’s Active Pokémon is now Confused."
       }
     ],
     "weaknesses": [
@@ -3918,7 +3918,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+        "text": "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing."
       },
       {
         "name": "Puncture",
@@ -3929,7 +3929,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -3986,7 +3986,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "Flip a coin. If tails, this Pokémon can't attack during your next turn."
+        "text": "Flip a coin. If tails, this Pokémon can’t attack during your next turn."
       }
     ],
     "weaknesses": [
@@ -4096,7 +4096,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Before doing damage, discard all Pokémon Tool cards attached to your opponent's Active Pokémon."
+        "text": "Before doing damage, discard all Pokémon Tool cards attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Tailspin Piledriver",
@@ -4107,7 +4107,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80+",
-        "text": "If your opponent's Active Pokémon already has any damage counters on it, this attack does 40 more damage."
+        "text": "If your opponent’s Active Pokémon already has any damage counters on it, this attack does 40 more damage."
       }
     ],
     "weaknesses": [
@@ -4152,7 +4152,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Metal Claw",
@@ -4212,7 +4212,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Your opponent's Active Pokémon is now Confused."
+        "text": "Your opponent’s Active Pokémon is now Confused."
       },
       {
         "name": "Metal Wallop",
@@ -4222,7 +4222,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": "During your next turn, this Pokémon's Metal Wallop attack does 40 more damage (before applying Weakness and Resistance)."
+        "text": "During your next turn, this Pokémon’s Metal Wallop attack does 40 more damage (before applying Weakness and Resistance)."
       }
     ],
     "weaknesses": [
@@ -4378,7 +4378,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "120",
-        "text": "This attack's damage isn't affected by Resistance."
+        "text": "This attack’s damage isn’t affected by Resistance."
       }
     ],
     "weaknesses": [
@@ -4425,7 +4425,7 @@
     ],
     "attacks": [
       {
-        "name": "King's Shield",
+        "name": "King’s Shield",
         "cost": [
           "Metal",
           "Metal",
@@ -4434,7 +4434,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "50",
-        "text": "Prevent all damage done to this Pokémon by attacks during your opponent's next turn. This Pokémon can't use King's Shield during your next turn."
+        "text": "Prevent all damage done to this Pokémon by attacks during your opponent’s next turn. This Pokémon can’t use King’s Shield during your next turn."
       }
     ],
     "weaknesses": [
@@ -4488,7 +4488,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Discard a Darkness Energy attached to your opponent's Active Pokémon."
+        "text": "Discard a Darkness Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -4538,7 +4538,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -4598,7 +4598,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "The Defending Pokémon can't attack during your opponent's next turn."
+        "text": "The Defending Pokémon can’t attack during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -4911,7 +4911,7 @@
     "evolvesFrom": "Swirlix",
     "ability": {
       "name": "Sweet Veil",
-      "text": "Each of your Pokémon that has any Fairy Energy attached to it can't be affected by any Special Conditions. (Remove any Special Conditions affecting those Pokémon.)",
+      "text": "Each of your Pokémon that has any Fairy Energy attached to it can’t be affected by any Special Conditions. (Remove any Special Conditions affecting those Pokémon.)",
       "type": "Ability"
     },
     "hp": "90",
@@ -5045,7 +5045,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "X Blast",
@@ -5057,7 +5057,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "140",
-        "text": "This Pokémon can't use X Blast during your next turn."
+        "text": "This Pokémon can’t use X Blast during your next turn."
       }
     ],
     "weaknesses": [
@@ -5257,7 +5257,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       },
       {
         "name": "Second Bite",
@@ -5267,7 +5267,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10+",
-        "text": "This attack does 10 more damage for each damage counter on your opponent's Active Pokémon."
+        "text": "This attack does 10 more damage for each damage counter on your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -5470,7 +5470,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+        "text": "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
       }
     ],
     "weaknesses": [
@@ -5720,7 +5720,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60+",
-        "text": "If your opponent's Active Pokémon is a Pokémon-EX, this attack does 60 more damage."
+        "text": "If your opponent’s Active Pokémon is a Pokémon-EX, this attack does 60 more damage."
       },
       {
         "name": "Wild Barking",
@@ -5732,7 +5732,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "80",
-        "text": "This attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -5772,7 +5772,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -5828,7 +5828,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
       }
     ],
     "weaknesses": [
@@ -5932,7 +5932,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
+        "text": "Flip a coin. If heads, discard an Energy attached to your opponent’s Active Pokémon."
       }
     ],
     "weaknesses": [
@@ -5974,7 +5974,7 @@
     "set": "XY",
     "setCode": "xy1",
     "text": [
-      "Search your deck for a card that evolves from 1 of your Pokémon and put it onto that Pokémon. (This counts as evolving that Pokémon.) Shuffle your deck afterward. You can't use this card during your first turn or on a Pokémon that was put into play this turn."
+      "Search your deck for a card that evolves from 1 of your Pokémon and put it onto that Pokémon. (This counts as evolving that Pokémon.) Shuffle your deck afterward. You can’t use this card during your first turn or on a Pokémon that was put into play this turn."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/116_hires.png"
   },
@@ -5991,7 +5991,7 @@
     "set": "XY",
     "setCode": "xy1",
     "text": [
-      "Each Pokémon that has any Fairy Energy attached to it (both yours and your opponent's) has no Retreat Cost."
+      "Each Pokémon that has any Fairy Energy attached to it (both yours and your opponent’s) has no Retreat Cost."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/117_hires.png"
   },
@@ -6025,7 +6025,7 @@
     "set": "XY",
     "setCode": "xy1",
     "text": [
-      "Any damage done to the Pokémon this card is attached to by an opponent's attack is reduced by 20 (after applying Weakness and Resistance)."
+      "Any damage done to the Pokémon this card is attached to by an opponent’s attack is reduced by 20 (after applying Weakness and Resistance)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/119_hires.png"
   },
@@ -6059,7 +6059,7 @@
     "set": "XY",
     "setCode": "xy1",
     "text": [
-      "The attacks of the Pokémon this card is attached to do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance)."
+      "The attacks of the Pokémon this card is attached to do 20 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance)."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/121_hires.png"
   },
@@ -6082,7 +6082,7 @@
   },
   {
     "id": "xy1-123",
-    "name": "Professor's Letter",
+    "name": "Professor’s Letter",
     "imageUrl": "https://images.pokemontcg.io/xy1/123.png",
     "subtype": "Item",
     "supertype": "Trainer",
@@ -6144,7 +6144,7 @@
     "set": "XY",
     "setCode": "xy1",
     "text": [
-      "Each Pokémon that has any Darkness Energy attached to it (both yours and your opponent's) has no Weakness."
+      "Each Pokémon that has any Darkness Energy attached to it (both yours and your opponent’s) has no Weakness."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/126_hires.png"
   },
@@ -6195,7 +6195,7 @@
     "set": "XY",
     "setCode": "xy1",
     "text": [
-      "Discard an Energy attached to your opponent's Active Pokémon."
+      "Discard an Energy attached to your opponent’s Active Pokémon."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/129_hires.png"
   },
@@ -6394,7 +6394,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "Your opponent's Active Pokémon is now Poisoned."
+        "text": "Your opponent’s Active Pokémon is now Poisoned."
       },
       {
         "name": "Jungle Hammer",
@@ -6624,7 +6624,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Before doing damage, discard all Pokémon Tool cards attached to your opponent's Active Pokémon."
+        "text": "Before doing damage, discard all Pokémon Tool cards attached to your opponent’s Active Pokémon."
       },
       {
         "name": "Tailspin Piledriver",
@@ -6635,7 +6635,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80+",
-        "text": "If your opponent's Active Pokémon already has any damage counters on it, this attack does 40 more damage."
+        "text": "If your opponent’s Active Pokémon already has any damage counters on it, this attack does 40 more damage."
       }
     ],
     "weaknesses": [
@@ -6686,7 +6686,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "X Blast",
@@ -6698,7 +6698,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "140",
-        "text": "This Pokémon can't use X Blast during your next turn."
+        "text": "This Pokémon can’t use X Blast during your next turn."
       }
     ],
     "weaknesses": [


### PR DESCRIPTION
Change all copies of 't and 's before word boundaries to apostrophe t and s.  **Both directions are submitted as PRs, obviously, choose only one **  The Fix Apostrophe changeset is much smaller than this one.  I recommend rejecting this one and using the fix_apostrophe