### PR TITLE
Remove Gyarados text since it's just an empty string

### DIFF
--- a/json/cards/Ancient Origins.json
+++ b/json/cards/Ancient Origins.json
@@ -1008,7 +1008,6 @@
     "series": "XY",
     "set": "Ancient Origins",
     "setCode": "xy7",
-    "text": "",
     "types": [
       "Water"
     ],


### PR DESCRIPTION
The `text` field is expected to be an array so setting it to an empty string causes parsing to error out in the Ruby SDK.

I had just fixed a similar error in #30 so to make sure this was the last problem, I wrote a simple script that went through each card and parsed with the Ruby SDK to make sure there weren't any other errors lurking out there. You can see the script [here](https://gist.github.com/getabetterpic/98736f3d0f30ace4c81112580fa30eda). This was the only other error that I was able to find using this method.