### PR TITLE
Correct retreat cost for Porygon (Team Rocket, 48)

### DIFF
--- a/json/cards/Team Rocket.json
+++ b/json/cards/Team Rocket.json
@@ -2439,11 +2439,6 @@
     "supertype": "Pokémon",
     "level": "26",
     "hp": "40",
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
     "convertedRetreatCost": 3,
     "number": "48",
     "artist": "Keiji Kinebuchi",


### PR DESCRIPTION
It’s zero :-)