### PR TITLE
Correct retreat cost for Sabrina's Abra

### DIFF
--- a/json/cards/Wizards Black Star Promos.json
+++ b/json/cards/Wizards Black Star Promos.json
@@ -923,7 +923,6 @@
     "supertype": "Pokémon",
     "level": "15",
     "hp": "40",
-    "retreatCost": "",
     "convertedRetreatCost": 0,
     "number": "19",
     "artist": "Atsuko Nishida",


### PR DESCRIPTION
Should be non-existent instead of an empty string. The empty string was throwing off parsing in the Ruby SDK.