### PR TITLE
BW87 Leafeon - Attack Fix

### DIFF
--- a/json/cards/BW Black Star Promos.json
+++ b/json/cards/BW Black Star Promos.json
@@ -4296,7 +4296,7 @@
     ],
     "attacks": [
       {
-        "name": "It basically does not fight. With cells similar to those of plants, it can perform photosynthesis.",
+        "name": "Quick Attack",
         "cost": [
           "Colorless"
         ],


### PR DESCRIPTION
Renamed BW87 Leafeon's first attack to Quick Attack, rather than the flavour text from the card.