### PR TITLE
Order values added to all cards

### DIFF
--- a/json/cards/Ancient Origins.json
+++ b/json/cards/Ancient Origins.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "xy7-1",
+    "setOrder":65,
+	"id": "xy7-1",
     "name": "Oddish",
     "imageUrl": "https://images.pokemontcg.io/xy7/1.png",
     "subtype": "Basic",
@@ -43,7 +44,8 @@
     ]
   },
   {
-    "id": "xy7-2",
+    "setOrder":65,
+	"id": "xy7-2",
     "name": "Gloom",
     "imageUrl": "https://images.pokemontcg.io/xy7/2.png",
     "subtype": "Stage 1",
@@ -89,7 +91,8 @@
     ]
   },
   {
-    "id": "xy7-3",
+    "setOrder":65,
+	"id": "xy7-3",
     "name": "Vileplume",
     "imageUrl": "https://images.pokemontcg.io/xy7/3.png",
     "subtype": "Stage 2",
@@ -139,7 +142,8 @@
     "nationalPokedexNumber": 45
   },
   {
-    "id": "xy7-4",
+    "setOrder":65,
+	"id": "xy7-4",
     "name": "Bellossom",
     "imageUrl": "https://images.pokemontcg.io/xy7/4.png",
     "subtype": "Stage 2",
@@ -190,7 +194,8 @@
     "nationalPokedexNumber": 182
   },
   {
-    "id": "xy7-5",
+    "setOrder":65,
+	"id": "xy7-5",
     "name": "Spinarak",
     "imageUrl": "https://images.pokemontcg.io/xy7/5.png",
     "subtype": "Basic",
@@ -233,7 +238,8 @@
     ]
   },
   {
-    "id": "xy7-6",
+    "setOrder":65,
+	"id": "xy7-6",
     "name": "Ariados",
     "imageUrl": "https://images.pokemontcg.io/xy7/6.png",
     "subtype": "Stage 1",
@@ -280,7 +286,8 @@
     "nationalPokedexNumber": 168
   },
   {
-    "id": "xy7-7",
+    "setOrder":65,
+	"id": "xy7-7",
     "name": "Sceptile-EX",
     "imageUrl": "https://images.pokemontcg.io/xy7/7.png",
     "subtype": "EX",
@@ -334,7 +341,8 @@
     "evolvesTo": "M Sceptile-EX"
   },
   {
-    "id": "xy7-8",
+    "setOrder":65,
+	"id": "xy7-8",
     "name": "M Sceptile-EX",
     "imageUrl": "https://images.pokemontcg.io/xy7/8.png",
     "subtype": "MEGA",
@@ -382,7 +390,8 @@
     "nationalPokedexNumber": 254
   },
   {
-    "id": "xy7-9",
+    "setOrder":65,
+	"id": "xy7-9",
     "name": "Combee",
     "imageUrl": "https://images.pokemontcg.io/xy7/9.png",
     "subtype": "Basic",
@@ -425,7 +434,8 @@
     ]
   },
   {
-    "id": "xy7-10",
+    "setOrder":65,
+	"id": "xy7-10",
     "name": "Vespiquen",
     "imageUrl": "https://images.pokemontcg.io/xy7/10.png",
     "subtype": "Stage 1",
@@ -473,7 +483,8 @@
     "nationalPokedexNumber": 416
   },
   {
-    "id": "xy7-11",
+    "setOrder":65,
+	"id": "xy7-11",
     "name": "Vespiquen",
     "imageUrl": "https://images.pokemontcg.io/xy7/11.png",
     "subtype": "Stage 1",
@@ -527,7 +538,8 @@
     "nationalPokedexNumber": 416
   },
   {
-    "id": "xy7-12",
+    "setOrder":65,
+	"id": "xy7-12",
     "name": "Virizion",
     "imageUrl": "https://images.pokemontcg.io/xy7/12.png",
     "subtype": "Basic",
@@ -577,7 +589,8 @@
     "nationalPokedexNumber": 640
   },
   {
-    "id": "xy7-13",
+    "setOrder":65,
+	"id": "xy7-13",
     "name": "Flareon",
     "imageUrl": "https://images.pokemontcg.io/xy7/13.png",
     "subtype": "Stage 1",
@@ -625,7 +638,8 @@
     "nationalPokedexNumber": 136
   },
   {
-    "id": "xy7-14",
+    "setOrder":65,
+	"id": "xy7-14",
     "name": "Entei",
     "imageUrl": "https://images.pokemontcg.io/xy7/14.png",
     "subtype": "Basic",
@@ -676,7 +690,8 @@
     "nationalPokedexNumber": 244
   },
   {
-    "id": "xy7-15",
+    "setOrder":65,
+	"id": "xy7-15",
     "name": "Entei",
     "imageUrl": "https://images.pokemontcg.io/xy7/15.png",
     "subtype": "Basic",
@@ -733,7 +748,8 @@
     "nationalPokedexNumber": 244
   },
   {
-    "id": "xy7-16",
+    "setOrder":65,
+	"id": "xy7-16",
     "name": "Larvesta",
     "imageUrl": "https://images.pokemontcg.io/xy7/16.png",
     "subtype": "Basic",
@@ -778,7 +794,8 @@
     ]
   },
   {
-    "id": "xy7-17",
+    "setOrder":65,
+	"id": "xy7-17",
     "name": "Volcarona",
     "imageUrl": "https://images.pokemontcg.io/xy7/17.png",
     "subtype": "Stage 1",
@@ -829,7 +846,8 @@
     "nationalPokedexNumber": 637
   },
   {
-    "id": "xy7-18",
+    "setOrder":65,
+	"id": "xy7-18",
     "name": "Volcarona",
     "imageUrl": "https://images.pokemontcg.io/xy7/18.png",
     "subtype": "Stage 1",
@@ -885,7 +903,8 @@
     "nationalPokedexNumber": 637
   },
   {
-    "id": "xy7-19",
+    "setOrder":65,
+	"id": "xy7-19",
     "name": "Magikarp",
     "imageUrl": "https://images.pokemontcg.io/xy7/19.png",
     "subtype": "Basic",
@@ -928,7 +947,8 @@
     ]
   },
   {
-    "id": "xy7-20",
+    "setOrder":65,
+	"id": "xy7-20",
     "name": "Gyarados",
     "imageUrl": "https://images.pokemontcg.io/xy7/20.png",
     "subtype": "Stage 1",
@@ -985,7 +1005,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "xy7-21",
+    "setOrder":65,
+	"id": "xy7-21",
     "name": "Gyarados",
     "imageUrl": "https://images.pokemontcg.io/xy7/21.png",
     "subtype": "Stage 1",
@@ -1045,7 +1066,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "xy7-22",
+    "setOrder":65,
+	"id": "xy7-22",
     "name": "Vaporeon",
     "imageUrl": "https://images.pokemontcg.io/xy7/22.png",
     "subtype": "Stage 1",
@@ -1094,7 +1116,8 @@
     "nationalPokedexNumber": 134
   },
   {
-    "id": "xy7-23",
+    "setOrder":65,
+	"id": "xy7-23",
     "name": "Relicanth",
     "imageUrl": "https://images.pokemontcg.io/xy7/23.png",
     "subtype": "Basic",
@@ -1144,7 +1167,8 @@
     "nationalPokedexNumber": 369
   },
   {
-    "id": "xy7-24",
+    "setOrder":65,
+	"id": "xy7-24",
     "name": "Regice",
     "imageUrl": "https://images.pokemontcg.io/xy7/24.png",
     "subtype": "Basic",
@@ -1198,7 +1222,8 @@
     "nationalPokedexNumber": 378
   },
   {
-    "id": "xy7-25",
+    "setOrder":65,
+	"id": "xy7-25",
     "name": "Kyurem-EX",
     "imageUrl": "https://images.pokemontcg.io/xy7/25.png",
     "subtype": "EX",
@@ -1257,7 +1282,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "xy7-26",
+    "setOrder":65,
+	"id": "xy7-26",
     "name": "Jolteon",
     "imageUrl": "https://images.pokemontcg.io/xy7/26.png",
     "subtype": "Stage 1",
@@ -1308,7 +1334,8 @@
     "nationalPokedexNumber": 135
   },
   {
-    "id": "xy7-27",
+    "setOrder":65,
+	"id": "xy7-27",
     "name": "Ampharos-EX",
     "imageUrl": "https://images.pokemontcg.io/xy7/27.png",
     "subtype": "EX",
@@ -1371,7 +1398,8 @@
     "evolvesTo": "M Ampharos-EX"
   },
   {
-    "id": "xy7-28",
+    "setOrder":65,
+	"id": "xy7-28",
     "name": "M Ampharos-EX",
     "imageUrl": "https://images.pokemontcg.io/xy7/28.png",
     "subtype": "MEGA",
@@ -1427,7 +1455,8 @@
     "nationalPokedexNumber": 181
   },
   {
-    "id": "xy7-29",
+    "setOrder":65,
+	"id": "xy7-29",
     "name": "Rotom",
     "imageUrl": "https://images.pokemontcg.io/xy7/29.png",
     "subtype": "Basic",
@@ -1483,7 +1512,8 @@
     "nationalPokedexNumber": 479
   },
   {
-    "id": "xy7-30",
+    "setOrder":65,
+	"id": "xy7-30",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/xy7/30.png",
     "subtype": "Basic",
@@ -1528,7 +1558,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "xy7-31",
+    "setOrder":65,
+	"id": "xy7-31",
     "name": "Baltoy",
     "imageUrl": "https://images.pokemontcg.io/xy7/31.png",
     "subtype": "Basic",
@@ -1581,7 +1612,8 @@
     ]
   },
   {
-    "id": "xy7-32",
+    "setOrder":65,
+	"id": "xy7-32",
     "name": "Baltoy",
     "imageUrl": "https://images.pokemontcg.io/xy7/32.png",
     "subtype": "Basic",
@@ -1627,7 +1659,8 @@
     ]
   },
   {
-    "id": "xy7-33",
+    "setOrder":65,
+	"id": "xy7-33",
     "name": "Claydol",
     "imageUrl": "https://images.pokemontcg.io/xy7/33.png",
     "subtype": "Stage 1",
@@ -1679,7 +1712,8 @@
     "nationalPokedexNumber": 344
   },
   {
-    "id": "xy7-34",
+    "setOrder":65,
+	"id": "xy7-34",
     "name": "Golett",
     "imageUrl": "https://images.pokemontcg.io/xy7/34.png",
     "subtype": "Basic",
@@ -1731,7 +1765,8 @@
     ]
   },
   {
-    "id": "xy7-35",
+    "setOrder":65,
+	"id": "xy7-35",
     "name": "Golurk",
     "imageUrl": "https://images.pokemontcg.io/xy7/35.png",
     "subtype": "Stage 1",
@@ -1792,7 +1827,8 @@
     "nationalPokedexNumber": 623
   },
   {
-    "id": "xy7-36",
+    "setOrder":65,
+	"id": "xy7-36",
     "name": "Hoopa-EX",
     "imageUrl": "https://images.pokemontcg.io/xy7/36.png",
     "subtype": "EX",
@@ -1843,7 +1879,8 @@
     "nationalPokedexNumber": 720
   },
   {
-    "id": "xy7-37",
+    "setOrder":65,
+	"id": "xy7-37",
     "name": "Machamp-EX",
     "imageUrl": "https://images.pokemontcg.io/xy7/37.png",
     "subtype": "EX",
@@ -1900,7 +1937,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "xy7-38",
+    "setOrder":65,
+	"id": "xy7-38",
     "name": "Wooper",
     "imageUrl": "https://images.pokemontcg.io/xy7/38.png",
     "subtype": "Basic",
@@ -1954,7 +1992,8 @@
     ]
   },
   {
-    "id": "xy7-39",
+    "setOrder":65,
+	"id": "xy7-39",
     "name": "Quagsire",
     "imageUrl": "https://images.pokemontcg.io/xy7/39.png",
     "subtype": "Stage 1",
@@ -2009,7 +2048,8 @@
     "nationalPokedexNumber": 195
   },
   {
-    "id": "xy7-40",
+    "setOrder":65,
+	"id": "xy7-40",
     "name": "Regirock",
     "imageUrl": "https://images.pokemontcg.io/xy7/40.png",
     "subtype": "Basic",
@@ -2063,7 +2103,8 @@
     "nationalPokedexNumber": 377
   },
   {
-    "id": "xy7-41",
+    "setOrder":65,
+	"id": "xy7-41",
     "name": "Golurk",
     "imageUrl": "https://images.pokemontcg.io/xy7/41.png",
     "subtype": "Stage 1",
@@ -2119,7 +2160,8 @@
     "nationalPokedexNumber": 623
   },
   {
-    "id": "xy7-42",
+    "setOrder":65,
+	"id": "xy7-42",
     "name": "Tyranitar-EX",
     "imageUrl": "https://images.pokemontcg.io/xy7/42.png",
     "subtype": "EX",
@@ -2186,7 +2228,8 @@
     "evolvesTo": "M Tyranitar-EX"
   },
   {
-    "id": "xy7-43",
+    "setOrder":65,
+	"id": "xy7-43",
     "name": "M Tyranitar-EX",
     "imageUrl": "https://images.pokemontcg.io/xy7/43.png",
     "subtype": "MEGA",
@@ -2244,7 +2287,8 @@
     "nationalPokedexNumber": 248
   },
   {
-    "id": "xy7-44",
+    "setOrder":65,
+	"id": "xy7-44",
     "name": "Sableye",
     "imageUrl": "https://images.pokemontcg.io/xy7/44.png",
     "subtype": "Basic",
@@ -2288,7 +2332,8 @@
     "nationalPokedexNumber": 302
   },
   {
-    "id": "xy7-45",
+    "setOrder":65,
+	"id": "xy7-45",
     "name": "Inkay",
     "imageUrl": "https://images.pokemontcg.io/xy7/45.png",
     "subtype": "Basic",
@@ -2337,7 +2382,8 @@
     ]
   },
   {
-    "id": "xy7-46",
+    "setOrder":65,
+	"id": "xy7-46",
     "name": "Malamar",
     "imageUrl": "https://images.pokemontcg.io/xy7/46.png",
     "subtype": "Stage 1",
@@ -2393,7 +2439,8 @@
     "nationalPokedexNumber": 687
   },
   {
-    "id": "xy7-47",
+    "setOrder":65,
+	"id": "xy7-47",
     "name": "Beldum",
     "imageUrl": "https://images.pokemontcg.io/xy7/47.png",
     "subtype": "Basic",
@@ -2454,7 +2501,8 @@
     ]
   },
   {
-    "id": "xy7-48",
+    "setOrder":65,
+	"id": "xy7-48",
     "name": "Metang",
     "imageUrl": "https://images.pokemontcg.io/xy7/48.png",
     "subtype": "Stage 1",
@@ -2518,7 +2566,8 @@
     ]
   },
   {
-    "id": "xy7-49",
+    "setOrder":65,
+	"id": "xy7-49",
     "name": "Metagross",
     "imageUrl": "https://images.pokemontcg.io/xy7/49.png",
     "subtype": "Stage 2",
@@ -2576,7 +2625,8 @@
     "nationalPokedexNumber": 376
   },
   {
-    "id": "xy7-50",
+    "setOrder":65,
+	"id": "xy7-50",
     "name": "Metagross",
     "imageUrl": "https://images.pokemontcg.io/xy7/50.png",
     "subtype": "Stage 2",
@@ -2642,7 +2692,8 @@
     "nationalPokedexNumber": 376
   },
   {
-    "id": "xy7-51",
+    "setOrder":65,
+	"id": "xy7-51",
     "name": "Registeel",
     "imageUrl": "https://images.pokemontcg.io/xy7/51.png",
     "subtype": "Basic",
@@ -2702,7 +2753,8 @@
     "nationalPokedexNumber": 379
   },
   {
-    "id": "xy7-52",
+    "setOrder":65,
+	"id": "xy7-52",
     "name": "Ralts",
     "imageUrl": "https://images.pokemontcg.io/xy7/52.png",
     "subtype": "Basic",
@@ -2761,7 +2813,8 @@
     ]
   },
   {
-    "id": "xy7-53",
+    "setOrder":65,
+	"id": "xy7-53",
     "name": "Kirlia",
     "imageUrl": "https://images.pokemontcg.io/xy7/53.png",
     "subtype": "Stage 1",
@@ -2823,7 +2876,8 @@
     ]
   },
   {
-    "id": "xy7-54",
+    "setOrder":65,
+	"id": "xy7-54",
     "name": "Gardevoir",
     "imageUrl": "https://images.pokemontcg.io/xy7/54.png",
     "subtype": "Stage 2",
@@ -2878,7 +2932,8 @@
     "nationalPokedexNumber": 282
   },
   {
-    "id": "xy7-55",
+    "setOrder":65,
+	"id": "xy7-55",
     "name": "Cottonee",
     "imageUrl": "https://images.pokemontcg.io/xy7/55.png",
     "subtype": "Basic",
@@ -2927,7 +2982,8 @@
     ]
   },
   {
-    "id": "xy7-56",
+    "setOrder":65,
+	"id": "xy7-56",
     "name": "Whimsicott",
     "imageUrl": "https://images.pokemontcg.io/xy7/56.png",
     "subtype": "Stage 1",
@@ -2984,7 +3040,8 @@
     "nationalPokedexNumber": 547
   },
   {
-    "id": "xy7-57",
+    "setOrder":65,
+	"id": "xy7-57",
     "name": "Giratina-EX",
     "imageUrl": "https://images.pokemontcg.io/xy7/57.png",
     "subtype": "EX",
@@ -3037,7 +3094,8 @@
     "nationalPokedexNumber": 487
   },
   {
-    "id": "xy7-58",
+    "setOrder":65,
+	"id": "xy7-58",
     "name": "Goomy",
     "imageUrl": "https://images.pokemontcg.io/xy7/58.png",
     "subtype": "Basic",
@@ -3087,7 +3145,8 @@
     ]
   },
   {
-    "id": "xy7-59",
+    "setOrder":65,
+	"id": "xy7-59",
     "name": "Sliggoo",
     "imageUrl": "https://images.pokemontcg.io/xy7/59.png",
     "subtype": "Stage 1",
@@ -3143,7 +3202,8 @@
     ]
   },
   {
-    "id": "xy7-60",
+    "setOrder":65,
+	"id": "xy7-60",
     "name": "Goodra",
     "imageUrl": "https://images.pokemontcg.io/xy7/60.png",
     "subtype": "Stage 2",
@@ -3199,7 +3259,8 @@
     "nationalPokedexNumber": 706
   },
   {
-    "id": "xy7-61",
+    "setOrder":65,
+	"id": "xy7-61",
     "name": "Meowth",
     "imageUrl": "https://images.pokemontcg.io/xy7/61.png",
     "subtype": "Basic",
@@ -3242,7 +3303,8 @@
     ]
   },
   {
-    "id": "xy7-62",
+    "setOrder":65,
+	"id": "xy7-62",
     "name": "Persian",
     "imageUrl": "https://images.pokemontcg.io/xy7/62.png",
     "subtype": "Stage 1",
@@ -3293,7 +3355,8 @@
     "nationalPokedexNumber": 53
   },
   {
-    "id": "xy7-63",
+    "setOrder":65,
+	"id": "xy7-63",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/xy7/63.png",
     "subtype": "Basic",
@@ -3353,7 +3416,8 @@
     ]
   },
   {
-    "id": "xy7-64",
+    "setOrder":65,
+	"id": "xy7-64",
     "name": "Porygon",
     "imageUrl": "https://images.pokemontcg.io/xy7/64.png",
     "subtype": "Basic",
@@ -3406,7 +3470,8 @@
     ]
   },
   {
-    "id": "xy7-65",
+    "setOrder":65,
+	"id": "xy7-65",
     "name": "Porygon2",
     "imageUrl": "https://images.pokemontcg.io/xy7/65.png",
     "subtype": "Stage 1",
@@ -3462,7 +3527,8 @@
     ]
   },
   {
-    "id": "xy7-66",
+    "setOrder":65,
+	"id": "xy7-66",
     "name": "Porygon-Z",
     "imageUrl": "https://images.pokemontcg.io/xy7/66.png",
     "subtype": "Stage 2",
@@ -3515,7 +3581,8 @@
     "nationalPokedexNumber": 474
   },
   {
-    "id": "xy7-67",
+    "setOrder":65,
+	"id": "xy7-67",
     "name": "Porygon-Z",
     "imageUrl": "https://images.pokemontcg.io/xy7/67.png",
     "subtype": "Stage 2",
@@ -3570,7 +3637,8 @@
     "nationalPokedexNumber": 474
   },
   {
-    "id": "xy7-68",
+    "setOrder":65,
+	"id": "xy7-68",
     "name": "Lugia-EX",
     "imageUrl": "https://images.pokemontcg.io/xy7/68.png",
     "subtype": "EX",
@@ -3633,7 +3701,8 @@
     "nationalPokedexNumber": 249
   },
   {
-    "id": "xy7-69",
+    "setOrder":65,
+	"id": "xy7-69",
     "name": "Ace Trainer",
     "imageUrl": "https://images.pokemontcg.io/xy7/69.png",
     "subtype": "Supporter",
@@ -3650,7 +3719,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy7/69_hires.png"
   },
   {
-    "id": "xy7-70",
+    "setOrder":65,
+	"id": "xy7-70",
     "name": "Ampharos Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xy7/70.png",
     "subtype": "Pokémon Tool",
@@ -3667,7 +3737,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy7/70_hires.png"
   },
   {
-    "id": "xy7-71",
+    "setOrder":65,
+	"id": "xy7-71",
     "name": "Eco Arm",
     "imageUrl": "https://images.pokemontcg.io/xy7/71.png",
     "subtype": "Item",
@@ -3684,7 +3755,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy7/71_hires.png"
   },
   {
-    "id": "xy7-72",
+    "setOrder":65,
+	"id": "xy7-72",
     "name": "Energy Recycler",
     "imageUrl": "https://images.pokemontcg.io/xy7/72.png",
     "subtype": "Item",
@@ -3701,7 +3773,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy7/72_hires.png"
   },
   {
-    "id": "xy7-73",
+    "setOrder":65,
+	"id": "xy7-73",
     "name": "Faded Town",
     "imageUrl": "https://images.pokemontcg.io/xy7/73.png",
     "subtype": "Stadium",
@@ -3718,7 +3791,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy7/73_hires.png"
   },
   {
-    "id": "xy7-74",
+    "setOrder":65,
+	"id": "xy7-74",
     "name": "Forest of Giant Plants",
     "imageUrl": "https://images.pokemontcg.io/xy7/74.png",
     "subtype": "Stadium",
@@ -3735,7 +3809,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy7/74_hires.png"
   },
   {
-    "id": "xy7-75",
+    "setOrder":65,
+	"id": "xy7-75",
     "name": "Hex Maniac",
     "imageUrl": "https://images.pokemontcg.io/xy7/75.png",
     "subtype": "Supporter",
@@ -3752,7 +3827,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy7/75_hires.png"
   },
   {
-    "id": "xy7-75a",
+    "setOrder":65,
+	"id": "xy7-75a",
     "name": "Hex Maniac",
     "imageUrl": "https://images.pokemontcg.io/xy7/75a.png",
     "subtype": "Supporter",
@@ -3769,7 +3845,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy7/75a_hires.png"
   },
   {
-    "id": "xy7-76",
+    "setOrder":65,
+	"id": "xy7-76",
     "name": "Level Ball",
     "imageUrl": "https://images.pokemontcg.io/xy7/76.png",
     "subtype": "Item",
@@ -3786,7 +3863,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy7/76_hires.png"
   },
   {
-    "id": "xy7-77",
+    "setOrder":65,
+	"id": "xy7-77",
     "name": "Lucky Helmet",
     "imageUrl": "https://images.pokemontcg.io/xy7/77.png",
     "subtype": "Pokémon Tool",
@@ -3803,7 +3881,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy7/77_hires.png"
   },
   {
-    "id": "xy7-78",
+    "setOrder":65,
+	"id": "xy7-78",
     "name": "Lysandre",
     "imageUrl": "https://images.pokemontcg.io/xy7/78.png",
     "subtype": "Supporter",
@@ -3820,7 +3899,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy7/78_hires.png"
   },
   {
-    "id": "xy7-79",
+    "setOrder":65,
+	"id": "xy7-79",
     "name": "Paint Roller",
     "imageUrl": "https://images.pokemontcg.io/xy7/79.png",
     "subtype": "Item",
@@ -3837,7 +3917,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy7/79_hires.png"
   },
   {
-    "id": "xy7-80",
+    "setOrder":65,
+	"id": "xy7-80",
     "name": "Sceptile Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xy7/80.png",
     "subtype": "Pokémon Tool",
@@ -3854,7 +3935,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy7/80_hires.png"
   },
   {
-    "id": "xy7-81",
+    "setOrder":65,
+	"id": "xy7-81",
     "name": "Tyranitar Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xy7/81.png",
     "subtype": "Pokémon Tool",
@@ -3871,7 +3953,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy7/81_hires.png"
   },
   {
-    "id": "xy7-82",
+    "setOrder":65,
+	"id": "xy7-82",
     "name": "Dangerous Energy",
     "imageUrl": "https://images.pokemontcg.io/xy7/82.png",
     "subtype": "Special",
@@ -3888,7 +3971,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy7/82_hires.png"
   },
   {
-    "id": "xy7-83",
+    "setOrder":65,
+	"id": "xy7-83",
     "name": "Flash Energy",
     "imageUrl": "https://images.pokemontcg.io/xy7/83.png",
     "subtype": "Special",
@@ -3905,7 +3989,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy7/83_hires.png"
   },
   {
-    "id": "xy7-84",
+    "setOrder":65,
+	"id": "xy7-84",
     "name": "Sceptile-EX",
     "imageUrl": "https://images.pokemontcg.io/xy7/84.png",
     "subtype": "EX",
@@ -3959,7 +4044,8 @@
     "evolvesTo": "M Sceptile-EX"
   },
   {
-    "id": "xy7-85",
+    "setOrder":65,
+	"id": "xy7-85",
     "name": "M Sceptile-EX",
     "imageUrl": "https://images.pokemontcg.io/xy7/85.png",
     "subtype": "MEGA",
@@ -4007,7 +4093,8 @@
     "nationalPokedexNumber": 254
   },
   {
-    "id": "xy7-86",
+    "setOrder":65,
+	"id": "xy7-86",
     "name": "Kyurem-EX",
     "imageUrl": "https://images.pokemontcg.io/xy7/86.png",
     "subtype": "EX",
@@ -4066,7 +4153,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "xy7-87",
+    "setOrder":65,
+	"id": "xy7-87",
     "name": "Ampharos-EX",
     "imageUrl": "https://images.pokemontcg.io/xy7/87.png",
     "subtype": "EX",
@@ -4129,7 +4217,8 @@
     "evolvesTo": "M Ampharos-EX"
   },
   {
-    "id": "xy7-88",
+    "setOrder":65,
+	"id": "xy7-88",
     "name": "M Ampharos-EX",
     "imageUrl": "https://images.pokemontcg.io/xy7/88.png",
     "subtype": "MEGA",
@@ -4185,7 +4274,8 @@
     "nationalPokedexNumber": 181
   },
   {
-    "id": "xy7-89",
+    "setOrder":65,
+	"id": "xy7-89",
     "name": "Hoopa-EX",
     "imageUrl": "https://images.pokemontcg.io/xy7/89.png",
     "subtype": "EX",
@@ -4236,7 +4326,8 @@
     "nationalPokedexNumber": 720
   },
   {
-    "id": "xy7-90",
+    "setOrder":65,
+	"id": "xy7-90",
     "name": "Machamp-EX",
     "imageUrl": "https://images.pokemontcg.io/xy7/90.png",
     "subtype": "EX",
@@ -4293,7 +4384,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "xy7-91",
+    "setOrder":65,
+	"id": "xy7-91",
     "name": "Tyranitar-EX",
     "imageUrl": "https://images.pokemontcg.io/xy7/91.png",
     "subtype": "EX",
@@ -4360,7 +4452,8 @@
     "evolvesTo": "M Tyranitar-EX"
   },
   {
-    "id": "xy7-92",
+    "setOrder":65,
+	"id": "xy7-92",
     "name": "M Tyranitar-EX",
     "imageUrl": "https://images.pokemontcg.io/xy7/92.png",
     "subtype": "MEGA",
@@ -4418,7 +4511,8 @@
     "nationalPokedexNumber": 248
   },
   {
-    "id": "xy7-93",
+    "setOrder":65,
+	"id": "xy7-93",
     "name": "Giratina-EX",
     "imageUrl": "https://images.pokemontcg.io/xy7/93.png",
     "subtype": "EX",
@@ -4471,7 +4565,8 @@
     "nationalPokedexNumber": 487
   },
   {
-    "id": "xy7-94",
+    "setOrder":65,
+	"id": "xy7-94",
     "name": "Lugia-EX",
     "imageUrl": "https://images.pokemontcg.io/xy7/94.png",
     "subtype": "EX",
@@ -4534,7 +4629,8 @@
     "nationalPokedexNumber": 249
   },
   {
-    "id": "xy7-95",
+    "setOrder":65,
+	"id": "xy7-95",
     "name": "Steven",
     "imageUrl": "https://images.pokemontcg.io/xy7/95.png",
     "subtype": "Supporter",
@@ -4551,7 +4647,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy7/95_hires.png"
   },
   {
-    "id": "xy7-96",
+    "setOrder":65,
+	"id": "xy7-96",
     "name": "Primal Kyogre-EX",
     "imageUrl": "https://images.pokemontcg.io/xy7/96.png",
     "subtype": "MEGA",
@@ -4602,7 +4699,8 @@
     "nationalPokedexNumber": 382
   },
   {
-    "id": "xy7-97",
+    "setOrder":65,
+	"id": "xy7-97",
     "name": "Primal Groudon-EX",
     "imageUrl": "https://images.pokemontcg.io/xy7/97.png",
     "subtype": "MEGA",
@@ -4653,7 +4751,8 @@
     "nationalPokedexNumber": 383
   },
   {
-    "id": "xy7-98",
+    "setOrder":65,
+	"id": "xy7-98",
     "name": "M Rayquaza-EX",
     "imageUrl": "https://images.pokemontcg.io/xy7/98.png",
     "subtype": "MEGA",
@@ -4707,7 +4806,8 @@
     "nationalPokedexNumber": 384
   },
   {
-    "id": "xy7-99",
+    "setOrder":65,
+	"id": "xy7-99",
     "name": "Energy Retrieval",
     "imageUrl": "https://images.pokemontcg.io/xy7/99.png",
     "subtype": "Item",
@@ -4724,7 +4824,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy7/99_hires.png"
   },
   {
-    "id": "xy7-100",
+    "setOrder":65,
+	"id": "xy7-100",
     "name": "Trainers' Mail",
     "imageUrl": "https://images.pokemontcg.io/xy7/100.png",
     "subtype": "Item",

--- a/json/cards/Aquapolis.json
+++ b/json/cards/Aquapolis.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "ecard2-1",
+    "setOrder":14,
+	"id": "ecard2-1",
     "name": "Ampharos",
     "imageUrl": "https://images.pokemontcg.io/ecard2/1.png",
     "subtype": "Stage 2",
@@ -53,7 +54,8 @@
     "nationalPokedexNumber": 181
   },
   {
-    "id": "ecard2-151",
+    "setOrder":14,
+	"id": "ecard2-151",
     "name": "Ampharos",
     "imageUrl": "https://images.pokemontcg.io/ecard2/151.png",
     "subtype": "Stage 2",
@@ -106,7 +108,8 @@
     "nationalPokedexNumber": 181
   },
   {
-    "id": "ecard2-2",
+    "setOrder":14,
+	"id": "ecard2-2",
     "name": "Arcanine",
     "imageUrl": "https://images.pokemontcg.io/ecard2/2.png",
     "subtype": "Stage 1",
@@ -156,7 +159,8 @@
     "nationalPokedexNumber": 59
   },
   {
-    "id": "ecard2-152",
+    "setOrder":14,
+	"id": "ecard2-152",
     "name": "Arcanine",
     "imageUrl": "https://images.pokemontcg.io/ecard2/152.png",
     "subtype": "Stage 1",
@@ -206,7 +210,8 @@
     "nationalPokedexNumber": 59
   },
   {
-    "id": "ecard2-3",
+    "setOrder":14,
+	"id": "ecard2-3",
     "name": "Ariados",
     "imageUrl": "https://images.pokemontcg.io/ecard2/3.png",
     "subtype": "Stage 1",
@@ -250,7 +255,8 @@
     "nationalPokedexNumber": 168
   },
   {
-    "id": "ecard2-153",
+    "setOrder":14,
+	"id": "ecard2-153",
     "name": "Ariados",
     "imageUrl": "https://images.pokemontcg.io/ecard2/153.png",
     "subtype": "Stage 1",
@@ -294,7 +300,8 @@
     "nationalPokedexNumber": 168
   },
   {
-    "id": "ecard2-4",
+    "setOrder":14,
+	"id": "ecard2-4",
     "name": "Azumarill",
     "imageUrl": "https://images.pokemontcg.io/ecard2/4.png",
     "subtype": "Stage 1",
@@ -342,7 +349,8 @@
     "nationalPokedexNumber": 184
   },
   {
-    "id": "ecard2-154",
+    "setOrder":14,
+	"id": "ecard2-154",
     "name": "Azumarill",
     "imageUrl": "https://images.pokemontcg.io/ecard2/154.png",
     "subtype": "Stage 1",
@@ -390,7 +398,8 @@
     "nationalPokedexNumber": 184
   },
   {
-    "id": "ecard2-5",
+    "setOrder":14,
+	"id": "ecard2-5",
     "name": "Bellossom",
     "imageUrl": "https://images.pokemontcg.io/ecard2/5.png",
     "subtype": "Stage 2",
@@ -445,7 +454,8 @@
     "nationalPokedexNumber": 182
   },
   {
-    "id": "ecard2-155",
+    "setOrder":14,
+	"id": "ecard2-155",
     "name": "Bellossom",
     "imageUrl": "https://images.pokemontcg.io/ecard2/155.png",
     "subtype": "Stage 2",
@@ -500,7 +510,8 @@
     "nationalPokedexNumber": 182
   },
   {
-    "id": "ecard2-6",
+    "setOrder":14,
+	"id": "ecard2-6",
     "name": "Blissey",
     "imageUrl": "https://images.pokemontcg.io/ecard2/6.png",
     "subtype": "Stage 1",
@@ -549,7 +560,8 @@
     "nationalPokedexNumber": 242
   },
   {
-    "id": "ecard2-156",
+    "setOrder":14,
+	"id": "ecard2-156",
     "name": "Blissey",
     "imageUrl": "https://images.pokemontcg.io/ecard2/156.png",
     "subtype": "Stage 1",
@@ -598,7 +610,8 @@
     "nationalPokedexNumber": 242
   },
   {
-    "id": "ecard2-157",
+    "setOrder":14,
+	"id": "ecard2-157",
     "name": "Electrode",
     "imageUrl": "https://images.pokemontcg.io/ecard2/157.png",
     "subtype": "Stage 1",
@@ -645,7 +658,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "ecard2-7",
+    "setOrder":14,
+	"id": "ecard2-7",
     "name": "Donphan",
     "imageUrl": "https://images.pokemontcg.io/ecard2/7.png",
     "subtype": "Stage 1",
@@ -704,7 +718,8 @@
     "nationalPokedexNumber": 232
   },
   {
-    "id": "ecard2-158",
+    "setOrder":14,
+	"id": "ecard2-158",
     "name": "Entei",
     "imageUrl": "https://images.pokemontcg.io/ecard2/158.png",
     "subtype": "Basic",
@@ -751,7 +766,8 @@
     "nationalPokedexNumber": 244
   },
   {
-    "id": "ecard2-8",
+    "setOrder":14,
+	"id": "ecard2-8",
     "name": "Electrode",
     "imageUrl": "https://images.pokemontcg.io/ecard2/8.png",
     "subtype": "Stage 1",
@@ -798,7 +814,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "ecard2-159",
+    "setOrder":14,
+	"id": "ecard2-159",
     "name": "Espeon",
     "imageUrl": "https://images.pokemontcg.io/ecard2/159.png",
     "subtype": "Stage 1",
@@ -843,7 +860,8 @@
     "nationalPokedexNumber": 196
   },
   {
-    "id": "ecard2-9",
+    "setOrder":14,
+	"id": "ecard2-9",
     "name": "Elekid",
     "imageUrl": "https://images.pokemontcg.io/ecard2/9.png",
     "subtype": "Basic",
@@ -883,7 +901,8 @@
     ]
   },
   {
-    "id": "ecard2-10",
+    "setOrder":14,
+	"id": "ecard2-10",
     "name": "Entei",
     "imageUrl": "https://images.pokemontcg.io/ecard2/10.png",
     "subtype": "Basic",
@@ -930,7 +949,8 @@
     "nationalPokedexNumber": 244
   },
   {
-    "id": "ecard2-160",
+    "setOrder":14,
+	"id": "ecard2-160",
     "name": "Exeggutor",
     "imageUrl": "https://images.pokemontcg.io/ecard2/160.png",
     "subtype": "Stage 1",
@@ -980,7 +1000,8 @@
     "nationalPokedexNumber": 103
   },
   {
-    "id": "ecard2-161",
+    "setOrder":14,
+	"id": "ecard2-161",
     "name": "Houndoom",
     "imageUrl": "https://images.pokemontcg.io/ecard2/161.png",
     "subtype": "Stage 1",
@@ -1039,7 +1060,8 @@
     "nationalPokedexNumber": 229
   },
   {
-    "id": "ecard2-11",
+    "setOrder":14,
+	"id": "ecard2-11",
     "name": "Espeon",
     "imageUrl": "https://images.pokemontcg.io/ecard2/11.png",
     "subtype": "Stage 1",
@@ -1084,7 +1106,8 @@
     "nationalPokedexNumber": 196
   },
   {
-    "id": "ecard2-12",
+    "setOrder":14,
+	"id": "ecard2-12",
     "name": "Exeggutor",
     "imageUrl": "https://images.pokemontcg.io/ecard2/12.png",
     "subtype": "Stage 1",
@@ -1134,7 +1157,8 @@
     "nationalPokedexNumber": 103
   },
   {
-    "id": "ecard2-162",
+    "setOrder":14,
+	"id": "ecard2-162",
     "name": "Hypno",
     "imageUrl": "https://images.pokemontcg.io/ecard2/162.png",
     "subtype": "Stage 1",
@@ -1182,7 +1206,8 @@
     "nationalPokedexNumber": 97
   },
   {
-    "id": "ecard2-163",
+    "setOrder":14,
+	"id": "ecard2-163",
     "name": "Jumpluff",
     "imageUrl": "https://images.pokemontcg.io/ecard2/163.png",
     "subtype": "Stage 2",
@@ -1231,7 +1256,8 @@
     "nationalPokedexNumber": 189
   },
   {
-    "id": "ecard2-13",
+    "setOrder":14,
+	"id": "ecard2-13",
     "name": "Exeggutor",
     "imageUrl": "https://images.pokemontcg.io/ecard2/13.png",
     "subtype": "Stage 1",
@@ -1283,7 +1309,8 @@
     "nationalPokedexNumber": 103
   },
   {
-    "id": "ecard2-14",
+    "setOrder":14,
+	"id": "ecard2-14",
     "name": "Houndoom",
     "imageUrl": "https://images.pokemontcg.io/ecard2/14.png",
     "subtype": "Stage 1",
@@ -1335,7 +1362,8 @@
     "nationalPokedexNumber": 229
   },
   {
-    "id": "ecard2-164",
+    "setOrder":14,
+	"id": "ecard2-164",
     "name": "Kingdra",
     "imageUrl": "https://images.pokemontcg.io/ecard2/164.png",
     "subtype": "Stage 2",
@@ -1386,7 +1414,8 @@
     "nationalPokedexNumber": 230
   },
   {
-    "id": "ecard2-15",
+    "setOrder":14,
+	"id": "ecard2-15",
     "name": "Houndoom",
     "imageUrl": "https://images.pokemontcg.io/ecard2/15.png",
     "subtype": "Stage 1",
@@ -1445,7 +1474,8 @@
     "nationalPokedexNumber": 229
   },
   {
-    "id": "ecard2-165",
+    "setOrder":14,
+	"id": "ecard2-165",
     "name": "Lanturn",
     "imageUrl": "https://images.pokemontcg.io/ecard2/165.png",
     "subtype": "Stage 1",
@@ -1492,7 +1522,8 @@
     "nationalPokedexNumber": 171
   },
   {
-    "id": "ecard2-16",
+    "setOrder":14,
+	"id": "ecard2-16",
     "name": "Hypno",
     "imageUrl": "https://images.pokemontcg.io/ecard2/16.png",
     "subtype": "Stage 1",
@@ -1540,7 +1571,8 @@
     "nationalPokedexNumber": 97
   },
   {
-    "id": "ecard2-166",
+    "setOrder":14,
+	"id": "ecard2-166",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/ecard2/166.png",
     "subtype": "Stage 1",
@@ -1598,7 +1630,8 @@
     ]
   },
   {
-    "id": "ecard2-17",
+    "setOrder":14,
+	"id": "ecard2-17",
     "name": "Jumpluff",
     "imageUrl": "https://images.pokemontcg.io/ecard2/17.png",
     "subtype": "Stage 2",
@@ -1647,7 +1680,8 @@
     "nationalPokedexNumber": 189
   },
   {
-    "id": "ecard2-167",
+    "setOrder":14,
+	"id": "ecard2-167",
     "name": "Muk",
     "imageUrl": "https://images.pokemontcg.io/ecard2/167.png",
     "subtype": "Stage 1",
@@ -1694,7 +1728,8 @@
     "nationalPokedexNumber": 89
   },
   {
-    "id": "ecard2-18",
+    "setOrder":14,
+	"id": "ecard2-18",
     "name": "Jynx",
     "imageUrl": "https://images.pokemontcg.io/ecard2/18.png",
     "subtype": "Basic",
@@ -1747,7 +1782,8 @@
     "nationalPokedexNumber": 124
   },
   {
-    "id": "ecard2-168",
+    "setOrder":14,
+	"id": "ecard2-168",
     "name": "Nidoking",
     "imageUrl": "https://images.pokemontcg.io/ecard2/168.png",
     "subtype": "Stage 2",
@@ -1804,7 +1840,8 @@
     "nationalPokedexNumber": 34
   },
   {
-    "id": "ecard2-19",
+    "setOrder":14,
+	"id": "ecard2-19",
     "name": "Kingdra",
     "imageUrl": "https://images.pokemontcg.io/ecard2/19.png",
     "subtype": "Stage 2",
@@ -1855,7 +1892,8 @@
     "nationalPokedexNumber": 230
   },
   {
-    "id": "ecard2-169",
+    "setOrder":14,
+	"id": "ecard2-169",
     "name": "Ninetales",
     "imageUrl": "https://images.pokemontcg.io/ecard2/169.png",
     "subtype": "Stage 1",
@@ -1907,7 +1945,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "ecard2-20",
+    "setOrder":14,
+	"id": "ecard2-20",
     "name": "Lanturn",
     "imageUrl": "https://images.pokemontcg.io/ecard2/20.png",
     "subtype": "Stage 1",
@@ -1959,7 +1998,8 @@
     "nationalPokedexNumber": 171
   },
   {
-    "id": "ecard2-170",
+    "setOrder":14,
+	"id": "ecard2-170",
     "name": "Octillery",
     "imageUrl": "https://images.pokemontcg.io/ecard2/170.png",
     "subtype": "Stage 1",
@@ -2008,7 +2048,8 @@
     "nationalPokedexNumber": 224
   },
   {
-    "id": "ecard2-21",
+    "setOrder":14,
+	"id": "ecard2-21",
     "name": "Lanturn",
     "imageUrl": "https://images.pokemontcg.io/ecard2/21.png",
     "subtype": "Stage 1",
@@ -2055,7 +2096,8 @@
     "nationalPokedexNumber": 171
   },
   {
-    "id": "ecard2-171",
+    "setOrder":14,
+	"id": "ecard2-171",
     "name": "Scizor",
     "imageUrl": "https://images.pokemontcg.io/ecard2/171.png",
     "subtype": "Stage 1",
@@ -2114,7 +2156,8 @@
     "nationalPokedexNumber": 212
   },
   {
-    "id": "ecard2-22",
+    "setOrder":14,
+	"id": "ecard2-22",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/ecard2/22.png",
     "subtype": "Stage 1",
@@ -2172,7 +2215,8 @@
     ]
   },
   {
-    "id": "ecard2-172",
+    "setOrder":14,
+	"id": "ecard2-172",
     "name": "Slowking",
     "imageUrl": "https://images.pokemontcg.io/ecard2/172.png",
     "subtype": "Stage 1",
@@ -2224,7 +2268,8 @@
     "nationalPokedexNumber": 199
   },
   {
-    "id": "ecard2-23",
+    "setOrder":14,
+	"id": "ecard2-23",
     "name": "Muk",
     "imageUrl": "https://images.pokemontcg.io/ecard2/23.png",
     "subtype": "Stage 1",
@@ -2271,7 +2316,8 @@
     "nationalPokedexNumber": 89
   },
   {
-    "id": "ecard2-173",
+    "setOrder":14,
+	"id": "ecard2-173",
     "name": "Steelix",
     "imageUrl": "https://images.pokemontcg.io/ecard2/173.png",
     "subtype": "Stage 1",
@@ -2334,7 +2380,8 @@
     "nationalPokedexNumber": 208
   },
   {
-    "id": "ecard2-174",
+    "setOrder":14,
+	"id": "ecard2-174",
     "name": "Sudowoodo",
     "imageUrl": "https://images.pokemontcg.io/ecard2/174.png",
     "subtype": "Basic",
@@ -2384,7 +2431,8 @@
     "nationalPokedexNumber": 185
   },
   {
-    "id": "ecard2-24",
+    "setOrder":14,
+	"id": "ecard2-24",
     "name": "Nidoking",
     "imageUrl": "https://images.pokemontcg.io/ecard2/24.png",
     "subtype": "Stage 2",
@@ -2441,7 +2489,8 @@
     "nationalPokedexNumber": 34
   },
   {
-    "id": "ecard2-25",
+    "setOrder":14,
+	"id": "ecard2-25",
     "name": "Ninetales",
     "imageUrl": "https://images.pokemontcg.io/ecard2/25.png",
     "subtype": "Stage 1",
@@ -2493,7 +2542,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "ecard2-175",
+    "setOrder":14,
+	"id": "ecard2-175",
     "name": "Suicune",
     "imageUrl": "https://images.pokemontcg.io/ecard2/175.png",
     "subtype": "Basic",
@@ -2540,7 +2590,8 @@
     "nationalPokedexNumber": 245
   },
   {
-    "id": "ecard2-176",
+    "setOrder":14,
+	"id": "ecard2-176",
     "name": "Tentacruel",
     "imageUrl": "https://images.pokemontcg.io/ecard2/176.png",
     "subtype": "Stage 1",
@@ -2584,7 +2635,8 @@
     "nationalPokedexNumber": 73
   },
   {
-    "id": "ecard2-26",
+    "setOrder":14,
+	"id": "ecard2-26",
     "name": "Octillery",
     "imageUrl": "https://images.pokemontcg.io/ecard2/26.png",
     "subtype": "Stage 1",
@@ -2633,7 +2685,8 @@
     "nationalPokedexNumber": 224
   },
   {
-    "id": "ecard2-177",
+    "setOrder":14,
+	"id": "ecard2-177",
     "name": "Togetic",
     "imageUrl": "https://images.pokemontcg.io/ecard2/177.png",
     "subtype": "Stage 1",
@@ -2688,7 +2741,8 @@
     ]
   },
   {
-    "id": "ecard2-27",
+    "setOrder":14,
+	"id": "ecard2-27",
     "name": "Parasect",
     "imageUrl": "https://images.pokemontcg.io/ecard2/27.png",
     "subtype": "Stage 1",
@@ -2739,7 +2793,8 @@
     "nationalPokedexNumber": 47
   },
   {
-    "id": "ecard2-28",
+    "setOrder":14,
+	"id": "ecard2-28",
     "name": "Porygon2",
     "imageUrl": "https://images.pokemontcg.io/ecard2/28.png",
     "subtype": "Stage 1",
@@ -2789,7 +2844,8 @@
     ]
   },
   {
-    "id": "ecard2-178",
+    "setOrder":14,
+	"id": "ecard2-178",
     "name": "Tyranitar",
     "imageUrl": "https://images.pokemontcg.io/ecard2/178.png",
     "subtype": "Stage 2",
@@ -2862,7 +2918,8 @@
     "nationalPokedexNumber": 248
   },
   {
-    "id": "ecard2-179",
+    "setOrder":14,
+	"id": "ecard2-179",
     "name": "Umbreon",
     "imageUrl": "https://images.pokemontcg.io/ecard2/179.png",
     "subtype": "Stage 1",
@@ -2916,7 +2973,8 @@
     "nationalPokedexNumber": 197
   },
   {
-    "id": "ecard2-29",
+    "setOrder":14,
+	"id": "ecard2-29",
     "name": "Primeape",
     "imageUrl": "https://images.pokemontcg.io/ecard2/29.png",
     "subtype": "Stage 1",
@@ -2969,7 +3027,8 @@
     "nationalPokedexNumber": 57
   },
   {
-    "id": "ecard2-30",
+    "setOrder":14,
+	"id": "ecard2-30",
     "name": "Quagsire",
     "imageUrl": "https://images.pokemontcg.io/ecard2/30.png",
     "subtype": "Stage 1",
@@ -3023,7 +3082,8 @@
     "nationalPokedexNumber": 195
   },
   {
-    "id": "ecard2-180",
+    "setOrder":14,
+	"id": "ecard2-180",
     "name": "Victreebel",
     "imageUrl": "https://images.pokemontcg.io/ecard2/180.png",
     "subtype": "Stage 2",
@@ -3072,7 +3132,8 @@
     "nationalPokedexNumber": 71
   },
   {
-    "id": "ecard2-181",
+    "setOrder":14,
+	"id": "ecard2-181",
     "name": "Vileplume",
     "imageUrl": "https://images.pokemontcg.io/ecard2/181.png",
     "subtype": "Stage 2",
@@ -3125,7 +3186,8 @@
     "nationalPokedexNumber": 45
   },
   {
-    "id": "ecard2-31",
+    "setOrder":14,
+	"id": "ecard2-31",
     "name": "Rapidash",
     "imageUrl": "https://images.pokemontcg.io/ecard2/31.png",
     "subtype": "Stage 1",
@@ -3175,7 +3237,8 @@
     "nationalPokedexNumber": 78
   },
   {
-    "id": "ecard2-182",
+    "setOrder":14,
+	"id": "ecard2-182",
     "name": "Zapdos",
     "imageUrl": "https://images.pokemontcg.io/ecard2/182.png",
     "subtype": "Basic",
@@ -3239,7 +3302,8 @@
     "nationalPokedexNumber": 145
   },
   {
-    "id": "ecard2-32",
+    "setOrder":14,
+	"id": "ecard2-32",
     "name": "Scizor",
     "imageUrl": "https://images.pokemontcg.io/ecard2/32.png",
     "subtype": "Stage 1",
@@ -3298,7 +3362,8 @@
     "nationalPokedexNumber": 212
   },
   {
-    "id": "ecard2-33",
+    "setOrder":14,
+	"id": "ecard2-33",
     "name": "Slowbro",
     "imageUrl": "https://images.pokemontcg.io/ecard2/33.png",
     "subtype": "Stage 1",
@@ -3346,7 +3411,8 @@
     "nationalPokedexNumber": 80
   },
   {
-    "id": "ecard2-34",
+    "setOrder":14,
+	"id": "ecard2-34",
     "name": "Slowking",
     "imageUrl": "https://images.pokemontcg.io/ecard2/34.png",
     "subtype": "Stage 1",
@@ -3398,7 +3464,8 @@
     "nationalPokedexNumber": 199
   },
   {
-    "id": "ecard2-35",
+    "setOrder":14,
+	"id": "ecard2-35",
     "name": "Steelix",
     "imageUrl": "https://images.pokemontcg.io/ecard2/35.png",
     "subtype": "Stage 1",
@@ -3461,7 +3528,8 @@
     "nationalPokedexNumber": 208
   },
   {
-    "id": "ecard2-36",
+    "setOrder":14,
+	"id": "ecard2-36",
     "name": "Sudowoodo",
     "imageUrl": "https://images.pokemontcg.io/ecard2/36.png",
     "subtype": "Basic",
@@ -3511,7 +3579,8 @@
     "nationalPokedexNumber": 185
   },
   {
-    "id": "ecard2-37",
+    "setOrder":14,
+	"id": "ecard2-37",
     "name": "Suicune",
     "imageUrl": "https://images.pokemontcg.io/ecard2/37.png",
     "subtype": "Basic",
@@ -3558,7 +3627,8 @@
     "nationalPokedexNumber": 245
   },
   {
-    "id": "ecard2-38",
+    "setOrder":14,
+	"id": "ecard2-38",
     "name": "Tentacruel",
     "imageUrl": "https://images.pokemontcg.io/ecard2/38.png",
     "subtype": "Stage 1",
@@ -3602,7 +3672,8 @@
     "nationalPokedexNumber": 73
   },
   {
-    "id": "ecard2-39",
+    "setOrder":14,
+	"id": "ecard2-39",
     "name": "Togetic",
     "imageUrl": "https://images.pokemontcg.io/ecard2/39.png",
     "subtype": "Stage 1",
@@ -3657,7 +3728,8 @@
     ]
   },
   {
-    "id": "ecard2-40",
+    "setOrder":14,
+	"id": "ecard2-40",
     "name": "Tyranitar",
     "imageUrl": "https://images.pokemontcg.io/ecard2/40.png",
     "subtype": "Stage 2",
@@ -3730,7 +3802,8 @@
     "nationalPokedexNumber": 248
   },
   {
-    "id": "ecard2-41",
+    "setOrder":14,
+	"id": "ecard2-41",
     "name": "Umbreon",
     "imageUrl": "https://images.pokemontcg.io/ecard2/41.png",
     "subtype": "Stage 1",
@@ -3784,7 +3857,8 @@
     "nationalPokedexNumber": 197
   },
   {
-    "id": "ecard2-42",
+    "setOrder":14,
+	"id": "ecard2-42",
     "name": "Victreebel",
     "imageUrl": "https://images.pokemontcg.io/ecard2/42.png",
     "subtype": "Stage 2",
@@ -3833,7 +3907,8 @@
     "nationalPokedexNumber": 71
   },
   {
-    "id": "ecard2-43",
+    "setOrder":14,
+	"id": "ecard2-43",
     "name": "Vileplume",
     "imageUrl": "https://images.pokemontcg.io/ecard2/43.png",
     "subtype": "Stage 2",
@@ -3886,7 +3961,8 @@
     "nationalPokedexNumber": 45
   },
   {
-    "id": "ecard2-44",
+    "setOrder":14,
+	"id": "ecard2-44",
     "name": "Zapdos",
     "imageUrl": "https://images.pokemontcg.io/ecard2/44.png",
     "subtype": "Basic",
@@ -3950,7 +4026,8 @@
     "nationalPokedexNumber": 145
   },
   {
-    "id": "ecard2-45",
+    "setOrder":14,
+	"id": "ecard2-45",
     "name": "Bellsprout",
     "imageUrl": "https://images.pokemontcg.io/ecard2/45.png",
     "subtype": "Basic",
@@ -3994,7 +4071,8 @@
     ]
   },
   {
-    "id": "ecard2-46",
+    "setOrder":14,
+	"id": "ecard2-46",
     "name": "Dodrio",
     "imageUrl": "https://images.pokemontcg.io/ecard2/46.png",
     "subtype": "Stage 1",
@@ -4051,7 +4129,8 @@
     "nationalPokedexNumber": 85
   },
   {
-    "id": "ecard2-47",
+    "setOrder":14,
+	"id": "ecard2-47",
     "name": "Flaaffy",
     "imageUrl": "https://images.pokemontcg.io/ecard2/47.png",
     "subtype": "Stage 1",
@@ -4106,7 +4185,8 @@
     ]
   },
   {
-    "id": "ecard2-48",
+    "setOrder":14,
+	"id": "ecard2-48",
     "name": "Furret",
     "imageUrl": "https://images.pokemontcg.io/ecard2/48.png",
     "subtype": "Stage 1",
@@ -4153,7 +4233,8 @@
     "nationalPokedexNumber": 162
   },
   {
-    "id": "ecard2-49",
+    "setOrder":14,
+	"id": "ecard2-49",
     "name": "Gloom",
     "imageUrl": "https://images.pokemontcg.io/ecard2/49.png",
     "subtype": "Stage 1",
@@ -4205,7 +4286,8 @@
     ]
   },
   {
-    "id": "ecard2-50",
+    "setOrder":14,
+	"id": "ecard2-50",
     "name": "Golduck",
     "imageUrl": "https://images.pokemontcg.io/ecard2/50.png",
     "subtype": "Stage 1",
@@ -4258,7 +4340,8 @@
     "nationalPokedexNumber": 55
   },
   {
-    "id": "ecard2-51",
+    "setOrder":14,
+	"id": "ecard2-51",
     "name": "Growlithe",
     "imageUrl": "https://images.pokemontcg.io/ecard2/51.png",
     "subtype": "Basic",
@@ -4302,7 +4385,8 @@
     ]
   },
   {
-    "id": "ecard2-52",
+    "setOrder":14,
+	"id": "ecard2-52",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/ecard2/52.png",
     "subtype": "Basic",
@@ -4361,7 +4445,8 @@
     ]
   },
   {
-    "id": "ecard2-53",
+    "setOrder":14,
+	"id": "ecard2-53",
     "name": "Marill",
     "imageUrl": "https://images.pokemontcg.io/ecard2/53.png",
     "subtype": "Basic",
@@ -4414,7 +4499,8 @@
     ]
   },
   {
-    "id": "ecard2-54",
+    "setOrder":14,
+	"id": "ecard2-54",
     "name": "Marowak",
     "imageUrl": "https://images.pokemontcg.io/ecard2/54.png",
     "subtype": "Stage 1",
@@ -4473,7 +4559,8 @@
     "nationalPokedexNumber": 105
   },
   {
-    "id": "ecard2-55",
+    "setOrder":14,
+	"id": "ecard2-55",
     "name": "Nidorino",
     "imageUrl": "https://images.pokemontcg.io/ecard2/55.png",
     "subtype": "Stage 1",
@@ -4528,7 +4615,8 @@
     ]
   },
   {
-    "id": "ecard2-56",
+    "setOrder":14,
+	"id": "ecard2-56",
     "name": "Pupitar",
     "imageUrl": "https://images.pokemontcg.io/ecard2/56.png",
     "subtype": "Stage 1",
@@ -4574,7 +4662,8 @@
     ]
   },
   {
-    "id": "ecard2-57",
+    "setOrder":14,
+	"id": "ecard2-57",
     "name": "Scyther",
     "imageUrl": "https://images.pokemontcg.io/ecard2/57.png",
     "subtype": "Basic",
@@ -4628,7 +4717,8 @@
     ]
   },
   {
-    "id": "ecard2-58",
+    "setOrder":14,
+	"id": "ecard2-58",
     "name": "Seadra",
     "imageUrl": "https://images.pokemontcg.io/ecard2/58.png",
     "subtype": "Stage 1",
@@ -4683,7 +4773,8 @@
     ]
   },
   {
-    "id": "ecard2-59",
+    "setOrder":14,
+	"id": "ecard2-59",
     "name": "Seaking",
     "imageUrl": "https://images.pokemontcg.io/ecard2/59.png",
     "subtype": "Stage 1",
@@ -4736,7 +4827,8 @@
     "nationalPokedexNumber": 119
   },
   {
-    "id": "ecard2-60",
+    "setOrder":14,
+	"id": "ecard2-60",
     "name": "Skiploom",
     "imageUrl": "https://images.pokemontcg.io/ecard2/60.png",
     "subtype": "Stage 1",
@@ -4791,7 +4883,8 @@
     ]
   },
   {
-    "id": "ecard2-61",
+    "setOrder":14,
+	"id": "ecard2-61",
     "name": "Smoochum",
     "imageUrl": "https://images.pokemontcg.io/ecard2/61.png",
     "subtype": "Basic",
@@ -4831,7 +4924,8 @@
     ]
   },
   {
-    "id": "ecard2-62",
+    "setOrder":14,
+	"id": "ecard2-62",
     "name": "Spinarak",
     "imageUrl": "https://images.pokemontcg.io/ecard2/62.png",
     "subtype": "Basic",
@@ -4884,7 +4978,8 @@
     ]
   },
   {
-    "id": "ecard2-63",
+    "setOrder":14,
+	"id": "ecard2-63",
     "name": "Tyrogue",
     "imageUrl": "https://images.pokemontcg.io/ecard2/63.png",
     "subtype": "Basic",
@@ -4926,7 +5021,8 @@
     ]
   },
   {
-    "id": "ecard2-64",
+    "setOrder":14,
+	"id": "ecard2-64",
     "name": "Voltorb",
     "imageUrl": "https://images.pokemontcg.io/ecard2/64.png",
     "subtype": "Basic",
@@ -4979,7 +5075,8 @@
     ]
   },
   {
-    "id": "ecard2-65",
+    "setOrder":14,
+	"id": "ecard2-65",
     "name": "Weepinbell",
     "imageUrl": "https://images.pokemontcg.io/ecard2/65.png",
     "subtype": "Stage 1",
@@ -5033,7 +5130,8 @@
     ]
   },
   {
-    "id": "ecard2-66",
+    "setOrder":14,
+	"id": "ecard2-66",
     "name": "Wooper",
     "imageUrl": "https://images.pokemontcg.io/ecard2/66.png",
     "subtype": "Basic",
@@ -5085,7 +5183,8 @@
     ]
   },
   {
-    "id": "ecard2-67",
+    "setOrder":14,
+	"id": "ecard2-67",
     "name": "Aipom",
     "imageUrl": "https://images.pokemontcg.io/ecard2/67.png",
     "subtype": "Basic",
@@ -5138,7 +5237,8 @@
     ]
   },
   {
-    "id": "ecard2-68",
+    "setOrder":14,
+	"id": "ecard2-68",
     "name": "Bellsprout",
     "imageUrl": "https://images.pokemontcg.io/ecard2/68.png",
     "subtype": "Basic",
@@ -5190,7 +5290,8 @@
     ]
   },
   {
-    "id": "ecard2-69",
+    "setOrder":14,
+	"id": "ecard2-69",
     "name": "Chansey",
     "imageUrl": "https://images.pokemontcg.io/ecard2/69.png",
     "subtype": "Basic",
@@ -5245,7 +5346,8 @@
     ]
   },
   {
-    "id": "ecard2-70",
+    "setOrder":14,
+	"id": "ecard2-70",
     "name": "Chinchou",
     "imageUrl": "https://images.pokemontcg.io/ecard2/70.png",
     "subtype": "Basic",
@@ -5298,7 +5400,8 @@
     ]
   },
   {
-    "id": "ecard2-71",
+    "setOrder":14,
+	"id": "ecard2-71",
     "name": "Chinchou",
     "imageUrl": "https://images.pokemontcg.io/ecard2/71.png",
     "subtype": "Basic",
@@ -5351,7 +5454,8 @@
     ]
   },
   {
-    "id": "ecard2-72",
+    "setOrder":14,
+	"id": "ecard2-72",
     "name": "Cubone",
     "imageUrl": "https://images.pokemontcg.io/ecard2/72.png",
     "subtype": "Basic",
@@ -5409,7 +5513,8 @@
     ]
   },
   {
-    "id": "ecard2-73",
+    "setOrder":14,
+	"id": "ecard2-73",
     "name": "Doduo",
     "imageUrl": "https://images.pokemontcg.io/ecard2/73.png",
     "subtype": "Basic",
@@ -5468,7 +5573,8 @@
     ]
   },
   {
-    "id": "ecard2-74",
+    "setOrder":14,
+	"id": "ecard2-74",
     "name": "Drowzee",
     "imageUrl": "https://images.pokemontcg.io/ecard2/74.png",
     "subtype": "Basic",
@@ -5521,7 +5627,8 @@
     ]
   },
   {
-    "id": "ecard2-75",
+    "setOrder":14,
+	"id": "ecard2-75",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/ecard2/75.png",
     "subtype": "Basic",
@@ -5580,7 +5687,8 @@
     ]
   },
   {
-    "id": "ecard2-76",
+    "setOrder":14,
+	"id": "ecard2-76",
     "name": "Exeggcute",
     "imageUrl": "https://images.pokemontcg.io/ecard2/76.png",
     "subtype": "Basic",
@@ -5632,7 +5740,8 @@
     ]
   },
   {
-    "id": "ecard2-77",
+    "setOrder":14,
+	"id": "ecard2-77",
     "name": "Exeggcute",
     "imageUrl": "https://images.pokemontcg.io/ecard2/77.png",
     "subtype": "Basic",
@@ -5684,7 +5793,8 @@
     ]
   },
   {
-    "id": "ecard2-78",
+    "setOrder":14,
+	"id": "ecard2-78",
     "name": "Goldeen",
     "imageUrl": "https://images.pokemontcg.io/ecard2/78.png",
     "subtype": "Basic",
@@ -5727,7 +5837,8 @@
     ]
   },
   {
-    "id": "ecard2-79",
+    "setOrder":14,
+	"id": "ecard2-79",
     "name": "Grimer",
     "imageUrl": "https://images.pokemontcg.io/ecard2/79.png",
     "subtype": "Basic",
@@ -5770,7 +5881,8 @@
     ]
   },
   {
-    "id": "ecard2-80",
+    "setOrder":14,
+	"id": "ecard2-80",
     "name": "Growlithe",
     "imageUrl": "https://images.pokemontcg.io/ecard2/80.png",
     "subtype": "Basic",
@@ -5822,7 +5934,8 @@
     ]
   },
   {
-    "id": "ecard2-81",
+    "setOrder":14,
+	"id": "ecard2-81",
     "name": "Hitmonchan",
     "imageUrl": "https://images.pokemontcg.io/ecard2/81.png",
     "subtype": "Basic",
@@ -5875,7 +5988,8 @@
     "nationalPokedexNumber": 107
   },
   {
-    "id": "ecard2-82",
+    "setOrder":14,
+	"id": "ecard2-82",
     "name": "Hitmontop",
     "imageUrl": "https://images.pokemontcg.io/ecard2/82.png",
     "subtype": "Basic",
@@ -5927,7 +6041,8 @@
     "nationalPokedexNumber": 237
   },
   {
-    "id": "ecard2-83",
+    "setOrder":14,
+	"id": "ecard2-83",
     "name": "Hoppip",
     "imageUrl": "https://images.pokemontcg.io/ecard2/83.png",
     "subtype": "Basic",
@@ -5981,7 +6096,8 @@
     ]
   },
   {
-    "id": "ecard2-84",
+    "setOrder":14,
+	"id": "ecard2-84",
     "name": "Horsea",
     "imageUrl": "https://images.pokemontcg.io/ecard2/84.png",
     "subtype": "Basic",
@@ -6024,7 +6140,8 @@
     ]
   },
   {
-    "id": "ecard2-85",
+    "setOrder":14,
+	"id": "ecard2-85",
     "name": "Horsea",
     "imageUrl": "https://images.pokemontcg.io/ecard2/85.png",
     "subtype": "Basic",
@@ -6068,7 +6185,8 @@
     ]
   },
   {
-    "id": "ecard2-86",
+    "setOrder":14,
+	"id": "ecard2-86",
     "name": "Houndour",
     "imageUrl": "https://images.pokemontcg.io/ecard2/86.png",
     "subtype": "Basic",
@@ -6121,7 +6239,8 @@
     ]
   },
   {
-    "id": "ecard2-87",
+    "setOrder":14,
+	"id": "ecard2-87",
     "name": "Houndour",
     "imageUrl": "https://images.pokemontcg.io/ecard2/87.png",
     "subtype": "Basic",
@@ -6171,7 +6290,8 @@
     ]
   },
   {
-    "id": "ecard2-88",
+    "setOrder":14,
+	"id": "ecard2-88",
     "name": "Kangaskhan",
     "imageUrl": "https://images.pokemontcg.io/ecard2/88.png",
     "subtype": "Basic",
@@ -6224,7 +6344,8 @@
     "nationalPokedexNumber": 115
   },
   {
-    "id": "ecard2-89",
+    "setOrder":14,
+	"id": "ecard2-89",
     "name": "Larvitar",
     "imageUrl": "https://images.pokemontcg.io/ecard2/89.png",
     "subtype": "Basic",
@@ -6276,7 +6397,8 @@
     ]
   },
   {
-    "id": "ecard2-90",
+    "setOrder":14,
+	"id": "ecard2-90",
     "name": "Lickitung",
     "imageUrl": "https://images.pokemontcg.io/ecard2/90.png",
     "subtype": "Basic",
@@ -6332,7 +6454,8 @@
     ]
   },
   {
-    "id": "ecard2-91",
+    "setOrder":14,
+	"id": "ecard2-91",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/ecard2/91.png",
     "subtype": "Basic",
@@ -6381,7 +6504,8 @@
     ]
   },
   {
-    "id": "ecard2-92",
+    "setOrder":14,
+	"id": "ecard2-92",
     "name": "Mankey",
     "imageUrl": "https://images.pokemontcg.io/ecard2/92.png",
     "subtype": "Basic",
@@ -6434,7 +6558,8 @@
     ]
   },
   {
-    "id": "ecard2-93",
+    "setOrder":14,
+	"id": "ecard2-93",
     "name": "Mareep",
     "imageUrl": "https://images.pokemontcg.io/ecard2/93.png",
     "subtype": "Basic",
@@ -6487,7 +6612,8 @@
     ]
   },
   {
-    "id": "ecard2-94",
+    "setOrder":14,
+	"id": "ecard2-94",
     "name": "Miltank",
     "imageUrl": "https://images.pokemontcg.io/ecard2/94.png",
     "subtype": "Basic",
@@ -6538,7 +6664,8 @@
     "nationalPokedexNumber": 241
   },
   {
-    "id": "ecard2-95",
+    "setOrder":14,
+	"id": "ecard2-95",
     "name": "Mr. Mime",
     "imageUrl": "https://images.pokemontcg.io/ecard2/95.png",
     "subtype": "Basic",
@@ -6579,7 +6706,8 @@
     "nationalPokedexNumber": 122
   },
   {
-    "id": "ecard2-96",
+    "setOrder":14,
+	"id": "ecard2-96",
     "name": "Nidoran♂",
     "imageUrl": "https://images.pokemontcg.io/ecard2/96.png",
     "subtype": "Basic",
@@ -6632,7 +6760,8 @@
     ]
   },
   {
-    "id": "ecard2-97",
+    "setOrder":14,
+	"id": "ecard2-97",
     "name": "Oddish",
     "imageUrl": "https://images.pokemontcg.io/ecard2/97.png",
     "subtype": "Basic",
@@ -6685,7 +6814,8 @@
     ]
   },
   {
-    "id": "ecard2-98",
+    "setOrder":14,
+	"id": "ecard2-98",
     "name": "Onix",
     "imageUrl": "https://images.pokemontcg.io/ecard2/98.png",
     "subtype": "Basic",
@@ -6730,7 +6860,8 @@
     ]
   },
   {
-    "id": "ecard2-99",
+    "setOrder":14,
+	"id": "ecard2-99",
     "name": "Paras",
     "imageUrl": "https://images.pokemontcg.io/ecard2/99.png",
     "subtype": "Basic",
@@ -6783,7 +6914,8 @@
     ]
   },
   {
-    "id": "ecard2-100",
+    "setOrder":14,
+	"id": "ecard2-100",
     "name": "Phanpy",
     "imageUrl": "https://images.pokemontcg.io/ecard2/100.png",
     "subtype": "Basic",
@@ -6842,7 +6974,8 @@
     ]
   },
   {
-    "id": "ecard2-101",
+    "setOrder":14,
+	"id": "ecard2-101",
     "name": "Pinsir",
     "imageUrl": "https://images.pokemontcg.io/ecard2/101.png",
     "subtype": "Basic",
@@ -6894,7 +7027,8 @@
     "nationalPokedexNumber": 127
   },
   {
-    "id": "ecard2-102",
+    "setOrder":14,
+	"id": "ecard2-102",
     "name": "Ponyta",
     "imageUrl": "https://images.pokemontcg.io/ecard2/102.png",
     "subtype": "Basic",
@@ -6947,7 +7081,8 @@
     ]
   },
   {
-    "id": "ecard2-103",
+    "setOrder":14,
+	"id": "ecard2-103",
     "name": "Porygon",
     "imageUrl": "https://images.pokemontcg.io/ecard2/103.png",
     "subtype": "Basic",
@@ -6999,7 +7134,8 @@
     ]
   },
   {
-    "id": "ecard2-104",
+    "setOrder":14,
+	"id": "ecard2-104",
     "name": "Psyduck",
     "imageUrl": "https://images.pokemontcg.io/ecard2/104.png",
     "subtype": "Basic",
@@ -7052,7 +7188,8 @@
     ]
   },
   {
-    "id": "ecard2-105",
+    "setOrder":14,
+	"id": "ecard2-105",
     "name": "Remoraid",
     "imageUrl": "https://images.pokemontcg.io/ecard2/105.png",
     "subtype": "Basic",
@@ -7095,7 +7232,8 @@
     ]
   },
   {
-    "id": "ecard2-106",
+    "setOrder":14,
+	"id": "ecard2-106",
     "name": "Scyther",
     "imageUrl": "https://images.pokemontcg.io/ecard2/106.png",
     "subtype": "Basic",
@@ -7154,7 +7292,8 @@
     ]
   },
   {
-    "id": "ecard2-107",
+    "setOrder":14,
+	"id": "ecard2-107",
     "name": "Sentret",
     "imageUrl": "https://images.pokemontcg.io/ecard2/107.png",
     "subtype": "Basic",
@@ -7206,7 +7345,8 @@
     ]
   },
   {
-    "id": "ecard2-108",
+    "setOrder":14,
+	"id": "ecard2-108",
     "name": "Slowpoke",
     "imageUrl": "https://images.pokemontcg.io/ecard2/108.png",
     "subtype": "Basic",
@@ -7260,7 +7400,8 @@
     ]
   },
   {
-    "id": "ecard2-109",
+    "setOrder":14,
+	"id": "ecard2-109",
     "name": "Smeargle",
     "imageUrl": "https://images.pokemontcg.io/ecard2/109.png",
     "subtype": "Basic",
@@ -7310,7 +7451,8 @@
     "nationalPokedexNumber": 235
   },
   {
-    "id": "ecard2-110",
+    "setOrder":14,
+	"id": "ecard2-110",
     "name": "Sneasel",
     "imageUrl": "https://images.pokemontcg.io/ecard2/110.png",
     "subtype": "Basic",
@@ -7369,7 +7511,8 @@
     ]
   },
   {
-    "id": "ecard2-111",
+    "setOrder":14,
+	"id": "ecard2-111",
     "name": "Spinarak",
     "imageUrl": "https://images.pokemontcg.io/ecard2/111.png",
     "subtype": "Basic",
@@ -7412,7 +7555,8 @@
     ]
   },
   {
-    "id": "ecard2-112",
+    "setOrder":14,
+	"id": "ecard2-112",
     "name": "Tangela",
     "imageUrl": "https://images.pokemontcg.io/ecard2/112.png",
     "subtype": "Basic",
@@ -7474,7 +7618,8 @@
     ]
   },
   {
-    "id": "ecard2-113",
+    "setOrder":14,
+	"id": "ecard2-113",
     "name": "Tentacool",
     "imageUrl": "https://images.pokemontcg.io/ecard2/113.png",
     "subtype": "Basic",
@@ -7526,7 +7671,8 @@
     ]
   },
   {
-    "id": "ecard2-114",
+    "setOrder":14,
+	"id": "ecard2-114",
     "name": "Togepi",
     "imageUrl": "https://images.pokemontcg.io/ecard2/114.png",
     "subtype": "Basic",
@@ -7578,7 +7724,8 @@
     ]
   },
   {
-    "id": "ecard2-115",
+    "setOrder":14,
+	"id": "ecard2-115",
     "name": "Voltorb",
     "imageUrl": "https://images.pokemontcg.io/ecard2/115.png",
     "subtype": "Basic",
@@ -7621,7 +7768,8 @@
     ]
   },
   {
-    "id": "ecard2-116",
+    "setOrder":14,
+	"id": "ecard2-116",
     "name": "Vulpix",
     "imageUrl": "https://images.pokemontcg.io/ecard2/116.png",
     "subtype": "Basic",
@@ -7664,7 +7812,8 @@
     ]
   },
   {
-    "id": "ecard2-117",
+    "setOrder":14,
+	"id": "ecard2-117",
     "name": "Wooper",
     "imageUrl": "https://images.pokemontcg.io/ecard2/117.png",
     "subtype": "Basic",
@@ -7717,7 +7866,8 @@
     ]
   },
   {
-    "id": "ecard2-118",
+    "setOrder":14,
+	"id": "ecard2-118",
     "name": "Apricorn Forest",
     "imageUrl": "https://images.pokemontcg.io/ecard2/118.png",
     "subtype": "",
@@ -7734,7 +7884,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/118_hires.png"
   },
   {
-    "id": "ecard2-119",
+    "setOrder":14,
+	"id": "ecard2-119",
     "name": "Darkness Cube 01",
     "imageUrl": "https://images.pokemontcg.io/ecard2/119.png",
     "subtype": "",
@@ -7751,7 +7902,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/119_hires.png"
   },
   {
-    "id": "ecard2-120",
+    "setOrder":14,
+	"id": "ecard2-120",
     "name": "Energy Switch",
     "imageUrl": "https://images.pokemontcg.io/ecard2/120.png",
     "subtype": "",
@@ -7768,7 +7920,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/120_hires.png"
   },
   {
-    "id": "ecard2-121",
+    "setOrder":14,
+	"id": "ecard2-121",
     "name": "Fighting Cube 01",
     "imageUrl": "https://images.pokemontcg.io/ecard2/121.png",
     "subtype": "",
@@ -7785,7 +7938,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/121_hires.png"
   },
   {
-    "id": "ecard2-122",
+    "setOrder":14,
+	"id": "ecard2-122",
     "name": "Fire Cube 01",
     "imageUrl": "https://images.pokemontcg.io/ecard2/122.png",
     "subtype": "",
@@ -7802,7 +7956,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/122_hires.png"
   },
   {
-    "id": "ecard2-123",
+    "setOrder":14,
+	"id": "ecard2-123",
     "name": "Forest Guardian",
     "imageUrl": "https://images.pokemontcg.io/ecard2/123.png",
     "subtype": "",
@@ -7819,7 +7974,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/123_hires.png"
   },
   {
-    "id": "ecard2-124",
+    "setOrder":14,
+	"id": "ecard2-124",
     "name": "Grass Cube 01",
     "imageUrl": "https://images.pokemontcg.io/ecard2/124.png",
     "subtype": "",
@@ -7836,7 +7992,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/124_hires.png"
   },
   {
-    "id": "ecard2-125",
+    "setOrder":14,
+	"id": "ecard2-125",
     "name": "Healing Berry",
     "imageUrl": "https://images.pokemontcg.io/ecard2/125.png",
     "subtype": "",
@@ -7853,7 +8010,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/125_hires.png"
   },
   {
-    "id": "ecard2-126",
+    "setOrder":14,
+	"id": "ecard2-126",
     "name": "Juggler",
     "imageUrl": "https://images.pokemontcg.io/ecard2/126.png",
     "subtype": "",
@@ -7870,7 +8028,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/126_hires.png"
   },
   {
-    "id": "ecard2-127",
+    "setOrder":14,
+	"id": "ecard2-127",
     "name": "Lightning Cube 01",
     "imageUrl": "https://images.pokemontcg.io/ecard2/127.png",
     "subtype": "",
@@ -7887,7 +8046,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/127_hires.png"
   },
   {
-    "id": "ecard2-128",
+    "setOrder":14,
+	"id": "ecard2-128",
     "name": "Memory Berry",
     "imageUrl": "https://images.pokemontcg.io/ecard2/128.png",
     "subtype": "",
@@ -7904,7 +8064,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/128_hires.png"
   },
   {
-    "id": "ecard2-129",
+    "setOrder":14,
+	"id": "ecard2-129",
     "name": "Metal Cube 01",
     "imageUrl": "https://images.pokemontcg.io/ecard2/129.png",
     "subtype": "",
@@ -7921,7 +8082,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/129_hires.png"
   },
   {
-    "id": "ecard2-130",
+    "setOrder":14,
+	"id": "ecard2-130",
     "name": "Pokémon Fan Club",
     "imageUrl": "https://images.pokemontcg.io/ecard2/130.png",
     "subtype": "",
@@ -7938,7 +8100,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/130_hires.png"
   },
   {
-    "id": "ecard2-131",
+    "setOrder":14,
+	"id": "ecard2-131",
     "name": "Pokémon Park",
     "imageUrl": "https://images.pokemontcg.io/ecard2/131.png",
     "subtype": "",
@@ -7955,7 +8118,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/131_hires.png"
   },
   {
-    "id": "ecard2-132",
+    "setOrder":14,
+	"id": "ecard2-132",
     "name": "Psychic Cube 01",
     "imageUrl": "https://images.pokemontcg.io/ecard2/132.png",
     "subtype": "",
@@ -7972,7 +8136,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/132_hires.png"
   },
   {
-    "id": "ecard2-133",
+    "setOrder":14,
+	"id": "ecard2-133",
     "name": "Seer",
     "imageUrl": "https://images.pokemontcg.io/ecard2/133.png",
     "subtype": "",
@@ -7989,7 +8154,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/133_hires.png"
   },
   {
-    "id": "ecard2-134",
+    "setOrder":14,
+	"id": "ecard2-134",
     "name": "Super Energy Removal 2",
     "imageUrl": "https://images.pokemontcg.io/ecard2/134.png",
     "subtype": "",
@@ -8006,7 +8172,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/134_hires.png"
   },
   {
-    "id": "ecard2-135",
+    "setOrder":14,
+	"id": "ecard2-135",
     "name": "Time Shard",
     "imageUrl": "https://images.pokemontcg.io/ecard2/135.png",
     "subtype": "",
@@ -8023,7 +8190,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/135_hires.png"
   },
   {
-    "id": "ecard2-136",
+    "setOrder":14,
+	"id": "ecard2-136",
     "name": "Town Volunteers",
     "imageUrl": "https://images.pokemontcg.io/ecard2/136.png",
     "subtype": "",
@@ -8040,7 +8208,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/136_hires.png"
   },
   {
-    "id": "ecard2-137",
+    "setOrder":14,
+	"id": "ecard2-137",
     "name": "Traveling Salesman",
     "imageUrl": "https://images.pokemontcg.io/ecard2/137.png",
     "subtype": "",
@@ -8057,7 +8226,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/137_hires.png"
   },
   {
-    "id": "ecard2-138",
+    "setOrder":14,
+	"id": "ecard2-138",
     "name": "Undersea Ruins",
     "imageUrl": "https://images.pokemontcg.io/ecard2/138.png",
     "subtype": "",
@@ -8074,7 +8244,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/138_hires.png"
   },
   {
-    "id": "ecard2-139",
+    "setOrder":14,
+	"id": "ecard2-139",
     "name": "Power Plant",
     "imageUrl": "https://images.pokemontcg.io/ecard2/139.png",
     "subtype": "",
@@ -8091,7 +8262,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/139_hires.png"
   },
   {
-    "id": "ecard2-140",
+    "setOrder":14,
+	"id": "ecard2-140",
     "name": "Water Cube 01",
     "imageUrl": "https://images.pokemontcg.io/ecard2/140.png",
     "subtype": "",
@@ -8108,7 +8280,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/140_hires.png"
   },
   {
-    "id": "ecard2-141",
+    "setOrder":14,
+	"id": "ecard2-141",
     "name": "Weakness Guard",
     "imageUrl": "https://images.pokemontcg.io/ecard2/141.png",
     "subtype": "",
@@ -8125,7 +8298,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/141_hires.png"
   },
   {
-    "id": "ecard2-142",
+    "setOrder":14,
+	"id": "ecard2-142",
     "name": "Darkness Energy",
     "imageUrl": "https://images.pokemontcg.io/ecard2/142.png",
     "subtype": "Special",
@@ -8142,7 +8316,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/142_hires.png"
   },
   {
-    "id": "ecard2-143",
+    "setOrder":14,
+	"id": "ecard2-143",
     "name": "Metal Energy",
     "imageUrl": "https://images.pokemontcg.io/ecard2/143.png",
     "subtype": "Special",
@@ -8159,7 +8334,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/143_hires.png"
   },
   {
-    "id": "ecard2-144",
+    "setOrder":14,
+	"id": "ecard2-144",
     "name": "Rainbow Energy",
     "imageUrl": "https://images.pokemontcg.io/ecard2/144.png",
     "subtype": "Special",
@@ -8176,7 +8352,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/144_hires.png"
   },
   {
-    "id": "ecard2-145",
+    "setOrder":14,
+	"id": "ecard2-145",
     "name": "Boost Energy",
     "imageUrl": "https://images.pokemontcg.io/ecard2/145.png",
     "subtype": "Special",
@@ -8193,7 +8370,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/145_hires.png"
   },
   {
-    "id": "ecard2-146",
+    "setOrder":14,
+	"id": "ecard2-146",
     "name": "Crystal Energy",
     "imageUrl": "https://images.pokemontcg.io/ecard2/146.png",
     "subtype": "Special",
@@ -8210,7 +8388,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/146_hires.png"
   },
   {
-    "id": "ecard2-147",
+    "setOrder":14,
+	"id": "ecard2-147",
     "name": "Warp Energy",
     "imageUrl": "https://images.pokemontcg.io/ecard2/147.png",
     "subtype": "Special",
@@ -8227,7 +8406,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard2/147_hires.png"
   },
   {
-    "id": "ecard2-148",
+    "setOrder":14,
+	"id": "ecard2-148",
     "name": "Kingdra",
     "imageUrl": "https://images.pokemontcg.io/ecard2/148.png",
     "subtype": "Stage 2",
@@ -8289,7 +8469,8 @@
     "nationalPokedexNumber": 230
   },
   {
-    "id": "ecard2-149",
+    "setOrder":14,
+	"id": "ecard2-149",
     "name": "Lugia",
     "imageUrl": "https://images.pokemontcg.io/ecard2/149.png",
     "subtype": "Basic",
@@ -8349,7 +8530,8 @@
     "nationalPokedexNumber": 249
   },
   {
-    "id": "ecard2-150",
+    "setOrder":14,
+	"id": "ecard2-150",
     "name": "Nidoking",
     "imageUrl": "https://images.pokemontcg.io/ecard2/150.png",
     "subtype": "Stage 2",

--- a/json/cards/Arceus.json
+++ b/json/cards/Arceus.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "pl4-1",
+    "setOrder"42:,
+	"id": "pl4-1",
     "name": "Charizard",
     "imageUrl": "https://images.pokemontcg.io/pl4/1.png",
     "subtype": "Stage 2",
@@ -66,7 +67,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "pl4-2",
+    "setOrder"42:,
+	"id": "pl4-2",
     "name": "Froslass",
     "imageUrl": "https://images.pokemontcg.io/pl4/2.png",
     "subtype": "Stage 1",
@@ -114,7 +116,8 @@
     "nationalPokedexNumber": 478
   },
   {
-    "id": "pl4-3",
+    "setOrder"42:,
+	"id": "pl4-3",
     "name": "Heatran",
     "imageUrl": "https://images.pokemontcg.io/pl4/3.png",
     "subtype": "Basic",
@@ -170,7 +173,8 @@
     "nationalPokedexNumber": 485
   },
   {
-    "id": "pl4-4",
+    "setOrder"42:,
+	"id": "pl4-4",
     "name": "Kabutops",
     "imageUrl": "https://images.pokemontcg.io/pl4/4.png",
     "subtype": "Stage 2",
@@ -224,7 +228,8 @@
     "nationalPokedexNumber": 141
   },
   {
-    "id": "pl4-5",
+    "setOrder"42:,
+	"id": "pl4-5",
     "name": "Luxray",
     "imageUrl": "https://images.pokemontcg.io/pl4/5.png",
     "subtype": "Stage 2",
@@ -280,7 +285,8 @@
     "nationalPokedexNumber": 405
   },
   {
-    "id": "pl4-6",
+    "setOrder"42:,
+	"id": "pl4-6",
     "name": "Mothim",
     "imageUrl": "https://images.pokemontcg.io/pl4/6.png",
     "subtype": "Stage 1",
@@ -337,7 +343,8 @@
     ]
   },
   {
-    "id": "pl4-7",
+    "setOrder"42:,
+	"id": "pl4-7",
     "name": "Probopass",
     "imageUrl": "https://images.pokemontcg.io/pl4/7.png",
     "subtype": "Stage 1",
@@ -404,7 +411,8 @@
     "nationalPokedexNumber": 476
   },
   {
-    "id": "pl4-8",
+    "setOrder"42:,
+	"id": "pl4-8",
     "name": "Salamence",
     "imageUrl": "https://images.pokemontcg.io/pl4/8.png",
     "subtype": "Stage 2",
@@ -472,7 +480,8 @@
     "nationalPokedexNumber": 373
   },
   {
-    "id": "pl4-9",
+    "setOrder"42:,
+	"id": "pl4-9",
     "name": "Swalot",
     "imageUrl": "https://images.pokemontcg.io/pl4/9.png",
     "subtype": "Stage 1",
@@ -527,7 +536,8 @@
     "nationalPokedexNumber": 317
   },
   {
-    "id": "pl4-10",
+    "setOrder"42:,
+	"id": "pl4-10",
     "name": "Tangrowth",
     "imageUrl": "https://images.pokemontcg.io/pl4/10.png",
     "subtype": "Stage 1",
@@ -590,7 +600,8 @@
     "nationalPokedexNumber": 465
   },
   {
-    "id": "pl4-11",
+    "setOrder"42:,
+	"id": "pl4-11",
     "name": "Toxicroak",
     "imageUrl": "https://images.pokemontcg.io/pl4/11.png",
     "subtype": "Stage 1",
@@ -642,7 +653,8 @@
     "nationalPokedexNumber": 454
   },
   {
-    "id": "pl4-12",
+    "setOrder"42:,
+	"id": "pl4-12",
     "name": "Zapdos G",
     "imageUrl": "https://images.pokemontcg.io/pl4/12.png",
     "subtype": "Basic",
@@ -701,7 +713,8 @@
     "nationalPokedexNumber": 145
   },
   {
-    "id": "pl4-13",
+    "setOrder"42:,
+	"id": "pl4-13",
     "name": "Aerodactyl",
     "imageUrl": "https://images.pokemontcg.io/pl4/13.png",
     "subtype": "Stage 1",
@@ -755,7 +768,8 @@
     "nationalPokedexNumber": 142
   },
   {
-    "id": "pl4-14",
+    "setOrder"42:,
+	"id": "pl4-14",
     "name": "Bronzong",
     "imageUrl": "https://images.pokemontcg.io/pl4/14.png",
     "subtype": "Stage 1",
@@ -817,7 +831,8 @@
     "nationalPokedexNumber": 437
   },
   {
-    "id": "pl4-15",
+    "setOrder"42:,
+	"id": "pl4-15",
     "name": "Cherrim",
     "imageUrl": "https://images.pokemontcg.io/pl4/15.png",
     "subtype": "Stage 1",
@@ -871,7 +886,8 @@
     "nationalPokedexNumber": 421
   },
   {
-    "id": "pl4-16",
+    "setOrder"42:,
+	"id": "pl4-16",
     "name": "Gengar",
     "imageUrl": "https://images.pokemontcg.io/pl4/16.png",
     "subtype": "Stage 2",
@@ -923,7 +939,8 @@
     "nationalPokedexNumber": 94
   },
   {
-    "id": "pl4-17",
+    "setOrder"42:,
+	"id": "pl4-17",
     "name": "Gengar",
     "imageUrl": "https://images.pokemontcg.io/pl4/17.png",
     "subtype": "Stage 2",
@@ -980,7 +997,8 @@
     "nationalPokedexNumber": 94
   },
   {
-    "id": "pl4-18",
+    "setOrder"42:,
+	"id": "pl4-18",
     "name": "Glalie",
     "imageUrl": "https://images.pokemontcg.io/pl4/18.png",
     "subtype": "Stage 1",
@@ -1034,7 +1052,8 @@
     "nationalPokedexNumber": 362
   },
   {
-    "id": "pl4-19",
+    "setOrder"42:,
+	"id": "pl4-19",
     "name": "Golem",
     "imageUrl": "https://images.pokemontcg.io/pl4/19.png",
     "subtype": "Stage 2",
@@ -1109,7 +1128,8 @@
     "nationalPokedexNumber": 76
   },
   {
-    "id": "pl4-20",
+    "setOrder"42:,
+	"id": "pl4-20",
     "name": "Hariyama",
     "imageUrl": "https://images.pokemontcg.io/pl4/20.png",
     "subtype": "Stage 1",
@@ -1168,7 +1188,8 @@
     "nationalPokedexNumber": 297
   },
   {
-    "id": "pl4-21",
+    "setOrder"42:,
+	"id": "pl4-21",
     "name": "Lopunny",
     "imageUrl": "https://images.pokemontcg.io/pl4/21.png",
     "subtype": "Stage 1",
@@ -1216,7 +1237,8 @@
     "nationalPokedexNumber": 428
   },
   {
-    "id": "pl4-22",
+    "setOrder"42:,
+	"id": "pl4-22",
     "name": "Manectric",
     "imageUrl": "https://images.pokemontcg.io/pl4/22.png",
     "subtype": "Stage 1",
@@ -1273,7 +1295,8 @@
     "nationalPokedexNumber": 310
   },
   {
-    "id": "pl4-23",
+    "setOrder"42:,
+	"id": "pl4-23",
     "name": "Omastar",
     "imageUrl": "https://images.pokemontcg.io/pl4/23.png",
     "subtype": "Stage 2",
@@ -1326,7 +1349,8 @@
     "nationalPokedexNumber": 139
   },
   {
-    "id": "pl4-24",
+    "setOrder"42:,
+	"id": "pl4-24",
     "name": "Pelipper",
     "imageUrl": "https://images.pokemontcg.io/pl4/24.png",
     "subtype": "Stage 1",
@@ -1388,7 +1412,8 @@
     "nationalPokedexNumber": 279
   },
   {
-    "id": "pl4-25",
+    "setOrder"42:,
+	"id": "pl4-25",
     "name": "Pichu",
     "imageUrl": "https://images.pokemontcg.io/pl4/25.png",
     "subtype": "Basic",
@@ -1443,7 +1468,8 @@
     ]
   },
   {
-    "id": "pl4-26",
+    "setOrder"42:,
+	"id": "pl4-26",
     "name": "Porygon-Z G",
     "imageUrl": "https://images.pokemontcg.io/pl4/26.png",
     "subtype": "Basic",
@@ -1491,7 +1517,8 @@
     "nationalPokedexNumber": 474
   },
   {
-    "id": "pl4-27",
+    "setOrder"42:,
+	"id": "pl4-27",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/pl4/27.png",
     "subtype": "Stage 1",
@@ -1550,7 +1577,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "pl4-28",
+    "setOrder"42:,
+	"id": "pl4-28",
     "name": "Rapidash",
     "imageUrl": "https://images.pokemontcg.io/pl4/28.png",
     "subtype": "Stage 1",
@@ -1605,7 +1633,8 @@
     "nationalPokedexNumber": 78
   },
   {
-    "id": "pl4-29",
+    "setOrder"42:,
+	"id": "pl4-29",
     "name": "Raticate",
     "imageUrl": "https://images.pokemontcg.io/pl4/29.png",
     "subtype": "Stage 1",
@@ -1653,7 +1682,8 @@
     "nationalPokedexNumber": 20
   },
   {
-    "id": "pl4-30",
+    "setOrder"42:,
+	"id": "pl4-30",
     "name": "Sceptile",
     "imageUrl": "https://images.pokemontcg.io/pl4/30.png",
     "subtype": "Stage 2",
@@ -1719,7 +1749,8 @@
     "nationalPokedexNumber": 254
   },
   {
-    "id": "pl4-31",
+    "setOrder"42:,
+	"id": "pl4-31",
     "name": "Sceptile",
     "imageUrl": "https://images.pokemontcg.io/pl4/31.png",
     "subtype": "Stage 2",
@@ -1778,7 +1809,8 @@
     "nationalPokedexNumber": 254
   },
   {
-    "id": "pl4-32",
+    "setOrder"42:,
+	"id": "pl4-32",
     "name": "Spiritomb",
     "imageUrl": "https://images.pokemontcg.io/pl4/32.png",
     "subtype": "Basic",
@@ -1833,7 +1865,8 @@
     "nationalPokedexNumber": 442
   },
   {
-    "id": "pl4-33",
+    "setOrder"42:,
+	"id": "pl4-33",
     "name": "Bronzong",
     "imageUrl": "https://images.pokemontcg.io/pl4/33.png",
     "subtype": "Stage 1",
@@ -1894,7 +1927,8 @@
     "nationalPokedexNumber": 437
   },
   {
-    "id": "pl4-34",
+    "setOrder"42:,
+	"id": "pl4-34",
     "name": "Bronzor",
     "imageUrl": "https://images.pokemontcg.io/pl4/34.png",
     "subtype": "Basic",
@@ -1956,7 +1990,8 @@
     ]
   },
   {
-    "id": "pl4-35",
+    "setOrder"42:,
+	"id": "pl4-35",
     "name": "Charmeleon",
     "imageUrl": "https://images.pokemontcg.io/pl4/35.png",
     "subtype": "Stage 1",
@@ -2013,7 +2048,8 @@
     ]
   },
   {
-    "id": "pl4-36",
+    "setOrder"42:,
+	"id": "pl4-36",
     "name": "Gastly",
     "imageUrl": "https://images.pokemontcg.io/pl4/36.png",
     "subtype": "Basic",
@@ -2073,7 +2109,8 @@
     ]
   },
   {
-    "id": "pl4-37",
+    "setOrder"42:,
+	"id": "pl4-37",
     "name": "Graveler",
     "imageUrl": "https://images.pokemontcg.io/pl4/37.png",
     "subtype": "Stage 1",
@@ -2138,7 +2175,8 @@
     ]
   },
   {
-    "id": "pl4-38",
+    "setOrder"42:,
+	"id": "pl4-38",
     "name": "Grovyle",
     "imageUrl": "https://images.pokemontcg.io/pl4/38.png",
     "subtype": "Stage 1",
@@ -2199,7 +2237,8 @@
     ]
   },
   {
-    "id": "pl4-39",
+    "setOrder"42:,
+	"id": "pl4-39",
     "name": "Grovyle",
     "imageUrl": "https://images.pokemontcg.io/pl4/39.png",
     "subtype": "Stage 1",
@@ -2262,7 +2301,8 @@
     ]
   },
   {
-    "id": "pl4-40",
+    "setOrder"42:,
+	"id": "pl4-40",
     "name": "Gulpin",
     "imageUrl": "https://images.pokemontcg.io/pl4/40.png",
     "subtype": "Basic",
@@ -2316,7 +2356,8 @@
     ]
   },
   {
-    "id": "pl4-41",
+    "setOrder"42:,
+	"id": "pl4-41",
     "name": "Haunter",
     "imageUrl": "https://images.pokemontcg.io/pl4/41.png",
     "subtype": "Stage 1",
@@ -2373,7 +2414,8 @@
     ]
   },
   {
-    "id": "pl4-42",
+    "setOrder"42:,
+	"id": "pl4-42",
     "name": "Haunter",
     "imageUrl": "https://images.pokemontcg.io/pl4/42.png",
     "subtype": "Stage 1",
@@ -2434,7 +2476,8 @@
     ]
   },
   {
-    "id": "pl4-43",
+    "setOrder"42:,
+	"id": "pl4-43",
     "name": "Luxio",
     "imageUrl": "https://images.pokemontcg.io/pl4/43.png",
     "subtype": "Stage 1",
@@ -2496,7 +2539,8 @@
     ]
   },
   {
-    "id": "pl4-44",
+    "setOrder"42:,
+	"id": "pl4-44",
     "name": "Manectric",
     "imageUrl": "https://images.pokemontcg.io/pl4/44.png",
     "subtype": "Stage 1",
@@ -2552,7 +2596,8 @@
     "nationalPokedexNumber": 310
   },
   {
-    "id": "pl4-45",
+    "setOrder"42:,
+	"id": "pl4-45",
     "name": "Pelipper",
     "imageUrl": "https://images.pokemontcg.io/pl4/45.png",
     "subtype": "Stage 1",
@@ -2612,7 +2657,8 @@
     "nationalPokedexNumber": 279
   },
   {
-    "id": "pl4-46",
+    "setOrder"42:,
+	"id": "pl4-46",
     "name": "Ponyta",
     "imageUrl": "https://images.pokemontcg.io/pl4/46.png",
     "subtype": "Basic",
@@ -2666,7 +2712,8 @@
     ]
   },
   {
-    "id": "pl4-47",
+    "setOrder"42:,
+	"id": "pl4-47",
     "name": "Rapidash",
     "imageUrl": "https://images.pokemontcg.io/pl4/47.png",
     "subtype": "Stage 1",
@@ -2715,7 +2762,8 @@
     "nationalPokedexNumber": 78
   },
   {
-    "id": "pl4-48",
+    "setOrder"42:,
+	"id": "pl4-48",
     "name": "Shelgon",
     "imageUrl": "https://images.pokemontcg.io/pl4/48.png",
     "subtype": "Stage 1",
@@ -2771,7 +2819,8 @@
     ]
   },
   {
-    "id": "pl4-49",
+    "setOrder"42:,
+	"id": "pl4-49",
     "name": "Wormadam Plant Cloak",
     "imageUrl": "https://images.pokemontcg.io/pl4/49.png",
     "subtype": "Stage 1",
@@ -2827,7 +2876,8 @@
     ]
   },
   {
-    "id": "pl4-50",
+    "setOrder"42:,
+	"id": "pl4-50",
     "name": "Wormadam Sandy Cloak",
     "imageUrl": "https://images.pokemontcg.io/pl4/50.png",
     "subtype": "Stage 1",
@@ -2889,7 +2939,8 @@
     ]
   },
   {
-    "id": "pl4-51",
+    "setOrder"42:,
+	"id": "pl4-51",
     "name": "Wormadam Trash Cloak",
     "imageUrl": "https://images.pokemontcg.io/pl4/51.png",
     "subtype": "Stage 1",
@@ -2950,7 +3001,8 @@
     ]
   },
   {
-    "id": "pl4-52",
+    "setOrder"42:,
+	"id": "pl4-52",
     "name": "Bagon",
     "imageUrl": "https://images.pokemontcg.io/pl4/52.png",
     "subtype": "Basic",
@@ -3004,7 +3056,8 @@
     ]
   },
   {
-    "id": "pl4-53",
+    "setOrder"42:,
+	"id": "pl4-53",
     "name": "Beedrill G",
     "imageUrl": "https://images.pokemontcg.io/pl4/53.png",
     "subtype": "Basic",
@@ -3056,7 +3109,8 @@
     "nationalPokedexNumber": 15
   },
   {
-    "id": "pl4-54",
+    "setOrder"42:,
+	"id": "pl4-54",
     "name": "Bronzor",
     "imageUrl": "https://images.pokemontcg.io/pl4/54.png",
     "subtype": "Basic",
@@ -3117,7 +3171,8 @@
     ]
   },
   {
-    "id": "pl4-55",
+    "setOrder"42:,
+	"id": "pl4-55",
     "name": "Buneary",
     "imageUrl": "https://images.pokemontcg.io/pl4/55.png",
     "subtype": "Basic",
@@ -3161,7 +3216,8 @@
     ]
   },
   {
-    "id": "pl4-56",
+    "setOrder"42:,
+	"id": "pl4-56",
     "name": "Burmy Plant Cloak",
     "imageUrl": "https://images.pokemontcg.io/pl4/56.png",
     "subtype": "Basic",
@@ -3211,7 +3267,8 @@
     ]
   },
   {
-    "id": "pl4-57",
+    "setOrder"42:,
+	"id": "pl4-57",
     "name": "Burmy Sandy Cloak",
     "imageUrl": "https://images.pokemontcg.io/pl4/57.png",
     "subtype": "Basic",
@@ -3261,7 +3318,8 @@
     ]
   },
   {
-    "id": "pl4-58",
+    "setOrder"42:,
+	"id": "pl4-58",
     "name": "Burmy Trash Cloak",
     "imageUrl": "https://images.pokemontcg.io/pl4/58.png",
     "subtype": "Basic",
@@ -3311,7 +3369,8 @@
     ]
   },
   {
-    "id": "pl4-59",
+    "setOrder"42:,
+	"id": "pl4-59",
     "name": "Charmander",
     "imageUrl": "https://images.pokemontcg.io/pl4/59.png",
     "subtype": "Basic",
@@ -3365,7 +3424,8 @@
     ]
   },
   {
-    "id": "pl4-60",
+    "setOrder"42:,
+	"id": "pl4-60",
     "name": "Cherubi",
     "imageUrl": "https://images.pokemontcg.io/pl4/60.png",
     "subtype": "Basic",
@@ -3425,7 +3485,8 @@
     ]
   },
   {
-    "id": "pl4-61",
+    "setOrder"42:,
+	"id": "pl4-61",
     "name": "Croagunk",
     "imageUrl": "https://images.pokemontcg.io/pl4/61.png",
     "subtype": "Basic",
@@ -3479,7 +3540,8 @@
     ]
   },
   {
-    "id": "pl4-62",
+    "setOrder"42:,
+	"id": "pl4-62",
     "name": "Electrike",
     "imageUrl": "https://images.pokemontcg.io/pl4/62.png",
     "subtype": "Basic",
@@ -3539,7 +3601,8 @@
     ]
   },
   {
-    "id": "pl4-63",
+    "setOrder"42:,
+	"id": "pl4-63",
     "name": "Electrike",
     "imageUrl": "https://images.pokemontcg.io/pl4/63.png",
     "subtype": "Basic",
@@ -3589,7 +3652,8 @@
     ]
   },
   {
-    "id": "pl4-64",
+    "setOrder"42:,
+	"id": "pl4-64",
     "name": "Gastly",
     "imageUrl": "https://images.pokemontcg.io/pl4/64.png",
     "subtype": "Basic",
@@ -3649,7 +3713,8 @@
     ]
   },
   {
-    "id": "pl4-65",
+    "setOrder"42:,
+	"id": "pl4-65",
     "name": "Geodude",
     "imageUrl": "https://images.pokemontcg.io/pl4/65.png",
     "subtype": "Basic",
@@ -3700,7 +3765,8 @@
     ]
   },
   {
-    "id": "pl4-66",
+    "setOrder"42:,
+	"id": "pl4-66",
     "name": "Gulpin",
     "imageUrl": "https://images.pokemontcg.io/pl4/66.png",
     "subtype": "Basic",
@@ -3754,7 +3820,8 @@
     ]
   },
   {
-    "id": "pl4-67",
+    "setOrder"42:,
+	"id": "pl4-67",
     "name": "Kabuto",
     "imageUrl": "https://images.pokemontcg.io/pl4/67.png",
     "subtype": "Stage 1",
@@ -3809,7 +3876,8 @@
     ]
   },
   {
-    "id": "pl4-68",
+    "setOrder"42:,
+	"id": "pl4-68",
     "name": "Makuhita",
     "imageUrl": "https://images.pokemontcg.io/pl4/68.png",
     "subtype": "Basic",
@@ -3864,7 +3932,8 @@
     ]
   },
   {
-    "id": "pl4-69",
+    "setOrder"42:,
+	"id": "pl4-69",
     "name": "Nosepass",
     "imageUrl": "https://images.pokemontcg.io/pl4/69.png",
     "subtype": "Basic",
@@ -3918,7 +3987,8 @@
     ]
   },
   {
-    "id": "pl4-70",
+    "setOrder"42:,
+	"id": "pl4-70",
     "name": "Omanyte",
     "imageUrl": "https://images.pokemontcg.io/pl4/70.png",
     "subtype": "Stage 1",
@@ -3973,7 +4043,8 @@
     ]
   },
   {
-    "id": "pl4-71",
+    "setOrder"42:,
+	"id": "pl4-71",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/pl4/71.png",
     "subtype": "Basic",
@@ -4034,7 +4105,8 @@
     ]
   },
   {
-    "id": "pl4-72",
+    "setOrder"42:,
+	"id": "pl4-72",
     "name": "Ponyta",
     "imageUrl": "https://images.pokemontcg.io/pl4/72.png",
     "subtype": "Basic",
@@ -4088,7 +4160,8 @@
     ]
   },
   {
-    "id": "pl4-73",
+    "setOrder"42:,
+	"id": "pl4-73",
     "name": "Rattata",
     "imageUrl": "https://images.pokemontcg.io/pl4/73.png",
     "subtype": "Basic",
@@ -4129,7 +4202,8 @@
     ]
   },
   {
-    "id": "pl4-74",
+    "setOrder"42:,
+	"id": "pl4-74",
     "name": "Shinx",
     "imageUrl": "https://images.pokemontcg.io/pl4/74.png",
     "subtype": "Basic",
@@ -4189,7 +4263,8 @@
     ]
   },
   {
-    "id": "pl4-75",
+    "setOrder"42:,
+	"id": "pl4-75",
     "name": "Snorunt",
     "imageUrl": "https://images.pokemontcg.io/pl4/75.png",
     "subtype": "Basic",
@@ -4244,7 +4319,8 @@
     ]
   },
   {
-    "id": "pl4-76",
+    "setOrder"42:,
+	"id": "pl4-76",
     "name": "Tangela",
     "imageUrl": "https://images.pokemontcg.io/pl4/76.png",
     "subtype": "Basic",
@@ -4305,7 +4381,8 @@
     ]
   },
   {
-    "id": "pl4-77",
+    "setOrder"42:,
+	"id": "pl4-77",
     "name": "Tangela",
     "imageUrl": "https://images.pokemontcg.io/pl4/77.png",
     "subtype": "Basic",
@@ -4366,7 +4443,8 @@
     ]
   },
   {
-    "id": "pl4-78",
+    "setOrder"42:,
+	"id": "pl4-78",
     "name": "Treecko",
     "imageUrl": "https://images.pokemontcg.io/pl4/78.png",
     "subtype": "Basic",
@@ -4417,7 +4495,8 @@
     ]
   },
   {
-    "id": "pl4-79",
+    "setOrder"42:,
+	"id": "pl4-79",
     "name": "Treecko",
     "imageUrl": "https://images.pokemontcg.io/pl4/79.png",
     "subtype": "Basic",
@@ -4477,7 +4556,8 @@
     ]
   },
   {
-    "id": "pl4-80",
+    "setOrder"42:,
+	"id": "pl4-80",
     "name": "Wingull",
     "imageUrl": "https://images.pokemontcg.io/pl4/80.png",
     "subtype": "Basic",
@@ -4537,7 +4617,8 @@
     ]
   },
   {
-    "id": "pl4-81",
+    "setOrder"42:,
+	"id": "pl4-81",
     "name": "Wingull",
     "imageUrl": "https://images.pokemontcg.io/pl4/81.png",
     "subtype": "Basic",
@@ -4587,7 +4668,8 @@
     ]
   },
   {
-    "id": "pl4-82",
+    "setOrder"42:,
+	"id": "pl4-82",
     "name": "Beginning Door",
     "imageUrl": "https://images.pokemontcg.io/pl4/82.png",
     "subtype": "Item",
@@ -4605,7 +4687,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl4/82_hires.png"
   },
   {
-    "id": "pl4-83",
+    "setOrder"42:,
+	"id": "pl4-83",
     "name": "Bench Shield",
     "imageUrl": "https://images.pokemontcg.io/pl4/83.png",
     "subtype": "Pokémon Tool",
@@ -4624,7 +4707,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl4/83_hires.png"
   },
   {
-    "id": "pl4-84",
+    "setOrder"42:,
+	"id": "pl4-84",
     "name": "Buffer Piece",
     "imageUrl": "https://images.pokemontcg.io/pl4/84.png",
     "subtype": "Pokémon Tool",
@@ -4643,7 +4727,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl4/84_hires.png"
   },
   {
-    "id": "pl4-85",
+    "setOrder"42:,
+	"id": "pl4-85",
     "name": "Department Store Girl",
     "imageUrl": "https://images.pokemontcg.io/pl4/85.png",
     "subtype": "Supporter",
@@ -4662,7 +4747,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl4/85_hires.png"
   },
   {
-    "id": "pl4-86",
+    "setOrder"42:,
+	"id": "pl4-86",
     "name": "Energy Restore",
     "imageUrl": "https://images.pokemontcg.io/pl4/86.png",
     "subtype": "Item",
@@ -4680,7 +4766,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl4/86_hires.png"
   },
   {
-    "id": "pl4-87",
+    "setOrder"42:,
+	"id": "pl4-87",
     "name": "Expert Belt",
     "imageUrl": "https://images.pokemontcg.io/pl4/87.png",
     "subtype": "Pokémon Tool",
@@ -4699,7 +4786,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl4/87_hires.png"
   },
   {
-    "id": "pl4-88",
+    "setOrder"42:,
+	"id": "pl4-88",
     "name": "Lucky Egg",
     "imageUrl": "https://images.pokemontcg.io/pl4/88.png",
     "subtype": "Pokémon Tool",
@@ -4718,7 +4806,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl4/88_hires.png"
   },
   {
-    "id": "pl4-89",
+    "setOrder"42:,
+	"id": "pl4-89",
     "name": "Old Amber",
     "imageUrl": "https://images.pokemontcg.io/pl4/89.png",
     "subtype": "Item",
@@ -4737,7 +4826,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl4/89_hires.png"
   },
   {
-    "id": "pl4-90",
+    "setOrder"42:,
+	"id": "pl4-90",
     "name": "Professor Oak's Visit",
     "imageUrl": "https://images.pokemontcg.io/pl4/90.png",
     "subtype": "Supporter",
@@ -4756,7 +4846,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl4/90_hires.png"
   },
   {
-    "id": "pl4-91",
+    "setOrder"42:,
+	"id": "pl4-91",
     "name": "Ultimate Zone",
     "imageUrl": "https://images.pokemontcg.io/pl4/91.png",
     "subtype": "Stadium",
@@ -4774,7 +4865,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl4/91_hires.png"
   },
   {
-    "id": "pl4-92",
+    "setOrder"42:,
+	"id": "pl4-92",
     "name": "Dome Fossil",
     "imageUrl": "https://images.pokemontcg.io/pl4/92.png",
     "subtype": "Item",
@@ -4793,7 +4885,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl4/92_hires.png"
   },
   {
-    "id": "pl4-93",
+    "setOrder"42:,
+	"id": "pl4-93",
     "name": "Helix Fossil",
     "imageUrl": "https://images.pokemontcg.io/pl4/93.png",
     "subtype": "Item",
@@ -4812,7 +4905,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl4/93_hires.png"
   },
   {
-    "id": "pl4-94",
+    "setOrder"42:,
+	"id": "pl4-94",
     "name": "Arceus",
     "imageUrl": "https://images.pokemontcg.io/pl4/94.png",
     "subtype": "Level Up",
@@ -4844,7 +4938,8 @@
     "nationalPokedexNumber": 493
   },
   {
-    "id": "pl4-95",
+    "setOrder"42:,
+	"id": "pl4-95",
     "name": "Arceus",
     "imageUrl": "https://images.pokemontcg.io/pl4/95.png",
     "subtype": "Level Up",
@@ -4889,7 +4984,8 @@
     "nationalPokedexNumber": 493
   },
   {
-    "id": "pl4-96",
+    "setOrder"42:,
+	"id": "pl4-96",
     "name": "Arceus",
     "imageUrl": "https://images.pokemontcg.io/pl4/96.png",
     "subtype": "Level Up",
@@ -4934,7 +5030,8 @@
     "nationalPokedexNumber": 493
   },
   {
-    "id": "pl4-97",
+    "setOrder"42:,
+	"id": "pl4-97",
     "name": "Gengar",
     "imageUrl": "https://images.pokemontcg.io/pl4/97.png",
     "subtype": "Level Up",
@@ -4988,7 +5085,8 @@
     "nationalPokedexNumber": 94
   },
   {
-    "id": "pl4-98",
+    "setOrder"42:,
+	"id": "pl4-98",
     "name": "Salamence",
     "imageUrl": "https://images.pokemontcg.io/pl4/98.png",
     "subtype": "Level Up",
@@ -5047,7 +5145,8 @@
     "nationalPokedexNumber": 373
   },
   {
-    "id": "pl4-99",
+    "setOrder"42:,
+	"id": "pl4-99",
     "name": "Tangrowth",
     "imageUrl": "https://images.pokemontcg.io/pl4/99.png",
     "subtype": "Level Up",
@@ -5104,7 +5203,8 @@
     "nationalPokedexNumber": 465
   },
   {
-    "id": "pl4-SH10",
+    "setOrder"42:,
+	"id": "pl4-SH10",
     "name": "Bagon",
     "imageUrl": "https://images.pokemontcg.io/pl4/SH10.png",
     "subtype": "Basic",
@@ -5153,7 +5253,8 @@
     ]
   },
   {
-    "id": "pl4-SH11",
+    "setOrder"42:,
+	"id": "pl4-SH11",
     "name": "Ponyta",
     "imageUrl": "https://images.pokemontcg.io/pl4/SH11.png",
     "subtype": "Basic",
@@ -5203,7 +5304,8 @@
     ]
   },
   {
-    "id": "pl4-SH12",
+    "setOrder"42:,
+	"id": "pl4-SH12",
     "name": "Shinx",
     "imageUrl": "https://images.pokemontcg.io/pl4/SH12.png",
     "subtype": "Basic",
@@ -5258,7 +5360,8 @@
     ]
   },
   {
-    "id": "pl4-AR1",
+    "setOrder"42:,
+	"id": "pl4-AR1",
     "name": "Arceus",
     "imageUrl": "https://images.pokemontcg.io/pl4/AR1.png",
     "subtype": "Basic",
@@ -5306,7 +5409,8 @@
     "nationalPokedexNumber": 493
   },
   {
-    "id": "pl4-AR2",
+    "setOrder"42:,
+	"id": "pl4-AR2",
     "name": "Arceus",
     "imageUrl": "https://images.pokemontcg.io/pl4/AR2.png",
     "subtype": "Basic",
@@ -5355,7 +5459,8 @@
     "nationalPokedexNumber": 493
   },
   {
-    "id": "pl4-AR3",
+    "setOrder"42:,
+	"id": "pl4-AR3",
     "name": "Arceus",
     "imageUrl": "https://images.pokemontcg.io/pl4/AR3.png",
     "subtype": "Basic",
@@ -5398,7 +5503,8 @@
     "nationalPokedexNumber": 493
   },
   {
-    "id": "pl4-AR4",
+    "setOrder"42:,
+	"id": "pl4-AR4",
     "name": "Arceus",
     "imageUrl": "https://images.pokemontcg.io/pl4/AR4.png",
     "subtype": "Basic",
@@ -5442,7 +5548,8 @@
     "nationalPokedexNumber": 493
   },
   {
-    "id": "pl4-AR5",
+    "setOrder"42:,
+	"id": "pl4-AR5",
     "name": "Arceus",
     "imageUrl": "https://images.pokemontcg.io/pl4/AR5.png",
     "subtype": "Basic",
@@ -5494,7 +5601,8 @@
     "nationalPokedexNumber": 493
   },
   {
-    "id": "pl4-AR6",
+    "setOrder"42:,
+	"id": "pl4-AR6",
     "name": "Arceus",
     "imageUrl": "https://images.pokemontcg.io/pl4/AR6.png",
     "subtype": "Basic",
@@ -5542,7 +5650,8 @@
     "nationalPokedexNumber": 493
   },
   {
-    "id": "pl4-AR7",
+    "setOrder"42:,
+	"id": "pl4-AR7",
     "name": "Arceus",
     "imageUrl": "https://images.pokemontcg.io/pl4/AR7.png",
     "subtype": "Basic",
@@ -5585,7 +5694,8 @@
     "nationalPokedexNumber": 493
   },
   {
-    "id": "pl4-AR8",
+    "setOrder"42:,
+	"id": "pl4-AR8",
     "name": "Arceus",
     "imageUrl": "https://images.pokemontcg.io/pl4/AR8.png",
     "subtype": "Basic",
@@ -5635,7 +5745,8 @@
     "nationalPokedexNumber": 493
   },
   {
-    "id": "pl4-AR9",
+    "setOrder"42:,
+	"id": "pl4-AR9",
     "name": "Arceus",
     "imageUrl": "https://images.pokemontcg.io/pl4/AR9.png",
     "subtype": "Basic",

--- a/json/cards/BREAKpoint.json
+++ b/json/cards/BREAKpoint.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "xy9-1",
+    "setOrder":67,
+	"id": "xy9-1",
     "name": "Chikorita",
     "imageUrl": "https://images.pokemontcg.io/xy9/1.png",
     "subtype": "Basic",
@@ -53,7 +54,8 @@
     ]
   },
   {
-    "id": "xy9-2",
+    "setOrder":67,
+	"id": "xy9-2",
     "name": "Bayleef",
     "imageUrl": "https://images.pokemontcg.io/xy9/2.png",
     "subtype": "Stage 1",
@@ -108,7 +110,8 @@
     ]
   },
   {
-    "id": "xy9-3",
+    "setOrder":67,
+	"id": "xy9-3",
     "name": "Meganium",
     "imageUrl": "https://images.pokemontcg.io/xy9/3.png",
     "subtype": "Stage 2",
@@ -158,7 +161,8 @@
     "nationalPokedexNumber": 154
   },
   {
-    "id": "xy9-4",
+    "setOrder":67,
+	"id": "xy9-4",
     "name": "Seedot",
     "imageUrl": "https://images.pokemontcg.io/xy9/4.png",
     "subtype": "Basic",
@@ -201,7 +205,8 @@
     ]
   },
   {
-    "id": "xy9-5",
+    "setOrder":67,
+	"id": "xy9-5",
     "name": "Kricketot",
     "imageUrl": "https://images.pokemontcg.io/xy9/5.png",
     "subtype": "Basic",
@@ -244,7 +249,8 @@
     ]
   },
   {
-    "id": "xy9-6",
+    "setOrder":67,
+	"id": "xy9-6",
     "name": "Kricketune",
     "imageUrl": "https://images.pokemontcg.io/xy9/6.png",
     "subtype": "Stage 1",
@@ -294,7 +300,8 @@
     "nationalPokedexNumber": 402
   },
   {
-    "id": "xy9-7",
+    "setOrder":67,
+	"id": "xy9-7",
     "name": "Petilil",
     "imageUrl": "https://images.pokemontcg.io/xy9/7.png",
     "subtype": "Basic",
@@ -337,7 +344,8 @@
     ]
   },
   {
-    "id": "xy9-8",
+    "setOrder":67,
+	"id": "xy9-8",
     "name": "Lilligant",
     "imageUrl": "https://images.pokemontcg.io/xy9/8.png",
     "subtype": "Stage 1",
@@ -388,7 +396,8 @@
     "nationalPokedexNumber": 549
   },
   {
-    "id": "xy9-9",
+    "setOrder":67,
+	"id": "xy9-9",
     "name": "Durant",
     "imageUrl": "https://images.pokemontcg.io/xy9/9.png",
     "subtype": "Basic",
@@ -438,7 +447,8 @@
     "nationalPokedexNumber": 632
   },
   {
-    "id": "xy9-10",
+    "setOrder":67,
+	"id": "xy9-10",
     "name": "Growlithe",
     "imageUrl": "https://images.pokemontcg.io/xy9/10.png",
     "subtype": "Basic",
@@ -483,7 +493,8 @@
     ]
   },
   {
-    "id": "xy9-11",
+    "setOrder":67,
+	"id": "xy9-11",
     "name": "Arcanine",
     "imageUrl": "https://images.pokemontcg.io/xy9/11.png",
     "subtype": "Stage 1",
@@ -536,7 +547,8 @@
     "nationalPokedexNumber": 59
   },
   {
-    "id": "xy9-12",
+    "setOrder":67,
+	"id": "xy9-12",
     "name": "Numel",
     "imageUrl": "https://images.pokemontcg.io/xy9/12.png",
     "subtype": "Basic",
@@ -592,7 +604,8 @@
     ]
   },
   {
-    "id": "xy9-13",
+    "setOrder":67,
+	"id": "xy9-13",
     "name": "Camerupt",
     "imageUrl": "https://images.pokemontcg.io/xy9/13.png",
     "subtype": "Stage 1",
@@ -648,7 +661,8 @@
     "nationalPokedexNumber": 323
   },
   {
-    "id": "xy9-14",
+    "setOrder":67,
+	"id": "xy9-14",
     "name": "Emboar-EX",
     "imageUrl": "https://images.pokemontcg.io/xy9/14.png",
     "subtype": "EX",
@@ -706,7 +720,8 @@
     "nationalPokedexNumber": 500
   },
   {
-    "id": "xy9-15",
+    "setOrder":67,
+	"id": "xy9-15",
     "name": "Heatmor",
     "imageUrl": "https://images.pokemontcg.io/xy9/15.png",
     "subtype": "Basic",
@@ -758,7 +773,8 @@
     "nationalPokedexNumber": 631
   },
   {
-    "id": "xy9-16",
+    "setOrder":67,
+	"id": "xy9-16",
     "name": "Psyduck",
     "imageUrl": "https://images.pokemontcg.io/xy9/16.png",
     "subtype": "Basic",
@@ -802,7 +818,8 @@
     ]
   },
   {
-    "id": "xy9-17",
+    "setOrder":67,
+	"id": "xy9-17",
     "name": "Golduck",
     "imageUrl": "https://images.pokemontcg.io/xy9/17.png",
     "subtype": "Stage 1",
@@ -854,7 +871,8 @@
     "nationalPokedexNumber": 55
   },
   {
-    "id": "xy9-18",
+    "setOrder":67,
+	"id": "xy9-18",
     "name": "Golduck BREAK",
     "imageUrl": "https://images.pokemontcg.io/xy9/18.png",
     "subtype": "BREAK",
@@ -883,7 +901,8 @@
     "nationalPokedexNumber": 55
   },
   {
-    "id": "xy9-19",
+    "setOrder":67,
+	"id": "xy9-19",
     "name": "Slowpoke",
     "imageUrl": "https://images.pokemontcg.io/xy9/19.png",
     "subtype": "Basic",
@@ -938,7 +957,8 @@
     ]
   },
   {
-    "id": "xy9-20",
+    "setOrder":67,
+	"id": "xy9-20",
     "name": "Slowbro",
     "imageUrl": "https://images.pokemontcg.io/xy9/20.png",
     "subtype": "Stage 1",
@@ -991,7 +1011,8 @@
     "nationalPokedexNumber": 80
   },
   {
-    "id": "xy9-21",
+    "setOrder":67,
+	"id": "xy9-21",
     "name": "Slowking",
     "imageUrl": "https://images.pokemontcg.io/xy9/21.png",
     "subtype": "Stage 1",
@@ -1039,7 +1060,8 @@
     "nationalPokedexNumber": 199
   },
   {
-    "id": "xy9-22",
+    "setOrder":67,
+	"id": "xy9-22",
     "name": "Shellder",
     "imageUrl": "https://images.pokemontcg.io/xy9/22.png",
     "subtype": "Basic",
@@ -1083,7 +1105,8 @@
     ]
   },
   {
-    "id": "xy9-23",
+    "setOrder":67,
+	"id": "xy9-23",
     "name": "Shellder",
     "imageUrl": "https://images.pokemontcg.io/xy9/23.png",
     "subtype": "Basic",
@@ -1127,7 +1150,8 @@
     ]
   },
   {
-    "id": "xy9-24",
+    "setOrder":67,
+	"id": "xy9-24",
     "name": "Cloyster",
     "imageUrl": "https://images.pokemontcg.io/xy9/24.png",
     "subtype": "Stage 1",
@@ -1180,7 +1204,8 @@
     "nationalPokedexNumber": 91
   },
   {
-    "id": "xy9-25",
+    "setOrder":67,
+	"id": "xy9-25",
     "name": "Staryu",
     "imageUrl": "https://images.pokemontcg.io/xy9/25.png",
     "subtype": "Basic",
@@ -1220,7 +1245,8 @@
     ]
   },
   {
-    "id": "xy9-26",
+    "setOrder":67,
+	"id": "xy9-26",
     "name": "Gyarados-EX",
     "imageUrl": "https://images.pokemontcg.io/xy9/26.png",
     "subtype": "EX",
@@ -1279,7 +1305,8 @@
     "evolvesTo": "M Gyarados-EX"
   },
   {
-    "id": "xy9-27",
+    "setOrder":67,
+	"id": "xy9-27",
     "name": "M Gyarados-EX",
     "imageUrl": "https://images.pokemontcg.io/xy9/27.png",
     "subtype": "MEGA",
@@ -1328,7 +1355,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "xy9-28",
+    "setOrder":67,
+	"id": "xy9-28",
     "name": "Lapras",
     "imageUrl": "https://images.pokemontcg.io/xy9/28.png",
     "subtype": "Basic",
@@ -1380,7 +1408,8 @@
     "nationalPokedexNumber": 131
   },
   {
-    "id": "xy9-29",
+    "setOrder":67,
+	"id": "xy9-29",
     "name": "Corsola",
     "imageUrl": "https://images.pokemontcg.io/xy9/29.png",
     "subtype": "Basic",
@@ -1432,7 +1461,8 @@
     "nationalPokedexNumber": 222
   },
   {
-    "id": "xy9-30",
+    "setOrder":67,
+	"id": "xy9-30",
     "name": "Suicune",
     "imageUrl": "https://images.pokemontcg.io/xy9/30.png",
     "subtype": "Basic",
@@ -1479,7 +1509,8 @@
     "nationalPokedexNumber": 245
   },
   {
-    "id": "xy9-31",
+    "setOrder":67,
+	"id": "xy9-31",
     "name": "Palkia-EX",
     "imageUrl": "https://images.pokemontcg.io/xy9/31.png",
     "subtype": "EX",
@@ -1536,7 +1567,8 @@
     "nationalPokedexNumber": 484
   },
   {
-    "id": "xy9-32",
+    "setOrder":67,
+	"id": "xy9-32",
     "name": "Manaphy-EX",
     "imageUrl": "https://images.pokemontcg.io/xy9/32.png",
     "subtype": "EX",
@@ -1585,7 +1617,8 @@
     "nationalPokedexNumber": 490
   },
   {
-    "id": "xy9-33",
+    "setOrder":67,
+	"id": "xy9-33",
     "name": "Tympole",
     "imageUrl": "https://images.pokemontcg.io/xy9/33.png",
     "subtype": "Basic",
@@ -1638,7 +1671,8 @@
     ]
   },
   {
-    "id": "xy9-34",
+    "setOrder":67,
+	"id": "xy9-34",
     "name": "Palpitoad",
     "imageUrl": "https://images.pokemontcg.io/xy9/34.png",
     "subtype": "Stage 1",
@@ -1696,7 +1730,8 @@
     ]
   },
   {
-    "id": "xy9-35",
+    "setOrder":67,
+	"id": "xy9-35",
     "name": "Seismitoad",
     "imageUrl": "https://images.pokemontcg.io/xy9/35.png",
     "subtype": "Stage 2",
@@ -1751,7 +1786,8 @@
     "nationalPokedexNumber": 537
   },
   {
-    "id": "xy9-36",
+    "setOrder":67,
+	"id": "xy9-36",
     "name": "Ducklett",
     "imageUrl": "https://images.pokemontcg.io/xy9/36.png",
     "subtype": "Basic",
@@ -1800,7 +1836,8 @@
     ]
   },
   {
-    "id": "xy9-37",
+    "setOrder":67,
+	"id": "xy9-37",
     "name": "Swanna",
     "imageUrl": "https://images.pokemontcg.io/xy9/37.png",
     "subtype": "Stage 1",
@@ -1855,7 +1892,8 @@
     "nationalPokedexNumber": 581
   },
   {
-    "id": "xy9-38",
+    "setOrder":67,
+	"id": "xy9-38",
     "name": "Froakie",
     "imageUrl": "https://images.pokemontcg.io/xy9/38.png",
     "subtype": "Basic",
@@ -1898,7 +1936,8 @@
     ]
   },
   {
-    "id": "xy9-39",
+    "setOrder":67,
+	"id": "xy9-39",
     "name": "Frogadier",
     "imageUrl": "https://images.pokemontcg.io/xy9/39.png",
     "subtype": "Stage 1",
@@ -1942,7 +1981,8 @@
     ]
   },
   {
-    "id": "xy9-40",
+    "setOrder":67,
+	"id": "xy9-40",
     "name": "Greninja",
     "imageUrl": "https://images.pokemontcg.io/xy9/40.png",
     "subtype": "Stage 2",
@@ -1989,7 +2029,8 @@
     "nationalPokedexNumber": 658
   },
   {
-    "id": "xy9-41",
+    "setOrder":67,
+	"id": "xy9-41",
     "name": "Greninja BREAK",
     "imageUrl": "https://images.pokemontcg.io/xy9/41.png",
     "subtype": "BREAK",
@@ -2018,7 +2059,8 @@
     "nationalPokedexNumber": 658
   },
   {
-    "id": "xy9-42",
+    "setOrder":67,
+	"id": "xy9-42",
     "name": "Electabuzz",
     "imageUrl": "https://images.pokemontcg.io/xy9/42.png",
     "subtype": "Basic",
@@ -2063,7 +2105,8 @@
     ]
   },
   {
-    "id": "xy9-43",
+    "setOrder":67,
+	"id": "xy9-43",
     "name": "Electivire",
     "imageUrl": "https://images.pokemontcg.io/xy9/43.png",
     "subtype": "Stage 1",
@@ -2118,7 +2161,8 @@
     "nationalPokedexNumber": 466
   },
   {
-    "id": "xy9-44",
+    "setOrder":67,
+	"id": "xy9-44",
     "name": "Shinx",
     "imageUrl": "https://images.pokemontcg.io/xy9/44.png",
     "subtype": "Basic",
@@ -2176,7 +2220,8 @@
     ]
   },
   {
-    "id": "xy9-45",
+    "setOrder":67,
+	"id": "xy9-45",
     "name": "Luxio",
     "imageUrl": "https://images.pokemontcg.io/xy9/45.png",
     "subtype": "Stage 1",
@@ -2236,7 +2281,8 @@
     ]
   },
   {
-    "id": "xy9-46",
+    "setOrder":67,
+	"id": "xy9-46",
     "name": "Luxray",
     "imageUrl": "https://images.pokemontcg.io/xy9/46.png",
     "subtype": "Stage 2",
@@ -2295,7 +2341,8 @@
     "nationalPokedexNumber": 405
   },
   {
-    "id": "xy9-47",
+    "setOrder":67,
+	"id": "xy9-47",
     "name": "Luxray BREAK",
     "imageUrl": "https://images.pokemontcg.io/xy9/47.png",
     "subtype": "BREAK",
@@ -2333,7 +2380,8 @@
     "nationalPokedexNumber": 405
   },
   {
-    "id": "xy9-48",
+    "setOrder":67,
+	"id": "xy9-48",
     "name": "Blitzle",
     "imageUrl": "https://images.pokemontcg.io/xy9/48.png",
     "subtype": "Basic",
@@ -2382,7 +2430,8 @@
     ]
   },
   {
-    "id": "xy9-49",
+    "setOrder":67,
+	"id": "xy9-49",
     "name": "Zebstrika",
     "imageUrl": "https://images.pokemontcg.io/xy9/49.png",
     "subtype": "Stage 1",
@@ -2435,7 +2484,8 @@
     "nationalPokedexNumber": 523
   },
   {
-    "id": "xy9-50",
+    "setOrder":67,
+	"id": "xy9-50",
     "name": "Drowzee",
     "imageUrl": "https://images.pokemontcg.io/xy9/50.png",
     "subtype": "Basic",
@@ -2489,7 +2539,8 @@
     ]
   },
   {
-    "id": "xy9-51",
+    "setOrder":67,
+	"id": "xy9-51",
     "name": "Hypno",
     "imageUrl": "https://images.pokemontcg.io/xy9/51.png",
     "subtype": "Stage 1",
@@ -2537,7 +2588,8 @@
     "nationalPokedexNumber": 97
   },
   {
-    "id": "xy9-52",
+    "setOrder":67,
+	"id": "xy9-52",
     "name": "Espeon-EX",
     "imageUrl": "https://images.pokemontcg.io/xy9/52.png",
     "subtype": "EX",
@@ -2591,7 +2643,8 @@
     "nationalPokedexNumber": 196
   },
   {
-    "id": "xy9-53",
+    "setOrder":67,
+	"id": "xy9-53",
     "name": "Skorupi",
     "imageUrl": "https://images.pokemontcg.io/xy9/53.png",
     "subtype": "Basic",
@@ -2636,7 +2689,8 @@
     ]
   },
   {
-    "id": "xy9-54",
+    "setOrder":67,
+	"id": "xy9-54",
     "name": "Drapion",
     "imageUrl": "https://images.pokemontcg.io/xy9/54.png",
     "subtype": "Stage 1",
@@ -2694,7 +2748,8 @@
     "nationalPokedexNumber": 452
   },
   {
-    "id": "xy9-55",
+    "setOrder":67,
+	"id": "xy9-55",
     "name": "Sigilyph",
     "imageUrl": "https://images.pokemontcg.io/xy9/55.png",
     "subtype": "Basic",
@@ -2750,7 +2805,8 @@
     "nationalPokedexNumber": 561
   },
   {
-    "id": "xy9-56",
+    "setOrder":67,
+	"id": "xy9-56",
     "name": "Trubbish",
     "imageUrl": "https://images.pokemontcg.io/xy9/56.png",
     "subtype": "Basic",
@@ -2794,7 +2850,8 @@
     ]
   },
   {
-    "id": "xy9-57",
+    "setOrder":67,
+	"id": "xy9-57",
     "name": "Garbodor",
     "imageUrl": "https://images.pokemontcg.io/xy9/57.png",
     "subtype": "Stage 1",
@@ -2845,7 +2902,8 @@
     "nationalPokedexNumber": 569
   },
   {
-    "id": "xy9-58",
+    "setOrder":67,
+	"id": "xy9-58",
     "name": "Espurr",
     "imageUrl": "https://images.pokemontcg.io/xy9/58.png",
     "subtype": "Basic",
@@ -2888,7 +2946,8 @@
     ]
   },
   {
-    "id": "xy9-59",
+    "setOrder":67,
+	"id": "xy9-59",
     "name": "Meowstic",
     "imageUrl": "https://images.pokemontcg.io/xy9/59.png",
     "subtype": "Stage 1",
@@ -2939,7 +2998,8 @@
     "nationalPokedexNumber": 678
   },
   {
-    "id": "xy9-60",
+    "setOrder":67,
+	"id": "xy9-60",
     "name": "Honedge",
     "imageUrl": "https://images.pokemontcg.io/xy9/60.png",
     "subtype": "Basic",
@@ -2989,7 +3049,8 @@
     ]
   },
   {
-    "id": "xy9-61",
+    "setOrder":67,
+	"id": "xy9-61",
     "name": "Doublade",
     "imageUrl": "https://images.pokemontcg.io/xy9/61.png",
     "subtype": "Stage 1",
@@ -3041,7 +3102,8 @@
     ]
   },
   {
-    "id": "xy9-62",
+    "setOrder":67,
+	"id": "xy9-62",
     "name": "Aegislash",
     "imageUrl": "https://images.pokemontcg.io/xy9/62.png",
     "subtype": "Stage 2",
@@ -3104,7 +3166,8 @@
     "nationalPokedexNumber": 681
   },
   {
-    "id": "xy9-63",
+    "setOrder":67,
+	"id": "xy9-63",
     "name": "Skrelp",
     "imageUrl": "https://images.pokemontcg.io/xy9/63.png",
     "subtype": "Basic",
@@ -3147,7 +3210,8 @@
     ]
   },
   {
-    "id": "xy9-64",
+    "setOrder":67,
+	"id": "xy9-64",
     "name": "Phantump",
     "imageUrl": "https://images.pokemontcg.io/xy9/64.png",
     "subtype": "Basic",
@@ -3197,7 +3261,8 @@
     ]
   },
   {
-    "id": "xy9-65",
+    "setOrder":67,
+	"id": "xy9-65",
     "name": "Trevenant",
     "imageUrl": "https://images.pokemontcg.io/xy9/65.png",
     "subtype": "Stage 1",
@@ -3253,7 +3318,8 @@
     "nationalPokedexNumber": 709
   },
   {
-    "id": "xy9-66",
+    "setOrder":67,
+	"id": "xy9-66",
     "name": "Trevenant BREAK",
     "imageUrl": "https://images.pokemontcg.io/xy9/66.png",
     "subtype": "BREAK",
@@ -3289,7 +3355,8 @@
     "nationalPokedexNumber": 709
   },
   {
-    "id": "xy9-67",
+    "setOrder":67,
+	"id": "xy9-67",
     "name": "Sudowoodo",
     "imageUrl": "https://images.pokemontcg.io/xy9/67.png",
     "subtype": "Basic",
@@ -3331,7 +3398,8 @@
     "nationalPokedexNumber": 185
   },
   {
-    "id": "xy9-68",
+    "setOrder":67,
+	"id": "xy9-68",
     "name": "Gible",
     "imageUrl": "https://images.pokemontcg.io/xy9/68.png",
     "subtype": "Basic",
@@ -3374,7 +3442,8 @@
     ]
   },
   {
-    "id": "xy9-69",
+    "setOrder":67,
+	"id": "xy9-69",
     "name": "Gabite",
     "imageUrl": "https://images.pokemontcg.io/xy9/69.png",
     "subtype": "Stage 1",
@@ -3418,7 +3487,8 @@
     ]
   },
   {
-    "id": "xy9-70",
+    "setOrder":67,
+	"id": "xy9-70",
     "name": "Garchomp",
     "imageUrl": "https://images.pokemontcg.io/xy9/70.png",
     "subtype": "Stage 2",
@@ -3466,7 +3536,8 @@
     "nationalPokedexNumber": 445
   },
   {
-    "id": "xy9-71",
+    "setOrder":67,
+	"id": "xy9-71",
     "name": "Pancham",
     "imageUrl": "https://images.pokemontcg.io/xy9/71.png",
     "subtype": "Basic",
@@ -3520,7 +3591,8 @@
     ]
   },
   {
-    "id": "xy9-72",
+    "setOrder":67,
+	"id": "xy9-72",
     "name": "Nuzleaf",
     "imageUrl": "https://images.pokemontcg.io/xy9/72.png",
     "subtype": "Stage 1",
@@ -3580,7 +3652,8 @@
     ]
   },
   {
-    "id": "xy9-73",
+    "setOrder":67,
+	"id": "xy9-73",
     "name": "Shiftry",
     "imageUrl": "https://images.pokemontcg.io/xy9/73.png",
     "subtype": "Stage 2",
@@ -3639,7 +3712,8 @@
     "nationalPokedexNumber": 275
   },
   {
-    "id": "xy9-74",
+    "setOrder":67,
+	"id": "xy9-74",
     "name": "Darkrai-EX",
     "imageUrl": "https://images.pokemontcg.io/xy9/74.png",
     "subtype": "EX",
@@ -3701,7 +3775,8 @@
     "nationalPokedexNumber": 491
   },
   {
-    "id": "xy9-75",
+    "setOrder":67,
+	"id": "xy9-75",
     "name": "Pangoro",
     "imageUrl": "https://images.pokemontcg.io/xy9/75.png",
     "subtype": "Stage 1",
@@ -3761,7 +3836,8 @@
     "nationalPokedexNumber": 675
   },
   {
-    "id": "xy9-76",
+    "setOrder":67,
+	"id": "xy9-76",
     "name": "Scizor-EX",
     "imageUrl": "https://images.pokemontcg.io/xy9/76.png",
     "subtype": "EX",
@@ -3822,7 +3898,8 @@
     "evolvesTo": "M Scizor-EX"
   },
   {
-    "id": "xy9-77",
+    "setOrder":67,
+	"id": "xy9-77",
     "name": "M Scizor-EX",
     "imageUrl": "https://images.pokemontcg.io/xy9/77.png",
     "subtype": "MEGA",
@@ -3875,7 +3952,8 @@
     "nationalPokedexNumber": 212
   },
   {
-    "id": "xy9-78",
+    "setOrder":67,
+	"id": "xy9-78",
     "name": "Mawile",
     "imageUrl": "https://images.pokemontcg.io/xy9/78.png",
     "subtype": "Basic",
@@ -3932,7 +4010,8 @@
     "nationalPokedexNumber": 303
   },
   {
-    "id": "xy9-79",
+    "setOrder":67,
+	"id": "xy9-79",
     "name": "Ferroseed",
     "imageUrl": "https://images.pokemontcg.io/xy9/79.png",
     "subtype": "Basic",
@@ -3983,7 +4062,8 @@
     ]
   },
   {
-    "id": "xy9-80",
+    "setOrder":67,
+	"id": "xy9-80",
     "name": "Ferrothorn",
     "imageUrl": "https://images.pokemontcg.io/xy9/80.png",
     "subtype": "Stage 1",
@@ -4044,7 +4124,8 @@
     "nationalPokedexNumber": 598
   },
   {
-    "id": "xy9-81",
+    "setOrder":67,
+	"id": "xy9-81",
     "name": "Clefairy",
     "imageUrl": "https://images.pokemontcg.io/xy9/81.png",
     "subtype": "Basic",
@@ -4103,7 +4184,8 @@
     ]
   },
   {
-    "id": "xy9-82",
+    "setOrder":67,
+	"id": "xy9-82",
     "name": "Clefable",
     "imageUrl": "https://images.pokemontcg.io/xy9/82.png",
     "subtype": "Stage 1",
@@ -4161,7 +4243,8 @@
     "nationalPokedexNumber": 36
   },
   {
-    "id": "xy9-83",
+    "setOrder":67,
+	"id": "xy9-83",
     "name": "Togekiss-EX",
     "imageUrl": "https://images.pokemontcg.io/xy9/83.png",
     "subtype": "EX",
@@ -4222,7 +4305,8 @@
     "nationalPokedexNumber": 468
   },
   {
-    "id": "xy9-84",
+    "setOrder":67,
+	"id": "xy9-84",
     "name": "Spritzee",
     "imageUrl": "https://images.pokemontcg.io/xy9/84.png",
     "subtype": "Basic",
@@ -4271,7 +4355,8 @@
     ]
   },
   {
-    "id": "xy9-85",
+    "setOrder":67,
+	"id": "xy9-85",
     "name": "Aromatisse",
     "imageUrl": "https://images.pokemontcg.io/xy9/85.png",
     "subtype": "Stage 1",
@@ -4328,7 +4413,8 @@
     "nationalPokedexNumber": 683
   },
   {
-    "id": "xy9-86",
+    "setOrder":67,
+	"id": "xy9-86",
     "name": "Dragalge",
     "imageUrl": "https://images.pokemontcg.io/xy9/86.png",
     "subtype": "Stage 1",
@@ -4380,7 +4466,8 @@
     "nationalPokedexNumber": 691
   },
   {
-    "id": "xy9-87",
+    "setOrder":67,
+	"id": "xy9-87",
     "name": "Rattata",
     "imageUrl": "https://images.pokemontcg.io/xy9/87.png",
     "subtype": "Basic",
@@ -4423,7 +4510,8 @@
     ]
   },
   {
-    "id": "xy9-88",
+    "setOrder":67,
+	"id": "xy9-88",
     "name": "Raticate",
     "imageUrl": "https://images.pokemontcg.io/xy9/88.png",
     "subtype": "Stage 1",
@@ -4466,7 +4554,8 @@
     "nationalPokedexNumber": 20
   },
   {
-    "id": "xy9-89",
+    "setOrder":67,
+	"id": "xy9-89",
     "name": "Raticate BREAK",
     "imageUrl": "https://images.pokemontcg.io/xy9/89.png",
     "subtype": "BREAK",
@@ -4502,7 +4591,8 @@
     "nationalPokedexNumber": 20
   },
   {
-    "id": "xy9-90",
+    "setOrder":67,
+	"id": "xy9-90",
     "name": "Dunsparce",
     "imageUrl": "https://images.pokemontcg.io/xy9/90.png",
     "subtype": "Basic",
@@ -4551,7 +4641,8 @@
     "nationalPokedexNumber": 206
   },
   {
-    "id": "xy9-91",
+    "setOrder":67,
+	"id": "xy9-91",
     "name": "Stantler",
     "imageUrl": "https://images.pokemontcg.io/xy9/91.png",
     "subtype": "Basic",
@@ -4601,7 +4692,8 @@
     "nationalPokedexNumber": 234
   },
   {
-    "id": "xy9-92",
+    "setOrder":67,
+	"id": "xy9-92",
     "name": "Ho-Oh-EX",
     "imageUrl": "https://images.pokemontcg.io/xy9/92.png",
     "subtype": "EX",
@@ -4658,7 +4750,8 @@
     "nationalPokedexNumber": 250
   },
   {
-    "id": "xy9-93",
+    "setOrder":67,
+	"id": "xy9-93",
     "name": "Glameow",
     "imageUrl": "https://images.pokemontcg.io/xy9/93.png",
     "subtype": "Basic",
@@ -4711,7 +4804,8 @@
     ]
   },
   {
-    "id": "xy9-94",
+    "setOrder":67,
+	"id": "xy9-94",
     "name": "Purugly",
     "imageUrl": "https://images.pokemontcg.io/xy9/94.png",
     "subtype": "Stage 1",
@@ -4765,7 +4859,8 @@
     "nationalPokedexNumber": 432
   },
   {
-    "id": "xy9-95",
+    "setOrder":67,
+	"id": "xy9-95",
     "name": "Furfrou",
     "imageUrl": "https://images.pokemontcg.io/xy9/95.png",
     "subtype": "Basic",
@@ -4815,7 +4910,8 @@
     "nationalPokedexNumber": 676
   },
   {
-    "id": "xy9-96",
+    "setOrder":67,
+	"id": "xy9-96",
     "name": "All-Night Party",
     "imageUrl": "https://images.pokemontcg.io/xy9/96.png",
     "subtype": "Stadium",
@@ -4832,7 +4928,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy9/96_hires.png"
   },
   {
-    "id": "xy9-97",
+    "setOrder":67,
+	"id": "xy9-97",
     "name": "Bursting Balloon",
     "imageUrl": "https://images.pokemontcg.io/xy9/97.png",
     "subtype": "Pokémon Tool",
@@ -4849,7 +4946,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy9/97_hires.png"
   },
   {
-    "id": "xy9-98",
+    "setOrder":67,
+	"id": "xy9-98",
     "name": "Delinquent",
     "imageUrl": "https://images.pokemontcg.io/xy9/98.png",
     "subtype": "Supporter",
@@ -4866,7 +4964,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy9/98_hires.png"
   },
   {
-    "id": "xy9-98b",
+    "setOrder":67,
+	"id": "xy9-98b",
     "name": "Delinquent",
     "imageUrl": "https://images.pokemontcg.io/xy9/98b.png",
     "subtype": "Supporter",
@@ -4883,7 +4982,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy9/98b_hires.png"
   },
   {
-    "id": "xy9-99",
+    "setOrder":67,
+	"id": "xy9-99",
     "name": "Fighting Fury Belt",
     "imageUrl": "https://images.pokemontcg.io/xy9/99.png",
     "subtype": "Pokémon Tool",
@@ -4900,7 +5000,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy9/99_hires.png"
   },
   {
-    "id": "xy9-100",
+    "setOrder":67,
+	"id": "xy9-100",
     "name": "Great Ball",
     "imageUrl": "https://images.pokemontcg.io/xy9/100.png",
     "subtype": "Item",
@@ -4917,7 +5018,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy9/100_hires.png"
   },
   {
-    "id": "xy9-101",
+    "setOrder":67,
+	"id": "xy9-101",
     "name": "Gyarados Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xy9/101.png",
     "subtype": "Pokémon Tool",
@@ -4934,7 +5036,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy9/101_hires.png"
   },
   {
-    "id": "xy9-102",
+    "setOrder":67,
+	"id": "xy9-102",
     "name": "Max Elixir",
     "imageUrl": "https://images.pokemontcg.io/xy9/102.png",
     "subtype": "Item",
@@ -4951,7 +5054,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy9/102_hires.png"
   },
   {
-    "id": "xy9-103",
+    "setOrder":67,
+	"id": "xy9-103",
     "name": "Max Potion",
     "imageUrl": "https://images.pokemontcg.io/xy9/103.png",
     "subtype": "Item",
@@ -4968,7 +5072,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy9/103_hires.png"
   },
   {
-    "id": "xy9-104",
+    "setOrder":67,
+	"id": "xy9-104",
     "name": "Misty's Determination",
     "imageUrl": "https://images.pokemontcg.io/xy9/104.png",
     "subtype": "Supporter",
@@ -4985,7 +5090,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy9/104_hires.png"
   },
   {
-    "id": "xy9-105",
+    "setOrder":67,
+	"id": "xy9-105",
     "name": "Pokémon Catcher",
     "imageUrl": "https://images.pokemontcg.io/xy9/105.png",
     "subtype": "Item",
@@ -5002,7 +5108,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy9/105_hires.png"
   },
   {
-    "id": "xy9-106",
+    "setOrder":67,
+	"id": "xy9-106",
     "name": "Potion",
     "imageUrl": "https://images.pokemontcg.io/xy9/106.png",
     "subtype": "Item",
@@ -5019,7 +5126,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy9/106_hires.png"
   },
   {
-    "id": "xy9-107",
+    "setOrder":67,
+	"id": "xy9-107",
     "name": "Professor Sycamore",
     "imageUrl": "https://images.pokemontcg.io/xy9/107.png",
     "subtype": "Supporter",
@@ -5036,7 +5144,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy9/107_hires.png"
   },
   {
-    "id": "xy9-107a",
+    "setOrder":67,
+	"id": "xy9-107a",
     "name": "Professor Sycamore",
     "imageUrl": "https://images.pokemontcg.io/xy9/107a.png",
     "subtype": "Supporter",
@@ -5053,7 +5162,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy9/107a_hires.png"
   },
   {
-    "id": "xy9-108",
+    "setOrder":67,
+	"id": "xy9-108",
     "name": "Psychic's Third Eye",
     "imageUrl": "https://images.pokemontcg.io/xy9/108.png",
     "subtype": "Supporter",
@@ -5070,7 +5180,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy9/108_hires.png"
   },
   {
-    "id": "xy9-109",
+    "setOrder":67,
+	"id": "xy9-109",
     "name": "Puzzle of Time",
     "imageUrl": "https://images.pokemontcg.io/xy9/109.png",
     "subtype": "Item",
@@ -5087,7 +5198,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy9/109_hires.png"
   },
   {
-    "id": "xy9-110",
+    "setOrder":67,
+	"id": "xy9-110",
     "name": "Reverse Valley",
     "imageUrl": "https://images.pokemontcg.io/xy9/110.png",
     "subtype": "Stadium",
@@ -5105,7 +5217,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy9/110_hires.png"
   },
   {
-    "id": "xy9-111",
+    "setOrder":67,
+	"id": "xy9-111",
     "name": "Scizor Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xy9/111.png",
     "subtype": "Pokémon Tool",
@@ -5122,7 +5235,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy9/111_hires.png"
   },
   {
-    "id": "xy9-112",
+    "setOrder":67,
+	"id": "xy9-112",
     "name": "Tierno",
     "imageUrl": "https://images.pokemontcg.io/xy9/112.png",
     "subtype": "Supporter",
@@ -5139,7 +5253,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy9/112_hires.png"
   },
   {
-    "id": "xy9-113",
+    "setOrder":67,
+	"id": "xy9-113",
     "name": "Splash Energy",
     "imageUrl": "https://images.pokemontcg.io/xy9/113.png",
     "subtype": "Special",
@@ -5156,7 +5271,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy9/113_hires.png"
   },
   {
-    "id": "xy9-114",
+    "setOrder":67,
+	"id": "xy9-114",
     "name": "Gyarados-EX",
     "imageUrl": "https://images.pokemontcg.io/xy9/114.png",
     "subtype": "EX",
@@ -5215,7 +5331,8 @@
     "evolvesTo": "M Gyarados-EX"
   },
   {
-    "id": "xy9-115",
+    "setOrder":67,
+	"id": "xy9-115",
     "name": "M Gyarados-EX",
     "imageUrl": "https://images.pokemontcg.io/xy9/115.png",
     "subtype": "MEGA",
@@ -5264,7 +5381,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "xy9-116",
+    "setOrder":67,
+	"id": "xy9-116",
     "name": "Manaphy-EX",
     "imageUrl": "https://images.pokemontcg.io/xy9/116.png",
     "subtype": "EX",
@@ -5313,7 +5431,8 @@
     "nationalPokedexNumber": 490
   },
   {
-    "id": "xy9-117",
+    "setOrder":67,
+	"id": "xy9-117",
     "name": "Espeon-EX",
     "imageUrl": "https://images.pokemontcg.io/xy9/117.png",
     "subtype": "EX",
@@ -5367,7 +5486,8 @@
     "nationalPokedexNumber": 196
   },
   {
-    "id": "xy9-118",
+    "setOrder":67,
+	"id": "xy9-118",
     "name": "Darkrai-EX",
     "imageUrl": "https://images.pokemontcg.io/xy9/118.png",
     "subtype": "EX",
@@ -5429,7 +5549,8 @@
     "nationalPokedexNumber": 491
   },
   {
-    "id": "xy9-119",
+    "setOrder":67,
+	"id": "xy9-119",
     "name": "Scizor-EX",
     "imageUrl": "https://images.pokemontcg.io/xy9/119.png",
     "subtype": "EX",
@@ -5490,7 +5611,8 @@
     "evolvesTo": "M Scizor-EX"
   },
   {
-    "id": "xy9-120",
+    "setOrder":67,
+	"id": "xy9-120",
     "name": "M Scizor-EX",
     "imageUrl": "https://images.pokemontcg.io/xy9/120.png",
     "subtype": "MEGA",
@@ -5543,7 +5665,8 @@
     "nationalPokedexNumber": 212
   },
   {
-    "id": "xy9-121",
+    "setOrder":67,
+	"id": "xy9-121",
     "name": "Ho-Oh-EX",
     "imageUrl": "https://images.pokemontcg.io/xy9/121.png",
     "subtype": "EX",
@@ -5600,7 +5723,8 @@
     "nationalPokedexNumber": 250
   },
   {
-    "id": "xy9-122",
+    "setOrder":67,
+	"id": "xy9-122",
     "name": "Skyla",
     "imageUrl": "https://images.pokemontcg.io/xy9/122.png",
     "subtype": "Supporter",
@@ -5617,7 +5741,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy9/122_hires.png"
   },
   {
-    "id": "xy9-123",
+    "setOrder":67,
+	"id": "xy9-123",
     "name": "Gyarados-EX",
     "imageUrl": "https://images.pokemontcg.io/xy9/123.png",
     "subtype": "EX",

--- a/json/cards/BREAKthrough.json
+++ b/json/cards/BREAKthrough.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "xy8-1",
+    "setOrder":66,
+	"id": "xy8-1",
     "name": "Paras",
     "imageUrl": "https://images.pokemontcg.io/xy8/1.png",
     "subtype": "Basic",
@@ -43,7 +44,8 @@
     ]
   },
   {
-    "id": "xy8-2",
+    "setOrder":66,
+	"id": "xy8-2",
     "name": "Parasect",
     "imageUrl": "https://images.pokemontcg.io/xy8/2.png",
     "subtype": "Stage 1",
@@ -95,7 +97,8 @@
     "nationalPokedexNumber": 47
   },
   {
-    "id": "xy8-3",
+    "setOrder":66,
+	"id": "xy8-3",
     "name": "Pinsir",
     "imageUrl": "https://images.pokemontcg.io/xy8/3.png",
     "subtype": "Basic",
@@ -147,7 +150,8 @@
     "nationalPokedexNumber": 127
   },
   {
-    "id": "xy8-4",
+    "setOrder":66,
+	"id": "xy8-4",
     "name": "Cacnea",
     "imageUrl": "https://images.pokemontcg.io/xy8/4.png",
     "subtype": "Basic",
@@ -190,7 +194,8 @@
     ]
   },
   {
-    "id": "xy8-5",
+    "setOrder":66,
+	"id": "xy8-5",
     "name": "Pansage",
     "imageUrl": "https://images.pokemontcg.io/xy8/5.png",
     "subtype": "Basic",
@@ -233,7 +238,8 @@
     ]
   },
   {
-    "id": "xy8-6",
+    "setOrder":66,
+	"id": "xy8-6",
     "name": "Simisage",
     "imageUrl": "https://images.pokemontcg.io/xy8/6.png",
     "subtype": "Stage 1",
@@ -284,7 +290,8 @@
     "nationalPokedexNumber": 512
   },
   {
-    "id": "xy8-7",
+    "setOrder":66,
+	"id": "xy8-7",
     "name": "Chespin",
     "imageUrl": "https://images.pokemontcg.io/xy8/7.png",
     "subtype": "Basic",
@@ -338,7 +345,8 @@
     ]
   },
   {
-    "id": "xy8-8",
+    "setOrder":66,
+	"id": "xy8-8",
     "name": "Chespin",
     "imageUrl": "https://images.pokemontcg.io/xy8/8.png",
     "subtype": "Basic",
@@ -392,7 +400,8 @@
     ]
   },
   {
-    "id": "xy8-9",
+    "setOrder":66,
+	"id": "xy8-9",
     "name": "Chespin",
     "imageUrl": "https://images.pokemontcg.io/xy8/9.png",
     "subtype": "Basic",
@@ -446,7 +455,8 @@
     ]
   },
   {
-    "id": "xy8-10",
+    "setOrder":66,
+	"id": "xy8-10",
     "name": "Quilladin",
     "imageUrl": "https://images.pokemontcg.io/xy8/10.png",
     "subtype": "Stage 1",
@@ -504,7 +514,8 @@
     ]
   },
   {
-    "id": "xy8-11",
+    "setOrder":66,
+	"id": "xy8-11",
     "name": "Chesnaught",
     "imageUrl": "https://images.pokemontcg.io/xy8/11.png",
     "subtype": "Stage 2",
@@ -562,7 +573,8 @@
     "nationalPokedexNumber": 652
   },
   {
-    "id": "xy8-12",
+    "setOrder":66,
+	"id": "xy8-12",
     "name": "Chesnaught BREAK",
     "imageUrl": "https://images.pokemontcg.io/xy8/12.png",
     "subtype": "BREAK",
@@ -600,7 +612,8 @@
     "nationalPokedexNumber": 652
   },
   {
-    "id": "xy8-13",
+    "setOrder":66,
+	"id": "xy8-13",
     "name": "Scatterbug",
     "imageUrl": "https://images.pokemontcg.io/xy8/13.png",
     "subtype": "Basic",
@@ -653,7 +666,8 @@
     ]
   },
   {
-    "id": "xy8-14",
+    "setOrder":66,
+	"id": "xy8-14",
     "name": "Spewpa",
     "imageUrl": "https://images.pokemontcg.io/xy8/14.png",
     "subtype": "Stage 1",
@@ -708,7 +722,8 @@
     ]
   },
   {
-    "id": "xy8-15",
+    "setOrder":66,
+	"id": "xy8-15",
     "name": "Vivillon",
     "imageUrl": "https://images.pokemontcg.io/xy8/15.png",
     "subtype": "Stage 2",
@@ -756,7 +771,8 @@
     "nationalPokedexNumber": 666
   },
   {
-    "id": "xy8-16",
+    "setOrder":66,
+	"id": "xy8-16",
     "name": "Skiddo",
     "imageUrl": "https://images.pokemontcg.io/xy8/16.png",
     "subtype": "Basic",
@@ -810,7 +826,8 @@
     ]
   },
   {
-    "id": "xy8-17",
+    "setOrder":66,
+	"id": "xy8-17",
     "name": "Gogoat",
     "imageUrl": "https://images.pokemontcg.io/xy8/17.png",
     "subtype": "Stage 1",
@@ -863,7 +880,8 @@
     "nationalPokedexNumber": 673
   },
   {
-    "id": "xy8-18",
+    "setOrder":66,
+	"id": "xy8-18",
     "name": "Cyndaquil",
     "imageUrl": "https://images.pokemontcg.io/xy8/18.png",
     "subtype": "Basic",
@@ -916,7 +934,8 @@
     ]
   },
   {
-    "id": "xy8-19",
+    "setOrder":66,
+	"id": "xy8-19",
     "name": "Quilava",
     "imageUrl": "https://images.pokemontcg.io/xy8/19.png",
     "subtype": "Stage 1",
@@ -961,7 +980,8 @@
     ]
   },
   {
-    "id": "xy8-20",
+    "setOrder":66,
+	"id": "xy8-20",
     "name": "Typhlosion",
     "imageUrl": "https://images.pokemontcg.io/xy8/20.png",
     "subtype": "Stage 2",
@@ -1015,7 +1035,8 @@
     "nationalPokedexNumber": 157
   },
   {
-    "id": "xy8-21",
+    "setOrder":66,
+	"id": "xy8-21",
     "name": "Houndoom-EX",
     "imageUrl": "https://images.pokemontcg.io/xy8/21.png",
     "subtype": "EX",
@@ -1070,7 +1091,8 @@
     "evolvesTo": "M Houndoom-EX"
   },
   {
-    "id": "xy8-22",
+    "setOrder":66,
+	"id": "xy8-22",
     "name": "M Houndoom-EX",
     "imageUrl": "https://images.pokemontcg.io/xy8/22.png",
     "subtype": "MEGA",
@@ -1116,7 +1138,8 @@
     "nationalPokedexNumber": 229
   },
   {
-    "id": "xy8-23",
+    "setOrder":66,
+	"id": "xy8-23",
     "name": "Pansear",
     "imageUrl": "https://images.pokemontcg.io/xy8/23.png",
     "subtype": "Basic",
@@ -1159,7 +1182,8 @@
     ]
   },
   {
-    "id": "xy8-24",
+    "setOrder":66,
+	"id": "xy8-24",
     "name": "Simisear",
     "imageUrl": "https://images.pokemontcg.io/xy8/24.png",
     "subtype": "Stage 1",
@@ -1210,7 +1234,8 @@
     "nationalPokedexNumber": 514
   },
   {
-    "id": "xy8-25",
+    "setOrder":66,
+	"id": "xy8-25",
     "name": "Fennekin",
     "imageUrl": "https://images.pokemontcg.io/xy8/25.png",
     "subtype": "Basic",
@@ -1254,7 +1279,8 @@
     ]
   },
   {
-    "id": "xy8-26",
+    "setOrder":66,
+	"id": "xy8-26",
     "name": "Braixen",
     "imageUrl": "https://images.pokemontcg.io/xy8/26.png",
     "subtype": "Stage 1",
@@ -1300,7 +1326,8 @@
     ]
   },
   {
-    "id": "xy8-27",
+    "setOrder":66,
+	"id": "xy8-27",
     "name": "Goldeen",
     "imageUrl": "https://images.pokemontcg.io/xy8/27.png",
     "subtype": "Basic",
@@ -1343,7 +1370,8 @@
     ]
   },
   {
-    "id": "xy8-28",
+    "setOrder":66,
+	"id": "xy8-28",
     "name": "Seaking",
     "imageUrl": "https://images.pokemontcg.io/xy8/28.png",
     "subtype": "Stage 1",
@@ -1394,7 +1422,8 @@
     "nationalPokedexNumber": 119
   },
   {
-    "id": "xy8-29",
+    "setOrder":66,
+	"id": "xy8-29",
     "name": "Staryu",
     "imageUrl": "https://images.pokemontcg.io/xy8/29.png",
     "subtype": "Basic",
@@ -1437,7 +1466,8 @@
     ]
   },
   {
-    "id": "xy8-30",
+    "setOrder":66,
+	"id": "xy8-30",
     "name": "Starmie",
     "imageUrl": "https://images.pokemontcg.io/xy8/30.png",
     "subtype": "Stage 1",
@@ -1488,7 +1518,8 @@
     "nationalPokedexNumber": 121
   },
   {
-    "id": "xy8-31",
+    "setOrder":66,
+	"id": "xy8-31",
     "name": "Remoraid",
     "imageUrl": "https://images.pokemontcg.io/xy8/31.png",
     "subtype": "Basic",
@@ -1541,7 +1572,8 @@
     ]
   },
   {
-    "id": "xy8-32",
+    "setOrder":66,
+	"id": "xy8-32",
     "name": "Remoraid",
     "imageUrl": "https://images.pokemontcg.io/xy8/32.png",
     "subtype": "Basic",
@@ -1594,7 +1626,8 @@
     ]
   },
   {
-    "id": "xy8-33",
+    "setOrder":66,
+	"id": "xy8-33",
     "name": "Octillery",
     "imageUrl": "https://images.pokemontcg.io/xy8/33.png",
     "subtype": "Stage 1",
@@ -1643,7 +1676,8 @@
     "nationalPokedexNumber": 224
   },
   {
-    "id": "xy8-34",
+    "setOrder":66,
+	"id": "xy8-34",
     "name": "Glalie-EX",
     "imageUrl": "https://images.pokemontcg.io/xy8/34.png",
     "subtype": "EX",
@@ -1700,7 +1734,8 @@
     "evolvesTo": "M Glalie-EX"
   },
   {
-    "id": "xy8-35",
+    "setOrder":66,
+	"id": "xy8-35",
     "name": "M Glalie-EX",
     "imageUrl": "https://images.pokemontcg.io/xy8/35.png",
     "subtype": "MEGA",
@@ -1749,7 +1784,8 @@
     "nationalPokedexNumber": 362
   },
   {
-    "id": "xy8-36",
+    "setOrder":66,
+	"id": "xy8-36",
     "name": "Piplup",
     "imageUrl": "https://images.pokemontcg.io/xy8/36.png",
     "subtype": "Basic",
@@ -1793,7 +1829,8 @@
     ]
   },
   {
-    "id": "xy8-37",
+    "setOrder":66,
+	"id": "xy8-37",
     "name": "Prinplup",
     "imageUrl": "https://images.pokemontcg.io/xy8/37.png",
     "subtype": "Stage 1",
@@ -1838,7 +1875,8 @@
     ]
   },
   {
-    "id": "xy8-38",
+    "setOrder":66,
+	"id": "xy8-38",
     "name": "Empoleon",
     "imageUrl": "https://images.pokemontcg.io/xy8/38.png",
     "subtype": "Stage 2",
@@ -1886,7 +1924,8 @@
     "nationalPokedexNumber": 395
   },
   {
-    "id": "xy8-39",
+    "setOrder":66,
+	"id": "xy8-39",
     "name": "Snover",
     "imageUrl": "https://images.pokemontcg.io/xy8/39.png",
     "subtype": "Basic",
@@ -1942,7 +1981,8 @@
     ]
   },
   {
-    "id": "xy8-40",
+    "setOrder":66,
+	"id": "xy8-40",
     "name": "Abomasnow",
     "imageUrl": "https://images.pokemontcg.io/xy8/40.png",
     "subtype": "Stage 1",
@@ -2000,7 +2040,8 @@
     "nationalPokedexNumber": 460
   },
   {
-    "id": "xy8-41",
+    "setOrder":66,
+	"id": "xy8-41",
     "name": "Panpour",
     "imageUrl": "https://images.pokemontcg.io/xy8/41.png",
     "subtype": "Basic",
@@ -2043,7 +2084,8 @@
     ]
   },
   {
-    "id": "xy8-42",
+    "setOrder":66,
+	"id": "xy8-42",
     "name": "Simipour",
     "imageUrl": "https://images.pokemontcg.io/xy8/42.png",
     "subtype": "Stage 1",
@@ -2094,7 +2136,8 @@
     "nationalPokedexNumber": 516
   },
   {
-    "id": "xy8-43",
+    "setOrder":66,
+	"id": "xy8-43",
     "name": "Vanillite",
     "imageUrl": "https://images.pokemontcg.io/xy8/43.png",
     "subtype": "Basic",
@@ -2147,7 +2190,8 @@
     ]
   },
   {
-    "id": "xy8-44",
+    "setOrder":66,
+	"id": "xy8-44",
     "name": "Vanillish",
     "imageUrl": "https://images.pokemontcg.io/xy8/44.png",
     "subtype": "Stage 1",
@@ -2202,7 +2246,8 @@
     ]
   },
   {
-    "id": "xy8-45",
+    "setOrder":66,
+	"id": "xy8-45",
     "name": "Vanilluxe",
     "imageUrl": "https://images.pokemontcg.io/xy8/45.png",
     "subtype": "Stage 2",
@@ -2255,7 +2300,8 @@
     "nationalPokedexNumber": 584
   },
   {
-    "id": "xy8-46",
+    "setOrder":66,
+	"id": "xy8-46",
     "name": "Froakie",
     "imageUrl": "https://images.pokemontcg.io/xy8/46.png",
     "subtype": "Basic",
@@ -2298,7 +2344,8 @@
     ]
   },
   {
-    "id": "xy8-47",
+    "setOrder":66,
+	"id": "xy8-47",
     "name": "Frogadier",
     "imageUrl": "https://images.pokemontcg.io/xy8/47.png",
     "subtype": "Stage 1",
@@ -2343,7 +2390,8 @@
     ]
   },
   {
-    "id": "xy8-48",
+    "setOrder":66,
+	"id": "xy8-48",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/xy8/48.png",
     "subtype": "Basic",
@@ -2402,7 +2450,8 @@
     ]
   },
   {
-    "id": "xy8-49",
+    "setOrder":66,
+	"id": "xy8-49",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/xy8/49.png",
     "subtype": "Stage 1",
@@ -2458,7 +2507,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "xy8-50",
+    "setOrder":66,
+	"id": "xy8-50",
     "name": "Raichu BREAK",
     "imageUrl": "https://images.pokemontcg.io/xy8/50.png",
     "subtype": "BREAK",
@@ -2495,7 +2545,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "xy8-51",
+    "setOrder":66,
+	"id": "xy8-51",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/xy8/51.png",
     "subtype": "Basic",
@@ -2550,7 +2601,8 @@
     ]
   },
   {
-    "id": "xy8-52",
+    "setOrder":66,
+	"id": "xy8-52",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/xy8/52.png",
     "subtype": "Basic",
@@ -2609,7 +2661,8 @@
     ]
   },
   {
-    "id": "xy8-53",
+    "setOrder":66,
+	"id": "xy8-53",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/xy8/53.png",
     "subtype": "Stage 1",
@@ -2670,7 +2723,8 @@
     ]
   },
   {
-    "id": "xy8-54",
+    "setOrder":66,
+	"id": "xy8-54",
     "name": "Magnezone",
     "imageUrl": "https://images.pokemontcg.io/xy8/54.png",
     "subtype": "Stage 2",
@@ -2726,7 +2780,8 @@
     "nationalPokedexNumber": 462
   },
   {
-    "id": "xy8-55",
+    "setOrder":66,
+	"id": "xy8-55",
     "name": "Raikou",
     "imageUrl": "https://images.pokemontcg.io/xy8/55.png",
     "subtype": "Basic",
@@ -2779,7 +2834,8 @@
     "nationalPokedexNumber": 243
   },
   {
-    "id": "xy8-56",
+    "setOrder":66,
+	"id": "xy8-56",
     "name": "Stunfisk",
     "imageUrl": "https://images.pokemontcg.io/xy8/56.png",
     "subtype": "Basic",
@@ -2839,7 +2895,8 @@
     "nationalPokedexNumber": 618
   },
   {
-    "id": "xy8-57",
+    "setOrder":66,
+	"id": "xy8-57",
     "name": "Dedenne",
     "imageUrl": "https://images.pokemontcg.io/xy8/57.png",
     "subtype": "Basic",
@@ -2885,7 +2942,8 @@
     "nationalPokedexNumber": 702
   },
   {
-    "id": "xy8-58",
+    "setOrder":66,
+	"id": "xy8-58",
     "name": "Gastly",
     "imageUrl": "https://images.pokemontcg.io/xy8/58.png",
     "subtype": "Basic",
@@ -2934,7 +2992,8 @@
     ]
   },
   {
-    "id": "xy8-59",
+    "setOrder":66,
+	"id": "xy8-59",
     "name": "Haunter",
     "imageUrl": "https://images.pokemontcg.io/xy8/59.png",
     "subtype": "Stage 1",
@@ -2990,7 +3049,8 @@
     ]
   },
   {
-    "id": "xy8-60",
+    "setOrder":66,
+	"id": "xy8-60",
     "name": "Gengar",
     "imageUrl": "https://images.pokemontcg.io/xy8/60.png",
     "subtype": "Stage 2",
@@ -3044,7 +3104,8 @@
     "nationalPokedexNumber": 94
   },
   {
-    "id": "xy8-61",
+    "setOrder":66,
+	"id": "xy8-61",
     "name": "Mewtwo-EX",
     "imageUrl": "https://images.pokemontcg.io/xy8/61.png",
     "subtype": "EX",
@@ -3102,7 +3163,8 @@
     "evolvesTo": "M Mewtwo-EX"
   },
   {
-    "id": "xy8-62",
+    "setOrder":66,
+	"id": "xy8-62",
     "name": "Mewtwo-EX",
     "imageUrl": "https://images.pokemontcg.io/xy8/62.png",
     "subtype": "EX",
@@ -3158,7 +3220,8 @@
     "evolvesTo": "M Mewtwo-EX"
   },
   {
-    "id": "xy8-63",
+    "setOrder":66,
+	"id": "xy8-63",
     "name": "M Mewtwo-EX",
     "imageUrl": "https://images.pokemontcg.io/xy8/63.png",
     "subtype": "MEGA",
@@ -3208,7 +3271,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "xy8-64",
+    "setOrder":66,
+	"id": "xy8-64",
     "name": "M Mewtwo-EX",
     "imageUrl": "https://images.pokemontcg.io/xy8/64.png",
     "subtype": "MEGA",
@@ -3255,7 +3319,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "xy8-65",
+    "setOrder":66,
+	"id": "xy8-65",
     "name": "Misdreavus",
     "imageUrl": "https://images.pokemontcg.io/xy8/65.png",
     "subtype": "Basic",
@@ -3304,7 +3369,8 @@
     ]
   },
   {
-    "id": "xy8-66",
+    "setOrder":66,
+	"id": "xy8-66",
     "name": "Mismagius",
     "imageUrl": "https://images.pokemontcg.io/xy8/66.png",
     "subtype": "Stage 1",
@@ -3358,7 +3424,8 @@
     "nationalPokedexNumber": 429
   },
   {
-    "id": "xy8-67",
+    "setOrder":66,
+	"id": "xy8-67",
     "name": "Wobbuffet",
     "imageUrl": "https://images.pokemontcg.io/xy8/67.png",
     "subtype": "Basic",
@@ -3411,7 +3478,8 @@
     "nationalPokedexNumber": 202
   },
   {
-    "id": "xy8-68",
+    "setOrder":66,
+	"id": "xy8-68",
     "name": "Ralts",
     "imageUrl": "https://images.pokemontcg.io/xy8/68.png",
     "subtype": "Basic",
@@ -3464,7 +3532,8 @@
     ]
   },
   {
-    "id": "xy8-69",
+    "setOrder":66,
+	"id": "xy8-69",
     "name": "Kirlia",
     "imageUrl": "https://images.pokemontcg.io/xy8/69.png",
     "subtype": "Stage 1",
@@ -3519,7 +3588,8 @@
     ]
   },
   {
-    "id": "xy8-70",
+    "setOrder":66,
+	"id": "xy8-70",
     "name": "Cresselia",
     "imageUrl": "https://images.pokemontcg.io/xy8/70.png",
     "subtype": "Basic",
@@ -3567,7 +3637,8 @@
     "nationalPokedexNumber": 488
   },
   {
-    "id": "xy8-71",
+    "setOrder":66,
+	"id": "xy8-71",
     "name": "Woobat",
     "imageUrl": "https://images.pokemontcg.io/xy8/71.png",
     "subtype": "Basic",
@@ -3625,7 +3696,8 @@
     ]
   },
   {
-    "id": "xy8-72",
+    "setOrder":66,
+	"id": "xy8-72",
     "name": "Swoobat",
     "imageUrl": "https://images.pokemontcg.io/xy8/72.png",
     "subtype": "Stage 1",
@@ -3681,7 +3753,8 @@
     "nationalPokedexNumber": 528
   },
   {
-    "id": "xy8-73",
+    "setOrder":66,
+	"id": "xy8-73",
     "name": "Elgyem",
     "imageUrl": "https://images.pokemontcg.io/xy8/73.png",
     "subtype": "Basic",
@@ -3724,7 +3797,8 @@
     ]
   },
   {
-    "id": "xy8-74",
+    "setOrder":66,
+	"id": "xy8-74",
     "name": "Beheeyem",
     "imageUrl": "https://images.pokemontcg.io/xy8/74.png",
     "subtype": "Stage 1",
@@ -3775,7 +3849,8 @@
     "nationalPokedexNumber": 606
   },
   {
-    "id": "xy8-75",
+    "setOrder":66,
+	"id": "xy8-75",
     "name": "Sandshrew",
     "imageUrl": "https://images.pokemontcg.io/xy8/75.png",
     "subtype": "Basic",
@@ -3828,7 +3903,8 @@
     ]
   },
   {
-    "id": "xy8-76",
+    "setOrder":66,
+	"id": "xy8-76",
     "name": "Sandslash",
     "imageUrl": "https://images.pokemontcg.io/xy8/76.png",
     "subtype": "Stage 1",
@@ -3880,7 +3956,8 @@
     "nationalPokedexNumber": 28
   },
   {
-    "id": "xy8-77",
+    "setOrder":66,
+	"id": "xy8-77",
     "name": "Cubone",
     "imageUrl": "https://images.pokemontcg.io/xy8/77.png",
     "subtype": "Basic",
@@ -3925,7 +4002,8 @@
     ]
   },
   {
-    "id": "xy8-78",
+    "setOrder":66,
+	"id": "xy8-78",
     "name": "Marowak",
     "imageUrl": "https://images.pokemontcg.io/xy8/78.png",
     "subtype": "Stage 1",
@@ -3977,7 +4055,8 @@
     "nationalPokedexNumber": 105
   },
   {
-    "id": "xy8-79",
+    "setOrder":66,
+	"id": "xy8-79",
     "name": "Marowak BREAK",
     "imageUrl": "https://images.pokemontcg.io/xy8/79.png",
     "subtype": "BREAK",
@@ -4013,7 +4092,8 @@
     "nationalPokedexNumber": 105
   },
   {
-    "id": "xy8-80",
+    "setOrder":66,
+	"id": "xy8-80",
     "name": "Swinub",
     "imageUrl": "https://images.pokemontcg.io/xy8/80.png",
     "subtype": "Basic",
@@ -4067,7 +4147,8 @@
     ]
   },
   {
-    "id": "xy8-81",
+    "setOrder":66,
+	"id": "xy8-81",
     "name": "Piloswine",
     "imageUrl": "https://images.pokemontcg.io/xy8/81.png",
     "subtype": "Stage 1",
@@ -4124,7 +4205,8 @@
     ]
   },
   {
-    "id": "xy8-82",
+    "setOrder":66,
+	"id": "xy8-82",
     "name": "Mamoswine",
     "imageUrl": "https://images.pokemontcg.io/xy8/82.png",
     "subtype": "Stage 2",
@@ -4176,7 +4258,8 @@
     "nationalPokedexNumber": 473
   },
   {
-    "id": "xy8-83",
+    "setOrder":66,
+	"id": "xy8-83",
     "name": "Hippopotas",
     "imageUrl": "https://images.pokemontcg.io/xy8/83.png",
     "subtype": "Basic",
@@ -4223,7 +4306,8 @@
     ]
   },
   {
-    "id": "xy8-84",
+    "setOrder":66,
+	"id": "xy8-84",
     "name": "Gallade",
     "imageUrl": "https://images.pokemontcg.io/xy8/84.png",
     "subtype": "Stage 2",
@@ -4271,7 +4355,8 @@
     "nationalPokedexNumber": 475
   },
   {
-    "id": "xy8-85",
+    "setOrder":66,
+	"id": "xy8-85",
     "name": "Meloetta",
     "imageUrl": "https://images.pokemontcg.io/xy8/85.png",
     "subtype": "Basic",
@@ -4322,7 +4407,8 @@
     "nationalPokedexNumber": 648
   },
   {
-    "id": "xy8-86",
+    "setOrder":66,
+	"id": "xy8-86",
     "name": "Pancham",
     "imageUrl": "https://images.pokemontcg.io/xy8/86.png",
     "subtype": "Basic",
@@ -4367,7 +4453,8 @@
     ]
   },
   {
-    "id": "xy8-87",
+    "setOrder":66,
+	"id": "xy8-87",
     "name": "Hawlucha",
     "imageUrl": "https://images.pokemontcg.io/xy8/87.png",
     "subtype": "Basic",
@@ -4423,7 +4510,8 @@
     "nationalPokedexNumber": 701
   },
   {
-    "id": "xy8-88",
+    "setOrder":66,
+	"id": "xy8-88",
     "name": "Cacturne",
     "imageUrl": "https://images.pokemontcg.io/xy8/88.png",
     "subtype": "Stage 1",
@@ -4481,7 +4569,8 @@
     "nationalPokedexNumber": 332
   },
   {
-    "id": "xy8-89",
+    "setOrder":66,
+	"id": "xy8-89",
     "name": "Zorua",
     "imageUrl": "https://images.pokemontcg.io/xy8/89.png",
     "subtype": "Basic",
@@ -4540,7 +4629,8 @@
     ]
   },
   {
-    "id": "xy8-90",
+    "setOrder":66,
+	"id": "xy8-90",
     "name": "Zorua",
     "imageUrl": "https://images.pokemontcg.io/xy8/90.png",
     "subtype": "Basic",
@@ -4599,7 +4689,8 @@
     ]
   },
   {
-    "id": "xy8-91",
+    "setOrder":66,
+	"id": "xy8-91",
     "name": "Zoroark",
     "imageUrl": "https://images.pokemontcg.io/xy8/91.png",
     "subtype": "Stage 1",
@@ -4653,7 +4744,8 @@
     "nationalPokedexNumber": 571
   },
   {
-    "id": "xy8-92",
+    "setOrder":66,
+	"id": "xy8-92",
     "name": "Zoroark BREAK",
     "imageUrl": "https://images.pokemontcg.io/xy8/92.png",
     "subtype": "BREAK",
@@ -4688,7 +4780,8 @@
     "nationalPokedexNumber": 571
   },
   {
-    "id": "xy8-93",
+    "setOrder":66,
+	"id": "xy8-93",
     "name": "Inkay",
     "imageUrl": "https://images.pokemontcg.io/xy8/93.png",
     "subtype": "Basic",
@@ -4738,7 +4831,8 @@
     ]
   },
   {
-    "id": "xy8-94",
+    "setOrder":66,
+	"id": "xy8-94",
     "name": "Yveltal",
     "imageUrl": "https://images.pokemontcg.io/xy8/94.png",
     "subtype": "Basic",
@@ -4792,7 +4886,8 @@
     "nationalPokedexNumber": 717
   },
   {
-    "id": "xy8-95",
+    "setOrder":66,
+	"id": "xy8-95",
     "name": "Bronzor",
     "imageUrl": "https://images.pokemontcg.io/xy8/95.png",
     "subtype": "Basic",
@@ -4843,7 +4938,8 @@
     ]
   },
   {
-    "id": "xy8-96",
+    "setOrder":66,
+	"id": "xy8-96",
     "name": "Bronzong",
     "imageUrl": "https://images.pokemontcg.io/xy8/96.png",
     "subtype": "Stage 1",
@@ -4904,7 +5000,8 @@
     "nationalPokedexNumber": 437
   },
   {
-    "id": "xy8-97",
+    "setOrder":66,
+	"id": "xy8-97",
     "name": "Mr. Mime",
     "imageUrl": "https://images.pokemontcg.io/xy8/97.png",
     "subtype": "Basic",
@@ -4956,7 +5053,8 @@
     "nationalPokedexNumber": 122
   },
   {
-    "id": "xy8-98",
+    "setOrder":66,
+	"id": "xy8-98",
     "name": "Snubbull",
     "imageUrl": "https://images.pokemontcg.io/xy8/98.png",
     "subtype": "Basic",
@@ -5017,7 +5115,8 @@
     ]
   },
   {
-    "id": "xy8-99",
+    "setOrder":66,
+	"id": "xy8-99",
     "name": "Granbull",
     "imageUrl": "https://images.pokemontcg.io/xy8/99.png",
     "subtype": "Stage 1",
@@ -5078,7 +5177,8 @@
     "nationalPokedexNumber": 210
   },
   {
-    "id": "xy8-100",
+    "setOrder":66,
+	"id": "xy8-100",
     "name": "Ralts",
     "imageUrl": "https://images.pokemontcg.io/xy8/100.png",
     "subtype": "Basic",
@@ -5137,7 +5237,8 @@
     ]
   },
   {
-    "id": "xy8-101",
+    "setOrder":66,
+	"id": "xy8-101",
     "name": "Flabébé",
     "imageUrl": "https://images.pokemontcg.io/xy8/101.png",
     "subtype": "Basic",
@@ -5186,7 +5287,8 @@
     ]
   },
   {
-    "id": "xy8-102",
+    "setOrder":66,
+	"id": "xy8-102",
     "name": "Floette",
     "imageUrl": "https://images.pokemontcg.io/xy8/102.png",
     "subtype": "Stage 1",
@@ -5246,7 +5348,8 @@
     ]
   },
   {
-    "id": "xy8-103",
+    "setOrder":66,
+	"id": "xy8-103",
     "name": "Florges",
     "imageUrl": "https://images.pokemontcg.io/xy8/103.png",
     "subtype": "Stage 2",
@@ -5300,7 +5403,8 @@
     "nationalPokedexNumber": 671
   },
   {
-    "id": "xy8-104",
+    "setOrder":66,
+	"id": "xy8-104",
     "name": "Florges BREAK",
     "imageUrl": "https://images.pokemontcg.io/xy8/104.png",
     "subtype": "BREAK",
@@ -5329,7 +5433,8 @@
     "nationalPokedexNumber": 671
   },
   {
-    "id": "xy8-105",
+    "setOrder":66,
+	"id": "xy8-105",
     "name": "Spritzee",
     "imageUrl": "https://images.pokemontcg.io/xy8/105.png",
     "subtype": "Basic",
@@ -5378,7 +5483,8 @@
     ]
   },
   {
-    "id": "xy8-106",
+    "setOrder":66,
+	"id": "xy8-106",
     "name": "Aromatisse",
     "imageUrl": "https://images.pokemontcg.io/xy8/106.png",
     "subtype": "Stage 1",
@@ -5434,7 +5540,8 @@
     "nationalPokedexNumber": 683
   },
   {
-    "id": "xy8-107",
+    "setOrder":66,
+	"id": "xy8-107",
     "name": "Xerneas",
     "imageUrl": "https://images.pokemontcg.io/xy8/107.png",
     "subtype": "Basic",
@@ -5495,7 +5602,8 @@
     "nationalPokedexNumber": 716
   },
   {
-    "id": "xy8-108",
+    "setOrder":66,
+	"id": "xy8-108",
     "name": "Axew",
     "imageUrl": "https://images.pokemontcg.io/xy8/108.png",
     "subtype": "Basic",
@@ -5550,7 +5658,8 @@
     ]
   },
   {
-    "id": "xy8-109",
+    "setOrder":66,
+	"id": "xy8-109",
     "name": "Axew",
     "imageUrl": "https://images.pokemontcg.io/xy8/109.png",
     "subtype": "Basic",
@@ -5605,7 +5714,8 @@
     ]
   },
   {
-    "id": "xy8-110",
+    "setOrder":66,
+	"id": "xy8-110",
     "name": "Fraxure",
     "imageUrl": "https://images.pokemontcg.io/xy8/110.png",
     "subtype": "Stage 1",
@@ -5661,7 +5771,8 @@
     ]
   },
   {
-    "id": "xy8-111",
+    "setOrder":66,
+	"id": "xy8-111",
     "name": "Haxorus",
     "imageUrl": "https://images.pokemontcg.io/xy8/111.png",
     "subtype": "Stage 2",
@@ -5723,7 +5834,8 @@
     "nationalPokedexNumber": 612
   },
   {
-    "id": "xy8-112",
+    "setOrder":66,
+	"id": "xy8-112",
     "name": "Noivern",
     "imageUrl": "https://images.pokemontcg.io/xy8/112.png",
     "subtype": "Stage 1",
@@ -5775,7 +5887,8 @@
     "nationalPokedexNumber": 715
   },
   {
-    "id": "xy8-113",
+    "setOrder":66,
+	"id": "xy8-113",
     "name": "Noivern BREAK",
     "imageUrl": "https://images.pokemontcg.io/xy8/113.png",
     "subtype": "BREAK",
@@ -5812,7 +5925,8 @@
     "nationalPokedexNumber": 715
   },
   {
-    "id": "xy8-114",
+    "setOrder":66,
+	"id": "xy8-114",
     "name": "Meowth",
     "imageUrl": "https://images.pokemontcg.io/xy8/114.png",
     "subtype": "Basic",
@@ -5855,7 +5969,8 @@
     ]
   },
   {
-    "id": "xy8-115",
+    "setOrder":66,
+	"id": "xy8-115",
     "name": "Doduo",
     "imageUrl": "https://images.pokemontcg.io/xy8/115.png",
     "subtype": "Basic",
@@ -5914,7 +6029,8 @@
     ]
   },
   {
-    "id": "xy8-116",
+    "setOrder":66,
+	"id": "xy8-116",
     "name": "Doduo",
     "imageUrl": "https://images.pokemontcg.io/xy8/116.png",
     "subtype": "Basic",
@@ -5973,7 +6089,8 @@
     ]
   },
   {
-    "id": "xy8-117",
+    "setOrder":66,
+	"id": "xy8-117",
     "name": "Dodrio",
     "imageUrl": "https://images.pokemontcg.io/xy8/117.png",
     "subtype": "Stage 1",
@@ -6027,7 +6144,8 @@
     "nationalPokedexNumber": 85
   },
   {
-    "id": "xy8-118",
+    "setOrder":66,
+	"id": "xy8-118",
     "name": "Snorlax",
     "imageUrl": "https://images.pokemontcg.io/xy8/118.png",
     "subtype": "Basic",
@@ -6078,7 +6196,8 @@
     "nationalPokedexNumber": 143
   },
   {
-    "id": "xy8-119",
+    "setOrder":66,
+	"id": "xy8-119",
     "name": "Hoothoot",
     "imageUrl": "https://images.pokemontcg.io/xy8/119.png",
     "subtype": "Basic",
@@ -6128,7 +6247,8 @@
     ]
   },
   {
-    "id": "xy8-120",
+    "setOrder":66,
+	"id": "xy8-120",
     "name": "Noctowl",
     "imageUrl": "https://images.pokemontcg.io/xy8/120.png",
     "subtype": "Stage 1",
@@ -6187,7 +6307,8 @@
     "nationalPokedexNumber": 164
   },
   {
-    "id": "xy8-121",
+    "setOrder":66,
+	"id": "xy8-121",
     "name": "Teddiursa",
     "imageUrl": "https://images.pokemontcg.io/xy8/121.png",
     "subtype": "Basic",
@@ -6232,7 +6353,8 @@
     ]
   },
   {
-    "id": "xy8-122",
+    "setOrder":66,
+	"id": "xy8-122",
     "name": "Ursaring",
     "imageUrl": "https://images.pokemontcg.io/xy8/122.png",
     "subtype": "Stage 1",
@@ -6289,7 +6411,8 @@
     "nationalPokedexNumber": 217
   },
   {
-    "id": "xy8-123",
+    "setOrder":66,
+	"id": "xy8-123",
     "name": "Smeargle",
     "imageUrl": "https://images.pokemontcg.io/xy8/123.png",
     "subtype": "Basic",
@@ -6335,7 +6458,8 @@
     "nationalPokedexNumber": 235
   },
   {
-    "id": "xy8-124",
+    "setOrder":66,
+	"id": "xy8-124",
     "name": "Swablu",
     "imageUrl": "https://images.pokemontcg.io/xy8/124.png",
     "subtype": "Basic",
@@ -6384,7 +6508,8 @@
     ]
   },
   {
-    "id": "xy8-125",
+    "setOrder":66,
+	"id": "xy8-125",
     "name": "Starly",
     "imageUrl": "https://images.pokemontcg.io/xy8/125.png",
     "subtype": "Basic",
@@ -6433,7 +6558,8 @@
     ]
   },
   {
-    "id": "xy8-126",
+    "setOrder":66,
+	"id": "xy8-126",
     "name": "Staravia",
     "imageUrl": "https://images.pokemontcg.io/xy8/126.png",
     "subtype": "Stage 1",
@@ -6493,7 +6619,8 @@
     ]
   },
   {
-    "id": "xy8-127",
+    "setOrder":66,
+	"id": "xy8-127",
     "name": "Staraptor",
     "imageUrl": "https://images.pokemontcg.io/xy8/127.png",
     "subtype": "Stage 2",
@@ -6552,7 +6679,8 @@
     "nationalPokedexNumber": 398
   },
   {
-    "id": "xy8-128",
+    "setOrder":66,
+	"id": "xy8-128",
     "name": "Chatot",
     "imageUrl": "https://images.pokemontcg.io/xy8/128.png",
     "subtype": "Basic",
@@ -6608,7 +6736,8 @@
     "nationalPokedexNumber": 441
   },
   {
-    "id": "xy8-129",
+    "setOrder":66,
+	"id": "xy8-129",
     "name": "Rufflet",
     "imageUrl": "https://images.pokemontcg.io/xy8/129.png",
     "subtype": "Basic",
@@ -6658,7 +6787,8 @@
     ]
   },
   {
-    "id": "xy8-130",
+    "setOrder":66,
+	"id": "xy8-130",
     "name": "Braviary",
     "imageUrl": "https://images.pokemontcg.io/xy8/130.png",
     "subtype": "Stage 1",
@@ -6719,7 +6849,8 @@
     "nationalPokedexNumber": 628
   },
   {
-    "id": "xy8-131",
+    "setOrder":66,
+	"id": "xy8-131",
     "name": "Noibat",
     "imageUrl": "https://images.pokemontcg.io/xy8/131.png",
     "subtype": "Basic",
@@ -6768,7 +6899,8 @@
     ]
   },
   {
-    "id": "xy8-132",
+    "setOrder":66,
+	"id": "xy8-132",
     "name": "Noibat",
     "imageUrl": "https://images.pokemontcg.io/xy8/132.png",
     "subtype": "Basic",
@@ -6827,7 +6959,8 @@
     ]
   },
   {
-    "id": "xy8-133",
+    "setOrder":66,
+	"id": "xy8-133",
     "name": "Assault Vest",
     "imageUrl": "https://images.pokemontcg.io/xy8/133.png",
     "subtype": "Pokémon Tool",
@@ -6844,7 +6977,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/133_hires.png"
   },
   {
-    "id": "xy8-134",
+    "setOrder":66,
+	"id": "xy8-134",
     "name": "Brigette",
     "imageUrl": "https://images.pokemontcg.io/xy8/134.png",
     "subtype": "Supporter",
@@ -6861,7 +6995,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/134_hires.png"
   },
   {
-    "id": "xy8-135",
+    "setOrder":66,
+	"id": "xy8-135",
     "name": "Buddy-Buddy Rescue",
     "imageUrl": "https://images.pokemontcg.io/xy8/135.png",
     "subtype": "Item",
@@ -6878,7 +7013,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/135_hires.png"
   },
   {
-    "id": "xy8-136",
+    "setOrder":66,
+	"id": "xy8-136",
     "name": "Fisherman",
     "imageUrl": "https://images.pokemontcg.io/xy8/136.png",
     "subtype": "Supporter",
@@ -6895,7 +7031,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/136_hires.png"
   },
   {
-    "id": "xy8-137",
+    "setOrder":66,
+	"id": "xy8-137",
     "name": "Float Stone",
     "imageUrl": "https://images.pokemontcg.io/xy8/137.png",
     "subtype": "Pokémon Tool",
@@ -6912,7 +7049,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/137_hires.png"
   },
   {
-    "id": "xy8-138",
+    "setOrder":66,
+	"id": "xy8-138",
     "name": "Giovanni's Scheme",
     "imageUrl": "https://images.pokemontcg.io/xy8/138.png",
     "subtype": "Supporter",
@@ -6929,7 +7067,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/138_hires.png"
   },
   {
-    "id": "xy8-139",
+    "setOrder":66,
+	"id": "xy8-139",
     "name": "Glalie Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xy8/139.png",
     "subtype": "Pokémon Tool",
@@ -6946,7 +7085,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/139_hires.png"
   },
   {
-    "id": "xy8-140",
+    "setOrder":66,
+	"id": "xy8-140",
     "name": "Heavy Ball",
     "imageUrl": "https://images.pokemontcg.io/xy8/140.png",
     "subtype": "Item",
@@ -6963,7 +7103,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/140_hires.png"
   },
   {
-    "id": "xy8-141",
+    "setOrder":66,
+	"id": "xy8-141",
     "name": "Heavy Boots",
     "imageUrl": "https://images.pokemontcg.io/xy8/141.png",
     "subtype": "Pokémon Tool",
@@ -6980,7 +7121,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/141_hires.png"
   },
   {
-    "id": "xy8-142",
+    "setOrder":66,
+	"id": "xy8-142",
     "name": "Houndoom Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xy8/142.png",
     "subtype": "Pokémon Tool",
@@ -6997,7 +7139,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/142_hires.png"
   },
   {
-    "id": "xy8-143",
+    "setOrder":66,
+	"id": "xy8-143",
     "name": "Judge",
     "imageUrl": "https://images.pokemontcg.io/xy8/143.png",
     "subtype": "Supporter",
@@ -7014,7 +7157,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/143_hires.png"
   },
   {
-    "id": "xy8-144",
+    "setOrder":66,
+	"id": "xy8-144",
     "name": "Mewtwo Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xy8/144.png",
     "subtype": "Pokémon Tool",
@@ -7031,7 +7175,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/144_hires.png"
   },
   {
-    "id": "xy8-145",
+    "setOrder":66,
+	"id": "xy8-145",
     "name": "Parallel City",
     "imageUrl": "https://images.pokemontcg.io/xy8/145.png",
     "subtype": "Stadium",
@@ -7049,7 +7194,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/145_hires.png"
   },
   {
-    "id": "xy8-146",
+    "setOrder":66,
+	"id": "xy8-146",
     "name": "Professor's Letter",
     "imageUrl": "https://images.pokemontcg.io/xy8/146.png",
     "subtype": "Item",
@@ -7066,7 +7212,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/146_hires.png"
   },
   {
-    "id": "xy8-147",
+    "setOrder":66,
+	"id": "xy8-147",
     "name": "Reserved Ticket",
     "imageUrl": "https://images.pokemontcg.io/xy8/147.png",
     "subtype": "Item",
@@ -7083,7 +7230,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/147_hires.png"
   },
   {
-    "id": "xy8-148",
+    "setOrder":66,
+	"id": "xy8-148",
     "name": "Skyla",
     "imageUrl": "https://images.pokemontcg.io/xy8/148.png",
     "subtype": "Supporter",
@@ -7100,7 +7248,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/148_hires.png"
   },
   {
-    "id": "xy8-149",
+    "setOrder":66,
+	"id": "xy8-149",
     "name": "Super Rod",
     "imageUrl": "https://images.pokemontcg.io/xy8/149.png",
     "subtype": "Item",
@@ -7117,7 +7266,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/149_hires.png"
   },
   {
-    "id": "xy8-150",
+    "setOrder":66,
+	"id": "xy8-150",
     "name": "Town Map",
     "imageUrl": "https://images.pokemontcg.io/xy8/150.png",
     "subtype": "Item",
@@ -7134,7 +7284,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/150_hires.png"
   },
   {
-    "id": "xy8-151",
+    "setOrder":66,
+	"id": "xy8-151",
     "name": "Burning Energy",
     "imageUrl": "https://images.pokemontcg.io/xy8/151.png",
     "subtype": "Special",
@@ -7151,7 +7302,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/151_hires.png"
   },
   {
-    "id": "xy8-152",
+    "setOrder":66,
+	"id": "xy8-152",
     "name": "Rainbow Energy",
     "imageUrl": "https://images.pokemontcg.io/xy8/152.png",
     "subtype": "Special",
@@ -7168,7 +7320,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/152_hires.png"
   },
   {
-    "id": "xy8-153",
+    "setOrder":66,
+	"id": "xy8-153",
     "name": "Houndoom-EX",
     "imageUrl": "https://images.pokemontcg.io/xy8/153.png",
     "subtype": "EX",
@@ -7223,7 +7376,8 @@
     "evolvesTo": "M Houndoom-EX"
   },
   {
-    "id": "xy8-154",
+    "setOrder":66,
+	"id": "xy8-154",
     "name": "M Houndoom-EX",
     "imageUrl": "https://images.pokemontcg.io/xy8/154.png",
     "subtype": "MEGA",
@@ -7269,7 +7423,8 @@
     "nationalPokedexNumber": 229
   },
   {
-    "id": "xy8-155",
+    "setOrder":66,
+	"id": "xy8-155",
     "name": "Glalie-EX",
     "imageUrl": "https://images.pokemontcg.io/xy8/155.png",
     "subtype": "EX",
@@ -7326,7 +7481,8 @@
     "evolvesTo": "M Glalie-EX"
   },
   {
-    "id": "xy8-156",
+    "setOrder":66,
+	"id": "xy8-156",
     "name": "M Glalie-EX",
     "imageUrl": "https://images.pokemontcg.io/xy8/156.png",
     "subtype": "MEGA",
@@ -7375,7 +7531,8 @@
     "nationalPokedexNumber": 362
   },
   {
-    "id": "xy8-157",
+    "setOrder":66,
+	"id": "xy8-157",
     "name": "Mewtwo-EX",
     "imageUrl": "https://images.pokemontcg.io/xy8/157.png",
     "subtype": "EX",
@@ -7433,7 +7590,8 @@
     "evolvesTo": "M Mewtwo-EX"
   },
   {
-    "id": "xy8-158",
+    "setOrder":66,
+	"id": "xy8-158",
     "name": "Mewtwo-EX",
     "imageUrl": "https://images.pokemontcg.io/xy8/158.png",
     "subtype": "EX",
@@ -7489,7 +7647,8 @@
     "evolvesTo": "M Mewtwo-EX"
   },
   {
-    "id": "xy8-159",
+    "setOrder":66,
+	"id": "xy8-159",
     "name": "M Mewtwo-EX",
     "imageUrl": "https://images.pokemontcg.io/xy8/159.png",
     "subtype": "MEGA",
@@ -7539,7 +7698,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "xy8-160",
+    "setOrder":66,
+	"id": "xy8-160",
     "name": "M Mewtwo-EX",
     "imageUrl": "https://images.pokemontcg.io/xy8/160.png",
     "subtype": "MEGA",
@@ -7586,7 +7746,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "xy8-161",
+    "setOrder":66,
+	"id": "xy8-161",
     "name": "Brigette",
     "imageUrl": "https://images.pokemontcg.io/xy8/161.png",
     "subtype": "Supporter",
@@ -7603,7 +7764,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/161_hires.png"
   },
   {
-    "id": "xy8-162",
+    "setOrder":66,
+	"id": "xy8-162",
     "name": "Giovanni's Scheme",
     "imageUrl": "https://images.pokemontcg.io/xy8/162.png",
     "subtype": "Supporter",
@@ -7620,7 +7782,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy8/162_hires.png"
   },
   {
-    "id": "xy8-163",
+    "setOrder":66,
+	"id": "xy8-163",
     "name": "Mewtwo-EX",
     "imageUrl": "https://images.pokemontcg.io/xy8/163.png",
     "subtype": "EX",
@@ -7678,7 +7841,8 @@
     "evolvesTo": "M Mewtwo-EX"
   },
   {
-    "id": "xy8-164",
+    "setOrder":66,
+	"id": "xy8-164",
     "name": "Mewtwo-EX",
     "imageUrl": "https://images.pokemontcg.io/xy8/164.png",
     "subtype": "EX",

--- a/json/cards/BW Black Star Promos.json
+++ b/json/cards/BW Black Star Promos.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "bwp-BW01",
+    "setOrder":1002,
+	"id": "bwp-BW01",
     "name": "Snivy",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW01.png",
     "subtype": "Basic",
@@ -50,7 +51,8 @@
     ]
   },
   {
-    "id": "bwp-BW02",
+    "setOrder":1002,
+	"id": "bwp-BW02",
     "name": "Tepig",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW02.png",
     "subtype": "Basic",
@@ -95,7 +97,8 @@
     ]
   },
   {
-    "id": "bwp-BW03",
+    "setOrder":1002,
+	"id": "bwp-BW03",
     "name": "Oshawott",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW03.png",
     "subtype": "Basic",
@@ -139,7 +142,8 @@
     ]
   },
   {
-    "id": "bwp-BW04",
+    "setOrder":1002,
+	"id": "bwp-BW04",
     "name": "Reshiram",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW04.png",
     "subtype": "Basic",
@@ -192,7 +196,8 @@
     "nationalPokedexNumber": 643
   },
   {
-    "id": "bwp-BW05",
+    "setOrder":1002,
+	"id": "bwp-BW05",
     "name": "Zekrom",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW05.png",
     "subtype": "Basic",
@@ -245,7 +250,8 @@
     "nationalPokedexNumber": 644
   },
   {
-    "id": "bwp-BW06",
+    "setOrder":1002,
+	"id": "bwp-BW06",
     "name": "Snivy",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW06.png",
     "subtype": "Basic",
@@ -304,7 +310,8 @@
     ]
   },
   {
-    "id": "bwp-BW07",
+    "setOrder":1002,
+	"id": "bwp-BW07",
     "name": "Tepig",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW07.png",
     "subtype": "Basic",
@@ -357,7 +364,8 @@
     ]
   },
   {
-    "id": "bwp-BW08",
+    "setOrder":1002,
+	"id": "bwp-BW08",
     "name": "Oshawott",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW08.png",
     "subtype": "Basic",
@@ -410,7 +418,8 @@
     ]
   },
   {
-    "id": "bwp-BW09",
+    "setOrder":1002,
+	"id": "bwp-BW09",
     "name": "Zoroark",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW09.png",
     "subtype": "Stage 1",
@@ -467,7 +476,8 @@
     "nationalPokedexNumber": 571
   },
   {
-    "id": "bwp-BW10",
+    "setOrder":1002,
+	"id": "bwp-BW10",
     "name": "Axew",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW10.png",
     "subtype": "Basic",
@@ -505,7 +515,8 @@
     ]
   },
   {
-    "id": "bwp-BW11",
+    "setOrder":1002,
+	"id": "bwp-BW11",
     "name": "Pansage",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW11.png",
     "subtype": "Basic",
@@ -555,7 +566,8 @@
     ]
   },
   {
-    "id": "bwp-BW12",
+    "setOrder":1002,
+	"id": "bwp-BW12",
     "name": "Zorua",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW12.png",
     "subtype": "Basic",
@@ -605,7 +617,8 @@
     ]
   },
   {
-    "id": "bwp-BW13",
+    "setOrder":1002,
+	"id": "bwp-BW13",
     "name": "Minccino",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW13.png",
     "subtype": "Basic",
@@ -658,7 +671,8 @@
     ]
   },
   {
-    "id": "bwp-BW14",
+    "setOrder":1002,
+	"id": "bwp-BW14",
     "name": "Pansage",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW14.png",
     "subtype": "Basic",
@@ -708,7 +722,8 @@
     ]
   },
   {
-    "id": "bwp-BW15",
+    "setOrder":1002,
+	"id": "bwp-BW15",
     "name": "Pidove",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW15.png",
     "subtype": "Basic",
@@ -758,7 +773,8 @@
     ]
   },
   {
-    "id": "bwp-BW16",
+    "setOrder":1002,
+	"id": "bwp-BW16",
     "name": "Axew",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW16.png",
     "subtype": "Basic",
@@ -796,7 +812,8 @@
     ]
   },
   {
-    "id": "bwp-BW17",
+    "setOrder":1002,
+	"id": "bwp-BW17",
     "name": "Ducklett",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW17.png",
     "subtype": "Basic",
@@ -845,7 +862,8 @@
     ]
   },
   {
-    "id": "bwp-BW18",
+    "setOrder":1002,
+	"id": "bwp-BW18",
     "name": "Darumaka",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW18.png",
     "subtype": "Basic",
@@ -890,7 +908,8 @@
     ]
   },
   {
-    "id": "bwp-BW19",
+    "setOrder":1002,
+	"id": "bwp-BW19",
     "name": "Zoroark",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW19.png",
     "subtype": "Stage 1",
@@ -948,7 +967,8 @@
     "nationalPokedexNumber": 571
   },
   {
-    "id": "bwp-BW20",
+    "setOrder":1002,
+	"id": "bwp-BW20",
     "name": "Serperior",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW20.png",
     "subtype": "Stage 2",
@@ -1001,7 +1021,8 @@
     "nationalPokedexNumber": 497
   },
   {
-    "id": "bwp-BW21",
+    "setOrder":1002,
+	"id": "bwp-BW21",
     "name": "Emboar",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW21.png",
     "subtype": "Stage 2",
@@ -1053,7 +1074,8 @@
     "nationalPokedexNumber": 500
   },
   {
-    "id": "bwp-BW22",
+    "setOrder":1002,
+	"id": "bwp-BW22",
     "name": "Samurott",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW22.png",
     "subtype": "Stage 2",
@@ -1102,7 +1124,8 @@
     "nationalPokedexNumber": 503
   },
   {
-    "id": "bwp-BW23",
+    "setOrder":1002,
+	"id": "bwp-BW23",
     "name": "Reshiram",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW23.png",
     "subtype": "Basic",
@@ -1155,7 +1178,8 @@
     "nationalPokedexNumber": 643
   },
   {
-    "id": "bwp-BW24",
+    "setOrder":1002,
+	"id": "bwp-BW24",
     "name": "Zekrom",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW24.png",
     "subtype": "Basic",
@@ -1208,7 +1232,8 @@
     "nationalPokedexNumber": 644
   },
   {
-    "id": "bwp-BW25",
+    "setOrder":1002,
+	"id": "bwp-BW25",
     "name": "Scraggy",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW25.png",
     "subtype": "Basic",
@@ -1268,7 +1293,8 @@
     ]
   },
   {
-    "id": "bwp-BW26",
+    "setOrder":1002,
+	"id": "bwp-BW26",
     "name": "Axew",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW26.png",
     "subtype": "Basic",
@@ -1306,7 +1332,8 @@
     ]
   },
   {
-    "id": "bwp-BW27",
+    "setOrder":1002,
+	"id": "bwp-BW27",
     "name": "Litwick",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW27.png",
     "subtype": "Basic",
@@ -1359,7 +1386,8 @@
     ]
   },
   {
-    "id": "bwp-BW28",
+    "setOrder":1002,
+	"id": "bwp-BW28",
     "name": "Tropical Beach",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW28.png",
     "subtype": "Stadium",
@@ -1377,7 +1405,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bwp/BW28_hires.png"
   },
   {
-    "id": "bwp-BW29",
+    "setOrder":1002,
+	"id": "bwp-BW29",
     "name": "Victory Cup",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW29.png",
     "subtype": "Item",
@@ -1394,7 +1423,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bwp/BW29_hires.png"
   },
   {
-    "id": "bwp-BW30",
+    "setOrder":1002,
+	"id": "bwp-BW30",
     "name": "Victory Cup",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW30.png",
     "subtype": "Item",
@@ -1411,7 +1441,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bwp/BW30_hires.png"
   },
   {
-    "id": "bwp-BW31",
+    "setOrder":1002,
+	"id": "bwp-BW31",
     "name": "Victory Cup",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW31.png",
     "subtype": "Item",
@@ -1428,7 +1459,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bwp/BW31_hires.png"
   },
   {
-    "id": "bwp-BW32",
+    "setOrder":1002,
+	"id": "bwp-BW32",
     "name": "Victini",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW32.png",
     "subtype": "Basic",
@@ -1474,7 +1506,8 @@
     "nationalPokedexNumber": 494
   },
   {
-    "id": "bwp-BW33",
+    "setOrder":1002,
+	"id": "bwp-BW33",
     "name": "Riolu",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW33.png",
     "subtype": "Basic",
@@ -1527,7 +1560,8 @@
     ]
   },
   {
-    "id": "bwp-BW34",
+    "setOrder":1002,
+	"id": "bwp-BW34",
     "name": "Luxio",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW34.png",
     "subtype": "Stage 1",
@@ -1582,7 +1616,8 @@
     ]
   },
   {
-    "id": "bwp-BW35",
+    "setOrder":1002,
+	"id": "bwp-BW35",
     "name": "Meowth",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW35.png",
     "subtype": "Basic",
@@ -1635,7 +1670,8 @@
     ]
   },
   {
-    "id": "bwp-BW36",
+    "setOrder":1002,
+	"id": "bwp-BW36",
     "name": "Reshiram-EX",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW36.png",
     "subtype": "EX",
@@ -1695,7 +1731,8 @@
     "nationalPokedexNumber": 643
   },
   {
-    "id": "bwp-BW37",
+    "setOrder":1002,
+	"id": "bwp-BW37",
     "name": "Kyurem-EX",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW37.png",
     "subtype": "EX",
@@ -1755,7 +1792,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "bwp-BW38",
+    "setOrder":1002,
+	"id": "bwp-BW38",
     "name": "Zekrom-EX",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW38.png",
     "subtype": "EX",
@@ -1815,7 +1853,8 @@
     "nationalPokedexNumber": 644
   },
   {
-    "id": "bwp-BW39",
+    "setOrder":1002,
+	"id": "bwp-BW39",
     "name": "Battle City",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW39.png",
     "subtype": "Stadium",
@@ -1832,7 +1871,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bwp/BW39_hires.png"
   },
   {
-    "id": "bwp-BW40",
+    "setOrder":1002,
+	"id": "bwp-BW40",
     "name": "Volcarona",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW40.png",
     "subtype": "Stage 1",
@@ -1882,7 +1922,8 @@
     "nationalPokedexNumber": 637
   },
   {
-    "id": "bwp-BW41",
+    "setOrder":1002,
+	"id": "bwp-BW41",
     "name": "Thundurus",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW41.png",
     "subtype": "Basic",
@@ -1933,7 +1974,8 @@
     "nationalPokedexNumber": 642
   },
   {
-    "id": "bwp-BW42",
+    "setOrder":1002,
+	"id": "bwp-BW42",
     "name": "Tornadus",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW42.png",
     "subtype": "Basic",
@@ -1990,7 +2032,8 @@
     "nationalPokedexNumber": 641
   },
   {
-    "id": "bwp-BW43",
+    "setOrder":1002,
+	"id": "bwp-BW43",
     "name": "Landorus",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW43.png",
     "subtype": "Basic",
@@ -2047,7 +2090,8 @@
     "nationalPokedexNumber": 645
   },
   {
-    "id": "bwp-BW44",
+    "setOrder":1002,
+	"id": "bwp-BW44",
     "name": "Kyurem",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW44.png",
     "subtype": "Basic",
@@ -2100,7 +2144,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "bwp-BW45",
+    "setOrder":1002,
+	"id": "bwp-BW45",
     "name": "Mewtwo-EX",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW45.png",
     "subtype": "EX",
@@ -2158,7 +2203,8 @@
     "evolvesTo": "M Mewtwo-EX"
   },
   {
-    "id": "bwp-BW46",
+    "setOrder":1002,
+	"id": "bwp-BW46",
     "name": "Darkrai-EX",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW46.png",
     "subtype": "EX",
@@ -2216,7 +2262,8 @@
     "nationalPokedexNumber": 491
   },
   {
-    "id": "bwp-BW47",
+    "setOrder":1002,
+	"id": "bwp-BW47",
     "name": "Rayquaza-EX",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW47.png",
     "subtype": "EX",
@@ -2271,7 +2318,8 @@
     "evolvesTo": "M Rayquaza-EX"
   },
   {
-    "id": "bwp-BW48",
+    "setOrder":1002,
+	"id": "bwp-BW48",
     "name": "Altaria",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW48.png",
     "subtype": "Stage 1",
@@ -2319,7 +2367,8 @@
     "nationalPokedexNumber": 334
   },
   {
-    "id": "bwp-BW49",
+    "setOrder":1002,
+	"id": "bwp-BW49",
     "name": "Lilligant",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW49.png",
     "subtype": "Stage 1",
@@ -2376,7 +2425,8 @@
     "nationalPokedexNumber": 549
   },
   {
-    "id": "bwp-BW50",
+    "setOrder":1002,
+	"id": "bwp-BW50",
     "name": "Tropical Beach",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW50.png",
     "subtype": "Stadium",
@@ -2394,7 +2444,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bwp/BW50_hires.png"
   },
   {
-    "id": "bwp-BW51",
+    "setOrder":1002,
+	"id": "bwp-BW51",
     "name": "Crobat",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW51.png",
     "subtype": "Stage 2",
@@ -2445,7 +2496,8 @@
     "nationalPokedexNumber": 169
   },
   {
-    "id": "bwp-BW52",
+    "setOrder":1002,
+	"id": "bwp-BW52",
     "name": "Lillipup",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW52.png",
     "subtype": "Basic",
@@ -2489,7 +2541,8 @@
     ]
   },
   {
-    "id": "bwp-BW53",
+    "setOrder":1002,
+	"id": "bwp-BW53",
     "name": "Flygon",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW53.png",
     "subtype": "Stage 2",
@@ -2538,7 +2591,8 @@
     "nationalPokedexNumber": 330
   },
   {
-    "id": "bwp-BW54",
+    "setOrder":1002,
+	"id": "bwp-BW54",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW54.png",
     "subtype": "Basic",
@@ -2592,7 +2646,8 @@
     ]
   },
   {
-    "id": "bwp-BW55",
+    "setOrder":1002,
+	"id": "bwp-BW55",
     "name": "Elgyem",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW55.png",
     "subtype": "Basic",
@@ -2641,7 +2696,8 @@
     ]
   },
   {
-    "id": "bwp-BW56",
+    "setOrder":1002,
+	"id": "bwp-BW56",
     "name": "Empoleon",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW56.png",
     "subtype": "Stage 2",
@@ -2694,7 +2750,8 @@
     "nationalPokedexNumber": 395
   },
   {
-    "id": "bwp-BW57",
+    "setOrder":1002,
+	"id": "bwp-BW57",
     "name": "Haxorus",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW57.png",
     "subtype": "Stage 2",
@@ -2749,7 +2806,8 @@
     "nationalPokedexNumber": 612
   },
   {
-    "id": "bwp-BW58",
+    "setOrder":1002,
+	"id": "bwp-BW58",
     "name": "Black Kyurem",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW58.png",
     "subtype": "Basic",
@@ -2803,7 +2861,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "bwp-BW59",
+    "setOrder":1002,
+	"id": "bwp-BW59",
     "name": "White Kyurem",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW59.png",
     "subtype": "Basic",
@@ -2857,7 +2916,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "bwp-BW60",
+    "setOrder":1002,
+	"id": "bwp-BW60",
     "name": "Keldeo",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW60.png",
     "subtype": "Basic",
@@ -2908,7 +2968,8 @@
     "nationalPokedexNumber": 647
   },
   {
-    "id": "bwp-BW61",
+    "setOrder":1002,
+	"id": "bwp-BW61",
     "name": "Keldeo-EX",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW61.png",
     "subtype": "EX",
@@ -2960,7 +3021,8 @@
     "nationalPokedexNumber": 647
   },
   {
-    "id": "bwp-BW62",
+    "setOrder":1002,
+	"id": "bwp-BW62",
     "name": "Black Kyurem-EX",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW62.png",
     "subtype": "EX",
@@ -3020,7 +3082,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "bwp-BW63",
+    "setOrder":1002,
+	"id": "bwp-BW63",
     "name": "White Kyurem-EX",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW63.png",
     "subtype": "EX",
@@ -3080,7 +3143,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "bwp-BW64",
+    "setOrder":1002,
+	"id": "bwp-BW64",
     "name": "Drifblim",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW64.png",
     "subtype": "Stage 1",
@@ -3131,7 +3195,8 @@
     "nationalPokedexNumber": 426
   },
   {
-    "id": "bwp-BW65",
+    "setOrder":1002,
+	"id": "bwp-BW65",
     "name": "Jigglypuff",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW65.png",
     "subtype": "Basic",
@@ -3174,7 +3239,8 @@
     ]
   },
   {
-    "id": "bwp-BW66",
+    "setOrder":1002,
+	"id": "bwp-BW66",
     "name": "Ninetales",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW66.png",
     "subtype": "Stage 1",
@@ -3220,7 +3286,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "bwp-BW67",
+    "setOrder":1002,
+	"id": "bwp-BW67",
     "name": "Ampharos",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW67.png",
     "subtype": "Stage 2",
@@ -3273,7 +3340,8 @@
     "nationalPokedexNumber": 181
   },
   {
-    "id": "bwp-BW68",
+    "setOrder":1002,
+	"id": "bwp-BW68",
     "name": "Meloetta",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW68.png",
     "subtype": "Basic",
@@ -3324,7 +3392,8 @@
     "nationalPokedexNumber": 648
   },
   {
-    "id": "bwp-BW69",
+    "setOrder":1002,
+	"id": "bwp-BW69",
     "name": "Meloetta",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW69.png",
     "subtype": "Basic",
@@ -3375,7 +3444,8 @@
     "nationalPokedexNumber": 648
   },
   {
-    "id": "bwp-BW70",
+    "setOrder":1002,
+	"id": "bwp-BW70",
     "name": "Virizion",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW70.png",
     "subtype": "Basic",
@@ -3428,7 +3498,8 @@
     "nationalPokedexNumber": 640
   },
   {
-    "id": "bwp-BW71",
+    "setOrder":1002,
+	"id": "bwp-BW71",
     "name": "Terrakion",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW71.png",
     "subtype": "Basic",
@@ -3479,7 +3550,8 @@
     "nationalPokedexNumber": 639
   },
   {
-    "id": "bwp-BW72",
+    "setOrder":1002,
+	"id": "bwp-BW72",
     "name": "Cobalion",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW72.png",
     "subtype": "Basic",
@@ -3534,7 +3606,8 @@
     "nationalPokedexNumber": 638
   },
   {
-    "id": "bwp-BW73",
+    "setOrder":1002,
+	"id": "bwp-BW73",
     "name": "Darkrai",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW73.png",
     "subtype": "Basic",
@@ -3594,7 +3667,8 @@
     "nationalPokedexNumber": 491
   },
   {
-    "id": "bwp-BW74",
+    "setOrder":1002,
+	"id": "bwp-BW74",
     "name": "Giratina",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW74.png",
     "subtype": "Basic",
@@ -3650,7 +3724,8 @@
     "nationalPokedexNumber": 487
   },
   {
-    "id": "bwp-BW75",
+    "setOrder":1002,
+	"id": "bwp-BW75",
     "name": "Metagross",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW75.png",
     "subtype": "Stage 2",
@@ -3700,7 +3775,8 @@
     "nationalPokedexNumber": 376
   },
   {
-    "id": "bwp-BW76",
+    "setOrder":1002,
+	"id": "bwp-BW76",
     "name": "Electrode",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW76.png",
     "subtype": "Stage 1",
@@ -3749,7 +3825,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "bwp-BW77",
+    "setOrder":1002,
+	"id": "bwp-BW77",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW77.png",
     "subtype": "Basic",
@@ -3796,7 +3873,8 @@
     "nationalPokedexNumber": 25
   },
   {
-    "id": "bwp-BW78",
+    "setOrder":1002,
+	"id": "bwp-BW78",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW78.png",
     "subtype": "Stage 1",
@@ -3845,7 +3923,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "bwp-BW79",
+    "setOrder":1002,
+	"id": "bwp-BW79",
     "name": "Landorus",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW79.png",
     "subtype": "Basic",
@@ -3905,7 +3984,8 @@
     "nationalPokedexNumber": 645
   },
   {
-    "id": "bwp-BW80",
+    "setOrder":1002,
+	"id": "bwp-BW80",
     "name": "Druddigon",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW80.png",
     "subtype": "Basic",
@@ -3957,7 +4037,8 @@
     "nationalPokedexNumber": 621
   },
   {
-    "id": "bwp-BW81",
+    "setOrder":1002,
+	"id": "bwp-BW81",
     "name": "Thundurus-EX",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW81.png",
     "subtype": "EX",
@@ -4013,7 +4094,8 @@
     "nationalPokedexNumber": 642
   },
   {
-    "id": "bwp-BW82",
+    "setOrder":1002,
+	"id": "bwp-BW82",
     "name": "Deoxys-EX",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW82.png",
     "subtype": "EX",
@@ -4064,7 +4146,8 @@
     "nationalPokedexNumber": 386
   },
   {
-    "id": "bwp-BW83",
+    "setOrder":1002,
+	"id": "bwp-BW83",
     "name": "Lugia-EX",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW83.png",
     "subtype": "EX",
@@ -4123,7 +4206,8 @@
     "nationalPokedexNumber": 249
   },
   {
-    "id": "bwp-BW84",
+    "setOrder":1002,
+	"id": "bwp-BW84",
     "name": "Porygon-Z",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW84.png",
     "subtype": "Stage 2",
@@ -4171,7 +4255,8 @@
     "nationalPokedexNumber": 474
   },
   {
-    "id": "bwp-BW85",
+    "setOrder":1002,
+	"id": "bwp-BW85",
     "name": "Lucario",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW85.png",
     "subtype": "Stage 1",
@@ -4220,7 +4305,8 @@
     "nationalPokedexNumber": 448
   },
   {
-    "id": "bwp-BW86",
+    "setOrder":1002,
+	"id": "bwp-BW86",
     "name": "Genesect",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW86.png",
     "subtype": "Basic",
@@ -4274,7 +4360,8 @@
     "nationalPokedexNumber": 649
   },
   {
-    "id": "bwp-BW87",
+    "setOrder":1002,
+	"id": "bwp-BW87",
     "name": "Leafeon",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW87.png",
     "subtype": "Stage 1",
@@ -4331,7 +4418,8 @@
     "nationalPokedexNumber": 470
   },
   {
-    "id": "bwp-BW88",
+    "setOrder":1002,
+	"id": "bwp-BW88",
     "name": "Flareon",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW88.png",
     "subtype": "Stage 1",
@@ -4383,7 +4471,8 @@
     "nationalPokedexNumber": 136
   },
   {
-    "id": "bwp-BW89",
+    "setOrder":1002,
+	"id": "bwp-BW89",
     "name": "Vaporeon",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW89.png",
     "subtype": "Stage 1",
@@ -4436,7 +4525,8 @@
     "nationalPokedexNumber": 134
   },
   {
-    "id": "bwp-BW90",
+    "setOrder":1002,
+	"id": "bwp-BW90",
     "name": "Glaceon",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW90.png",
     "subtype": "Stage 1",
@@ -4487,7 +4577,8 @@
     "nationalPokedexNumber": 471
   },
   {
-    "id": "bwp-BW91",
+    "setOrder":1002,
+	"id": "bwp-BW91",
     "name": "Jolteon",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW91.png",
     "subtype": "Stage 1",
@@ -4536,7 +4627,8 @@
     "nationalPokedexNumber": 135
   },
   {
-    "id": "bwp-BW92",
+    "setOrder":1002,
+	"id": "bwp-BW92",
     "name": "Espeon",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW92.png",
     "subtype": "Stage 1",
@@ -4584,7 +4676,8 @@
     "nationalPokedexNumber": 196
   },
   {
-    "id": "bwp-BW93",
+    "setOrder":1002,
+	"id": "bwp-BW93",
     "name": "Umbreon",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW93.png",
     "subtype": "Stage 1",
@@ -4644,7 +4737,8 @@
     "nationalPokedexNumber": 197
   },
   {
-    "id": "bwp-BW94",
+    "setOrder":1002,
+	"id": "bwp-BW94",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW94.png",
     "subtype": "Basic",
@@ -4704,7 +4798,8 @@
     ]
   },
   {
-    "id": "bwp-BW95",
+    "setOrder":1002,
+	"id": "bwp-BW95",
     "name": "Champions Festival",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW95.png",
     "subtype": "Stadium",
@@ -4722,7 +4817,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bwp/BW95_hires.png"
   },
   {
-    "id": "bwp-BW96",
+    "setOrder":1002,
+	"id": "bwp-BW96",
     "name": "Tornadus-EX",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW96.png",
     "subtype": "EX",
@@ -4790,7 +4886,8 @@
     "nationalPokedexNumber": 641
   },
   {
-    "id": "bwp-BW97",
+    "setOrder":1002,
+	"id": "bwp-BW97",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW97.png",
     "subtype": "Basic",
@@ -4850,7 +4947,8 @@
     ]
   },
   {
-    "id": "bwp-BW98",
+    "setOrder":1002,
+	"id": "bwp-BW98",
     "name": "Mew",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW98.png",
     "subtype": "Basic",
@@ -4895,7 +4993,8 @@
     "nationalPokedexNumber": 151
   },
   {
-    "id": "bwp-BW99",
+    "setOrder":1002,
+	"id": "bwp-BW99",
     "name": "Genesect",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW99.png",
     "subtype": "Basic",
@@ -4948,7 +5047,8 @@
     "nationalPokedexNumber": 649
   },
   {
-    "id": "bwp-BW100",
+    "setOrder":1002,
+	"id": "bwp-BW100",
     "name": "N",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW100.png",
     "subtype": "Supporter",
@@ -4965,7 +5065,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bwp/BW100_hires.png"
   },
   {
-    "id": "bwp-BW101",
+    "setOrder":1002,
+	"id": "bwp-BW101",
     "name": "Genesect",
     "imageUrl": "https://images.pokemontcg.io/bwp/BW101.png",
     "subtype": "Basic",

--- a/json/cards/Base Set 2.json
+++ b/json/cards/Base Set 2.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "base4-1",
+    "setOrder":4,
+	"id": "base4-1",
     "name": "Alakazam",
     "imageUrl": "https://images.pokemontcg.io/base4/1.png",
     "subtype": "Stage 2",
@@ -51,7 +52,8 @@
     "nationalPokedexNumber": 65
   },
   {
-    "id": "base4-2",
+    "setOrder":4,
+	"id": "base4-2",
     "name": "Blastoise",
     "imageUrl": "https://images.pokemontcg.io/base4/2.png",
     "subtype": "Stage 2",
@@ -102,7 +104,8 @@
     "nationalPokedexNumber": 9
   },
   {
-    "id": "base4-3",
+    "setOrder":4,
+	"id": "base4-3",
     "name": "Chansey",
     "imageUrl": "https://images.pokemontcg.io/base4/3.png",
     "subtype": "Basic",
@@ -165,7 +168,8 @@
     ]
   },
   {
-    "id": "base4-4",
+    "setOrder":4,
+	"id": "base4-4",
     "name": "Charizard",
     "imageUrl": "https://images.pokemontcg.io/base4/4.png",
     "subtype": "Stage 2",
@@ -222,7 +226,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "base4-5",
+    "setOrder":4,
+	"id": "base4-5",
     "name": "Clefable",
     "imageUrl": "https://images.pokemontcg.io/base4/5.png",
     "subtype": "Stage 1",
@@ -281,7 +286,8 @@
     "nationalPokedexNumber": 36
   },
   {
-    "id": "base4-6",
+    "setOrder":4,
+	"id": "base4-6",
     "name": "Clefairy",
     "imageUrl": "https://images.pokemontcg.io/base4/6.png",
     "subtype": "Basic",
@@ -342,7 +348,8 @@
     ]
   },
   {
-    "id": "base4-7",
+    "setOrder":4,
+	"id": "base4-7",
     "name": "Gyarados",
     "imageUrl": "https://images.pokemontcg.io/base4/7.png",
     "subtype": "Stage 1",
@@ -406,7 +413,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "base4-8",
+    "setOrder":4,
+	"id": "base4-8",
     "name": "Hitmonchan",
     "imageUrl": "https://images.pokemontcg.io/base4/8.png",
     "subtype": "Basic",
@@ -459,7 +467,8 @@
     "nationalPokedexNumber": 107
   },
   {
-    "id": "base4-9",
+    "setOrder":4,
+	"id": "base4-9",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/base4/9.png",
     "subtype": "Stage 1",
@@ -518,7 +527,8 @@
     ]
   },
   {
-    "id": "base4-10",
+    "setOrder":4,
+	"id": "base4-10",
     "name": "Mewtwo",
     "imageUrl": "https://images.pokemontcg.io/base4/10.png",
     "subtype": "Basic",
@@ -572,7 +582,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "base4-11",
+    "setOrder":4,
+	"id": "base4-11",
     "name": "Nidoking",
     "imageUrl": "https://images.pokemontcg.io/base4/11.png",
     "subtype": "Stage 2",
@@ -629,7 +640,8 @@
     "nationalPokedexNumber": 34
   },
   {
-    "id": "base4-12",
+    "setOrder":4,
+	"id": "base4-12",
     "name": "Nidoqueen",
     "imageUrl": "https://images.pokemontcg.io/base4/12.png",
     "subtype": "Stage 2",
@@ -686,7 +698,8 @@
     "nationalPokedexNumber": 31
   },
   {
-    "id": "base4-13",
+    "setOrder":4,
+	"id": "base4-13",
     "name": "Ninetales",
     "imageUrl": "https://images.pokemontcg.io/base4/13.png",
     "subtype": "Stage 1",
@@ -741,7 +754,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "base4-14",
+    "setOrder":4,
+	"id": "base4-14",
     "name": "Pidgeot",
     "imageUrl": "https://images.pokemontcg.io/base4/14.png",
     "subtype": "Stage 2",
@@ -798,7 +812,8 @@
     "nationalPokedexNumber": 18
   },
   {
-    "id": "base4-15",
+    "setOrder":4,
+	"id": "base4-15",
     "name": "Poliwrath",
     "imageUrl": "https://images.pokemontcg.io/base4/15.png",
     "subtype": "Stage 2",
@@ -856,7 +871,8 @@
     "nationalPokedexNumber": 62
   },
   {
-    "id": "base4-16",
+    "setOrder":4,
+	"id": "base4-16",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/base4/16.png",
     "subtype": "Stage 1",
@@ -912,7 +928,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "base4-17",
+    "setOrder":4,
+	"id": "base4-17",
     "name": "Scyther",
     "imageUrl": "https://images.pokemontcg.io/base4/17.png",
     "subtype": "Basic",
@@ -970,7 +987,8 @@
     ]
   },
   {
-    "id": "base4-18",
+    "setOrder":4,
+	"id": "base4-18",
     "name": "Venusaur",
     "imageUrl": "https://images.pokemontcg.io/base4/18.png",
     "subtype": "Stage 2",
@@ -1021,7 +1039,8 @@
     "nationalPokedexNumber": 3
   },
   {
-    "id": "base4-19",
+    "setOrder":4,
+	"id": "base4-19",
     "name": "Wigglytuff",
     "imageUrl": "https://images.pokemontcg.io/base4/19.png",
     "subtype": "Stage 1",
@@ -1081,7 +1100,8 @@
     "nationalPokedexNumber": 40
   },
   {
-    "id": "base4-20",
+    "setOrder":4,
+	"id": "base4-20",
     "name": "Zapdos",
     "imageUrl": "https://images.pokemontcg.io/base4/20.png",
     "subtype": "Basic",
@@ -1139,7 +1159,8 @@
     "nationalPokedexNumber": 145
   },
   {
-    "id": "base4-21",
+    "setOrder":4,
+	"id": "base4-21",
     "name": "Beedrill",
     "imageUrl": "https://images.pokemontcg.io/base4/21.png",
     "subtype": "Stage 2",
@@ -1197,7 +1218,8 @@
     "nationalPokedexNumber": 15
   },
   {
-    "id": "base4-22",
+    "setOrder":4,
+	"id": "base4-22",
     "name": "Dragonair",
     "imageUrl": "https://images.pokemontcg.io/base4/22.png",
     "subtype": "Stage 1",
@@ -1257,7 +1279,8 @@
     ]
   },
   {
-    "id": "base4-23",
+    "setOrder":4,
+	"id": "base4-23",
     "name": "Dugtrio",
     "imageUrl": "https://images.pokemontcg.io/base4/23.png",
     "subtype": "Stage 1",
@@ -1320,7 +1343,8 @@
     "nationalPokedexNumber": 51
   },
   {
-    "id": "base4-24",
+    "setOrder":4,
+	"id": "base4-24",
     "name": "Electabuzz",
     "imageUrl": "https://images.pokemontcg.io/base4/24.png",
     "subtype": "Basic",
@@ -1375,7 +1399,8 @@
     ]
   },
   {
-    "id": "base4-25",
+    "setOrder":4,
+	"id": "base4-25",
     "name": "Electrode",
     "imageUrl": "https://images.pokemontcg.io/base4/25.png",
     "subtype": "Stage 1",
@@ -1423,7 +1448,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/25_hires.png"
   },
   {
-    "id": "base4-26",
+    "setOrder":4,
+	"id": "base4-26",
     "name": "Kangaskhan",
     "imageUrl": "https://images.pokemontcg.io/base4/26.png",
     "subtype": "Basic",
@@ -1484,7 +1510,8 @@
     "nationalPokedexNumber": 115
   },
   {
-    "id": "base4-27",
+    "setOrder":4,
+	"id": "base4-27",
     "name": "Mr. Mime",
     "imageUrl": "https://images.pokemontcg.io/base4/27.png",
     "subtype": "Basic",
@@ -1532,7 +1559,8 @@
     "nationalPokedexNumber": 122
   },
   {
-    "id": "base4-28",
+    "setOrder":4,
+	"id": "base4-28",
     "name": "Pidgeotto",
     "imageUrl": "https://images.pokemontcg.io/base4/28.png",
     "subtype": "Stage 1",
@@ -1595,7 +1623,8 @@
     ]
   },
   {
-    "id": "base4-29",
+    "setOrder":4,
+	"id": "base4-29",
     "name": "Pinsir",
     "imageUrl": "https://images.pokemontcg.io/base4/29.png",
     "subtype": "Basic",
@@ -1649,7 +1678,8 @@
     "nationalPokedexNumber": 127
   },
   {
-    "id": "base4-30",
+    "setOrder":4,
+	"id": "base4-30",
     "name": "Snorlax",
     "imageUrl": "https://images.pokemontcg.io/base4/30.png",
     "subtype": "Basic",
@@ -1708,7 +1738,8 @@
     "nationalPokedexNumber": 143
   },
   {
-    "id": "base4-31",
+    "setOrder":4,
+	"id": "base4-31",
     "name": "Venomoth",
     "imageUrl": "https://images.pokemontcg.io/base4/31.png",
     "subtype": "Stage 1",
@@ -1759,7 +1790,8 @@
     "nationalPokedexNumber": 49
   },
   {
-    "id": "base4-32",
+    "setOrder":4,
+	"id": "base4-32",
     "name": "Victreebel",
     "imageUrl": "https://images.pokemontcg.io/base4/32.png",
     "subtype": "Stage 2",
@@ -1812,7 +1844,8 @@
     "nationalPokedexNumber": 71
   },
   {
-    "id": "base4-33",
+    "setOrder":4,
+	"id": "base4-33",
     "name": "Arcanine",
     "imageUrl": "https://images.pokemontcg.io/base4/33.png",
     "subtype": "Stage 1",
@@ -1870,7 +1903,8 @@
     "nationalPokedexNumber": 59
   },
   {
-    "id": "base4-34",
+    "setOrder":4,
+	"id": "base4-34",
     "name": "Butterfree",
     "imageUrl": "https://images.pokemontcg.io/base4/34.png",
     "subtype": "Stage 2",
@@ -1928,7 +1962,8 @@
     "nationalPokedexNumber": 12
   },
   {
-    "id": "base4-35",
+    "setOrder":4,
+	"id": "base4-35",
     "name": "Charmeleon",
     "imageUrl": "https://images.pokemontcg.io/base4/35.png",
     "subtype": "Stage 1",
@@ -1986,7 +2021,8 @@
     ]
   },
   {
-    "id": "base4-36",
+    "setOrder":4,
+	"id": "base4-36",
     "name": "Dewgong",
     "imageUrl": "https://images.pokemontcg.io/base4/36.png",
     "subtype": "Stage 1",
@@ -2044,7 +2080,8 @@
     "nationalPokedexNumber": 87
   },
   {
-    "id": "base4-37",
+    "setOrder":4,
+	"id": "base4-37",
     "name": "Dodrio",
     "imageUrl": "https://images.pokemontcg.io/base4/37.png",
     "subtype": "Stage 1",
@@ -2096,7 +2133,8 @@
     "nationalPokedexNumber": 85
   },
   {
-    "id": "base4-38",
+    "setOrder":4,
+	"id": "base4-38",
     "name": "Dratini",
     "imageUrl": "https://images.pokemontcg.io/base4/38.png",
     "subtype": "Basic",
@@ -2140,7 +2178,8 @@
     ]
   },
   {
-    "id": "base4-39",
+    "setOrder":4,
+	"id": "base4-39",
     "name": "Exeggutor",
     "imageUrl": "https://images.pokemontcg.io/base4/39.png",
     "subtype": "Stage 1",
@@ -2193,7 +2232,8 @@
     "nationalPokedexNumber": 103
   },
   {
-    "id": "base4-40",
+    "setOrder":4,
+	"id": "base4-40",
     "name": "Farfetch'd",
     "imageUrl": "https://images.pokemontcg.io/base4/40.png",
     "subtype": "Basic",
@@ -2251,7 +2291,8 @@
     "nationalPokedexNumber": 83
   },
   {
-    "id": "base4-41",
+    "setOrder":4,
+	"id": "base4-41",
     "name": "Fearow",
     "imageUrl": "https://images.pokemontcg.io/base4/41.png",
     "subtype": "Stage 1",
@@ -2310,7 +2351,8 @@
     "nationalPokedexNumber": 22
   },
   {
-    "id": "base4-42",
+    "setOrder":4,
+	"id": "base4-42",
     "name": "Growlithe",
     "imageUrl": "https://images.pokemontcg.io/base4/42.png",
     "subtype": "Basic",
@@ -2355,7 +2397,8 @@
     ]
   },
   {
-    "id": "base4-43",
+    "setOrder":4,
+	"id": "base4-43",
     "name": "Haunter",
     "imageUrl": "https://images.pokemontcg.io/base4/43.png",
     "subtype": "Stage 1",
@@ -2410,7 +2453,8 @@
     ]
   },
   {
-    "id": "base4-44",
+    "setOrder":4,
+	"id": "base4-44",
     "name": "Ivysaur",
     "imageUrl": "https://images.pokemontcg.io/base4/44.png",
     "subtype": "Stage 1",
@@ -2468,7 +2512,8 @@
     ]
   },
   {
-    "id": "base4-45",
+    "setOrder":4,
+	"id": "base4-45",
     "name": "Jynx",
     "imageUrl": "https://images.pokemontcg.io/base4/45.png",
     "subtype": "Basic",
@@ -2521,7 +2566,8 @@
     "nationalPokedexNumber": 124
   },
   {
-    "id": "base4-46",
+    "setOrder":4,
+	"id": "base4-46",
     "name": "Kadabra",
     "imageUrl": "https://images.pokemontcg.io/base4/46.png",
     "subtype": "Stage 1",
@@ -2580,7 +2626,8 @@
     ]
   },
   {
-    "id": "base4-47",
+    "setOrder":4,
+	"id": "base4-47",
     "name": "Kakuna",
     "imageUrl": "https://images.pokemontcg.io/base4/47.png",
     "subtype": "Stage 1",
@@ -2637,7 +2684,8 @@
     ]
   },
   {
-    "id": "base4-48",
+    "setOrder":4,
+	"id": "base4-48",
     "name": "Lickitung",
     "imageUrl": "https://images.pokemontcg.io/base4/48.png",
     "subtype": "Basic",
@@ -2697,7 +2745,8 @@
     ]
   },
   {
-    "id": "base4-49",
+    "setOrder":4,
+	"id": "base4-49",
     "name": "Machoke",
     "imageUrl": "https://images.pokemontcg.io/base4/49.png",
     "subtype": "Stage 1",
@@ -2758,7 +2807,8 @@
     ]
   },
   {
-    "id": "base4-50",
+    "setOrder":4,
+	"id": "base4-50",
     "name": "Magikarp",
     "imageUrl": "https://images.pokemontcg.io/base4/50.png",
     "subtype": "Basic",
@@ -2811,7 +2861,8 @@
     ]
   },
   {
-    "id": "base4-51",
+    "setOrder":4,
+	"id": "base4-51",
     "name": "Magmar",
     "imageUrl": "https://images.pokemontcg.io/base4/51.png",
     "subtype": "Basic",
@@ -2868,7 +2919,8 @@
     ]
   },
   {
-    "id": "base4-52",
+    "setOrder":4,
+	"id": "base4-52",
     "name": "Marowak",
     "imageUrl": "https://images.pokemontcg.io/base4/52.png",
     "subtype": "Stage 1",
@@ -2928,7 +2980,8 @@
     "nationalPokedexNumber": 105
   },
   {
-    "id": "base4-53",
+    "setOrder":4,
+	"id": "base4-53",
     "name": "Nidorina",
     "imageUrl": "https://images.pokemontcg.io/base4/53.png",
     "subtype": "Stage 1",
@@ -2984,7 +3037,8 @@
     ]
   },
   {
-    "id": "base4-54",
+    "setOrder":4,
+	"id": "base4-54",
     "name": "Nidorino",
     "imageUrl": "https://images.pokemontcg.io/base4/54.png",
     "subtype": "Stage 1",
@@ -3043,7 +3097,8 @@
     ]
   },
   {
-    "id": "base4-55",
+    "setOrder":4,
+	"id": "base4-55",
     "name": "Parasect",
     "imageUrl": "https://images.pokemontcg.io/base4/55.png",
     "subtype": "Stage 1",
@@ -3097,7 +3152,8 @@
     "nationalPokedexNumber": 47
   },
   {
-    "id": "base4-56",
+    "setOrder":4,
+	"id": "base4-56",
     "name": "Persian",
     "imageUrl": "https://images.pokemontcg.io/base4/56.png",
     "subtype": "Stage 1",
@@ -3154,7 +3210,8 @@
     "nationalPokedexNumber": 53
   },
   {
-    "id": "base4-57",
+    "setOrder":4,
+	"id": "base4-57",
     "name": "Poliwhirl",
     "imageUrl": "https://images.pokemontcg.io/base4/57.png",
     "subtype": "Stage 1",
@@ -3212,7 +3269,8 @@
     ]
   },
   {
-    "id": "base4-58",
+    "setOrder":4,
+	"id": "base4-58",
     "name": "Raticate",
     "imageUrl": "https://images.pokemontcg.io/base4/58.png",
     "subtype": "Stage 1",
@@ -3271,7 +3329,8 @@
     "nationalPokedexNumber": 20
   },
   {
-    "id": "base4-59",
+    "setOrder":4,
+	"id": "base4-59",
     "name": "Rhydon",
     "imageUrl": "https://images.pokemontcg.io/base4/59.png",
     "subtype": "Stage 1",
@@ -3338,7 +3397,8 @@
     ]
   },
   {
-    "id": "base4-60",
+    "setOrder":4,
+	"id": "base4-60",
     "name": "Seaking",
     "imageUrl": "https://images.pokemontcg.io/base4/60.png",
     "subtype": "Stage 1",
@@ -3390,7 +3450,8 @@
     "nationalPokedexNumber": 119
   },
   {
-    "id": "base4-61",
+    "setOrder":4,
+	"id": "base4-61",
     "name": "Seel",
     "imageUrl": "https://images.pokemontcg.io/base4/61.png",
     "subtype": "Basic",
@@ -3434,7 +3495,8 @@
     ]
   },
   {
-    "id": "base4-62",
+    "setOrder":4,
+	"id": "base4-62",
     "name": "Tauros",
     "imageUrl": "https://images.pokemontcg.io/base4/62.png",
     "subtype": "Basic",
@@ -3494,7 +3556,8 @@
     "nationalPokedexNumber": 128
   },
   {
-    "id": "base4-63",
+    "setOrder":4,
+	"id": "base4-63",
     "name": "Wartortle",
     "imageUrl": "https://images.pokemontcg.io/base4/63.png",
     "subtype": "Stage 1",
@@ -3551,7 +3614,8 @@
     ]
   },
   {
-    "id": "base4-64",
+    "setOrder":4,
+	"id": "base4-64",
     "name": "Weepinbell",
     "imageUrl": "https://images.pokemontcg.io/base4/64.png",
     "subtype": "Stage 1",
@@ -3606,7 +3670,8 @@
     ]
   },
   {
-    "id": "base4-65",
+    "setOrder":4,
+	"id": "base4-65",
     "name": "Abra",
     "imageUrl": "https://images.pokemontcg.io/base4/65.png",
     "subtype": "Basic",
@@ -3647,7 +3712,8 @@
     ]
   },
   {
-    "id": "base4-66",
+    "setOrder":4,
+	"id": "base4-66",
     "name": "Bellsprout",
     "imageUrl": "https://images.pokemontcg.io/base4/66.png",
     "subtype": "Basic",
@@ -3700,7 +3766,8 @@
     ]
   },
   {
-    "id": "base4-67",
+    "setOrder":4,
+	"id": "base4-67",
     "name": "Bulbasaur",
     "imageUrl": "https://images.pokemontcg.io/base4/67.png",
     "subtype": "Basic",
@@ -3745,7 +3812,8 @@
     ]
   },
   {
-    "id": "base4-68",
+    "setOrder":4,
+	"id": "base4-68",
     "name": "Caterpie",
     "imageUrl": "https://images.pokemontcg.io/base4/68.png",
     "subtype": "Basic",
@@ -3789,7 +3857,8 @@
     ]
   },
   {
-    "id": "base4-69",
+    "setOrder":4,
+	"id": "base4-69",
     "name": "Charmander",
     "imageUrl": "https://images.pokemontcg.io/base4/69.png",
     "subtype": "Basic",
@@ -3843,7 +3912,8 @@
     ]
   },
   {
-    "id": "base4-70",
+    "setOrder":4,
+	"id": "base4-70",
     "name": "Cubone",
     "imageUrl": "https://images.pokemontcg.io/base4/70.png",
     "subtype": "Basic",
@@ -3903,7 +3973,8 @@
     ]
   },
   {
-    "id": "base4-71",
+    "setOrder":4,
+	"id": "base4-71",
     "name": "Diglett",
     "imageUrl": "https://images.pokemontcg.io/base4/71.png",
     "subtype": "Basic",
@@ -3960,7 +4031,8 @@
     ]
   },
   {
-    "id": "base4-72",
+    "setOrder":4,
+	"id": "base4-72",
     "name": "Doduo",
     "imageUrl": "https://images.pokemontcg.io/base4/72.png",
     "subtype": "Basic",
@@ -4007,7 +4079,8 @@
     ]
   },
   {
-    "id": "base4-73",
+    "setOrder":4,
+	"id": "base4-73",
     "name": "Drowzee",
     "imageUrl": "https://images.pokemontcg.io/base4/73.png",
     "subtype": "Basic",
@@ -4058,7 +4131,8 @@
     ]
   },
   {
-    "id": "base4-74",
+    "setOrder":4,
+	"id": "base4-74",
     "name": "Exeggcute",
     "imageUrl": "https://images.pokemontcg.io/base4/74.png",
     "subtype": "Basic",
@@ -4112,7 +4186,8 @@
     ]
   },
   {
-    "id": "base4-75",
+    "setOrder":4,
+	"id": "base4-75",
     "name": "Gastly",
     "imageUrl": "https://images.pokemontcg.io/base4/75.png",
     "subtype": "Basic",
@@ -4163,7 +4238,8 @@
     ]
   },
   {
-    "id": "base4-76",
+    "setOrder":4,
+	"id": "base4-76",
     "name": "Goldeen",
     "imageUrl": "https://images.pokemontcg.io/base4/76.png",
     "subtype": "Basic",
@@ -4204,7 +4280,8 @@
     ]
   },
   {
-    "id": "base4-77",
+    "setOrder":4,
+	"id": "base4-77",
     "name": "Jigglypuff",
     "imageUrl": "https://images.pokemontcg.io/base4/77.png",
     "subtype": "Basic",
@@ -4264,7 +4341,8 @@
     ]
   },
   {
-    "id": "base4-78",
+    "setOrder":4,
+	"id": "base4-78",
     "name": "Machop",
     "imageUrl": "https://images.pokemontcg.io/base4/78.png",
     "subtype": "Basic",
@@ -4308,7 +4386,8 @@
     ]
   },
   {
-    "id": "base4-79",
+    "setOrder":4,
+	"id": "base4-79",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/base4/79.png",
     "subtype": "Basic",
@@ -4362,7 +4441,8 @@
     ]
   },
   {
-    "id": "base4-80",
+    "setOrder":4,
+	"id": "base4-80",
     "name": "Meowth",
     "imageUrl": "https://images.pokemontcg.io/base4/80.png",
     "subtype": "Basic",
@@ -4413,7 +4493,8 @@
     ]
   },
   {
-    "id": "base4-81",
+    "setOrder":4,
+	"id": "base4-81",
     "name": "Metapod",
     "imageUrl": "https://images.pokemontcg.io/base4/81.png",
     "subtype": "Stage 1",
@@ -4470,7 +4551,8 @@
     ]
   },
   {
-    "id": "base4-82",
+    "setOrder":4,
+	"id": "base4-82",
     "name": "Nidoran♀",
     "imageUrl": "https://images.pokemontcg.io/base4/82.png",
     "subtype": "Basic",
@@ -4524,7 +4606,8 @@
     ]
   },
   {
-    "id": "base4-83",
+    "setOrder":4,
+	"id": "base4-83",
     "name": "Nidoran♂",
     "imageUrl": "https://images.pokemontcg.io/base4/83.png",
     "subtype": "Basic",
@@ -4568,7 +4651,8 @@
     ]
   },
   {
-    "id": "base4-84",
+    "setOrder":4,
+	"id": "base4-84",
     "name": "Onix",
     "imageUrl": "https://images.pokemontcg.io/base4/84.png",
     "subtype": "Basic",
@@ -4624,7 +4708,8 @@
     ]
   },
   {
-    "id": "base4-85",
+    "setOrder":4,
+	"id": "base4-85",
     "name": "Paras",
     "imageUrl": "https://images.pokemontcg.io/base4/85.png",
     "subtype": "Basic",
@@ -4679,7 +4764,8 @@
     ]
   },
   {
-    "id": "base4-86",
+    "setOrder":4,
+	"id": "base4-86",
     "name": "Pidgey",
     "imageUrl": "https://images.pokemontcg.io/base4/86.png",
     "subtype": "Basic",
@@ -4730,7 +4816,8 @@
     ]
   },
   {
-    "id": "base4-87",
+    "setOrder":4,
+	"id": "base4-87",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/base4/87.png",
     "subtype": "Basic",
@@ -4784,7 +4871,8 @@
     ]
   },
   {
-    "id": "base4-88",
+    "setOrder":4,
+	"id": "base4-88",
     "name": "Poliwag",
     "imageUrl": "https://images.pokemontcg.io/base4/88.png",
     "subtype": "Basic",
@@ -4828,7 +4916,8 @@
     ]
   },
   {
-    "id": "base4-89",
+    "setOrder":4,
+	"id": "base4-89",
     "name": "Rattata",
     "imageUrl": "https://images.pokemontcg.io/base4/89.png",
     "subtype": "Basic",
@@ -4875,7 +4964,8 @@
     ]
   },
   {
-    "id": "base4-90",
+    "setOrder":4,
+	"id": "base4-90",
     "name": "Rhyhorn",
     "imageUrl": "https://images.pokemontcg.io/base4/90.png",
     "subtype": "Basic",
@@ -4938,7 +5028,8 @@
     ]
   },
   {
-    "id": "base4-91",
+    "setOrder":4,
+	"id": "base4-91",
     "name": "Sandshrew",
     "imageUrl": "https://images.pokemontcg.io/base4/91.png",
     "subtype": "Basic",
@@ -4988,7 +5079,8 @@
     ]
   },
   {
-    "id": "base4-92",
+    "setOrder":4,
+	"id": "base4-92",
     "name": "Spearow",
     "imageUrl": "https://images.pokemontcg.io/base4/92.png",
     "subtype": "Basic",
@@ -5046,7 +5138,8 @@
     ]
   },
   {
-    "id": "base4-93",
+    "setOrder":4,
+	"id": "base4-93",
     "name": "Squirtle",
     "imageUrl": "https://images.pokemontcg.io/base4/93.png",
     "subtype": "Basic",
@@ -5100,7 +5193,8 @@
     ]
   },
   {
-    "id": "base4-94",
+    "setOrder":4,
+	"id": "base4-94",
     "name": "Starmie",
     "imageUrl": "https://images.pokemontcg.io/base4/94.png",
     "subtype": "Stage 1",
@@ -5154,7 +5248,8 @@
     "nationalPokedexNumber": 121
   },
   {
-    "id": "base4-95",
+    "setOrder":4,
+	"id": "base4-95",
     "name": "Staryu",
     "imageUrl": "https://images.pokemontcg.io/base4/95.png",
     "subtype": "Basic",
@@ -5198,7 +5293,8 @@
     ]
   },
   {
-    "id": "base4-96",
+    "setOrder":4,
+	"id": "base4-96",
     "name": "Tangela",
     "imageUrl": "https://images.pokemontcg.io/base4/96.png",
     "subtype": "Basic",
@@ -5255,7 +5351,8 @@
     ]
   },
   {
-    "id": "base4-97",
+    "setOrder":4,
+	"id": "base4-97",
     "name": "Venonat",
     "imageUrl": "https://images.pokemontcg.io/base4/97.png",
     "subtype": "Basic",
@@ -5309,7 +5406,8 @@
     ]
   },
   {
-    "id": "base4-98",
+    "setOrder":4,
+	"id": "base4-98",
     "name": "Voltorb",
     "imageUrl": "https://images.pokemontcg.io/base4/98.png",
     "subtype": "Basic",
@@ -5353,7 +5451,8 @@
     ]
   },
   {
-    "id": "base4-99",
+    "setOrder":4,
+	"id": "base4-99",
     "name": "Vulpix",
     "imageUrl": "https://images.pokemontcg.io/base4/99.png",
     "subtype": "Basic",
@@ -5398,7 +5497,8 @@
     ]
   },
   {
-    "id": "base4-100",
+    "setOrder":4,
+	"id": "base4-100",
     "name": "Weedle",
     "imageUrl": "https://images.pokemontcg.io/base4/100.png",
     "subtype": "Basic",
@@ -5442,7 +5542,8 @@
     ]
   },
   {
-    "id": "base4-101",
+    "setOrder":4,
+	"id": "base4-101",
     "name": "Computer Search",
     "imageUrl": "https://images.pokemontcg.io/base4/101.png",
     "subtype": "",
@@ -5459,7 +5560,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/101_hires.png"
   },
   {
-    "id": "base4-102",
+    "setOrder":4,
+	"id": "base4-102",
     "name": "Impostor Professor Oak",
     "imageUrl": "https://images.pokemontcg.io/base4/102.png",
     "subtype": "",
@@ -5476,7 +5578,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/102_hires.png"
   },
   {
-    "id": "base4-103",
+    "setOrder":4,
+	"id": "base4-103",
     "name": "Item Finder",
     "imageUrl": "https://images.pokemontcg.io/base4/103.png",
     "subtype": "",
@@ -5493,7 +5596,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/103_hires.png"
   },
   {
-    "id": "base4-104",
+    "setOrder":4,
+	"id": "base4-104",
     "name": "Lass",
     "imageUrl": "https://images.pokemontcg.io/base4/104.png",
     "subtype": "",
@@ -5510,7 +5614,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/104_hires.png"
   },
   {
-    "id": "base4-105",
+    "setOrder":4,
+	"id": "base4-105",
     "name": "Pokémon Breeder",
     "imageUrl": "https://images.pokemontcg.io/base4/105.png",
     "subtype": "",
@@ -5527,7 +5632,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/105_hires.png"
   },
   {
-    "id": "base4-106",
+    "setOrder":4,
+	"id": "base4-106",
     "name": "Pokémon Trader",
     "imageUrl": "https://images.pokemontcg.io/base4/106.png",
     "subtype": "",
@@ -5544,7 +5650,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/106_hires.png"
   },
   {
-    "id": "base4-107",
+    "setOrder":4,
+	"id": "base4-107",
     "name": "Scoop Up",
     "imageUrl": "https://images.pokemontcg.io/base4/107.png",
     "subtype": "",
@@ -5561,7 +5668,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/107_hires.png"
   },
   {
-    "id": "base4-108",
+    "setOrder":4,
+	"id": "base4-108",
     "name": "Super Energy Removal",
     "imageUrl": "https://images.pokemontcg.io/base4/108.png",
     "subtype": "",
@@ -5578,7 +5686,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/108_hires.png"
   },
   {
-    "id": "base4-109",
+    "setOrder":4,
+	"id": "base4-109",
     "name": "Defender",
     "imageUrl": "https://images.pokemontcg.io/base4/109.png",
     "subtype": "",
@@ -5595,7 +5704,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/109_hires.png"
   },
   {
-    "id": "base4-110",
+    "setOrder":4,
+	"id": "base4-110",
     "name": "Energy Retrieval",
     "imageUrl": "https://images.pokemontcg.io/base4/110.png",
     "subtype": "",
@@ -5612,7 +5722,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/110_hires.png"
   },
   {
-    "id": "base4-111",
+    "setOrder":4,
+	"id": "base4-111",
     "name": "Full Heal",
     "imageUrl": "https://images.pokemontcg.io/base4/111.png",
     "subtype": "",
@@ -5629,7 +5740,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/111_hires.png"
   },
   {
-    "id": "base4-112",
+    "setOrder":4,
+	"id": "base4-112",
     "name": "Maintenance",
     "imageUrl": "https://images.pokemontcg.io/base4/112.png",
     "subtype": "",
@@ -5646,7 +5758,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/112_hires.png"
   },
   {
-    "id": "base4-113",
+    "setOrder":4,
+	"id": "base4-113",
     "name": "PlusPower",
     "imageUrl": "https://images.pokemontcg.io/base4/113.png",
     "subtype": "",
@@ -5663,7 +5776,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/113_hires.png"
   },
   {
-    "id": "base4-114",
+    "setOrder":4,
+	"id": "base4-114",
     "name": "Pokémon Center",
     "imageUrl": "https://images.pokemontcg.io/base4/114.png",
     "subtype": "",
@@ -5680,7 +5794,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/114_hires.png"
   },
   {
-    "id": "base4-115",
+    "setOrder":4,
+	"id": "base4-115",
     "name": "Pokédex",
     "imageUrl": "https://images.pokemontcg.io/base4/115.png",
     "subtype": "",
@@ -5697,7 +5812,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/115_hires.png"
   },
   {
-    "id": "base4-116",
+    "setOrder":4,
+	"id": "base4-116",
     "name": "Professor Oak",
     "imageUrl": "https://images.pokemontcg.io/base4/116.png",
     "subtype": "",
@@ -5714,7 +5830,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/116_hires.png"
   },
   {
-    "id": "base4-117",
+    "setOrder":4,
+	"id": "base4-117",
     "name": "Super Potion",
     "imageUrl": "https://images.pokemontcg.io/base4/117.png",
     "subtype": "",
@@ -5731,7 +5848,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/117_hires.png"
   },
   {
-    "id": "base4-118",
+    "setOrder":4,
+	"id": "base4-118",
     "name": "Bill",
     "imageUrl": "https://images.pokemontcg.io/base4/118.png",
     "subtype": "",
@@ -5748,7 +5866,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/118_hires.png"
   },
   {
-    "id": "base4-119",
+    "setOrder":4,
+	"id": "base4-119",
     "name": "Energy Removal",
     "imageUrl": "https://images.pokemontcg.io/base4/119.png",
     "subtype": "",
@@ -5765,7 +5884,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/119_hires.png"
   },
   {
-    "id": "base4-120",
+    "setOrder":4,
+	"id": "base4-120",
     "name": "Gust of Wind",
     "imageUrl": "https://images.pokemontcg.io/base4/120.png",
     "subtype": "",
@@ -5782,7 +5902,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/120_hires.png"
   },
   {
-    "id": "base4-121",
+    "setOrder":4,
+	"id": "base4-121",
     "name": "Poké Ball",
     "imageUrl": "https://images.pokemontcg.io/base4/121.png",
     "subtype": "",
@@ -5799,7 +5920,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/121_hires.png"
   },
   {
-    "id": "base4-122",
+    "setOrder":4,
+	"id": "base4-122",
     "name": "Potion",
     "imageUrl": "https://images.pokemontcg.io/base4/122.png",
     "subtype": "",
@@ -5816,7 +5938,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/122_hires.png"
   },
   {
-    "id": "base4-123",
+    "setOrder":4,
+	"id": "base4-123",
     "name": "Switch",
     "imageUrl": "https://images.pokemontcg.io/base4/123.png",
     "subtype": "",
@@ -5833,7 +5956,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/123_hires.png"
   },
   {
-    "id": "base4-124",
+    "setOrder":4,
+	"id": "base4-124",
     "name": "Double Colorless Energy",
     "imageUrl": "https://images.pokemontcg.io/base4/124.png",
     "subtype": "Special",
@@ -5850,7 +5974,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/124_hires.png"
   },
   {
-    "id": "base4-125",
+    "setOrder":4,
+	"id": "base4-125",
     "name": "Fighting Energy",
     "imageUrl": "https://images.pokemontcg.io/base4/125.png",
     "subtype": "Basic",
@@ -5864,7 +5989,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/125_hires.png"
   },
   {
-    "id": "base4-126",
+    "setOrder":4,
+	"id": "base4-126",
     "name": "Fire Energy",
     "imageUrl": "https://images.pokemontcg.io/base4/126.png",
     "subtype": "Basic",
@@ -5878,7 +6004,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/126_hires.png"
   },
   {
-    "id": "base4-127",
+    "setOrder":4,
+	"id": "base4-127",
     "name": "Grass Energy",
     "imageUrl": "https://images.pokemontcg.io/base4/127.png",
     "subtype": "Basic",
@@ -5892,7 +6019,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/127_hires.png"
   },
   {
-    "id": "base4-128",
+    "setOrder":4,
+	"id": "base4-128",
     "name": "Lightning Energy",
     "imageUrl": "https://images.pokemontcg.io/base4/128.png",
     "subtype": "Basic",
@@ -5906,7 +6034,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/128_hires.png"
   },
   {
-    "id": "base4-129",
+    "setOrder":4,
+	"id": "base4-129",
     "name": "Psychic Energy",
     "imageUrl": "https://images.pokemontcg.io/base4/129.png",
     "subtype": "Basic",
@@ -5920,7 +6049,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base4/129_hires.png"
   },
   {
-    "id": "base4-130",
+    "setOrder":4,
+	"id": "base4-130",
     "name": "Water Energy",
     "imageUrl": "https://images.pokemontcg.io/base4/130.png",
     "subtype": "Basic",

--- a/json/cards/Base.json
+++ b/json/cards/Base.json
@@ -1,5 +1,6 @@
 [
   {
+	"setOrder":1,
     "id": "base1-1",
     "name": "Alakazam",
     "imageUrl": "https://images.pokemontcg.io/base1/1.png",
@@ -51,6 +52,7 @@
     "nationalPokedexNumber": 65
   },
   {
+	"setOrder":1,
     "id": "base1-2",
     "name": "Blastoise",
     "imageUrl": "https://images.pokemontcg.io/base1/2.png",
@@ -102,6 +104,7 @@
     "nationalPokedexNumber": 9
   },
   {
+	"setOrder":1,
     "id": "base1-3",
     "name": "Chansey",
     "imageUrl": "https://images.pokemontcg.io/base1/3.png",
@@ -165,6 +168,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-4",
     "name": "Charizard",
     "imageUrl": "https://images.pokemontcg.io/base1/4.png",
@@ -223,6 +227,7 @@
     "nationalPokedexNumber": 6
   },
   {
+	"setOrder":1,
     "id": "base1-5",
     "name": "Clefairy",
     "imageUrl": "https://images.pokemontcg.io/base1/5.png",
@@ -284,6 +289,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-6",
     "name": "Gyarados",
     "imageUrl": "https://images.pokemontcg.io/base1/6.png",
@@ -348,6 +354,7 @@
     "nationalPokedexNumber": 130
   },
   {
+	"setOrder":1,
     "id": "base1-7",
     "name": "Hitmonchan",
     "imageUrl": "https://images.pokemontcg.io/base1/7.png",
@@ -401,6 +408,7 @@
     "nationalPokedexNumber": 107
   },
   {
+	"setOrder":1,
     "id": "base1-8",
     "name": "Machamp",
     "imageUrl": "https://images.pokemontcg.io/base1/8.png",
@@ -453,6 +461,7 @@
     "nationalPokedexNumber": 68
   },
   {
+	"setOrder":1,
     "id": "base1-9",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/base1/9.png",
@@ -512,6 +521,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-10",
     "name": "Mewtwo",
     "imageUrl": "https://images.pokemontcg.io/base1/10.png",
@@ -566,6 +576,7 @@
     "nationalPokedexNumber": 150
   },
   {
+	"setOrder":1,
     "id": "base1-11",
     "name": "Nidoking",
     "imageUrl": "https://images.pokemontcg.io/base1/11.png",
@@ -623,6 +634,7 @@
     "nationalPokedexNumber": 34
   },
   {
+	"setOrder":1,
     "id": "base1-12",
     "name": "Ninetales",
     "imageUrl": "https://images.pokemontcg.io/base1/12.png",
@@ -678,6 +690,7 @@
     "nationalPokedexNumber": 38
   },
   {
+	"setOrder":1,
     "id": "base1-13",
     "name": "Poliwrath",
     "imageUrl": "https://images.pokemontcg.io/base1/13.png",
@@ -736,6 +749,7 @@
     "nationalPokedexNumber": 62
   },
   {
+	"setOrder":1,
     "id": "base1-14",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/base1/14.png",
@@ -792,6 +806,7 @@
     "nationalPokedexNumber": 26
   },
   {
+	"setOrder":1,
     "id": "base1-15",
     "name": "Venusaur",
     "imageUrl": "https://images.pokemontcg.io/base1/15.png",
@@ -843,6 +858,7 @@
     "nationalPokedexNumber": 3
   },
   {
+	"setOrder":1,
     "id": "base1-16",
     "name": "Zapdos",
     "imageUrl": "https://images.pokemontcg.io/base1/16.png",
@@ -901,6 +917,7 @@
     "nationalPokedexNumber": 145
   },
   {
+	"setOrder":1,
     "id": "base1-17",
     "name": "Beedrill",
     "imageUrl": "https://images.pokemontcg.io/base1/17.png",
@@ -959,6 +976,7 @@
     "nationalPokedexNumber": 15
   },
   {
+	"setOrder":1,
     "id": "base1-18",
     "name": "Dragonair",
     "imageUrl": "https://images.pokemontcg.io/base1/18.png",
@@ -1019,6 +1037,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-19",
     "name": "Dugtrio",
     "imageUrl": "https://images.pokemontcg.io/base1/19.png",
@@ -1082,6 +1101,7 @@
     "nationalPokedexNumber": 51
   },
   {
+	"setOrder":1,
     "id": "base1-20",
     "name": "Electabuzz",
     "imageUrl": "https://images.pokemontcg.io/base1/20.png",
@@ -1137,6 +1157,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-21",
     "name": "Electrode",
     "imageUrl": "https://images.pokemontcg.io/base1/21.png",
@@ -1186,6 +1207,7 @@
     "nationalPokedexNumber": 101
   },
   {
+	"setOrder":1,
     "id": "base1-22",
     "name": "Pidgeotto",
     "imageUrl": "https://images.pokemontcg.io/base1/22.png",
@@ -1249,6 +1271,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-23",
     "name": "Arcanine",
     "imageUrl": "https://images.pokemontcg.io/base1/23.png",
@@ -1307,6 +1330,7 @@
     "nationalPokedexNumber": 59
   },
   {
+	"setOrder":1,
     "id": "base1-24",
     "name": "Charmeleon",
     "imageUrl": "https://images.pokemontcg.io/base1/24.png",
@@ -1365,6 +1389,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-25",
     "name": "Dewgong",
     "imageUrl": "https://images.pokemontcg.io/base1/25.png",
@@ -1423,6 +1448,7 @@
     "nationalPokedexNumber": 87
   },
   {
+	"setOrder":1,
     "id": "base1-26",
     "name": "Dratini",
     "imageUrl": "https://images.pokemontcg.io/base1/26.png",
@@ -1467,6 +1493,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-27",
     "name": "Farfetch'd",
     "imageUrl": "https://images.pokemontcg.io/base1/27.png",
@@ -1525,6 +1552,7 @@
     "nationalPokedexNumber": 83
   },
   {
+	"setOrder":1,
     "id": "base1-28",
     "name": "Growlithe",
     "imageUrl": "https://images.pokemontcg.io/base1/28.png",
@@ -1570,6 +1598,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-29",
     "name": "Haunter",
     "imageUrl": "https://images.pokemontcg.io/base1/29.png",
@@ -1625,6 +1654,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-30",
     "name": "Ivysaur",
     "imageUrl": "https://images.pokemontcg.io/base1/30.png",
@@ -1683,6 +1713,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-31",
     "name": "Jynx",
     "imageUrl": "https://images.pokemontcg.io/base1/31.png",
@@ -1736,6 +1767,7 @@
     "nationalPokedexNumber": 124
   },
   {
+	"setOrder":1,
     "id": "base1-32",
     "name": "Kadabra",
     "imageUrl": "https://images.pokemontcg.io/base1/32.png",
@@ -1795,6 +1827,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-33",
     "name": "Kakuna",
     "imageUrl": "https://images.pokemontcg.io/base1/33.png",
@@ -1852,6 +1885,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-34",
     "name": "Machoke",
     "imageUrl": "https://images.pokemontcg.io/base1/34.png",
@@ -1913,6 +1947,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-35",
     "name": "Magikarp",
     "imageUrl": "https://images.pokemontcg.io/base1/35.png",
@@ -1966,6 +2001,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-36",
     "name": "Magmar",
     "imageUrl": "https://images.pokemontcg.io/base1/36.png",
@@ -2023,6 +2059,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-37",
     "name": "Nidorino",
     "imageUrl": "https://images.pokemontcg.io/base1/37.png",
@@ -2082,6 +2119,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-38",
     "name": "Poliwhirl",
     "imageUrl": "https://images.pokemontcg.io/base1/38.png",
@@ -2140,6 +2178,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-39",
     "name": "Porygon",
     "imageUrl": "https://images.pokemontcg.io/base1/39.png",
@@ -2200,6 +2239,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-40",
     "name": "Raticate",
     "imageUrl": "https://images.pokemontcg.io/base1/40.png",
@@ -2259,6 +2299,7 @@
     "nationalPokedexNumber": 20
   },
   {
+	"setOrder":1,
     "id": "base1-41",
     "name": "Seel",
     "imageUrl": "https://images.pokemontcg.io/base1/41.png",
@@ -2303,6 +2344,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-42",
     "name": "Wartortle",
     "imageUrl": "https://images.pokemontcg.io/base1/42.png",
@@ -2360,6 +2402,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-43",
     "name": "Abra",
     "imageUrl": "https://images.pokemontcg.io/base1/43.png",
@@ -2401,6 +2444,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-44",
     "name": "Bulbasaur",
     "imageUrl": "https://images.pokemontcg.io/base1/44.png",
@@ -2446,6 +2490,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-45",
     "name": "Caterpie",
     "imageUrl": "https://images.pokemontcg.io/base1/45.png",
@@ -2490,6 +2535,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-46",
     "name": "Charmander",
     "imageUrl": "https://images.pokemontcg.io/base1/46.png",
@@ -2544,6 +2590,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-47",
     "name": "Diglett",
     "imageUrl": "https://images.pokemontcg.io/base1/47.png",
@@ -2601,6 +2648,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-48",
     "name": "Doduo",
     "imageUrl": "https://images.pokemontcg.io/base1/48.png",
@@ -2648,6 +2696,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-49",
     "name": "Drowzee",
     "imageUrl": "https://images.pokemontcg.io/base1/49.png",
@@ -2699,6 +2748,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-50",
     "name": "Gastly",
     "imageUrl": "https://images.pokemontcg.io/base1/50.png",
@@ -2750,6 +2800,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-51",
     "name": "Koffing",
     "imageUrl": "https://images.pokemontcg.io/base1/51.png",
@@ -2795,6 +2846,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-52",
     "name": "Machop",
     "imageUrl": "https://images.pokemontcg.io/base1/52.png",
@@ -2839,6 +2891,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-53",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/base1/53.png",
@@ -2893,6 +2946,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-54",
     "name": "Metapod",
     "imageUrl": "https://images.pokemontcg.io/base1/54.png",
@@ -2950,6 +3004,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-55",
     "name": "Nidoran♂",
     "imageUrl": "https://images.pokemontcg.io/base1/55.png",
@@ -2994,6 +3049,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-56",
     "name": "Onix",
     "imageUrl": "https://images.pokemontcg.io/base1/56.png",
@@ -3050,6 +3106,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-57",
     "name": "Pidgey",
     "imageUrl": "https://images.pokemontcg.io/base1/57.png",
@@ -3101,6 +3158,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-58",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/base1/58.png",
@@ -3155,6 +3213,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-59",
     "name": "Poliwag",
     "imageUrl": "https://images.pokemontcg.io/base1/59.png",
@@ -3199,6 +3258,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-60",
     "name": "Ponyta",
     "imageUrl": "https://images.pokemontcg.io/base1/60.png",
@@ -3254,6 +3314,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-61",
     "name": "Rattata",
     "imageUrl": "https://images.pokemontcg.io/base1/61.png",
@@ -3301,6 +3362,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-62",
     "name": "Sandshrew",
     "imageUrl": "https://images.pokemontcg.io/base1/62.png",
@@ -3351,6 +3413,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-63",
     "name": "Squirtle",
     "imageUrl": "https://images.pokemontcg.io/base1/63.png",
@@ -3405,6 +3468,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-64",
     "name": "Starmie",
     "imageUrl": "https://images.pokemontcg.io/base1/64.png",
@@ -3459,6 +3523,7 @@
     "nationalPokedexNumber": 121
   },
   {
+	"setOrder":1,
     "id": "base1-65",
     "name": "Staryu",
     "imageUrl": "https://images.pokemontcg.io/base1/65.png",
@@ -3503,6 +3568,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-66",
     "name": "Tangela",
     "imageUrl": "https://images.pokemontcg.io/base1/66.png",
@@ -3560,6 +3626,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-67",
     "name": "Voltorb",
     "imageUrl": "https://images.pokemontcg.io/base1/67.png",
@@ -3604,6 +3671,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-68",
     "name": "Vulpix",
     "imageUrl": "https://images.pokemontcg.io/base1/68.png",
@@ -3649,6 +3717,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-69",
     "name": "Weedle",
     "imageUrl": "https://images.pokemontcg.io/base1/69.png",
@@ -3693,6 +3762,7 @@
     ]
   },
   {
+	"setOrder":1,
     "id": "base1-70",
     "name": "Clefairy Doll",
     "imageUrl": "https://images.pokemontcg.io/base1/70.png",
@@ -3711,6 +3781,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/70_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-71",
     "name": "Computer Search",
     "imageUrl": "https://images.pokemontcg.io/base1/71.png",
@@ -3728,6 +3799,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/71_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-72",
     "name": "Devolution Spray",
     "imageUrl": "https://images.pokemontcg.io/base1/72.png",
@@ -3745,6 +3817,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/72_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-73",
     "name": "Impostor Professor Oak",
     "imageUrl": "https://images.pokemontcg.io/base1/73.png",
@@ -3762,6 +3835,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/73_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-74",
     "name": "Item Finder",
     "imageUrl": "https://images.pokemontcg.io/base1/74.png",
@@ -3779,6 +3853,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/74_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-75",
     "name": "Lass",
     "imageUrl": "https://images.pokemontcg.io/base1/75.png",
@@ -3796,6 +3871,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/75_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-76",
     "name": "Pokémon Breeder",
     "imageUrl": "https://images.pokemontcg.io/base1/76.png",
@@ -3813,6 +3889,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/76_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-77",
     "name": "Pokémon Trader",
     "imageUrl": "https://images.pokemontcg.io/base1/77.png",
@@ -3830,6 +3907,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/77_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-78",
     "name": "Scoop Up",
     "imageUrl": "https://images.pokemontcg.io/base1/78.png",
@@ -3847,6 +3925,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/78_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-79",
     "name": "Super Energy Removal",
     "imageUrl": "https://images.pokemontcg.io/base1/79.png",
@@ -3864,6 +3943,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/79_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-80",
     "name": "Defender",
     "imageUrl": "https://images.pokemontcg.io/base1/80.png",
@@ -3881,6 +3961,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/80_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-81",
     "name": "Energy Retrieval",
     "imageUrl": "https://images.pokemontcg.io/base1/81.png",
@@ -3898,6 +3979,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/81_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-82",
     "name": "Full Heal",
     "imageUrl": "https://images.pokemontcg.io/base1/82.png",
@@ -3915,6 +3997,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/82_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-83",
     "name": "Maintenance",
     "imageUrl": "https://images.pokemontcg.io/base1/83.png",
@@ -3932,6 +4015,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/83_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-84",
     "name": "PlusPower",
     "imageUrl": "https://images.pokemontcg.io/base1/84.png",
@@ -3949,6 +4033,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/84_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-85",
     "name": "Pokémon Center",
     "imageUrl": "https://images.pokemontcg.io/base1/85.png",
@@ -3966,6 +4051,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/85_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-86",
     "name": "Pokémon Flute",
     "imageUrl": "https://images.pokemontcg.io/base1/86.png",
@@ -3983,6 +4069,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/86_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-87",
     "name": "Pokédex",
     "imageUrl": "https://images.pokemontcg.io/base1/87.png",
@@ -4000,6 +4087,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/87_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-88",
     "name": "Professor Oak",
     "imageUrl": "https://images.pokemontcg.io/base1/88.png",
@@ -4017,6 +4105,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/88_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-89",
     "name": "Revive",
     "imageUrl": "https://images.pokemontcg.io/base1/89.png",
@@ -4034,6 +4123,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/89_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-90",
     "name": "Super Potion",
     "imageUrl": "https://images.pokemontcg.io/base1/90.png",
@@ -4051,6 +4141,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/90_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-91",
     "name": "Bill",
     "imageUrl": "https://images.pokemontcg.io/base1/91.png",
@@ -4068,6 +4159,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/91_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-92",
     "name": "Energy Removal",
     "imageUrl": "https://images.pokemontcg.io/base1/92.png",
@@ -4085,6 +4177,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/92_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-93",
     "name": "Gust of Wind",
     "imageUrl": "https://images.pokemontcg.io/base1/93.png",
@@ -4102,6 +4195,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/93_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-94",
     "name": "Potion",
     "imageUrl": "https://images.pokemontcg.io/base1/94.png",
@@ -4119,6 +4213,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/94_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-95",
     "name": "Switch",
     "imageUrl": "https://images.pokemontcg.io/base1/95.png",
@@ -4136,6 +4231,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/95_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-96",
     "name": "Double Colorless Energy",
     "imageUrl": "https://images.pokemontcg.io/base1/96.png",
@@ -4153,6 +4249,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/96_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-97",
     "name": "Fighting Energy",
     "imageUrl": "https://images.pokemontcg.io/base1/97.png",
@@ -4167,6 +4264,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/97_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-98",
     "name": "Fire Energy",
     "imageUrl": "https://images.pokemontcg.io/base1/98.png",
@@ -4181,6 +4279,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/98_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-99",
     "name": "Grass Energy",
     "imageUrl": "https://images.pokemontcg.io/base1/99.png",
@@ -4195,6 +4294,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/99_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-100",
     "name": "Lightning Energy",
     "imageUrl": "https://images.pokemontcg.io/base1/100.png",
@@ -4209,6 +4309,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/100_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-101",
     "name": "Psychic Energy",
     "imageUrl": "https://images.pokemontcg.io/base1/101.png",
@@ -4223,6 +4324,7 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base1/101_hires.png"
   },
   {
+	"setOrder":1,
     "id": "base1-102",
     "name": "Water Energy",
     "imageUrl": "https://images.pokemontcg.io/base1/102.png",

--- a/json/cards/Black & White.json
+++ b/json/cards/Black & White.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "bw1-1",
+    "setOrder":48,
+	"id": "bw1-1",
     "name": "Snivy",
     "imageUrl": "https://images.pokemontcg.io/bw1/1.png",
     "subtype": "Basic",
@@ -59,7 +60,8 @@
     ]
   },
   {
-    "id": "bw1-2",
+    "setOrder":48,
+	"id": "bw1-2",
     "name": "Snivy",
     "imageUrl": "https://images.pokemontcg.io/bw1/2.png",
     "subtype": "Basic",
@@ -109,7 +111,8 @@
     ]
   },
   {
-    "id": "bw1-3",
+    "setOrder":48,
+	"id": "bw1-3",
     "name": "Servine",
     "imageUrl": "https://images.pokemontcg.io/bw1/3.png",
     "subtype": "Stage 1",
@@ -169,7 +172,8 @@
     ]
   },
   {
-    "id": "bw1-4",
+    "setOrder":48,
+	"id": "bw1-4",
     "name": "Servine",
     "imageUrl": "https://images.pokemontcg.io/bw1/4.png",
     "subtype": "Stage 1",
@@ -220,7 +224,8 @@
     ]
   },
   {
-    "id": "bw1-5",
+    "setOrder":48,
+	"id": "bw1-5",
     "name": "Serperior",
     "imageUrl": "https://images.pokemontcg.io/bw1/5.png",
     "subtype": "Stage 2",
@@ -275,7 +280,8 @@
     "nationalPokedexNumber": 497
   },
   {
-    "id": "bw1-6",
+    "setOrder":48,
+	"id": "bw1-6",
     "name": "Serperior",
     "imageUrl": "https://images.pokemontcg.io/bw1/6.png",
     "subtype": "Stage 2",
@@ -328,7 +334,8 @@
     "nationalPokedexNumber": 497
   },
   {
-    "id": "bw1-7",
+    "setOrder":48,
+	"id": "bw1-7",
     "name": "Pansage",
     "imageUrl": "https://images.pokemontcg.io/bw1/7.png",
     "subtype": "Basic",
@@ -388,7 +395,8 @@
     ]
   },
   {
-    "id": "bw1-8",
+    "setOrder":48,
+	"id": "bw1-8",
     "name": "Simisage",
     "imageUrl": "https://images.pokemontcg.io/bw1/8.png",
     "subtype": "Stage 1",
@@ -447,7 +455,8 @@
     "nationalPokedexNumber": 512
   },
   {
-    "id": "bw1-9",
+    "setOrder":48,
+	"id": "bw1-9",
     "name": "Petilil",
     "imageUrl": "https://images.pokemontcg.io/bw1/9.png",
     "subtype": "Basic",
@@ -496,7 +505,8 @@
     ]
   },
   {
-    "id": "bw1-10",
+    "setOrder":48,
+	"id": "bw1-10",
     "name": "Lilligant",
     "imageUrl": "https://images.pokemontcg.io/bw1/10.png",
     "subtype": "Stage 1",
@@ -553,7 +563,8 @@
     "nationalPokedexNumber": 549
   },
   {
-    "id": "bw1-11",
+    "setOrder":48,
+	"id": "bw1-11",
     "name": "Maractus",
     "imageUrl": "https://images.pokemontcg.io/bw1/11.png",
     "subtype": "Basic",
@@ -611,7 +622,8 @@
     "nationalPokedexNumber": 556
   },
   {
-    "id": "bw1-12",
+    "setOrder":48,
+	"id": "bw1-12",
     "name": "Maractus",
     "imageUrl": "https://images.pokemontcg.io/bw1/12.png",
     "subtype": "Basic",
@@ -669,7 +681,8 @@
     "nationalPokedexNumber": 556
   },
   {
-    "id": "bw1-13",
+    "setOrder":48,
+	"id": "bw1-13",
     "name": "Deerling",
     "imageUrl": "https://images.pokemontcg.io/bw1/13.png",
     "subtype": "Basic",
@@ -728,7 +741,8 @@
     ]
   },
   {
-    "id": "bw1-14",
+    "setOrder":48,
+	"id": "bw1-14",
     "name": "Sawsbuck",
     "imageUrl": "https://images.pokemontcg.io/bw1/14.png",
     "subtype": "Stage 1",
@@ -786,7 +800,8 @@
     "nationalPokedexNumber": 586
   },
   {
-    "id": "bw1-15",
+    "setOrder":48,
+	"id": "bw1-15",
     "name": "Tepig",
     "imageUrl": "https://images.pokemontcg.io/bw1/15.png",
     "subtype": "Basic",
@@ -839,7 +854,8 @@
     ]
   },
   {
-    "id": "bw1-16",
+    "setOrder":48,
+	"id": "bw1-16",
     "name": "Tepig",
     "imageUrl": "https://images.pokemontcg.io/bw1/16.png",
     "subtype": "Basic",
@@ -884,7 +900,8 @@
     ]
   },
   {
-    "id": "bw1-17",
+    "setOrder":48,
+	"id": "bw1-17",
     "name": "Pignite",
     "imageUrl": "https://images.pokemontcg.io/bw1/17.png",
     "subtype": "Stage 1",
@@ -941,7 +958,8 @@
     ]
   },
   {
-    "id": "bw1-18",
+    "setOrder":48,
+	"id": "bw1-18",
     "name": "Pignite",
     "imageUrl": "https://images.pokemontcg.io/bw1/18.png",
     "subtype": "Stage 1",
@@ -999,7 +1017,8 @@
     ]
   },
   {
-    "id": "bw1-19",
+    "setOrder":48,
+	"id": "bw1-19",
     "name": "Emboar",
     "imageUrl": "https://images.pokemontcg.io/bw1/19.png",
     "subtype": "Stage 2",
@@ -1057,7 +1076,8 @@
     "nationalPokedexNumber": 500
   },
   {
-    "id": "bw1-20",
+    "setOrder":48,
+	"id": "bw1-20",
     "name": "Emboar",
     "imageUrl": "https://images.pokemontcg.io/bw1/20.png",
     "subtype": "Stage 2",
@@ -1109,7 +1129,8 @@
     "nationalPokedexNumber": 500
   },
   {
-    "id": "bw1-21",
+    "setOrder":48,
+	"id": "bw1-21",
     "name": "Pansear",
     "imageUrl": "https://images.pokemontcg.io/bw1/21.png",
     "subtype": "Basic",
@@ -1163,7 +1184,8 @@
     ]
   },
   {
-    "id": "bw1-22",
+    "setOrder":48,
+	"id": "bw1-22",
     "name": "Simisear",
     "imageUrl": "https://images.pokemontcg.io/bw1/22.png",
     "subtype": "Stage 1",
@@ -1215,7 +1237,8 @@
     "nationalPokedexNumber": 514
   },
   {
-    "id": "bw1-23",
+    "setOrder":48,
+	"id": "bw1-23",
     "name": "Darumaka",
     "imageUrl": "https://images.pokemontcg.io/bw1/23.png",
     "subtype": "Basic",
@@ -1259,7 +1282,8 @@
     ]
   },
   {
-    "id": "bw1-24",
+    "setOrder":48,
+	"id": "bw1-24",
     "name": "Darumaka",
     "imageUrl": "https://images.pokemontcg.io/bw1/24.png",
     "subtype": "Basic",
@@ -1313,7 +1337,8 @@
     ]
   },
   {
-    "id": "bw1-25",
+    "setOrder":48,
+	"id": "bw1-25",
     "name": "Darmanitan",
     "imageUrl": "https://images.pokemontcg.io/bw1/25.png",
     "subtype": "Stage 1",
@@ -1367,7 +1392,8 @@
     "nationalPokedexNumber": 555
   },
   {
-    "id": "bw1-26",
+    "setOrder":48,
+	"id": "bw1-26",
     "name": "Reshiram",
     "imageUrl": "https://images.pokemontcg.io/bw1/26.png",
     "subtype": "Basic",
@@ -1420,7 +1446,8 @@
     "nationalPokedexNumber": 643
   },
   {
-    "id": "bw1-27",
+    "setOrder":48,
+	"id": "bw1-27",
     "name": "Oshawott",
     "imageUrl": "https://images.pokemontcg.io/bw1/27.png",
     "subtype": "Basic",
@@ -1473,7 +1500,8 @@
     ]
   },
   {
-    "id": "bw1-28",
+    "setOrder":48,
+	"id": "bw1-28",
     "name": "Oshawott",
     "imageUrl": "https://images.pokemontcg.io/bw1/28.png",
     "subtype": "Basic",
@@ -1517,7 +1545,8 @@
     ]
   },
   {
-    "id": "bw1-29",
+    "setOrder":48,
+	"id": "bw1-29",
     "name": "Dewott",
     "imageUrl": "https://images.pokemontcg.io/bw1/29.png",
     "subtype": "Stage 1",
@@ -1573,7 +1602,8 @@
     ]
   },
   {
-    "id": "bw1-30",
+    "setOrder":48,
+	"id": "bw1-30",
     "name": "Dewott",
     "imageUrl": "https://images.pokemontcg.io/bw1/30.png",
     "subtype": "Stage 1",
@@ -1618,7 +1648,8 @@
     ]
   },
   {
-    "id": "bw1-31",
+    "setOrder":48,
+	"id": "bw1-31",
     "name": "Samurott",
     "imageUrl": "https://images.pokemontcg.io/bw1/31.png",
     "subtype": "Stage 2",
@@ -1672,7 +1703,8 @@
     "nationalPokedexNumber": 503
   },
   {
-    "id": "bw1-32",
+    "setOrder":48,
+	"id": "bw1-32",
     "name": "Samurott",
     "imageUrl": "https://images.pokemontcg.io/bw1/32.png",
     "subtype": "Stage 2",
@@ -1721,7 +1753,8 @@
     "nationalPokedexNumber": 503
   },
   {
-    "id": "bw1-33",
+    "setOrder":48,
+	"id": "bw1-33",
     "name": "Panpour",
     "imageUrl": "https://images.pokemontcg.io/bw1/33.png",
     "subtype": "Basic",
@@ -1775,7 +1808,8 @@
     ]
   },
   {
-    "id": "bw1-34",
+    "setOrder":48,
+	"id": "bw1-34",
     "name": "Simipour",
     "imageUrl": "https://images.pokemontcg.io/bw1/34.png",
     "subtype": "Stage 1",
@@ -1827,7 +1861,8 @@
     "nationalPokedexNumber": 516
   },
   {
-    "id": "bw1-35",
+    "setOrder":48,
+	"id": "bw1-35",
     "name": "Basculin",
     "imageUrl": "https://images.pokemontcg.io/bw1/35.png",
     "subtype": "Basic",
@@ -1868,7 +1903,8 @@
     "nationalPokedexNumber": 550
   },
   {
-    "id": "bw1-36",
+    "setOrder":48,
+	"id": "bw1-36",
     "name": "Ducklett",
     "imageUrl": "https://images.pokemontcg.io/bw1/36.png",
     "subtype": "Basic",
@@ -1917,7 +1953,8 @@
     ]
   },
   {
-    "id": "bw1-37",
+    "setOrder":48,
+	"id": "bw1-37",
     "name": "Swanna",
     "imageUrl": "https://images.pokemontcg.io/bw1/37.png",
     "subtype": "Stage 1",
@@ -1974,7 +2011,8 @@
     "nationalPokedexNumber": 581
   },
   {
-    "id": "bw1-38",
+    "setOrder":48,
+	"id": "bw1-38",
     "name": "Alomomola",
     "imageUrl": "https://images.pokemontcg.io/bw1/38.png",
     "subtype": "Basic",
@@ -2028,7 +2066,8 @@
     "nationalPokedexNumber": 594
   },
   {
-    "id": "bw1-39",
+    "setOrder":48,
+	"id": "bw1-39",
     "name": "Alomomola",
     "imageUrl": "https://images.pokemontcg.io/bw1/39.png",
     "subtype": "Basic",
@@ -2082,7 +2121,8 @@
     "nationalPokedexNumber": 594
   },
   {
-    "id": "bw1-40",
+    "setOrder":48,
+	"id": "bw1-40",
     "name": "Blitzle",
     "imageUrl": "https://images.pokemontcg.io/bw1/40.png",
     "subtype": "Basic",
@@ -2126,7 +2166,8 @@
     ]
   },
   {
-    "id": "bw1-41",
+    "setOrder":48,
+	"id": "bw1-41",
     "name": "Blitzle",
     "imageUrl": "https://images.pokemontcg.io/bw1/41.png",
     "subtype": "Basic",
@@ -2169,7 +2210,8 @@
     ]
   },
   {
-    "id": "bw1-42",
+    "setOrder":48,
+	"id": "bw1-42",
     "name": "Zebstrika",
     "imageUrl": "https://images.pokemontcg.io/bw1/42.png",
     "subtype": "Stage 1",
@@ -2222,7 +2264,8 @@
     "nationalPokedexNumber": 523
   },
   {
-    "id": "bw1-43",
+    "setOrder":48,
+	"id": "bw1-43",
     "name": "Zebstrika",
     "imageUrl": "https://images.pokemontcg.io/bw1/43.png",
     "subtype": "Stage 1",
@@ -2274,7 +2317,8 @@
     "nationalPokedexNumber": 523
   },
   {
-    "id": "bw1-44",
+    "setOrder":48,
+	"id": "bw1-44",
     "name": "Joltik",
     "imageUrl": "https://images.pokemontcg.io/bw1/44.png",
     "subtype": "Basic",
@@ -2317,7 +2361,8 @@
     ]
   },
   {
-    "id": "bw1-45",
+    "setOrder":48,
+	"id": "bw1-45",
     "name": "Joltik",
     "imageUrl": "https://images.pokemontcg.io/bw1/45.png",
     "subtype": "Basic",
@@ -2360,7 +2405,8 @@
     ]
   },
   {
-    "id": "bw1-46",
+    "setOrder":48,
+	"id": "bw1-46",
     "name": "Galvantula",
     "imageUrl": "https://images.pokemontcg.io/bw1/46.png",
     "subtype": "Stage 1",
@@ -2411,7 +2457,8 @@
     "nationalPokedexNumber": 596
   },
   {
-    "id": "bw1-47",
+    "setOrder":48,
+	"id": "bw1-47",
     "name": "Zekrom",
     "imageUrl": "https://images.pokemontcg.io/bw1/47.png",
     "subtype": "Basic",
@@ -2464,7 +2511,8 @@
     "nationalPokedexNumber": 644
   },
   {
-    "id": "bw1-48",
+    "setOrder":48,
+	"id": "bw1-48",
     "name": "Munna",
     "imageUrl": "https://images.pokemontcg.io/bw1/48.png",
     "subtype": "Basic",
@@ -2518,7 +2566,8 @@
     ]
   },
   {
-    "id": "bw1-49",
+    "setOrder":48,
+	"id": "bw1-49",
     "name": "Musharna",
     "imageUrl": "https://images.pokemontcg.io/bw1/49.png",
     "subtype": "Stage 1",
@@ -2570,7 +2619,8 @@
     "nationalPokedexNumber": 518
   },
   {
-    "id": "bw1-50",
+    "setOrder":48,
+	"id": "bw1-50",
     "name": "Woobat",
     "imageUrl": "https://images.pokemontcg.io/bw1/50.png",
     "subtype": "Basic",
@@ -2619,7 +2669,8 @@
     ]
   },
   {
-    "id": "bw1-51",
+    "setOrder":48,
+	"id": "bw1-51",
     "name": "Swoobat",
     "imageUrl": "https://images.pokemontcg.io/bw1/51.png",
     "subtype": "Stage 1",
@@ -2676,7 +2727,8 @@
     "nationalPokedexNumber": 528
   },
   {
-    "id": "bw1-52",
+    "setOrder":48,
+	"id": "bw1-52",
     "name": "Venipede",
     "imageUrl": "https://images.pokemontcg.io/bw1/52.png",
     "subtype": "Basic",
@@ -2731,7 +2783,8 @@
     ]
   },
   {
-    "id": "bw1-53",
+    "setOrder":48,
+	"id": "bw1-53",
     "name": "Whirlipede",
     "imageUrl": "https://images.pokemontcg.io/bw1/53.png",
     "subtype": "Stage 1",
@@ -2788,7 +2841,8 @@
     ]
   },
   {
-    "id": "bw1-54",
+    "setOrder":48,
+	"id": "bw1-54",
     "name": "Scolipede",
     "imageUrl": "https://images.pokemontcg.io/bw1/54.png",
     "subtype": "Stage 2",
@@ -2845,7 +2899,8 @@
     "nationalPokedexNumber": 545
   },
   {
-    "id": "bw1-55",
+    "setOrder":48,
+	"id": "bw1-55",
     "name": "Solosis",
     "imageUrl": "https://images.pokemontcg.io/bw1/55.png",
     "subtype": "Basic",
@@ -2898,7 +2953,8 @@
     ]
   },
   {
-    "id": "bw1-56",
+    "setOrder":48,
+	"id": "bw1-56",
     "name": "Duosion",
     "imageUrl": "https://images.pokemontcg.io/bw1/56.png",
     "subtype": "Stage 1",
@@ -2952,7 +3008,8 @@
     ]
   },
   {
-    "id": "bw1-57",
+    "setOrder":48,
+	"id": "bw1-57",
     "name": "Reuniclus",
     "imageUrl": "https://images.pokemontcg.io/bw1/57.png",
     "subtype": "Stage 2",
@@ -3001,7 +3058,8 @@
     "nationalPokedexNumber": 579
   },
   {
-    "id": "bw1-58",
+    "setOrder":48,
+	"id": "bw1-58",
     "name": "Timburr",
     "imageUrl": "https://images.pokemontcg.io/bw1/58.png",
     "subtype": "Basic",
@@ -3045,7 +3103,8 @@
     ]
   },
   {
-    "id": "bw1-59",
+    "setOrder":48,
+	"id": "bw1-59",
     "name": "Timburr",
     "imageUrl": "https://images.pokemontcg.io/bw1/59.png",
     "subtype": "Basic",
@@ -3099,7 +3158,8 @@
     ]
   },
   {
-    "id": "bw1-60",
+    "setOrder":48,
+	"id": "bw1-60",
     "name": "Gurdurr",
     "imageUrl": "https://images.pokemontcg.io/bw1/60.png",
     "subtype": "Stage 1",
@@ -3155,7 +3215,8 @@
     ]
   },
   {
-    "id": "bw1-61",
+    "setOrder":48,
+	"id": "bw1-61",
     "name": "Throh",
     "imageUrl": "https://images.pokemontcg.io/bw1/61.png",
     "subtype": "Basic",
@@ -3209,7 +3270,8 @@
     "nationalPokedexNumber": 538
   },
   {
-    "id": "bw1-62",
+    "setOrder":48,
+	"id": "bw1-62",
     "name": "Sawk",
     "imageUrl": "https://images.pokemontcg.io/bw1/62.png",
     "subtype": "Basic",
@@ -3259,7 +3321,8 @@
     "nationalPokedexNumber": 539
   },
   {
-    "id": "bw1-63",
+    "setOrder":48,
+	"id": "bw1-63",
     "name": "Sandile",
     "imageUrl": "https://images.pokemontcg.io/bw1/63.png",
     "subtype": "Basic",
@@ -3320,7 +3383,8 @@
     ]
   },
   {
-    "id": "bw1-64",
+    "setOrder":48,
+	"id": "bw1-64",
     "name": "Krokorok",
     "imageUrl": "https://images.pokemontcg.io/bw1/64.png",
     "subtype": "Stage 1",
@@ -3382,7 +3446,8 @@
     ]
   },
   {
-    "id": "bw1-65",
+    "setOrder":48,
+	"id": "bw1-65",
     "name": "Krookodile",
     "imageUrl": "https://images.pokemontcg.io/bw1/65.png",
     "subtype": "Stage 2",
@@ -3444,7 +3509,8 @@
     "nationalPokedexNumber": 553
   },
   {
-    "id": "bw1-66",
+    "setOrder":48,
+	"id": "bw1-66",
     "name": "Purrloin",
     "imageUrl": "https://images.pokemontcg.io/bw1/66.png",
     "subtype": "Basic",
@@ -3503,7 +3569,8 @@
     ]
   },
   {
-    "id": "bw1-67",
+    "setOrder":48,
+	"id": "bw1-67",
     "name": "Liepard",
     "imageUrl": "https://images.pokemontcg.io/bw1/67.png",
     "subtype": "Stage 1",
@@ -3560,7 +3627,8 @@
     "nationalPokedexNumber": 510
   },
   {
-    "id": "bw1-68",
+    "setOrder":48,
+	"id": "bw1-68",
     "name": "Scraggy",
     "imageUrl": "https://images.pokemontcg.io/bw1/68.png",
     "subtype": "Basic",
@@ -3609,7 +3677,8 @@
     ]
   },
   {
-    "id": "bw1-69",
+    "setOrder":48,
+	"id": "bw1-69",
     "name": "Scrafty",
     "imageUrl": "https://images.pokemontcg.io/bw1/69.png",
     "subtype": "Stage 1",
@@ -3667,7 +3736,8 @@
     "nationalPokedexNumber": 560
   },
   {
-    "id": "bw1-70",
+    "setOrder":48,
+	"id": "bw1-70",
     "name": "Zorua",
     "imageUrl": "https://images.pokemontcg.io/bw1/70.png",
     "subtype": "Basic",
@@ -3717,7 +3787,8 @@
     ]
   },
   {
-    "id": "bw1-71",
+    "setOrder":48,
+	"id": "bw1-71",
     "name": "Zoroark",
     "imageUrl": "https://images.pokemontcg.io/bw1/71.png",
     "subtype": "Stage 1",
@@ -3774,7 +3845,8 @@
     "nationalPokedexNumber": 571
   },
   {
-    "id": "bw1-72",
+    "setOrder":48,
+	"id": "bw1-72",
     "name": "Vullaby",
     "imageUrl": "https://images.pokemontcg.io/bw1/72.png",
     "subtype": "Basic",
@@ -3823,7 +3895,8 @@
     ]
   },
   {
-    "id": "bw1-73",
+    "setOrder":48,
+	"id": "bw1-73",
     "name": "Mandibuzz",
     "imageUrl": "https://images.pokemontcg.io/bw1/73.png",
     "subtype": "Stage 1",
@@ -3881,7 +3954,8 @@
     "nationalPokedexNumber": 630
   },
   {
-    "id": "bw1-74",
+    "setOrder":48,
+	"id": "bw1-74",
     "name": "Klink",
     "imageUrl": "https://images.pokemontcg.io/bw1/74.png",
     "subtype": "Basic",
@@ -3931,7 +4005,8 @@
     ]
   },
   {
-    "id": "bw1-75",
+    "setOrder":48,
+	"id": "bw1-75",
     "name": "Klang",
     "imageUrl": "https://images.pokemontcg.io/bw1/75.png",
     "subtype": "Stage 1",
@@ -3993,7 +4068,8 @@
     ]
   },
   {
-    "id": "bw1-76",
+    "setOrder":48,
+	"id": "bw1-76",
     "name": "Klinklang",
     "imageUrl": "https://images.pokemontcg.io/bw1/76.png",
     "subtype": "Stage 2",
@@ -4049,7 +4125,8 @@
     "nationalPokedexNumber": 601
   },
   {
-    "id": "bw1-77",
+    "setOrder":48,
+	"id": "bw1-77",
     "name": "Patrat",
     "imageUrl": "https://images.pokemontcg.io/bw1/77.png",
     "subtype": "Basic",
@@ -4102,7 +4179,8 @@
     ]
   },
   {
-    "id": "bw1-78",
+    "setOrder":48,
+	"id": "bw1-78",
     "name": "Patrat",
     "imageUrl": "https://images.pokemontcg.io/bw1/78.png",
     "subtype": "Basic",
@@ -4145,7 +4223,8 @@
     ]
   },
   {
-    "id": "bw1-79",
+    "setOrder":48,
+	"id": "bw1-79",
     "name": "Watchog",
     "imageUrl": "https://images.pokemontcg.io/bw1/79.png",
     "subtype": "Stage 1",
@@ -4197,7 +4276,8 @@
     "nationalPokedexNumber": 505
   },
   {
-    "id": "bw1-80",
+    "setOrder":48,
+	"id": "bw1-80",
     "name": "Lillipup",
     "imageUrl": "https://images.pokemontcg.io/bw1/80.png",
     "subtype": "Basic",
@@ -4249,7 +4329,8 @@
     ]
   },
   {
-    "id": "bw1-81",
+    "setOrder":48,
+	"id": "bw1-81",
     "name": "Lillipup",
     "imageUrl": "https://images.pokemontcg.io/bw1/81.png",
     "subtype": "Basic",
@@ -4302,7 +4383,8 @@
     ]
   },
   {
-    "id": "bw1-82",
+    "setOrder":48,
+	"id": "bw1-82",
     "name": "Herdier",
     "imageUrl": "https://images.pokemontcg.io/bw1/82.png",
     "subtype": "Stage 1",
@@ -4358,7 +4440,8 @@
     ]
   },
   {
-    "id": "bw1-83",
+    "setOrder":48,
+	"id": "bw1-83",
     "name": "Stoutland",
     "imageUrl": "https://images.pokemontcg.io/bw1/83.png",
     "subtype": "Stage 2",
@@ -4414,7 +4497,8 @@
     "nationalPokedexNumber": 508
   },
   {
-    "id": "bw1-84",
+    "setOrder":48,
+	"id": "bw1-84",
     "name": "Pidove",
     "imageUrl": "https://images.pokemontcg.io/bw1/84.png",
     "subtype": "Basic",
@@ -4463,7 +4547,8 @@
     ]
   },
   {
-    "id": "bw1-85",
+    "setOrder":48,
+	"id": "bw1-85",
     "name": "Tranquill",
     "imageUrl": "https://images.pokemontcg.io/bw1/85.png",
     "subtype": "Stage 1",
@@ -4523,7 +4608,8 @@
     ]
   },
   {
-    "id": "bw1-86",
+    "setOrder":48,
+	"id": "bw1-86",
     "name": "Unfezant",
     "imageUrl": "https://images.pokemontcg.io/bw1/86.png",
     "subtype": "Stage 2",
@@ -4582,7 +4668,8 @@
     "nationalPokedexNumber": 521
   },
   {
-    "id": "bw1-87",
+    "setOrder":48,
+	"id": "bw1-87",
     "name": "Audino",
     "imageUrl": "https://images.pokemontcg.io/bw1/87.png",
     "subtype": "Basic",
@@ -4624,7 +4711,8 @@
     "nationalPokedexNumber": 531
   },
   {
-    "id": "bw1-88",
+    "setOrder":48,
+	"id": "bw1-88",
     "name": "Minccino",
     "imageUrl": "https://images.pokemontcg.io/bw1/88.png",
     "subtype": "Basic",
@@ -4667,7 +4755,8 @@
     ]
   },
   {
-    "id": "bw1-89",
+    "setOrder":48,
+	"id": "bw1-89",
     "name": "Cinccino",
     "imageUrl": "https://images.pokemontcg.io/bw1/89.png",
     "subtype": "Stage 1",
@@ -4718,7 +4807,8 @@
     "nationalPokedexNumber": 573
   },
   {
-    "id": "bw1-90",
+    "setOrder":48,
+	"id": "bw1-90",
     "name": "Bouffalant",
     "imageUrl": "https://images.pokemontcg.io/bw1/90.png",
     "subtype": "Basic",
@@ -4771,7 +4861,8 @@
     "nationalPokedexNumber": 626
   },
   {
-    "id": "bw1-91",
+    "setOrder":48,
+	"id": "bw1-91",
     "name": "Bouffalant",
     "imageUrl": "https://images.pokemontcg.io/bw1/91.png",
     "subtype": "Basic",
@@ -4825,7 +4916,8 @@
     "nationalPokedexNumber": 626
   },
   {
-    "id": "bw1-92",
+    "setOrder":48,
+	"id": "bw1-92",
     "name": "Energy Retrieval",
     "imageUrl": "https://images.pokemontcg.io/bw1/92.png",
     "subtype": "Item",
@@ -4843,7 +4935,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw1/92_hires.png"
   },
   {
-    "id": "bw1-93",
+    "setOrder":48,
+	"id": "bw1-93",
     "name": "Energy Search",
     "imageUrl": "https://images.pokemontcg.io/bw1/93.png",
     "subtype": "Item",
@@ -4861,7 +4954,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw1/93_hires.png"
   },
   {
-    "id": "bw1-94",
+    "setOrder":48,
+	"id": "bw1-94",
     "name": "Energy Switch",
     "imageUrl": "https://images.pokemontcg.io/bw1/94.png",
     "subtype": "Item",
@@ -4878,7 +4972,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw1/94_hires.png"
   },
   {
-    "id": "bw1-95",
+    "setOrder":48,
+	"id": "bw1-95",
     "name": "Full Heal",
     "imageUrl": "https://images.pokemontcg.io/bw1/95.png",
     "subtype": "Item",
@@ -4895,7 +4990,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw1/95_hires.png"
   },
   {
-    "id": "bw1-96",
+    "setOrder":48,
+	"id": "bw1-96",
     "name": "PlusPower",
     "imageUrl": "https://images.pokemontcg.io/bw1/96.png",
     "subtype": "Item",
@@ -4912,7 +5008,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw1/96_hires.png"
   },
   {
-    "id": "bw1-97",
+    "setOrder":48,
+	"id": "bw1-97",
     "name": "Poké Ball",
     "imageUrl": "https://images.pokemontcg.io/bw1/97.png",
     "subtype": "Item",
@@ -4929,7 +5026,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw1/97_hires.png"
   },
   {
-    "id": "bw1-98",
+    "setOrder":48,
+	"id": "bw1-98",
     "name": "Pokédex",
     "imageUrl": "https://images.pokemontcg.io/bw1/98.png",
     "subtype": "Item",
@@ -4946,7 +5044,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw1/98_hires.png"
   },
   {
-    "id": "bw1-99",
+    "setOrder":48,
+	"id": "bw1-99",
     "name": "Pokémon Communication",
     "imageUrl": "https://images.pokemontcg.io/bw1/99.png",
     "subtype": "Item",
@@ -4963,7 +5062,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw1/99_hires.png"
   },
   {
-    "id": "bw1-100",
+    "setOrder":48,
+	"id": "bw1-100",
     "name": "Potion",
     "imageUrl": "https://images.pokemontcg.io/bw1/100.png",
     "subtype": "Item",
@@ -4980,7 +5080,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw1/100_hires.png"
   },
   {
-    "id": "bw1-101",
+    "setOrder":48,
+	"id": "bw1-101",
     "name": "Professor Juniper",
     "imageUrl": "https://images.pokemontcg.io/bw1/101.png",
     "subtype": "Supporter",
@@ -4998,7 +5099,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw1/101_hires.png"
   },
   {
-    "id": "bw1-102",
+    "setOrder":48,
+	"id": "bw1-102",
     "name": "Revive",
     "imageUrl": "https://images.pokemontcg.io/bw1/102.png",
     "subtype": "Item",
@@ -5016,7 +5118,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw1/102_hires.png"
   },
   {
-    "id": "bw1-103",
+    "setOrder":48,
+	"id": "bw1-103",
     "name": "Super Scoop Up",
     "imageUrl": "https://images.pokemontcg.io/bw1/103.png",
     "subtype": "Item",
@@ -5033,7 +5136,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw1/103_hires.png"
   },
   {
-    "id": "bw1-104",
+    "setOrder":48,
+	"id": "bw1-104",
     "name": "Switch",
     "imageUrl": "https://images.pokemontcg.io/bw1/104.png",
     "subtype": "Item",
@@ -5050,7 +5154,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw1/104_hires.png"
   },
   {
-    "id": "bw1-105",
+    "setOrder":48,
+	"id": "bw1-105",
     "name": "Grass Energy",
     "imageUrl": "https://images.pokemontcg.io/bw1/105.png",
     "subtype": "Basic",
@@ -5064,7 +5169,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw1/105_hires.png"
   },
   {
-    "id": "bw1-106",
+    "setOrder":48,
+	"id": "bw1-106",
     "name": "Fire Energy",
     "imageUrl": "https://images.pokemontcg.io/bw1/106.png",
     "subtype": "Basic",
@@ -5078,7 +5184,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw1/106_hires.png"
   },
   {
-    "id": "bw1-107",
+    "setOrder":48,
+	"id": "bw1-107",
     "name": "Water Energy",
     "imageUrl": "https://images.pokemontcg.io/bw1/107.png",
     "subtype": "Basic",
@@ -5092,7 +5199,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw1/107_hires.png"
   },
   {
-    "id": "bw1-108",
+    "setOrder":48,
+	"id": "bw1-108",
     "name": "Lightning Energy",
     "imageUrl": "https://images.pokemontcg.io/bw1/108.png",
     "subtype": "Basic",
@@ -5106,7 +5214,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw1/108_hires.png"
   },
   {
-    "id": "bw1-109",
+    "setOrder":48,
+	"id": "bw1-109",
     "name": "Psychic Energy",
     "imageUrl": "https://images.pokemontcg.io/bw1/109.png",
     "subtype": "Basic",
@@ -5120,7 +5229,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw1/109_hires.png"
   },
   {
-    "id": "bw1-110",
+    "setOrder":48,
+	"id": "bw1-110",
     "name": "Fighting Energy",
     "imageUrl": "https://images.pokemontcg.io/bw1/110.png",
     "subtype": "Basic",
@@ -5134,7 +5244,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw1/110_hires.png"
   },
   {
-    "id": "bw1-111",
+    "setOrder":48,
+	"id": "bw1-111",
     "name": "Darkness Energy",
     "imageUrl": "https://images.pokemontcg.io/bw1/111.png",
     "subtype": "Basic",
@@ -5148,7 +5259,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw1/111_hires.png"
   },
   {
-    "id": "bw1-112",
+    "setOrder":48,
+	"id": "bw1-112",
     "name": "Metal Energy",
     "imageUrl": "https://images.pokemontcg.io/bw1/112.png",
     "subtype": "Basic",
@@ -5162,7 +5274,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw1/112_hires.png"
   },
   {
-    "id": "bw1-113",
+    "setOrder":48,
+	"id": "bw1-113",
     "name": "Reshiram",
     "imageUrl": "https://images.pokemontcg.io/bw1/113.png",
     "subtype": "Basic",
@@ -5215,7 +5328,8 @@
     "nationalPokedexNumber": 643
   },
   {
-    "id": "bw1-114",
+    "setOrder":48,
+	"id": "bw1-114",
     "name": "Zekrom",
     "imageUrl": "https://images.pokemontcg.io/bw1/114.png",
     "subtype": "Basic",

--- a/json/cards/Boundaries Crossed.json
+++ b/json/cards/Boundaries Crossed.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "bw7-1",
+    "setOrder":54,
+	"id": "bw7-1",
     "name": "Oddish",
     "imageUrl": "https://images.pokemontcg.io/bw7/1.png",
     "subtype": "Basic",
@@ -59,7 +60,8 @@
     ]
   },
   {
-    "id": "bw7-2",
+    "setOrder":54,
+	"id": "bw7-2",
     "name": "Gloom",
     "imageUrl": "https://images.pokemontcg.io/bw7/2.png",
     "subtype": "Stage 1",
@@ -122,7 +124,8 @@
     ]
   },
   {
-    "id": "bw7-3",
+    "setOrder":54,
+	"id": "bw7-3",
     "name": "Vileplume",
     "imageUrl": "https://images.pokemontcg.io/bw7/3.png",
     "subtype": "Stage 2",
@@ -179,7 +182,8 @@
     "nationalPokedexNumber": 45
   },
   {
-    "id": "bw7-4",
+    "setOrder":54,
+	"id": "bw7-4",
     "name": "Bellossom",
     "imageUrl": "https://images.pokemontcg.io/bw7/4.png",
     "subtype": "Stage 2",
@@ -237,7 +241,8 @@
     "nationalPokedexNumber": 182
   },
   {
-    "id": "bw7-5",
+    "setOrder":54,
+	"id": "bw7-5",
     "name": "Tangela",
     "imageUrl": "https://images.pokemontcg.io/bw7/5.png",
     "subtype": "Basic",
@@ -298,7 +303,8 @@
     ]
   },
   {
-    "id": "bw7-6",
+    "setOrder":54,
+	"id": "bw7-6",
     "name": "Tangrowth",
     "imageUrl": "https://images.pokemontcg.io/bw7/6.png",
     "subtype": "Stage 1",
@@ -360,7 +366,8 @@
     "nationalPokedexNumber": 465
   },
   {
-    "id": "bw7-7",
+    "setOrder":54,
+	"id": "bw7-7",
     "name": "Scyther",
     "imageUrl": "https://images.pokemontcg.io/bw7/7.png",
     "subtype": "Basic",
@@ -413,7 +420,8 @@
     ]
   },
   {
-    "id": "bw7-8",
+    "setOrder":54,
+	"id": "bw7-8",
     "name": "Heracross",
     "imageUrl": "https://images.pokemontcg.io/bw7/8.png",
     "subtype": "Basic",
@@ -465,7 +473,8 @@
     "nationalPokedexNumber": 214
   },
   {
-    "id": "bw7-9",
+    "setOrder":54,
+	"id": "bw7-9",
     "name": "Celebi-EX",
     "imageUrl": "https://images.pokemontcg.io/bw7/9.png",
     "subtype": "EX",
@@ -521,7 +530,8 @@
     "nationalPokedexNumber": 251
   },
   {
-    "id": "bw7-10",
+    "setOrder":54,
+	"id": "bw7-10",
     "name": "Shaymin",
     "imageUrl": "https://images.pokemontcg.io/bw7/10.png",
     "subtype": "Basic",
@@ -571,7 +581,8 @@
     "nationalPokedexNumber": 492
   },
   {
-    "id": "bw7-11",
+    "setOrder":54,
+	"id": "bw7-11",
     "name": "Snivy",
     "imageUrl": "https://images.pokemontcg.io/bw7/11.png",
     "subtype": "Basic",
@@ -624,7 +635,8 @@
     ]
   },
   {
-    "id": "bw7-12",
+    "setOrder":54,
+	"id": "bw7-12",
     "name": "Servine",
     "imageUrl": "https://images.pokemontcg.io/bw7/12.png",
     "subtype": "Stage 1",
@@ -679,7 +691,8 @@
     ]
   },
   {
-    "id": "bw7-13",
+    "setOrder":54,
+	"id": "bw7-13",
     "name": "Serperior",
     "imageUrl": "https://images.pokemontcg.io/bw7/13.png",
     "subtype": "Stage 2",
@@ -732,7 +745,8 @@
     "nationalPokedexNumber": 497
   },
   {
-    "id": "bw7-14",
+    "setOrder":54,
+	"id": "bw7-14",
     "name": "Cottonee",
     "imageUrl": "https://images.pokemontcg.io/bw7/14.png",
     "subtype": "Basic",
@@ -781,7 +795,8 @@
     ]
   },
   {
-    "id": "bw7-15",
+    "setOrder":54,
+	"id": "bw7-15",
     "name": "Whimsicott",
     "imageUrl": "https://images.pokemontcg.io/bw7/15.png",
     "subtype": "Stage 1",
@@ -837,7 +852,8 @@
     "nationalPokedexNumber": 547
   },
   {
-    "id": "bw7-16",
+    "setOrder":54,
+	"id": "bw7-16",
     "name": "Petilil",
     "imageUrl": "https://images.pokemontcg.io/bw7/16.png",
     "subtype": "Basic",
@@ -886,7 +902,8 @@
     ]
   },
   {
-    "id": "bw7-17",
+    "setOrder":54,
+	"id": "bw7-17",
     "name": "Lilligant",
     "imageUrl": "https://images.pokemontcg.io/bw7/17.png",
     "subtype": "Stage 1",
@@ -944,7 +961,8 @@
     "nationalPokedexNumber": 549
   },
   {
-    "id": "bw7-18",
+    "setOrder":54,
+	"id": "bw7-18",
     "name": "Charmander",
     "imageUrl": "https://images.pokemontcg.io/bw7/18.png",
     "subtype": "Basic",
@@ -998,7 +1016,8 @@
     ]
   },
   {
-    "id": "bw7-19",
+    "setOrder":54,
+	"id": "bw7-19",
     "name": "Charmeleon",
     "imageUrl": "https://images.pokemontcg.io/bw7/19.png",
     "subtype": "Stage 1",
@@ -1054,7 +1073,8 @@
     ]
   },
   {
-    "id": "bw7-20",
+    "setOrder":54,
+	"id": "bw7-20",
     "name": "Charizard",
     "imageUrl": "https://images.pokemontcg.io/bw7/20.png",
     "subtype": "Stage 2",
@@ -1112,7 +1132,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "bw7-21",
+    "setOrder":54,
+	"id": "bw7-21",
     "name": "Numel",
     "imageUrl": "https://images.pokemontcg.io/bw7/21.png",
     "subtype": "Basic",
@@ -1159,7 +1180,8 @@
     ]
   },
   {
-    "id": "bw7-22",
+    "setOrder":54,
+	"id": "bw7-22",
     "name": "Camerupt",
     "imageUrl": "https://images.pokemontcg.io/bw7/22.png",
     "subtype": "Stage 1",
@@ -1217,7 +1239,8 @@
     "nationalPokedexNumber": 323
   },
   {
-    "id": "bw7-23",
+    "setOrder":54,
+	"id": "bw7-23",
     "name": "Victini",
     "imageUrl": "https://images.pokemontcg.io/bw7/23.png",
     "subtype": "Basic",
@@ -1267,7 +1290,8 @@
     "nationalPokedexNumber": 494
   },
   {
-    "id": "bw7-24",
+    "setOrder":54,
+	"id": "bw7-24",
     "name": "Tepig",
     "imageUrl": "https://images.pokemontcg.io/bw7/24.png",
     "subtype": "Basic",
@@ -1320,7 +1344,8 @@
     ]
   },
   {
-    "id": "bw7-25",
+    "setOrder":54,
+	"id": "bw7-25",
     "name": "Pignite",
     "imageUrl": "https://images.pokemontcg.io/bw7/25.png",
     "subtype": "Stage 1",
@@ -1377,7 +1402,8 @@
     ]
   },
   {
-    "id": "bw7-26",
+    "setOrder":54,
+	"id": "bw7-26",
     "name": "Emboar",
     "imageUrl": "https://images.pokemontcg.io/bw7/26.png",
     "subtype": "Stage 2",
@@ -1435,7 +1461,8 @@
     "nationalPokedexNumber": 500
   },
   {
-    "id": "bw7-27",
+    "setOrder":54,
+	"id": "bw7-27",
     "name": "Darumaka",
     "imageUrl": "https://images.pokemontcg.io/bw7/27.png",
     "subtype": "Basic",
@@ -1480,7 +1507,8 @@
     ]
   },
   {
-    "id": "bw7-28",
+    "setOrder":54,
+	"id": "bw7-28",
     "name": "Darmanitan",
     "imageUrl": "https://images.pokemontcg.io/bw7/28.png",
     "subtype": "Stage 1",
@@ -1533,7 +1561,8 @@
     "nationalPokedexNumber": 555
   },
   {
-    "id": "bw7-29",
+    "setOrder":54,
+	"id": "bw7-29",
     "name": "Squirtle",
     "imageUrl": "https://images.pokemontcg.io/bw7/29.png",
     "subtype": "Basic",
@@ -1582,7 +1611,8 @@
     ]
   },
   {
-    "id": "bw7-30",
+    "setOrder":54,
+	"id": "bw7-30",
     "name": "Wartortle",
     "imageUrl": "https://images.pokemontcg.io/bw7/30.png",
     "subtype": "Stage 1",
@@ -1638,7 +1668,8 @@
     ]
   },
   {
-    "id": "bw7-31",
+    "setOrder":54,
+	"id": "bw7-31",
     "name": "Blastoise",
     "imageUrl": "https://images.pokemontcg.io/bw7/31.png",
     "subtype": "Stage 2",
@@ -1690,7 +1721,8 @@
     "nationalPokedexNumber": 9
   },
   {
-    "id": "bw7-32",
+    "setOrder":54,
+	"id": "bw7-32",
     "name": "Psyduck",
     "imageUrl": "https://images.pokemontcg.io/bw7/32.png",
     "subtype": "Basic",
@@ -1733,7 +1765,8 @@
     ]
   },
   {
-    "id": "bw7-33",
+    "setOrder":54,
+	"id": "bw7-33",
     "name": "Psyduck",
     "imageUrl": "https://images.pokemontcg.io/bw7/33.png",
     "subtype": "Basic",
@@ -1778,7 +1811,8 @@
     ]
   },
   {
-    "id": "bw7-34",
+    "setOrder":54,
+	"id": "bw7-34",
     "name": "Golduck",
     "imageUrl": "https://images.pokemontcg.io/bw7/34.png",
     "subtype": "Stage 1",
@@ -1826,7 +1860,8 @@
     "nationalPokedexNumber": 55
   },
   {
-    "id": "bw7-35",
+    "setOrder":54,
+	"id": "bw7-35",
     "name": "Golduck",
     "imageUrl": "https://images.pokemontcg.io/bw7/35.png",
     "subtype": "Stage 1",
@@ -1874,7 +1909,8 @@
     "nationalPokedexNumber": 55
   },
   {
-    "id": "bw7-36",
+    "setOrder":54,
+	"id": "bw7-36",
     "name": "Marill",
     "imageUrl": "https://images.pokemontcg.io/bw7/36.png",
     "subtype": "Basic",
@@ -1930,7 +1966,8 @@
     ]
   },
   {
-    "id": "bw7-37",
+    "setOrder":54,
+	"id": "bw7-37",
     "name": "Azumarill",
     "imageUrl": "https://images.pokemontcg.io/bw7/37.png",
     "subtype": "Stage 1",
@@ -1983,7 +2020,8 @@
     "nationalPokedexNumber": 184
   },
   {
-    "id": "bw7-38",
+    "setOrder":54,
+	"id": "bw7-38",
     "name": "Delibird",
     "imageUrl": "https://images.pokemontcg.io/bw7/38.png",
     "subtype": "Basic",
@@ -2033,7 +2071,8 @@
     "nationalPokedexNumber": 225
   },
   {
-    "id": "bw7-39",
+    "setOrder":54,
+	"id": "bw7-39",
     "name": "Oshawott",
     "imageUrl": "https://images.pokemontcg.io/bw7/39.png",
     "subtype": "Basic",
@@ -2086,7 +2125,8 @@
     ]
   },
   {
-    "id": "bw7-40",
+    "setOrder":54,
+	"id": "bw7-40",
     "name": "Dewott",
     "imageUrl": "https://images.pokemontcg.io/bw7/40.png",
     "subtype": "Stage 1",
@@ -2141,7 +2181,8 @@
     ]
   },
   {
-    "id": "bw7-41",
+    "setOrder":54,
+	"id": "bw7-41",
     "name": "Samurott",
     "imageUrl": "https://images.pokemontcg.io/bw7/41.png",
     "subtype": "Stage 2",
@@ -2197,7 +2238,8 @@
     "nationalPokedexNumber": 503
   },
   {
-    "id": "bw7-42",
+    "setOrder":54,
+	"id": "bw7-42",
     "name": "Ducklett",
     "imageUrl": "https://images.pokemontcg.io/bw7/42.png",
     "subtype": "Basic",
@@ -2247,7 +2289,8 @@
     ]
   },
   {
-    "id": "bw7-43",
+    "setOrder":54,
+	"id": "bw7-43",
     "name": "Swanna",
     "imageUrl": "https://images.pokemontcg.io/bw7/43.png",
     "subtype": "Stage 1",
@@ -2306,7 +2349,8 @@
     "nationalPokedexNumber": 581
   },
   {
-    "id": "bw7-44",
+    "setOrder":54,
+	"id": "bw7-44",
     "name": "Frillish",
     "imageUrl": "https://images.pokemontcg.io/bw7/44.png",
     "subtype": "Basic",
@@ -2352,7 +2396,8 @@
     ]
   },
   {
-    "id": "bw7-45",
+    "setOrder":54,
+	"id": "bw7-45",
     "name": "Jellicent",
     "imageUrl": "https://images.pokemontcg.io/bw7/45.png",
     "subtype": "Stage 1",
@@ -2402,7 +2447,8 @@
     "nationalPokedexNumber": 593
   },
   {
-    "id": "bw7-46",
+    "setOrder":54,
+	"id": "bw7-46",
     "name": "Cryogonal",
     "imageUrl": "https://images.pokemontcg.io/bw7/46.png",
     "subtype": "Basic",
@@ -2443,7 +2489,8 @@
     "nationalPokedexNumber": 615
   },
   {
-    "id": "bw7-47",
+    "setOrder":54,
+	"id": "bw7-47",
     "name": "Keldeo",
     "imageUrl": "https://images.pokemontcg.io/bw7/47.png",
     "subtype": "Basic",
@@ -2495,7 +2542,8 @@
     "nationalPokedexNumber": 647
   },
   {
-    "id": "bw7-48",
+    "setOrder":54,
+	"id": "bw7-48",
     "name": "Keldeo",
     "imageUrl": "https://images.pokemontcg.io/bw7/48.png",
     "subtype": "Basic",
@@ -2547,7 +2595,8 @@
     "nationalPokedexNumber": 647
   },
   {
-    "id": "bw7-49",
+    "setOrder":54,
+	"id": "bw7-49",
     "name": "Keldeo-EX",
     "imageUrl": "https://images.pokemontcg.io/bw7/49.png",
     "subtype": "EX",
@@ -2598,7 +2647,8 @@
     "nationalPokedexNumber": 647
   },
   {
-    "id": "bw7-50",
+    "setOrder":54,
+	"id": "bw7-50",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/bw7/50.png",
     "subtype": "Basic",
@@ -2652,7 +2702,8 @@
     ]
   },
   {
-    "id": "bw7-51",
+    "setOrder":54,
+	"id": "bw7-51",
     "name": "Voltorb",
     "imageUrl": "https://images.pokemontcg.io/bw7/51.png",
     "subtype": "Basic",
@@ -2695,7 +2746,8 @@
     ]
   },
   {
-    "id": "bw7-52",
+    "setOrder":54,
+	"id": "bw7-52",
     "name": "Electrode",
     "imageUrl": "https://images.pokemontcg.io/bw7/52.png",
     "subtype": "Stage 1",
@@ -2744,7 +2796,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "bw7-53",
+    "setOrder":54,
+	"id": "bw7-53",
     "name": "Electabuzz",
     "imageUrl": "https://images.pokemontcg.io/bw7/53.png",
     "subtype": "Basic",
@@ -2800,7 +2853,8 @@
     ]
   },
   {
-    "id": "bw7-54",
+    "setOrder":54,
+	"id": "bw7-54",
     "name": "Electivire",
     "imageUrl": "https://images.pokemontcg.io/bw7/54.png",
     "subtype": "Stage 1",
@@ -2857,7 +2911,8 @@
     "nationalPokedexNumber": 466
   },
   {
-    "id": "bw7-55",
+    "setOrder":54,
+	"id": "bw7-55",
     "name": "Chinchou",
     "imageUrl": "https://images.pokemontcg.io/bw7/55.png",
     "subtype": "Basic",
@@ -2901,7 +2956,8 @@
     ]
   },
   {
-    "id": "bw7-56",
+    "setOrder":54,
+	"id": "bw7-56",
     "name": "Blitzle",
     "imageUrl": "https://images.pokemontcg.io/bw7/56.png",
     "subtype": "Basic",
@@ -2944,7 +3000,8 @@
     ]
   },
   {
-    "id": "bw7-57",
+    "setOrder":54,
+	"id": "bw7-57",
     "name": "Zebstrika",
     "imageUrl": "https://images.pokemontcg.io/bw7/57.png",
     "subtype": "Stage 1",
@@ -2996,7 +3053,8 @@
     "nationalPokedexNumber": 523
   },
   {
-    "id": "bw7-58",
+    "setOrder":54,
+	"id": "bw7-58",
     "name": "Wobbuffet",
     "imageUrl": "https://images.pokemontcg.io/bw7/58.png",
     "subtype": "Basic",
@@ -3039,7 +3097,8 @@
     "nationalPokedexNumber": 202
   },
   {
-    "id": "bw7-59",
+    "setOrder":54,
+	"id": "bw7-59",
     "name": "Spoink",
     "imageUrl": "https://images.pokemontcg.io/bw7/59.png",
     "subtype": "Basic",
@@ -3082,7 +3141,8 @@
     ]
   },
   {
-    "id": "bw7-60",
+    "setOrder":54,
+	"id": "bw7-60",
     "name": "Grumpig",
     "imageUrl": "https://images.pokemontcg.io/bw7/60.png",
     "subtype": "Stage 1",
@@ -3136,7 +3196,8 @@
     "nationalPokedexNumber": 326
   },
   {
-    "id": "bw7-61",
+    "setOrder":54,
+	"id": "bw7-61",
     "name": "Duskull",
     "imageUrl": "https://images.pokemontcg.io/bw7/61.png",
     "subtype": "Basic",
@@ -3179,7 +3240,8 @@
     ]
   },
   {
-    "id": "bw7-62",
+    "setOrder":54,
+	"id": "bw7-62",
     "name": "Dusclops",
     "imageUrl": "https://images.pokemontcg.io/bw7/62.png",
     "subtype": "Stage 1",
@@ -3235,7 +3297,8 @@
     ]
   },
   {
-    "id": "bw7-63",
+    "setOrder":54,
+	"id": "bw7-63",
     "name": "Dusknoir",
     "imageUrl": "https://images.pokemontcg.io/bw7/63.png",
     "subtype": "Stage 2",
@@ -3286,7 +3349,8 @@
     "nationalPokedexNumber": 477
   },
   {
-    "id": "bw7-64",
+    "setOrder":54,
+	"id": "bw7-64",
     "name": "Croagunk",
     "imageUrl": "https://images.pokemontcg.io/bw7/64.png",
     "subtype": "Basic",
@@ -3330,7 +3394,8 @@
     ]
   },
   {
-    "id": "bw7-65",
+    "setOrder":54,
+	"id": "bw7-65",
     "name": "Croagunk",
     "imageUrl": "https://images.pokemontcg.io/bw7/65.png",
     "subtype": "Basic",
@@ -3374,7 +3439,8 @@
     ]
   },
   {
-    "id": "bw7-66",
+    "setOrder":54,
+	"id": "bw7-66",
     "name": "Toxicroak",
     "imageUrl": "https://images.pokemontcg.io/bw7/66.png",
     "subtype": "Stage 1",
@@ -3426,7 +3492,8 @@
     "nationalPokedexNumber": 454
   },
   {
-    "id": "bw7-67",
+    "setOrder":54,
+	"id": "bw7-67",
     "name": "Cresselia-EX",
     "imageUrl": "https://images.pokemontcg.io/bw7/67.png",
     "subtype": "EX",
@@ -3477,7 +3544,8 @@
     "nationalPokedexNumber": 488
   },
   {
-    "id": "bw7-68",
+    "setOrder":54,
+	"id": "bw7-68",
     "name": "Munna",
     "imageUrl": "https://images.pokemontcg.io/bw7/68.png",
     "subtype": "Basic",
@@ -3527,7 +3595,8 @@
     ]
   },
   {
-    "id": "bw7-69",
+    "setOrder":54,
+	"id": "bw7-69",
     "name": "Musharna",
     "imageUrl": "https://images.pokemontcg.io/bw7/69.png",
     "subtype": "Stage 1",
@@ -3581,7 +3650,8 @@
     "nationalPokedexNumber": 518
   },
   {
-    "id": "bw7-70",
+    "setOrder":54,
+	"id": "bw7-70",
     "name": "Woobat",
     "imageUrl": "https://images.pokemontcg.io/bw7/70.png",
     "subtype": "Basic",
@@ -3640,7 +3710,8 @@
     ]
   },
   {
-    "id": "bw7-71",
+    "setOrder":54,
+	"id": "bw7-71",
     "name": "Swoobat",
     "imageUrl": "https://images.pokemontcg.io/bw7/71.png",
     "subtype": "Stage 1",
@@ -3697,7 +3768,8 @@
     "nationalPokedexNumber": 528
   },
   {
-    "id": "bw7-72",
+    "setOrder":54,
+	"id": "bw7-72",
     "name": "Venipede",
     "imageUrl": "https://images.pokemontcg.io/bw7/72.png",
     "subtype": "Basic",
@@ -3747,7 +3819,8 @@
     ]
   },
   {
-    "id": "bw7-73",
+    "setOrder":54,
+	"id": "bw7-73",
     "name": "Whirlipede",
     "imageUrl": "https://images.pokemontcg.io/bw7/73.png",
     "subtype": "Stage 1",
@@ -3800,7 +3873,8 @@
     ]
   },
   {
-    "id": "bw7-74",
+    "setOrder":54,
+	"id": "bw7-74",
     "name": "Scolipede",
     "imageUrl": "https://images.pokemontcg.io/bw7/74.png",
     "subtype": "Stage 2",
@@ -3852,7 +3926,8 @@
     "nationalPokedexNumber": 545
   },
   {
-    "id": "bw7-75",
+    "setOrder":54,
+	"id": "bw7-75",
     "name": "Gothita",
     "imageUrl": "https://images.pokemontcg.io/bw7/75.png",
     "subtype": "Basic",
@@ -3905,7 +3980,8 @@
     ]
   },
   {
-    "id": "bw7-76",
+    "setOrder":54,
+	"id": "bw7-76",
     "name": "Gothorita",
     "imageUrl": "https://images.pokemontcg.io/bw7/76.png",
     "subtype": "Stage 1",
@@ -3961,7 +4037,8 @@
     ]
   },
   {
-    "id": "bw7-77",
+    "setOrder":54,
+	"id": "bw7-77",
     "name": "Meloetta",
     "imageUrl": "https://images.pokemontcg.io/bw7/77.png",
     "subtype": "Basic",
@@ -4012,7 +4089,8 @@
     "nationalPokedexNumber": 648
   },
   {
-    "id": "bw7-78",
+    "setOrder":54,
+	"id": "bw7-78",
     "name": "Sandshrew",
     "imageUrl": "https://images.pokemontcg.io/bw7/78.png",
     "subtype": "Basic",
@@ -4073,7 +4151,8 @@
     ]
   },
   {
-    "id": "bw7-79",
+    "setOrder":54,
+	"id": "bw7-79",
     "name": "Sandslash",
     "imageUrl": "https://images.pokemontcg.io/bw7/79.png",
     "subtype": "Stage 1",
@@ -4132,7 +4211,8 @@
     "nationalPokedexNumber": 28
   },
   {
-    "id": "bw7-80",
+    "setOrder":54,
+	"id": "bw7-80",
     "name": "Gligar",
     "imageUrl": "https://images.pokemontcg.io/bw7/80.png",
     "subtype": "Basic",
@@ -4191,7 +4271,8 @@
     ]
   },
   {
-    "id": "bw7-81",
+    "setOrder":54,
+	"id": "bw7-81",
     "name": "Gliscor",
     "imageUrl": "https://images.pokemontcg.io/bw7/81.png",
     "subtype": "Stage 1",
@@ -4248,7 +4329,8 @@
     "nationalPokedexNumber": 472
   },
   {
-    "id": "bw7-82",
+    "setOrder":54,
+	"id": "bw7-82",
     "name": "Makuhita",
     "imageUrl": "https://images.pokemontcg.io/bw7/82.png",
     "subtype": "Basic",
@@ -4293,7 +4375,8 @@
     ]
   },
   {
-    "id": "bw7-83",
+    "setOrder":54,
+	"id": "bw7-83",
     "name": "Trapinch",
     "imageUrl": "https://images.pokemontcg.io/bw7/83.png",
     "subtype": "Basic",
@@ -4352,7 +4435,8 @@
     ]
   },
   {
-    "id": "bw7-84",
+    "setOrder":54,
+	"id": "bw7-84",
     "name": "Dwebble",
     "imageUrl": "https://images.pokemontcg.io/bw7/84.png",
     "subtype": "Basic",
@@ -4397,7 +4481,8 @@
     ]
   },
   {
-    "id": "bw7-85",
+    "setOrder":54,
+	"id": "bw7-85",
     "name": "Crustle",
     "imageUrl": "https://images.pokemontcg.io/bw7/85.png",
     "subtype": "Stage 1",
@@ -4447,7 +4532,8 @@
     "nationalPokedexNumber": 558
   },
   {
-    "id": "bw7-86",
+    "setOrder":54,
+	"id": "bw7-86",
     "name": "Mienfoo",
     "imageUrl": "https://images.pokemontcg.io/bw7/86.png",
     "subtype": "Basic",
@@ -4490,7 +4576,8 @@
     ]
   },
   {
-    "id": "bw7-87",
+    "setOrder":54,
+	"id": "bw7-87",
     "name": "Mienfoo",
     "imageUrl": "https://images.pokemontcg.io/bw7/87.png",
     "subtype": "Basic",
@@ -4533,7 +4620,8 @@
     ]
   },
   {
-    "id": "bw7-88",
+    "setOrder":54,
+	"id": "bw7-88",
     "name": "Mienshao",
     "imageUrl": "https://images.pokemontcg.io/bw7/88.png",
     "subtype": "Stage 1",
@@ -4586,7 +4674,8 @@
     "nationalPokedexNumber": 620
   },
   {
-    "id": "bw7-89",
+    "setOrder":54,
+	"id": "bw7-89",
     "name": "Landorus-EX",
     "imageUrl": "https://images.pokemontcg.io/bw7/89.png",
     "subtype": "EX",
@@ -4648,7 +4737,8 @@
     "nationalPokedexNumber": 645
   },
   {
-    "id": "bw7-90",
+    "setOrder":54,
+	"id": "bw7-90",
     "name": "Purrloin",
     "imageUrl": "https://images.pokemontcg.io/bw7/90.png",
     "subtype": "Basic",
@@ -4697,7 +4787,8 @@
     ]
   },
   {
-    "id": "bw7-91",
+    "setOrder":54,
+	"id": "bw7-91",
     "name": "Liepard",
     "imageUrl": "https://images.pokemontcg.io/bw7/91.png",
     "subtype": "Stage 1",
@@ -4755,7 +4846,8 @@
     "nationalPokedexNumber": 510
   },
   {
-    "id": "bw7-92",
+    "setOrder":54,
+	"id": "bw7-92",
     "name": "Vullaby",
     "imageUrl": "https://images.pokemontcg.io/bw7/92.png",
     "subtype": "Basic",
@@ -4814,7 +4906,8 @@
     ]
   },
   {
-    "id": "bw7-93",
+    "setOrder":54,
+	"id": "bw7-93",
     "name": "Mandibuzz",
     "imageUrl": "https://images.pokemontcg.io/bw7/93.png",
     "subtype": "Stage 1",
@@ -4874,7 +4967,8 @@
     "nationalPokedexNumber": 630
   },
   {
-    "id": "bw7-94",
+    "setOrder":54,
+	"id": "bw7-94",
     "name": "Scizor",
     "imageUrl": "https://images.pokemontcg.io/bw7/94.png",
     "subtype": "Stage 1",
@@ -4934,7 +5028,8 @@
     "nationalPokedexNumber": 212
   },
   {
-    "id": "bw7-95",
+    "setOrder":54,
+	"id": "bw7-95",
     "name": "Skarmory",
     "imageUrl": "https://images.pokemontcg.io/bw7/95.png",
     "subtype": "Basic",
@@ -4992,7 +5087,8 @@
     "nationalPokedexNumber": 227
   },
   {
-    "id": "bw7-96",
+    "setOrder":54,
+	"id": "bw7-96",
     "name": "Skarmory",
     "imageUrl": "https://images.pokemontcg.io/bw7/96.png",
     "subtype": "Basic",
@@ -5050,7 +5146,8 @@
     "nationalPokedexNumber": 227
   },
   {
-    "id": "bw7-97",
+    "setOrder":54,
+	"id": "bw7-97",
     "name": "Klink",
     "imageUrl": "https://images.pokemontcg.io/bw7/97.png",
     "subtype": "Basic",
@@ -5101,7 +5198,8 @@
     ]
   },
   {
-    "id": "bw7-98",
+    "setOrder":54,
+	"id": "bw7-98",
     "name": "Vibrava",
     "imageUrl": "https://images.pokemontcg.io/bw7/98.png",
     "subtype": "Stage 1",
@@ -5156,7 +5254,8 @@
     ]
   },
   {
-    "id": "bw7-99",
+    "setOrder":54,
+	"id": "bw7-99",
     "name": "Flygon",
     "imageUrl": "https://images.pokemontcg.io/bw7/99.png",
     "subtype": "Stage 2",
@@ -5205,7 +5304,8 @@
     "nationalPokedexNumber": 330
   },
   {
-    "id": "bw7-100",
+    "setOrder":54,
+	"id": "bw7-100",
     "name": "Black Kyurem",
     "imageUrl": "https://images.pokemontcg.io/bw7/100.png",
     "subtype": "Basic",
@@ -5259,7 +5359,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "bw7-101",
+    "setOrder":54,
+	"id": "bw7-101",
     "name": "Black Kyurem-EX",
     "imageUrl": "https://images.pokemontcg.io/bw7/101.png",
     "subtype": "EX",
@@ -5318,7 +5419,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "bw7-102",
+    "setOrder":54,
+	"id": "bw7-102",
     "name": "White Kyurem",
     "imageUrl": "https://images.pokemontcg.io/bw7/102.png",
     "subtype": "Basic",
@@ -5372,7 +5474,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "bw7-103",
+    "setOrder":54,
+	"id": "bw7-103",
     "name": "White Kyurem-EX",
     "imageUrl": "https://images.pokemontcg.io/bw7/103.png",
     "subtype": "EX",
@@ -5431,7 +5534,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "bw7-104",
+    "setOrder":54,
+	"id": "bw7-104",
     "name": "Rattata",
     "imageUrl": "https://images.pokemontcg.io/bw7/104.png",
     "subtype": "Basic",
@@ -5474,7 +5578,8 @@
     ]
   },
   {
-    "id": "bw7-105",
+    "setOrder":54,
+	"id": "bw7-105",
     "name": "Raticate",
     "imageUrl": "https://images.pokemontcg.io/bw7/105.png",
     "subtype": "Stage 1",
@@ -5523,7 +5628,8 @@
     "nationalPokedexNumber": 20
   },
   {
-    "id": "bw7-106",
+    "setOrder":54,
+	"id": "bw7-106",
     "name": "Meowth",
     "imageUrl": "https://images.pokemontcg.io/bw7/106.png",
     "subtype": "Basic",
@@ -5567,7 +5673,8 @@
     ]
   },
   {
-    "id": "bw7-107",
+    "setOrder":54,
+	"id": "bw7-107",
     "name": "Farfetch'd",
     "imageUrl": "https://images.pokemontcg.io/bw7/107.png",
     "subtype": "Basic",
@@ -5614,7 +5721,8 @@
     "nationalPokedexNumber": 83
   },
   {
-    "id": "bw7-108",
+    "setOrder":54,
+	"id": "bw7-108",
     "name": "Ditto",
     "imageUrl": "https://images.pokemontcg.io/bw7/108.png",
     "subtype": "Basic",
@@ -5648,7 +5756,8 @@
     "nationalPokedexNumber": 132
   },
   {
-    "id": "bw7-109",
+    "setOrder":54,
+	"id": "bw7-109",
     "name": "Snorlax",
     "imageUrl": "https://images.pokemontcg.io/bw7/109.png",
     "subtype": "Basic",
@@ -5705,7 +5814,8 @@
     "nationalPokedexNumber": 143
   },
   {
-    "id": "bw7-110",
+    "setOrder":54,
+	"id": "bw7-110",
     "name": "Togepi",
     "imageUrl": "https://images.pokemontcg.io/bw7/110.png",
     "subtype": "Basic",
@@ -5748,7 +5858,8 @@
     ]
   },
   {
-    "id": "bw7-111",
+    "setOrder":54,
+	"id": "bw7-111",
     "name": "Dunsparce",
     "imageUrl": "https://images.pokemontcg.io/bw7/111.png",
     "subtype": "Basic",
@@ -5794,7 +5905,8 @@
     "nationalPokedexNumber": 206
   },
   {
-    "id": "bw7-112",
+    "setOrder":54,
+	"id": "bw7-112",
     "name": "Taillow",
     "imageUrl": "https://images.pokemontcg.io/bw7/112.png",
     "subtype": "Basic",
@@ -5843,7 +5955,8 @@
     ]
   },
   {
-    "id": "bw7-113",
+    "setOrder":54,
+	"id": "bw7-113",
     "name": "Skitty",
     "imageUrl": "https://images.pokemontcg.io/bw7/113.png",
     "subtype": "Basic",
@@ -5896,7 +6009,8 @@
     ]
   },
   {
-    "id": "bw7-114",
+    "setOrder":54,
+	"id": "bw7-114",
     "name": "Delcatty",
     "imageUrl": "https://images.pokemontcg.io/bw7/114.png",
     "subtype": "Stage 1",
@@ -5947,7 +6061,8 @@
     "nationalPokedexNumber": 301
   },
   {
-    "id": "bw7-115",
+    "setOrder":54,
+	"id": "bw7-115",
     "name": "Spinda",
     "imageUrl": "https://images.pokemontcg.io/bw7/115.png",
     "subtype": "Basic",
@@ -5988,7 +6103,8 @@
     "nationalPokedexNumber": 327
   },
   {
-    "id": "bw7-116",
+    "setOrder":54,
+	"id": "bw7-116",
     "name": "Buneary",
     "imageUrl": "https://images.pokemontcg.io/bw7/116.png",
     "subtype": "Basic",
@@ -6041,7 +6157,8 @@
     ]
   },
   {
-    "id": "bw7-117",
+    "setOrder":54,
+	"id": "bw7-117",
     "name": "Lopunny",
     "imageUrl": "https://images.pokemontcg.io/bw7/117.png",
     "subtype": "Stage 1",
@@ -6093,7 +6210,8 @@
     "nationalPokedexNumber": 428
   },
   {
-    "id": "bw7-118",
+    "setOrder":54,
+	"id": "bw7-118",
     "name": "Patrat",
     "imageUrl": "https://images.pokemontcg.io/bw7/118.png",
     "subtype": "Basic",
@@ -6136,7 +6254,8 @@
     ]
   },
   {
-    "id": "bw7-119",
+    "setOrder":54,
+	"id": "bw7-119",
     "name": "Watchog",
     "imageUrl": "https://images.pokemontcg.io/bw7/119.png",
     "subtype": "Stage 1",
@@ -6187,7 +6306,8 @@
     "nationalPokedexNumber": 505
   },
   {
-    "id": "bw7-120",
+    "setOrder":54,
+	"id": "bw7-120",
     "name": "Lillipup",
     "imageUrl": "https://images.pokemontcg.io/bw7/120.png",
     "subtype": "Basic",
@@ -6240,7 +6360,8 @@
     ]
   },
   {
-    "id": "bw7-121",
+    "setOrder":54,
+	"id": "bw7-121",
     "name": "Herdier",
     "imageUrl": "https://images.pokemontcg.io/bw7/121.png",
     "subtype": "Stage 1",
@@ -6295,7 +6416,8 @@
     ]
   },
   {
-    "id": "bw7-122",
+    "setOrder":54,
+	"id": "bw7-122",
     "name": "Stoutland",
     "imageUrl": "https://images.pokemontcg.io/bw7/122.png",
     "subtype": "Stage 2",
@@ -6345,7 +6467,8 @@
     "nationalPokedexNumber": 508
   },
   {
-    "id": "bw7-123",
+    "setOrder":54,
+	"id": "bw7-123",
     "name": "Pidove",
     "imageUrl": "https://images.pokemontcg.io/bw7/123.png",
     "subtype": "Basic",
@@ -6395,7 +6518,8 @@
     ]
   },
   {
-    "id": "bw7-124",
+    "setOrder":54,
+	"id": "bw7-124",
     "name": "Tranquill",
     "imageUrl": "https://images.pokemontcg.io/bw7/124.png",
     "subtype": "Stage 1",
@@ -6447,7 +6571,8 @@
     ]
   },
   {
-    "id": "bw7-125",
+    "setOrder":54,
+	"id": "bw7-125",
     "name": "Unfezant",
     "imageUrl": "https://images.pokemontcg.io/bw7/125.png",
     "subtype": "Stage 2",
@@ -6506,7 +6631,8 @@
     "nationalPokedexNumber": 521
   },
   {
-    "id": "bw7-126",
+    "setOrder":54,
+	"id": "bw7-126",
     "name": "Audino",
     "imageUrl": "https://images.pokemontcg.io/bw7/126.png",
     "subtype": "Basic",
@@ -6553,7 +6679,8 @@
     "nationalPokedexNumber": 531
   },
   {
-    "id": "bw7-127",
+    "setOrder":54,
+	"id": "bw7-127",
     "name": "Aspertia City Gym",
     "imageUrl": "https://images.pokemontcg.io/bw7/127.png",
     "subtype": "Stadium",
@@ -6570,7 +6697,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw7/127_hires.png"
   },
   {
-    "id": "bw7-128",
+    "setOrder":54,
+	"id": "bw7-128",
     "name": "Energy Search",
     "imageUrl": "https://images.pokemontcg.io/bw7/128.png",
     "subtype": "Item",
@@ -6587,7 +6715,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw7/128_hires.png"
   },
   {
-    "id": "bw7-129",
+    "setOrder":54,
+	"id": "bw7-129",
     "name": "Great Ball",
     "imageUrl": "https://images.pokemontcg.io/bw7/129.png",
     "subtype": "Item",
@@ -6604,7 +6733,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw7/129_hires.png"
   },
   {
-    "id": "bw7-130",
+    "setOrder":54,
+	"id": "bw7-130",
     "name": "Hugh",
     "imageUrl": "https://images.pokemontcg.io/bw7/130.png",
     "subtype": "Supporter",
@@ -6621,7 +6751,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw7/130_hires.png"
   },
   {
-    "id": "bw7-131",
+    "setOrder":54,
+	"id": "bw7-131",
     "name": "Poké Ball",
     "imageUrl": "https://images.pokemontcg.io/bw7/131.png",
     "subtype": "Item",
@@ -6638,7 +6769,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw7/131_hires.png"
   },
   {
-    "id": "bw7-132",
+    "setOrder":54,
+	"id": "bw7-132",
     "name": "Potion",
     "imageUrl": "https://images.pokemontcg.io/bw7/132.png",
     "subtype": "Item",
@@ -6655,7 +6787,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw7/132_hires.png"
   },
   {
-    "id": "bw7-133",
+    "setOrder":54,
+	"id": "bw7-133",
     "name": "Rocky Helmet",
     "imageUrl": "https://images.pokemontcg.io/bw7/133.png",
     "subtype": "Pokémon Tool",
@@ -6672,7 +6805,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw7/133_hires.png"
   },
   {
-    "id": "bw7-134",
+    "setOrder":54,
+	"id": "bw7-134",
     "name": "Skyla",
     "imageUrl": "https://images.pokemontcg.io/bw7/134.png",
     "subtype": "Supporter",
@@ -6689,7 +6823,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw7/134_hires.png"
   },
   {
-    "id": "bw7-135",
+    "setOrder":54,
+	"id": "bw7-135",
     "name": "Switch",
     "imageUrl": "https://images.pokemontcg.io/bw7/135.png",
     "subtype": "Item",
@@ -6706,7 +6841,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw7/135_hires.png"
   },
   {
-    "id": "bw7-136",
+    "setOrder":54,
+	"id": "bw7-136",
     "name": "Town Map",
     "imageUrl": "https://images.pokemontcg.io/bw7/136.png",
     "subtype": "Item",
@@ -6723,7 +6859,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw7/136_hires.png"
   },
   {
-    "id": "bw7-137",
+    "setOrder":54,
+	"id": "bw7-137",
     "name": "Computer Search",
     "imageUrl": "https://images.pokemontcg.io/bw7/137.png",
     "subtype": "Item",
@@ -6740,7 +6877,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw7/137_hires.png"
   },
   {
-    "id": "bw7-138",
+    "setOrder":54,
+	"id": "bw7-138",
     "name": "Crystal Edge",
     "imageUrl": "https://images.pokemontcg.io/bw7/138.png",
     "subtype": "Pokémon Tool",
@@ -6757,7 +6895,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw7/138_hires.png"
   },
   {
-    "id": "bw7-139",
+    "setOrder":54,
+	"id": "bw7-139",
     "name": "Crystal Wall",
     "imageUrl": "https://images.pokemontcg.io/bw7/139.png",
     "subtype": "Pokémon Tool",
@@ -6774,7 +6913,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw7/139_hires.png"
   },
   {
-    "id": "bw7-140",
+    "setOrder":54,
+	"id": "bw7-140",
     "name": "Gold Potion",
     "imageUrl": "https://images.pokemontcg.io/bw7/140.png",
     "subtype": "Item",
@@ -6791,7 +6931,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw7/140_hires.png"
   },
   {
-    "id": "bw7-141",
+    "setOrder":54,
+	"id": "bw7-141",
     "name": "Celebi-EX",
     "imageUrl": "https://images.pokemontcg.io/bw7/141.png",
     "subtype": "EX",
@@ -6847,7 +6988,8 @@
     "nationalPokedexNumber": 251
   },
   {
-    "id": "bw7-142",
+    "setOrder":54,
+	"id": "bw7-142",
     "name": "Keldeo-EX",
     "imageUrl": "https://images.pokemontcg.io/bw7/142.png",
     "subtype": "EX",
@@ -6898,7 +7040,8 @@
     "nationalPokedexNumber": 647
   },
   {
-    "id": "bw7-143",
+    "setOrder":54,
+	"id": "bw7-143",
     "name": "Cresselia-EX",
     "imageUrl": "https://images.pokemontcg.io/bw7/143.png",
     "subtype": "EX",
@@ -6949,7 +7092,8 @@
     "nationalPokedexNumber": 488
   },
   {
-    "id": "bw7-144",
+    "setOrder":54,
+	"id": "bw7-144",
     "name": "Landorus-EX",
     "imageUrl": "https://images.pokemontcg.io/bw7/144.png",
     "subtype": "EX",
@@ -7011,7 +7155,8 @@
     "nationalPokedexNumber": 645
   },
   {
-    "id": "bw7-145",
+    "setOrder":54,
+	"id": "bw7-145",
     "name": "Black Kyurem-EX",
     "imageUrl": "https://images.pokemontcg.io/bw7/145.png",
     "subtype": "EX",
@@ -7070,7 +7215,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "bw7-146",
+    "setOrder":54,
+	"id": "bw7-146",
     "name": "White Kyurem-EX",
     "imageUrl": "https://images.pokemontcg.io/bw7/146.png",
     "subtype": "EX",
@@ -7129,7 +7275,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "bw7-147",
+    "setOrder":54,
+	"id": "bw7-147",
     "name": "Bianca",
     "imageUrl": "https://images.pokemontcg.io/bw7/147.png",
     "subtype": "Supporter",
@@ -7146,7 +7293,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw7/147_hires.png"
   },
   {
-    "id": "bw7-148",
+    "setOrder":54,
+	"id": "bw7-148",
     "name": "Cheren",
     "imageUrl": "https://images.pokemontcg.io/bw7/148.png",
     "subtype": "Supporter",
@@ -7163,7 +7311,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw7/148_hires.png"
   },
   {
-    "id": "bw7-149",
+    "setOrder":54,
+	"id": "bw7-149",
     "name": "Skyla",
     "imageUrl": "https://images.pokemontcg.io/bw7/149.png",
     "subtype": "Supporter",
@@ -7180,7 +7329,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw7/149_hires.png"
   },
   {
-    "id": "bw7-150",
+    "setOrder":54,
+	"id": "bw7-150",
     "name": "Golurk",
     "imageUrl": "https://images.pokemontcg.io/bw7/150.png",
     "subtype": "Stage 1",
@@ -7238,7 +7388,8 @@
     "nationalPokedexNumber": 623
   },
   {
-    "id": "bw7-151",
+    "setOrder":54,
+	"id": "bw7-151",
     "name": "Terrakion",
     "imageUrl": "https://images.pokemontcg.io/bw7/151.png",
     "subtype": "Basic",
@@ -7293,7 +7444,8 @@
     "nationalPokedexNumber": 639
   },
   {
-    "id": "bw7-152",
+    "setOrder":54,
+	"id": "bw7-152",
     "name": "Altaria",
     "imageUrl": "https://images.pokemontcg.io/bw7/152.png",
     "subtype": "Stage 1",
@@ -7341,7 +7493,8 @@
     "nationalPokedexNumber": 334
   },
   {
-    "id": "bw7-153",
+    "setOrder":54,
+	"id": "bw7-153",
     "name": "Rocky Helmet",
     "imageUrl": "https://images.pokemontcg.io/bw7/153.png",
     "subtype": "Pokémon Tool",

--- a/json/cards/Burning Shadows.json
+++ b/json/cards/Burning Shadows.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "sm3-1",
+    "setOrder":74,
+	"id": "sm3-1",
     "name": "Caterpie",
     "imageUrl": "https://images.pokemontcg.io/sm3/1.png",
     "subtype": "Basic",
@@ -43,7 +44,8 @@
     ]
   },
   {
-    "id": "sm3-2",
+    "setOrder":74,
+	"id": "sm3-2",
     "name": "Metapod",
     "imageUrl": "https://images.pokemontcg.io/sm3/2.png",
     "subtype": "Stage 1",
@@ -98,7 +100,8 @@
     ]
   },
   {
-    "id": "sm3-3",
+    "setOrder":74,
+	"id": "sm3-3",
     "name": "Butterfree",
     "imageUrl": "https://images.pokemontcg.io/sm3/3.png",
     "subtype": "Stage 2",
@@ -150,7 +153,8 @@
     "nationalPokedexNumber": 12
   },
   {
-    "id": "sm3-4",
+    "setOrder":74,
+	"id": "sm3-4",
     "name": "Oddish",
     "imageUrl": "https://images.pokemontcg.io/sm3/4.png",
     "subtype": "Basic",
@@ -193,7 +197,8 @@
     ]
   },
   {
-    "id": "sm3-5",
+    "setOrder":74,
+	"id": "sm3-5",
     "name": "Gloom",
     "imageUrl": "https://images.pokemontcg.io/sm3/5.png",
     "subtype": "Stage 1",
@@ -249,7 +254,8 @@
     ]
   },
   {
-    "id": "sm3-6",
+    "setOrder":74,
+	"id": "sm3-6",
     "name": "Vileplume",
     "imageUrl": "https://images.pokemontcg.io/sm3/6.png",
     "subtype": "Stage 2",
@@ -299,7 +305,8 @@
     "nationalPokedexNumber": 45
   },
   {
-    "id": "sm3-7",
+    "setOrder":74,
+	"id": "sm3-7",
     "name": "Tangela",
     "imageUrl": "https://images.pokemontcg.io/sm3/7.png",
     "subtype": "Basic",
@@ -343,7 +350,8 @@
     ]
   },
   {
-    "id": "sm3-8",
+    "setOrder":74,
+	"id": "sm3-8",
     "name": "Tangrowth",
     "imageUrl": "https://images.pokemontcg.io/sm3/8.png",
     "subtype": "Stage 1",
@@ -399,7 +407,8 @@
     "nationalPokedexNumber": 465
   },
   {
-    "id": "sm3-9",
+    "setOrder":74,
+	"id": "sm3-9",
     "name": "Ledyba",
     "imageUrl": "https://images.pokemontcg.io/sm3/9.png",
     "subtype": "Basic",
@@ -442,7 +451,8 @@
     ]
   },
   {
-    "id": "sm3-10",
+    "setOrder":74,
+	"id": "sm3-10",
     "name": "Ledian",
     "imageUrl": "https://images.pokemontcg.io/sm3/10.png",
     "subtype": "Stage 1",
@@ -494,7 +504,8 @@
     "nationalPokedexNumber": 166
   },
   {
-    "id": "sm3-11",
+    "setOrder":74,
+	"id": "sm3-11",
     "name": "Heracross",
     "imageUrl": "https://images.pokemontcg.io/sm3/11.png",
     "subtype": "Basic",
@@ -541,7 +552,8 @@
     "nationalPokedexNumber": 214
   },
   {
-    "id": "sm3-12",
+    "setOrder":74,
+	"id": "sm3-12",
     "name": "Pansage",
     "imageUrl": "https://images.pokemontcg.io/sm3/12.png",
     "subtype": "Basic",
@@ -584,7 +596,8 @@
     ]
   },
   {
-    "id": "sm3-13",
+    "setOrder":74,
+	"id": "sm3-13",
     "name": "Simisage",
     "imageUrl": "https://images.pokemontcg.io/sm3/13.png",
     "subtype": "Stage 1",
@@ -635,7 +648,8 @@
     "nationalPokedexNumber": 512
   },
   {
-    "id": "sm3-14",
+    "setOrder":74,
+	"id": "sm3-14",
     "name": "Dewpider",
     "imageUrl": "https://images.pokemontcg.io/sm3/14.png",
     "subtype": "Basic",
@@ -678,7 +692,8 @@
     ]
   },
   {
-    "id": "sm3-15",
+    "setOrder":74,
+	"id": "sm3-15",
     "name": "Araquanid",
     "imageUrl": "https://images.pokemontcg.io/sm3/15.png",
     "subtype": "Stage 1",
@@ -731,7 +746,8 @@
     "nationalPokedexNumber": 752
   },
   {
-    "id": "sm3-16",
+    "setOrder":74,
+	"id": "sm3-16",
     "name": "Wimpod",
     "imageUrl": "https://images.pokemontcg.io/sm3/16.png",
     "subtype": "Basic",
@@ -783,7 +799,8 @@
     ]
   },
   {
-    "id": "sm3-17",
+    "setOrder":74,
+	"id": "sm3-17",
     "name": "Golisopod-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/17.png",
     "subtype": "GX",
@@ -852,7 +869,8 @@
     "nationalPokedexNumber": 768
   },
   {
-    "id": "sm3-18",
+    "setOrder":74,
+	"id": "sm3-18",
     "name": "Charmander",
     "imageUrl": "https://images.pokemontcg.io/sm3/18.png",
     "subtype": "Basic",
@@ -905,7 +923,8 @@
     ]
   },
   {
-    "id": "sm3-19",
+    "setOrder":74,
+	"id": "sm3-19",
     "name": "Charmeleon",
     "imageUrl": "https://images.pokemontcg.io/sm3/19.png",
     "subtype": "Stage 1",
@@ -962,7 +981,8 @@
     ]
   },
   {
-    "id": "sm3-20",
+    "setOrder":74,
+	"id": "sm3-20",
     "name": "Charizard-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/20.png",
     "subtype": "GX",
@@ -1034,7 +1054,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "sm3-21",
+    "setOrder":74,
+	"id": "sm3-21",
     "name": "Ho-Oh-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/21.png",
     "subtype": "GX",
@@ -1110,7 +1131,8 @@
     "nationalPokedexNumber": 250
   },
   {
-    "id": "sm3-22",
+    "setOrder":74,
+	"id": "sm3-22",
     "name": "Pansear",
     "imageUrl": "https://images.pokemontcg.io/sm3/22.png",
     "subtype": "Basic",
@@ -1153,7 +1175,8 @@
     ]
   },
   {
-    "id": "sm3-23",
+    "setOrder":74,
+	"id": "sm3-23",
     "name": "Simisear",
     "imageUrl": "https://images.pokemontcg.io/sm3/23.png",
     "subtype": "Stage 1",
@@ -1204,7 +1227,8 @@
     "nationalPokedexNumber": 514
   },
   {
-    "id": "sm3-24",
+    "setOrder":74,
+	"id": "sm3-24",
     "name": "Heatmor",
     "imageUrl": "https://images.pokemontcg.io/sm3/24.png",
     "subtype": "Basic",
@@ -1257,7 +1281,8 @@
     "nationalPokedexNumber": 631
   },
   {
-    "id": "sm3-25",
+    "setOrder":74,
+	"id": "sm3-25",
     "name": "Salazzle-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/25.png",
     "subtype": "GX",
@@ -1324,7 +1349,8 @@
     "nationalPokedexNumber": 758
   },
   {
-    "id": "sm3-26",
+    "setOrder":74,
+	"id": "sm3-26",
     "name": "Turtonator",
     "imageUrl": "https://images.pokemontcg.io/sm3/26.png",
     "subtype": "Basic",
@@ -1378,7 +1404,8 @@
     "nationalPokedexNumber": 776
   },
   {
-    "id": "sm3-27",
+    "setOrder":74,
+	"id": "sm3-27",
     "name": "Alolan Vulpix",
     "imageUrl": "https://images.pokemontcg.io/sm3/27.png",
     "subtype": "Basic",
@@ -1431,7 +1458,8 @@
     ]
   },
   {
-    "id": "sm3-28",
+    "setOrder":74,
+	"id": "sm3-28",
     "name": "Alolan Ninetales",
     "imageUrl": "https://images.pokemontcg.io/sm3/28.png",
     "subtype": "Stage 1",
@@ -1479,7 +1507,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "sm3-29",
+    "setOrder":74,
+	"id": "sm3-29",
     "name": "Horsea",
     "imageUrl": "https://images.pokemontcg.io/sm3/29.png",
     "subtype": "Basic",
@@ -1522,7 +1551,8 @@
     ]
   },
   {
-    "id": "sm3-30",
+    "setOrder":74,
+	"id": "sm3-30",
     "name": "Seadra",
     "imageUrl": "https://images.pokemontcg.io/sm3/30.png",
     "subtype": "Stage 1",
@@ -1566,7 +1596,8 @@
     ]
   },
   {
-    "id": "sm3-31",
+    "setOrder":74,
+	"id": "sm3-31",
     "name": "Kingdra",
     "imageUrl": "https://images.pokemontcg.io/sm3/31.png",
     "subtype": "Stage 2",
@@ -1616,7 +1647,8 @@
     "nationalPokedexNumber": 230
   },
   {
-    "id": "sm3-32",
+    "setOrder":74,
+	"id": "sm3-32",
     "name": "Magikarp",
     "imageUrl": "https://images.pokemontcg.io/sm3/32.png",
     "subtype": "Basic",
@@ -1659,7 +1691,8 @@
     ]
   },
   {
-    "id": "sm3-33",
+    "setOrder":74,
+	"id": "sm3-33",
     "name": "Gyarados",
     "imageUrl": "https://images.pokemontcg.io/sm3/33.png",
     "subtype": "Stage 1",
@@ -1716,7 +1749,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "sm3-34",
+    "setOrder":74,
+	"id": "sm3-34",
     "name": "Marill",
     "imageUrl": "https://images.pokemontcg.io/sm3/34.png",
     "subtype": "Basic",
@@ -1769,7 +1803,8 @@
     ]
   },
   {
-    "id": "sm3-35",
+    "setOrder":74,
+	"id": "sm3-35",
     "name": "Azumarill",
     "imageUrl": "https://images.pokemontcg.io/sm3/35.png",
     "subtype": "Stage 1",
@@ -1819,7 +1854,8 @@
     "nationalPokedexNumber": 184
   },
   {
-    "id": "sm3-36",
+    "setOrder":74,
+	"id": "sm3-36",
     "name": "Panpour",
     "imageUrl": "https://images.pokemontcg.io/sm3/36.png",
     "subtype": "Basic",
@@ -1862,7 +1898,8 @@
     ]
   },
   {
-    "id": "sm3-37",
+    "setOrder":74,
+	"id": "sm3-37",
     "name": "Simipour",
     "imageUrl": "https://images.pokemontcg.io/sm3/37.png",
     "subtype": "Stage 1",
@@ -1913,7 +1950,8 @@
     "nationalPokedexNumber": 516
   },
   {
-    "id": "sm3-38",
+    "setOrder":74,
+	"id": "sm3-38",
     "name": "Bruxish",
     "imageUrl": "https://images.pokemontcg.io/sm3/38.png",
     "subtype": "Basic",
@@ -1964,7 +2002,8 @@
     "nationalPokedexNumber": 779
   },
   {
-    "id": "sm3-39",
+    "setOrder":74,
+	"id": "sm3-39",
     "name": "Tapu Fini-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/39.png",
     "subtype": "GX",
@@ -2021,7 +2060,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/39_hires.png"
   },
   {
-    "id": "sm3-40",
+    "setOrder":74,
+	"id": "sm3-40",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/sm3/40.png",
     "subtype": "Basic",
@@ -2080,7 +2120,8 @@
     ]
   },
   {
-    "id": "sm3-41",
+    "setOrder":74,
+	"id": "sm3-41",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/sm3/41.png",
     "subtype": "Stage 1",
@@ -2134,7 +2175,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "sm3-42",
+    "setOrder":74,
+	"id": "sm3-42",
     "name": "Electabuzz",
     "imageUrl": "https://images.pokemontcg.io/sm3/42.png",
     "subtype": "Basic",
@@ -2196,7 +2238,8 @@
     ]
   },
   {
-    "id": "sm3-43",
+    "setOrder":74,
+	"id": "sm3-43",
     "name": "Electivire",
     "imageUrl": "https://images.pokemontcg.io/sm3/43.png",
     "subtype": "Stage 1",
@@ -2260,7 +2303,8 @@
     "nationalPokedexNumber": 466
   },
   {
-    "id": "sm3-44",
+    "setOrder":74,
+	"id": "sm3-44",
     "name": "Tynamo",
     "imageUrl": "https://images.pokemontcg.io/sm3/44.png",
     "subtype": "Basic",
@@ -2309,7 +2353,8 @@
     ]
   },
   {
-    "id": "sm3-45",
+    "setOrder":74,
+	"id": "sm3-45",
     "name": "Eelektrik",
     "imageUrl": "https://images.pokemontcg.io/sm3/45.png",
     "subtype": "Stage 1",
@@ -2361,7 +2406,8 @@
     ]
   },
   {
-    "id": "sm3-46",
+    "setOrder":74,
+	"id": "sm3-46",
     "name": "Eelektross",
     "imageUrl": "https://images.pokemontcg.io/sm3/46.png",
     "subtype": "Stage 2",
@@ -2422,7 +2468,8 @@
     "nationalPokedexNumber": 604
   },
   {
-    "id": "sm3-47",
+    "setOrder":74,
+	"id": "sm3-47",
     "name": "Togedemaru",
     "imageUrl": "https://images.pokemontcg.io/sm3/47.png",
     "subtype": "Basic",
@@ -2478,7 +2525,8 @@
     "nationalPokedexNumber": 777
   },
   {
-    "id": "sm3-48",
+    "setOrder":74,
+	"id": "sm3-48",
     "name": "Slowking",
     "imageUrl": "https://images.pokemontcg.io/sm3/48.png",
     "subtype": "Stage 1",
@@ -2531,7 +2579,8 @@
     "nationalPokedexNumber": 199
   },
   {
-    "id": "sm3-49",
+    "setOrder":74,
+	"id": "sm3-49",
     "name": "Wobbuffet",
     "imageUrl": "https://images.pokemontcg.io/sm3/49.png",
     "subtype": "Basic",
@@ -2575,7 +2624,8 @@
     "nationalPokedexNumber": 202
   },
   {
-    "id": "sm3-50",
+    "setOrder":74,
+	"id": "sm3-50",
     "name": "Seviper",
     "imageUrl": "https://images.pokemontcg.io/sm3/50.png",
     "subtype": "Basic",
@@ -2623,7 +2673,8 @@
     "nationalPokedexNumber": 336
   },
   {
-    "id": "sm3-51",
+    "setOrder":74,
+	"id": "sm3-51",
     "name": "Duskull",
     "imageUrl": "https://images.pokemontcg.io/sm3/51.png",
     "subtype": "Basic",
@@ -2682,7 +2733,8 @@
     ]
   },
   {
-    "id": "sm3-52",
+    "setOrder":74,
+	"id": "sm3-52",
     "name": "Dusclops",
     "imageUrl": "https://images.pokemontcg.io/sm3/52.png",
     "subtype": "Stage 1",
@@ -2745,7 +2797,8 @@
     ]
   },
   {
-    "id": "sm3-53",
+    "setOrder":74,
+	"id": "sm3-53",
     "name": "Dusknoir",
     "imageUrl": "https://images.pokemontcg.io/sm3/53.png",
     "subtype": "Stage 2",
@@ -2801,7 +2854,8 @@
     "nationalPokedexNumber": 477
   },
   {
-    "id": "sm3-54",
+    "setOrder":74,
+	"id": "sm3-54",
     "name": "Croagunk",
     "imageUrl": "https://images.pokemontcg.io/sm3/54.png",
     "subtype": "Basic",
@@ -2854,7 +2908,8 @@
     ]
   },
   {
-    "id": "sm3-55",
+    "setOrder":74,
+	"id": "sm3-55",
     "name": "Toxicroak",
     "imageUrl": "https://images.pokemontcg.io/sm3/55.png",
     "subtype": "Stage 1",
@@ -2908,7 +2963,8 @@
     "nationalPokedexNumber": 454
   },
   {
-    "id": "sm3-56",
+    "setOrder":74,
+	"id": "sm3-56",
     "name": "Venipede",
     "imageUrl": "https://images.pokemontcg.io/sm3/56.png",
     "subtype": "Basic",
@@ -2962,7 +3018,8 @@
     ]
   },
   {
-    "id": "sm3-57",
+    "setOrder":74,
+	"id": "sm3-57",
     "name": "Whirlipede",
     "imageUrl": "https://images.pokemontcg.io/sm3/57.png",
     "subtype": "Stage 1",
@@ -3020,7 +3077,8 @@
     ]
   },
   {
-    "id": "sm3-58",
+    "setOrder":74,
+	"id": "sm3-58",
     "name": "Scolipede",
     "imageUrl": "https://images.pokemontcg.io/sm3/58.png",
     "subtype": "Stage 2",
@@ -3078,7 +3136,8 @@
     "nationalPokedexNumber": 545
   },
   {
-    "id": "sm3-59",
+    "setOrder":74,
+	"id": "sm3-59",
     "name": "Espurr",
     "imageUrl": "https://images.pokemontcg.io/sm3/59.png",
     "subtype": "Basic",
@@ -3121,7 +3180,8 @@
     ]
   },
   {
-    "id": "sm3-60",
+    "setOrder":74,
+	"id": "sm3-60",
     "name": "Meowstic",
     "imageUrl": "https://images.pokemontcg.io/sm3/60.png",
     "subtype": "Stage 1",
@@ -3172,7 +3232,8 @@
     "nationalPokedexNumber": 678
   },
   {
-    "id": "sm3-61",
+    "setOrder":74,
+	"id": "sm3-61",
     "name": "Sandygast",
     "imageUrl": "https://images.pokemontcg.io/sm3/61.png",
     "subtype": "Basic",
@@ -3223,7 +3284,8 @@
     ]
   },
   {
-    "id": "sm3-62",
+    "setOrder":74,
+	"id": "sm3-62",
     "name": "Palossand",
     "imageUrl": "https://images.pokemontcg.io/sm3/62.png",
     "subtype": "Stage 1",
@@ -3287,7 +3349,8 @@
     "nationalPokedexNumber": 770
   },
   {
-    "id": "sm3-63",
+    "setOrder":74,
+	"id": "sm3-63",
     "name": "Necrozma-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/63.png",
     "subtype": "GX",
@@ -3350,7 +3413,8 @@
     "nationalPokedexNumber": 800
   },
   {
-    "id": "sm3-64",
+    "setOrder":74,
+	"id": "sm3-64",
     "name": "Machamp-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/64.png",
     "subtype": "GX",
@@ -3420,7 +3484,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "sm3-65",
+    "setOrder":74,
+	"id": "sm3-65",
     "name": "Rhyhorn",
     "imageUrl": "https://images.pokemontcg.io/sm3/65.png",
     "subtype": "Basic",
@@ -3477,7 +3542,8 @@
     ]
   },
   {
-    "id": "sm3-66",
+    "setOrder":74,
+	"id": "sm3-66",
     "name": "Rhydon",
     "imageUrl": "https://images.pokemontcg.io/sm3/66.png",
     "subtype": "Stage 1",
@@ -3538,7 +3604,8 @@
     ]
   },
   {
-    "id": "sm3-67",
+    "setOrder":74,
+	"id": "sm3-67",
     "name": "Rhyperior",
     "imageUrl": "https://images.pokemontcg.io/sm3/67.png",
     "subtype": "Stage 2",
@@ -3590,7 +3657,8 @@
     "nationalPokedexNumber": 464
   },
   {
-    "id": "sm3-68",
+    "setOrder":74,
+	"id": "sm3-68",
     "name": "Lunatone",
     "imageUrl": "https://images.pokemontcg.io/sm3/68.png",
     "subtype": "Basic",
@@ -3637,7 +3705,8 @@
     "nationalPokedexNumber": 337
   },
   {
-    "id": "sm3-69",
+    "setOrder":74,
+	"id": "sm3-69",
     "name": "Solrock",
     "imageUrl": "https://images.pokemontcg.io/sm3/69.png",
     "subtype": "Basic",
@@ -3686,7 +3755,8 @@
     "nationalPokedexNumber": 338
   },
   {
-    "id": "sm3-70",
+    "setOrder":74,
+	"id": "sm3-70",
     "name": "Riolu",
     "imageUrl": "https://images.pokemontcg.io/sm3/70.png",
     "subtype": "Basic",
@@ -3739,7 +3809,8 @@
     ]
   },
   {
-    "id": "sm3-71",
+    "setOrder":74,
+	"id": "sm3-71",
     "name": "Lucario",
     "imageUrl": "https://images.pokemontcg.io/sm3/71.png",
     "subtype": "Stage 1",
@@ -3787,7 +3858,8 @@
     "nationalPokedexNumber": 448
   },
   {
-    "id": "sm3-72",
+    "setOrder":74,
+	"id": "sm3-72",
     "name": "Sawk",
     "imageUrl": "https://images.pokemontcg.io/sm3/72.png",
     "subtype": "Basic",
@@ -3838,7 +3910,8 @@
     "nationalPokedexNumber": 539
   },
   {
-    "id": "sm3-73",
+    "setOrder":74,
+	"id": "sm3-73",
     "name": "Crabrawler",
     "imageUrl": "https://images.pokemontcg.io/sm3/73.png",
     "subtype": "Basic",
@@ -3883,7 +3956,8 @@
     ]
   },
   {
-    "id": "sm3-74",
+    "setOrder":74,
+	"id": "sm3-74",
     "name": "Crabominable",
     "imageUrl": "https://images.pokemontcg.io/sm3/74.png",
     "subtype": "Stage 1",
@@ -3938,7 +4012,8 @@
     "nationalPokedexNumber": 740
   },
   {
-    "id": "sm3-75",
+    "setOrder":74,
+	"id": "sm3-75",
     "name": "Lycanroc",
     "imageUrl": "https://images.pokemontcg.io/sm3/75.png",
     "subtype": "Stage 1",
@@ -3991,7 +4066,8 @@
     "nationalPokedexNumber": 745
   },
   {
-    "id": "sm3-76",
+    "setOrder":74,
+	"id": "sm3-76",
     "name": "Lycanroc",
     "imageUrl": "https://images.pokemontcg.io/sm3/76.png",
     "subtype": "Stage 1",
@@ -4045,7 +4121,8 @@
     "nationalPokedexNumber": 745
   },
   {
-    "id": "sm3-77",
+    "setOrder":74,
+	"id": "sm3-77",
     "name": "Mudbray",
     "imageUrl": "https://images.pokemontcg.io/sm3/77.png",
     "subtype": "Basic",
@@ -4090,7 +4167,8 @@
     ]
   },
   {
-    "id": "sm3-78",
+    "setOrder":74,
+	"id": "sm3-78",
     "name": "Mudsdale",
     "imageUrl": "https://images.pokemontcg.io/sm3/78.png",
     "subtype": "Stage 1",
@@ -4147,7 +4225,8 @@
     "nationalPokedexNumber": 750
   },
   {
-    "id": "sm3-79",
+    "setOrder":74,
+	"id": "sm3-79",
     "name": "Passimian",
     "imageUrl": "https://images.pokemontcg.io/sm3/79.png",
     "subtype": "Basic",
@@ -4198,7 +4277,8 @@
     "nationalPokedexNumber": 766
   },
   {
-    "id": "sm3-80",
+    "setOrder":74,
+	"id": "sm3-80",
     "name": "Marshadow-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/80.png",
     "subtype": "GX",
@@ -4258,7 +4338,8 @@
     "nationalPokedexNumber": 802
   },
   {
-    "id": "sm3-81",
+    "setOrder":74,
+	"id": "sm3-81",
     "name": "Alolan Rattata",
     "imageUrl": "https://images.pokemontcg.io/sm3/81.png",
     "subtype": "Basic",
@@ -4316,7 +4397,8 @@
     ]
   },
   {
-    "id": "sm3-82",
+    "setOrder":74,
+	"id": "sm3-82",
     "name": "Alolan Raticate",
     "imageUrl": "https://images.pokemontcg.io/sm3/82.png",
     "subtype": "Stage 1",
@@ -4374,7 +4456,8 @@
     "nationalPokedexNumber": 20
   },
   {
-    "id": "sm3-83",
+    "setOrder":74,
+	"id": "sm3-83",
     "name": "Alolan Grimer",
     "imageUrl": "https://images.pokemontcg.io/sm3/83.png",
     "subtype": "Basic",
@@ -4435,7 +4518,8 @@
     ]
   },
   {
-    "id": "sm3-84",
+    "setOrder":74,
+	"id": "sm3-84",
     "name": "Alolan Muk-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/84.png",
     "subtype": "GX",
@@ -4512,7 +4596,8 @@
     "nationalPokedexNumber": 89
   },
   {
-    "id": "sm3-85",
+    "setOrder":74,
+	"id": "sm3-85",
     "name": "Sneasel",
     "imageUrl": "https://images.pokemontcg.io/sm3/85.png",
     "subtype": "Basic",
@@ -4571,7 +4656,8 @@
     ]
   },
   {
-    "id": "sm3-86",
+    "setOrder":74,
+	"id": "sm3-86",
     "name": "Weavile",
     "imageUrl": "https://images.pokemontcg.io/sm3/86.png",
     "subtype": "Stage 1",
@@ -4625,7 +4711,8 @@
     "nationalPokedexNumber": 461
   },
   {
-    "id": "sm3-87",
+    "setOrder":74,
+	"id": "sm3-87",
     "name": "Darkrai",
     "imageUrl": "https://images.pokemontcg.io/sm3/87.png",
     "subtype": "Basic",
@@ -4684,7 +4771,8 @@
     "nationalPokedexNumber": 491
   },
   {
-    "id": "sm3-88",
+    "setOrder":74,
+	"id": "sm3-88",
     "name": "Darkrai-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/88.png",
     "subtype": "GX",
@@ -4753,7 +4841,8 @@
     "nationalPokedexNumber": 491
   },
   {
-    "id": "sm3-89",
+    "setOrder":74,
+	"id": "sm3-89",
     "name": "Inkay",
     "imageUrl": "https://images.pokemontcg.io/sm3/89.png",
     "subtype": "Basic",
@@ -4812,7 +4901,8 @@
     ]
   },
   {
-    "id": "sm3-90",
+    "setOrder":74,
+	"id": "sm3-90",
     "name": "Malamar",
     "imageUrl": "https://images.pokemontcg.io/sm3/90.png",
     "subtype": "Stage 1",
@@ -4870,7 +4960,8 @@
     "nationalPokedexNumber": 687
   },
   {
-    "id": "sm3-91",
+    "setOrder":74,
+	"id": "sm3-91",
     "name": "Ralts",
     "imageUrl": "https://images.pokemontcg.io/sm3/91.png",
     "subtype": "Basic",
@@ -4919,7 +5010,8 @@
     ]
   },
   {
-    "id": "sm3-92",
+    "setOrder":74,
+	"id": "sm3-92",
     "name": "Kirlia",
     "imageUrl": "https://images.pokemontcg.io/sm3/92.png",
     "subtype": "Stage 1",
@@ -4980,7 +5072,8 @@
     ]
   },
   {
-    "id": "sm3-93",
+    "setOrder":74,
+	"id": "sm3-93",
     "name": "Gardevoir-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/93.png",
     "subtype": "GX",
@@ -5046,7 +5139,8 @@
     "nationalPokedexNumber": 282
   },
   {
-    "id": "sm3-94",
+    "setOrder":74,
+	"id": "sm3-94",
     "name": "Diancie",
     "imageUrl": "https://images.pokemontcg.io/sm3/94.png",
     "subtype": "Basic",
@@ -5102,7 +5196,8 @@
     "nationalPokedexNumber": 719
   },
   {
-    "id": "sm3-95",
+    "setOrder":74,
+	"id": "sm3-95",
     "name": "Cutiefly",
     "imageUrl": "https://images.pokemontcg.io/sm3/95.png",
     "subtype": "Basic",
@@ -5148,7 +5243,8 @@
     ]
   },
   {
-    "id": "sm3-96",
+    "setOrder":74,
+	"id": "sm3-96",
     "name": "Ribombee",
     "imageUrl": "https://images.pokemontcg.io/sm3/96.png",
     "subtype": "Stage 1",
@@ -5200,7 +5296,8 @@
     "nationalPokedexNumber": 743
   },
   {
-    "id": "sm3-97",
+    "setOrder":74,
+	"id": "sm3-97",
     "name": "Morelull",
     "imageUrl": "https://images.pokemontcg.io/sm3/97.png",
     "subtype": "Basic",
@@ -5249,7 +5346,8 @@
     ]
   },
   {
-    "id": "sm3-98",
+    "setOrder":74,
+	"id": "sm3-98",
     "name": "Shiinotic",
     "imageUrl": "https://images.pokemontcg.io/sm3/98.png",
     "subtype": "Stage 1",
@@ -5309,7 +5407,8 @@
     "nationalPokedexNumber": 756
   },
   {
-    "id": "sm3-99",
+    "setOrder":74,
+	"id": "sm3-99",
     "name": "Noivern-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/99.png",
     "subtype": "GX",
@@ -5374,7 +5473,8 @@
     "nationalPokedexNumber": 715
   },
   {
-    "id": "sm3-100",
+    "setOrder":74,
+	"id": "sm3-100",
     "name": "Zygarde",
     "imageUrl": "https://images.pokemontcg.io/sm3/100.png",
     "subtype": "Basic",
@@ -5431,7 +5531,8 @@
     "nationalPokedexNumber": 718
   },
   {
-    "id": "sm3-101",
+    "setOrder":74,
+	"id": "sm3-101",
     "name": "Meowth",
     "imageUrl": "https://images.pokemontcg.io/sm3/101.png",
     "subtype": "Basic",
@@ -5474,7 +5575,8 @@
     ]
   },
   {
-    "id": "sm3-102",
+    "setOrder":74,
+	"id": "sm3-102",
     "name": "Persian",
     "imageUrl": "https://images.pokemontcg.io/sm3/102.png",
     "subtype": "Stage 1",
@@ -5524,7 +5626,8 @@
     "nationalPokedexNumber": 53
   },
   {
-    "id": "sm3-103",
+    "setOrder":74,
+	"id": "sm3-103",
     "name": "Porygon",
     "imageUrl": "https://images.pokemontcg.io/sm3/103.png",
     "subtype": "Basic",
@@ -5576,7 +5679,8 @@
     ]
   },
   {
-    "id": "sm3-104",
+    "setOrder":74,
+	"id": "sm3-104",
     "name": "Porygon2",
     "imageUrl": "https://images.pokemontcg.io/sm3/104.png",
     "subtype": "Stage 1",
@@ -5631,7 +5735,8 @@
     ]
   },
   {
-    "id": "sm3-105",
+    "setOrder":74,
+	"id": "sm3-105",
     "name": "Porygon-Z",
     "imageUrl": "https://images.pokemontcg.io/sm3/105.png",
     "subtype": "Stage 2",
@@ -5680,7 +5785,8 @@
     "nationalPokedexNumber": 474
   },
   {
-    "id": "sm3-106",
+    "setOrder":74,
+	"id": "sm3-106",
     "name": "Hoothoot",
     "imageUrl": "https://images.pokemontcg.io/sm3/106.png",
     "subtype": "Basic",
@@ -5739,7 +5845,8 @@
     ]
   },
   {
-    "id": "sm3-107",
+    "setOrder":74,
+	"id": "sm3-107",
     "name": "Noctowl",
     "imageUrl": "https://images.pokemontcg.io/sm3/107.png",
     "subtype": "Stage 1",
@@ -5797,7 +5904,8 @@
     "nationalPokedexNumber": 164
   },
   {
-    "id": "sm3-108",
+    "setOrder":74,
+	"id": "sm3-108",
     "name": "Bouffalant",
     "imageUrl": "https://images.pokemontcg.io/sm3/108.png",
     "subtype": "Basic",
@@ -5850,7 +5958,8 @@
     "nationalPokedexNumber": 626
   },
   {
-    "id": "sm3-109",
+    "setOrder":74,
+	"id": "sm3-109",
     "name": "Noibat",
     "imageUrl": "https://images.pokemontcg.io/sm3/109.png",
     "subtype": "Basic",
@@ -5899,7 +6008,8 @@
     ]
   },
   {
-    "id": "sm3-110",
+    "setOrder":74,
+	"id": "sm3-110",
     "name": "Stufful",
     "imageUrl": "https://images.pokemontcg.io/sm3/110.png",
     "subtype": "Basic",
@@ -5953,7 +6063,8 @@
     ]
   },
   {
-    "id": "sm3-111",
+    "setOrder":74,
+	"id": "sm3-111",
     "name": "Bewear",
     "imageUrl": "https://images.pokemontcg.io/sm3/111.png",
     "subtype": "Stage 1",
@@ -6007,7 +6118,8 @@
     "nationalPokedexNumber": 760
   },
   {
-    "id": "sm3-112",
+    "setOrder":74,
+	"id": "sm3-112",
     "name": "Acerola",
     "imageUrl": "https://images.pokemontcg.io/sm3/112.png",
     "subtype": "Supporter",
@@ -6024,7 +6136,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/112_hires.png"
   },
   {
-    "id": "sm3-113",
+    "setOrder":74,
+	"id": "sm3-113",
     "name": "Bodybuilding Dumbbells",
     "imageUrl": "https://images.pokemontcg.io/sm3/113.png",
     "subtype": "Pokémon Tool",
@@ -6041,7 +6154,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/113_hires.png"
   },
   {
-    "id": "sm3-114",
+    "setOrder":74,
+	"id": "sm3-114",
     "name": "Escape Rope",
     "imageUrl": "https://images.pokemontcg.io/sm3/114.png",
     "subtype": "Item",
@@ -6058,7 +6172,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/114_hires.png"
   },
   {
-    "id": "sm3-115",
+    "setOrder":74,
+	"id": "sm3-115",
     "name": "Guzma",
     "imageUrl": "https://images.pokemontcg.io/sm3/115.png",
     "subtype": "Supporter",
@@ -6075,7 +6190,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/115_hires.png"
   },
   {
-    "id": "sm3-116",
+    "setOrder":74,
+	"id": "sm3-116",
     "name": "Kiawe",
     "imageUrl": "https://images.pokemontcg.io/sm3/116.png",
     "subtype": "Supporter",
@@ -6092,7 +6208,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/116_hires.png"
   },
   {
-    "id": "sm3-117",
+    "setOrder":74,
+	"id": "sm3-117",
     "name": "Lana",
     "imageUrl": "https://images.pokemontcg.io/sm3/117.png",
     "subtype": "Supporter",
@@ -6109,7 +6226,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/117_hires.png"
   },
   {
-    "id": "sm3-118",
+    "setOrder":74,
+	"id": "sm3-118",
     "name": "Mount Lanakila",
     "imageUrl": "https://images.pokemontcg.io/sm3/118.png",
     "subtype": "Stadium",
@@ -6126,7 +6244,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/118_hires.png"
   },
   {
-    "id": "sm3-119",
+    "setOrder":74,
+	"id": "sm3-119",
     "name": "Olivia",
     "imageUrl": "https://images.pokemontcg.io/sm3/119.png",
     "subtype": "Supporter",
@@ -6143,7 +6262,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/119_hires.png"
   },
   {
-    "id": "sm3-120",
+    "setOrder":74,
+	"id": "sm3-120",
     "name": "Plumeria",
     "imageUrl": "https://images.pokemontcg.io/sm3/120.png",
     "subtype": "Supporter",
@@ -6160,7 +6280,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/120_hires.png"
   },
   {
-    "id": "sm3-121",
+    "setOrder":74,
+	"id": "sm3-121",
     "name": "Po Town",
     "imageUrl": "https://images.pokemontcg.io/sm3/121.png",
     "subtype": "Stadium",
@@ -6177,7 +6298,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/121_hires.png"
   },
   {
-    "id": "sm3-122",
+    "setOrder":74,
+	"id": "sm3-122",
     "name": "Rotom Dex—Poké Finder Mode",
     "imageUrl": "https://images.pokemontcg.io/sm3/122.png",
     "subtype": "Item",
@@ -6194,7 +6316,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/122_hires.png"
   },
   {
-    "id": "sm3-123",
+    "setOrder":74,
+	"id": "sm3-123",
     "name": "Sophocles",
     "imageUrl": "https://images.pokemontcg.io/sm3/123.png",
     "subtype": "Supporter",
@@ -6211,7 +6334,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/123_hires.png"
   },
   {
-    "id": "sm3-124",
+    "setOrder":74,
+	"id": "sm3-124",
     "name": "Super Scoop Up",
     "imageUrl": "https://images.pokemontcg.io/sm3/124.png",
     "subtype": "Item",
@@ -6228,7 +6352,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/124_hires.png"
   },
   {
-    "id": "sm3-125",
+    "setOrder":74,
+	"id": "sm3-125",
     "name": "Tormenting Spray",
     "imageUrl": "https://images.pokemontcg.io/sm3/125.png",
     "subtype": "Item",
@@ -6245,7 +6370,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/125_hires.png"
   },
   {
-    "id": "sm3-126",
+    "setOrder":74,
+	"id": "sm3-126",
     "name": "Weakness Policy",
     "imageUrl": "https://images.pokemontcg.io/sm3/126.png",
     "subtype": "Pokémon Tool",
@@ -6262,7 +6388,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/126_hires.png"
   },
   {
-    "id": "sm3-127",
+    "setOrder":74,
+	"id": "sm3-127",
     "name": "Wicke",
     "imageUrl": "https://images.pokemontcg.io/sm3/127.png",
     "subtype": "Supporter",
@@ -6279,7 +6406,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/127_hires.png"
   },
   {
-    "id": "sm3-128",
+    "setOrder":74,
+	"id": "sm3-128",
     "name": "Wishful Baton",
     "imageUrl": "https://images.pokemontcg.io/sm3/128.png",
     "subtype": "Pokémon Tool",
@@ -6296,7 +6424,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/128_hires.png"
   },
   {
-    "id": "sm3-129",
+    "setOrder":74,
+	"id": "sm3-129",
     "name": "Golisopod-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/129.png",
     "subtype": "GX",
@@ -6365,7 +6494,8 @@
     "nationalPokedexNumber": 768
   },
   {
-    "id": "sm3-130",
+    "setOrder":74,
+	"id": "sm3-130",
     "name": "Tapu Bulu-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/130.png",
     "subtype": "GX",
@@ -6426,7 +6556,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/130_hires.png"
   },
   {
-    "id": "sm3-131",
+    "setOrder":74,
+	"id": "sm3-131",
     "name": "Ho-Oh-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/131.png",
     "subtype": "GX",
@@ -6502,7 +6633,8 @@
     "nationalPokedexNumber": 250
   },
   {
-    "id": "sm3-132",
+    "setOrder":74,
+	"id": "sm3-132",
     "name": "Salazzle-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/132.png",
     "subtype": "GX",
@@ -6569,7 +6701,8 @@
     "nationalPokedexNumber": 758
   },
   {
-    "id": "sm3-133",
+    "setOrder":74,
+	"id": "sm3-133",
     "name": "Tapu Fini-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/133.png",
     "subtype": "GX",
@@ -6626,7 +6759,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/133_hires.png"
   },
   {
-    "id": "sm3-134",
+    "setOrder":74,
+	"id": "sm3-134",
     "name": "Necrozma-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/134.png",
     "subtype": "GX",
@@ -6689,7 +6823,8 @@
     "nationalPokedexNumber": 800
   },
   {
-    "id": "sm3-135",
+    "setOrder":74,
+	"id": "sm3-135",
     "name": "Machamp-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/135.png",
     "subtype": "GX",
@@ -6759,7 +6894,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "sm3-136",
+    "setOrder":74,
+	"id": "sm3-136",
     "name": "Lycanroc-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/136.png",
     "subtype": "GX",
@@ -6827,7 +6963,8 @@
     "nationalPokedexNumber": 745
   },
   {
-    "id": "sm3-137",
+    "setOrder":74,
+	"id": "sm3-137",
     "name": "Marshadow-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/137.png",
     "subtype": "GX",
@@ -6887,7 +7024,8 @@
     "nationalPokedexNumber": 802
   },
   {
-    "id": "sm3-138",
+    "setOrder":74,
+	"id": "sm3-138",
     "name": "Alolan Muk-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/138.png",
     "subtype": "GX",
@@ -6964,7 +7102,8 @@
     "nationalPokedexNumber": 89
   },
   {
-    "id": "sm3-139",
+    "setOrder":74,
+	"id": "sm3-139",
     "name": "Darkrai-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/139.png",
     "subtype": "GX",
@@ -7033,7 +7172,8 @@
     "nationalPokedexNumber": 491
   },
   {
-    "id": "sm3-140",
+    "setOrder":74,
+	"id": "sm3-140",
     "name": "Gardevoir-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/140.png",
     "subtype": "GX",
@@ -7099,7 +7239,8 @@
     "nationalPokedexNumber": 282
   },
   {
-    "id": "sm3-141",
+    "setOrder":74,
+	"id": "sm3-141",
     "name": "Noivern-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/141.png",
     "subtype": "GX",
@@ -7164,7 +7305,8 @@
     "nationalPokedexNumber": 715
   },
   {
-    "id": "sm3-142",
+    "setOrder":74,
+	"id": "sm3-142",
     "name": "Acerola",
     "imageUrl": "https://images.pokemontcg.io/sm3/142.png",
     "subtype": "Supporter",
@@ -7181,7 +7323,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/142_hires.png"
   },
   {
-    "id": "sm3-143",
+    "setOrder":74,
+	"id": "sm3-143",
     "name": "Guzma",
     "imageUrl": "https://images.pokemontcg.io/sm3/143.png",
     "subtype": "Supporter",
@@ -7198,7 +7341,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/143_hires.png"
   },
   {
-    "id": "sm3-144",
+    "setOrder":74,
+	"id": "sm3-144",
     "name": "Kiawe",
     "imageUrl": "https://images.pokemontcg.io/sm3/144.png",
     "subtype": "Supporter",
@@ -7215,7 +7359,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/144_hires.png"
   },
   {
-    "id": "sm3-145",
+    "setOrder":74,
+	"id": "sm3-145",
     "name": "Plumeria",
     "imageUrl": "https://images.pokemontcg.io/sm3/145.png",
     "subtype": "Supporter",
@@ -7232,7 +7377,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/145_hires.png"
   },
   {
-    "id": "sm3-146",
+    "setOrder":74,
+	"id": "sm3-146",
     "name": "Sophocles",
     "imageUrl": "https://images.pokemontcg.io/sm3/146.png",
     "subtype": "Supporter",
@@ -7249,7 +7395,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/146_hires.png"
   },
   {
-    "id": "sm3-147",
+    "setOrder":74,
+	"id": "sm3-147",
     "name": "Wicke",
     "imageUrl": "https://images.pokemontcg.io/sm3/147.png",
     "subtype": "Supporter",
@@ -7266,7 +7413,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/147_hires.png"
   },
   {
-    "id": "sm3-148",
+    "setOrder":74,
+	"id": "sm3-148",
     "name": "Golisopod-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/148.png",
     "subtype": "GX",
@@ -7335,7 +7483,8 @@
     "nationalPokedexNumber": 768
   },
   {
-    "id": "sm3-149",
+    "setOrder":74,
+	"id": "sm3-149",
     "name": "Tapu Bulu-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/149.png",
     "subtype": "GX",
@@ -7396,7 +7545,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/149_hires.png"
   },
   {
-    "id": "sm3-150",
+    "setOrder":74,
+	"id": "sm3-150",
     "name": "Charizard GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/150.png",
     "subtype": "GX",
@@ -7466,7 +7616,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "sm3-151",
+    "setOrder":74,
+	"id": "sm3-151",
     "name": "Salazzle-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/151.png",
     "subtype": "GX",
@@ -7533,7 +7684,8 @@
     "nationalPokedexNumber": 758
   },
   {
-    "id": "sm3-152",
+    "setOrder":74,
+	"id": "sm3-152",
     "name": "Tapu Fini-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/152.png",
     "subtype": "GX",
@@ -7590,7 +7742,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/152_hires.png"
   },
   {
-    "id": "sm3-153",
+    "setOrder":74,
+	"id": "sm3-153",
     "name": "Necrozma-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/153.png",
     "subtype": "GX",
@@ -7653,7 +7806,8 @@
     "nationalPokedexNumber": 800
   },
   {
-    "id": "sm3-154",
+    "setOrder":74,
+	"id": "sm3-154",
     "name": "Machamp-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/154.png",
     "subtype": "GX",
@@ -7723,7 +7877,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "sm3-155",
+    "setOrder":74,
+	"id": "sm3-155",
     "name": "Lycanroc-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/155.png",
     "subtype": "GX",
@@ -7791,7 +7946,8 @@
     "nationalPokedexNumber": 745
   },
   {
-    "id": "sm3-156",
+    "setOrder":74,
+	"id": "sm3-156",
     "name": "Marshadow-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/156.png",
     "subtype": "GX",
@@ -7851,7 +8007,8 @@
     "nationalPokedexNumber": 802
   },
   {
-    "id": "sm3-157",
+    "setOrder":74,
+	"id": "sm3-157",
     "name": "Alolan Muk-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/157.png",
     "subtype": "GX",
@@ -7928,7 +8085,8 @@
     "nationalPokedexNumber": 89
   },
   {
-    "id": "sm3-158",
+    "setOrder":74,
+	"id": "sm3-158",
     "name": "Darkrai-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/158.png",
     "subtype": "GX",
@@ -7997,7 +8155,8 @@
     "nationalPokedexNumber": 491
   },
   {
-    "id": "sm3-159",
+    "setOrder":74,
+	"id": "sm3-159",
     "name": "Gardevoir-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/159.png",
     "subtype": "GX",
@@ -8063,7 +8222,8 @@
     "nationalPokedexNumber": 282
   },
   {
-    "id": "sm3-160",
+    "setOrder":74,
+	"id": "sm3-160",
     "name": "Noivern-GX",
     "imageUrl": "https://images.pokemontcg.io/sm3/160.png",
     "subtype": "GX",
@@ -8128,7 +8288,8 @@
     "nationalPokedexNumber": 715
   },
   {
-    "id": "sm3-161",
+    "setOrder":74,
+	"id": "sm3-161",
     "name": "Bodybuilding Dumbbells",
     "imageUrl": "https://images.pokemontcg.io/sm3/161.png",
     "subtype": "Pokémon Tool",
@@ -8145,7 +8306,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/161_hires.png"
   },
   {
-    "id": "sm3-162",
+    "setOrder":74,
+	"id": "sm3-162",
     "name": "Choice Band",
     "imageUrl": "https://images.pokemontcg.io/sm3/162.png",
     "subtype": "Pokémon Tool",
@@ -8162,7 +8324,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/162_hires.png"
   },
   {
-    "id": "sm3-163",
+    "setOrder":74,
+	"id": "sm3-163",
     "name": "Escape Rope",
     "imageUrl": "https://images.pokemontcg.io/sm3/163.png",
     "subtype": "Item",
@@ -8179,7 +8342,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/163_hires.png"
   },
   {
-    "id": "sm3-164",
+    "setOrder":74,
+	"id": "sm3-164",
     "name": "Multi Switch",
     "imageUrl": "https://images.pokemontcg.io/sm3/164.png",
     "subtype": "Item",
@@ -8196,7 +8360,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/164_hires.png"
   },
   {
-    "id": "sm3-165",
+    "setOrder":74,
+	"id": "sm3-165",
     "name": "Rescue Stretcher",
     "imageUrl": "https://images.pokemontcg.io/sm3/165.png",
     "subtype": "Item",
@@ -8213,7 +8378,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/165_hires.png"
   },
   {
-    "id": "sm3-166",
+    "setOrder":74,
+	"id": "sm3-166",
     "name": "Super Scoop Up",
     "imageUrl": "https://images.pokemontcg.io/sm3/166.png",
     "subtype": "Item",
@@ -8230,7 +8396,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/166_hires.png"
   },
   {
-    "id": "sm3-167",
+    "setOrder":74,
+	"id": "sm3-167",
     "name": "Fire Energy",
     "imageUrl": "https://images.pokemontcg.io/sm3/167.png",
     "subtype": "Basic",
@@ -8244,7 +8411,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/167_hires.png"
   },
   {
-    "id": "sm3-168",
+    "setOrder":74,
+	"id": "sm3-168",
     "name": "Darkness Energy",
     "imageUrl": "https://images.pokemontcg.io/sm3/168.png",
     "subtype": "Basic",
@@ -8258,7 +8426,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm3/168_hires.png"
   },
   {
-    "id": "sm3-169",
+    "setOrder":74,
+	"id": "sm3-169",
     "name": "Fairy Energy",
     "imageUrl": "https://images.pokemontcg.io/sm3/169.png",
     "subtype": "Basic",

--- a/json/cards/Call of Legends.json
+++ b/json/cards/Call of Legends.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "col1-1",
+    "setOrder":47,
+	"id": "col1-1",
     "name": "Clefable",
     "imageUrl": "https://images.pokemontcg.io/col1/1.png",
     "subtype": "Stage 1",
@@ -52,7 +53,8 @@
     "nationalPokedexNumber": 36
   },
   {
-    "id": "col1-2",
+    "setOrder":47,
+	"id": "col1-2",
     "name": "Deoxys",
     "imageUrl": "https://images.pokemontcg.io/col1/2.png",
     "subtype": "Basic",
@@ -94,7 +96,8 @@
     "nationalPokedexNumber": 386
   },
   {
-    "id": "col1-3",
+    "setOrder":47,
+	"id": "col1-3",
     "name": "Dialga",
     "imageUrl": "https://images.pokemontcg.io/col1/3.png",
     "subtype": "Basic",
@@ -145,7 +148,8 @@
     "nationalPokedexNumber": 483
   },
   {
-    "id": "col1-4",
+    "setOrder":47,
+	"id": "col1-4",
     "name": "Espeon",
     "imageUrl": "https://images.pokemontcg.io/col1/4.png",
     "subtype": "Stage 1",
@@ -196,7 +200,8 @@
     "nationalPokedexNumber": 196
   },
   {
-    "id": "col1-5",
+    "setOrder":47,
+	"id": "col1-5",
     "name": "Forretress",
     "imageUrl": "https://images.pokemontcg.io/col1/5.png",
     "subtype": "Stage 1",
@@ -257,7 +262,8 @@
     "nationalPokedexNumber": 205
   },
   {
-    "id": "col1-6",
+    "setOrder":47,
+	"id": "col1-6",
     "name": "Groudon",
     "imageUrl": "https://images.pokemontcg.io/col1/6.png",
     "subtype": "Basic",
@@ -303,7 +309,8 @@
     "nationalPokedexNumber": 383
   },
   {
-    "id": "col1-7",
+    "setOrder":47,
+	"id": "col1-7",
     "name": "Gyarados",
     "imageUrl": "https://images.pokemontcg.io/col1/7.png",
     "subtype": "Stage 1",
@@ -366,7 +373,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "col1-8",
+    "setOrder":47,
+	"id": "col1-8",
     "name": "Hitmontop",
     "imageUrl": "https://images.pokemontcg.io/col1/8.png",
     "subtype": "Basic",
@@ -417,7 +425,8 @@
     "nationalPokedexNumber": 237
   },
   {
-    "id": "col1-9",
+    "setOrder":47,
+	"id": "col1-9",
     "name": "Ho-Oh",
     "imageUrl": "https://images.pokemontcg.io/col1/9.png",
     "subtype": "Basic",
@@ -480,7 +489,8 @@
     "nationalPokedexNumber": 250
   },
   {
-    "id": "col1-10",
+    "setOrder":47,
+	"id": "col1-10",
     "name": "Houndoom",
     "imageUrl": "https://images.pokemontcg.io/col1/10.png",
     "subtype": "Stage 1",
@@ -537,7 +547,8 @@
     "nationalPokedexNumber": 229
   },
   {
-    "id": "col1-11",
+    "setOrder":47,
+	"id": "col1-11",
     "name": "Jirachi",
     "imageUrl": "https://images.pokemontcg.io/col1/11.png",
     "subtype": "Basic",
@@ -582,7 +593,8 @@
     "nationalPokedexNumber": 385
   },
   {
-    "id": "col1-12",
+    "setOrder":47,
+	"id": "col1-12",
     "name": "Kyogre",
     "imageUrl": "https://images.pokemontcg.io/col1/12.png",
     "subtype": "Basic",
@@ -628,7 +640,8 @@
     "nationalPokedexNumber": 382
   },
   {
-    "id": "col1-13",
+    "setOrder":47,
+	"id": "col1-13",
     "name": "Leafeon",
     "imageUrl": "https://images.pokemontcg.io/col1/13.png",
     "subtype": "Stage 1",
@@ -684,7 +697,8 @@
     "nationalPokedexNumber": 470
   },
   {
-    "id": "col1-14",
+    "setOrder":47,
+	"id": "col1-14",
     "name": "Lucario",
     "imageUrl": "https://images.pokemontcg.io/col1/14.png",
     "subtype": "Stage 1",
@@ -737,7 +751,8 @@
     "nationalPokedexNumber": 448
   },
   {
-    "id": "col1-15",
+    "setOrder":47,
+	"id": "col1-15",
     "name": "Lugia",
     "imageUrl": "https://images.pokemontcg.io/col1/15.png",
     "subtype": "Basic",
@@ -800,7 +815,8 @@
     "nationalPokedexNumber": 249
   },
   {
-    "id": "col1-16",
+    "setOrder":47,
+	"id": "col1-16",
     "name": "Magmortar",
     "imageUrl": "https://images.pokemontcg.io/col1/16.png",
     "subtype": "Stage 1",
@@ -856,7 +872,8 @@
     "nationalPokedexNumber": 467
   },
   {
-    "id": "col1-17",
+    "setOrder":47,
+	"id": "col1-17",
     "name": "Ninetales",
     "imageUrl": "https://images.pokemontcg.io/col1/17.png",
     "subtype": "Stage 1",
@@ -904,7 +921,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "col1-18",
+    "setOrder":47,
+	"id": "col1-18",
     "name": "Pachirisu",
     "imageUrl": "https://images.pokemontcg.io/col1/18.png",
     "subtype": "Basic",
@@ -956,7 +974,8 @@
     "nationalPokedexNumber": 417
   },
   {
-    "id": "col1-19",
+    "setOrder":47,
+	"id": "col1-19",
     "name": "Palkia",
     "imageUrl": "https://images.pokemontcg.io/col1/19.png",
     "subtype": "Basic",
@@ -1001,7 +1020,8 @@
     "nationalPokedexNumber": 484
   },
   {
-    "id": "col1-20",
+    "setOrder":47,
+	"id": "col1-20",
     "name": "Rayquaza",
     "imageUrl": "https://images.pokemontcg.io/col1/20.png",
     "subtype": "Basic",
@@ -1051,7 +1071,8 @@
     "nationalPokedexNumber": 384
   },
   {
-    "id": "col1-21",
+    "setOrder":47,
+	"id": "col1-21",
     "name": "Smeargle",
     "imageUrl": "https://images.pokemontcg.io/col1/21.png",
     "subtype": "Basic",
@@ -1097,7 +1118,8 @@
     "nationalPokedexNumber": 235
   },
   {
-    "id": "col1-22",
+    "setOrder":47,
+	"id": "col1-22",
     "name": "Umbreon",
     "imageUrl": "https://images.pokemontcg.io/col1/22.png",
     "subtype": "Stage 1",
@@ -1154,7 +1176,8 @@
     "nationalPokedexNumber": 197
   },
   {
-    "id": "col1-23",
+    "setOrder":47,
+	"id": "col1-23",
     "name": "Ampharos",
     "imageUrl": "https://images.pokemontcg.io/col1/23.png",
     "subtype": "Stage 2",
@@ -1212,7 +1235,8 @@
     "nationalPokedexNumber": 181
   },
   {
-    "id": "col1-24",
+    "setOrder":47,
+	"id": "col1-24",
     "name": "Cleffa",
     "imageUrl": "https://images.pokemontcg.io/col1/24.png",
     "subtype": "Basic",
@@ -1251,7 +1275,8 @@
     ]
   },
   {
-    "id": "col1-25",
+    "setOrder":47,
+	"id": "col1-25",
     "name": "Feraligatr",
     "imageUrl": "https://images.pokemontcg.io/col1/25.png",
     "subtype": "Stage 2",
@@ -1307,7 +1332,8 @@
     "nationalPokedexNumber": 160
   },
   {
-    "id": "col1-26",
+    "setOrder":47,
+	"id": "col1-26",
     "name": "Granbull",
     "imageUrl": "https://images.pokemontcg.io/col1/26.png",
     "subtype": "Stage 1",
@@ -1363,7 +1389,8 @@
     "nationalPokedexNumber": 210
   },
   {
-    "id": "col1-27",
+    "setOrder":47,
+	"id": "col1-27",
     "name": "Meganium",
     "imageUrl": "https://images.pokemontcg.io/col1/27.png",
     "subtype": "Stage 2",
@@ -1422,7 +1449,8 @@
     "nationalPokedexNumber": 154
   },
   {
-    "id": "col1-28",
+    "setOrder":47,
+	"id": "col1-28",
     "name": "Mismagius",
     "imageUrl": "https://images.pokemontcg.io/col1/28.png",
     "subtype": "Stage 1",
@@ -1479,7 +1507,8 @@
     "nationalPokedexNumber": 429
   },
   {
-    "id": "col1-29",
+    "setOrder":47,
+	"id": "col1-29",
     "name": "Mr. Mime",
     "imageUrl": "https://images.pokemontcg.io/col1/29.png",
     "subtype": "Basic",
@@ -1525,7 +1554,8 @@
     "nationalPokedexNumber": 122
   },
   {
-    "id": "col1-30",
+    "setOrder":47,
+	"id": "col1-30",
     "name": "Pidgeot",
     "imageUrl": "https://images.pokemontcg.io/col1/30.png",
     "subtype": "Stage 2",
@@ -1581,7 +1611,8 @@
     "nationalPokedexNumber": 18
   },
   {
-    "id": "col1-31",
+    "setOrder":47,
+	"id": "col1-31",
     "name": "Skarmory",
     "imageUrl": "https://images.pokemontcg.io/col1/31.png",
     "subtype": "Basic",
@@ -1638,7 +1669,8 @@
     "nationalPokedexNumber": 227
   },
   {
-    "id": "col1-32",
+    "setOrder":47,
+	"id": "col1-32",
     "name": "Slowking",
     "imageUrl": "https://images.pokemontcg.io/col1/32.png",
     "subtype": "Stage 1",
@@ -1686,7 +1718,8 @@
     "nationalPokedexNumber": 199
   },
   {
-    "id": "col1-33",
+    "setOrder":47,
+	"id": "col1-33",
     "name": "Snorlax",
     "imageUrl": "https://images.pokemontcg.io/col1/33.png",
     "subtype": "Basic",
@@ -1743,7 +1776,8 @@
     "nationalPokedexNumber": 143
   },
   {
-    "id": "col1-34",
+    "setOrder":47,
+	"id": "col1-34",
     "name": "Tangrowth",
     "imageUrl": "https://images.pokemontcg.io/col1/34.png",
     "subtype": "Stage 1",
@@ -1804,7 +1838,8 @@
     "nationalPokedexNumber": 465
   },
   {
-    "id": "col1-35",
+    "setOrder":47,
+	"id": "col1-35",
     "name": "Typhlosion",
     "imageUrl": "https://images.pokemontcg.io/col1/35.png",
     "subtype": "Stage 2",
@@ -1857,7 +1892,8 @@
     "nationalPokedexNumber": 157
   },
   {
-    "id": "col1-36",
+    "setOrder":47,
+	"id": "col1-36",
     "name": "Tyrogue",
     "imageUrl": "https://images.pokemontcg.io/col1/36.png",
     "subtype": "Basic",
@@ -1898,7 +1934,8 @@
     ]
   },
   {
-    "id": "col1-37",
+    "setOrder":47,
+	"id": "col1-37",
     "name": "Ursaring",
     "imageUrl": "https://images.pokemontcg.io/col1/37.png",
     "subtype": "Stage 1",
@@ -1952,7 +1989,8 @@
     "nationalPokedexNumber": 217
   },
   {
-    "id": "col1-38",
+    "setOrder":47,
+	"id": "col1-38",
     "name": "Weezing",
     "imageUrl": "https://images.pokemontcg.io/col1/38.png",
     "subtype": "Stage 1",
@@ -2004,7 +2042,8 @@
     "nationalPokedexNumber": 110
   },
   {
-    "id": "col1-39",
+    "setOrder":47,
+	"id": "col1-39",
     "name": "Zangoose",
     "imageUrl": "https://images.pokemontcg.io/col1/39.png",
     "subtype": "Basic",
@@ -2056,7 +2095,8 @@
     "nationalPokedexNumber": 335
   },
   {
-    "id": "col1-40",
+    "setOrder":47,
+	"id": "col1-40",
     "name": "Bayleef",
     "imageUrl": "https://images.pokemontcg.io/col1/40.png",
     "subtype": "Stage 1",
@@ -2118,7 +2158,8 @@
     ]
   },
   {
-    "id": "col1-41",
+    "setOrder":47,
+	"id": "col1-41",
     "name": "Croconaw",
     "imageUrl": "https://images.pokemontcg.io/col1/41.png",
     "subtype": "Stage 1",
@@ -2175,7 +2216,8 @@
     ]
   },
   {
-    "id": "col1-42",
+    "setOrder":47,
+	"id": "col1-42",
     "name": "Donphan",
     "imageUrl": "https://images.pokemontcg.io/col1/42.png",
     "subtype": "Stage 1",
@@ -2238,7 +2280,8 @@
     "nationalPokedexNumber": 232
   },
   {
-    "id": "col1-43",
+    "setOrder":47,
+	"id": "col1-43",
     "name": "Flaaffy",
     "imageUrl": "https://images.pokemontcg.io/col1/43.png",
     "subtype": "Stage 1",
@@ -2299,7 +2342,8 @@
     ]
   },
   {
-    "id": "col1-44",
+    "setOrder":47,
+	"id": "col1-44",
     "name": "Flareon",
     "imageUrl": "https://images.pokemontcg.io/col1/44.png",
     "subtype": "Stage 1",
@@ -2351,7 +2395,8 @@
     "nationalPokedexNumber": 136
   },
   {
-    "id": "col1-45",
+    "setOrder":47,
+	"id": "col1-45",
     "name": "Jolteon",
     "imageUrl": "https://images.pokemontcg.io/col1/45.png",
     "subtype": "Stage 1",
@@ -2406,7 +2451,8 @@
     "nationalPokedexNumber": 135
   },
   {
-    "id": "col1-46",
+    "setOrder":47,
+	"id": "col1-46",
     "name": "Magby",
     "imageUrl": "https://images.pokemontcg.io/col1/46.png",
     "subtype": "Basic",
@@ -2445,7 +2491,8 @@
     ]
   },
   {
-    "id": "col1-47",
+    "setOrder":47,
+	"id": "col1-47",
     "name": "Mime Jr.",
     "imageUrl": "https://images.pokemontcg.io/col1/47.png",
     "subtype": "Basic",
@@ -2481,7 +2528,8 @@
     "nationalPokedexNumber": 439
   },
   {
-    "id": "col1-48",
+    "setOrder":47,
+	"id": "col1-48",
     "name": "Pidgeotto",
     "imageUrl": "https://images.pokemontcg.io/col1/48.png",
     "subtype": "Stage 1",
@@ -2543,7 +2591,8 @@
     ]
   },
   {
-    "id": "col1-49",
+    "setOrder":47,
+	"id": "col1-49",
     "name": "Quilava",
     "imageUrl": "https://images.pokemontcg.io/col1/49.png",
     "subtype": "Stage 1",
@@ -2599,7 +2648,8 @@
     ]
   },
   {
-    "id": "col1-50",
+    "setOrder":47,
+	"id": "col1-50",
     "name": "Riolu",
     "imageUrl": "https://images.pokemontcg.io/col1/50.png",
     "subtype": "Basic",
@@ -2642,7 +2692,8 @@
     ]
   },
   {
-    "id": "col1-51",
+    "setOrder":47,
+	"id": "col1-51",
     "name": "Seviper",
     "imageUrl": "https://images.pokemontcg.io/col1/51.png",
     "subtype": "Basic",
@@ -2693,7 +2744,8 @@
     "nationalPokedexNumber": 336
   },
   {
-    "id": "col1-52",
+    "setOrder":47,
+	"id": "col1-52",
     "name": "Vaporeon",
     "imageUrl": "https://images.pokemontcg.io/col1/52.png",
     "subtype": "Stage 1",
@@ -2746,7 +2798,8 @@
     "nationalPokedexNumber": 134
   },
   {
-    "id": "col1-53",
+    "setOrder":47,
+	"id": "col1-53",
     "name": "Chikorita",
     "imageUrl": "https://images.pokemontcg.io/col1/53.png",
     "subtype": "Basic",
@@ -2805,7 +2858,8 @@
     ]
   },
   {
-    "id": "col1-54",
+    "setOrder":47,
+	"id": "col1-54",
     "name": "Clefairy",
     "imageUrl": "https://images.pokemontcg.io/col1/54.png",
     "subtype": "Basic",
@@ -2857,7 +2911,8 @@
     ]
   },
   {
-    "id": "col1-55",
+    "setOrder":47,
+	"id": "col1-55",
     "name": "Cyndaquil",
     "imageUrl": "https://images.pokemontcg.io/col1/55.png",
     "subtype": "Basic",
@@ -2900,7 +2955,8 @@
     ]
   },
   {
-    "id": "col1-56",
+    "setOrder":47,
+	"id": "col1-56",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/col1/56.png",
     "subtype": "Basic",
@@ -2960,7 +3016,8 @@
     ]
   },
   {
-    "id": "col1-57",
+    "setOrder":47,
+	"id": "col1-57",
     "name": "Hitmonchan",
     "imageUrl": "https://images.pokemontcg.io/col1/57.png",
     "subtype": "Basic",
@@ -3010,7 +3067,8 @@
     "nationalPokedexNumber": 107
   },
   {
-    "id": "col1-58",
+    "setOrder":47,
+	"id": "col1-58",
     "name": "Hitmonlee",
     "imageUrl": "https://images.pokemontcg.io/col1/58.png",
     "subtype": "Basic",
@@ -3062,7 +3120,8 @@
     "nationalPokedexNumber": 106
   },
   {
-    "id": "col1-59",
+    "setOrder":47,
+	"id": "col1-59",
     "name": "Houndour",
     "imageUrl": "https://images.pokemontcg.io/col1/59.png",
     "subtype": "Basic",
@@ -3111,7 +3170,8 @@
     ]
   },
   {
-    "id": "col1-60",
+    "setOrder":47,
+	"id": "col1-60",
     "name": "Koffing",
     "imageUrl": "https://images.pokemontcg.io/col1/60.png",
     "subtype": "Basic",
@@ -3164,7 +3224,8 @@
     ]
   },
   {
-    "id": "col1-61",
+    "setOrder":47,
+	"id": "col1-61",
     "name": "Magikarp",
     "imageUrl": "https://images.pokemontcg.io/col1/61.png",
     "subtype": "Basic",
@@ -3207,7 +3268,8 @@
     ]
   },
   {
-    "id": "col1-62",
+    "setOrder":47,
+	"id": "col1-62",
     "name": "Magmar",
     "imageUrl": "https://images.pokemontcg.io/col1/62.png",
     "subtype": "Basic",
@@ -3260,7 +3322,8 @@
     ]
   },
   {
-    "id": "col1-63",
+    "setOrder":47,
+	"id": "col1-63",
     "name": "Mareep",
     "imageUrl": "https://images.pokemontcg.io/col1/63.png",
     "subtype": "Basic",
@@ -3309,7 +3372,8 @@
     ]
   },
   {
-    "id": "col1-64",
+    "setOrder":47,
+	"id": "col1-64",
     "name": "Mawile",
     "imageUrl": "https://images.pokemontcg.io/col1/64.png",
     "subtype": "Basic",
@@ -3366,7 +3430,8 @@
     "nationalPokedexNumber": 303
   },
   {
-    "id": "col1-65",
+    "setOrder":47,
+	"id": "col1-65",
     "name": "Misdreavus",
     "imageUrl": "https://images.pokemontcg.io/col1/65.png",
     "subtype": "Basic",
@@ -3424,7 +3489,8 @@
     ]
   },
   {
-    "id": "col1-66",
+    "setOrder":47,
+	"id": "col1-66",
     "name": "Phanpy",
     "imageUrl": "https://images.pokemontcg.io/col1/66.png",
     "subtype": "Basic",
@@ -3480,7 +3546,8 @@
     ]
   },
   {
-    "id": "col1-67",
+    "setOrder":47,
+	"id": "col1-67",
     "name": "Pidgey",
     "imageUrl": "https://images.pokemontcg.io/col1/67.png",
     "subtype": "Basic",
@@ -3538,7 +3605,8 @@
     ]
   },
   {
-    "id": "col1-68",
+    "setOrder":47,
+	"id": "col1-68",
     "name": "Pineco",
     "imageUrl": "https://images.pokemontcg.io/col1/68.png",
     "subtype": "Basic",
@@ -3582,7 +3650,8 @@
     ]
   },
   {
-    "id": "col1-69",
+    "setOrder":47,
+	"id": "col1-69",
     "name": "Relicanth",
     "imageUrl": "https://images.pokemontcg.io/col1/69.png",
     "subtype": "Basic",
@@ -3634,7 +3703,8 @@
     "nationalPokedexNumber": 369
   },
   {
-    "id": "col1-70",
+    "setOrder":47,
+	"id": "col1-70",
     "name": "Slowpoke",
     "imageUrl": "https://images.pokemontcg.io/col1/70.png",
     "subtype": "Basic",
@@ -3679,7 +3749,8 @@
     ]
   },
   {
-    "id": "col1-71",
+    "setOrder":47,
+	"id": "col1-71",
     "name": "Snubbull",
     "imageUrl": "https://images.pokemontcg.io/col1/71.png",
     "subtype": "Basic",
@@ -3733,7 +3804,8 @@
     ]
   },
   {
-    "id": "col1-72",
+    "setOrder":47,
+	"id": "col1-72",
     "name": "Tangela",
     "imageUrl": "https://images.pokemontcg.io/col1/72.png",
     "subtype": "Basic",
@@ -3794,7 +3866,8 @@
     ]
   },
   {
-    "id": "col1-73",
+    "setOrder":47,
+	"id": "col1-73",
     "name": "Teddiursa",
     "imageUrl": "https://images.pokemontcg.io/col1/73.png",
     "subtype": "Basic",
@@ -3837,7 +3910,8 @@
     ]
   },
   {
-    "id": "col1-74",
+    "setOrder":47,
+	"id": "col1-74",
     "name": "Totodile",
     "imageUrl": "https://images.pokemontcg.io/col1/74.png",
     "subtype": "Basic",
@@ -3883,7 +3957,8 @@
     ]
   },
   {
-    "id": "col1-75",
+    "setOrder":47,
+	"id": "col1-75",
     "name": "Vulpix",
     "imageUrl": "https://images.pokemontcg.io/col1/75.png",
     "subtype": "Basic",
@@ -3936,7 +4011,8 @@
     ]
   },
   {
-    "id": "col1-76",
+    "setOrder":47,
+	"id": "col1-76",
     "name": "Cheerleader's Cheer",
     "imageUrl": "https://images.pokemontcg.io/col1/76.png",
     "subtype": "Supporter",
@@ -3954,7 +4030,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/col1/76_hires.png"
   },
   {
-    "id": "col1-77",
+    "setOrder":47,
+	"id": "col1-77",
     "name": "Copycat",
     "imageUrl": "https://images.pokemontcg.io/col1/77.png",
     "subtype": "Supporter",
@@ -3972,7 +4049,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/col1/77_hires.png"
   },
   {
-    "id": "col1-78",
+    "setOrder":47,
+	"id": "col1-78",
     "name": "Dual Ball",
     "imageUrl": "https://images.pokemontcg.io/col1/78.png",
     "subtype": "Item",
@@ -3989,7 +4067,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/col1/78_hires.png"
   },
   {
-    "id": "col1-79",
+    "setOrder":47,
+	"id": "col1-79",
     "name": "Interviewer's Questions",
     "imageUrl": "https://images.pokemontcg.io/col1/79.png",
     "subtype": "Supporter",
@@ -4007,7 +4086,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/col1/79_hires.png"
   },
   {
-    "id": "col1-80",
+    "setOrder":47,
+	"id": "col1-80",
     "name": "Lost Remover",
     "imageUrl": "https://images.pokemontcg.io/col1/80.png",
     "subtype": "Item",
@@ -4024,7 +4104,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/col1/80_hires.png"
   },
   {
-    "id": "col1-81",
+    "setOrder":47,
+	"id": "col1-81",
     "name": "Lost World",
     "imageUrl": "https://images.pokemontcg.io/col1/81.png",
     "subtype": "Stadium",
@@ -4042,7 +4123,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/col1/81_hires.png"
   },
   {
-    "id": "col1-82",
+    "setOrder":47,
+	"id": "col1-82",
     "name": "Professor Elm's Training Method",
     "imageUrl": "https://images.pokemontcg.io/col1/82.png",
     "subtype": "Supporter",
@@ -4060,7 +4142,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/col1/82_hires.png"
   },
   {
-    "id": "col1-83",
+    "setOrder":47,
+	"id": "col1-83",
     "name": "Professor Oak's New Theory",
     "imageUrl": "https://images.pokemontcg.io/col1/83.png",
     "subtype": "Supporter",
@@ -4078,7 +4161,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/col1/83_hires.png"
   },
   {
-    "id": "col1-84",
+    "setOrder":47,
+	"id": "col1-84",
     "name": "Research Record",
     "imageUrl": "https://images.pokemontcg.io/col1/84.png",
     "subtype": "Item",
@@ -4095,7 +4179,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/col1/84_hires.png"
   },
   {
-    "id": "col1-85",
+    "setOrder":47,
+	"id": "col1-85",
     "name": "Sage's Training",
     "imageUrl": "https://images.pokemontcg.io/col1/85.png",
     "subtype": "Supporter",
@@ -4113,7 +4198,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/col1/85_hires.png"
   },
   {
-    "id": "col1-86",
+    "setOrder":47,
+	"id": "col1-86",
     "name": "Darkness Energy",
     "imageUrl": "https://images.pokemontcg.io/col1/86.png",
     "subtype": "Special",
@@ -4130,7 +4216,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/col1/86_hires.png"
   },
   {
-    "id": "col1-87",
+    "setOrder":47,
+	"id": "col1-87",
     "name": "Metal Energy",
     "imageUrl": "https://images.pokemontcg.io/col1/87.png",
     "subtype": "Special",
@@ -4147,7 +4234,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/col1/87_hires.png"
   },
   {
-    "id": "col1-88",
+    "setOrder":47,
+	"id": "col1-88",
     "name": "Grass Energy",
     "imageUrl": "https://images.pokemontcg.io/col1/88.png",
     "subtype": "Basic",
@@ -4161,7 +4249,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/col1/88_hires.png"
   },
   {
-    "id": "col1-89",
+    "setOrder":47,
+	"id": "col1-89",
     "name": "Fire Energy",
     "imageUrl": "https://images.pokemontcg.io/col1/89.png",
     "subtype": "Basic",
@@ -4175,7 +4264,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/col1/89_hires.png"
   },
   {
-    "id": "col1-90",
+    "setOrder":47,
+	"id": "col1-90",
     "name": "Water Energy",
     "imageUrl": "https://images.pokemontcg.io/col1/90.png",
     "subtype": "Basic",
@@ -4189,7 +4279,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/col1/90_hires.png"
   },
   {
-    "id": "col1-91",
+    "setOrder":47,
+	"id": "col1-91",
     "name": "Lightning Energy",
     "imageUrl": "https://images.pokemontcg.io/col1/91.png",
     "subtype": "Basic",
@@ -4203,7 +4294,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/col1/91_hires.png"
   },
   {
-    "id": "col1-92",
+    "setOrder":47,
+	"id": "col1-92",
     "name": "Psychic Energy",
     "imageUrl": "https://images.pokemontcg.io/col1/92.png",
     "subtype": "Basic",
@@ -4217,7 +4309,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/col1/92_hires.png"
   },
   {
-    "id": "col1-93",
+    "setOrder":47,
+	"id": "col1-93",
     "name": "Fighting Energy",
     "imageUrl": "https://images.pokemontcg.io/col1/93.png",
     "subtype": "Basic",
@@ -4231,7 +4324,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/col1/93_hires.png"
   },
   {
-    "id": "col1-94",
+    "setOrder":47,
+	"id": "col1-94",
     "name": "Darkness Energy",
     "imageUrl": "https://images.pokemontcg.io/col1/94.png",
     "subtype": "Basic",
@@ -4245,7 +4339,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/col1/94_hires.png"
   },
   {
-    "id": "col1-95",
+    "setOrder":47,
+	"id": "col1-95",
     "name": "Metal Energy",
     "imageUrl": "https://images.pokemontcg.io/col1/95.png",
     "subtype": "Basic",
@@ -4259,7 +4354,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/col1/95_hires.png"
   },
   {
-    "id": "col1-SL1",
+    "setOrder":47,
+	"id": "col1-SL1",
     "name": "Deoxys",
     "imageUrl": "https://images.pokemontcg.io/col1/SL1.png",
     "subtype": "Basic",
@@ -4301,7 +4397,8 @@
     "nationalPokedexNumber": 386
   },
   {
-    "id": "col1-SL2",
+    "setOrder":47,
+	"id": "col1-SL2",
     "name": "Dialga",
     "imageUrl": "https://images.pokemontcg.io/col1/SL2.png",
     "subtype": "Basic",
@@ -4352,7 +4449,8 @@
     "nationalPokedexNumber": 483
   },
   {
-    "id": "col1-SL3",
+    "setOrder":47,
+	"id": "col1-SL3",
     "name": "Entei",
     "imageUrl": "https://images.pokemontcg.io/col1/SL3.png",
     "subtype": "Basic",
@@ -4400,7 +4498,8 @@
     "nationalPokedexNumber": 244
   },
   {
-    "id": "col1-SL4",
+    "setOrder":47,
+	"id": "col1-SL4",
     "name": "Groudon",
     "imageUrl": "https://images.pokemontcg.io/col1/SL4.png",
     "subtype": "Basic",
@@ -4446,7 +4545,8 @@
     "nationalPokedexNumber": 383
   },
   {
-    "id": "col1-SL5",
+    "setOrder":47,
+	"id": "col1-SL5",
     "name": "Ho-Oh",
     "imageUrl": "https://images.pokemontcg.io/col1/SL5.png",
     "subtype": "Basic",
@@ -4509,7 +4609,8 @@
     "nationalPokedexNumber": 250
   },
   {
-    "id": "col1-SL6",
+    "setOrder":47,
+	"id": "col1-SL6",
     "name": "Kyogre",
     "imageUrl": "https://images.pokemontcg.io/col1/SL6.png",
     "subtype": "Basic",
@@ -4555,7 +4656,8 @@
     "nationalPokedexNumber": 382
   },
   {
-    "id": "col1-SL7",
+    "setOrder":47,
+	"id": "col1-SL7",
     "name": "Lugia",
     "imageUrl": "https://images.pokemontcg.io/col1/SL7.png",
     "subtype": "Basic",
@@ -4618,7 +4720,8 @@
     "nationalPokedexNumber": 249
   },
   {
-    "id": "col1-SL8",
+    "setOrder":47,
+	"id": "col1-SL8",
     "name": "Palkia",
     "imageUrl": "https://images.pokemontcg.io/col1/SL8.png",
     "subtype": "Basic",
@@ -4663,7 +4766,8 @@
     "nationalPokedexNumber": 484
   },
   {
-    "id": "col1-SL9",
+    "setOrder":47,
+	"id": "col1-SL9",
     "name": "Raikou",
     "imageUrl": "https://images.pokemontcg.io/col1/SL9.png",
     "subtype": "Basic",
@@ -4717,7 +4821,8 @@
     "nationalPokedexNumber": 243
   },
   {
-    "id": "col1-SL10",
+    "setOrder":47,
+	"id": "col1-SL10",
     "name": "Rayquaza",
     "imageUrl": "https://images.pokemontcg.io/col1/SL10.png",
     "subtype": "Basic",
@@ -4767,7 +4872,8 @@
     "nationalPokedexNumber": 384
   },
   {
-    "id": "col1-SL11",
+    "setOrder":47,
+	"id": "col1-SL11",
     "name": "Suicune",
     "imageUrl": "https://images.pokemontcg.io/col1/SL11.png",
     "subtype": "Basic",

--- a/json/cards/Celestial Storm.json
+++ b/json/cards/Celestial Storm.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "sm7-1",
+    "setOrder":79,
+	"id": "sm7-1",
     "name": "Bellsprout",
     "imageUrl": "https://images.pokemontcg.io/sm7/1.png",
     "subtype": "Basic",
@@ -44,7 +45,8 @@
     ]
   },
   {
-    "id": "sm7-2",
+    "setOrder":79,
+	"id": "sm7-2",
     "name": "Weepinbell",
     "imageUrl": "https://images.pokemontcg.io/sm7/2.png",
     "subtype": "Stage 1",
@@ -98,7 +100,8 @@
     ]
   },
   {
-    "id": "sm7-3",
+    "setOrder":79,
+	"id": "sm7-3",
     "name": "Victreebel",
     "imageUrl": "https://images.pokemontcg.io/sm7/3.png",
     "subtype": "Stage 2",
@@ -147,7 +150,8 @@
     "nationalPokedexNumber": 71
   },
   {
-    "id": "sm7-4",
+    "setOrder":79,
+	"id": "sm7-4",
     "name": "Scyther",
     "imageUrl": "https://images.pokemontcg.io/sm7/4.png",
     "subtype": "Basic",
@@ -200,7 +204,8 @@
     ]
   },
   {
-    "id": "sm7-5",
+    "setOrder":79,
+	"id": "sm7-5",
     "name": "Spinarak",
     "imageUrl": "https://images.pokemontcg.io/sm7/5.png",
     "subtype": "Basic",
@@ -253,7 +258,8 @@
     ]
   },
   {
-    "id": "sm7-6",
+    "setOrder":79,
+	"id": "sm7-6",
     "name": "Ariados",
     "imageUrl": "https://images.pokemontcg.io/sm7/6.png",
     "subtype": "Stage 1",
@@ -303,7 +309,8 @@
     "nationalPokedexNumber": 168
   },
   {
-    "id": "sm7-7",
+    "setOrder":79,
+	"id": "sm7-7",
     "name": "Treecko",
     "imageUrl": "https://images.pokemontcg.io/sm7/7.png",
     "subtype": "Basic",
@@ -346,7 +353,8 @@
     ]
   },
   {
-    "id": "sm7-8",
+    "setOrder":79,
+	"id": "sm7-8",
     "name": "Treecko",
     "imageUrl": "https://images.pokemontcg.io/sm7/8.png",
     "subtype": "Basic",
@@ -399,7 +407,8 @@
     ]
   },
   {
-    "id": "sm7-9",
+    "setOrder":79,
+	"id": "sm7-9",
     "name": "Grovyle",
     "imageUrl": "https://images.pokemontcg.io/sm7/9.png",
     "subtype": "Stage 1",
@@ -443,7 +452,8 @@
     ]
   },
   {
-    "id": "sm7-10",
+    "setOrder":79,
+	"id": "sm7-10",
     "name": "Sceptile",
     "imageUrl": "https://images.pokemontcg.io/sm7/10.png",
     "subtype": "Stage 2",
@@ -489,7 +499,8 @@
     "nationalPokedexNumber": 254
   },
   {
-    "id": "sm7-11",
+    "setOrder":79,
+	"id": "sm7-11",
     "name": "Seedot",
     "imageUrl": "https://images.pokemontcg.io/sm7/11.png",
     "subtype": "Basic",
@@ -541,7 +552,8 @@
     ]
   },
   {
-    "id": "sm7-12",
+    "setOrder":79,
+	"id": "sm7-12",
     "name": "Seedot",
     "imageUrl": "https://images.pokemontcg.io/sm7/12.png",
     "subtype": "Basic",
@@ -586,7 +598,8 @@
     ]
   },
   {
-    "id": "sm7-13",
+    "setOrder":79,
+	"id": "sm7-13",
     "name": "Nuzleaf",
     "imageUrl": "https://images.pokemontcg.io/sm7/13.png",
     "subtype": "Stage 1",
@@ -641,7 +654,8 @@
     ]
   },
   {
-    "id": "sm7-14",
+    "setOrder":79,
+	"id": "sm7-14",
     "name": "Shiftry-GX",
     "imageUrl": "https://images.pokemontcg.io/sm7/14.png",
     "subtype": "GX",
@@ -709,7 +723,8 @@
     "nationalPokedexNumber": 275
   },
   {
-    "id": "sm7-15",
+    "setOrder":79,
+	"id": "sm7-15",
     "name": "Surskit",
     "imageUrl": "https://images.pokemontcg.io/sm7/15.png",
     "subtype": "Basic",
@@ -752,7 +767,8 @@
     ]
   },
   {
-    "id": "sm7-16",
+    "setOrder":79,
+	"id": "sm7-16",
     "name": "Masquerain",
     "imageUrl": "https://images.pokemontcg.io/sm7/16.png",
     "subtype": "Stage 1",
@@ -804,7 +820,8 @@
     "nationalPokedexNumber": 284
   },
   {
-    "id": "sm7-17",
+    "setOrder":79,
+	"id": "sm7-17",
     "name": "Volbeat",
     "imageUrl": "https://images.pokemontcg.io/sm7/17.png",
     "subtype": "Basic",
@@ -844,7 +861,8 @@
     "nationalPokedexNumber": 313
   },
   {
-    "id": "sm7-18",
+    "setOrder":79,
+	"id": "sm7-18",
     "name": "Illumise",
     "imageUrl": "https://images.pokemontcg.io/sm7/18.png",
     "subtype": "Basic",
@@ -884,7 +902,8 @@
     "nationalPokedexNumber": 314
   },
   {
-    "id": "sm7-19",
+    "setOrder":79,
+	"id": "sm7-19",
     "name": "Cacnea",
     "imageUrl": "https://images.pokemontcg.io/sm7/19.png",
     "subtype": "Basic",
@@ -932,7 +951,8 @@
     ]
   },
   {
-    "id": "sm7-20",
+    "setOrder":79,
+	"id": "sm7-20",
     "name": "Cacturne",
     "imageUrl": "https://images.pokemontcg.io/sm7/20.png",
     "subtype": "Stage 1",
@@ -980,7 +1000,8 @@
     "nationalPokedexNumber": 332
   },
   {
-    "id": "sm7-21",
+    "setOrder":79,
+	"id": "sm7-21",
     "name": "Tropius",
     "imageUrl": "https://images.pokemontcg.io/sm7/21.png",
     "subtype": "Basic",
@@ -1031,7 +1052,8 @@
     "nationalPokedexNumber": 357
   },
   {
-    "id": "sm7-22",
+    "setOrder":79,
+	"id": "sm7-22",
     "name": "Dhelmise",
     "imageUrl": "https://images.pokemontcg.io/sm7/22.png",
     "subtype": "Basic",
@@ -1085,7 +1107,8 @@
     "nationalPokedexNumber": 781
   },
   {
-    "id": "sm7-23",
+    "setOrder":79,
+	"id": "sm7-23",
     "name": "Slugma",
     "imageUrl": "https://images.pokemontcg.io/sm7/23.png",
     "subtype": "Basic",
@@ -1139,7 +1162,8 @@
     ]
   },
   {
-    "id": "sm7-24",
+    "setOrder":79,
+	"id": "sm7-24",
     "name": "Magcargo",
     "imageUrl": "https://images.pokemontcg.io/sm7/24.png",
     "subtype": "Stage 1",
@@ -1189,7 +1213,8 @@
     "nationalPokedexNumber": 219
   },
   {
-    "id": "sm7-25",
+    "setOrder":79,
+	"id": "sm7-25",
     "name": "Torchic",
     "imageUrl": "https://images.pokemontcg.io/sm7/25.png",
     "subtype": "Basic",
@@ -1232,7 +1257,8 @@
     ]
   },
   {
-    "id": "sm7-26",
+    "setOrder":79,
+	"id": "sm7-26",
     "name": "Torchic",
     "imageUrl": "https://images.pokemontcg.io/sm7/26.png",
     "subtype": "Basic",
@@ -1285,7 +1311,8 @@
     ]
   },
   {
-    "id": "sm7-27",
+    "setOrder":79,
+	"id": "sm7-27",
     "name": "Combusken",
     "imageUrl": "https://images.pokemontcg.io/sm7/27.png",
     "subtype": "Stage 1",
@@ -1341,7 +1368,8 @@
     ]
   },
   {
-    "id": "sm7-28",
+    "setOrder":79,
+	"id": "sm7-28",
     "name": "Blaziken-GX",
     "imageUrl": "https://images.pokemontcg.io/sm7/28.png",
     "subtype": "GX",
@@ -1407,7 +1435,8 @@
     "nationalPokedexNumber": 257
   },
   {
-    "id": "sm7-29",
+    "setOrder":79,
+	"id": "sm7-29",
     "name": "Torkoal",
     "imageUrl": "https://images.pokemontcg.io/sm7/29.png",
     "subtype": "Basic",
@@ -1461,7 +1490,8 @@
     "nationalPokedexNumber": 324
   },
   {
-    "id": "sm7-30",
+    "setOrder":79,
+	"id": "sm7-30",
     "name": "Oricorio",
     "imageUrl": "https://images.pokemontcg.io/sm7/30.png",
     "subtype": "Basic",
@@ -1518,7 +1548,8 @@
     "nationalPokedexNumber": 741
   },
   {
-    "id": "sm7-31",
+    "setOrder":79,
+	"id": "sm7-31",
     "name": "Articuno-GX",
     "imageUrl": "https://images.pokemontcg.io/sm7/31.png",
     "subtype": "GX",
@@ -1579,7 +1610,8 @@
     "nationalPokedexNumber": 144
   },
   {
-    "id": "sm7-32",
+    "setOrder":79,
+	"id": "sm7-32",
     "name": "Mudkip",
     "imageUrl": "https://images.pokemontcg.io/sm7/32.png",
     "subtype": "Basic",
@@ -1622,7 +1654,8 @@
     ]
   },
   {
-    "id": "sm7-33",
+    "setOrder":79,
+	"id": "sm7-33",
     "name": "Mudkip",
     "imageUrl": "https://images.pokemontcg.io/sm7/33.png",
     "subtype": "Basic",
@@ -1675,7 +1708,8 @@
     ]
   },
   {
-    "id": "sm7-34",
+    "setOrder":79,
+	"id": "sm7-34",
     "name": "Marshtomp",
     "imageUrl": "https://images.pokemontcg.io/sm7/34.png",
     "subtype": "Stage 1",
@@ -1733,7 +1767,8 @@
     ]
   },
   {
-    "id": "sm7-35",
+    "setOrder":79,
+	"id": "sm7-35",
     "name": "Swampert",
     "imageUrl": "https://images.pokemontcg.io/sm7/35.png",
     "subtype": "Stage 2",
@@ -1783,7 +1818,8 @@
     "nationalPokedexNumber": 260
   },
   {
-    "id": "sm7-36",
+    "setOrder":79,
+	"id": "sm7-36",
     "name": "Lotad",
     "imageUrl": "https://images.pokemontcg.io/sm7/36.png",
     "subtype": "Basic",
@@ -1826,7 +1862,8 @@
     ]
   },
   {
-    "id": "sm7-37",
+    "setOrder":79,
+	"id": "sm7-37",
     "name": "Lombre",
     "imageUrl": "https://images.pokemontcg.io/sm7/37.png",
     "subtype": "Stage 1",
@@ -1876,7 +1913,8 @@
     ]
   },
   {
-    "id": "sm7-38",
+    "setOrder":79,
+	"id": "sm7-38",
     "name": "Ludicolo",
     "imageUrl": "https://images.pokemontcg.io/sm7/38.png",
     "subtype": "Stage 2",
@@ -1925,7 +1963,8 @@
     "nationalPokedexNumber": 272
   },
   {
-    "id": "sm7-39",
+    "setOrder":79,
+	"id": "sm7-39",
     "name": "Wailmer",
     "imageUrl": "https://images.pokemontcg.io/sm7/39.png",
     "subtype": "Basic",
@@ -1972,7 +2011,8 @@
     ]
   },
   {
-    "id": "sm7-40",
+    "setOrder":79,
+	"id": "sm7-40",
     "name": "Wailord",
     "imageUrl": "https://images.pokemontcg.io/sm7/40.png",
     "subtype": "Stage 1",
@@ -2019,7 +2059,8 @@
     "nationalPokedexNumber": 321
   },
   {
-    "id": "sm7-41",
+    "setOrder":79,
+	"id": "sm7-41",
     "name": "Clamperl",
     "imageUrl": "https://images.pokemontcg.io/sm7/41.png",
     "subtype": "Basic",
@@ -2070,7 +2111,8 @@
     ]
   },
   {
-    "id": "sm7-42",
+    "setOrder":79,
+	"id": "sm7-42",
     "name": "Huntail",
     "imageUrl": "https://images.pokemontcg.io/sm7/42.png",
     "subtype": "Stage 1",
@@ -2122,7 +2164,8 @@
     "nationalPokedexNumber": 367
   },
   {
-    "id": "sm7-43",
+    "setOrder":79,
+	"id": "sm7-43",
     "name": "Gorebyss",
     "imageUrl": "https://images.pokemontcg.io/sm7/43.png",
     "subtype": "Stage 1",
@@ -2160,7 +2203,8 @@
     "nationalPokedexNumber": 368
   },
   {
-    "id": "sm7-44",
+    "setOrder":79,
+	"id": "sm7-44",
     "name": "Luvdisc",
     "imageUrl": "https://images.pokemontcg.io/sm7/44.png",
     "subtype": "Basic",
@@ -2210,7 +2254,8 @@
     "nationalPokedexNumber": 370
   },
   {
-    "id": "sm7-45",
+    "setOrder":79,
+	"id": "sm7-45",
     "name": "Regice",
     "imageUrl": "https://images.pokemontcg.io/sm7/45.png",
     "subtype": "Basic",
@@ -2259,7 +2304,8 @@
     "nationalPokedexNumber": 378
   },
   {
-    "id": "sm7-46",
+    "setOrder":79,
+	"id": "sm7-46",
     "name": "Kyogre",
     "imageUrl": "https://images.pokemontcg.io/sm7/46.png",
     "subtype": "Basic",
@@ -2314,7 +2360,8 @@
     "nationalPokedexNumber": 382
   },
   {
-    "id": "sm7-47",
+    "setOrder":79,
+	"id": "sm7-47",
     "name": "Voltorb",
     "imageUrl": "https://images.pokemontcg.io/sm7/47.png",
     "subtype": "Basic",
@@ -2369,7 +2416,8 @@
     ]
   },
   {
-    "id": "sm7-48",
+    "setOrder":79,
+	"id": "sm7-48",
     "name": "Electrode-GX",
     "imageUrl": "https://images.pokemontcg.io/sm7/48.png",
     "subtype": "GX",
@@ -2436,7 +2484,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "sm7-49",
+    "setOrder":79,
+	"id": "sm7-49",
     "name": "Chinchou",
     "imageUrl": "https://images.pokemontcg.io/sm7/49.png",
     "subtype": "Basic",
@@ -2495,7 +2544,8 @@
     ]
   },
   {
-    "id": "sm7-50",
+    "setOrder":79,
+	"id": "sm7-50",
     "name": "Lanturn",
     "imageUrl": "https://images.pokemontcg.io/sm7/50.png",
     "subtype": "Stage 1",
@@ -2550,7 +2600,8 @@
     "nationalPokedexNumber": 171
   },
   {
-    "id": "sm7-51",
+    "setOrder":79,
+	"id": "sm7-51",
     "name": "Electrike",
     "imageUrl": "https://images.pokemontcg.io/sm7/51.png",
     "subtype": "Basic",
@@ -2599,7 +2650,8 @@
     ]
   },
   {
-    "id": "sm7-52",
+    "setOrder":79,
+	"id": "sm7-52",
     "name": "Manectric",
     "imageUrl": "https://images.pokemontcg.io/sm7/52.png",
     "subtype": "Stage 1",
@@ -2648,7 +2700,8 @@
     "nationalPokedexNumber": 310
   },
   {
-    "id": "sm7-53",
+    "setOrder":79,
+	"id": "sm7-53",
     "name": "Plusle",
     "imageUrl": "https://images.pokemontcg.io/sm7/53.png",
     "subtype": "Basic",
@@ -2704,7 +2757,8 @@
     "nationalPokedexNumber": 311
   },
   {
-    "id": "sm7-54",
+    "setOrder":79,
+	"id": "sm7-54",
     "name": "Minun",
     "imageUrl": "https://images.pokemontcg.io/sm7/54.png",
     "subtype": "Basic",
@@ -2760,7 +2814,8 @@
     "nationalPokedexNumber": 312
   },
   {
-    "id": "sm7-55",
+    "setOrder":79,
+	"id": "sm7-55",
     "name": "Oricorio",
     "imageUrl": "https://images.pokemontcg.io/sm7/55.png",
     "subtype": "Basic",
@@ -2817,7 +2872,8 @@
     "nationalPokedexNumber": 741
   },
   {
-    "id": "sm7-56",
+    "setOrder":79,
+	"id": "sm7-56",
     "name": "Mr. Mime-GX",
     "imageUrl": "https://images.pokemontcg.io/sm7/56.png",
     "subtype": "GX",
@@ -2871,7 +2927,8 @@
     "nationalPokedexNumber": 122
   },
   {
-    "id": "sm7-57",
+    "setOrder":79,
+	"id": "sm7-57",
     "name": "Gulpin",
     "imageUrl": "https://images.pokemontcg.io/sm7/57.png",
     "subtype": "Basic",
@@ -2923,7 +2980,8 @@
     ]
   },
   {
-    "id": "sm7-58",
+    "setOrder":79,
+	"id": "sm7-58",
     "name": "Swalot",
     "imageUrl": "https://images.pokemontcg.io/sm7/58.png",
     "subtype": "Stage 1",
@@ -2976,7 +3034,8 @@
     "nationalPokedexNumber": 317
   },
   {
-    "id": "sm7-59",
+    "setOrder":79,
+	"id": "sm7-59",
     "name": "Spoink",
     "imageUrl": "https://images.pokemontcg.io/sm7/59.png",
     "subtype": "Basic",
@@ -3019,7 +3078,8 @@
     ]
   },
   {
-    "id": "sm7-60",
+    "setOrder":79,
+	"id": "sm7-60",
     "name": "Grumpig",
     "imageUrl": "https://images.pokemontcg.io/sm7/60.png",
     "subtype": "Stage 1",
@@ -3061,7 +3121,8 @@
     "nationalPokedexNumber": 326
   },
   {
-    "id": "sm7-61",
+    "setOrder":79,
+	"id": "sm7-61",
     "name": "Lunatone",
     "imageUrl": "https://images.pokemontcg.io/sm7/61.png",
     "subtype": "Basic",
@@ -3106,7 +3167,8 @@
     "nationalPokedexNumber": 337
   },
   {
-    "id": "sm7-62",
+    "setOrder":79,
+	"id": "sm7-62",
     "name": "Solrock",
     "imageUrl": "https://images.pokemontcg.io/sm7/62.png",
     "subtype": "Basic",
@@ -3151,7 +3213,8 @@
     "nationalPokedexNumber": 338
   },
   {
-    "id": "sm7-63",
+    "setOrder":79,
+	"id": "sm7-63",
     "name": "Shuppet",
     "imageUrl": "https://images.pokemontcg.io/sm7/63.png",
     "subtype": "Basic",
@@ -3210,7 +3273,8 @@
     ]
   },
   {
-    "id": "sm7-64",
+    "setOrder":79,
+	"id": "sm7-64",
     "name": "Shuppet",
     "imageUrl": "https://images.pokemontcg.io/sm7/64.png",
     "subtype": "Basic",
@@ -3259,7 +3323,8 @@
     ]
   },
   {
-    "id": "sm7-65",
+    "setOrder":79,
+	"id": "sm7-65",
     "name": "Banette",
     "imageUrl": "https://images.pokemontcg.io/sm7/65.png",
     "subtype": "Stage 1",
@@ -3312,7 +3377,8 @@
     "nationalPokedexNumber": 354
   },
   {
-    "id": "sm7-66",
+    "setOrder":79,
+	"id": "sm7-66",
     "name": "Banette-GX",
     "imageUrl": "https://images.pokemontcg.io/sm7/66.png",
     "subtype": "GX",
@@ -3377,7 +3443,8 @@
     "nationalPokedexNumber": 354
   },
   {
-    "id": "sm7-67",
+    "setOrder":79,
+	"id": "sm7-67",
     "name": "Deoxys",
     "imageUrl": "https://images.pokemontcg.io/sm7/67.png",
     "subtype": "Basic",
@@ -3429,7 +3496,8 @@
     "nationalPokedexNumber": 386
   },
   {
-    "id": "sm7-68",
+    "setOrder":79,
+	"id": "sm7-68",
     "name": "Deoxys",
     "imageUrl": "https://images.pokemontcg.io/sm7/68.png",
     "subtype": "Basic",
@@ -3482,7 +3550,8 @@
     "nationalPokedexNumber": 386
   },
   {
-    "id": "sm7-69",
+    "setOrder":79,
+	"id": "sm7-69",
     "name": "Deoxys",
     "imageUrl": "https://images.pokemontcg.io/sm7/69.png",
     "subtype": "Basic",
@@ -3533,7 +3602,8 @@
     "nationalPokedexNumber": 386
   },
   {
-    "id": "sm7-70",
+    "setOrder":79,
+	"id": "sm7-70",
     "name": "Lunala",
     "imageUrl": "https://images.pokemontcg.io/sm7/70.png",
     "subtype": "Stage 2",
@@ -3588,7 +3658,8 @@
     "nationalPokedexNumber": 792
   },
   {
-    "id": "sm7-71",
+    "setOrder":79,
+	"id": "sm7-71",
     "name": "Onix",
     "imageUrl": "https://images.pokemontcg.io/sm7/71.png",
     "subtype": "Basic",
@@ -3642,7 +3713,8 @@
     ]
   },
   {
-    "id": "sm7-72",
+    "setOrder":79,
+	"id": "sm7-72",
     "name": "Phanpy",
     "imageUrl": "https://images.pokemontcg.io/sm7/72.png",
     "subtype": "Basic",
@@ -3694,7 +3766,8 @@
     ]
   },
   {
-    "id": "sm7-73",
+    "setOrder":79,
+	"id": "sm7-73",
     "name": "Donphan",
     "imageUrl": "https://images.pokemontcg.io/sm7/73.png",
     "subtype": "Stage 1",
@@ -3748,7 +3821,8 @@
     "nationalPokedexNumber": 232
   },
   {
-    "id": "sm7-74",
+    "setOrder":79,
+	"id": "sm7-74",
     "name": "Larvitar",
     "imageUrl": "https://images.pokemontcg.io/sm7/74.png",
     "subtype": "Basic",
@@ -3801,7 +3875,8 @@
     ]
   },
   {
-    "id": "sm7-75",
+    "setOrder":79,
+	"id": "sm7-75",
     "name": "Pupitar",
     "imageUrl": "https://images.pokemontcg.io/sm7/75.png",
     "subtype": "Stage 1",
@@ -3856,7 +3931,8 @@
     ]
   },
   {
-    "id": "sm7-76",
+    "setOrder":79,
+	"id": "sm7-76",
     "name": "Meditite",
     "imageUrl": "https://images.pokemontcg.io/sm7/76.png",
     "subtype": "Basic",
@@ -3909,7 +3985,8 @@
     ]
   },
   {
-    "id": "sm7-77",
+    "setOrder":79,
+	"id": "sm7-77",
     "name": "Medicham",
     "imageUrl": "https://images.pokemontcg.io/sm7/77.png",
     "subtype": "Stage 1",
@@ -3961,7 +4038,8 @@
     "nationalPokedexNumber": 308
   },
   {
-    "id": "sm7-78",
+    "setOrder":79,
+	"id": "sm7-78",
     "name": "Baltoy",
     "imageUrl": "https://images.pokemontcg.io/sm7/78.png",
     "subtype": "Basic",
@@ -4005,7 +4083,8 @@
     ]
   },
   {
-    "id": "sm7-79",
+    "setOrder":79,
+	"id": "sm7-79",
     "name": "Claydol",
     "imageUrl": "https://images.pokemontcg.io/sm7/79.png",
     "subtype": "Stage 1",
@@ -4058,7 +4137,8 @@
     "nationalPokedexNumber": 344
   },
   {
-    "id": "sm7-80",
+    "setOrder":79,
+	"id": "sm7-80",
     "name": "Regirock",
     "imageUrl": "https://images.pokemontcg.io/sm7/80.png",
     "subtype": "Basic",
@@ -4111,7 +4191,8 @@
     "nationalPokedexNumber": 377
   },
   {
-    "id": "sm7-81",
+    "setOrder":79,
+	"id": "sm7-81",
     "name": "Groudon",
     "imageUrl": "https://images.pokemontcg.io/sm7/81.png",
     "subtype": "Basic",
@@ -4168,7 +4249,8 @@
     "nationalPokedexNumber": 383
   },
   {
-    "id": "sm7-82",
+    "setOrder":79,
+	"id": "sm7-82",
     "name": "Palossand-GX",
     "imageUrl": "https://images.pokemontcg.io/sm7/82.png",
     "subtype": "Stage 1",
@@ -4239,7 +4321,8 @@
     "nationalPokedexNumber": 770
   },
   {
-    "id": "sm7-83",
+    "setOrder":79,
+	"id": "sm7-83",
     "name": "Minior",
     "imageUrl": "https://images.pokemontcg.io/sm7/83.png",
     "subtype": "Basic",
@@ -4285,7 +4368,8 @@
     "nationalPokedexNumber": 774
   },
   {
-    "id": "sm7-84",
+    "setOrder":79,
+	"id": "sm7-84",
     "name": "Alolan Rattata",
     "imageUrl": "https://images.pokemontcg.io/sm7/84.png",
     "subtype": "Basic",
@@ -4344,7 +4428,8 @@
     ]
   },
   {
-    "id": "sm7-85",
+    "setOrder":79,
+	"id": "sm7-85",
     "name": "Alolan Raticate-GX",
     "imageUrl": "https://images.pokemontcg.io/sm7/85.png",
     "subtype": "GX",
@@ -4417,7 +4502,8 @@
     "nationalPokedexNumber": 20
   },
   {
-    "id": "sm7-86",
+    "setOrder":79,
+	"id": "sm7-86",
     "name": "Sneasel",
     "imageUrl": "https://images.pokemontcg.io/sm7/86.png",
     "subtype": "Basic",
@@ -4476,7 +4562,8 @@
     ]
   },
   {
-    "id": "sm7-87",
+    "setOrder":79,
+	"id": "sm7-87",
     "name": "Tyranitar",
     "imageUrl": "https://images.pokemontcg.io/sm7/87.png",
     "subtype": "Stage 2",
@@ -4539,7 +4626,8 @@
     "nationalPokedexNumber": 248
   },
   {
-    "id": "sm7-88",
+    "setOrder":79,
+	"id": "sm7-88",
     "name": "Sableye",
     "imageUrl": "https://images.pokemontcg.io/sm7/88.png",
     "subtype": "Basic",
@@ -4578,7 +4666,8 @@
     "nationalPokedexNumber": 302
   },
   {
-    "id": "sm7-89",
+    "setOrder":79,
+	"id": "sm7-89",
     "name": "Steelix",
     "imageUrl": "https://images.pokemontcg.io/sm7/89.png",
     "subtype": "Stage 1",
@@ -4640,7 +4729,8 @@
     "nationalPokedexNumber": 208
   },
   {
-    "id": "sm7-90",
+    "setOrder":79,
+	"id": "sm7-90",
     "name": "Scizor-GX",
     "imageUrl": "https://images.pokemontcg.io/sm7/90.png",
     "subtype": "GX",
@@ -4708,7 +4798,8 @@
     "nationalPokedexNumber": 212
   },
   {
-    "id": "sm7-91",
+    "setOrder":79,
+	"id": "sm7-91",
     "name": "Mawile",
     "imageUrl": "https://images.pokemontcg.io/sm7/91.png",
     "subtype": "Basic",
@@ -4764,7 +4855,8 @@
     "nationalPokedexNumber": 303
   },
   {
-    "id": "sm7-92",
+    "setOrder":79,
+	"id": "sm7-92",
     "name": "Beldum",
     "imageUrl": "https://images.pokemontcg.io/sm7/92.png",
     "subtype": "Basic",
@@ -4819,7 +4911,8 @@
     ]
   },
   {
-    "id": "sm7-93",
+    "setOrder":79,
+	"id": "sm7-93",
     "name": "Beldum",
     "imageUrl": "https://images.pokemontcg.io/sm7/93.png",
     "subtype": "Basic",
@@ -4871,7 +4964,8 @@
     ]
   },
   {
-    "id": "sm7-94",
+    "setOrder":79,
+	"id": "sm7-94",
     "name": "Metang",
     "imageUrl": "https://images.pokemontcg.io/sm7/94.png",
     "subtype": "Stage 1",
@@ -4923,7 +5017,8 @@
     ]
   },
   {
-    "id": "sm7-95",
+    "setOrder":79,
+	"id": "sm7-95",
     "name": "Metagross",
     "imageUrl": "https://images.pokemontcg.io/sm7/95.png",
     "subtype": "Stage 2",
@@ -4978,7 +5073,8 @@
     "nationalPokedexNumber": 376
   },
   {
-    "id": "sm7-96",
+    "setOrder":79,
+	"id": "sm7-96",
     "name": "Registeel",
     "imageUrl": "https://images.pokemontcg.io/sm7/96.png",
     "subtype": "Basic",
@@ -5033,7 +5129,8 @@
     "nationalPokedexNumber": 379
   },
   {
-    "id": "sm7-97",
+    "setOrder":79,
+	"id": "sm7-97",
     "name": "Jirachi ◇",
     "imageUrl": "https://images.pokemontcg.io/sm7/97.png",
     "subtype": "Basic",
@@ -5089,7 +5186,8 @@
     "nationalPokedexNumber": 385
   },
   {
-    "id": "sm7-98",
+    "setOrder":79,
+	"id": "sm7-98",
     "name": "Heatran",
     "imageUrl": "https://images.pokemontcg.io/sm7/98.png",
     "subtype": "Basic",
@@ -5149,7 +5247,8 @@
     "nationalPokedexNumber": 485
   },
   {
-    "id": "sm7-99",
+    "setOrder":79,
+	"id": "sm7-99",
     "name": "Solgaleo",
     "imageUrl": "https://images.pokemontcg.io/sm7/99.png",
     "subtype": "Stage 2",
@@ -5205,7 +5304,8 @@
     "nationalPokedexNumber": 791
   },
   {
-    "id": "sm7-100",
+    "setOrder":79,
+	"id": "sm7-100",
     "name": "Celesteela",
     "imageUrl": "https://images.pokemontcg.io/sm7/100.png",
     "subtype": "Basic",
@@ -5258,7 +5358,8 @@
     "nationalPokedexNumber": 797
   },
   {
-    "id": "sm7-101",
+    "setOrder":79,
+	"id": "sm7-101",
     "name": "Kartana",
     "imageUrl": "https://images.pokemontcg.io/sm7/101.png",
     "subtype": "Basic",
@@ -5305,7 +5406,8 @@
     "nationalPokedexNumber": 798
   },
   {
-    "id": "sm7-102",
+    "setOrder":79,
+	"id": "sm7-102",
     "name": "Stakataka-GX",
     "imageUrl": "https://images.pokemontcg.io/sm7/102.png",
     "subtype": "GX",
@@ -5374,7 +5476,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/102_hires.png"
   },
   {
-    "id": "sm7-103",
+    "setOrder":79,
+	"id": "sm7-103",
     "name": "Bagon",
     "imageUrl": "https://images.pokemontcg.io/sm7/103.png",
     "subtype": "Basic",
@@ -5417,7 +5520,8 @@
     ]
   },
   {
-    "id": "sm7-104",
+    "setOrder":79,
+	"id": "sm7-104",
     "name": "Bagon",
     "imageUrl": "https://images.pokemontcg.io/sm7/104.png",
     "subtype": "Basic",
@@ -5462,7 +5566,8 @@
     ]
   },
   {
-    "id": "sm7-105",
+    "setOrder":79,
+	"id": "sm7-105",
     "name": "Shelgon",
     "imageUrl": "https://images.pokemontcg.io/sm7/105.png",
     "subtype": "Stage 1",
@@ -5509,7 +5614,8 @@
     ]
   },
   {
-    "id": "sm7-106",
+    "setOrder":79,
+	"id": "sm7-106",
     "name": "Salamence",
     "imageUrl": "https://images.pokemontcg.io/sm7/106.png",
     "subtype": "Stage 2",
@@ -5560,7 +5666,8 @@
     "nationalPokedexNumber": 373
   },
   {
-    "id": "sm7-107",
+    "setOrder":79,
+	"id": "sm7-107",
     "name": "Latias ◇",
     "imageUrl": "https://images.pokemontcg.io/sm7/107.png",
     "subtype": "Basic",
@@ -5603,7 +5710,8 @@
     "nationalPokedexNumber": 380
   },
   {
-    "id": "sm7-108",
+    "setOrder":79,
+	"id": "sm7-108",
     "name": "Latios ◇",
     "imageUrl": "https://images.pokemontcg.io/sm7/108.png",
     "subtype": "Basic",
@@ -5647,7 +5755,8 @@
     "nationalPokedexNumber": 381
   },
   {
-    "id": "sm7-109",
+    "setOrder":79,
+	"id": "sm7-109",
     "name": "Rayquaza-GX",
     "imageUrl": "https://images.pokemontcg.io/sm7/109.png",
     "subtype": "GX",
@@ -5709,7 +5818,8 @@
     "nationalPokedexNumber": 384
   },
   {
-    "id": "sm7-110",
+    "setOrder":79,
+	"id": "sm7-110",
     "name": "Dunsparce",
     "imageUrl": "https://images.pokemontcg.io/sm7/110.png",
     "subtype": "Basic",
@@ -5758,7 +5868,8 @@
     "nationalPokedexNumber": 206
   },
   {
-    "id": "sm7-111",
+    "setOrder":79,
+	"id": "sm7-111",
     "name": "Wingull",
     "imageUrl": "https://images.pokemontcg.io/sm7/111.png",
     "subtype": "Basic",
@@ -5807,7 +5918,8 @@
     ]
   },
   {
-    "id": "sm7-112",
+    "setOrder":79,
+	"id": "sm7-112",
     "name": "Pelipper",
     "imageUrl": "https://images.pokemontcg.io/sm7/112.png",
     "subtype": "Stage 1",
@@ -5866,7 +5978,8 @@
     "nationalPokedexNumber": 279
   },
   {
-    "id": "sm7-113",
+    "setOrder":79,
+	"id": "sm7-113",
     "name": "Slakoth",
     "imageUrl": "https://images.pokemontcg.io/sm7/113.png",
     "subtype": "Basic",
@@ -5919,7 +6032,8 @@
     ]
   },
   {
-    "id": "sm7-114",
+    "setOrder":79,
+	"id": "sm7-114",
     "name": "Vigoroth",
     "imageUrl": "https://images.pokemontcg.io/sm7/114.png",
     "subtype": "Stage 1",
@@ -5975,7 +6089,8 @@
     ]
   },
   {
-    "id": "sm7-115",
+    "setOrder":79,
+	"id": "sm7-115",
     "name": "Slaking",
     "imageUrl": "https://images.pokemontcg.io/sm7/115.png",
     "subtype": "Stage 2",
@@ -6025,7 +6140,8 @@
     "nationalPokedexNumber": 289
   },
   {
-    "id": "sm7-116",
+    "setOrder":79,
+	"id": "sm7-116",
     "name": "Whismur",
     "imageUrl": "https://images.pokemontcg.io/sm7/116.png",
     "subtype": "Basic",
@@ -6079,7 +6195,8 @@
     ]
   },
   {
-    "id": "sm7-117",
+    "setOrder":79,
+	"id": "sm7-117",
     "name": "Whismur",
     "imageUrl": "https://images.pokemontcg.io/sm7/117.png",
     "subtype": "Basic",
@@ -6125,7 +6242,8 @@
     ]
   },
   {
-    "id": "sm7-118",
+    "setOrder":79,
+	"id": "sm7-118",
     "name": "Loudred",
     "imageUrl": "https://images.pokemontcg.io/sm7/118.png",
     "subtype": "Stage 1",
@@ -6173,7 +6291,8 @@
     ]
   },
   {
-    "id": "sm7-119",
+    "setOrder":79,
+	"id": "sm7-119",
     "name": "Exploud",
     "imageUrl": "https://images.pokemontcg.io/sm7/119.png",
     "subtype": "Stage 2",
@@ -6231,7 +6350,8 @@
     "nationalPokedexNumber": 295
   },
   {
-    "id": "sm7-120",
+    "setOrder":79,
+	"id": "sm7-120",
     "name": "Skitty",
     "imageUrl": "https://images.pokemontcg.io/sm7/120.png",
     "subtype": "Basic",
@@ -6274,7 +6394,8 @@
     ]
   },
   {
-    "id": "sm7-121",
+    "setOrder":79,
+	"id": "sm7-121",
     "name": "Delcatty",
     "imageUrl": "https://images.pokemontcg.io/sm7/121.png",
     "subtype": "Stage 1",
@@ -6321,7 +6442,8 @@
     "nationalPokedexNumber": 301
   },
   {
-    "id": "sm7-122",
+    "setOrder":79,
+	"id": "sm7-122",
     "name": "Kecleon",
     "imageUrl": "https://images.pokemontcg.io/sm7/122.png",
     "subtype": "Basic",
@@ -6368,7 +6490,8 @@
     "nationalPokedexNumber": 352
   },
   {
-    "id": "sm7-123",
+    "setOrder":79,
+	"id": "sm7-123",
     "name": "Acro Bike",
     "imageUrl": "https://images.pokemontcg.io/sm7/123.png",
     "subtype": "Item",
@@ -6386,7 +6509,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/123_hires.png"
   },
   {
-    "id": "sm7-124",
+    "setOrder":79,
+	"id": "sm7-124",
     "name": "Apricorn Maker",
     "imageUrl": "https://images.pokemontcg.io/sm7/124.png",
     "subtype": "Supporter",
@@ -6404,7 +6528,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/124_hires.png"
   },
   {
-    "id": "sm7-125",
+    "setOrder":79,
+	"id": "sm7-125",
     "name": "Beast Ball",
     "imageUrl": "https://images.pokemontcg.io/sm7/125.png",
     "subtype": "Item",
@@ -6422,7 +6547,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/125_hires.png"
   },
   {
-    "id": "sm7-126",
+    "setOrder":79,
+	"id": "sm7-126",
     "name": "Bill's Maintenance",
     "imageUrl": "https://images.pokemontcg.io/sm7/126.png",
     "subtype": "Supporter",
@@ -6440,7 +6566,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/126_hires.png"
   },
   {
-    "id": "sm7-127",
+    "setOrder":79,
+	"id": "sm7-127",
     "name": "Copycat",
     "imageUrl": "https://images.pokemontcg.io/sm7/127.png",
     "subtype": "Supporter",
@@ -6458,7 +6585,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/127_hires.png"
   },
   {
-    "id": "sm7-128",
+    "setOrder":79,
+	"id": "sm7-128",
     "name": "Energy Recycle System",
     "imageUrl": "https://images.pokemontcg.io/sm7/128.png",
     "subtype": "Item",
@@ -6476,7 +6604,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/128_hires.png"
   },
   {
-    "id": "sm7-129",
+    "setOrder":79,
+	"id": "sm7-129",
     "name": "Energy Switch",
     "imageUrl": "https://images.pokemontcg.io/sm7/129.png",
     "subtype": "Item",
@@ -6494,7 +6623,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/129_hires.png"
   },
   {
-    "id": "sm7-130",
+    "setOrder":79,
+	"id": "sm7-130",
     "name": "Fisherman",
     "imageUrl": "https://images.pokemontcg.io/sm7/130.png",
     "subtype": "Supporter",
@@ -6512,7 +6642,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/130_hires.png"
   },
   {
-    "id": "sm7-131",
+    "setOrder":79,
+	"id": "sm7-131",
     "name": "Friend Ball",
     "imageUrl": "https://images.pokemontcg.io/sm7/131.png",
     "subtype": "Item",
@@ -6530,7 +6661,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/131_hires.png"
   },
   {
-    "id": "sm7-132",
+    "setOrder":79,
+	"id": "sm7-132",
     "name": "Hau",
     "imageUrl": "https://images.pokemontcg.io/sm7/132.png",
     "subtype": "Supporter",
@@ -6548,7 +6680,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/132_hires.png"
   },
   {
-    "id": "sm7-133",
+    "setOrder":79,
+	"id": "sm7-133",
     "name": "Hiker",
     "imageUrl": "https://images.pokemontcg.io/sm7/133.png",
     "subtype": "Supporter",
@@ -6566,7 +6699,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/133_hires.png"
   },
   {
-    "id": "sm7-134",
+    "setOrder":79,
+	"id": "sm7-134",
     "name": "Hustle Belt",
     "imageUrl": "https://images.pokemontcg.io/sm7/134.png",
     "subtype": "Pokémon Tool",
@@ -6584,7 +6718,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/134_hires.png"
   },
   {
-    "id": "sm7-135",
+    "setOrder":79,
+	"id": "sm7-135",
     "name": "Last Chance Potion",
     "imageUrl": "https://images.pokemontcg.io/sm7/135.png",
     "subtype": "Item",
@@ -6602,7 +6737,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/135_hires.png"
   },
   {
-    "id": "sm7-136",
+    "setOrder":79,
+	"id": "sm7-136",
     "name": "Life Herb",
     "imageUrl": "https://images.pokemontcg.io/sm7/136.png",
     "subtype": "Item",
@@ -6620,7 +6756,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/136_hires.png"
   },
   {
-    "id": "sm7-137",
+    "setOrder":79,
+	"id": "sm7-137",
     "name": "Lisia",
     "imageUrl": "https://images.pokemontcg.io/sm7/137.png",
     "subtype": "Supporter",
@@ -6638,7 +6775,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/137_hires.png"
   },
   {
-    "id": "sm7-138",
+    "setOrder":79,
+	"id": "sm7-138",
     "name": "Lure Ball",
     "imageUrl": "https://images.pokemontcg.io/sm7/138.png",
     "subtype": "Item",
@@ -6656,7 +6794,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/138_hires.png"
   },
   {
-    "id": "sm7-139",
+    "setOrder":79,
+	"id": "sm7-139",
     "name": "The Masked Royal",
     "imageUrl": "https://images.pokemontcg.io/sm7/139.png",
     "subtype": "Supporter",
@@ -6674,7 +6813,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/139_hires.png"
   },
   {
-    "id": "sm7-140",
+    "setOrder":79,
+	"id": "sm7-140",
     "name": "PokéNav",
     "imageUrl": "https://images.pokemontcg.io/sm7/140.png",
     "subtype": "Item",
@@ -6692,7 +6832,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/140_hires.png"
   },
   {
-    "id": "sm7-141",
+    "setOrder":79,
+	"id": "sm7-141",
     "name": "Rainbow Brush",
     "imageUrl": "https://images.pokemontcg.io/sm7/141.png",
     "subtype": "Item",
@@ -6710,7 +6851,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/141_hires.png"
   },
   {
-    "id": "sm7-142",
+    "setOrder":79,
+	"id": "sm7-142",
     "name": "Rare Candy",
     "imageUrl": "https://images.pokemontcg.io/sm7/142.png",
     "subtype": "Item",
@@ -6728,7 +6870,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/142_hires.png"
   },
   {
-    "id": "sm7-143",
+    "setOrder":79,
+	"id": "sm7-143",
     "name": "Shrine of Punishment",
     "imageUrl": "https://images.pokemontcg.io/sm7/143.png",
     "subtype": "Stadium",
@@ -6746,7 +6889,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/143_hires.png"
   },
   {
-    "id": "sm7-144",
+    "setOrder":79,
+	"id": "sm7-144",
     "name": "Sky Pillar",
     "imageUrl": "https://images.pokemontcg.io/sm7/144.png",
     "subtype": "Stadium",
@@ -6764,7 +6908,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/144_hires.png"
   },
   {
-    "id": "sm7-145",
+    "setOrder":79,
+	"id": "sm7-145",
     "name": "Steven's Resolve",
     "imageUrl": "https://images.pokemontcg.io/sm7/145.png",
     "subtype": "Supporter",
@@ -6782,7 +6927,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/145_hires.png"
   },
   {
-    "id": "sm7-146",
+    "setOrder":79,
+	"id": "sm7-146",
     "name": "Super Scoop Up",
     "imageUrl": "https://images.pokemontcg.io/sm7/146.png",
     "subtype": "Item",
@@ -6800,7 +6946,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/146_hires.png"
   },
   {
-    "id": "sm7-147",
+    "setOrder":79,
+	"id": "sm7-147",
     "name": "Switch",
     "imageUrl": "https://images.pokemontcg.io/sm7/147.png",
     "subtype": "Item",
@@ -6818,7 +6965,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/147_hires.png"
   },
   {
-    "id": "sm7-148",
+    "setOrder":79,
+	"id": "sm7-148",
     "name": "Tate & Liza",
     "imageUrl": "https://images.pokemontcg.io/sm7/148.png",
     "subtype": "Supporter",
@@ -6836,7 +6984,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/148_hires.png"
   },
   {
-    "id": "sm7-149",
+    "setOrder":79,
+	"id": "sm7-149",
     "name": "TV Reporter",
     "imageUrl": "https://images.pokemontcg.io/sm7/149.png",
     "subtype": "Supporter",
@@ -6854,7 +7003,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/149_hires.png"
   },
   {
-    "id": "sm7-150",
+    "setOrder":79,
+	"id": "sm7-150",
     "name": "Underground Expedition",
     "imageUrl": "https://images.pokemontcg.io/sm7/150.png",
     "subtype": "Supporter",
@@ -6872,7 +7022,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/150_hires.png"
   },
   {
-    "id": "sm7-151",
+    "setOrder":79,
+	"id": "sm7-151",
     "name": "Rainbow Energy",
     "imageUrl": "https://images.pokemontcg.io/sm7/151.png",
     "subtype": "Special",
@@ -6890,7 +7041,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/151_hires.png"
   },
   {
-    "id": "sm7-152",
+    "setOrder":79,
+	"id": "sm7-152",
     "name": "Shiftry-GX",
     "imageUrl": "https://images.pokemontcg.io/sm7/152.png",
     "subtype": "GX",
@@ -6958,7 +7110,8 @@
     "nationalPokedexNumber": 275
   },
   {
-    "id": "sm7-153",
+    "setOrder":79,
+	"id": "sm7-153",
     "name": "Blaziken-GX",
     "imageUrl": "https://images.pokemontcg.io/sm7/153.png",
     "subtype": "GX",
@@ -7024,7 +7177,8 @@
     "nationalPokedexNumber": 257
   },
   {
-    "id": "sm7-154",
+    "setOrder":79,
+	"id": "sm7-154",
     "name": "Articuno-GX",
     "imageUrl": "https://images.pokemontcg.io/sm7/154.png",
     "subtype": "GX",
@@ -7085,7 +7239,8 @@
     "nationalPokedexNumber": 144
   },
   {
-    "id": "sm7-155",
+    "setOrder":79,
+	"id": "sm7-155",
     "name": "Electrode-GX",
     "imageUrl": "https://images.pokemontcg.io/sm7/155.png",
     "subtype": "GX",
@@ -7152,7 +7307,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "sm7-156",
+    "setOrder":79,
+	"id": "sm7-156",
     "name": "Mr. Mime-GX",
     "imageUrl": "https://images.pokemontcg.io/sm7/156.png",
     "subtype": "GX",
@@ -7206,7 +7362,8 @@
     "nationalPokedexNumber": 122
   },
   {
-    "id": "sm7-157",
+    "setOrder":79,
+	"id": "sm7-157",
     "name": "Banette-GX",
     "imageUrl": "https://images.pokemontcg.io/sm7/157.png",
     "subtype": "GX",
@@ -7271,7 +7428,8 @@
     "nationalPokedexNumber": 354
   },
   {
-    "id": "sm7-158",
+    "setOrder":79,
+	"id": "sm7-158",
     "name": "Scizor-GX",
     "imageUrl": "https://images.pokemontcg.io/sm7/158.png",
     "subtype": "GX",
@@ -7339,7 +7497,8 @@
     "nationalPokedexNumber": 212
   },
   {
-    "id": "sm7-159",
+    "setOrder":79,
+	"id": "sm7-159",
     "name": "Stakataka-GX",
     "imageUrl": "https://images.pokemontcg.io/sm7/159.png",
     "subtype": "GX",
@@ -7408,7 +7567,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/159_hires.png"
   },
   {
-    "id": "sm7-160",
+    "setOrder":79,
+	"id": "sm7-160",
     "name": "Rayquaza-GX",
     "imageUrl": "https://images.pokemontcg.io/sm7/160.png",
     "subtype": "GX",
@@ -7470,7 +7630,8 @@
     "nationalPokedexNumber": 384
   },
   {
-    "id": "sm7-161",
+    "setOrder":79,
+	"id": "sm7-161",
     "name": "Apricorn Maker",
     "imageUrl": "https://images.pokemontcg.io/sm7/161.png",
     "subtype": "Supporter",
@@ -7488,7 +7649,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/161_hires.png"
   },
   {
-    "id": "sm7-162",
+    "setOrder":79,
+	"id": "sm7-162",
     "name": "Bill's Maintenance",
     "imageUrl": "https://images.pokemontcg.io/sm7/162.png",
     "subtype": "Supporter",
@@ -7506,7 +7668,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/162_hires.png"
   },
   {
-    "id": "sm7-163",
+    "setOrder":79,
+	"id": "sm7-163",
     "name": "Copycat",
     "imageUrl": "https://images.pokemontcg.io/sm7/163.png",
     "subtype": "Supporter",
@@ -7524,7 +7687,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/163_hires.png"
   },
   {
-    "id": "sm7-164",
+    "setOrder":79,
+	"id": "sm7-164",
     "name": "Lisia",
     "imageUrl": "https://images.pokemontcg.io/sm7/164.png",
     "subtype": "Supporter",
@@ -7542,7 +7706,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/164_hires.png"
   },
   {
-    "id": "sm7-165",
+    "setOrder":79,
+	"id": "sm7-165",
     "name": "Steven's Resolve",
     "imageUrl": "https://images.pokemontcg.io/sm7/165.png",
     "subtype": "Supporter",
@@ -7560,7 +7725,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/165_hires.png"
   },
   {
-    "id": "sm7-166",
+    "setOrder":79,
+	"id": "sm7-166",
     "name": "Tate & Liza",
     "imageUrl": "https://images.pokemontcg.io/sm7/166.png",
     "subtype": "Supporter",
@@ -7578,7 +7744,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/166_hires.png"
   },
   {
-    "id": "sm7-167",
+    "setOrder":79,
+	"id": "sm7-167",
     "name": "TV Reporter",
     "imageUrl": "https://images.pokemontcg.io/sm7/167.png",
     "subtype": "Supporter",
@@ -7596,7 +7763,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm7/167_hires.png"
   },
   {
-    "id": "sm7-168",
+    "setOrder":79,
+	"id": "sm7-168",
     "name": "Underground Expedition",
     "imageUrl": "https://images.pokemontcg.io/sm7/168.png",
     "subtype": "Supporter",

--- a/json/cards/Crimson Invasion.json
+++ b/json/cards/Crimson Invasion.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "sm4-1",
+    "setOrder":76,
+	"id": "sm4-1",
     "name": "Weedle",
     "imageUrl": "https://images.pokemontcg.io/sm4/1.png",
     "subtype": "Basic",
@@ -43,7 +44,8 @@
     ]
   },
   {
-    "id": "sm4-2",
+    "setOrder":76,
+	"id": "sm4-2",
     "name": "Kakuna",
     "imageUrl": "https://images.pokemontcg.io/sm4/2.png",
     "subtype": "Stage 1",
@@ -88,7 +90,8 @@
     ]
   },
   {
-    "id": "sm4-3",
+    "setOrder":76,
+	"id": "sm4-3",
     "name": "Beedrill",
     "imageUrl": "https://images.pokemontcg.io/sm4/3.png",
     "subtype": "Stage 2",
@@ -135,7 +138,8 @@
     "nationalPokedexNumber": 15
   },
   {
-    "id": "sm4-4",
+    "setOrder":76,
+	"id": "sm4-4",
     "name": "Exeggcute",
     "imageUrl": "https://images.pokemontcg.io/sm4/4.png",
     "subtype": "Basic",
@@ -187,7 +191,8 @@
     ]
   },
   {
-    "id": "sm4-5",
+    "setOrder":76,
+	"id": "sm4-5",
     "name": "Cacnea",
     "imageUrl": "https://images.pokemontcg.io/sm4/5.png",
     "subtype": "Basic",
@@ -230,7 +235,8 @@
     ]
   },
   {
-    "id": "sm4-6",
+    "setOrder":76,
+	"id": "sm4-6",
     "name": "Cacturne",
     "imageUrl": "https://images.pokemontcg.io/sm4/6.png",
     "subtype": "Stage 1",
@@ -282,7 +288,8 @@
     "nationalPokedexNumber": 332
   },
   {
-    "id": "sm4-7",
+    "setOrder":76,
+	"id": "sm4-7",
     "name": "Karrablast",
     "imageUrl": "https://images.pokemontcg.io/sm4/7.png",
     "subtype": "Basic",
@@ -333,7 +340,8 @@
     ]
   },
   {
-    "id": "sm4-8",
+    "setOrder":76,
+	"id": "sm4-8",
     "name": "Shelmet",
     "imageUrl": "https://images.pokemontcg.io/sm4/8.png",
     "subtype": "Basic",
@@ -378,7 +386,8 @@
     ]
   },
   {
-    "id": "sm4-9",
+    "setOrder":76,
+	"id": "sm4-9",
     "name": "Accelgor",
     "imageUrl": "https://images.pokemontcg.io/sm4/9.png",
     "subtype": "Stage 1",
@@ -429,7 +438,8 @@
     "nationalPokedexNumber": 617
   },
   {
-    "id": "sm4-10",
+    "setOrder":76,
+	"id": "sm4-10",
     "name": "Skiddo",
     "imageUrl": "https://images.pokemontcg.io/sm4/10.png",
     "subtype": "Basic",
@@ -473,7 +483,8 @@
     ]
   },
   {
-    "id": "sm4-11",
+    "setOrder":76,
+	"id": "sm4-11",
     "name": "Gogoat",
     "imageUrl": "https://images.pokemontcg.io/sm4/11.png",
     "subtype": "Stage 1",
@@ -522,7 +533,8 @@
     "nationalPokedexNumber": 673
   },
   {
-    "id": "sm4-12",
+    "setOrder":76,
+	"id": "sm4-12",
     "name": "Alolan Marowak",
     "imageUrl": "https://images.pokemontcg.io/sm4/12.png",
     "subtype": "Stage 1",
@@ -575,7 +587,8 @@
     "nationalPokedexNumber": 105
   },
   {
-    "id": "sm4-13",
+    "setOrder":76,
+	"id": "sm4-13",
     "name": "Numel",
     "imageUrl": "https://images.pokemontcg.io/sm4/13.png",
     "subtype": "Basic",
@@ -621,7 +634,8 @@
     ]
   },
   {
-    "id": "sm4-14",
+    "setOrder":76,
+	"id": "sm4-14",
     "name": "Camerupt",
     "imageUrl": "https://images.pokemontcg.io/sm4/14.png",
     "subtype": "Stage 1",
@@ -679,7 +693,8 @@
     "nationalPokedexNumber": 323
   },
   {
-    "id": "sm4-15",
+    "setOrder":76,
+	"id": "sm4-15",
     "name": "Staryu",
     "imageUrl": "https://images.pokemontcg.io/sm4/15.png",
     "subtype": "Basic",
@@ -722,7 +737,8 @@
     ]
   },
   {
-    "id": "sm4-16",
+    "setOrder":76,
+	"id": "sm4-16",
     "name": "Starmie",
     "imageUrl": "https://images.pokemontcg.io/sm4/16.png",
     "subtype": "Stage 1",
@@ -768,7 +784,8 @@
     "nationalPokedexNumber": 121
   },
   {
-    "id": "sm4-17",
+    "setOrder":76,
+	"id": "sm4-17",
     "name": "Magikarp",
     "imageUrl": "https://images.pokemontcg.io/sm4/17.png",
     "subtype": "Basic",
@@ -818,7 +835,8 @@
     ]
   },
   {
-    "id": "sm4-18",
+    "setOrder":76,
+	"id": "sm4-18",
     "name": "Gyarados-GX",
     "imageUrl": "https://images.pokemontcg.io/sm4/18.png",
     "subtype": "GX",
@@ -890,7 +908,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "sm4-19",
+    "setOrder":76,
+	"id": "sm4-19",
     "name": "Swinub",
     "imageUrl": "https://images.pokemontcg.io/sm4/19.png",
     "subtype": "Basic",
@@ -936,7 +955,8 @@
     ]
   },
   {
-    "id": "sm4-20",
+    "setOrder":76,
+	"id": "sm4-20",
     "name": "Piloswine",
     "imageUrl": "https://images.pokemontcg.io/sm4/20.png",
     "subtype": "Stage 1",
@@ -995,7 +1015,8 @@
     ]
   },
   {
-    "id": "sm4-21",
+    "setOrder":76,
+	"id": "sm4-21",
     "name": "Mamoswine",
     "imageUrl": "https://images.pokemontcg.io/sm4/21.png",
     "subtype": "Stage 2",
@@ -1053,7 +1074,8 @@
     "nationalPokedexNumber": 473
   },
   {
-    "id": "sm4-22",
+    "setOrder":76,
+	"id": "sm4-22",
     "name": "Remoraid",
     "imageUrl": "https://images.pokemontcg.io/sm4/22.png",
     "subtype": "Basic",
@@ -1097,7 +1119,8 @@
     ]
   },
   {
-    "id": "sm4-23",
+    "setOrder":76,
+	"id": "sm4-23",
     "name": "Octillery",
     "imageUrl": "https://images.pokemontcg.io/sm4/23.png",
     "subtype": "Stage 1",
@@ -1149,7 +1172,8 @@
     "nationalPokedexNumber": 224
   },
   {
-    "id": "sm4-24",
+    "setOrder":76,
+	"id": "sm4-24",
     "name": "Corphish",
     "imageUrl": "https://images.pokemontcg.io/sm4/24.png",
     "subtype": "Basic",
@@ -1194,7 +1218,8 @@
     ]
   },
   {
-    "id": "sm4-25",
+    "setOrder":76,
+	"id": "sm4-25",
     "name": "Crawdaunt",
     "imageUrl": "https://images.pokemontcg.io/sm4/25.png",
     "subtype": "Stage 1",
@@ -1239,7 +1264,8 @@
     "nationalPokedexNumber": 342
   },
   {
-    "id": "sm4-26",
+    "setOrder":76,
+	"id": "sm4-26",
     "name": "Feebas",
     "imageUrl": "https://images.pokemontcg.io/sm4/26.png",
     "subtype": "Basic",
@@ -1282,7 +1308,8 @@
     ]
   },
   {
-    "id": "sm4-27",
+    "setOrder":76,
+	"id": "sm4-27",
     "name": "Milotic",
     "imageUrl": "https://images.pokemontcg.io/sm4/27.png",
     "subtype": "Stage 1",
@@ -1336,7 +1363,8 @@
     "nationalPokedexNumber": 350
   },
   {
-    "id": "sm4-28",
+    "setOrder":76,
+	"id": "sm4-28",
     "name": "Regice",
     "imageUrl": "https://images.pokemontcg.io/sm4/28.png",
     "subtype": "Basic",
@@ -1385,7 +1413,8 @@
     "nationalPokedexNumber": 378
   },
   {
-    "id": "sm4-29",
+    "setOrder":76,
+	"id": "sm4-29",
     "name": "Shellos",
     "imageUrl": "https://images.pokemontcg.io/sm4/29.png",
     "subtype": "Basic",
@@ -1437,7 +1466,8 @@
     ]
   },
   {
-    "id": "sm4-30",
+    "setOrder":76,
+	"id": "sm4-30",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/sm4/30.png",
     "subtype": "Basic",
@@ -1496,7 +1526,8 @@
     ]
   },
   {
-    "id": "sm4-31",
+    "setOrder":76,
+	"id": "sm4-31",
     "name": "Alolan Raichu",
     "imageUrl": "https://images.pokemontcg.io/sm4/31.png",
     "subtype": "Stage 1",
@@ -1551,7 +1582,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "sm4-32",
+    "setOrder":76,
+	"id": "sm4-32",
     "name": "Alolan Geodude",
     "imageUrl": "https://images.pokemontcg.io/sm4/32.png",
     "subtype": "Basic",
@@ -1611,7 +1643,8 @@
     ]
   },
   {
-    "id": "sm4-33",
+    "setOrder":76,
+	"id": "sm4-33",
     "name": "Alolan Graveler",
     "imageUrl": "https://images.pokemontcg.io/sm4/33.png",
     "subtype": "Stage 1",
@@ -1675,7 +1708,8 @@
     ]
   },
   {
-    "id": "sm4-34",
+    "setOrder":76,
+	"id": "sm4-34",
     "name": "Alolan Golem-GX",
     "imageUrl": "https://images.pokemontcg.io/sm4/34.png",
     "subtype": "GX",
@@ -1755,7 +1789,8 @@
     "nationalPokedexNumber": 76
   },
   {
-    "id": "sm4-35",
+    "setOrder":76,
+	"id": "sm4-35",
     "name": "Emolga",
     "imageUrl": "https://images.pokemontcg.io/sm4/35.png",
     "subtype": "Basic",
@@ -1810,7 +1845,8 @@
     "nationalPokedexNumber": 587
   },
   {
-    "id": "sm4-36",
+    "setOrder":76,
+	"id": "sm4-36",
     "name": "Gastly",
     "imageUrl": "https://images.pokemontcg.io/sm4/36.png",
     "subtype": "Basic",
@@ -1859,7 +1895,8 @@
     ]
   },
   {
-    "id": "sm4-37",
+    "setOrder":76,
+	"id": "sm4-37",
     "name": "Haunter",
     "imageUrl": "https://images.pokemontcg.io/sm4/37.png",
     "subtype": "Stage 1",
@@ -1909,7 +1946,8 @@
     ]
   },
   {
-    "id": "sm4-38",
+    "setOrder":76,
+	"id": "sm4-38",
     "name": "Gengar",
     "imageUrl": "https://images.pokemontcg.io/sm4/38.png",
     "subtype": "Stage 2",
@@ -1960,7 +1998,8 @@
     "nationalPokedexNumber": 94
   },
   {
-    "id": "sm4-39",
+    "setOrder":76,
+	"id": "sm4-39",
     "name": "Misdreavus",
     "imageUrl": "https://images.pokemontcg.io/sm4/39.png",
     "subtype": "Basic",
@@ -2009,7 +2048,8 @@
     ]
   },
   {
-    "id": "sm4-40",
+    "setOrder":76,
+	"id": "sm4-40",
     "name": "Mismagius",
     "imageUrl": "https://images.pokemontcg.io/sm4/40.png",
     "subtype": "Stage 1",
@@ -2067,7 +2107,8 @@
     "nationalPokedexNumber": 429
   },
   {
-    "id": "sm4-41",
+    "setOrder":76,
+	"id": "sm4-41",
     "name": "Spoink",
     "imageUrl": "https://images.pokemontcg.io/sm4/41.png",
     "subtype": "Basic",
@@ -2110,7 +2151,8 @@
     ]
   },
   {
-    "id": "sm4-42",
+    "setOrder":76,
+	"id": "sm4-42",
     "name": "Grumpig",
     "imageUrl": "https://images.pokemontcg.io/sm4/42.png",
     "subtype": "Stage 1",
@@ -2159,7 +2201,8 @@
     "nationalPokedexNumber": 326
   },
   {
-    "id": "sm4-43",
+    "setOrder":76,
+	"id": "sm4-43",
     "name": "Chimecho",
     "imageUrl": "https://images.pokemontcg.io/sm4/43.png",
     "subtype": "Basic",
@@ -2199,7 +2242,8 @@
     "nationalPokedexNumber": 358
   },
   {
-    "id": "sm4-44",
+    "setOrder":76,
+	"id": "sm4-44",
     "name": "Pumpkaboo",
     "imageUrl": "https://images.pokemontcg.io/sm4/44.png",
     "subtype": "Basic",
@@ -2249,7 +2293,8 @@
     ]
   },
   {
-    "id": "sm4-45",
+    "setOrder":76,
+	"id": "sm4-45",
     "name": "Gourgeist",
     "imageUrl": "https://images.pokemontcg.io/sm4/45.png",
     "subtype": "Stage 1",
@@ -2308,7 +2353,8 @@
     "nationalPokedexNumber": 711
   },
   {
-    "id": "sm4-46",
+    "setOrder":76,
+	"id": "sm4-46",
     "name": "Salandit",
     "imageUrl": "https://images.pokemontcg.io/sm4/46.png",
     "subtype": "Basic",
@@ -2351,7 +2397,8 @@
     ]
   },
   {
-    "id": "sm4-47",
+    "setOrder":76,
+	"id": "sm4-47",
     "name": "Salazzle",
     "imageUrl": "https://images.pokemontcg.io/sm4/47.png",
     "subtype": "Stage 1",
@@ -2401,7 +2448,8 @@
     "nationalPokedexNumber": 758
   },
   {
-    "id": "sm4-48",
+    "setOrder":76,
+	"id": "sm4-48",
     "name": "Oranguru",
     "imageUrl": "https://images.pokemontcg.io/sm4/48.png",
     "subtype": "Basic",
@@ -2453,7 +2501,8 @@
     "nationalPokedexNumber": 765
   },
   {
-    "id": "sm4-49",
+    "setOrder":76,
+	"id": "sm4-49",
     "name": "Nihilego-GX",
     "imageUrl": "https://images.pokemontcg.io/sm4/49.png",
     "subtype": "GX",
@@ -2516,7 +2565,8 @@
     "nationalPokedexNumber": 793
   },
   {
-    "id": "sm4-50",
+    "setOrder":76,
+	"id": "sm4-50",
     "name": "Mankey",
     "imageUrl": "https://images.pokemontcg.io/sm4/50.png",
     "subtype": "Basic",
@@ -2559,7 +2609,8 @@
     ]
   },
   {
-    "id": "sm4-51",
+    "setOrder":76,
+	"id": "sm4-51",
     "name": "Primeape",
     "imageUrl": "https://images.pokemontcg.io/sm4/51.png",
     "subtype": "Stage 1",
@@ -2611,7 +2662,8 @@
     "nationalPokedexNumber": 57
   },
   {
-    "id": "sm4-52",
+    "setOrder":76,
+	"id": "sm4-52",
     "name": "Cubone",
     "imageUrl": "https://images.pokemontcg.io/sm4/52.png",
     "subtype": "Basic",
@@ -2665,7 +2717,8 @@
     ]
   },
   {
-    "id": "sm4-53",
+    "setOrder":76,
+	"id": "sm4-53",
     "name": "Regirock",
     "imageUrl": "https://images.pokemontcg.io/sm4/53.png",
     "subtype": "Basic",
@@ -2714,7 +2767,8 @@
     "nationalPokedexNumber": 377
   },
   {
-    "id": "sm4-54",
+    "setOrder":76,
+	"id": "sm4-54",
     "name": "Gastrodon",
     "imageUrl": "https://images.pokemontcg.io/sm4/54.png",
     "subtype": "Stage 1",
@@ -2769,7 +2823,8 @@
     "nationalPokedexNumber": 423
   },
   {
-    "id": "sm4-55",
+    "setOrder":76,
+	"id": "sm4-55",
     "name": "Stufful",
     "imageUrl": "https://images.pokemontcg.io/sm4/55.png",
     "subtype": "Basic",
@@ -2814,7 +2869,8 @@
     ]
   },
   {
-    "id": "sm4-56",
+    "setOrder":76,
+	"id": "sm4-56",
     "name": "Bewear",
     "imageUrl": "https://images.pokemontcg.io/sm4/56.png",
     "subtype": "Stage 1",
@@ -2864,7 +2920,8 @@
     "nationalPokedexNumber": 760
   },
   {
-    "id": "sm4-57",
+    "setOrder":76,
+	"id": "sm4-57",
     "name": "Buzzwole-GX",
     "imageUrl": "https://images.pokemontcg.io/sm4/57.png",
     "subtype": "GX",
@@ -2931,7 +2988,8 @@
     "nationalPokedexNumber": 794
   },
   {
-    "id": "sm4-58",
+    "setOrder":76,
+	"id": "sm4-58",
     "name": "Houndour",
     "imageUrl": "https://images.pokemontcg.io/sm4/58.png",
     "subtype": "Basic",
@@ -2990,7 +3048,8 @@
     ]
   },
   {
-    "id": "sm4-59",
+    "setOrder":76,
+	"id": "sm4-59",
     "name": "Houndoom",
     "imageUrl": "https://images.pokemontcg.io/sm4/59.png",
     "subtype": "Stage 1",
@@ -3049,7 +3108,8 @@
     "nationalPokedexNumber": 229
   },
   {
-    "id": "sm4-60",
+    "setOrder":76,
+	"id": "sm4-60",
     "name": "Deino",
     "imageUrl": "https://images.pokemontcg.io/sm4/60.png",
     "subtype": "Basic",
@@ -3111,7 +3171,8 @@
     ]
   },
   {
-    "id": "sm4-61",
+    "setOrder":76,
+	"id": "sm4-61",
     "name": "Zweilous",
     "imageUrl": "https://images.pokemontcg.io/sm4/61.png",
     "subtype": "Stage 1",
@@ -3174,7 +3235,8 @@
     ]
   },
   {
-    "id": "sm4-62",
+    "setOrder":76,
+	"id": "sm4-62",
     "name": "Hydreigon",
     "imageUrl": "https://images.pokemontcg.io/sm4/62.png",
     "subtype": "Stage 2",
@@ -3229,7 +3291,8 @@
     "nationalPokedexNumber": 635
   },
   {
-    "id": "sm4-63",
+    "setOrder":76,
+	"id": "sm4-63",
     "name": "Guzzlord-GX",
     "imageUrl": "https://images.pokemontcg.io/sm4/63.png",
     "subtype": "GX",
@@ -3308,7 +3371,8 @@
     "nationalPokedexNumber": 799
   },
   {
-    "id": "sm4-63a",
+    "setOrder":76,
+	"id": "sm4-63a",
     "name": "Guzzlord-GX",
     "imageUrl": "https://images.pokemontcg.io/sm4/63a.png",
     "subtype": "GX",
@@ -3387,7 +3451,8 @@
     "nationalPokedexNumber": 799
   },
   {
-    "id": "sm4-64",
+    "setOrder":76,
+	"id": "sm4-64",
     "name": "Mawile",
     "imageUrl": "https://images.pokemontcg.io/sm4/64.png",
     "subtype": "Basic",
@@ -3443,7 +3508,8 @@
     "nationalPokedexNumber": 303
   },
   {
-    "id": "sm4-65",
+    "setOrder":76,
+	"id": "sm4-65",
     "name": "Aron",
     "imageUrl": "https://images.pokemontcg.io/sm4/65.png",
     "subtype": "Basic",
@@ -3503,7 +3569,8 @@
     ]
   },
   {
-    "id": "sm4-66",
+    "setOrder":76,
+	"id": "sm4-66",
     "name": "Lairon",
     "imageUrl": "https://images.pokemontcg.io/sm4/66.png",
     "subtype": "Stage 1",
@@ -3567,7 +3634,8 @@
     ]
   },
   {
-    "id": "sm4-67",
+    "setOrder":76,
+	"id": "sm4-67",
     "name": "Aggron",
     "imageUrl": "https://images.pokemontcg.io/sm4/67.png",
     "subtype": "Stage 2",
@@ -3631,7 +3699,8 @@
     "nationalPokedexNumber": 306
   },
   {
-    "id": "sm4-68",
+    "setOrder":76,
+	"id": "sm4-68",
     "name": "Registeel",
     "imageUrl": "https://images.pokemontcg.io/sm4/68.png",
     "subtype": "Basic",
@@ -3690,7 +3759,8 @@
     "nationalPokedexNumber": 379
   },
   {
-    "id": "sm4-69",
+    "setOrder":76,
+	"id": "sm4-69",
     "name": "Escavalier",
     "imageUrl": "https://images.pokemontcg.io/sm4/69.png",
     "subtype": "Stage 1",
@@ -3749,7 +3819,8 @@
     "nationalPokedexNumber": 589
   },
   {
-    "id": "sm4-70",
+    "setOrder":76,
+	"id": "sm4-70",
     "name": "Kartana-GX",
     "imageUrl": "https://images.pokemontcg.io/sm4/70.png",
     "subtype": "GX",
@@ -3815,7 +3886,8 @@
     "nationalPokedexNumber": 798
   },
   {
-    "id": "sm4-71",
+    "setOrder":76,
+	"id": "sm4-71",
     "name": "Jigglypuff",
     "imageUrl": "https://images.pokemontcg.io/sm4/71.png",
     "subtype": "Basic",
@@ -3874,7 +3946,8 @@
     ]
   },
   {
-    "id": "sm4-72",
+    "setOrder":76,
+	"id": "sm4-72",
     "name": "Wigglytuff",
     "imageUrl": "https://images.pokemontcg.io/sm4/72.png",
     "subtype": "Stage 1",
@@ -3934,7 +4007,8 @@
     "nationalPokedexNumber": 40
   },
   {
-    "id": "sm4-73",
+    "setOrder":76,
+	"id": "sm4-73",
     "name": "Xerneas",
     "imageUrl": "https://images.pokemontcg.io/sm4/73.png",
     "subtype": "Basic",
@@ -3992,7 +4066,8 @@
     "nationalPokedexNumber": 716
   },
   {
-    "id": "sm4-74",
+    "setOrder":76,
+	"id": "sm4-74",
     "name": "Alolan Exeggutor-GX",
     "imageUrl": "https://images.pokemontcg.io/sm4/74.png",
     "subtype": "GX",
@@ -4063,7 +4138,8 @@
     "nationalPokedexNumber": 103
   },
   {
-    "id": "sm4-75",
+    "setOrder":76,
+	"id": "sm4-75",
     "name": "Jangmo-o",
     "imageUrl": "https://images.pokemontcg.io/sm4/75.png",
     "subtype": "Basic",
@@ -4116,7 +4192,8 @@
     ]
   },
   {
-    "id": "sm4-76",
+    "setOrder":76,
+	"id": "sm4-76",
     "name": "Hakamo-o",
     "imageUrl": "https://images.pokemontcg.io/sm4/76.png",
     "subtype": "Stage 1",
@@ -4170,7 +4247,8 @@
     ]
   },
   {
-    "id": "sm4-77",
+    "setOrder":76,
+	"id": "sm4-77",
     "name": "Kommo-o",
     "imageUrl": "https://images.pokemontcg.io/sm4/77.png",
     "subtype": "Stage 2",
@@ -4224,7 +4302,8 @@
     "nationalPokedexNumber": 784
   },
   {
-    "id": "sm4-78",
+    "setOrder":76,
+	"id": "sm4-78",
     "name": "Miltank",
     "imageUrl": "https://images.pokemontcg.io/sm4/78.png",
     "subtype": "Basic",
@@ -4272,7 +4351,8 @@
     "nationalPokedexNumber": 241
   },
   {
-    "id": "sm4-79",
+    "setOrder":76,
+	"id": "sm4-79",
     "name": "Swablu",
     "imageUrl": "https://images.pokemontcg.io/sm4/79.png",
     "subtype": "Basic",
@@ -4321,7 +4401,8 @@
     ]
   },
   {
-    "id": "sm4-80",
+    "setOrder":76,
+	"id": "sm4-80",
     "name": "Altaria",
     "imageUrl": "https://images.pokemontcg.io/sm4/80.png",
     "subtype": "Stage 1",
@@ -4377,7 +4458,8 @@
     "nationalPokedexNumber": 334
   },
   {
-    "id": "sm4-81",
+    "setOrder":76,
+	"id": "sm4-81",
     "name": "Starly",
     "imageUrl": "https://images.pokemontcg.io/sm4/81.png",
     "subtype": "Basic",
@@ -4436,7 +4518,8 @@
     ]
   },
   {
-    "id": "sm4-82",
+    "setOrder":76,
+	"id": "sm4-82",
     "name": "Staravia",
     "imageUrl": "https://images.pokemontcg.io/sm4/82.png",
     "subtype": "Stage 1",
@@ -4497,7 +4580,8 @@
     ]
   },
   {
-    "id": "sm4-83",
+    "setOrder":76,
+	"id": "sm4-83",
     "name": "Staraptor",
     "imageUrl": "https://images.pokemontcg.io/sm4/83.png",
     "subtype": "Stage 2",
@@ -4557,7 +4641,8 @@
     "nationalPokedexNumber": 398
   },
   {
-    "id": "sm4-84",
+    "setOrder":76,
+	"id": "sm4-84",
     "name": "Regigigas",
     "imageUrl": "https://images.pokemontcg.io/sm4/84.png",
     "subtype": "Basic",
@@ -4609,7 +4694,8 @@
     "nationalPokedexNumber": 486
   },
   {
-    "id": "sm4-85",
+    "setOrder":76,
+	"id": "sm4-85",
     "name": "Minccino",
     "imageUrl": "https://images.pokemontcg.io/sm4/85.png",
     "subtype": "Basic",
@@ -4652,7 +4738,8 @@
     ]
   },
   {
-    "id": "sm4-86",
+    "setOrder":76,
+	"id": "sm4-86",
     "name": "Cinccino",
     "imageUrl": "https://images.pokemontcg.io/sm4/86.png",
     "subtype": "Stage 1",
@@ -4693,7 +4780,8 @@
     "nationalPokedexNumber": 573
   },
   {
-    "id": "sm4-87",
+    "setOrder":76,
+	"id": "sm4-87",
     "name": "Bunnelby",
     "imageUrl": "https://images.pokemontcg.io/sm4/87.png",
     "subtype": "Basic",
@@ -4738,7 +4826,8 @@
     ]
   },
   {
-    "id": "sm4-88",
+    "setOrder":76,
+	"id": "sm4-88",
     "name": "Diggersby",
     "imageUrl": "https://images.pokemontcg.io/sm4/88.png",
     "subtype": "Stage 1",
@@ -4795,7 +4884,8 @@
     "nationalPokedexNumber": 660
   },
   {
-    "id": "sm4-89",
+    "setOrder":76,
+	"id": "sm4-89",
     "name": "Type: Null",
     "imageUrl": "https://images.pokemontcg.io/sm4/89.png",
     "subtype": "Basic",
@@ -4847,7 +4937,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm4/89_hires.png"
   },
   {
-    "id": "sm4-90",
+    "setOrder":76,
+	"id": "sm4-90",
     "name": "Silvally-GX",
     "imageUrl": "https://images.pokemontcg.io/sm4/90.png",
     "subtype": "GX",
@@ -4911,7 +5002,8 @@
     "nationalPokedexNumber": 773
   },
   {
-    "id": "sm4-91",
+    "setOrder":76,
+	"id": "sm4-91",
     "name": "Counter Catcher",
     "imageUrl": "https://images.pokemontcg.io/sm4/91.png",
     "subtype": "Item",
@@ -4928,7 +5020,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm4/91_hires.png"
   },
   {
-    "id": "sm4-92",
+    "setOrder":76,
+	"id": "sm4-92",
     "name": "Dashing Pouch",
     "imageUrl": "https://images.pokemontcg.io/sm4/92.png",
     "subtype": "Pokémon Tool",
@@ -4945,7 +5038,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm4/92_hires.png"
   },
   {
-    "id": "sm4-93",
+    "setOrder":76,
+	"id": "sm4-93",
     "name": "Devoured Field",
     "imageUrl": "https://images.pokemontcg.io/sm4/93.png",
     "subtype": "Stadium",
@@ -4962,7 +5056,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm4/93_hires.png"
   },
   {
-    "id": "sm4-94",
+    "setOrder":76,
+	"id": "sm4-94",
     "name": "Fighting Memory",
     "imageUrl": "https://images.pokemontcg.io/sm4/94.png",
     "subtype": "Pokémon Tool",
@@ -4979,7 +5074,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm4/94_hires.png"
   },
   {
-    "id": "sm4-95",
+    "setOrder":76,
+	"id": "sm4-95",
     "name": "Gladion",
     "imageUrl": "https://images.pokemontcg.io/sm4/95.png",
     "subtype": "Supporter",
@@ -4996,7 +5092,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm4/95_hires.png"
   },
   {
-    "id": "sm4-96",
+    "setOrder":76,
+	"id": "sm4-96",
     "name": "Lusamine",
     "imageUrl": "https://images.pokemontcg.io/sm4/96.png",
     "subtype": "Supporter",
@@ -5013,7 +5110,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm4/96_hires.png"
   },
   {
-    "id": "sm4-97",
+    "setOrder":76,
+	"id": "sm4-97",
     "name": "Peeking Red Card",
     "imageUrl": "https://images.pokemontcg.io/sm4/97.png",
     "subtype": "Item",
@@ -5030,7 +5128,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm4/97_hires.png"
   },
   {
-    "id": "sm4-98",
+    "setOrder":76,
+	"id": "sm4-98",
     "name": "Psychic Memory",
     "imageUrl": "https://images.pokemontcg.io/sm4/98.png",
     "subtype": "Pokémon Tool",
@@ -5047,7 +5146,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm4/98_hires.png"
   },
   {
-    "id": "sm4-99",
+    "setOrder":76,
+	"id": "sm4-99",
     "name": "Sea of Nothingness",
     "imageUrl": "https://images.pokemontcg.io/sm4/99.png",
     "subtype": "Stadium",
@@ -5064,7 +5164,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm4/99_hires.png"
   },
   {
-    "id": "sm4-100",
+    "setOrder":76,
+	"id": "sm4-100",
     "name": "Counter Energy",
     "imageUrl": "https://images.pokemontcg.io/sm4/100.png",
     "subtype": "Special",
@@ -5081,7 +5182,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm4/100_hires.png"
   },
   {
-    "id": "sm4-101",
+    "setOrder":76,
+	"id": "sm4-101",
     "name": "Gyarados-GX",
     "imageUrl": "https://images.pokemontcg.io/sm4/101.png",
     "subtype": "GX",
@@ -5153,7 +5255,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "sm4-102",
+    "setOrder":76,
+	"id": "sm4-102",
     "name": "Alolan Golem-GX",
     "imageUrl": "https://images.pokemontcg.io/sm4/102.png",
     "subtype": "GX",
@@ -5233,7 +5336,8 @@
     "nationalPokedexNumber": 76
   },
   {
-    "id": "sm4-103",
+    "setOrder":76,
+	"id": "sm4-103",
     "name": "Nihilego-GX",
     "imageUrl": "https://images.pokemontcg.io/sm4/103.png",
     "subtype": "GX",
@@ -5296,7 +5400,8 @@
     "nationalPokedexNumber": 793
   },
   {
-    "id": "sm4-104",
+    "setOrder":76,
+	"id": "sm4-104",
     "name": "Buzzwole-GX",
     "imageUrl": "https://images.pokemontcg.io/sm4/104.png",
     "subtype": "GX",
@@ -5363,7 +5468,8 @@
     "nationalPokedexNumber": 794
   },
   {
-    "id": "sm4-105",
+    "setOrder":76,
+	"id": "sm4-105",
     "name": "Guzzlord-GX",
     "imageUrl": "https://images.pokemontcg.io/sm4/105.png",
     "subtype": "GX",
@@ -5442,7 +5548,8 @@
     "nationalPokedexNumber": 799
   },
   {
-    "id": "sm4-106",
+    "setOrder":76,
+	"id": "sm4-106",
     "name": "Kartana-GX",
     "imageUrl": "https://images.pokemontcg.io/sm4/106.png",
     "subtype": "GX",
@@ -5508,7 +5615,8 @@
     "nationalPokedexNumber": 798
   },
   {
-    "id": "sm4-107",
+    "setOrder":76,
+	"id": "sm4-107",
     "name": "Alolan Exeggutor-GX",
     "imageUrl": "https://images.pokemontcg.io/sm4/107.png",
     "subtype": "GX",
@@ -5579,7 +5687,8 @@
     "nationalPokedexNumber": 103
   },
   {
-    "id": "sm4-108",
+    "setOrder":76,
+	"id": "sm4-108",
     "name": "Silvally-GX",
     "imageUrl": "https://images.pokemontcg.io/sm4/108.png",
     "subtype": "GX",
@@ -5643,7 +5752,8 @@
     "nationalPokedexNumber": 773
   },
   {
-    "id": "sm4-109",
+    "setOrder":76,
+	"id": "sm4-109",
     "name": "Gladion",
     "imageUrl": "https://images.pokemontcg.io/sm4/109.png",
     "subtype": "Supporter",
@@ -5660,7 +5770,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm4/109_hires.png"
   },
   {
-    "id": "sm4-110",
+    "setOrder":76,
+	"id": "sm4-110",
     "name": "Lusamine",
     "imageUrl": "https://images.pokemontcg.io/sm4/110.png",
     "subtype": "Supporter",
@@ -5677,7 +5788,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm4/110_hires.png"
   },
   {
-    "id": "sm4-111",
+    "setOrder":76,
+	"id": "sm4-111",
     "name": "Olivia",
     "imageUrl": "https://images.pokemontcg.io/sm4/111.png",
     "subtype": "Supporter",
@@ -5694,7 +5806,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm4/111_hires.png"
   },
   {
-    "id": "sm4-112",
+    "setOrder":76,
+	"id": "sm4-112",
     "name": "Gyarados-GX",
     "imageUrl": "https://images.pokemontcg.io/sm4/112.png",
     "subtype": "GX",
@@ -5766,7 +5879,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "sm4-113",
+    "setOrder":76,
+	"id": "sm4-113",
     "name": "Alolan Golem-GX",
     "imageUrl": "https://images.pokemontcg.io/sm4/113.png",
     "subtype": "GX",
@@ -5846,7 +5960,8 @@
     "nationalPokedexNumber": 76
   },
   {
-    "id": "sm4-114",
+    "setOrder":76,
+	"id": "sm4-114",
     "name": "Nihilego-GX",
     "imageUrl": "https://images.pokemontcg.io/sm4/114.png",
     "subtype": "GX",
@@ -5909,7 +6024,8 @@
     "nationalPokedexNumber": 793
   },
   {
-    "id": "sm4-115",
+    "setOrder":76,
+	"id": "sm4-115",
     "name": "Buzzwole-GX",
     "imageUrl": "https://images.pokemontcg.io/sm4/115.png",
     "subtype": "GX",
@@ -5976,7 +6092,8 @@
     "nationalPokedexNumber": 794
   },
   {
-    "id": "sm4-116",
+    "setOrder":76,
+	"id": "sm4-116",
     "name": "Guzzlord-GX",
     "imageUrl": "https://images.pokemontcg.io/sm4/116.png",
     "subtype": "GX",
@@ -6055,7 +6172,8 @@
     "nationalPokedexNumber": 799
   },
   {
-    "id": "sm4-117",
+    "setOrder":76,
+	"id": "sm4-117",
     "name": "Kartana-GX",
     "imageUrl": "https://images.pokemontcg.io/sm4/117.png",
     "subtype": "GX",
@@ -6121,7 +6239,8 @@
     "nationalPokedexNumber": 798
   },
   {
-    "id": "sm4-118",
+    "setOrder":76,
+	"id": "sm4-118",
     "name": "Alolan Exeggutor-GX",
     "imageUrl": "https://images.pokemontcg.io/sm4/118.png",
     "subtype": "GX",
@@ -6192,7 +6311,8 @@
     "nationalPokedexNumber": 103
   },
   {
-    "id": "sm4-119",
+    "setOrder":76,
+	"id": "sm4-119",
     "name": "Silvally-GX",
     "imageUrl": "https://images.pokemontcg.io/sm4/119.png",
     "subtype": "GX",
@@ -6256,7 +6376,8 @@
     "nationalPokedexNumber": 773
   },
   {
-    "id": "sm4-120",
+    "setOrder":76,
+	"id": "sm4-120",
     "name": "Counter Catcher",
     "imageUrl": "https://images.pokemontcg.io/sm4/120.png",
     "subtype": "Item",
@@ -6273,7 +6394,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm4/120_hires.png"
   },
   {
-    "id": "sm4-121",
+    "setOrder":76,
+	"id": "sm4-121",
     "name": "Wishful Baton",
     "imageUrl": "https://images.pokemontcg.io/sm4/121.png",
     "subtype": "Pokémon Tool",
@@ -6290,7 +6412,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm4/121_hires.png"
   },
   {
-    "id": "sm4-122",
+    "setOrder":76,
+	"id": "sm4-122",
     "name": "Counter Energy",
     "imageUrl": "https://images.pokemontcg.io/sm4/122.png",
     "subtype": "Special",
@@ -6307,7 +6430,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm4/122_hires.png"
   },
   {
-    "id": "sm4-123",
+    "setOrder":76,
+	"id": "sm4-123",
     "name": "Warp Energy",
     "imageUrl": "https://images.pokemontcg.io/sm4/123.png",
     "subtype": "Special",
@@ -6324,7 +6448,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm4/123_hires.png"
   },
   {
-    "id": "sm4-124",
+    "setOrder":76,
+	"id": "sm4-124",
     "name": "Water Energy",
     "imageUrl": "https://images.pokemontcg.io/sm4/124.png",
     "subtype": "Basic",

--- a/json/cards/Crystal Guardians.json
+++ b/json/cards/Crystal Guardians.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "ex14-1",
+    "setOrder":29,
+	"id": "ex14-1",
     "name": "Banette",
     "imageUrl": "https://images.pokemontcg.io/ex14/1.png",
     "subtype": "Stage 1",
@@ -53,7 +54,8 @@
     "nationalPokedexNumber": 354
   },
   {
-    "id": "ex14-2",
+    "setOrder":29,
+	"id": "ex14-2",
     "name": "Blastoise δ",
     "imageUrl": "https://images.pokemontcg.io/ex14/2.png",
     "subtype": "Stage 2",
@@ -117,7 +119,8 @@
     "nationalPokedexNumber": 9
   },
   {
-    "id": "ex14-3",
+    "setOrder":29,
+	"id": "ex14-3",
     "name": "Camerupt",
     "imageUrl": "https://images.pokemontcg.io/ex14/3.png",
     "subtype": "Stage 1",
@@ -176,7 +179,8 @@
     "nationalPokedexNumber": 323
   },
   {
-    "id": "ex14-4",
+    "setOrder":29,
+	"id": "ex14-4",
     "name": "Charizard δ",
     "imageUrl": "https://images.pokemontcg.io/ex14/4.png",
     "subtype": "Stage 2",
@@ -230,7 +234,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "ex14-5",
+    "setOrder":29,
+	"id": "ex14-5",
     "name": "Dugtrio",
     "imageUrl": "https://images.pokemontcg.io/ex14/5.png",
     "subtype": "Stage 1",
@@ -288,7 +293,8 @@
     "nationalPokedexNumber": 51
   },
   {
-    "id": "ex14-6",
+    "setOrder":29,
+	"id": "ex14-6",
     "name": "Ludicolo δ",
     "imageUrl": "https://images.pokemontcg.io/ex14/6.png",
     "subtype": "Stage 2",
@@ -347,7 +353,8 @@
     "nationalPokedexNumber": 272
   },
   {
-    "id": "ex14-7",
+    "setOrder":29,
+	"id": "ex14-7",
     "name": "Luvdisc",
     "imageUrl": "https://images.pokemontcg.io/ex14/7.png",
     "subtype": "Basic",
@@ -396,7 +403,8 @@
     "nationalPokedexNumber": 370
   },
   {
-    "id": "ex14-8",
+    "setOrder":29,
+	"id": "ex14-8",
     "name": "Manectric",
     "imageUrl": "https://images.pokemontcg.io/ex14/8.png",
     "subtype": "Stage 1",
@@ -455,7 +463,8 @@
     "nationalPokedexNumber": 310
   },
   {
-    "id": "ex14-9",
+    "setOrder":29,
+	"id": "ex14-9",
     "name": "Mawile",
     "imageUrl": "https://images.pokemontcg.io/ex14/9.png",
     "subtype": "Basic",
@@ -511,7 +520,8 @@
     "nationalPokedexNumber": 303
   },
   {
-    "id": "ex14-10",
+    "setOrder":29,
+	"id": "ex14-10",
     "name": "Sableye",
     "imageUrl": "https://images.pokemontcg.io/ex14/10.png",
     "subtype": "Basic",
@@ -556,7 +566,8 @@
     "nationalPokedexNumber": 302
   },
   {
-    "id": "ex14-11",
+    "setOrder":29,
+	"id": "ex14-11",
     "name": "Swalot",
     "imageUrl": "https://images.pokemontcg.io/ex14/11.png",
     "subtype": "Stage 1",
@@ -609,7 +620,8 @@
     "nationalPokedexNumber": 317
   },
   {
-    "id": "ex14-12",
+    "setOrder":29,
+	"id": "ex14-12",
     "name": "Tauros",
     "imageUrl": "https://images.pokemontcg.io/ex14/12.png",
     "subtype": "Basic",
@@ -664,7 +676,8 @@
     "nationalPokedexNumber": 128
   },
   {
-    "id": "ex14-13",
+    "setOrder":29,
+	"id": "ex14-13",
     "name": "Wigglytuff",
     "imageUrl": "https://images.pokemontcg.io/ex14/13.png",
     "subtype": "Stage 1",
@@ -721,7 +734,8 @@
     "nationalPokedexNumber": 40
   },
   {
-    "id": "ex14-14",
+    "setOrder":29,
+	"id": "ex14-14",
     "name": "Blastoise",
     "imageUrl": "https://images.pokemontcg.io/ex14/14.png",
     "subtype": "Stage 2",
@@ -770,7 +784,8 @@
     "nationalPokedexNumber": 9
   },
   {
-    "id": "ex14-15",
+    "setOrder":29,
+	"id": "ex14-15",
     "name": "Cacturne δ",
     "imageUrl": "https://images.pokemontcg.io/ex14/15.png",
     "subtype": "Stage 1",
@@ -827,7 +842,8 @@
     "nationalPokedexNumber": 332
   },
   {
-    "id": "ex14-16",
+    "setOrder":29,
+	"id": "ex14-16",
     "name": "Combusken",
     "imageUrl": "https://images.pokemontcg.io/ex14/16.png",
     "subtype": "Stage 1",
@@ -881,7 +897,8 @@
     ]
   },
   {
-    "id": "ex14-17",
+    "setOrder":29,
+	"id": "ex14-17",
     "name": "Dusclops",
     "imageUrl": "https://images.pokemontcg.io/ex14/17.png",
     "subtype": "Stage 1",
@@ -948,7 +965,8 @@
     ]
   },
   {
-    "id": "ex14-18",
+    "setOrder":29,
+	"id": "ex14-18",
     "name": "Fearow δ",
     "imageUrl": "https://images.pokemontcg.io/ex14/18.png",
     "subtype": "Stage 1",
@@ -1001,7 +1019,8 @@
     "nationalPokedexNumber": 22
   },
   {
-    "id": "ex14-19",
+    "setOrder":29,
+	"id": "ex14-19",
     "name": "Grovyle δ",
     "imageUrl": "https://images.pokemontcg.io/ex14/19.png",
     "subtype": "Stage 1",
@@ -1063,7 +1082,8 @@
     ]
   },
   {
-    "id": "ex14-20",
+    "setOrder":29,
+	"id": "ex14-20",
     "name": "Grumpig",
     "imageUrl": "https://images.pokemontcg.io/ex14/20.png",
     "subtype": "Stage 1",
@@ -1112,7 +1132,8 @@
     "nationalPokedexNumber": 326
   },
   {
-    "id": "ex14-21",
+    "setOrder":29,
+	"id": "ex14-21",
     "name": "Igglybuff",
     "imageUrl": "https://images.pokemontcg.io/ex14/21.png",
     "subtype": "Basic",
@@ -1149,7 +1170,8 @@
     ]
   },
   {
-    "id": "ex14-22",
+    "setOrder":29,
+	"id": "ex14-22",
     "name": "Kingler δ",
     "imageUrl": "https://images.pokemontcg.io/ex14/22.png",
     "subtype": "Stage 1",
@@ -1208,7 +1230,8 @@
     "nationalPokedexNumber": 99
   },
   {
-    "id": "ex14-23",
+    "setOrder":29,
+	"id": "ex14-23",
     "name": "Loudred",
     "imageUrl": "https://images.pokemontcg.io/ex14/23.png",
     "subtype": "Stage 1",
@@ -1264,7 +1287,8 @@
     ]
   },
   {
-    "id": "ex14-24",
+    "setOrder":29,
+	"id": "ex14-24",
     "name": "Marshtomp",
     "imageUrl": "https://images.pokemontcg.io/ex14/24.png",
     "subtype": "Stage 1",
@@ -1319,7 +1343,8 @@
     ]
   },
   {
-    "id": "ex14-25",
+    "setOrder":29,
+	"id": "ex14-25",
     "name": "Medicham",
     "imageUrl": "https://images.pokemontcg.io/ex14/25.png",
     "subtype": "Stage 1",
@@ -1377,7 +1402,8 @@
     "nationalPokedexNumber": 308
   },
   {
-    "id": "ex14-26",
+    "setOrder":29,
+	"id": "ex14-26",
     "name": "Pelipper δ",
     "imageUrl": "https://images.pokemontcg.io/ex14/26.png",
     "subtype": "Stage 1",
@@ -1441,7 +1467,8 @@
     "nationalPokedexNumber": 279
   },
   {
-    "id": "ex14-27",
+    "setOrder":29,
+	"id": "ex14-27",
     "name": "Swampert",
     "imageUrl": "https://images.pokemontcg.io/ex14/27.png",
     "subtype": "Stage 2",
@@ -1490,7 +1517,8 @@
     "nationalPokedexNumber": 260
   },
   {
-    "id": "ex14-28",
+    "setOrder":29,
+	"id": "ex14-28",
     "name": "Venusaur",
     "imageUrl": "https://images.pokemontcg.io/ex14/28.png",
     "subtype": "Stage 2",
@@ -1550,7 +1578,8 @@
     "nationalPokedexNumber": 3
   },
   {
-    "id": "ex14-29",
+    "setOrder":29,
+	"id": "ex14-29",
     "name": "Charmeleon",
     "imageUrl": "https://images.pokemontcg.io/ex14/29.png",
     "subtype": "Stage 1",
@@ -1606,7 +1635,8 @@
     ]
   },
   {
-    "id": "ex14-30",
+    "setOrder":29,
+	"id": "ex14-30",
     "name": "Charmeleon δ",
     "imageUrl": "https://images.pokemontcg.io/ex14/30.png",
     "subtype": "Stage 1",
@@ -1662,7 +1692,8 @@
     ]
   },
   {
-    "id": "ex14-31",
+    "setOrder":29,
+	"id": "ex14-31",
     "name": "Combusken",
     "imageUrl": "https://images.pokemontcg.io/ex14/31.png",
     "subtype": "Stage 1",
@@ -1719,7 +1750,8 @@
     ]
   },
   {
-    "id": "ex14-32",
+    "setOrder":29,
+	"id": "ex14-32",
     "name": "Grovyle",
     "imageUrl": "https://images.pokemontcg.io/ex14/32.png",
     "subtype": "Stage 1",
@@ -1780,7 +1812,8 @@
     ]
   },
   {
-    "id": "ex14-33",
+    "setOrder":29,
+	"id": "ex14-33",
     "name": "Gulpin",
     "imageUrl": "https://images.pokemontcg.io/ex14/33.png",
     "subtype": "Basic",
@@ -1834,7 +1867,8 @@
     ]
   },
   {
-    "id": "ex14-34",
+    "setOrder":29,
+	"id": "ex14-34",
     "name": "Ivysaur",
     "imageUrl": "https://images.pokemontcg.io/ex14/34.png",
     "subtype": "Stage 1",
@@ -1890,7 +1924,8 @@
     ]
   },
   {
-    "id": "ex14-35",
+    "setOrder":29,
+	"id": "ex14-35",
     "name": "Ivysaur",
     "imageUrl": "https://images.pokemontcg.io/ex14/35.png",
     "subtype": "Stage 1",
@@ -1946,7 +1981,8 @@
     ]
   },
   {
-    "id": "ex14-36",
+    "setOrder":29,
+	"id": "ex14-36",
     "name": "Lairon",
     "imageUrl": "https://images.pokemontcg.io/ex14/36.png",
     "subtype": "Stage 1",
@@ -2008,7 +2044,8 @@
     ]
   },
   {
-    "id": "ex14-37",
+    "setOrder":29,
+	"id": "ex14-37",
     "name": "Lombre",
     "imageUrl": "https://images.pokemontcg.io/ex14/37.png",
     "subtype": "Stage 1",
@@ -2064,7 +2101,8 @@
     ]
   },
   {
-    "id": "ex14-38",
+    "setOrder":29,
+	"id": "ex14-38",
     "name": "Marshtomp",
     "imageUrl": "https://images.pokemontcg.io/ex14/38.png",
     "subtype": "Stage 1",
@@ -2120,7 +2158,8 @@
     ]
   },
   {
-    "id": "ex14-39",
+    "setOrder":29,
+	"id": "ex14-39",
     "name": "Nuzleaf",
     "imageUrl": "https://images.pokemontcg.io/ex14/39.png",
     "subtype": "Stage 1",
@@ -2181,7 +2220,8 @@
     ]
   },
   {
-    "id": "ex14-40",
+    "setOrder":29,
+	"id": "ex14-40",
     "name": "Shuppet",
     "imageUrl": "https://images.pokemontcg.io/ex14/40.png",
     "subtype": "Basic",
@@ -2240,7 +2280,8 @@
     ]
   },
   {
-    "id": "ex14-41",
+    "setOrder":29,
+	"id": "ex14-41",
     "name": "Skitty",
     "imageUrl": "https://images.pokemontcg.io/ex14/41.png",
     "subtype": "Basic",
@@ -2293,7 +2334,8 @@
     ]
   },
   {
-    "id": "ex14-42",
+    "setOrder":29,
+	"id": "ex14-42",
     "name": "Wartortle",
     "imageUrl": "https://images.pokemontcg.io/ex14/42.png",
     "subtype": "Stage 1",
@@ -2349,7 +2391,8 @@
     ]
   },
   {
-    "id": "ex14-43",
+    "setOrder":29,
+	"id": "ex14-43",
     "name": "Wartortle",
     "imageUrl": "https://images.pokemontcg.io/ex14/43.png",
     "subtype": "Stage 1",
@@ -2404,7 +2447,8 @@
     ]
   },
   {
-    "id": "ex14-44",
+    "setOrder":29,
+	"id": "ex14-44",
     "name": "Aron",
     "imageUrl": "https://images.pokemontcg.io/ex14/44.png",
     "subtype": "Basic",
@@ -2453,7 +2497,8 @@
     ]
   },
   {
-    "id": "ex14-45",
+    "setOrder":29,
+	"id": "ex14-45",
     "name": "Bulbasaur",
     "imageUrl": "https://images.pokemontcg.io/ex14/45.png",
     "subtype": "Basic",
@@ -2505,7 +2550,8 @@
     ]
   },
   {
-    "id": "ex14-46",
+    "setOrder":29,
+	"id": "ex14-46",
     "name": "Bulbasaur",
     "imageUrl": "https://images.pokemontcg.io/ex14/46.png",
     "subtype": "Basic",
@@ -2558,7 +2604,8 @@
     ]
   },
   {
-    "id": "ex14-47",
+    "setOrder":29,
+	"id": "ex14-47",
     "name": "Cacnea",
     "imageUrl": "https://images.pokemontcg.io/ex14/47.png",
     "subtype": "Basic",
@@ -2611,7 +2658,8 @@
     ]
   },
   {
-    "id": "ex14-48",
+    "setOrder":29,
+	"id": "ex14-48",
     "name": "Charmander",
     "imageUrl": "https://images.pokemontcg.io/ex14/48.png",
     "subtype": "Basic",
@@ -2664,7 +2712,8 @@
     ]
   },
   {
-    "id": "ex14-49",
+    "setOrder":29,
+	"id": "ex14-49",
     "name": "Charmander δ",
     "imageUrl": "https://images.pokemontcg.io/ex14/49.png",
     "subtype": "Basic",
@@ -2717,7 +2766,8 @@
     ]
   },
   {
-    "id": "ex14-50",
+    "setOrder":29,
+	"id": "ex14-50",
     "name": "Diglett",
     "imageUrl": "https://images.pokemontcg.io/ex14/50.png",
     "subtype": "Basic",
@@ -2770,7 +2820,8 @@
     ]
   },
   {
-    "id": "ex14-51",
+    "setOrder":29,
+	"id": "ex14-51",
     "name": "Duskull",
     "imageUrl": "https://images.pokemontcg.io/ex14/51.png",
     "subtype": "Basic",
@@ -2828,7 +2879,8 @@
     ]
   },
   {
-    "id": "ex14-52",
+    "setOrder":29,
+	"id": "ex14-52",
     "name": "Electrike",
     "imageUrl": "https://images.pokemontcg.io/ex14/52.png",
     "subtype": "Basic",
@@ -2886,7 +2938,8 @@
     ]
   },
   {
-    "id": "ex14-53",
+    "setOrder":29,
+	"id": "ex14-53",
     "name": "Jigglypuff",
     "imageUrl": "https://images.pokemontcg.io/ex14/53.png",
     "subtype": "Basic",
@@ -2929,7 +2982,8 @@
     ]
   },
   {
-    "id": "ex14-54",
+    "setOrder":29,
+	"id": "ex14-54",
     "name": "Krabby",
     "imageUrl": "https://images.pokemontcg.io/ex14/54.png",
     "subtype": "Basic",
@@ -2972,7 +3026,8 @@
     ]
   },
   {
-    "id": "ex14-55",
+    "setOrder":29,
+	"id": "ex14-55",
     "name": "Lotad",
     "imageUrl": "https://images.pokemontcg.io/ex14/55.png",
     "subtype": "Basic",
@@ -3021,7 +3076,8 @@
     ]
   },
   {
-    "id": "ex14-56",
+    "setOrder":29,
+	"id": "ex14-56",
     "name": "Meditite",
     "imageUrl": "https://images.pokemontcg.io/ex14/56.png",
     "subtype": "Basic",
@@ -3074,7 +3130,8 @@
     ]
   },
   {
-    "id": "ex14-57",
+    "setOrder":29,
+	"id": "ex14-57",
     "name": "Mudkip",
     "imageUrl": "https://images.pokemontcg.io/ex14/57.png",
     "subtype": "Basic",
@@ -3122,7 +3179,8 @@
     ]
   },
   {
-    "id": "ex14-58",
+    "setOrder":29,
+	"id": "ex14-58",
     "name": "Mudkip",
     "imageUrl": "https://images.pokemontcg.io/ex14/58.png",
     "subtype": "Basic",
@@ -3175,7 +3233,8 @@
     ]
   },
   {
-    "id": "ex14-59",
+    "setOrder":29,
+	"id": "ex14-59",
     "name": "Numel",
     "imageUrl": "https://images.pokemontcg.io/ex14/59.png",
     "subtype": "Basic",
@@ -3219,7 +3278,8 @@
     ]
   },
   {
-    "id": "ex14-60",
+    "setOrder":29,
+	"id": "ex14-60",
     "name": "Seedot",
     "imageUrl": "https://images.pokemontcg.io/ex14/60.png",
     "subtype": "Basic",
@@ -3262,7 +3322,8 @@
     ]
   },
   {
-    "id": "ex14-61",
+    "setOrder":29,
+	"id": "ex14-61",
     "name": "Spearow",
     "imageUrl": "https://images.pokemontcg.io/ex14/61.png",
     "subtype": "Basic",
@@ -3311,7 +3372,8 @@
     ]
   },
   {
-    "id": "ex14-62",
+    "setOrder":29,
+	"id": "ex14-62",
     "name": "Spoink",
     "imageUrl": "https://images.pokemontcg.io/ex14/62.png",
     "subtype": "Basic",
@@ -3364,7 +3426,8 @@
     ]
   },
   {
-    "id": "ex14-63",
+    "setOrder":29,
+	"id": "ex14-63",
     "name": "Squirtle",
     "imageUrl": "https://images.pokemontcg.io/ex14/63.png",
     "subtype": "Basic",
@@ -3418,7 +3481,8 @@
     ]
   },
   {
-    "id": "ex14-64",
+    "setOrder":29,
+	"id": "ex14-64",
     "name": "Squirtle",
     "imageUrl": "https://images.pokemontcg.io/ex14/64.png",
     "subtype": "Basic",
@@ -3466,7 +3530,8 @@
     ]
   },
   {
-    "id": "ex14-65",
+    "setOrder":29,
+	"id": "ex14-65",
     "name": "Torchic",
     "imageUrl": "https://images.pokemontcg.io/ex14/65.png",
     "subtype": "Basic",
@@ -3509,7 +3574,8 @@
     ]
   },
   {
-    "id": "ex14-66",
+    "setOrder":29,
+	"id": "ex14-66",
     "name": "Torchic",
     "imageUrl": "https://images.pokemontcg.io/ex14/66.png",
     "subtype": "Basic",
@@ -3552,7 +3618,8 @@
     ]
   },
   {
-    "id": "ex14-67",
+    "setOrder":29,
+	"id": "ex14-67",
     "name": "Treecko",
     "imageUrl": "https://images.pokemontcg.io/ex14/67.png",
     "subtype": "Basic",
@@ -3611,7 +3678,8 @@
     ]
   },
   {
-    "id": "ex14-68",
+    "setOrder":29,
+	"id": "ex14-68",
     "name": "Treecko δ",
     "imageUrl": "https://images.pokemontcg.io/ex14/68.png",
     "subtype": "Basic",
@@ -3669,7 +3737,8 @@
     ]
   },
   {
-    "id": "ex14-69",
+    "setOrder":29,
+	"id": "ex14-69",
     "name": "Whismur",
     "imageUrl": "https://images.pokemontcg.io/ex14/69.png",
     "subtype": "Basic",
@@ -3723,7 +3792,8 @@
     ]
   },
   {
-    "id": "ex14-70",
+    "setOrder":29,
+	"id": "ex14-70",
     "name": "Wingull",
     "imageUrl": "https://images.pokemontcg.io/ex14/70.png",
     "subtype": "Basic",
@@ -3772,7 +3842,8 @@
     ]
   },
   {
-    "id": "ex14-71",
+    "setOrder":29,
+	"id": "ex14-71",
     "name": "Bill's Maintenance",
     "imageUrl": "https://images.pokemontcg.io/ex14/71.png",
     "subtype": "Supporter",
@@ -3791,7 +3862,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex14/71_hires.png"
   },
   {
-    "id": "ex14-72",
+    "setOrder":29,
+	"id": "ex14-72",
     "name": "Castaway",
     "imageUrl": "https://images.pokemontcg.io/ex14/72.png",
     "subtype": "Supporter",
@@ -3810,7 +3882,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex14/72_hires.png"
   },
   {
-    "id": "ex14-73",
+    "setOrder":29,
+	"id": "ex14-73",
     "name": "Celio's Network",
     "imageUrl": "https://images.pokemontcg.io/ex14/73.png",
     "subtype": "Supporter",
@@ -3829,7 +3902,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex14/73_hires.png"
   },
   {
-    "id": "ex14-74",
+    "setOrder":29,
+	"id": "ex14-74",
     "name": "Cessation Crystal",
     "imageUrl": "https://images.pokemontcg.io/ex14/74.png",
     "subtype": "Pokémon Tool",
@@ -3848,7 +3922,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex14/74_hires.png"
   },
   {
-    "id": "ex14-75",
+    "setOrder":29,
+	"id": "ex14-75",
     "name": "Crystal Beach",
     "imageUrl": "https://images.pokemontcg.io/ex14/75.png",
     "subtype": "Stadium",
@@ -3867,7 +3942,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex14/75_hires.png"
   },
   {
-    "id": "ex14-76",
+    "setOrder":29,
+	"id": "ex14-76",
     "name": "Crystal Shard",
     "imageUrl": "https://images.pokemontcg.io/ex14/76.png",
     "subtype": "Pokémon Tool",
@@ -3886,7 +3962,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex14/76_hires.png"
   },
   {
-    "id": "ex14-77",
+    "setOrder":29,
+	"id": "ex14-77",
     "name": "Double Full Heal",
     "imageUrl": "https://images.pokemontcg.io/ex14/77.png",
     "subtype": "Item",
@@ -3904,7 +3981,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex14/77_hires.png"
   },
   {
-    "id": "ex14-78",
+    "setOrder":29,
+	"id": "ex14-78",
     "name": "Dual Ball",
     "imageUrl": "https://images.pokemontcg.io/ex14/78.png",
     "subtype": "Item",
@@ -3922,7 +4000,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex14/78_hires.png"
   },
   {
-    "id": "ex14-79",
+    "setOrder":29,
+	"id": "ex14-79",
     "name": "Holon Circle",
     "imageUrl": "https://images.pokemontcg.io/ex14/79.png",
     "subtype": "Stadium",
@@ -3941,7 +4020,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex14/79_hires.png"
   },
   {
-    "id": "ex14-80",
+    "setOrder":29,
+	"id": "ex14-80",
     "name": "Memory Berry",
     "imageUrl": "https://images.pokemontcg.io/ex14/80.png",
     "subtype": "Pokémon Tool",
@@ -3960,7 +4040,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex14/80_hires.png"
   },
   {
-    "id": "ex14-81",
+    "setOrder":29,
+	"id": "ex14-81",
     "name": "Mysterious Shard",
     "imageUrl": "https://images.pokemontcg.io/ex14/81.png",
     "subtype": "Pokémon Tool",
@@ -3979,7 +4060,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex14/81_hires.png"
   },
   {
-    "id": "ex14-82",
+    "setOrder":29,
+	"id": "ex14-82",
     "name": "Poké Ball",
     "imageUrl": "https://images.pokemontcg.io/ex14/82.png",
     "subtype": "Item",
@@ -3997,7 +4079,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex14/82_hires.png"
   },
   {
-    "id": "ex14-83",
+    "setOrder":29,
+	"id": "ex14-83",
     "name": "PokéNav",
     "imageUrl": "https://images.pokemontcg.io/ex14/83.png",
     "subtype": "Item",
@@ -4015,7 +4098,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex14/83_hires.png"
   },
   {
-    "id": "ex14-84",
+    "setOrder":29,
+	"id": "ex14-84",
     "name": "Warp Point",
     "imageUrl": "https://images.pokemontcg.io/ex14/84.png",
     "subtype": "Item",
@@ -4033,7 +4117,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex14/84_hires.png"
   },
   {
-    "id": "ex14-85",
+    "setOrder":29,
+	"id": "ex14-85",
     "name": "Windstorm",
     "imageUrl": "https://images.pokemontcg.io/ex14/85.png",
     "subtype": "Item",
@@ -4051,7 +4136,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex14/85_hires.png"
   },
   {
-    "id": "ex14-86",
+    "setOrder":29,
+	"id": "ex14-86",
     "name": "Energy Search",
     "imageUrl": "https://images.pokemontcg.io/ex14/86.png",
     "subtype": "Item",
@@ -4069,7 +4155,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex14/86_hires.png"
   },
   {
-    "id": "ex14-87",
+    "setOrder":29,
+	"id": "ex14-87",
     "name": "Potion",
     "imageUrl": "https://images.pokemontcg.io/ex14/87.png",
     "subtype": "Item",
@@ -4087,7 +4174,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex14/87_hires.png"
   },
   {
-    "id": "ex14-88",
+    "setOrder":29,
+	"id": "ex14-88",
     "name": "Double Rainbow Energy",
     "imageUrl": "https://images.pokemontcg.io/ex14/88.png",
     "subtype": "Special",
@@ -4104,7 +4192,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex14/88_hires.png"
   },
   {
-    "id": "ex14-89",
+    "setOrder":29,
+	"id": "ex14-89",
     "name": "Aggron ex",
     "imageUrl": "https://images.pokemontcg.io/ex14/89.png",
     "subtype": "EX",
@@ -4177,7 +4266,8 @@
     "nationalPokedexNumber": 306
   },
   {
-    "id": "ex14-90",
+    "setOrder":29,
+	"id": "ex14-90",
     "name": "Blaziken ex",
     "imageUrl": "https://images.pokemontcg.io/ex14/90.png",
     "subtype": "EX",
@@ -4236,7 +4326,8 @@
     "nationalPokedexNumber": 257
   },
   {
-    "id": "ex14-91",
+    "setOrder":29,
+	"id": "ex14-91",
     "name": "Delcatty ex",
     "imageUrl": "https://images.pokemontcg.io/ex14/91.png",
     "subtype": "EX",
@@ -4294,7 +4385,8 @@
     "nationalPokedexNumber": 301
   },
   {
-    "id": "ex14-92",
+    "setOrder":29,
+	"id": "ex14-92",
     "name": "Exploud ex",
     "imageUrl": "https://images.pokemontcg.io/ex14/92.png",
     "subtype": "EX",
@@ -4358,7 +4450,8 @@
     "nationalPokedexNumber": 295
   },
   {
-    "id": "ex14-93",
+    "setOrder":29,
+	"id": "ex14-93",
     "name": "Groudon ex",
     "imageUrl": "https://images.pokemontcg.io/ex14/93.png",
     "subtype": "EX",
@@ -4410,7 +4503,8 @@
     "nationalPokedexNumber": 383
   },
   {
-    "id": "ex14-94",
+    "setOrder":29,
+	"id": "ex14-94",
     "name": "Jirachi ex",
     "imageUrl": "https://images.pokemontcg.io/ex14/94.png",
     "subtype": "EX",
@@ -4465,7 +4559,8 @@
     "nationalPokedexNumber": 385
   },
   {
-    "id": "ex14-95",
+    "setOrder":29,
+	"id": "ex14-95",
     "name": "Kyogre ex",
     "imageUrl": "https://images.pokemontcg.io/ex14/95.png",
     "subtype": "EX",
@@ -4517,7 +4612,8 @@
     "nationalPokedexNumber": 382
   },
   {
-    "id": "ex14-96",
+    "setOrder":29,
+	"id": "ex14-96",
     "name": "Sceptile ex δ",
     "imageUrl": "https://images.pokemontcg.io/ex14/96.png",
     "subtype": "Stage 2",
@@ -4574,7 +4670,8 @@
     "nationalPokedexNumber": 254
   },
   {
-    "id": "ex14-97",
+    "setOrder":29,
+	"id": "ex14-97",
     "name": "Shiftry ex",
     "imageUrl": "https://images.pokemontcg.io/ex14/97.png",
     "subtype": "EX",
@@ -4639,7 +4736,8 @@
     "nationalPokedexNumber": 275
   },
   {
-    "id": "ex14-98",
+    "setOrder":29,
+	"id": "ex14-98",
     "name": "Swampert ex",
     "imageUrl": "https://images.pokemontcg.io/ex14/98.png",
     "subtype": "EX",
@@ -4693,7 +4791,8 @@
     "nationalPokedexNumber": 260
   },
   {
-    "id": "ex14-99",
+    "setOrder":29,
+	"id": "ex14-99",
     "name": "Alakazam Star",
     "imageUrl": "https://images.pokemontcg.io/ex14/99.png",
     "subtype": "Basic",
@@ -4747,7 +4846,8 @@
     "nationalPokedexNumber": 65
   },
   {
-    "id": "ex14-100",
+    "setOrder":29,
+	"id": "ex14-100",
     "name": "Celebi Star",
     "imageUrl": "https://images.pokemontcg.io/ex14/100.png",
     "subtype": "Basic",

--- a/json/cards/Dark Explorers.json
+++ b/json/cards/Dark Explorers.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "bw5-1",
+    "setOrder":52,
+	"id": "bw5-1",
     "name": "Bulbasaur",
     "imageUrl": "https://images.pokemontcg.io/bw5/1.png",
     "subtype": "Basic",
@@ -61,7 +62,8 @@
     ]
   },
   {
-    "id": "bw5-2",
+    "setOrder":52,
+	"id": "bw5-2",
     "name": "Ivysaur",
     "imageUrl": "https://images.pokemontcg.io/bw5/2.png",
     "subtype": "Stage 1",
@@ -125,7 +127,8 @@
     ]
   },
   {
-    "id": "bw5-3",
+    "setOrder":52,
+	"id": "bw5-3",
     "name": "Venusaur",
     "imageUrl": "https://images.pokemontcg.io/bw5/3.png",
     "subtype": "Stage 2",
@@ -183,7 +186,8 @@
     "nationalPokedexNumber": 3
   },
   {
-    "id": "bw5-4",
+    "setOrder":52,
+	"id": "bw5-4",
     "name": "Scyther",
     "imageUrl": "https://images.pokemontcg.io/bw5/4.png",
     "subtype": "Basic",
@@ -228,7 +232,8 @@
     ]
   },
   {
-    "id": "bw5-5",
+    "setOrder":52,
+	"id": "bw5-5",
     "name": "Carnivine",
     "imageUrl": "https://images.pokemontcg.io/bw5/5.png",
     "subtype": "Basic",
@@ -286,7 +291,8 @@
     "nationalPokedexNumber": 455
   },
   {
-    "id": "bw5-6",
+    "setOrder":52,
+	"id": "bw5-6",
     "name": "Leafeon",
     "imageUrl": "https://images.pokemontcg.io/bw5/6.png",
     "subtype": "Stage 1",
@@ -343,7 +349,8 @@
     "nationalPokedexNumber": 470
   },
   {
-    "id": "bw5-7",
+    "setOrder":52,
+	"id": "bw5-7",
     "name": "Dwebble",
     "imageUrl": "https://images.pokemontcg.io/bw5/7.png",
     "subtype": "Basic",
@@ -398,7 +405,8 @@
     ]
   },
   {
-    "id": "bw5-8",
+    "setOrder":52,
+	"id": "bw5-8",
     "name": "Crustle",
     "imageUrl": "https://images.pokemontcg.io/bw5/8.png",
     "subtype": "Stage 1",
@@ -453,7 +461,8 @@
     "nationalPokedexNumber": 558
   },
   {
-    "id": "bw5-9",
+    "setOrder":52,
+	"id": "bw5-9",
     "name": "Karrablast",
     "imageUrl": "https://images.pokemontcg.io/bw5/9.png",
     "subtype": "Basic",
@@ -507,7 +516,8 @@
     ]
   },
   {
-    "id": "bw5-10",
+    "setOrder":52,
+	"id": "bw5-10",
     "name": "Shelmet",
     "imageUrl": "https://images.pokemontcg.io/bw5/10.png",
     "subtype": "Basic",
@@ -553,7 +563,8 @@
     ]
   },
   {
-    "id": "bw5-11",
+    "setOrder":52,
+	"id": "bw5-11",
     "name": "Accelgor",
     "imageUrl": "https://images.pokemontcg.io/bw5/11.png",
     "subtype": "Stage 1",
@@ -601,7 +612,8 @@
     "nationalPokedexNumber": 617
   },
   {
-    "id": "bw5-12",
+    "setOrder":52,
+	"id": "bw5-12",
     "name": "Flareon",
     "imageUrl": "https://images.pokemontcg.io/bw5/12.png",
     "subtype": "Stage 1",
@@ -653,7 +665,8 @@
     "nationalPokedexNumber": 136
   },
   {
-    "id": "bw5-13",
+    "setOrder":52,
+	"id": "bw5-13",
     "name": "Entei-EX",
     "imageUrl": "https://images.pokemontcg.io/bw5/13.png",
     "subtype": "EX",
@@ -710,7 +723,8 @@
     "nationalPokedexNumber": 244
   },
   {
-    "id": "bw5-14",
+    "setOrder":52,
+	"id": "bw5-14",
     "name": "Torchic",
     "imageUrl": "https://images.pokemontcg.io/bw5/14.png",
     "subtype": "Basic",
@@ -754,7 +768,8 @@
     ]
   },
   {
-    "id": "bw5-15",
+    "setOrder":52,
+	"id": "bw5-15",
     "name": "Torchic",
     "imageUrl": "https://images.pokemontcg.io/bw5/15.png",
     "subtype": "Basic",
@@ -807,7 +822,8 @@
     ]
   },
   {
-    "id": "bw5-16",
+    "setOrder":52,
+	"id": "bw5-16",
     "name": "Combusken",
     "imageUrl": "https://images.pokemontcg.io/bw5/16.png",
     "subtype": "Stage 1",
@@ -862,7 +878,8 @@
     ]
   },
   {
-    "id": "bw5-17",
+    "setOrder":52,
+	"id": "bw5-17",
     "name": "Blaziken",
     "imageUrl": "https://images.pokemontcg.io/bw5/17.png",
     "subtype": "Stage 2",
@@ -916,7 +933,8 @@
     "nationalPokedexNumber": 257
   },
   {
-    "id": "bw5-18",
+    "setOrder":52,
+	"id": "bw5-18",
     "name": "Torkoal",
     "imageUrl": "https://images.pokemontcg.io/bw5/18.png",
     "subtype": "Basic",
@@ -968,7 +986,8 @@
     "nationalPokedexNumber": 324
   },
   {
-    "id": "bw5-19",
+    "setOrder":52,
+	"id": "bw5-19",
     "name": "Heatmor",
     "imageUrl": "https://images.pokemontcg.io/bw5/19.png",
     "subtype": "Basic",
@@ -1019,7 +1038,8 @@
     "nationalPokedexNumber": 631
   },
   {
-    "id": "bw5-20",
+    "setOrder":52,
+	"id": "bw5-20",
     "name": "Larvesta",
     "imageUrl": "https://images.pokemontcg.io/bw5/20.png",
     "subtype": "Basic",
@@ -1076,7 +1096,8 @@
     ]
   },
   {
-    "id": "bw5-21",
+    "setOrder":52,
+	"id": "bw5-21",
     "name": "Larvesta",
     "imageUrl": "https://images.pokemontcg.io/bw5/21.png",
     "subtype": "Basic",
@@ -1120,7 +1141,8 @@
     ]
   },
   {
-    "id": "bw5-22",
+    "setOrder":52,
+	"id": "bw5-22",
     "name": "Volcarona",
     "imageUrl": "https://images.pokemontcg.io/bw5/22.png",
     "subtype": "Stage 1",
@@ -1170,7 +1192,8 @@
     "nationalPokedexNumber": 637
   },
   {
-    "id": "bw5-23",
+    "setOrder":52,
+	"id": "bw5-23",
     "name": "Slowpoke",
     "imageUrl": "https://images.pokemontcg.io/bw5/23.png",
     "subtype": "Basic",
@@ -1226,7 +1249,8 @@
     ]
   },
   {
-    "id": "bw5-24",
+    "setOrder":52,
+	"id": "bw5-24",
     "name": "Slowbro",
     "imageUrl": "https://images.pokemontcg.io/bw5/24.png",
     "subtype": "Stage 1",
@@ -1275,7 +1299,8 @@
     "nationalPokedexNumber": 80
   },
   {
-    "id": "bw5-25",
+    "setOrder":52,
+	"id": "bw5-25",
     "name": "Vaporeon",
     "imageUrl": "https://images.pokemontcg.io/bw5/25.png",
     "subtype": "Stage 1",
@@ -1328,7 +1353,8 @@
     "nationalPokedexNumber": 134
   },
   {
-    "id": "bw5-26",
+    "setOrder":52,
+	"id": "bw5-26",
     "name": "Kyogre-EX",
     "imageUrl": "https://images.pokemontcg.io/bw5/26.png",
     "subtype": "EX",
@@ -1386,7 +1412,8 @@
     "nationalPokedexNumber": 382
   },
   {
-    "id": "bw5-27",
+    "setOrder":52,
+	"id": "bw5-27",
     "name": "Piplup",
     "imageUrl": "https://images.pokemontcg.io/bw5/27.png",
     "subtype": "Basic",
@@ -1429,7 +1456,8 @@
     ]
   },
   {
-    "id": "bw5-28",
+    "setOrder":52,
+	"id": "bw5-28",
     "name": "Prinplup",
     "imageUrl": "https://images.pokemontcg.io/bw5/28.png",
     "subtype": "Stage 1",
@@ -1485,7 +1513,8 @@
     ]
   },
   {
-    "id": "bw5-29",
+    "setOrder":52,
+	"id": "bw5-29",
     "name": "Empoleon",
     "imageUrl": "https://images.pokemontcg.io/bw5/29.png",
     "subtype": "Stage 2",
@@ -1532,7 +1561,8 @@
     "nationalPokedexNumber": 395
   },
   {
-    "id": "bw5-30",
+    "setOrder":52,
+	"id": "bw5-30",
     "name": "Glaceon",
     "imageUrl": "https://images.pokemontcg.io/bw5/30.png",
     "subtype": "Stage 1",
@@ -1583,7 +1613,8 @@
     "nationalPokedexNumber": 471
   },
   {
-    "id": "bw5-31",
+    "setOrder":52,
+	"id": "bw5-31",
     "name": "Tympole",
     "imageUrl": "https://images.pokemontcg.io/bw5/31.png",
     "subtype": "Basic",
@@ -1627,7 +1658,8 @@
     ]
   },
   {
-    "id": "bw5-32",
+    "setOrder":52,
+	"id": "bw5-32",
     "name": "Palpitoad",
     "imageUrl": "https://images.pokemontcg.io/bw5/32.png",
     "subtype": "Stage 1",
@@ -1673,7 +1705,8 @@
     ]
   },
   {
-    "id": "bw5-33",
+    "setOrder":52,
+	"id": "bw5-33",
     "name": "Vanillite",
     "imageUrl": "https://images.pokemontcg.io/bw5/33.png",
     "subtype": "Basic",
@@ -1716,7 +1749,8 @@
     ]
   },
   {
-    "id": "bw5-34",
+    "setOrder":52,
+	"id": "bw5-34",
     "name": "Vanillish",
     "imageUrl": "https://images.pokemontcg.io/bw5/34.png",
     "subtype": "Stage 1",
@@ -1771,7 +1805,8 @@
     ]
   },
   {
-    "id": "bw5-35",
+    "setOrder":52,
+	"id": "bw5-35",
     "name": "Ducklett",
     "imageUrl": "https://images.pokemontcg.io/bw5/35.png",
     "subtype": "Basic",
@@ -1821,7 +1856,8 @@
     ]
   },
   {
-    "id": "bw5-36",
+    "setOrder":52,
+	"id": "bw5-36",
     "name": "Swanna",
     "imageUrl": "https://images.pokemontcg.io/bw5/36.png",
     "subtype": "Stage 1",
@@ -1879,7 +1915,8 @@
     "nationalPokedexNumber": 581
   },
   {
-    "id": "bw5-37",
+    "setOrder":52,
+	"id": "bw5-37",
     "name": "Jolteon",
     "imageUrl": "https://images.pokemontcg.io/bw5/37.png",
     "subtype": "Stage 1",
@@ -1928,7 +1965,8 @@
     "nationalPokedexNumber": 135
   },
   {
-    "id": "bw5-38",
+    "setOrder":52,
+	"id": "bw5-38",
     "name": "Raikou-EX",
     "imageUrl": "https://images.pokemontcg.io/bw5/38.png",
     "subtype": "EX",
@@ -1983,7 +2021,8 @@
     "nationalPokedexNumber": 243
   },
   {
-    "id": "bw5-39",
+    "setOrder":52,
+	"id": "bw5-39",
     "name": "Plusle",
     "imageUrl": "https://images.pokemontcg.io/bw5/39.png",
     "subtype": "Basic",
@@ -2032,7 +2071,8 @@
     "nationalPokedexNumber": 311
   },
   {
-    "id": "bw5-40",
+    "setOrder":52,
+	"id": "bw5-40",
     "name": "Minun",
     "imageUrl": "https://images.pokemontcg.io/bw5/40.png",
     "subtype": "Basic",
@@ -2081,7 +2121,8 @@
     "nationalPokedexNumber": 312
   },
   {
-    "id": "bw5-41",
+    "setOrder":52,
+	"id": "bw5-41",
     "name": "Joltik",
     "imageUrl": "https://images.pokemontcg.io/bw5/41.png",
     "subtype": "Basic",
@@ -2134,7 +2175,8 @@
     ]
   },
   {
-    "id": "bw5-42",
+    "setOrder":52,
+	"id": "bw5-42",
     "name": "Joltik",
     "imageUrl": "https://images.pokemontcg.io/bw5/42.png",
     "subtype": "Basic",
@@ -2177,7 +2219,8 @@
     ]
   },
   {
-    "id": "bw5-43",
+    "setOrder":52,
+	"id": "bw5-43",
     "name": "Galvantula",
     "imageUrl": "https://images.pokemontcg.io/bw5/43.png",
     "subtype": "Stage 1",
@@ -2228,7 +2271,8 @@
     "nationalPokedexNumber": 596
   },
   {
-    "id": "bw5-44",
+    "setOrder":52,
+	"id": "bw5-44",
     "name": "Tynamo",
     "imageUrl": "https://images.pokemontcg.io/bw5/44.png",
     "subtype": "Basic",
@@ -2271,7 +2315,8 @@
     ]
   },
   {
-    "id": "bw5-45",
+    "setOrder":52,
+	"id": "bw5-45",
     "name": "Tynamo",
     "imageUrl": "https://images.pokemontcg.io/bw5/45.png",
     "subtype": "Basic",
@@ -2314,7 +2359,8 @@
     ]
   },
   {
-    "id": "bw5-46",
+    "setOrder":52,
+	"id": "bw5-46",
     "name": "Eelektrik",
     "imageUrl": "https://images.pokemontcg.io/bw5/46.png",
     "subtype": "Stage 1",
@@ -2370,7 +2416,8 @@
     ]
   },
   {
-    "id": "bw5-47",
+    "setOrder":52,
+	"id": "bw5-47",
     "name": "Eelektross",
     "imageUrl": "https://images.pokemontcg.io/bw5/47.png",
     "subtype": "Stage 2",
@@ -2427,7 +2474,8 @@
     "nationalPokedexNumber": 604
   },
   {
-    "id": "bw5-48",
+    "setOrder":52,
+	"id": "bw5-48",
     "name": "Espeon",
     "imageUrl": "https://images.pokemontcg.io/bw5/48.png",
     "subtype": "Stage 1",
@@ -2475,7 +2523,8 @@
     "nationalPokedexNumber": 196
   },
   {
-    "id": "bw5-49",
+    "setOrder":52,
+	"id": "bw5-49",
     "name": "Slowking",
     "imageUrl": "https://images.pokemontcg.io/bw5/49.png",
     "subtype": "Stage 1",
@@ -2528,7 +2577,8 @@
     "nationalPokedexNumber": 199
   },
   {
-    "id": "bw5-50",
+    "setOrder":52,
+	"id": "bw5-50",
     "name": "Woobat",
     "imageUrl": "https://images.pokemontcg.io/bw5/50.png",
     "subtype": "Basic",
@@ -2587,7 +2637,8 @@
     ]
   },
   {
-    "id": "bw5-51",
+    "setOrder":52,
+	"id": "bw5-51",
     "name": "Yamask",
     "imageUrl": "https://images.pokemontcg.io/bw5/51.png",
     "subtype": "Basic",
@@ -2630,7 +2681,8 @@
     ]
   },
   {
-    "id": "bw5-52",
+    "setOrder":52,
+	"id": "bw5-52",
     "name": "Cofagrigus",
     "imageUrl": "https://images.pokemontcg.io/bw5/52.png",
     "subtype": "Stage 1",
@@ -2683,7 +2735,8 @@
     "nationalPokedexNumber": 563
   },
   {
-    "id": "bw5-53",
+    "setOrder":52,
+	"id": "bw5-53",
     "name": "Aerodactyl",
     "imageUrl": "https://images.pokemontcg.io/bw5/53.png",
     "subtype": "Restored",
@@ -2733,7 +2786,8 @@
     "nationalPokedexNumber": 142
   },
   {
-    "id": "bw5-54",
+    "setOrder":52,
+	"id": "bw5-54",
     "name": "Groudon-EX",
     "imageUrl": "https://images.pokemontcg.io/bw5/54.png",
     "subtype": "EX",
@@ -2797,7 +2851,8 @@
     "nationalPokedexNumber": 383
   },
   {
-    "id": "bw5-55",
+    "setOrder":52,
+	"id": "bw5-55",
     "name": "Drilbur",
     "imageUrl": "https://images.pokemontcg.io/bw5/55.png",
     "subtype": "Basic",
@@ -2848,7 +2903,8 @@
     ]
   },
   {
-    "id": "bw5-56",
+    "setOrder":52,
+	"id": "bw5-56",
     "name": "Excadrill",
     "imageUrl": "https://images.pokemontcg.io/bw5/56.png",
     "subtype": "Stage 1",
@@ -2907,7 +2963,8 @@
     "nationalPokedexNumber": 530
   },
   {
-    "id": "bw5-57",
+    "setOrder":52,
+	"id": "bw5-57",
     "name": "Excadrill",
     "imageUrl": "https://images.pokemontcg.io/bw5/57.png",
     "subtype": "Stage 1",
@@ -2971,7 +3028,8 @@
     "nationalPokedexNumber": 530
   },
   {
-    "id": "bw5-58",
+    "setOrder":52,
+	"id": "bw5-58",
     "name": "Timburr",
     "imageUrl": "https://images.pokemontcg.io/bw5/58.png",
     "subtype": "Basic",
@@ -3025,7 +3083,8 @@
     ]
   },
   {
-    "id": "bw5-59",
+    "setOrder":52,
+	"id": "bw5-59",
     "name": "Gurdurr",
     "imageUrl": "https://images.pokemontcg.io/bw5/59.png",
     "subtype": "Stage 1",
@@ -3081,7 +3140,8 @@
     ]
   },
   {
-    "id": "bw5-60",
+    "setOrder":52,
+	"id": "bw5-60",
     "name": "Umbreon",
     "imageUrl": "https://images.pokemontcg.io/bw5/60.png",
     "subtype": "Stage 1",
@@ -3141,7 +3201,8 @@
     "nationalPokedexNumber": 197
   },
   {
-    "id": "bw5-61",
+    "setOrder":52,
+	"id": "bw5-61",
     "name": "Umbreon",
     "imageUrl": "https://images.pokemontcg.io/bw5/61.png",
     "subtype": "Stage 1",
@@ -3200,7 +3261,8 @@
     "nationalPokedexNumber": 197
   },
   {
-    "id": "bw5-62",
+    "setOrder":52,
+	"id": "bw5-62",
     "name": "Sableye",
     "imageUrl": "https://images.pokemontcg.io/bw5/62.png",
     "subtype": "Basic",
@@ -3243,7 +3305,8 @@
     "nationalPokedexNumber": 302
   },
   {
-    "id": "bw5-63",
+    "setOrder":52,
+	"id": "bw5-63",
     "name": "Darkrai-EX",
     "imageUrl": "https://images.pokemontcg.io/bw5/63.png",
     "subtype": "EX",
@@ -3300,7 +3363,8 @@
     "nationalPokedexNumber": 491
   },
   {
-    "id": "bw5-64",
+    "setOrder":52,
+	"id": "bw5-64",
     "name": "Sandile",
     "imageUrl": "https://images.pokemontcg.io/bw5/64.png",
     "subtype": "Basic",
@@ -3361,7 +3425,8 @@
     ]
   },
   {
-    "id": "bw5-65",
+    "setOrder":52,
+	"id": "bw5-65",
     "name": "Krokorok",
     "imageUrl": "https://images.pokemontcg.io/bw5/65.png",
     "subtype": "Stage 1",
@@ -3426,7 +3491,8 @@
     ]
   },
   {
-    "id": "bw5-66",
+    "setOrder":52,
+	"id": "bw5-66",
     "name": "Krookodile",
     "imageUrl": "https://images.pokemontcg.io/bw5/66.png",
     "subtype": "Stage 2",
@@ -3489,7 +3555,8 @@
     "nationalPokedexNumber": 553
   },
   {
-    "id": "bw5-67",
+    "setOrder":52,
+	"id": "bw5-67",
     "name": "Scraggy",
     "imageUrl": "https://images.pokemontcg.io/bw5/67.png",
     "subtype": "Basic",
@@ -3539,7 +3606,8 @@
     ]
   },
   {
-    "id": "bw5-68",
+    "setOrder":52,
+	"id": "bw5-68",
     "name": "Scrafty",
     "imageUrl": "https://images.pokemontcg.io/bw5/68.png",
     "subtype": "Stage 1",
@@ -3599,7 +3667,8 @@
     "nationalPokedexNumber": 560
   },
   {
-    "id": "bw5-69",
+    "setOrder":52,
+	"id": "bw5-69",
     "name": "Zorua",
     "imageUrl": "https://images.pokemontcg.io/bw5/69.png",
     "subtype": "Basic",
@@ -3658,7 +3727,8 @@
     ]
   },
   {
-    "id": "bw5-70",
+    "setOrder":52,
+	"id": "bw5-70",
     "name": "Zorua",
     "imageUrl": "https://images.pokemontcg.io/bw5/70.png",
     "subtype": "Basic",
@@ -3717,7 +3787,8 @@
     ]
   },
   {
-    "id": "bw5-71",
+    "setOrder":52,
+	"id": "bw5-71",
     "name": "Zoroark",
     "imageUrl": "https://images.pokemontcg.io/bw5/71.png",
     "subtype": "Stage 1",
@@ -3776,7 +3847,8 @@
     "nationalPokedexNumber": 571
   },
   {
-    "id": "bw5-72",
+    "setOrder":52,
+	"id": "bw5-72",
     "name": "Bisharp",
     "imageUrl": "https://images.pokemontcg.io/bw5/72.png",
     "subtype": "Stage 1",
@@ -3835,7 +3907,8 @@
     "nationalPokedexNumber": 625
   },
   {
-    "id": "bw5-73",
+    "setOrder":52,
+	"id": "bw5-73",
     "name": "Vullaby",
     "imageUrl": "https://images.pokemontcg.io/bw5/73.png",
     "subtype": "Basic",
@@ -3884,7 +3957,8 @@
     ]
   },
   {
-    "id": "bw5-74",
+    "setOrder":52,
+	"id": "bw5-74",
     "name": "Escavalier",
     "imageUrl": "https://images.pokemontcg.io/bw5/74.png",
     "subtype": "Stage 1",
@@ -3944,7 +4018,8 @@
     "nationalPokedexNumber": 589
   },
   {
-    "id": "bw5-75",
+    "setOrder":52,
+	"id": "bw5-75",
     "name": "Klink",
     "imageUrl": "https://images.pokemontcg.io/bw5/75.png",
     "subtype": "Basic",
@@ -3996,7 +4071,8 @@
     ]
   },
   {
-    "id": "bw5-76",
+    "setOrder":52,
+	"id": "bw5-76",
     "name": "Klang",
     "imageUrl": "https://images.pokemontcg.io/bw5/76.png",
     "subtype": "Stage 1",
@@ -4060,7 +4136,8 @@
     ]
   },
   {
-    "id": "bw5-77",
+    "setOrder":52,
+	"id": "bw5-77",
     "name": "Klinklang",
     "imageUrl": "https://images.pokemontcg.io/bw5/77.png",
     "subtype": "Stage 2",
@@ -4122,7 +4199,8 @@
     "nationalPokedexNumber": 601
   },
   {
-    "id": "bw5-78",
+    "setOrder":52,
+	"id": "bw5-78",
     "name": "Pawniard",
     "imageUrl": "https://images.pokemontcg.io/bw5/78.png",
     "subtype": "Basic",
@@ -4183,7 +4261,8 @@
     ]
   },
   {
-    "id": "bw5-79",
+    "setOrder":52,
+	"id": "bw5-79",
     "name": "Bisharp",
     "imageUrl": "https://images.pokemontcg.io/bw5/79.png",
     "subtype": "Stage 1",
@@ -4243,7 +4322,8 @@
     "nationalPokedexNumber": 625
   },
   {
-    "id": "bw5-80",
+    "setOrder":52,
+	"id": "bw5-80",
     "name": "Chansey",
     "imageUrl": "https://images.pokemontcg.io/bw5/80.png",
     "subtype": "Basic",
@@ -4299,7 +4379,8 @@
     ]
   },
   {
-    "id": "bw5-81",
+    "setOrder":52,
+	"id": "bw5-81",
     "name": "Chansey",
     "imageUrl": "https://images.pokemontcg.io/bw5/81.png",
     "subtype": "Basic",
@@ -4344,7 +4425,8 @@
     ]
   },
   {
-    "id": "bw5-82",
+    "setOrder":52,
+	"id": "bw5-82",
     "name": "Blissey",
     "imageUrl": "https://images.pokemontcg.io/bw5/82.png",
     "subtype": "Stage 1",
@@ -4394,7 +4476,8 @@
     "nationalPokedexNumber": 242
   },
   {
-    "id": "bw5-83",
+    "setOrder":52,
+	"id": "bw5-83",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/bw5/83.png",
     "subtype": "Basic",
@@ -4444,7 +4527,8 @@
     ]
   },
   {
-    "id": "bw5-84",
+    "setOrder":52,
+	"id": "bw5-84",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/bw5/84.png",
     "subtype": "Basic",
@@ -4504,7 +4588,8 @@
     ]
   },
   {
-    "id": "bw5-85",
+    "setOrder":52,
+	"id": "bw5-85",
     "name": "Chatot",
     "imageUrl": "https://images.pokemontcg.io/bw5/85.png",
     "subtype": "Basic",
@@ -4560,7 +4645,8 @@
     "nationalPokedexNumber": 441
   },
   {
-    "id": "bw5-86",
+    "setOrder":52,
+	"id": "bw5-86",
     "name": "Lillipup",
     "imageUrl": "https://images.pokemontcg.io/bw5/86.png",
     "subtype": "Basic",
@@ -4613,7 +4699,8 @@
     ]
   },
   {
-    "id": "bw5-87",
+    "setOrder":52,
+	"id": "bw5-87",
     "name": "Herdier",
     "imageUrl": "https://images.pokemontcg.io/bw5/87.png",
     "subtype": "Stage 1",
@@ -4668,7 +4755,8 @@
     ]
   },
   {
-    "id": "bw5-88",
+    "setOrder":52,
+	"id": "bw5-88",
     "name": "Stoutland",
     "imageUrl": "https://images.pokemontcg.io/bw5/88.png",
     "subtype": "Stage 2",
@@ -4725,7 +4813,8 @@
     "nationalPokedexNumber": 508
   },
   {
-    "id": "bw5-89",
+    "setOrder":52,
+	"id": "bw5-89",
     "name": "Haxorus",
     "imageUrl": "https://images.pokemontcg.io/bw5/89.png",
     "subtype": "Stage 2",
@@ -4776,7 +4865,8 @@
     "nationalPokedexNumber": 612
   },
   {
-    "id": "bw5-90",
+    "setOrder":52,
+	"id": "bw5-90",
     "name": "Tornadus-EX",
     "imageUrl": "https://images.pokemontcg.io/bw5/90.png",
     "subtype": "EX",
@@ -4837,7 +4927,8 @@
     "nationalPokedexNumber": 641
   },
   {
-    "id": "bw5-91",
+    "setOrder":52,
+	"id": "bw5-91",
     "name": "Cheren",
     "imageUrl": "https://images.pokemontcg.io/bw5/91.png",
     "subtype": "Supporter",
@@ -4854,7 +4945,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw5/91_hires.png"
   },
   {
-    "id": "bw5-92",
+    "setOrder":52,
+	"id": "bw5-92",
     "name": "Dark Claw",
     "imageUrl": "https://images.pokemontcg.io/bw5/92.png",
     "subtype": "Pokémon Tool",
@@ -4871,7 +4963,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw5/92_hires.png"
   },
   {
-    "id": "bw5-93",
+    "setOrder":52,
+	"id": "bw5-93",
     "name": "Dark Patch",
     "imageUrl": "https://images.pokemontcg.io/bw5/93.png",
     "subtype": "Item",
@@ -4888,7 +4981,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw5/93_hires.png"
   },
   {
-    "id": "bw5-94",
+    "setOrder":52,
+	"id": "bw5-94",
     "name": "Enhanced Hammer",
     "imageUrl": "https://images.pokemontcg.io/bw5/94.png",
     "subtype": "Item",
@@ -4905,7 +4999,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw5/94_hires.png"
   },
   {
-    "id": "bw5-95",
+    "setOrder":52,
+	"id": "bw5-95",
     "name": "Hooligans Jim & Cas",
     "imageUrl": "https://images.pokemontcg.io/bw5/95.png",
     "subtype": "Supporter",
@@ -4922,7 +5017,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw5/95_hires.png"
   },
   {
-    "id": "bw5-96",
+    "setOrder":52,
+	"id": "bw5-96",
     "name": "N",
     "imageUrl": "https://images.pokemontcg.io/bw5/96.png",
     "subtype": "Supporter",
@@ -4939,7 +5035,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw5/96_hires.png"
   },
   {
-    "id": "bw5-97",
+    "setOrder":52,
+	"id": "bw5-97",
     "name": "Old Amber Aerodactyl",
     "imageUrl": "https://images.pokemontcg.io/bw5/97.png",
     "subtype": "Item",
@@ -4956,7 +5053,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw5/97_hires.png"
   },
   {
-    "id": "bw5-98",
+    "setOrder":52,
+	"id": "bw5-98",
     "name": "Professor Juniper",
     "imageUrl": "https://images.pokemontcg.io/bw5/98.png",
     "subtype": "Supporter",
@@ -4973,7 +5071,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw5/98_hires.png"
   },
   {
-    "id": "bw5-99",
+    "setOrder":52,
+	"id": "bw5-99",
     "name": "Random Receiver",
     "imageUrl": "https://images.pokemontcg.io/bw5/99.png",
     "subtype": "Item",
@@ -4990,7 +5089,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw5/99_hires.png"
   },
   {
-    "id": "bw5-100",
+    "setOrder":52,
+	"id": "bw5-100",
     "name": "Rare Candy",
     "imageUrl": "https://images.pokemontcg.io/bw5/100.png",
     "subtype": "Item",
@@ -5007,7 +5107,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw5/100_hires.png"
   },
   {
-    "id": "bw5-101",
+    "setOrder":52,
+	"id": "bw5-101",
     "name": "Twist Mountain",
     "imageUrl": "https://images.pokemontcg.io/bw5/101.png",
     "subtype": "Stadium",
@@ -5024,7 +5125,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw5/101_hires.png"
   },
   {
-    "id": "bw5-102",
+    "setOrder":52,
+	"id": "bw5-102",
     "name": "Ultra Ball",
     "imageUrl": "https://images.pokemontcg.io/bw5/102.png",
     "subtype": "Item",
@@ -5041,7 +5143,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw5/102_hires.png"
   },
   {
-    "id": "bw5-103",
+    "setOrder":52,
+	"id": "bw5-103",
     "name": "Entei-EX",
     "imageUrl": "https://images.pokemontcg.io/bw5/103.png",
     "subtype": "EX",
@@ -5098,7 +5201,8 @@
     "nationalPokedexNumber": 244
   },
   {
-    "id": "bw5-104",
+    "setOrder":52,
+	"id": "bw5-104",
     "name": "Kyogre-EX",
     "imageUrl": "https://images.pokemontcg.io/bw5/104.png",
     "subtype": "EX",
@@ -5156,7 +5260,8 @@
     "nationalPokedexNumber": 382
   },
   {
-    "id": "bw5-105",
+    "setOrder":52,
+	"id": "bw5-105",
     "name": "Raikou-EX",
     "imageUrl": "https://images.pokemontcg.io/bw5/105.png",
     "subtype": "EX",
@@ -5211,7 +5316,8 @@
     "nationalPokedexNumber": 243
   },
   {
-    "id": "bw5-106",
+    "setOrder":52,
+	"id": "bw5-106",
     "name": "Groudon-EX",
     "imageUrl": "https://images.pokemontcg.io/bw5/106.png",
     "subtype": "EX",
@@ -5275,7 +5381,8 @@
     "nationalPokedexNumber": 383
   },
   {
-    "id": "bw5-107",
+    "setOrder":52,
+	"id": "bw5-107",
     "name": "Darkrai-EX",
     "imageUrl": "https://images.pokemontcg.io/bw5/107.png",
     "subtype": "EX",
@@ -5332,7 +5439,8 @@
     "nationalPokedexNumber": 491
   },
   {
-    "id": "bw5-108",
+    "setOrder":52,
+	"id": "bw5-108",
     "name": "Tornadus-EX",
     "imageUrl": "https://images.pokemontcg.io/bw5/108.png",
     "subtype": "EX",
@@ -5393,7 +5501,8 @@
     "nationalPokedexNumber": 641
   },
   {
-    "id": "bw5-109",
+    "setOrder":52,
+	"id": "bw5-109",
     "name": "Gardevoir",
     "imageUrl": "https://images.pokemontcg.io/bw5/109.png",
     "subtype": "Stage 2",
@@ -5443,7 +5552,8 @@
     "nationalPokedexNumber": 282
   },
   {
-    "id": "bw5-110",
+    "setOrder":52,
+	"id": "bw5-110",
     "name": "Archeops",
     "imageUrl": "https://images.pokemontcg.io/bw5/110.png",
     "subtype": "Stage 1",
@@ -5492,7 +5602,8 @@
     "nationalPokedexNumber": 567
   },
   {
-    "id": "bw5-111",
+    "setOrder":52,
+	"id": "bw5-111",
     "name": "Pokémon Catcher",
     "imageUrl": "https://images.pokemontcg.io/bw5/111.png",
     "subtype": "Item",

--- a/json/cards/Delta Species.json
+++ b/json/cards/Delta Species.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "ex11-1",
+    "setOrder":26,
+	"id": "ex11-1",
     "name": "Beedrill δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/1.png",
     "subtype": "Stage 2",
@@ -49,7 +50,8 @@
     "nationalPokedexNumber": 15
   },
   {
-    "id": "ex11-2",
+    "setOrder":26,
+	"id": "ex11-2",
     "name": "Crobat δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/2.png",
     "subtype": "Stage 2",
@@ -103,7 +105,8 @@
     "nationalPokedexNumber": 169
   },
   {
-    "id": "ex11-3",
+    "setOrder":26,
+	"id": "ex11-3",
     "name": "Dragonite δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/3.png",
     "subtype": "Stage 2",
@@ -177,7 +180,8 @@
     "nationalPokedexNumber": 149
   },
   {
-    "id": "ex11-4",
+    "setOrder":26,
+	"id": "ex11-4",
     "name": "Espeon δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/4.png",
     "subtype": "Stage 1",
@@ -228,7 +232,8 @@
     "nationalPokedexNumber": 196
   },
   {
-    "id": "ex11-5",
+    "setOrder":26,
+	"id": "ex11-5",
     "name": "Flareon δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/5.png",
     "subtype": "Stage 1",
@@ -282,7 +287,8 @@
     "nationalPokedexNumber": 136
   },
   {
-    "id": "ex11-6",
+    "setOrder":26,
+	"id": "ex11-6",
     "name": "Gardevoir δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/6.png",
     "subtype": "Stage 2",
@@ -345,7 +351,8 @@
     "nationalPokedexNumber": 282
   },
   {
-    "id": "ex11-7",
+    "setOrder":26,
+	"id": "ex11-7",
     "name": "Jolteon δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/7.png",
     "subtype": "Stage 1",
@@ -407,7 +414,8 @@
     "nationalPokedexNumber": 135
   },
   {
-    "id": "ex11-8",
+    "setOrder":26,
+	"id": "ex11-8",
     "name": "Latias δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/8.png",
     "subtype": "Basic",
@@ -480,7 +488,8 @@
     "nationalPokedexNumber": 380
   },
   {
-    "id": "ex11-9",
+    "setOrder":26,
+	"id": "ex11-9",
     "name": "Latios δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/9.png",
     "subtype": "Basic",
@@ -554,7 +563,8 @@
     "nationalPokedexNumber": 381
   },
   {
-    "id": "ex11-10",
+    "setOrder":26,
+	"id": "ex11-10",
     "name": "Marowak δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/10.png",
     "subtype": "Stage 1",
@@ -611,7 +621,8 @@
     "nationalPokedexNumber": 105
   },
   {
-    "id": "ex11-11",
+    "setOrder":26,
+	"id": "ex11-11",
     "name": "Metagross δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/11.png",
     "subtype": "Stage 2",
@@ -670,7 +681,8 @@
     "nationalPokedexNumber": 376
   },
   {
-    "id": "ex11-12",
+    "setOrder":26,
+	"id": "ex11-12",
     "name": "Mewtwo δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/12.png",
     "subtype": "Basic",
@@ -720,7 +732,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "ex11-13",
+    "setOrder":26,
+	"id": "ex11-13",
     "name": "Rayquaza δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/13.png",
     "subtype": "Basic",
@@ -793,7 +806,8 @@
     "nationalPokedexNumber": 384
   },
   {
-    "id": "ex11-14",
+    "setOrder":26,
+	"id": "ex11-14",
     "name": "Salamence δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/14.png",
     "subtype": "Stage 2",
@@ -861,7 +875,8 @@
     "nationalPokedexNumber": 373
   },
   {
-    "id": "ex11-15",
+    "setOrder":26,
+	"id": "ex11-15",
     "name": "Starmie δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/15.png",
     "subtype": "Stage 1",
@@ -917,7 +932,8 @@
     "nationalPokedexNumber": 121
   },
   {
-    "id": "ex11-16",
+    "setOrder":26,
+	"id": "ex11-16",
     "name": "Tyranitar δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/16.png",
     "subtype": "Stage 2",
@@ -970,7 +986,8 @@
     "nationalPokedexNumber": 248
   },
   {
-    "id": "ex11-17",
+    "setOrder":26,
+	"id": "ex11-17",
     "name": "Umbreon δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/17.png",
     "subtype": "Stage 1",
@@ -1027,7 +1044,8 @@
     "nationalPokedexNumber": 197
   },
   {
-    "id": "ex11-18",
+    "setOrder":26,
+	"id": "ex11-18",
     "name": "Vaporeon δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/18.png",
     "subtype": "Stage 1",
@@ -1083,7 +1101,8 @@
     "nationalPokedexNumber": 134
   },
   {
-    "id": "ex11-19",
+    "setOrder":26,
+	"id": "ex11-19",
     "name": "Azumarill δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/19.png",
     "subtype": "Stage 1",
@@ -1141,7 +1160,8 @@
     "nationalPokedexNumber": 184
   },
   {
-    "id": "ex11-20",
+    "setOrder":26,
+	"id": "ex11-20",
     "name": "Azurill",
     "imageUrl": "https://images.pokemontcg.io/ex11/20.png",
     "subtype": "Basic",
@@ -1189,7 +1209,8 @@
     ]
   },
   {
-    "id": "ex11-21",
+    "setOrder":26,
+	"id": "ex11-21",
     "name": "Holon's Electrode",
     "imageUrl": "https://images.pokemontcg.io/ex11/21.png",
     "subtype": "Stage 1",
@@ -1231,7 +1252,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "ex11-22",
+    "setOrder":26,
+	"id": "ex11-22",
     "name": "Holon's Magneton",
     "imageUrl": "https://images.pokemontcg.io/ex11/22.png",
     "subtype": "Stage 1",
@@ -1285,7 +1307,8 @@
     ]
   },
   {
-    "id": "ex11-23",
+    "setOrder":26,
+	"id": "ex11-23",
     "name": "Hypno",
     "imageUrl": "https://images.pokemontcg.io/ex11/23.png",
     "subtype": "Stage 1",
@@ -1341,7 +1364,8 @@
     "nationalPokedexNumber": 97
   },
   {
-    "id": "ex11-24",
+    "setOrder":26,
+	"id": "ex11-24",
     "name": "Mightyena δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/24.png",
     "subtype": "Stage 1",
@@ -1403,7 +1427,8 @@
     "nationalPokedexNumber": 262
   },
   {
-    "id": "ex11-25",
+    "setOrder":26,
+	"id": "ex11-25",
     "name": "Porygon2",
     "imageUrl": "https://images.pokemontcg.io/ex11/25.png",
     "subtype": "Stage 1",
@@ -1452,7 +1477,8 @@
     ]
   },
   {
-    "id": "ex11-26",
+    "setOrder":26,
+	"id": "ex11-26",
     "name": "Rain Castform",
     "imageUrl": "https://images.pokemontcg.io/ex11/26.png",
     "subtype": "Basic",
@@ -1499,7 +1525,8 @@
     "nationalPokedexNumber": 351
   },
   {
-    "id": "ex11-27",
+    "setOrder":26,
+	"id": "ex11-27",
     "name": "Sandslash δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/27.png",
     "subtype": "Stage 1",
@@ -1561,7 +1588,8 @@
     "nationalPokedexNumber": 28
   },
   {
-    "id": "ex11-28",
+    "setOrder":26,
+	"id": "ex11-28",
     "name": "Slowking",
     "imageUrl": "https://images.pokemontcg.io/ex11/28.png",
     "subtype": "Stage 1",
@@ -1608,7 +1636,8 @@
     "nationalPokedexNumber": 199
   },
   {
-    "id": "ex11-29",
+    "setOrder":26,
+	"id": "ex11-29",
     "name": "Snow-cloud Castform",
     "imageUrl": "https://images.pokemontcg.io/ex11/29.png",
     "subtype": "Basic",
@@ -1654,7 +1683,8 @@
     "nationalPokedexNumber": 351
   },
   {
-    "id": "ex11-30",
+    "setOrder":26,
+	"id": "ex11-30",
     "name": "Starmie δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/30.png",
     "subtype": "Stage 1",
@@ -1710,7 +1740,8 @@
     "nationalPokedexNumber": 121
   },
   {
-    "id": "ex11-31",
+    "setOrder":26,
+	"id": "ex11-31",
     "name": "Sunny Castform",
     "imageUrl": "https://images.pokemontcg.io/ex11/31.png",
     "subtype": "Basic",
@@ -1757,7 +1788,8 @@
     "nationalPokedexNumber": 351
   },
   {
-    "id": "ex11-32",
+    "setOrder":26,
+	"id": "ex11-32",
     "name": "Swellow",
     "imageUrl": "https://images.pokemontcg.io/ex11/32.png",
     "subtype": "Stage 1",
@@ -1812,7 +1844,8 @@
     "nationalPokedexNumber": 277
   },
   {
-    "id": "ex11-33",
+    "setOrder":26,
+	"id": "ex11-33",
     "name": "Weezing",
     "imageUrl": "https://images.pokemontcg.io/ex11/33.png",
     "subtype": "Stage 1",
@@ -1870,7 +1903,8 @@
     "nationalPokedexNumber": 110
   },
   {
-    "id": "ex11-34",
+    "setOrder":26,
+	"id": "ex11-34",
     "name": "Castform",
     "imageUrl": "https://images.pokemontcg.io/ex11/34.png",
     "subtype": "Basic",
@@ -1915,7 +1949,8 @@
     "nationalPokedexNumber": 351
   },
   {
-    "id": "ex11-35",
+    "setOrder":26,
+	"id": "ex11-35",
     "name": "Ditto",
     "imageUrl": "https://images.pokemontcg.io/ex11/35.png",
     "subtype": "Basic",
@@ -1960,7 +1995,8 @@
     "nationalPokedexNumber": 132
   },
   {
-    "id": "ex11-36",
+    "setOrder":26,
+	"id": "ex11-36",
     "name": "Ditto",
     "imageUrl": "https://images.pokemontcg.io/ex11/36.png",
     "subtype": "Basic",
@@ -2006,7 +2042,8 @@
     "nationalPokedexNumber": 132
   },
   {
-    "id": "ex11-37",
+    "setOrder":26,
+	"id": "ex11-37",
     "name": "Ditto",
     "imageUrl": "https://images.pokemontcg.io/ex11/37.png",
     "subtype": "Basic",
@@ -2052,7 +2089,8 @@
     "nationalPokedexNumber": 132
   },
   {
-    "id": "ex11-38",
+    "setOrder":26,
+	"id": "ex11-38",
     "name": "Ditto",
     "imageUrl": "https://images.pokemontcg.io/ex11/38.png",
     "subtype": "Basic",
@@ -2097,7 +2135,8 @@
     "nationalPokedexNumber": 132
   },
   {
-    "id": "ex11-39",
+    "setOrder":26,
+	"id": "ex11-39",
     "name": "Ditto",
     "imageUrl": "https://images.pokemontcg.io/ex11/39.png",
     "subtype": "Basic",
@@ -2143,7 +2182,8 @@
     "nationalPokedexNumber": 132
   },
   {
-    "id": "ex11-40",
+    "setOrder":26,
+	"id": "ex11-40",
     "name": "Ditto",
     "imageUrl": "https://images.pokemontcg.io/ex11/40.png",
     "subtype": "Basic",
@@ -2189,7 +2229,8 @@
     "nationalPokedexNumber": 132
   },
   {
-    "id": "ex11-41",
+    "setOrder":26,
+	"id": "ex11-41",
     "name": "Dragonair δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/41.png",
     "subtype": "Stage 1",
@@ -2255,7 +2296,8 @@
     ]
   },
   {
-    "id": "ex11-42",
+    "setOrder":26,
+	"id": "ex11-42",
     "name": "Dragonair δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/42.png",
     "subtype": "Stage 1",
@@ -2311,7 +2353,8 @@
     ]
   },
   {
-    "id": "ex11-43",
+    "setOrder":26,
+	"id": "ex11-43",
     "name": "Golbat",
     "imageUrl": "https://images.pokemontcg.io/ex11/43.png",
     "subtype": "Stage 1",
@@ -2365,7 +2408,8 @@
     ]
   },
   {
-    "id": "ex11-44",
+    "setOrder":26,
+	"id": "ex11-44",
     "name": "Hariyama",
     "imageUrl": "https://images.pokemontcg.io/ex11/44.png",
     "subtype": "Stage 1",
@@ -2422,7 +2466,8 @@
     "nationalPokedexNumber": 297
   },
   {
-    "id": "ex11-45",
+    "setOrder":26,
+	"id": "ex11-45",
     "name": "Illumise",
     "imageUrl": "https://images.pokemontcg.io/ex11/45.png",
     "subtype": "Basic",
@@ -2477,7 +2522,8 @@
     "nationalPokedexNumber": 314
   },
   {
-    "id": "ex11-46",
+    "setOrder":26,
+	"id": "ex11-46",
     "name": "Kakuna",
     "imageUrl": "https://images.pokemontcg.io/ex11/46.png",
     "subtype": "Stage 1",
@@ -2533,7 +2579,8 @@
     ]
   },
   {
-    "id": "ex11-47",
+    "setOrder":26,
+	"id": "ex11-47",
     "name": "Kirlia",
     "imageUrl": "https://images.pokemontcg.io/ex11/47.png",
     "subtype": "Stage 1",
@@ -2588,7 +2635,8 @@
     ]
   },
   {
-    "id": "ex11-48",
+    "setOrder":26,
+	"id": "ex11-48",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/ex11/48.png",
     "subtype": "Stage 1",
@@ -2650,7 +2698,8 @@
     ]
   },
   {
-    "id": "ex11-49",
+    "setOrder":26,
+	"id": "ex11-49",
     "name": "Metang δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/49.png",
     "subtype": "Stage 1",
@@ -2713,7 +2762,8 @@
     ]
   },
   {
-    "id": "ex11-50",
+    "setOrder":26,
+	"id": "ex11-50",
     "name": "Persian",
     "imageUrl": "https://images.pokemontcg.io/ex11/50.png",
     "subtype": "Stage 1",
@@ -2760,7 +2810,8 @@
     "nationalPokedexNumber": 53
   },
   {
-    "id": "ex11-51",
+    "setOrder":26,
+	"id": "ex11-51",
     "name": "Pupitar δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/51.png",
     "subtype": "Stage 1",
@@ -2812,7 +2863,8 @@
     ]
   },
   {
-    "id": "ex11-52",
+    "setOrder":26,
+	"id": "ex11-52",
     "name": "Rapidash",
     "imageUrl": "https://images.pokemontcg.io/ex11/52.png",
     "subtype": "Stage 1",
@@ -2860,7 +2912,8 @@
     "nationalPokedexNumber": 78
   },
   {
-    "id": "ex11-53",
+    "setOrder":26,
+	"id": "ex11-53",
     "name": "Shelgon δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/53.png",
     "subtype": "Stage 1",
@@ -2926,7 +2979,8 @@
     ]
   },
   {
-    "id": "ex11-54",
+    "setOrder":26,
+	"id": "ex11-54",
     "name": "Shelgon δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/54.png",
     "subtype": "Stage 1",
@@ -2986,7 +3040,8 @@
     ]
   },
   {
-    "id": "ex11-55",
+    "setOrder":26,
+	"id": "ex11-55",
     "name": "Skarmory",
     "imageUrl": "https://images.pokemontcg.io/ex11/55.png",
     "subtype": "Basic",
@@ -3047,7 +3102,8 @@
     "nationalPokedexNumber": 227
   },
   {
-    "id": "ex11-56",
+    "setOrder":26,
+	"id": "ex11-56",
     "name": "Volbeat",
     "imageUrl": "https://images.pokemontcg.io/ex11/56.png",
     "subtype": "Basic",
@@ -3093,7 +3149,8 @@
     "nationalPokedexNumber": 313
   },
   {
-    "id": "ex11-57",
+    "setOrder":26,
+	"id": "ex11-57",
     "name": "Bagon δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/57.png",
     "subtype": "Basic",
@@ -3146,7 +3203,8 @@
     ]
   },
   {
-    "id": "ex11-58",
+    "setOrder":26,
+	"id": "ex11-58",
     "name": "Bagon δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/58.png",
     "subtype": "Basic",
@@ -3200,7 +3258,8 @@
     ]
   },
   {
-    "id": "ex11-59",
+    "setOrder":26,
+	"id": "ex11-59",
     "name": "Beldum δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/59.png",
     "subtype": "Basic",
@@ -3255,7 +3314,8 @@
     ]
   },
   {
-    "id": "ex11-60",
+    "setOrder":26,
+	"id": "ex11-60",
     "name": "Cubone",
     "imageUrl": "https://images.pokemontcg.io/ex11/60.png",
     "subtype": "Basic",
@@ -3307,7 +3367,8 @@
     ]
   },
   {
-    "id": "ex11-61",
+    "setOrder":26,
+	"id": "ex11-61",
     "name": "Ditto",
     "imageUrl": "https://images.pokemontcg.io/ex11/61.png",
     "subtype": "Basic",
@@ -3353,7 +3414,8 @@
     "nationalPokedexNumber": 132
   },
   {
-    "id": "ex11-62",
+    "setOrder":26,
+	"id": "ex11-62",
     "name": "Ditto",
     "imageUrl": "https://images.pokemontcg.io/ex11/62.png",
     "subtype": "Basic",
@@ -3399,7 +3461,8 @@
     "nationalPokedexNumber": 132
   },
   {
-    "id": "ex11-63",
+    "setOrder":26,
+	"id": "ex11-63",
     "name": "Ditto",
     "imageUrl": "https://images.pokemontcg.io/ex11/63.png",
     "subtype": "Basic",
@@ -3445,7 +3508,8 @@
     "nationalPokedexNumber": 132
   },
   {
-    "id": "ex11-64",
+    "setOrder":26,
+	"id": "ex11-64",
     "name": "Ditto",
     "imageUrl": "https://images.pokemontcg.io/ex11/64.png",
     "subtype": "Basic",
@@ -3491,7 +3555,8 @@
     "nationalPokedexNumber": 132
   },
   {
-    "id": "ex11-65",
+    "setOrder":26,
+	"id": "ex11-65",
     "name": "Dratini δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/65.png",
     "subtype": "Basic",
@@ -3554,7 +3619,8 @@
     ]
   },
   {
-    "id": "ex11-66",
+    "setOrder":26,
+	"id": "ex11-66",
     "name": "Dratini δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/66.png",
     "subtype": "Basic",
@@ -3607,7 +3673,8 @@
     ]
   },
   {
-    "id": "ex11-67",
+    "setOrder":26,
+	"id": "ex11-67",
     "name": "Drowzee",
     "imageUrl": "https://images.pokemontcg.io/ex11/67.png",
     "subtype": "Basic",
@@ -3660,7 +3727,8 @@
     ]
   },
   {
-    "id": "ex11-68",
+    "setOrder":26,
+	"id": "ex11-68",
     "name": "Eevee δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/68.png",
     "subtype": "Basic",
@@ -3710,7 +3778,8 @@
     ]
   },
   {
-    "id": "ex11-69",
+    "setOrder":26,
+	"id": "ex11-69",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/ex11/69.png",
     "subtype": "Basic",
@@ -3770,7 +3839,8 @@
     ]
   },
   {
-    "id": "ex11-70",
+    "setOrder":26,
+	"id": "ex11-70",
     "name": "Holon's Magnemite",
     "imageUrl": "https://images.pokemontcg.io/ex11/70.png",
     "subtype": "Basic",
@@ -3822,7 +3892,8 @@
     ]
   },
   {
-    "id": "ex11-71",
+    "setOrder":26,
+	"id": "ex11-71",
     "name": "Holon's Voltorb",
     "imageUrl": "https://images.pokemontcg.io/ex11/71.png",
     "subtype": "Basic",
@@ -3868,7 +3939,8 @@
     ]
   },
   {
-    "id": "ex11-72",
+    "setOrder":26,
+	"id": "ex11-72",
     "name": "Koffing",
     "imageUrl": "https://images.pokemontcg.io/ex11/72.png",
     "subtype": "Basic",
@@ -3921,7 +3993,8 @@
     ]
   },
   {
-    "id": "ex11-73",
+    "setOrder":26,
+	"id": "ex11-73",
     "name": "Larvitar δ",
     "imageUrl": "https://images.pokemontcg.io/ex11/73.png",
     "subtype": "Basic",
@@ -3973,7 +4046,8 @@
     ]
   },
   {
-    "id": "ex11-74",
+    "setOrder":26,
+	"id": "ex11-74",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/ex11/74.png",
     "subtype": "Basic",
@@ -4031,7 +4105,8 @@
     ]
   },
   {
-    "id": "ex11-75",
+    "setOrder":26,
+	"id": "ex11-75",
     "name": "Makuhita",
     "imageUrl": "https://images.pokemontcg.io/ex11/75.png",
     "subtype": "Basic",
@@ -4074,7 +4149,8 @@
     ]
   },
   {
-    "id": "ex11-76",
+    "setOrder":26,
+	"id": "ex11-76",
     "name": "Marill",
     "imageUrl": "https://images.pokemontcg.io/ex11/76.png",
     "subtype": "Basic",
@@ -4127,7 +4203,8 @@
     ]
   },
   {
-    "id": "ex11-77",
+    "setOrder":26,
+	"id": "ex11-77",
     "name": "Meowth",
     "imageUrl": "https://images.pokemontcg.io/ex11/77.png",
     "subtype": "Basic",
@@ -4179,7 +4256,8 @@
     ]
   },
   {
-    "id": "ex11-78",
+    "setOrder":26,
+	"id": "ex11-78",
     "name": "Ponyta",
     "imageUrl": "https://images.pokemontcg.io/ex11/78.png",
     "subtype": "Basic",
@@ -4222,7 +4300,8 @@
     ]
   },
   {
-    "id": "ex11-79",
+    "setOrder":26,
+	"id": "ex11-79",
     "name": "Poochyena",
     "imageUrl": "https://images.pokemontcg.io/ex11/79.png",
     "subtype": "Basic",
@@ -4281,7 +4360,8 @@
     ]
   },
   {
-    "id": "ex11-80",
+    "setOrder":26,
+	"id": "ex11-80",
     "name": "Porygon",
     "imageUrl": "https://images.pokemontcg.io/ex11/80.png",
     "subtype": "Basic",
@@ -4325,7 +4405,8 @@
     ]
   },
   {
-    "id": "ex11-81",
+    "setOrder":26,
+	"id": "ex11-81",
     "name": "Ralts",
     "imageUrl": "https://images.pokemontcg.io/ex11/81.png",
     "subtype": "Basic",
@@ -4377,7 +4458,8 @@
     ]
   },
   {
-    "id": "ex11-82",
+    "setOrder":26,
+	"id": "ex11-82",
     "name": "Sandshrew",
     "imageUrl": "https://images.pokemontcg.io/ex11/82.png",
     "subtype": "Basic",
@@ -4430,7 +4512,8 @@
     ]
   },
   {
-    "id": "ex11-83",
+    "setOrder":26,
+	"id": "ex11-83",
     "name": "Slowpoke",
     "imageUrl": "https://images.pokemontcg.io/ex11/83.png",
     "subtype": "Basic",
@@ -4484,7 +4567,8 @@
     ]
   },
   {
-    "id": "ex11-84",
+    "setOrder":26,
+	"id": "ex11-84",
     "name": "Staryu",
     "imageUrl": "https://images.pokemontcg.io/ex11/84.png",
     "subtype": "Basic",
@@ -4537,7 +4621,8 @@
     ]
   },
   {
-    "id": "ex11-85",
+    "setOrder":26,
+	"id": "ex11-85",
     "name": "Staryu",
     "imageUrl": "https://images.pokemontcg.io/ex11/85.png",
     "subtype": "Basic",
@@ -4589,7 +4674,8 @@
     ]
   },
   {
-    "id": "ex11-86",
+    "setOrder":26,
+	"id": "ex11-86",
     "name": "Taillow",
     "imageUrl": "https://images.pokemontcg.io/ex11/86.png",
     "subtype": "Basic",
@@ -4638,7 +4724,8 @@
     ]
   },
   {
-    "id": "ex11-87",
+    "setOrder":26,
+	"id": "ex11-87",
     "name": "Weedle",
     "imageUrl": "https://images.pokemontcg.io/ex11/87.png",
     "subtype": "Basic",
@@ -4681,7 +4768,8 @@
     ]
   },
   {
-    "id": "ex11-88",
+    "setOrder":26,
+	"id": "ex11-88",
     "name": "Zubat",
     "imageUrl": "https://images.pokemontcg.io/ex11/88.png",
     "subtype": "Basic",
@@ -4724,7 +4812,8 @@
     ]
   },
   {
-    "id": "ex11-89",
+    "setOrder":26,
+	"id": "ex11-89",
     "name": "Dual Ball",
     "imageUrl": "https://images.pokemontcg.io/ex11/89.png",
     "subtype": "Item",
@@ -4750,7 +4839,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/89_hires.png"
   },
   {
-    "id": "ex11-90",
+    "setOrder":26,
+	"id": "ex11-90",
     "name": "Great Ball",
     "imageUrl": "https://images.pokemontcg.io/ex11/90.png",
     "subtype": "Item",
@@ -4776,7 +4866,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/90_hires.png"
   },
   {
-    "id": "ex11-91",
+    "setOrder":26,
+	"id": "ex11-91",
     "name": "Holon Farmer",
     "imageUrl": "https://images.pokemontcg.io/ex11/91.png",
     "subtype": "Supporter",
@@ -4795,7 +4886,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/91_hires.png"
   },
   {
-    "id": "ex11-92",
+    "setOrder":26,
+	"id": "ex11-92",
     "name": "Holon Lass",
     "imageUrl": "https://images.pokemontcg.io/ex11/92.png",
     "subtype": "Supporter",
@@ -4814,7 +4906,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/92_hires.png"
   },
   {
-    "id": "ex11-93",
+    "setOrder":26,
+	"id": "ex11-93",
     "name": "Holon Mentor",
     "imageUrl": "https://images.pokemontcg.io/ex11/93.png",
     "subtype": "Supporter",
@@ -4833,7 +4926,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/93_hires.png"
   },
   {
-    "id": "ex11-94",
+    "setOrder":26,
+	"id": "ex11-94",
     "name": "Holon Research Tower",
     "imageUrl": "https://images.pokemontcg.io/ex11/94.png",
     "subtype": "Stadium",
@@ -4852,7 +4946,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/94_hires.png"
   },
   {
-    "id": "ex11-95",
+    "setOrder":26,
+	"id": "ex11-95",
     "name": "Holon Researcher",
     "imageUrl": "https://images.pokemontcg.io/ex11/95.png",
     "subtype": "Supporter",
@@ -4871,7 +4966,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/95_hires.png"
   },
   {
-    "id": "ex11-96",
+    "setOrder":26,
+	"id": "ex11-96",
     "name": "Holon Ruins",
     "imageUrl": "https://images.pokemontcg.io/ex11/96.png",
     "subtype": "Stadium",
@@ -4890,7 +4986,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/96_hires.png"
   },
   {
-    "id": "ex11-97",
+    "setOrder":26,
+	"id": "ex11-97",
     "name": "Holon Scientist",
     "imageUrl": "https://images.pokemontcg.io/ex11/97.png",
     "subtype": "Supporter",
@@ -4909,7 +5006,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/97_hires.png"
   },
   {
-    "id": "ex11-98",
+    "setOrder":26,
+	"id": "ex11-98",
     "name": "Holon Transceiver",
     "imageUrl": "https://images.pokemontcg.io/ex11/98.png",
     "subtype": "Pokémon Tool",
@@ -4927,7 +5025,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/98_hires.png"
   },
   {
-    "id": "ex11-99",
+    "setOrder":26,
+	"id": "ex11-99",
     "name": "Master Ball",
     "imageUrl": "https://images.pokemontcg.io/ex11/99.png",
     "subtype": "Item",
@@ -4945,7 +5044,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/99_hires.png"
   },
   {
-    "id": "ex11-100",
+    "setOrder":26,
+	"id": "ex11-100",
     "name": "Super Scoop Up",
     "imageUrl": "https://images.pokemontcg.io/ex11/100.png",
     "subtype": "Item",
@@ -4963,7 +5063,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/100_hires.png"
   },
   {
-    "id": "ex11-101",
+    "setOrder":26,
+	"id": "ex11-101",
     "name": "Potion",
     "imageUrl": "https://images.pokemontcg.io/ex11/101.png",
     "subtype": "Item",
@@ -4981,7 +5082,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/101_hires.png"
   },
   {
-    "id": "ex11-102",
+    "setOrder":26,
+	"id": "ex11-102",
     "name": "Switch",
     "imageUrl": "https://images.pokemontcg.io/ex11/102.png",
     "subtype": "Item",
@@ -4999,7 +5101,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/102_hires.png"
   },
   {
-    "id": "ex11-103",
+    "setOrder":26,
+	"id": "ex11-103",
     "name": "Darkness Energy",
     "imageUrl": "https://images.pokemontcg.io/ex11/103.png",
     "subtype": "Special",
@@ -5016,7 +5119,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/103_hires.png"
   },
   {
-    "id": "ex11-104",
+    "setOrder":26,
+	"id": "ex11-104",
     "name": "Holon Energy FF",
     "imageUrl": "https://images.pokemontcg.io/ex11/104.png",
     "subtype": "Special",
@@ -5033,7 +5137,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/104_hires.png"
   },
   {
-    "id": "ex11-105",
+    "setOrder":26,
+	"id": "ex11-105",
     "name": "Holon Energy GL",
     "imageUrl": "https://images.pokemontcg.io/ex11/105.png",
     "subtype": "Special",
@@ -5050,7 +5155,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/105_hires.png"
   },
   {
-    "id": "ex11-106",
+    "setOrder":26,
+	"id": "ex11-106",
     "name": "Holon Energy WP",
     "imageUrl": "https://images.pokemontcg.io/ex11/106.png",
     "subtype": "Special",
@@ -5067,7 +5173,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/106_hires.png"
   },
   {
-    "id": "ex11-107",
+    "setOrder":26,
+	"id": "ex11-107",
     "name": "Metal Energy",
     "imageUrl": "https://images.pokemontcg.io/ex11/107.png",
     "subtype": "Special",
@@ -5084,7 +5191,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex11/107_hires.png"
   },
   {
-    "id": "ex11-108",
+    "setOrder":26,
+	"id": "ex11-108",
     "name": "Flareon ex",
     "imageUrl": "https://images.pokemontcg.io/ex11/108.png",
     "subtype": "EX",
@@ -5146,7 +5254,8 @@
     "nationalPokedexNumber": 136
   },
   {
-    "id": "ex11-109",
+    "setOrder":26,
+	"id": "ex11-109",
     "name": "Jolteon ex",
     "imageUrl": "https://images.pokemontcg.io/ex11/109.png",
     "subtype": "EX",
@@ -5211,7 +5320,8 @@
     "nationalPokedexNumber": 135
   },
   {
-    "id": "ex11-110",
+    "setOrder":26,
+	"id": "ex11-110",
     "name": "Vaporeon ex",
     "imageUrl": "https://images.pokemontcg.io/ex11/110.png",
     "subtype": "EX",
@@ -5273,7 +5383,8 @@
     "nationalPokedexNumber": 134
   },
   {
-    "id": "ex11-111",
+    "setOrder":26,
+	"id": "ex11-111",
     "name": "Groudon Star",
     "imageUrl": "https://images.pokemontcg.io/ex11/111.png",
     "subtype": "Basic",
@@ -5331,7 +5442,8 @@
     "nationalPokedexNumber": 383
   },
   {
-    "id": "ex11-112",
+    "setOrder":26,
+	"id": "ex11-112",
     "name": "Kyogre Star",
     "imageUrl": "https://images.pokemontcg.io/ex11/112.png",
     "subtype": "Basic",
@@ -5389,7 +5501,8 @@
     "nationalPokedexNumber": 382
   },
   {
-    "id": "ex11-113",
+    "setOrder":26,
+	"id": "ex11-113",
     "name": "Metagross Star",
     "imageUrl": "https://images.pokemontcg.io/ex11/113.png",
     "subtype": "Basic",
@@ -5453,7 +5566,8 @@
     "nationalPokedexNumber": 376
   },
   {
-    "id": "ex11-114",
+    "setOrder":26,
+	"id": "ex11-114",
     "name": "Azumarill",
     "imageUrl": "https://images.pokemontcg.io/ex11/114.png",
     "subtype": "Stage 1",

--- a/json/cards/Deoxys.json
+++ b/json/cards/Deoxys.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "ex8-1",
+    "setOrder":23,
+	"id": "ex8-1",
     "name": "Altaria",
     "imageUrl": "https://images.pokemontcg.io/ex8/1.png",
     "subtype": "Stage 1",
@@ -63,7 +64,8 @@
     "nationalPokedexNumber": 334
   },
   {
-    "id": "ex8-2",
+    "setOrder":23,
+	"id": "ex8-2",
     "name": "Beautifly",
     "imageUrl": "https://images.pokemontcg.io/ex8/2.png",
     "subtype": "Stage 2",
@@ -120,7 +122,8 @@
     "nationalPokedexNumber": 267
   },
   {
-    "id": "ex8-3",
+    "setOrder":23,
+	"id": "ex8-3",
     "name": "Breloom",
     "imageUrl": "https://images.pokemontcg.io/ex8/3.png",
     "subtype": "Stage 1",
@@ -172,7 +175,8 @@
     "nationalPokedexNumber": 286
   },
   {
-    "id": "ex8-4",
+    "setOrder":23,
+	"id": "ex8-4",
     "name": "Camerupt",
     "imageUrl": "https://images.pokemontcg.io/ex8/4.png",
     "subtype": "Stage 1",
@@ -225,7 +229,8 @@
     "nationalPokedexNumber": 323
   },
   {
-    "id": "ex8-5",
+    "setOrder":23,
+	"id": "ex8-5",
     "name": "Claydol",
     "imageUrl": "https://images.pokemontcg.io/ex8/5.png",
     "subtype": "Stage 1",
@@ -272,7 +277,8 @@
     "nationalPokedexNumber": 344
   },
   {
-    "id": "ex8-6",
+    "setOrder":23,
+	"id": "ex8-6",
     "name": "Crawdaunt",
     "imageUrl": "https://images.pokemontcg.io/ex8/6.png",
     "subtype": "Stage 1",
@@ -336,7 +342,8 @@
     "nationalPokedexNumber": 342
   },
   {
-    "id": "ex8-7",
+    "setOrder":23,
+	"id": "ex8-7",
     "name": "Dusclops",
     "imageUrl": "https://images.pokemontcg.io/ex8/7.png",
     "subtype": "Stage 1",
@@ -397,7 +404,8 @@
     ]
   },
   {
-    "id": "ex8-8",
+    "setOrder":23,
+	"id": "ex8-8",
     "name": "Gyarados",
     "imageUrl": "https://images.pokemontcg.io/ex8/8.png",
     "subtype": "Stage 1",
@@ -461,7 +469,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "ex8-9",
+    "setOrder":23,
+	"id": "ex8-9",
     "name": "Jirachi",
     "imageUrl": "https://images.pokemontcg.io/ex8/9.png",
     "subtype": "Basic",
@@ -513,7 +522,8 @@
     "nationalPokedexNumber": 385
   },
   {
-    "id": "ex8-10",
+    "setOrder":23,
+	"id": "ex8-10",
     "name": "Ludicolo",
     "imageUrl": "https://images.pokemontcg.io/ex8/10.png",
     "subtype": "Stage 2",
@@ -571,7 +581,8 @@
     "nationalPokedexNumber": 272
   },
   {
-    "id": "ex8-11",
+    "setOrder":23,
+	"id": "ex8-11",
     "name": "Metagross",
     "imageUrl": "https://images.pokemontcg.io/ex8/11.png",
     "subtype": "Stage 2",
@@ -619,7 +630,8 @@
     "nationalPokedexNumber": 376
   },
   {
-    "id": "ex8-12",
+    "setOrder":23,
+	"id": "ex8-12",
     "name": "Mightyena",
     "imageUrl": "https://images.pokemontcg.io/ex8/12.png",
     "subtype": "Stage 1",
@@ -673,7 +685,8 @@
     "nationalPokedexNumber": 262
   },
   {
-    "id": "ex8-13",
+    "setOrder":23,
+	"id": "ex8-13",
     "name": "Ninjask",
     "imageUrl": "https://images.pokemontcg.io/ex8/13.png",
     "subtype": "Stage 1",
@@ -728,7 +741,8 @@
     ]
   },
   {
-    "id": "ex8-14",
+    "setOrder":23,
+	"id": "ex8-14",
     "name": "Shedinja",
     "imageUrl": "https://images.pokemontcg.io/ex8/14.png",
     "subtype": "Stage 1",
@@ -765,7 +779,8 @@
     "nationalPokedexNumber": 292
   },
   {
-    "id": "ex8-15",
+    "setOrder":23,
+	"id": "ex8-15",
     "name": "Slaking",
     "imageUrl": "https://images.pokemontcg.io/ex8/15.png",
     "subtype": "Stage 2",
@@ -826,7 +841,8 @@
     "nationalPokedexNumber": 289
   },
   {
-    "id": "ex8-16",
+    "setOrder":23,
+	"id": "ex8-16",
     "name": "Deoxys",
     "imageUrl": "https://images.pokemontcg.io/ex8/16.png",
     "subtype": "Basic",
@@ -872,7 +888,8 @@
     "nationalPokedexNumber": 386
   },
   {
-    "id": "ex8-17",
+    "setOrder":23,
+	"id": "ex8-17",
     "name": "Deoxys",
     "imageUrl": "https://images.pokemontcg.io/ex8/17.png",
     "subtype": "Basic",
@@ -919,7 +936,8 @@
     "nationalPokedexNumber": 386
   },
   {
-    "id": "ex8-18",
+    "setOrder":23,
+	"id": "ex8-18",
     "name": "Deoxys",
     "imageUrl": "https://images.pokemontcg.io/ex8/18.png",
     "subtype": "Basic",
@@ -965,7 +983,8 @@
     "nationalPokedexNumber": 386
   },
   {
-    "id": "ex8-19",
+    "setOrder":23,
+	"id": "ex8-19",
     "name": "Ludicolo",
     "imageUrl": "https://images.pokemontcg.io/ex8/19.png",
     "subtype": "Stage 2",
@@ -1014,7 +1033,8 @@
     "nationalPokedexNumber": 272
   },
   {
-    "id": "ex8-20",
+    "setOrder":23,
+	"id": "ex8-20",
     "name": "Magcargo",
     "imageUrl": "https://images.pokemontcg.io/ex8/20.png",
     "subtype": "Stage 1",
@@ -1073,7 +1093,8 @@
     "nationalPokedexNumber": 219
   },
   {
-    "id": "ex8-21",
+    "setOrder":23,
+	"id": "ex8-21",
     "name": "Pelipper",
     "imageUrl": "https://images.pokemontcg.io/ex8/21.png",
     "subtype": "Stage 1",
@@ -1131,7 +1152,8 @@
     "nationalPokedexNumber": 279
   },
   {
-    "id": "ex8-22",
+    "setOrder":23,
+	"id": "ex8-22",
     "name": "Rayquaza",
     "imageUrl": "https://images.pokemontcg.io/ex8/22.png",
     "subtype": "Basic",
@@ -1177,7 +1199,8 @@
     "nationalPokedexNumber": 384
   },
   {
-    "id": "ex8-23",
+    "setOrder":23,
+	"id": "ex8-23",
     "name": "Sableye",
     "imageUrl": "https://images.pokemontcg.io/ex8/23.png",
     "subtype": "Basic",
@@ -1231,7 +1254,8 @@
     "nationalPokedexNumber": 302
   },
   {
-    "id": "ex8-24",
+    "setOrder":23,
+	"id": "ex8-24",
     "name": "Seaking",
     "imageUrl": "https://images.pokemontcg.io/ex8/24.png",
     "subtype": "Stage 1",
@@ -1279,7 +1303,8 @@
     "nationalPokedexNumber": 119
   },
   {
-    "id": "ex8-25",
+    "setOrder":23,
+	"id": "ex8-25",
     "name": "Shiftry",
     "imageUrl": "https://images.pokemontcg.io/ex8/25.png",
     "subtype": "Stage 2",
@@ -1327,7 +1352,8 @@
     "nationalPokedexNumber": 275
   },
   {
-    "id": "ex8-26",
+    "setOrder":23,
+	"id": "ex8-26",
     "name": "Skarmory",
     "imageUrl": "https://images.pokemontcg.io/ex8/26.png",
     "subtype": "Basic",
@@ -1388,7 +1414,8 @@
     "nationalPokedexNumber": 227
   },
   {
-    "id": "ex8-27",
+    "setOrder":23,
+	"id": "ex8-27",
     "name": "Tropius",
     "imageUrl": "https://images.pokemontcg.io/ex8/27.png",
     "subtype": "Basic",
@@ -1445,7 +1472,8 @@
     "nationalPokedexNumber": 357
   },
   {
-    "id": "ex8-28",
+    "setOrder":23,
+	"id": "ex8-28",
     "name": "Whiscash",
     "imageUrl": "https://images.pokemontcg.io/ex8/28.png",
     "subtype": "Stage 1",
@@ -1498,7 +1526,8 @@
     "nationalPokedexNumber": 340
   },
   {
-    "id": "ex8-29",
+    "setOrder":23,
+	"id": "ex8-29",
     "name": "Xatu",
     "imageUrl": "https://images.pokemontcg.io/ex8/29.png",
     "subtype": "Stage 1",
@@ -1557,7 +1586,8 @@
     "nationalPokedexNumber": 178
   },
   {
-    "id": "ex8-30",
+    "setOrder":23,
+	"id": "ex8-30",
     "name": "Donphan",
     "imageUrl": "https://images.pokemontcg.io/ex8/30.png",
     "subtype": "Stage 1",
@@ -1609,7 +1639,8 @@
     "nationalPokedexNumber": 232
   },
   {
-    "id": "ex8-31",
+    "setOrder":23,
+	"id": "ex8-31",
     "name": "Golbat",
     "imageUrl": "https://images.pokemontcg.io/ex8/31.png",
     "subtype": "Stage 1",
@@ -1656,7 +1687,8 @@
     ]
   },
   {
-    "id": "ex8-32",
+    "setOrder":23,
+	"id": "ex8-32",
     "name": "Grumpig",
     "imageUrl": "https://images.pokemontcg.io/ex8/32.png",
     "subtype": "Stage 1",
@@ -1714,7 +1746,8 @@
     "nationalPokedexNumber": 326
   },
   {
-    "id": "ex8-33",
+    "setOrder":23,
+	"id": "ex8-33",
     "name": "Lombre",
     "imageUrl": "https://images.pokemontcg.io/ex8/33.png",
     "subtype": "Stage 1",
@@ -1764,7 +1797,8 @@
     ]
   },
   {
-    "id": "ex8-34",
+    "setOrder":23,
+	"id": "ex8-34",
     "name": "Lombre",
     "imageUrl": "https://images.pokemontcg.io/ex8/34.png",
     "subtype": "Stage 1",
@@ -1814,7 +1848,8 @@
     ]
   },
   {
-    "id": "ex8-35",
+    "setOrder":23,
+	"id": "ex8-35",
     "name": "Lotad",
     "imageUrl": "https://images.pokemontcg.io/ex8/35.png",
     "subtype": "Basic",
@@ -1857,7 +1892,8 @@
     ]
   },
   {
-    "id": "ex8-36",
+    "setOrder":23,
+	"id": "ex8-36",
     "name": "Lunatone",
     "imageUrl": "https://images.pokemontcg.io/ex8/36.png",
     "subtype": "Basic",
@@ -1912,7 +1948,8 @@
     "nationalPokedexNumber": 337
   },
   {
-    "id": "ex8-37",
+    "setOrder":23,
+	"id": "ex8-37",
     "name": "Magcargo",
     "imageUrl": "https://images.pokemontcg.io/ex8/37.png",
     "subtype": "Stage 1",
@@ -1965,7 +2002,8 @@
     "nationalPokedexNumber": 219
   },
   {
-    "id": "ex8-38",
+    "setOrder":23,
+	"id": "ex8-38",
     "name": "Manectric",
     "imageUrl": "https://images.pokemontcg.io/ex8/38.png",
     "subtype": "Stage 1",
@@ -2023,7 +2061,8 @@
     "nationalPokedexNumber": 310
   },
   {
-    "id": "ex8-39",
+    "setOrder":23,
+	"id": "ex8-39",
     "name": "Masquerain",
     "imageUrl": "https://images.pokemontcg.io/ex8/39.png",
     "subtype": "Stage 1",
@@ -2072,7 +2111,8 @@
     "nationalPokedexNumber": 284
   },
   {
-    "id": "ex8-40",
+    "setOrder":23,
+	"id": "ex8-40",
     "name": "Metang",
     "imageUrl": "https://images.pokemontcg.io/ex8/40.png",
     "subtype": "Stage 1",
@@ -2129,7 +2169,8 @@
     ]
   },
   {
-    "id": "ex8-41",
+    "setOrder":23,
+	"id": "ex8-41",
     "name": "Minun",
     "imageUrl": "https://images.pokemontcg.io/ex8/41.png",
     "subtype": "Basic",
@@ -2178,7 +2219,8 @@
     "nationalPokedexNumber": 312
   },
   {
-    "id": "ex8-42",
+    "setOrder":23,
+	"id": "ex8-42",
     "name": "Nosepass",
     "imageUrl": "https://images.pokemontcg.io/ex8/42.png",
     "subtype": "Basic",
@@ -2226,7 +2268,8 @@
     ]
   },
   {
-    "id": "ex8-43",
+    "setOrder":23,
+	"id": "ex8-43",
     "name": "Nuzleaf",
     "imageUrl": "https://images.pokemontcg.io/ex8/43.png",
     "subtype": "Stage 1",
@@ -2281,7 +2324,8 @@
     ]
   },
   {
-    "id": "ex8-44",
+    "setOrder":23,
+	"id": "ex8-44",
     "name": "Plusle",
     "imageUrl": "https://images.pokemontcg.io/ex8/44.png",
     "subtype": "Basic",
@@ -2330,7 +2374,8 @@
     "nationalPokedexNumber": 311
   },
   {
-    "id": "ex8-45",
+    "setOrder":23,
+	"id": "ex8-45",
     "name": "Shelgon",
     "imageUrl": "https://images.pokemontcg.io/ex8/45.png",
     "subtype": "Stage 1",
@@ -2391,7 +2436,8 @@
     ]
   },
   {
-    "id": "ex8-46",
+    "setOrder":23,
+	"id": "ex8-46",
     "name": "Silcoon",
     "imageUrl": "https://images.pokemontcg.io/ex8/46.png",
     "subtype": "Stage 1",
@@ -2446,7 +2492,8 @@
     ]
   },
   {
-    "id": "ex8-47",
+    "setOrder":23,
+	"id": "ex8-47",
     "name": "Solrock",
     "imageUrl": "https://images.pokemontcg.io/ex8/47.png",
     "subtype": "Basic",
@@ -2501,7 +2548,8 @@
     "nationalPokedexNumber": 338
   },
   {
-    "id": "ex8-48",
+    "setOrder":23,
+	"id": "ex8-48",
     "name": "Starmie",
     "imageUrl": "https://images.pokemontcg.io/ex8/48.png",
     "subtype": "Stage 1",
@@ -2556,7 +2604,8 @@
     "nationalPokedexNumber": 121
   },
   {
-    "id": "ex8-49",
+    "setOrder":23,
+	"id": "ex8-49",
     "name": "Swellow",
     "imageUrl": "https://images.pokemontcg.io/ex8/49.png",
     "subtype": "Stage 1",
@@ -2611,7 +2660,8 @@
     "nationalPokedexNumber": 277
   },
   {
-    "id": "ex8-50",
+    "setOrder":23,
+	"id": "ex8-50",
     "name": "Vigoroth",
     "imageUrl": "https://images.pokemontcg.io/ex8/50.png",
     "subtype": "Stage 1",
@@ -2662,7 +2712,8 @@
     ]
   },
   {
-    "id": "ex8-51",
+    "setOrder":23,
+	"id": "ex8-51",
     "name": "Weezing",
     "imageUrl": "https://images.pokemontcg.io/ex8/51.png",
     "subtype": "Stage 1",
@@ -2713,7 +2764,8 @@
     "nationalPokedexNumber": 110
   },
   {
-    "id": "ex8-52",
+    "setOrder":23,
+	"id": "ex8-52",
     "name": "Bagon",
     "imageUrl": "https://images.pokemontcg.io/ex8/52.png",
     "subtype": "Basic",
@@ -2775,7 +2827,8 @@
     ]
   },
   {
-    "id": "ex8-53",
+    "setOrder":23,
+	"id": "ex8-53",
     "name": "Baltoy",
     "imageUrl": "https://images.pokemontcg.io/ex8/53.png",
     "subtype": "Basic",
@@ -2828,7 +2881,8 @@
     ]
   },
   {
-    "id": "ex8-54",
+    "setOrder":23,
+	"id": "ex8-54",
     "name": "Barboach",
     "imageUrl": "https://images.pokemontcg.io/ex8/54.png",
     "subtype": "Basic",
@@ -2880,7 +2934,8 @@
     ]
   },
   {
-    "id": "ex8-55",
+    "setOrder":23,
+	"id": "ex8-55",
     "name": "Beldum",
     "imageUrl": "https://images.pokemontcg.io/ex8/55.png",
     "subtype": "Basic",
@@ -2924,7 +2979,8 @@
     ]
   },
   {
-    "id": "ex8-56",
+    "setOrder":23,
+	"id": "ex8-56",
     "name": "Carvanha",
     "imageUrl": "https://images.pokemontcg.io/ex8/56.png",
     "subtype": "Basic",
@@ -2983,7 +3039,8 @@
     ]
   },
   {
-    "id": "ex8-57",
+    "setOrder":23,
+	"id": "ex8-57",
     "name": "Corphish",
     "imageUrl": "https://images.pokemontcg.io/ex8/57.png",
     "subtype": "Basic",
@@ -3031,7 +3088,8 @@
     ]
   },
   {
-    "id": "ex8-58",
+    "setOrder":23,
+	"id": "ex8-58",
     "name": "Duskull",
     "imageUrl": "https://images.pokemontcg.io/ex8/58.png",
     "subtype": "Basic",
@@ -3090,7 +3148,8 @@
     ]
   },
   {
-    "id": "ex8-59",
+    "setOrder":23,
+	"id": "ex8-59",
     "name": "Electrike",
     "imageUrl": "https://images.pokemontcg.io/ex8/59.png",
     "subtype": "Basic",
@@ -3149,7 +3208,8 @@
     ]
   },
   {
-    "id": "ex8-60",
+    "setOrder":23,
+	"id": "ex8-60",
     "name": "Electrike",
     "imageUrl": "https://images.pokemontcg.io/ex8/60.png",
     "subtype": "Basic",
@@ -3202,7 +3262,8 @@
     ]
   },
   {
-    "id": "ex8-61",
+    "setOrder":23,
+	"id": "ex8-61",
     "name": "Goldeen",
     "imageUrl": "https://images.pokemontcg.io/ex8/61.png",
     "subtype": "Basic",
@@ -3254,7 +3315,8 @@
     ]
   },
   {
-    "id": "ex8-62",
+    "setOrder":23,
+	"id": "ex8-62",
     "name": "Koffing",
     "imageUrl": "https://images.pokemontcg.io/ex8/62.png",
     "subtype": "Basic",
@@ -3297,7 +3359,8 @@
     ]
   },
   {
-    "id": "ex8-63",
+    "setOrder":23,
+	"id": "ex8-63",
     "name": "Lotad",
     "imageUrl": "https://images.pokemontcg.io/ex8/63.png",
     "subtype": "Basic",
@@ -3350,7 +3413,8 @@
     ]
   },
   {
-    "id": "ex8-64",
+    "setOrder":23,
+	"id": "ex8-64",
     "name": "Magikarp",
     "imageUrl": "https://images.pokemontcg.io/ex8/64.png",
     "subtype": "Basic",
@@ -3403,7 +3467,8 @@
     ]
   },
   {
-    "id": "ex8-65",
+    "setOrder":23,
+	"id": "ex8-65",
     "name": "Makuhita",
     "imageUrl": "https://images.pokemontcg.io/ex8/65.png",
     "subtype": "Basic",
@@ -3456,7 +3521,8 @@
     ]
   },
   {
-    "id": "ex8-66",
+    "setOrder":23,
+	"id": "ex8-66",
     "name": "Natu",
     "imageUrl": "https://images.pokemontcg.io/ex8/66.png",
     "subtype": "Basic",
@@ -3504,7 +3570,8 @@
     ]
   },
   {
-    "id": "ex8-67",
+    "setOrder":23,
+	"id": "ex8-67",
     "name": "Nincada",
     "imageUrl": "https://images.pokemontcg.io/ex8/67.png",
     "subtype": "Basic",
@@ -3557,7 +3624,8 @@
     ]
   },
   {
-    "id": "ex8-68",
+    "setOrder":23,
+	"id": "ex8-68",
     "name": "Numel",
     "imageUrl": "https://images.pokemontcg.io/ex8/68.png",
     "subtype": "Basic",
@@ -3605,7 +3673,8 @@
     ]
   },
   {
-    "id": "ex8-69",
+    "setOrder":23,
+	"id": "ex8-69",
     "name": "Phanpy",
     "imageUrl": "https://images.pokemontcg.io/ex8/69.png",
     "subtype": "Basic",
@@ -3658,7 +3727,8 @@
     ]
   },
   {
-    "id": "ex8-70",
+    "setOrder":23,
+	"id": "ex8-70",
     "name": "Poochyena",
     "imageUrl": "https://images.pokemontcg.io/ex8/70.png",
     "subtype": "Basic",
@@ -3717,7 +3787,8 @@
     ]
   },
   {
-    "id": "ex8-71",
+    "setOrder":23,
+	"id": "ex8-71",
     "name": "Seedot",
     "imageUrl": "https://images.pokemontcg.io/ex8/71.png",
     "subtype": "Basic",
@@ -3769,7 +3840,8 @@
     ]
   },
   {
-    "id": "ex8-72",
+    "setOrder":23,
+	"id": "ex8-72",
     "name": "Shroomish",
     "imageUrl": "https://images.pokemontcg.io/ex8/72.png",
     "subtype": "Basic",
@@ -3827,7 +3899,8 @@
     ]
   },
   {
-    "id": "ex8-73",
+    "setOrder":23,
+	"id": "ex8-73",
     "name": "Slakoth",
     "imageUrl": "https://images.pokemontcg.io/ex8/73.png",
     "subtype": "Basic",
@@ -3879,7 +3952,8 @@
     ]
   },
   {
-    "id": "ex8-74",
+    "setOrder":23,
+	"id": "ex8-74",
     "name": "Slugma",
     "imageUrl": "https://images.pokemontcg.io/ex8/74.png",
     "subtype": "Basic",
@@ -3932,7 +4006,8 @@
     ]
   },
   {
-    "id": "ex8-75",
+    "setOrder":23,
+	"id": "ex8-75",
     "name": "Slugma",
     "imageUrl": "https://images.pokemontcg.io/ex8/75.png",
     "subtype": "Basic",
@@ -3986,7 +4061,8 @@
     ]
   },
   {
-    "id": "ex8-76",
+    "setOrder":23,
+	"id": "ex8-76",
     "name": "Spoink",
     "imageUrl": "https://images.pokemontcg.io/ex8/76.png",
     "subtype": "Basic",
@@ -4039,7 +4115,8 @@
     ]
   },
   {
-    "id": "ex8-77",
+    "setOrder":23,
+	"id": "ex8-77",
     "name": "Staryu",
     "imageUrl": "https://images.pokemontcg.io/ex8/77.png",
     "subtype": "Basic",
@@ -4082,7 +4159,8 @@
     ]
   },
   {
-    "id": "ex8-78",
+    "setOrder":23,
+	"id": "ex8-78",
     "name": "Surskit",
     "imageUrl": "https://images.pokemontcg.io/ex8/78.png",
     "subtype": "Basic",
@@ -4125,7 +4203,8 @@
     ]
   },
   {
-    "id": "ex8-79",
+    "setOrder":23,
+	"id": "ex8-79",
     "name": "Swablu",
     "imageUrl": "https://images.pokemontcg.io/ex8/79.png",
     "subtype": "Basic",
@@ -4179,7 +4258,8 @@
     ]
   },
   {
-    "id": "ex8-80",
+    "setOrder":23,
+	"id": "ex8-80",
     "name": "Taillow",
     "imageUrl": "https://images.pokemontcg.io/ex8/80.png",
     "subtype": "Basic",
@@ -4228,7 +4308,8 @@
     ]
   },
   {
-    "id": "ex8-81",
+    "setOrder":23,
+	"id": "ex8-81",
     "name": "Wingull",
     "imageUrl": "https://images.pokemontcg.io/ex8/81.png",
     "subtype": "Basic",
@@ -4278,7 +4359,8 @@
     ]
   },
   {
-    "id": "ex8-82",
+    "setOrder":23,
+	"id": "ex8-82",
     "name": "Wurmple",
     "imageUrl": "https://images.pokemontcg.io/ex8/82.png",
     "subtype": "Basic",
@@ -4331,7 +4413,8 @@
     ]
   },
   {
-    "id": "ex8-83",
+    "setOrder":23,
+	"id": "ex8-83",
     "name": "Zubat",
     "imageUrl": "https://images.pokemontcg.io/ex8/83.png",
     "subtype": "Basic",
@@ -4379,7 +4462,8 @@
     ]
   },
   {
-    "id": "ex8-84",
+    "setOrder":23,
+	"id": "ex8-84",
     "name": "Balloon Berry",
     "imageUrl": "https://images.pokemontcg.io/ex8/84.png",
     "subtype": "Pokémon Tool",
@@ -4398,7 +4482,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex8/84_hires.png"
   },
   {
-    "id": "ex8-85",
+    "setOrder":23,
+	"id": "ex8-85",
     "name": "Crystal Shard",
     "imageUrl": "https://images.pokemontcg.io/ex8/85.png",
     "subtype": "Pokémon Tool",
@@ -4417,7 +4502,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex8/85_hires.png"
   },
   {
-    "id": "ex8-86",
+    "setOrder":23,
+	"id": "ex8-86",
     "name": "Energy Charge",
     "imageUrl": "https://images.pokemontcg.io/ex8/86.png",
     "subtype": "Special",
@@ -4434,7 +4520,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex8/86_hires.png"
   },
   {
-    "id": "ex8-87",
+    "setOrder":23,
+	"id": "ex8-87",
     "name": "Lady Outing",
     "imageUrl": "https://images.pokemontcg.io/ex8/87.png",
     "subtype": "Supporter",
@@ -4453,7 +4540,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex8/87_hires.png"
   },
   {
-    "id": "ex8-88",
+    "setOrder":23,
+	"id": "ex8-88",
     "name": "Master Ball",
     "imageUrl": "https://images.pokemontcg.io/ex8/88.png",
     "subtype": "Item",
@@ -4471,7 +4559,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex8/88_hires.png"
   },
   {
-    "id": "ex8-89",
+    "setOrder":23,
+	"id": "ex8-89",
     "name": "Meteor Falls",
     "imageUrl": "https://images.pokemontcg.io/ex8/89.png",
     "subtype": "Stadium",
@@ -4490,7 +4579,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex8/89_hires.png"
   },
   {
-    "id": "ex8-90",
+    "setOrder":23,
+	"id": "ex8-90",
     "name": "Professor Cozmo's Discovery",
     "imageUrl": "https://images.pokemontcg.io/ex8/90.png",
     "subtype": "Supporter",
@@ -4509,7 +4599,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex8/90_hires.png"
   },
   {
-    "id": "ex8-91",
+    "setOrder":23,
+	"id": "ex8-91",
     "name": "Space Center",
     "imageUrl": "https://images.pokemontcg.io/ex8/91.png",
     "subtype": "Stadium",
@@ -4528,7 +4619,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex8/91_hires.png"
   },
   {
-    "id": "ex8-92",
+    "setOrder":23,
+	"id": "ex8-92",
     "name": "Strength Charm",
     "imageUrl": "https://images.pokemontcg.io/ex8/92.png",
     "subtype": "Pokémon Tool",
@@ -4547,7 +4639,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex8/92_hires.png"
   },
   {
-    "id": "ex8-93",
+    "setOrder":23,
+	"id": "ex8-93",
     "name": "Boost Energy",
     "imageUrl": "https://images.pokemontcg.io/ex8/93.png",
     "subtype": "Special",
@@ -4564,7 +4657,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex8/93_hires.png"
   },
   {
-    "id": "ex8-94",
+    "setOrder":23,
+	"id": "ex8-94",
     "name": "Heal Energy",
     "imageUrl": "https://images.pokemontcg.io/ex8/94.png",
     "subtype": "Special",
@@ -4581,7 +4675,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex8/94_hires.png"
   },
   {
-    "id": "ex8-95",
+    "setOrder":23,
+	"id": "ex8-95",
     "name": "Scramble Energy",
     "imageUrl": "https://images.pokemontcg.io/ex8/95.png",
     "subtype": "Special",
@@ -4598,7 +4693,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex8/95_hires.png"
   },
   {
-    "id": "ex8-96",
+    "setOrder":23,
+	"id": "ex8-96",
     "name": "Crobat ex",
     "imageUrl": "https://images.pokemontcg.io/ex8/96.png",
     "subtype": "EX",
@@ -4663,7 +4759,8 @@
     "nationalPokedexNumber": 169
   },
   {
-    "id": "ex8-97",
+    "setOrder":23,
+	"id": "ex8-97",
     "name": "Deoxys ex",
     "imageUrl": "https://images.pokemontcg.io/ex8/97.png",
     "subtype": "EX",
@@ -4713,7 +4810,8 @@
     "nationalPokedexNumber": 386
   },
   {
-    "id": "ex8-98",
+    "setOrder":23,
+	"id": "ex8-98",
     "name": "Deoxys ex",
     "imageUrl": "https://images.pokemontcg.io/ex8/98.png",
     "subtype": "EX",
@@ -4765,7 +4863,8 @@
     "nationalPokedexNumber": 386
   },
   {
-    "id": "ex8-99",
+    "setOrder":23,
+	"id": "ex8-99",
     "name": "Deoxys ex",
     "imageUrl": "https://images.pokemontcg.io/ex8/99.png",
     "subtype": "EX",
@@ -4817,7 +4916,8 @@
     "nationalPokedexNumber": 386
   },
   {
-    "id": "ex8-100",
+    "setOrder":23,
+	"id": "ex8-100",
     "name": "Hariyama ex",
     "imageUrl": "https://images.pokemontcg.io/ex8/100.png",
     "subtype": "EX",
@@ -4880,7 +4980,8 @@
     "nationalPokedexNumber": 297
   },
   {
-    "id": "ex8-101",
+    "setOrder":23,
+	"id": "ex8-101",
     "name": "Manectric ex",
     "imageUrl": "https://images.pokemontcg.io/ex8/101.png",
     "subtype": "EX",
@@ -4943,7 +5044,8 @@
     "nationalPokedexNumber": 310
   },
   {
-    "id": "ex8-102",
+    "setOrder":23,
+	"id": "ex8-102",
     "name": "Rayquaza ex",
     "imageUrl": "https://images.pokemontcg.io/ex8/102.png",
     "subtype": "EX",
@@ -5004,7 +5106,8 @@
     "nationalPokedexNumber": 384
   },
   {
-    "id": "ex8-103",
+    "setOrder":23,
+	"id": "ex8-103",
     "name": "Salamence ex",
     "imageUrl": "https://images.pokemontcg.io/ex8/103.png",
     "subtype": "EX",
@@ -5078,7 +5181,8 @@
     "nationalPokedexNumber": 373
   },
   {
-    "id": "ex8-104",
+    "setOrder":23,
+	"id": "ex8-104",
     "name": "Sharpedo ex",
     "imageUrl": "https://images.pokemontcg.io/ex8/104.png",
     "subtype": "EX",
@@ -5138,7 +5242,8 @@
     "nationalPokedexNumber": 319
   },
   {
-    "id": "ex8-105",
+    "setOrder":23,
+	"id": "ex8-105",
     "name": "Latias Star",
     "imageUrl": "https://images.pokemontcg.io/ex8/105.png",
     "subtype": "Basic",
@@ -5202,7 +5307,8 @@
     "nationalPokedexNumber": 380
   },
   {
-    "id": "ex8-106",
+    "setOrder":23,
+	"id": "ex8-106",
     "name": "Latios Star",
     "imageUrl": "https://images.pokemontcg.io/ex8/106.png",
     "subtype": "Basic",
@@ -5266,7 +5372,8 @@
     "nationalPokedexNumber": 381
   },
   {
-    "id": "ex8-107",
+    "setOrder":23,
+	"id": "ex8-107",
     "name": "Rayquaza Star",
     "imageUrl": "https://images.pokemontcg.io/ex8/107.png",
     "subtype": "Basic",

--- a/json/cards/Diamond & Pearl.json
+++ b/json/cards/Diamond & Pearl.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "dp1-1",
+    "setOrder":32,
+	"id": "dp1-1",
     "name": "Dialga",
     "imageUrl": "https://images.pokemontcg.io/dp1/1.png",
     "subtype": "Basic",
@@ -59,7 +60,8 @@
     "nationalPokedexNumber": 483
   },
   {
-    "id": "dp1-2",
+    "setOrder":32,
+	"id": "dp1-2",
     "name": "Dusknoir",
     "imageUrl": "https://images.pokemontcg.io/dp1/2.png",
     "subtype": "Stage 2",
@@ -116,7 +118,8 @@
     "nationalPokedexNumber": 477
   },
   {
-    "id": "dp1-3",
+    "setOrder":32,
+	"id": "dp1-3",
     "name": "Electivire",
     "imageUrl": "https://images.pokemontcg.io/dp1/3.png",
     "subtype": "Stage 1",
@@ -174,7 +177,8 @@
     "nationalPokedexNumber": 466
   },
   {
-    "id": "dp1-4",
+    "setOrder":32,
+	"id": "dp1-4",
     "name": "Empoleon",
     "imageUrl": "https://images.pokemontcg.io/dp1/4.png",
     "subtype": "Stage 2",
@@ -229,7 +233,8 @@
     "nationalPokedexNumber": 395
   },
   {
-    "id": "dp1-5",
+    "setOrder":32,
+	"id": "dp1-5",
     "name": "Infernape",
     "imageUrl": "https://images.pokemontcg.io/dp1/5.png",
     "subtype": "Stage 2",
@@ -278,7 +283,8 @@
     "nationalPokedexNumber": 392
   },
   {
-    "id": "dp1-6",
+    "setOrder":32,
+	"id": "dp1-6",
     "name": "Lucario",
     "imageUrl": "https://images.pokemontcg.io/dp1/6.png",
     "subtype": "Stage 1",
@@ -330,7 +336,8 @@
     "nationalPokedexNumber": 448
   },
   {
-    "id": "dp1-7",
+    "setOrder":32,
+	"id": "dp1-7",
     "name": "Luxray",
     "imageUrl": "https://images.pokemontcg.io/dp1/7.png",
     "subtype": "Stage 2",
@@ -386,7 +393,8 @@
     "nationalPokedexNumber": 405
   },
   {
-    "id": "dp1-8",
+    "setOrder":32,
+	"id": "dp1-8",
     "name": "Magnezone",
     "imageUrl": "https://images.pokemontcg.io/dp1/8.png",
     "subtype": "Stage 2",
@@ -444,7 +452,8 @@
     "nationalPokedexNumber": 462
   },
   {
-    "id": "dp1-9",
+    "setOrder":32,
+	"id": "dp1-9",
     "name": "Manaphy",
     "imageUrl": "https://images.pokemontcg.io/dp1/9.png",
     "subtype": "Basic",
@@ -495,7 +504,8 @@
     "nationalPokedexNumber": 490
   },
   {
-    "id": "dp1-10",
+    "setOrder":32,
+	"id": "dp1-10",
     "name": "Mismagius",
     "imageUrl": "https://images.pokemontcg.io/dp1/10.png",
     "subtype": "Stage 1",
@@ -554,7 +564,8 @@
     "nationalPokedexNumber": 429
   },
   {
-    "id": "dp1-11",
+    "setOrder":32,
+	"id": "dp1-11",
     "name": "Palkia",
     "imageUrl": "https://images.pokemontcg.io/dp1/11.png",
     "subtype": "Basic",
@@ -607,7 +618,8 @@
     "nationalPokedexNumber": 484
   },
   {
-    "id": "dp1-12",
+    "setOrder":32,
+	"id": "dp1-12",
     "name": "Rhyperior",
     "imageUrl": "https://images.pokemontcg.io/dp1/12.png",
     "subtype": "Stage 2",
@@ -665,7 +677,8 @@
     "nationalPokedexNumber": 464
   },
   {
-    "id": "dp1-13",
+    "setOrder":32,
+	"id": "dp1-13",
     "name": "Roserade",
     "imageUrl": "https://images.pokemontcg.io/dp1/13.png",
     "subtype": "Stage 1",
@@ -719,7 +732,8 @@
     "nationalPokedexNumber": 407
   },
   {
-    "id": "dp1-14",
+    "setOrder":32,
+	"id": "dp1-14",
     "name": "Shiftry",
     "imageUrl": "https://images.pokemontcg.io/dp1/14.png",
     "subtype": "Stage 2",
@@ -775,7 +789,8 @@
     "nationalPokedexNumber": 275
   },
   {
-    "id": "dp1-15",
+    "setOrder":32,
+	"id": "dp1-15",
     "name": "Skuntank",
     "imageUrl": "https://images.pokemontcg.io/dp1/15.png",
     "subtype": "Stage 1",
@@ -835,7 +850,8 @@
     "nationalPokedexNumber": 435
   },
   {
-    "id": "dp1-16",
+    "setOrder":32,
+	"id": "dp1-16",
     "name": "Staraptor",
     "imageUrl": "https://images.pokemontcg.io/dp1/16.png",
     "subtype": "Stage 2",
@@ -892,7 +908,8 @@
     "nationalPokedexNumber": 398
   },
   {
-    "id": "dp1-17",
+    "setOrder":32,
+	"id": "dp1-17",
     "name": "Torterra",
     "imageUrl": "https://images.pokemontcg.io/dp1/17.png",
     "subtype": "Stage 2",
@@ -951,7 +968,8 @@
     "nationalPokedexNumber": 389
   },
   {
-    "id": "dp1-18",
+    "setOrder":32,
+	"id": "dp1-18",
     "name": "Azumarill",
     "imageUrl": "https://images.pokemontcg.io/dp1/18.png",
     "subtype": "Stage 1",
@@ -1004,7 +1022,8 @@
     "nationalPokedexNumber": 184
   },
   {
-    "id": "dp1-19",
+    "setOrder":32,
+	"id": "dp1-19",
     "name": "Beautifly",
     "imageUrl": "https://images.pokemontcg.io/dp1/19.png",
     "subtype": "Stage 2",
@@ -1065,7 +1084,8 @@
     "nationalPokedexNumber": 267
   },
   {
-    "id": "dp1-20",
+    "setOrder":32,
+	"id": "dp1-20",
     "name": "Bibarel",
     "imageUrl": "https://images.pokemontcg.io/dp1/20.png",
     "subtype": "Stage 1",
@@ -1119,7 +1139,8 @@
     "nationalPokedexNumber": 400
   },
   {
-    "id": "dp1-21",
+    "setOrder":32,
+	"id": "dp1-21",
     "name": "Carnivine",
     "imageUrl": "https://images.pokemontcg.io/dp1/21.png",
     "subtype": "Basic",
@@ -1177,7 +1198,8 @@
     "nationalPokedexNumber": 455
   },
   {
-    "id": "dp1-22",
+    "setOrder":32,
+	"id": "dp1-22",
     "name": "Clefable",
     "imageUrl": "https://images.pokemontcg.io/dp1/22.png",
     "subtype": "Stage 1",
@@ -1232,7 +1254,8 @@
     "nationalPokedexNumber": 36
   },
   {
-    "id": "dp1-23",
+    "setOrder":32,
+	"id": "dp1-23",
     "name": "Drapion",
     "imageUrl": "https://images.pokemontcg.io/dp1/23.png",
     "subtype": "Stage 1",
@@ -1288,7 +1311,8 @@
     "nationalPokedexNumber": 452
   },
   {
-    "id": "dp1-24",
+    "setOrder":32,
+	"id": "dp1-24",
     "name": "Drifblim",
     "imageUrl": "https://images.pokemontcg.io/dp1/24.png",
     "subtype": "Stage 1",
@@ -1344,7 +1368,8 @@
     "nationalPokedexNumber": 426
   },
   {
-    "id": "dp1-25",
+    "setOrder":32,
+	"id": "dp1-25",
     "name": "Dustox",
     "imageUrl": "https://images.pokemontcg.io/dp1/25.png",
     "subtype": "Stage 2",
@@ -1400,7 +1425,8 @@
     "nationalPokedexNumber": 269
   },
   {
-    "id": "dp1-26",
+    "setOrder":32,
+	"id": "dp1-26",
     "name": "Floatzel",
     "imageUrl": "https://images.pokemontcg.io/dp1/26.png",
     "subtype": "Stage 1",
@@ -1453,7 +1479,8 @@
     "nationalPokedexNumber": 419
   },
   {
-    "id": "dp1-27",
+    "setOrder":32,
+	"id": "dp1-27",
     "name": "Gengar",
     "imageUrl": "https://images.pokemontcg.io/dp1/27.png",
     "subtype": "Stage 2",
@@ -1512,7 +1539,8 @@
     "nationalPokedexNumber": 94
   },
   {
-    "id": "dp1-28",
+    "setOrder":32,
+	"id": "dp1-28",
     "name": "Heracross",
     "imageUrl": "https://images.pokemontcg.io/dp1/28.png",
     "subtype": "Basic",
@@ -1564,7 +1592,8 @@
     "nationalPokedexNumber": 214
   },
   {
-    "id": "dp1-29",
+    "setOrder":32,
+	"id": "dp1-29",
     "name": "Hippowdon",
     "imageUrl": "https://images.pokemontcg.io/dp1/29.png",
     "subtype": "Stage 1",
@@ -1628,7 +1657,8 @@
     "nationalPokedexNumber": 450
   },
   {
-    "id": "dp1-30",
+    "setOrder":32,
+	"id": "dp1-30",
     "name": "Lopunny",
     "imageUrl": "https://images.pokemontcg.io/dp1/30.png",
     "subtype": "Stage 1",
@@ -1681,7 +1711,8 @@
     "nationalPokedexNumber": 428
   },
   {
-    "id": "dp1-31",
+    "setOrder":32,
+	"id": "dp1-31",
     "name": "Machamp",
     "imageUrl": "https://images.pokemontcg.io/dp1/31.png",
     "subtype": "Stage 2",
@@ -1736,7 +1767,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "dp1-32",
+    "setOrder":32,
+	"id": "dp1-32",
     "name": "Medicham",
     "imageUrl": "https://images.pokemontcg.io/dp1/32.png",
     "subtype": "Stage 1",
@@ -1790,7 +1822,8 @@
     "nationalPokedexNumber": 308
   },
   {
-    "id": "dp1-33",
+    "setOrder":32,
+	"id": "dp1-33",
     "name": "Munchlax",
     "imageUrl": "https://images.pokemontcg.io/dp1/33.png",
     "subtype": "Basic",
@@ -1840,7 +1873,8 @@
     ]
   },
   {
-    "id": "dp1-34",
+    "setOrder":32,
+	"id": "dp1-34",
     "name": "Noctowl",
     "imageUrl": "https://images.pokemontcg.io/dp1/34.png",
     "subtype": "Stage 1",
@@ -1899,7 +1933,8 @@
     "nationalPokedexNumber": 164
   },
   {
-    "id": "dp1-35",
+    "setOrder":32,
+	"id": "dp1-35",
     "name": "Pachirisu",
     "imageUrl": "https://images.pokemontcg.io/dp1/35.png",
     "subtype": "Basic",
@@ -1955,7 +1990,8 @@
     "nationalPokedexNumber": 417
   },
   {
-    "id": "dp1-36",
+    "setOrder":32,
+	"id": "dp1-36",
     "name": "Purugly",
     "imageUrl": "https://images.pokemontcg.io/dp1/36.png",
     "subtype": "Stage 1",
@@ -2009,7 +2045,8 @@
     "nationalPokedexNumber": 432
   },
   {
-    "id": "dp1-37",
+    "setOrder":32,
+	"id": "dp1-37",
     "name": "Snorlax",
     "imageUrl": "https://images.pokemontcg.io/dp1/37.png",
     "subtype": "Basic",
@@ -2065,7 +2102,8 @@
     "nationalPokedexNumber": 143
   },
   {
-    "id": "dp1-38",
+    "setOrder":32,
+	"id": "dp1-38",
     "name": "Steelix",
     "imageUrl": "https://images.pokemontcg.io/dp1/38.png",
     "subtype": "Stage 1",
@@ -2128,7 +2166,8 @@
     "nationalPokedexNumber": 208
   },
   {
-    "id": "dp1-39",
+    "setOrder":32,
+	"id": "dp1-39",
     "name": "Vespiquen",
     "imageUrl": "https://images.pokemontcg.io/dp1/39.png",
     "subtype": "Stage 1",
@@ -2189,7 +2228,8 @@
     "nationalPokedexNumber": 416
   },
   {
-    "id": "dp1-40",
+    "setOrder":32,
+	"id": "dp1-40",
     "name": "Weavile",
     "imageUrl": "https://images.pokemontcg.io/dp1/40.png",
     "subtype": "Stage 1",
@@ -2248,7 +2288,8 @@
     "nationalPokedexNumber": 461
   },
   {
-    "id": "dp1-41",
+    "setOrder":32,
+	"id": "dp1-41",
     "name": "Wobbuffet",
     "imageUrl": "https://images.pokemontcg.io/dp1/41.png",
     "subtype": "Basic",
@@ -2292,7 +2333,8 @@
     "nationalPokedexNumber": 202
   },
   {
-    "id": "dp1-42",
+    "setOrder":32,
+	"id": "dp1-42",
     "name": "Wynaut",
     "imageUrl": "https://images.pokemontcg.io/dp1/42.png",
     "subtype": "Basic",
@@ -2341,7 +2383,8 @@
     ]
   },
   {
-    "id": "dp1-43",
+    "setOrder":32,
+	"id": "dp1-43",
     "name": "Budew",
     "imageUrl": "https://images.pokemontcg.io/dp1/43.png",
     "subtype": "Basic",
@@ -2390,7 +2433,8 @@
     ]
   },
   {
-    "id": "dp1-44",
+    "setOrder":32,
+	"id": "dp1-44",
     "name": "Cascoon",
     "imageUrl": "https://images.pokemontcg.io/dp1/44.png",
     "subtype": "Stage 1",
@@ -2447,7 +2491,8 @@
     ]
   },
   {
-    "id": "dp1-45",
+    "setOrder":32,
+	"id": "dp1-45",
     "name": "Cherrim",
     "imageUrl": "https://images.pokemontcg.io/dp1/45.png",
     "subtype": "Stage 1",
@@ -2506,7 +2551,8 @@
     "nationalPokedexNumber": 421
   },
   {
-    "id": "dp1-46",
+    "setOrder":32,
+	"id": "dp1-46",
     "name": "Drifloon",
     "imageUrl": "https://images.pokemontcg.io/dp1/46.png",
     "subtype": "Basic",
@@ -2566,7 +2612,8 @@
     ]
   },
   {
-    "id": "dp1-47",
+    "setOrder":32,
+	"id": "dp1-47",
     "name": "Dusclops",
     "imageUrl": "https://images.pokemontcg.io/dp1/47.png",
     "subtype": "Stage 1",
@@ -2629,7 +2676,8 @@
     ]
   },
   {
-    "id": "dp1-48",
+    "setOrder":32,
+	"id": "dp1-48",
     "name": "Elekid",
     "imageUrl": "https://images.pokemontcg.io/dp1/48.png",
     "subtype": "Basic",
@@ -2684,7 +2732,8 @@
     ]
   },
   {
-    "id": "dp1-49",
+    "setOrder":32,
+	"id": "dp1-49",
     "name": "Grotle",
     "imageUrl": "https://images.pokemontcg.io/dp1/49.png",
     "subtype": "Stage 1",
@@ -2748,7 +2797,8 @@
     ]
   },
   {
-    "id": "dp1-50",
+    "setOrder":32,
+	"id": "dp1-50",
     "name": "Haunter",
     "imageUrl": "https://images.pokemontcg.io/dp1/50.png",
     "subtype": "Stage 1",
@@ -2806,7 +2856,8 @@
     ]
   },
   {
-    "id": "dp1-51",
+    "setOrder":32,
+	"id": "dp1-51",
     "name": "Hippopotas",
     "imageUrl": "https://images.pokemontcg.io/dp1/51.png",
     "subtype": "Basic",
@@ -2866,7 +2917,8 @@
     ]
   },
   {
-    "id": "dp1-52",
+    "setOrder":32,
+	"id": "dp1-52",
     "name": "Luxio",
     "imageUrl": "https://images.pokemontcg.io/dp1/52.png",
     "subtype": "Stage 1",
@@ -2924,7 +2976,8 @@
     ]
   },
   {
-    "id": "dp1-53",
+    "setOrder":32,
+	"id": "dp1-53",
     "name": "Machoke",
     "imageUrl": "https://images.pokemontcg.io/dp1/53.png",
     "subtype": "Stage 1",
@@ -2982,7 +3035,8 @@
     ]
   },
   {
-    "id": "dp1-54",
+    "setOrder":32,
+	"id": "dp1-54",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/dp1/54.png",
     "subtype": "Stage 1",
@@ -3046,7 +3100,8 @@
     ]
   },
   {
-    "id": "dp1-55",
+    "setOrder":32,
+	"id": "dp1-55",
     "name": "Mantyke",
     "imageUrl": "https://images.pokemontcg.io/dp1/55.png",
     "subtype": "Basic",
@@ -3101,7 +3156,8 @@
     ]
   },
   {
-    "id": "dp1-56",
+    "setOrder":32,
+	"id": "dp1-56",
     "name": "Monferno",
     "imageUrl": "https://images.pokemontcg.io/dp1/56.png",
     "subtype": "Stage 1",
@@ -3153,7 +3209,8 @@
     ]
   },
   {
-    "id": "dp1-57",
+    "setOrder":32,
+	"id": "dp1-57",
     "name": "Nuzleaf",
     "imageUrl": "https://images.pokemontcg.io/dp1/57.png",
     "subtype": "Stage 1",
@@ -3214,7 +3271,8 @@
     ]
   },
   {
-    "id": "dp1-58",
+    "setOrder":32,
+	"id": "dp1-58",
     "name": "Prinplup",
     "imageUrl": "https://images.pokemontcg.io/dp1/58.png",
     "subtype": "Stage 1",
@@ -3269,7 +3327,8 @@
     ]
   },
   {
-    "id": "dp1-59",
+    "setOrder":32,
+	"id": "dp1-59",
     "name": "Rapidash",
     "imageUrl": "https://images.pokemontcg.io/dp1/59.png",
     "subtype": "Stage 1",
@@ -3320,7 +3379,8 @@
     "nationalPokedexNumber": 78
   },
   {
-    "id": "dp1-60",
+    "setOrder":32,
+	"id": "dp1-60",
     "name": "Rhydon",
     "imageUrl": "https://images.pokemontcg.io/dp1/60.png",
     "subtype": "Stage 1",
@@ -3384,7 +3444,8 @@
     ]
   },
   {
-    "id": "dp1-61",
+    "setOrder":32,
+	"id": "dp1-61",
     "name": "Riolu",
     "imageUrl": "https://images.pokemontcg.io/dp1/61.png",
     "subtype": "Basic",
@@ -3428,7 +3489,8 @@
     ]
   },
   {
-    "id": "dp1-62",
+    "setOrder":32,
+	"id": "dp1-62",
     "name": "Seaking",
     "imageUrl": "https://images.pokemontcg.io/dp1/62.png",
     "subtype": "Stage 1",
@@ -3481,7 +3543,8 @@
     "nationalPokedexNumber": 119
   },
   {
-    "id": "dp1-63",
+    "setOrder":32,
+	"id": "dp1-63",
     "name": "Silcoon",
     "imageUrl": "https://images.pokemontcg.io/dp1/63.png",
     "subtype": "Stage 1",
@@ -3538,7 +3601,8 @@
     ]
   },
   {
-    "id": "dp1-64",
+    "setOrder":32,
+	"id": "dp1-64",
     "name": "Staravia",
     "imageUrl": "https://images.pokemontcg.io/dp1/64.png",
     "subtype": "Stage 1",
@@ -3597,7 +3661,8 @@
     ]
   },
   {
-    "id": "dp1-65",
+    "setOrder":32,
+	"id": "dp1-65",
     "name": "Unown A",
     "imageUrl": "https://images.pokemontcg.io/dp1/65.png",
     "subtype": "Basic",
@@ -3643,7 +3708,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp1-66",
+    "setOrder":32,
+	"id": "dp1-66",
     "name": "Unown B",
     "imageUrl": "https://images.pokemontcg.io/dp1/66.png",
     "subtype": "Basic",
@@ -3689,7 +3755,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp1-67",
+    "setOrder":32,
+	"id": "dp1-67",
     "name": "Unown C",
     "imageUrl": "https://images.pokemontcg.io/dp1/67.png",
     "subtype": "Basic",
@@ -3735,7 +3802,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp1-68",
+    "setOrder":32,
+	"id": "dp1-68",
     "name": "Unown D",
     "imageUrl": "https://images.pokemontcg.io/dp1/68.png",
     "subtype": "Basic",
@@ -3781,7 +3849,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp1-69",
+    "setOrder":32,
+	"id": "dp1-69",
     "name": "Azurill",
     "imageUrl": "https://images.pokemontcg.io/dp1/69.png",
     "subtype": "Basic",
@@ -3830,7 +3899,8 @@
     ]
   },
   {
-    "id": "dp1-70",
+    "setOrder":32,
+	"id": "dp1-70",
     "name": "Bidoof",
     "imageUrl": "https://images.pokemontcg.io/dp1/70.png",
     "subtype": "Basic",
@@ -3883,7 +3953,8 @@
     ]
   },
   {
-    "id": "dp1-71",
+    "setOrder":32,
+	"id": "dp1-71",
     "name": "Bonsly",
     "imageUrl": "https://images.pokemontcg.io/dp1/71.png",
     "subtype": "Basic",
@@ -3932,7 +4003,8 @@
     ]
   },
   {
-    "id": "dp1-72",
+    "setOrder":32,
+	"id": "dp1-72",
     "name": "Buizel",
     "imageUrl": "https://images.pokemontcg.io/dp1/72.png",
     "subtype": "Basic",
@@ -3976,7 +4048,8 @@
     ]
   },
   {
-    "id": "dp1-73",
+    "setOrder":32,
+	"id": "dp1-73",
     "name": "Buneary",
     "imageUrl": "https://images.pokemontcg.io/dp1/73.png",
     "subtype": "Basic",
@@ -4030,7 +4103,8 @@
     ]
   },
   {
-    "id": "dp1-74",
+    "setOrder":32,
+	"id": "dp1-74",
     "name": "Chatot",
     "imageUrl": "https://images.pokemontcg.io/dp1/74.png",
     "subtype": "Basic",
@@ -4086,7 +4160,8 @@
     "nationalPokedexNumber": 441
   },
   {
-    "id": "dp1-75",
+    "setOrder":32,
+	"id": "dp1-75",
     "name": "Cherubi",
     "imageUrl": "https://images.pokemontcg.io/dp1/75.png",
     "subtype": "Basic",
@@ -4146,7 +4221,8 @@
     ]
   },
   {
-    "id": "dp1-76",
+    "setOrder":32,
+	"id": "dp1-76",
     "name": "Chimchar",
     "imageUrl": "https://images.pokemontcg.io/dp1/76.png",
     "subtype": "Basic",
@@ -4200,7 +4276,8 @@
     ]
   },
   {
-    "id": "dp1-77",
+    "setOrder":32,
+	"id": "dp1-77",
     "name": "Clefairy",
     "imageUrl": "https://images.pokemontcg.io/dp1/77.png",
     "subtype": "Basic",
@@ -4254,7 +4331,8 @@
     ]
   },
   {
-    "id": "dp1-78",
+    "setOrder":32,
+	"id": "dp1-78",
     "name": "Cleffa",
     "imageUrl": "https://images.pokemontcg.io/dp1/78.png",
     "subtype": "Basic",
@@ -4303,7 +4381,8 @@
     ]
   },
   {
-    "id": "dp1-79",
+    "setOrder":32,
+	"id": "dp1-79",
     "name": "Combee",
     "imageUrl": "https://images.pokemontcg.io/dp1/79.png",
     "subtype": "Basic",
@@ -4363,7 +4442,8 @@
     ]
   },
   {
-    "id": "dp1-80",
+    "setOrder":32,
+	"id": "dp1-80",
     "name": "Duskull",
     "imageUrl": "https://images.pokemontcg.io/dp1/80.png",
     "subtype": "Basic",
@@ -4423,7 +4503,8 @@
     ]
   },
   {
-    "id": "dp1-81",
+    "setOrder":32,
+	"id": "dp1-81",
     "name": "Electabuzz",
     "imageUrl": "https://images.pokemontcg.io/dp1/81.png",
     "subtype": "Basic",
@@ -4485,7 +4566,8 @@
     ]
   },
   {
-    "id": "dp1-82",
+    "setOrder":32,
+	"id": "dp1-82",
     "name": "Gastly",
     "imageUrl": "https://images.pokemontcg.io/dp1/82.png",
     "subtype": "Basic",
@@ -4535,7 +4617,8 @@
     ]
   },
   {
-    "id": "dp1-83",
+    "setOrder":32,
+	"id": "dp1-83",
     "name": "Glameow",
     "imageUrl": "https://images.pokemontcg.io/dp1/83.png",
     "subtype": "Basic",
@@ -4589,7 +4672,8 @@
     ]
   },
   {
-    "id": "dp1-84",
+    "setOrder":32,
+	"id": "dp1-84",
     "name": "Goldeen",
     "imageUrl": "https://images.pokemontcg.io/dp1/84.png",
     "subtype": "Basic",
@@ -4643,7 +4727,8 @@
     ]
   },
   {
-    "id": "dp1-85",
+    "setOrder":32,
+	"id": "dp1-85",
     "name": "Hoothoot",
     "imageUrl": "https://images.pokemontcg.io/dp1/85.png",
     "subtype": "Basic",
@@ -4703,7 +4788,8 @@
     ]
   },
   {
-    "id": "dp1-86",
+    "setOrder":32,
+	"id": "dp1-86",
     "name": "Machop",
     "imageUrl": "https://images.pokemontcg.io/dp1/86.png",
     "subtype": "Basic",
@@ -4748,7 +4834,8 @@
     ]
   },
   {
-    "id": "dp1-87",
+    "setOrder":32,
+	"id": "dp1-87",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/dp1/87.png",
     "subtype": "Basic",
@@ -4808,7 +4895,8 @@
     ]
   },
   {
-    "id": "dp1-88",
+    "setOrder":32,
+	"id": "dp1-88",
     "name": "Marill",
     "imageUrl": "https://images.pokemontcg.io/dp1/88.png",
     "subtype": "Basic",
@@ -4862,7 +4950,8 @@
     ]
   },
   {
-    "id": "dp1-89",
+    "setOrder":32,
+	"id": "dp1-89",
     "name": "Meditite",
     "imageUrl": "https://images.pokemontcg.io/dp1/89.png",
     "subtype": "Basic",
@@ -4916,7 +5005,8 @@
     ]
   },
   {
-    "id": "dp1-90",
+    "setOrder":32,
+	"id": "dp1-90",
     "name": "Mime Jr.",
     "imageUrl": "https://images.pokemontcg.io/dp1/90.png",
     "subtype": "Basic",
@@ -4962,7 +5052,8 @@
     "nationalPokedexNumber": 439
   },
   {
-    "id": "dp1-91",
+    "setOrder":32,
+	"id": "dp1-91",
     "name": "Misdreavus",
     "imageUrl": "https://images.pokemontcg.io/dp1/91.png",
     "subtype": "Basic",
@@ -5022,7 +5113,8 @@
     ]
   },
   {
-    "id": "dp1-92",
+    "setOrder":32,
+	"id": "dp1-92",
     "name": "Onix",
     "imageUrl": "https://images.pokemontcg.io/dp1/92.png",
     "subtype": "Basic",
@@ -5078,7 +5170,8 @@
     ]
   },
   {
-    "id": "dp1-93",
+    "setOrder":32,
+	"id": "dp1-93",
     "name": "Piplup",
     "imageUrl": "https://images.pokemontcg.io/dp1/93.png",
     "subtype": "Basic",
@@ -5132,7 +5225,8 @@
     ]
   },
   {
-    "id": "dp1-94",
+    "setOrder":32,
+	"id": "dp1-94",
     "name": "Ponyta",
     "imageUrl": "https://images.pokemontcg.io/dp1/94.png",
     "subtype": "Basic",
@@ -5186,7 +5280,8 @@
     ]
   },
   {
-    "id": "dp1-95",
+    "setOrder":32,
+	"id": "dp1-95",
     "name": "Rhyhorn",
     "imageUrl": "https://images.pokemontcg.io/dp1/95.png",
     "subtype": "Basic",
@@ -5247,7 +5342,8 @@
     ]
   },
   {
-    "id": "dp1-96",
+    "setOrder":32,
+	"id": "dp1-96",
     "name": "Roselia",
     "imageUrl": "https://images.pokemontcg.io/dp1/96.png",
     "subtype": "Basic",
@@ -5301,7 +5397,8 @@
     ]
   },
   {
-    "id": "dp1-97",
+    "setOrder":32,
+	"id": "dp1-97",
     "name": "Seedot",
     "imageUrl": "https://images.pokemontcg.io/dp1/97.png",
     "subtype": "Basic",
@@ -5361,7 +5458,8 @@
     ]
   },
   {
-    "id": "dp1-98",
+    "setOrder":32,
+	"id": "dp1-98",
     "name": "Shinx",
     "imageUrl": "https://images.pokemontcg.io/dp1/98.png",
     "subtype": "Basic",
@@ -5411,7 +5509,8 @@
     ]
   },
   {
-    "id": "dp1-99",
+    "setOrder":32,
+	"id": "dp1-99",
     "name": "Skorupi",
     "imageUrl": "https://images.pokemontcg.io/dp1/99.png",
     "subtype": "Basic",
@@ -5466,7 +5565,8 @@
     ]
   },
   {
-    "id": "dp1-100",
+    "setOrder":32,
+	"id": "dp1-100",
     "name": "Sneasel",
     "imageUrl": "https://images.pokemontcg.io/dp1/100.png",
     "subtype": "Basic",
@@ -5526,7 +5626,8 @@
     ]
   },
   {
-    "id": "dp1-101",
+    "setOrder":32,
+	"id": "dp1-101",
     "name": "Starly",
     "imageUrl": "https://images.pokemontcg.io/dp1/101.png",
     "subtype": "Basic",
@@ -5586,7 +5687,8 @@
     ]
   },
   {
-    "id": "dp1-102",
+    "setOrder":32,
+	"id": "dp1-102",
     "name": "Stunky",
     "imageUrl": "https://images.pokemontcg.io/dp1/102.png",
     "subtype": "Basic",
@@ -5646,7 +5748,8 @@
     ]
   },
   {
-    "id": "dp1-103",
+    "setOrder":32,
+	"id": "dp1-103",
     "name": "Turtwig",
     "imageUrl": "https://images.pokemontcg.io/dp1/103.png",
     "subtype": "Basic",
@@ -5706,7 +5809,8 @@
     ]
   },
   {
-    "id": "dp1-104",
+    "setOrder":32,
+	"id": "dp1-104",
     "name": "Wurmple",
     "imageUrl": "https://images.pokemontcg.io/dp1/104.png",
     "subtype": "Basic",
@@ -5760,7 +5864,8 @@
     ]
   },
   {
-    "id": "dp1-105",
+    "setOrder":32,
+	"id": "dp1-105",
     "name": "Double Full Heal",
     "imageUrl": "https://images.pokemontcg.io/dp1/105.png",
     "subtype": "Item",
@@ -5778,7 +5883,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp1/105_hires.png"
   },
   {
-    "id": "dp1-106",
+    "setOrder":32,
+	"id": "dp1-106",
     "name": "Energy Restore",
     "imageUrl": "https://images.pokemontcg.io/dp1/106.png",
     "subtype": "Item",
@@ -5796,7 +5902,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp1/106_hires.png"
   },
   {
-    "id": "dp1-107",
+    "setOrder":32,
+	"id": "dp1-107",
     "name": "Energy Switch",
     "imageUrl": "https://images.pokemontcg.io/dp1/107.png",
     "subtype": "Item",
@@ -5814,7 +5921,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp1/107_hires.png"
   },
   {
-    "id": "dp1-108",
+    "setOrder":32,
+	"id": "dp1-108",
     "name": "Night Pokémon Center",
     "imageUrl": "https://images.pokemontcg.io/dp1/108.png",
     "subtype": "Item",
@@ -5832,7 +5940,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp1/108_hires.png"
   },
   {
-    "id": "dp1-109",
+    "setOrder":32,
+	"id": "dp1-109",
     "name": "PlusPower",
     "imageUrl": "https://images.pokemontcg.io/dp1/109.png",
     "subtype": "Item",
@@ -5850,7 +5959,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp1/109_hires.png"
   },
   {
-    "id": "dp1-110",
+    "setOrder":32,
+	"id": "dp1-110",
     "name": "Poké Ball",
     "imageUrl": "https://images.pokemontcg.io/dp1/110.png",
     "subtype": "Item",
@@ -5868,7 +5978,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp1/110_hires.png"
   },
   {
-    "id": "dp1-111",
+    "setOrder":32,
+	"id": "dp1-111",
     "name": "Pokédex HANDY910is",
     "imageUrl": "https://images.pokemontcg.io/dp1/111.png",
     "subtype": "Item",
@@ -5886,7 +5997,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp1/111_hires.png"
   },
   {
-    "id": "dp1-112",
+    "setOrder":32,
+	"id": "dp1-112",
     "name": "Professor Rowan",
     "imageUrl": "https://images.pokemontcg.io/dp1/112.png",
     "subtype": "Supporter",
@@ -5905,7 +6017,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp1/112_hires.png"
   },
   {
-    "id": "dp1-113",
+    "setOrder":32,
+	"id": "dp1-113",
     "name": "Rival",
     "imageUrl": "https://images.pokemontcg.io/dp1/113.png",
     "subtype": "Supporter",
@@ -5924,7 +6037,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp1/113_hires.png"
   },
   {
-    "id": "dp1-114",
+    "setOrder":32,
+	"id": "dp1-114",
     "name": "Speed Stadium",
     "imageUrl": "https://images.pokemontcg.io/dp1/114.png",
     "subtype": "Stadium",
@@ -5942,7 +6056,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp1/114_hires.png"
   },
   {
-    "id": "dp1-115",
+    "setOrder":32,
+	"id": "dp1-115",
     "name": "Super Scoop Up",
     "imageUrl": "https://images.pokemontcg.io/dp1/115.png",
     "subtype": "Item",
@@ -5960,7 +6075,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp1/115_hires.png"
   },
   {
-    "id": "dp1-116",
+    "setOrder":32,
+	"id": "dp1-116",
     "name": "Warp Point",
     "imageUrl": "https://images.pokemontcg.io/dp1/116.png",
     "subtype": "Item",
@@ -5978,7 +6094,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp1/116_hires.png"
   },
   {
-    "id": "dp1-117",
+    "setOrder":32,
+	"id": "dp1-117",
     "name": "Energy Search",
     "imageUrl": "https://images.pokemontcg.io/dp1/117.png",
     "subtype": "Item",
@@ -5996,7 +6113,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp1/117_hires.png"
   },
   {
-    "id": "dp1-118",
+    "setOrder":32,
+	"id": "dp1-118",
     "name": "Potion",
     "imageUrl": "https://images.pokemontcg.io/dp1/118.png",
     "subtype": "Item",
@@ -6014,7 +6132,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp1/118_hires.png"
   },
   {
-    "id": "dp1-119",
+    "setOrder":32,
+	"id": "dp1-119",
     "name": "Switch",
     "imageUrl": "https://images.pokemontcg.io/dp1/119.png",
     "subtype": "Item",
@@ -6032,7 +6151,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp1/119_hires.png"
   },
   {
-    "id": "dp1-120",
+    "setOrder":32,
+	"id": "dp1-120",
     "name": "Empoleon",
     "imageUrl": "https://images.pokemontcg.io/dp1/120.png",
     "subtype": "Level Up",
@@ -6084,7 +6204,8 @@
     "nationalPokedexNumber": 395
   },
   {
-    "id": "dp1-121",
+    "setOrder":32,
+	"id": "dp1-121",
     "name": "Infernape",
     "imageUrl": "https://images.pokemontcg.io/dp1/121.png",
     "subtype": "Level Up",
@@ -6131,7 +6252,8 @@
     "nationalPokedexNumber": 392
   },
   {
-    "id": "dp1-122",
+    "setOrder":32,
+	"id": "dp1-122",
     "name": "Torterra",
     "imageUrl": "https://images.pokemontcg.io/dp1/122.png",
     "subtype": "Level Up",
@@ -6186,7 +6308,8 @@
     "nationalPokedexNumber": 389
   },
   {
-    "id": "dp1-123",
+    "setOrder":32,
+	"id": "dp1-123",
     "name": "Grass Energy",
     "imageUrl": "https://images.pokemontcg.io/dp1/123.png",
     "subtype": "Basic",
@@ -6200,7 +6323,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp1/123_hires.png"
   },
   {
-    "id": "dp1-124",
+    "setOrder":32,
+	"id": "dp1-124",
     "name": "Fire Energy",
     "imageUrl": "https://images.pokemontcg.io/dp1/124.png",
     "subtype": "Basic",
@@ -6214,7 +6338,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp1/124_hires.png"
   },
   {
-    "id": "dp1-125",
+    "setOrder":32,
+	"id": "dp1-125",
     "name": "Water Energy",
     "imageUrl": "https://images.pokemontcg.io/dp1/125.png",
     "subtype": "Basic",
@@ -6228,7 +6353,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp1/125_hires.png"
   },
   {
-    "id": "dp1-126",
+    "setOrder":32,
+	"id": "dp1-126",
     "name": "Lightning Energy",
     "imageUrl": "https://images.pokemontcg.io/dp1/126.png",
     "subtype": "Basic",
@@ -6242,7 +6368,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp1/126_hires.png"
   },
   {
-    "id": "dp1-127",
+    "setOrder":32,
+	"id": "dp1-127",
     "name": "Psychic Energy",
     "imageUrl": "https://images.pokemontcg.io/dp1/127.png",
     "subtype": "Basic",
@@ -6256,7 +6383,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp1/127_hires.png"
   },
   {
-    "id": "dp1-128",
+    "setOrder":32,
+	"id": "dp1-128",
     "name": "Fighting Energy",
     "imageUrl": "https://images.pokemontcg.io/dp1/128.png",
     "subtype": "Basic",
@@ -6270,7 +6398,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp1/128_hires.png"
   },
   {
-    "id": "dp1-129",
+    "setOrder":32,
+	"id": "dp1-129",
     "name": "Darkness Energy",
     "imageUrl": "https://images.pokemontcg.io/dp1/129.png",
     "subtype": "Basic",
@@ -6284,7 +6413,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp1/129_hires.png"
   },
   {
-    "id": "dp1-130",
+    "setOrder":32,
+	"id": "dp1-130",
     "name": "Metal Energy",
     "imageUrl": "https://images.pokemontcg.io/dp1/130.png",
     "subtype": "Basic",

--- a/json/cards/Dragon Frontiers.json
+++ b/json/cards/Dragon Frontiers.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "ex15-1",
+    "setOrder":30,
+	"id": "ex15-1",
     "name": "Ampharos δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/1.png",
     "subtype": "Stage 2",
@@ -49,7 +50,8 @@
     "nationalPokedexNumber": 181
   },
   {
-    "id": "ex15-2",
+    "setOrder":30,
+	"id": "ex15-2",
     "name": "Feraligatr δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/2.png",
     "subtype": "Stage 2",
@@ -108,7 +110,8 @@
     "nationalPokedexNumber": 160
   },
   {
-    "id": "ex15-3",
+    "setOrder":30,
+	"id": "ex15-3",
     "name": "Heracross δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/3.png",
     "subtype": "Basic",
@@ -163,7 +166,8 @@
     "nationalPokedexNumber": 214
   },
   {
-    "id": "ex15-4",
+    "setOrder":30,
+	"id": "ex15-4",
     "name": "Meganium δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/4.png",
     "subtype": "Stage 2",
@@ -228,7 +232,8 @@
     "nationalPokedexNumber": 154
   },
   {
-    "id": "ex15-5",
+    "setOrder":30,
+	"id": "ex15-5",
     "name": "Milotic δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/5.png",
     "subtype": "Stage 1",
@@ -277,7 +282,8 @@
     "nationalPokedexNumber": 350
   },
   {
-    "id": "ex15-6",
+    "setOrder":30,
+	"id": "ex15-6",
     "name": "Nidoking δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/6.png",
     "subtype": "Stage 2",
@@ -332,7 +338,8 @@
     "nationalPokedexNumber": 34
   },
   {
-    "id": "ex15-7",
+    "setOrder":30,
+	"id": "ex15-7",
     "name": "Nidoqueen δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/7.png",
     "subtype": "Stage 2",
@@ -381,7 +388,8 @@
     "nationalPokedexNumber": 31
   },
   {
-    "id": "ex15-8",
+    "setOrder":30,
+	"id": "ex15-8",
     "name": "Ninetales δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/8.png",
     "subtype": "Stage 1",
@@ -425,7 +433,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "ex15-9",
+    "setOrder":30,
+	"id": "ex15-9",
     "name": "Pinsir δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/9.png",
     "subtype": "Basic",
@@ -481,7 +490,8 @@
     "nationalPokedexNumber": 127
   },
   {
-    "id": "ex15-10",
+    "setOrder":30,
+	"id": "ex15-10",
     "name": "Snorlax δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/10.png",
     "subtype": "Basic",
@@ -517,7 +527,8 @@
     "nationalPokedexNumber": 143
   },
   {
-    "id": "ex15-11",
+    "setOrder":30,
+	"id": "ex15-11",
     "name": "Togetic δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/11.png",
     "subtype": "Stage 1",
@@ -575,7 +586,8 @@
     ]
   },
   {
-    "id": "ex15-12",
+    "setOrder":30,
+	"id": "ex15-12",
     "name": "Typhlosion δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/12.png",
     "subtype": "Stage 2",
@@ -623,7 +635,8 @@
     "nationalPokedexNumber": 157
   },
   {
-    "id": "ex15-13",
+    "setOrder":30,
+	"id": "ex15-13",
     "name": "Arbok δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/13.png",
     "subtype": "Stage 1",
@@ -675,7 +688,8 @@
     "nationalPokedexNumber": 24
   },
   {
-    "id": "ex15-14",
+    "setOrder":30,
+	"id": "ex15-14",
     "name": "Cloyster δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/14.png",
     "subtype": "Stage 1",
@@ -721,7 +735,8 @@
     "nationalPokedexNumber": 91
   },
   {
-    "id": "ex15-15",
+    "setOrder":30,
+	"id": "ex15-15",
     "name": "Dewgong δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/15.png",
     "subtype": "Stage 1",
@@ -780,7 +795,8 @@
     "nationalPokedexNumber": 87
   },
   {
-    "id": "ex15-16",
+    "setOrder":30,
+	"id": "ex15-16",
     "name": "Gligar δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/16.png",
     "subtype": "Basic",
@@ -832,7 +848,8 @@
     ]
   },
   {
-    "id": "ex15-17",
+    "setOrder":30,
+	"id": "ex15-17",
     "name": "Jynx δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/17.png",
     "subtype": "Basic",
@@ -878,7 +895,8 @@
     "nationalPokedexNumber": 124
   },
   {
-    "id": "ex15-18",
+    "setOrder":30,
+	"id": "ex15-18",
     "name": "Ledian δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/18.png",
     "subtype": "Stage 1",
@@ -922,7 +940,8 @@
     "nationalPokedexNumber": 166
   },
   {
-    "id": "ex15-19",
+    "setOrder":30,
+	"id": "ex15-19",
     "name": "Lickitung δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/19.png",
     "subtype": "Basic",
@@ -974,7 +993,8 @@
     ]
   },
   {
-    "id": "ex15-20",
+    "setOrder":30,
+	"id": "ex15-20",
     "name": "Mantine δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/20.png",
     "subtype": "Basic",
@@ -1019,7 +1039,8 @@
     "nationalPokedexNumber": 226
   },
   {
-    "id": "ex15-21",
+    "setOrder":30,
+	"id": "ex15-21",
     "name": "Quagsire δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/21.png",
     "subtype": "Stage 1",
@@ -1067,7 +1088,8 @@
     "nationalPokedexNumber": 195
   },
   {
-    "id": "ex15-22",
+    "setOrder":30,
+	"id": "ex15-22",
     "name": "Seadra δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/22.png",
     "subtype": "Stage 1",
@@ -1123,7 +1145,8 @@
     ]
   },
   {
-    "id": "ex15-23",
+    "setOrder":30,
+	"id": "ex15-23",
     "name": "Tropius δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/23.png",
     "subtype": "Basic",
@@ -1168,7 +1191,8 @@
     "nationalPokedexNumber": 357
   },
   {
-    "id": "ex15-24",
+    "setOrder":30,
+	"id": "ex15-24",
     "name": "Vibrava δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/24.png",
     "subtype": "Stage 1",
@@ -1229,7 +1253,8 @@
     ]
   },
   {
-    "id": "ex15-25",
+    "setOrder":30,
+	"id": "ex15-25",
     "name": "Xatu δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/25.png",
     "subtype": "Stage 1",
@@ -1276,7 +1301,8 @@
     "nationalPokedexNumber": 178
   },
   {
-    "id": "ex15-26",
+    "setOrder":30,
+	"id": "ex15-26",
     "name": "Bayleef δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/26.png",
     "subtype": "Stage 1",
@@ -1327,7 +1353,8 @@
     ]
   },
   {
-    "id": "ex15-27",
+    "setOrder":30,
+	"id": "ex15-27",
     "name": "Croconaw δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/27.png",
     "subtype": "Stage 1",
@@ -1382,7 +1409,8 @@
     ]
   },
   {
-    "id": "ex15-28",
+    "setOrder":30,
+	"id": "ex15-28",
     "name": "Dragonair δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/28.png",
     "subtype": "Stage 1",
@@ -1432,7 +1460,8 @@
     ]
   },
   {
-    "id": "ex15-29",
+    "setOrder":30,
+	"id": "ex15-29",
     "name": "Electabuzz δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/29.png",
     "subtype": "Basic",
@@ -1481,7 +1510,8 @@
     ]
   },
   {
-    "id": "ex15-30",
+    "setOrder":30,
+	"id": "ex15-30",
     "name": "Flaaffy δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/30.png",
     "subtype": "Stage 1",
@@ -1526,7 +1556,8 @@
     ]
   },
   {
-    "id": "ex15-31",
+    "setOrder":30,
+	"id": "ex15-31",
     "name": "Horsea δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/31.png",
     "subtype": "Basic",
@@ -1579,7 +1610,8 @@
     ]
   },
   {
-    "id": "ex15-32",
+    "setOrder":30,
+	"id": "ex15-32",
     "name": "Kirlia",
     "imageUrl": "https://images.pokemontcg.io/ex15/32.png",
     "subtype": "Stage 1",
@@ -1636,7 +1668,8 @@
     ]
   },
   {
-    "id": "ex15-33",
+    "setOrder":30,
+	"id": "ex15-33",
     "name": "Kirlia δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/33.png",
     "subtype": "Stage 1",
@@ -1693,7 +1726,8 @@
     ]
   },
   {
-    "id": "ex15-34",
+    "setOrder":30,
+	"id": "ex15-34",
     "name": "Nidorina δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/34.png",
     "subtype": "Stage 1",
@@ -1749,7 +1783,8 @@
     ]
   },
   {
-    "id": "ex15-35",
+    "setOrder":30,
+	"id": "ex15-35",
     "name": "Nidorino δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/35.png",
     "subtype": "Stage 1",
@@ -1805,7 +1840,8 @@
     ]
   },
   {
-    "id": "ex15-36",
+    "setOrder":30,
+	"id": "ex15-36",
     "name": "Quilava δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/36.png",
     "subtype": "Stage 1",
@@ -1861,7 +1897,8 @@
     ]
   },
   {
-    "id": "ex15-37",
+    "setOrder":30,
+	"id": "ex15-37",
     "name": "Seadra δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/37.png",
     "subtype": "Stage 1",
@@ -1917,7 +1954,8 @@
     ]
   },
   {
-    "id": "ex15-38",
+    "setOrder":30,
+	"id": "ex15-38",
     "name": "Shelgon δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/38.png",
     "subtype": "Stage 1",
@@ -1968,7 +2006,8 @@
     ]
   },
   {
-    "id": "ex15-39",
+    "setOrder":30,
+	"id": "ex15-39",
     "name": "Smeargle δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/39.png",
     "subtype": "Basic",
@@ -2017,7 +2056,8 @@
     "nationalPokedexNumber": 235
   },
   {
-    "id": "ex15-40",
+    "setOrder":30,
+	"id": "ex15-40",
     "name": "Swellow δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/40.png",
     "subtype": "Stage 1",
@@ -2067,7 +2107,8 @@
     "nationalPokedexNumber": 277
   },
   {
-    "id": "ex15-41",
+    "setOrder":30,
+	"id": "ex15-41",
     "name": "Togepi δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/41.png",
     "subtype": "Basic",
@@ -2110,7 +2151,8 @@
     ]
   },
   {
-    "id": "ex15-42",
+    "setOrder":30,
+	"id": "ex15-42",
     "name": "Vibrava δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/42.png",
     "subtype": "Stage 1",
@@ -2158,7 +2200,8 @@
     ]
   },
   {
-    "id": "ex15-43",
+    "setOrder":30,
+	"id": "ex15-43",
     "name": "Bagon δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/43.png",
     "subtype": "Basic",
@@ -2195,7 +2238,8 @@
     ]
   },
   {
-    "id": "ex15-44",
+    "setOrder":30,
+	"id": "ex15-44",
     "name": "Chikorita δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/44.png",
     "subtype": "Basic",
@@ -2254,7 +2298,8 @@
     ]
   },
   {
-    "id": "ex15-45",
+    "setOrder":30,
+	"id": "ex15-45",
     "name": "Cyndaquil δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/45.png",
     "subtype": "Basic",
@@ -2298,7 +2343,8 @@
     ]
   },
   {
-    "id": "ex15-46",
+    "setOrder":30,
+	"id": "ex15-46",
     "name": "Dratini δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/46.png",
     "subtype": "Basic",
@@ -2335,7 +2381,8 @@
     ]
   },
   {
-    "id": "ex15-47",
+    "setOrder":30,
+	"id": "ex15-47",
     "name": "Ekans δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/47.png",
     "subtype": "Basic",
@@ -2388,7 +2435,8 @@
     ]
   },
   {
-    "id": "ex15-48",
+    "setOrder":30,
+	"id": "ex15-48",
     "name": "Elekid δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/48.png",
     "subtype": "Basic",
@@ -2436,7 +2484,8 @@
     ]
   },
   {
-    "id": "ex15-49",
+    "setOrder":30,
+	"id": "ex15-49",
     "name": "Feebas δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/49.png",
     "subtype": "Basic",
@@ -2479,7 +2528,8 @@
     ]
   },
   {
-    "id": "ex15-50",
+    "setOrder":30,
+	"id": "ex15-50",
     "name": "Horsea δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/50.png",
     "subtype": "Basic",
@@ -2522,7 +2572,8 @@
     ]
   },
   {
-    "id": "ex15-51",
+    "setOrder":30,
+	"id": "ex15-51",
     "name": "Larvitar",
     "imageUrl": "https://images.pokemontcg.io/ex15/51.png",
     "subtype": "Basic",
@@ -2575,7 +2626,8 @@
     ]
   },
   {
-    "id": "ex15-52",
+    "setOrder":30,
+	"id": "ex15-52",
     "name": "Larvitar δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/52.png",
     "subtype": "Basic",
@@ -2628,7 +2680,8 @@
     ]
   },
   {
-    "id": "ex15-53",
+    "setOrder":30,
+	"id": "ex15-53",
     "name": "Ledyba δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/53.png",
     "subtype": "Basic",
@@ -2680,7 +2733,8 @@
     ]
   },
   {
-    "id": "ex15-54",
+    "setOrder":30,
+	"id": "ex15-54",
     "name": "Mareep δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/54.png",
     "subtype": "Basic",
@@ -2723,7 +2777,8 @@
     ]
   },
   {
-    "id": "ex15-55",
+    "setOrder":30,
+	"id": "ex15-55",
     "name": "Natu δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/55.png",
     "subtype": "Basic",
@@ -2766,7 +2821,8 @@
     ]
   },
   {
-    "id": "ex15-56",
+    "setOrder":30,
+	"id": "ex15-56",
     "name": "Nidoran♀ δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/56.png",
     "subtype": "Basic",
@@ -2818,7 +2874,8 @@
     ]
   },
   {
-    "id": "ex15-57",
+    "setOrder":30,
+	"id": "ex15-57",
     "name": "Nidoran♂ δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/57.png",
     "subtype": "Basic",
@@ -2870,7 +2927,8 @@
     ]
   },
   {
-    "id": "ex15-58",
+    "setOrder":30,
+	"id": "ex15-58",
     "name": "Pupitar",
     "imageUrl": "https://images.pokemontcg.io/ex15/58.png",
     "subtype": "Stage 1",
@@ -2914,7 +2972,8 @@
     ]
   },
   {
-    "id": "ex15-59",
+    "setOrder":30,
+	"id": "ex15-59",
     "name": "Pupitar δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/59.png",
     "subtype": "Stage 1",
@@ -2959,7 +3018,8 @@
     ]
   },
   {
-    "id": "ex15-60",
+    "setOrder":30,
+	"id": "ex15-60",
     "name": "Ralts",
     "imageUrl": "https://images.pokemontcg.io/ex15/60.png",
     "subtype": "Basic",
@@ -3011,7 +3071,8 @@
     ]
   },
   {
-    "id": "ex15-61",
+    "setOrder":30,
+	"id": "ex15-61",
     "name": "Ralts δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/61.png",
     "subtype": "Basic",
@@ -3064,7 +3125,8 @@
     ]
   },
   {
-    "id": "ex15-62",
+    "setOrder":30,
+	"id": "ex15-62",
     "name": "Seel δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/62.png",
     "subtype": "Basic",
@@ -3117,7 +3179,8 @@
     ]
   },
   {
-    "id": "ex15-63",
+    "setOrder":30,
+	"id": "ex15-63",
     "name": "Shellder δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/63.png",
     "subtype": "Basic",
@@ -3160,7 +3223,8 @@
     ]
   },
   {
-    "id": "ex15-64",
+    "setOrder":30,
+	"id": "ex15-64",
     "name": "Smoochum δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/64.png",
     "subtype": "Basic",
@@ -3208,7 +3272,8 @@
     ]
   },
   {
-    "id": "ex15-65",
+    "setOrder":30,
+	"id": "ex15-65",
     "name": "Swablu δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/65.png",
     "subtype": "Basic",
@@ -3257,7 +3322,8 @@
     ]
   },
   {
-    "id": "ex15-66",
+    "setOrder":30,
+	"id": "ex15-66",
     "name": "Taillow δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/66.png",
     "subtype": "Basic",
@@ -3306,7 +3372,8 @@
     ]
   },
   {
-    "id": "ex15-67",
+    "setOrder":30,
+	"id": "ex15-67",
     "name": "Totodile δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/67.png",
     "subtype": "Basic",
@@ -3359,7 +3426,8 @@
     ]
   },
   {
-    "id": "ex15-68",
+    "setOrder":30,
+	"id": "ex15-68",
     "name": "Trapinch δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/68.png",
     "subtype": "Basic",
@@ -3412,7 +3480,8 @@
     ]
   },
   {
-    "id": "ex15-69",
+    "setOrder":30,
+	"id": "ex15-69",
     "name": "Trapinch δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/69.png",
     "subtype": "Basic",
@@ -3455,7 +3524,8 @@
     ]
   },
   {
-    "id": "ex15-70",
+    "setOrder":30,
+	"id": "ex15-70",
     "name": "Vulpix δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/70.png",
     "subtype": "Basic",
@@ -3508,7 +3578,8 @@
     ]
   },
   {
-    "id": "ex15-71",
+    "setOrder":30,
+	"id": "ex15-71",
     "name": "Wooper δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/71.png",
     "subtype": "Basic",
@@ -3561,7 +3632,8 @@
     ]
   },
   {
-    "id": "ex15-72",
+    "setOrder":30,
+	"id": "ex15-72",
     "name": "Buffer Piece",
     "imageUrl": "https://images.pokemontcg.io/ex15/72.png",
     "subtype": "Pokémon Tool",
@@ -3580,7 +3652,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/72_hires.png"
   },
   {
-    "id": "ex15-73",
+    "setOrder":30,
+	"id": "ex15-73",
     "name": "Copycat",
     "imageUrl": "https://images.pokemontcg.io/ex15/73.png",
     "subtype": "Supporter",
@@ -3599,7 +3672,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/73_hires.png"
   },
   {
-    "id": "ex15-74",
+    "setOrder":30,
+	"id": "ex15-74",
     "name": "Holon Legacy",
     "imageUrl": "https://images.pokemontcg.io/ex15/74.png",
     "subtype": "Stadium",
@@ -3618,7 +3692,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/74_hires.png"
   },
   {
-    "id": "ex15-75",
+    "setOrder":30,
+	"id": "ex15-75",
     "name": "Holon Mentor",
     "imageUrl": "https://images.pokemontcg.io/ex15/75.png",
     "subtype": "Supporter",
@@ -3637,7 +3712,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/75_hires.png"
   },
   {
-    "id": "ex15-76",
+    "setOrder":30,
+	"id": "ex15-76",
     "name": "Island Hermit",
     "imageUrl": "https://images.pokemontcg.io/ex15/76.png",
     "subtype": "Supporter",
@@ -3656,7 +3732,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/76_hires.png"
   },
   {
-    "id": "ex15-77",
+    "setOrder":30,
+	"id": "ex15-77",
     "name": "Mr. Stone's Project",
     "imageUrl": "https://images.pokemontcg.io/ex15/77.png",
     "subtype": "Supporter",
@@ -3675,7 +3752,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/77_hires.png"
   },
   {
-    "id": "ex15-78",
+    "setOrder":30,
+	"id": "ex15-78",
     "name": "Old Rod",
     "imageUrl": "https://images.pokemontcg.io/ex15/78.png",
     "subtype": "Item",
@@ -3693,7 +3771,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/78_hires.png"
   },
   {
-    "id": "ex15-79",
+    "setOrder":30,
+	"id": "ex15-79",
     "name": "Professor Elm's Training Method",
     "imageUrl": "https://images.pokemontcg.io/ex15/79.png",
     "subtype": "Supporter",
@@ -3712,7 +3791,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/79_hires.png"
   },
   {
-    "id": "ex15-80",
+    "setOrder":30,
+	"id": "ex15-80",
     "name": "Professor Oak's Research",
     "imageUrl": "https://images.pokemontcg.io/ex15/80.png",
     "subtype": "Supporter",
@@ -3731,7 +3811,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/80_hires.png"
   },
   {
-    "id": "ex15-81",
+    "setOrder":30,
+	"id": "ex15-81",
     "name": "Strength Charm",
     "imageUrl": "https://images.pokemontcg.io/ex15/81.png",
     "subtype": "Pokémon Tool",
@@ -3750,7 +3831,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/81_hires.png"
   },
   {
-    "id": "ex15-82",
+    "setOrder":30,
+	"id": "ex15-82",
     "name": "TV Reporter",
     "imageUrl": "https://images.pokemontcg.io/ex15/82.png",
     "subtype": "Supporter",
@@ -3769,7 +3851,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/82_hires.png"
   },
   {
-    "id": "ex15-83",
+    "setOrder":30,
+	"id": "ex15-83",
     "name": "Switch",
     "imageUrl": "https://images.pokemontcg.io/ex15/83.png",
     "subtype": "Item",
@@ -3787,7 +3870,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/83_hires.png"
   },
   {
-    "id": "ex15-84",
+    "setOrder":30,
+	"id": "ex15-84",
     "name": "Holon Energy FF",
     "imageUrl": "https://images.pokemontcg.io/ex15/84.png",
     "subtype": "Special",
@@ -3804,7 +3888,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/84_hires.png"
   },
   {
-    "id": "ex15-85",
+    "setOrder":30,
+	"id": "ex15-85",
     "name": "Holon Energy GL",
     "imageUrl": "https://images.pokemontcg.io/ex15/85.png",
     "subtype": "Special",
@@ -3821,7 +3906,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/85_hires.png"
   },
   {
-    "id": "ex15-86",
+    "setOrder":30,
+	"id": "ex15-86",
     "name": "Holon Energy WP",
     "imageUrl": "https://images.pokemontcg.io/ex15/86.png",
     "subtype": "Special",
@@ -3838,7 +3924,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/86_hires.png"
   },
   {
-    "id": "ex15-87",
+    "setOrder":30,
+	"id": "ex15-87",
     "name": "Boost Energy",
     "imageUrl": "https://images.pokemontcg.io/ex15/87.png",
     "subtype": "Special",
@@ -3855,7 +3942,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/87_hires.png"
   },
   {
-    "id": "ex15-88",
+    "setOrder":30,
+	"id": "ex15-88",
     "name": "δ Rainbow Energy",
     "imageUrl": "https://images.pokemontcg.io/ex15/88.png",
     "subtype": "Special",
@@ -3872,7 +3960,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/88_hires.png"
   },
   {
-    "id": "ex15-89",
+    "setOrder":30,
+	"id": "ex15-89",
     "name": "Scramble Energy",
     "imageUrl": "https://images.pokemontcg.io/ex15/89.png",
     "subtype": "Special",
@@ -3889,7 +3978,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex15/89_hires.png"
   },
   {
-    "id": "ex15-90",
+    "setOrder":30,
+	"id": "ex15-90",
     "name": "Altaria ex δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/90.png",
     "subtype": "Stage 1",
@@ -3951,7 +4041,8 @@
     "nationalPokedexNumber": 334
   },
   {
-    "id": "ex15-91",
+    "setOrder":30,
+	"id": "ex15-91",
     "name": "Dragonite ex δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/91.png",
     "subtype": "Stage 2",
@@ -4004,7 +4095,8 @@
     "nationalPokedexNumber": 149
   },
   {
-    "id": "ex15-92",
+    "setOrder":30,
+	"id": "ex15-92",
     "name": "Flygon ex δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/92.png",
     "subtype": "Stage 2",
@@ -4051,7 +4143,8 @@
     "nationalPokedexNumber": 330
   },
   {
-    "id": "ex15-93",
+    "setOrder":30,
+	"id": "ex15-93",
     "name": "Gardevoir ex δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/93.png",
     "subtype": "Stage 2",
@@ -4104,7 +4197,8 @@
     "nationalPokedexNumber": 282
   },
   {
-    "id": "ex15-94",
+    "setOrder":30,
+	"id": "ex15-94",
     "name": "Kingdra ex δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/94.png",
     "subtype": "Stage 2",
@@ -4166,7 +4260,8 @@
     "nationalPokedexNumber": 230
   },
   {
-    "id": "ex15-95",
+    "setOrder":30,
+	"id": "ex15-95",
     "name": "Latias ex δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/95.png",
     "subtype": "Basic",
@@ -4218,7 +4313,8 @@
     "nationalPokedexNumber": 380
   },
   {
-    "id": "ex15-96",
+    "setOrder":30,
+	"id": "ex15-96",
     "name": "Latios ex δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/96.png",
     "subtype": "Basic",
@@ -4280,7 +4376,8 @@
     "nationalPokedexNumber": 381
   },
   {
-    "id": "ex15-97",
+    "setOrder":30,
+	"id": "ex15-97",
     "name": "Rayquaza ex δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/97.png",
     "subtype": "Basic",
@@ -4337,7 +4434,8 @@
     "nationalPokedexNumber": 384
   },
   {
-    "id": "ex15-98",
+    "setOrder":30,
+	"id": "ex15-98",
     "name": "Salamence ex δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/98.png",
     "subtype": "Stage 2",
@@ -4412,7 +4510,8 @@
     "nationalPokedexNumber": 373
   },
   {
-    "id": "ex15-99",
+    "setOrder":30,
+	"id": "ex15-99",
     "name": "Tyranitar ex δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/99.png",
     "subtype": "Stage 2",
@@ -4482,7 +4581,8 @@
     "nationalPokedexNumber": 248
   },
   {
-    "id": "ex15-100",
+    "setOrder":30,
+	"id": "ex15-100",
     "name": "Charizard Star δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/100.png",
     "subtype": "Basic",
@@ -4541,7 +4641,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "ex15-101",
+    "setOrder":30,
+	"id": "ex15-101",
     "name": "Mew Star δ",
     "imageUrl": "https://images.pokemontcg.io/ex15/101.png",
     "subtype": "Basic",

--- a/json/cards/Dragon Majesty.json
+++ b/json/cards/Dragon Majesty.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "sm75-1",
+    "setOrder":80,
+	"id": "sm75-1",
     "name": "Charmander",
     "imageUrl": "https://images.pokemontcg.io/sm75/1.png",
     "subtype": "Basic",
@@ -45,7 +46,8 @@
     ]
   },
   {
-    "id": "sm75-2",
+    "setOrder":80,
+	"id": "sm75-2",
     "name": "Charmeleon",
     "imageUrl": "https://images.pokemontcg.io/sm75/2.png",
     "subtype": "Stage 1",
@@ -97,7 +99,8 @@
     ]
   },
   {
-    "id": "sm75-3",
+    "setOrder":80,
+	"id": "sm75-3",
     "name": "Charizard",
     "imageUrl": "https://images.pokemontcg.io/sm75/3.png",
     "subtype": "Stage 2",
@@ -146,7 +149,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "sm75-4",
+    "setOrder":80,
+	"id": "sm75-4",
     "name": "Torchic",
     "imageUrl": "https://images.pokemontcg.io/sm75/4.png",
     "subtype": "Basic",
@@ -189,7 +193,8 @@
     ]
   },
   {
-    "id": "sm75-5",
+    "setOrder":80,
+	"id": "sm75-5",
     "name": "Combusken",
     "imageUrl": "https://images.pokemontcg.io/sm75/5.png",
     "subtype": "Stage 1",
@@ -239,7 +244,8 @@
     ]
   },
   {
-    "id": "sm75-6",
+    "setOrder":80,
+	"id": "sm75-6",
     "name": "Blaziken",
     "imageUrl": "https://images.pokemontcg.io/sm75/6.png",
     "subtype": "Stage 2",
@@ -288,7 +294,8 @@
     "nationalPokedexNumber": 257
   },
   {
-    "id": "sm75-7",
+    "setOrder":80,
+	"id": "sm75-7",
     "name": "Victini ◇",
     "imageUrl": "https://images.pokemontcg.io/sm75/7.png",
     "subtype": "Basic",
@@ -332,7 +339,8 @@
     "nationalPokedexNumber": 494
   },
   {
-    "id": "sm75-8",
+    "setOrder":80,
+	"id": "sm75-8",
     "name": "Darumaka",
     "imageUrl": "https://images.pokemontcg.io/sm75/8.png",
     "subtype": "Basic",
@@ -377,7 +385,8 @@
     ]
   },
   {
-    "id": "sm75-9",
+    "setOrder":80,
+	"id": "sm75-9",
     "name": "Darmanitan",
     "imageUrl": "https://images.pokemontcg.io/sm75/9.png",
     "subtype": "Stage 1",
@@ -430,7 +439,8 @@
     "nationalPokedexNumber": 555
   },
   {
-    "id": "sm75-10",
+    "setOrder":80,
+	"id": "sm75-10",
     "name": "Heatmor",
     "imageUrl": "https://images.pokemontcg.io/sm75/10.png",
     "subtype": "Basic",
@@ -481,7 +491,8 @@
     "nationalPokedexNumber": 631
   },
   {
-    "id": "sm75-11",
+    "setOrder":80,
+	"id": "sm75-11",
     "name": "Reshiram-GX",
     "imageUrl": "https://images.pokemontcg.io/sm75/11.png",
     "subtype": "GX",
@@ -550,7 +561,8 @@
     "nationalPokedexNumber": 643
   },
   {
-    "id": "sm75-12",
+    "setOrder":80,
+	"id": "sm75-12",
     "name": "Litten",
     "imageUrl": "https://images.pokemontcg.io/sm75/12.png",
     "subtype": "Basic",
@@ -593,7 +605,8 @@
     ]
   },
   {
-    "id": "sm75-13",
+    "setOrder":80,
+	"id": "sm75-13",
     "name": "Salandit",
     "imageUrl": "https://images.pokemontcg.io/sm75/13.png",
     "subtype": "Basic",
@@ -646,7 +659,8 @@
     ]
   },
   {
-    "id": "sm75-14",
+    "setOrder":80,
+	"id": "sm75-14",
     "name": "Salazzle",
     "imageUrl": "https://images.pokemontcg.io/sm75/14.png",
     "subtype": "Stage 1",
@@ -697,7 +711,8 @@
     "nationalPokedexNumber": 758
   },
   {
-    "id": "sm75-15",
+    "setOrder":80,
+	"id": "sm75-15",
     "name": "Horsea",
     "imageUrl": "https://images.pokemontcg.io/sm75/15.png",
     "subtype": "Basic",
@@ -740,7 +755,8 @@
     ]
   },
   {
-    "id": "sm75-16",
+    "setOrder":80,
+	"id": "sm75-16",
     "name": "Horsea",
     "imageUrl": "https://images.pokemontcg.io/sm75/16.png",
     "subtype": "Basic",
@@ -783,7 +799,8 @@
     ]
   },
   {
-    "id": "sm75-17",
+    "setOrder":80,
+	"id": "sm75-17",
     "name": "Seadra",
     "imageUrl": "https://images.pokemontcg.io/sm75/17.png",
     "subtype": "Stage 1",
@@ -827,7 +844,8 @@
     ]
   },
   {
-    "id": "sm75-18",
+    "setOrder":80,
+	"id": "sm75-18",
     "name": "Kingdra-GX",
     "imageUrl": "https://images.pokemontcg.io/sm75/18.png",
     "subtype": "GX",
@@ -891,7 +909,8 @@
     "nationalPokedexNumber": 230
   },
   {
-    "id": "sm75-19",
+    "setOrder":80,
+	"id": "sm75-19",
     "name": "Magikarp",
     "imageUrl": "https://images.pokemontcg.io/sm75/19.png",
     "subtype": "Basic",
@@ -934,7 +953,8 @@
     ]
   },
   {
-    "id": "sm75-20",
+    "setOrder":80,
+	"id": "sm75-20",
     "name": "Gyarados",
     "imageUrl": "https://images.pokemontcg.io/sm75/20.png",
     "subtype": "Stage 1",
@@ -985,7 +1005,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "sm75-21",
+    "setOrder":80,
+	"id": "sm75-21",
     "name": "Lapras",
     "imageUrl": "https://images.pokemontcg.io/sm75/21.png",
     "subtype": "Basic",
@@ -1037,7 +1058,8 @@
     "nationalPokedexNumber": 131
   },
   {
-    "id": "sm75-22",
+    "setOrder":80,
+	"id": "sm75-22",
     "name": "Totodile",
     "imageUrl": "https://images.pokemontcg.io/sm75/22.png",
     "subtype": "Basic",
@@ -1089,7 +1111,8 @@
     ]
   },
   {
-    "id": "sm75-23",
+    "setOrder":80,
+	"id": "sm75-23",
     "name": "Croconaw",
     "imageUrl": "https://images.pokemontcg.io/sm75/23.png",
     "subtype": "Stage 1",
@@ -1146,7 +1169,8 @@
     ]
   },
   {
-    "id": "sm75-24",
+    "setOrder":80,
+	"id": "sm75-24",
     "name": "Feraligatr",
     "imageUrl": "https://images.pokemontcg.io/sm75/24.png",
     "subtype": "Stage 2",
@@ -1195,7 +1219,8 @@
     "nationalPokedexNumber": 160
   },
   {
-    "id": "sm75-25",
+    "setOrder":80,
+	"id": "sm75-25",
     "name": "Wooper",
     "imageUrl": "https://images.pokemontcg.io/sm75/25.png",
     "subtype": "Basic",
@@ -1248,7 +1273,8 @@
     ]
   },
   {
-    "id": "sm75-26",
+    "setOrder":80,
+	"id": "sm75-26",
     "name": "Quagsire",
     "imageUrl": "https://images.pokemontcg.io/sm75/26.png",
     "subtype": "Stage 1",
@@ -1297,7 +1323,8 @@
     "nationalPokedexNumber": 195
   },
   {
-    "id": "sm75-27",
+    "setOrder":80,
+	"id": "sm75-27",
     "name": "Corsola",
     "imageUrl": "https://images.pokemontcg.io/sm75/27.png",
     "subtype": "Basic",
@@ -1337,7 +1364,8 @@
     "nationalPokedexNumber": 222
   },
   {
-    "id": "sm75-28",
+    "setOrder":80,
+	"id": "sm75-28",
     "name": "Feebas",
     "imageUrl": "https://images.pokemontcg.io/sm75/28.png",
     "subtype": "Basic",
@@ -1385,7 +1413,8 @@
     ]
   },
   {
-    "id": "sm75-29",
+    "setOrder":80,
+	"id": "sm75-29",
     "name": "Milotic",
     "imageUrl": "https://images.pokemontcg.io/sm75/29.png",
     "subtype": "Stage 1",
@@ -1437,7 +1466,8 @@
     "nationalPokedexNumber": 350
   },
   {
-    "id": "sm75-30",
+    "setOrder":80,
+	"id": "sm75-30",
     "name": "Phione",
     "imageUrl": "https://images.pokemontcg.io/sm75/30.png",
     "subtype": "Basic",
@@ -1483,7 +1513,8 @@
     "nationalPokedexNumber": 489
   },
   {
-    "id": "sm75-31",
+    "setOrder":80,
+	"id": "sm75-31",
     "name": "Wishiwashi",
     "imageUrl": "https://images.pokemontcg.io/sm75/31.png",
     "subtype": "Basic",
@@ -1528,7 +1559,8 @@
     "nationalPokedexNumber": 746
   },
   {
-    "id": "sm75-32",
+    "setOrder":80,
+	"id": "sm75-32",
     "name": "Trapinch",
     "imageUrl": "https://images.pokemontcg.io/sm75/32.png",
     "subtype": "Basic",
@@ -1571,7 +1603,8 @@
     ]
   },
   {
-    "id": "sm75-33",
+    "setOrder":80,
+	"id": "sm75-33",
     "name": "Hydreigon",
     "imageUrl": "https://images.pokemontcg.io/sm75/33.png",
     "subtype": "Stage 2",
@@ -1626,7 +1659,8 @@
     "nationalPokedexNumber": 635
   },
   {
-    "id": "sm75-34",
+    "setOrder":80,
+	"id": "sm75-34",
     "name": "Dratini",
     "imageUrl": "https://images.pokemontcg.io/sm75/34.png",
     "subtype": "Basic",
@@ -1670,7 +1704,8 @@
     ]
   },
   {
-    "id": "sm75-35",
+    "setOrder":80,
+	"id": "sm75-35",
     "name": "Dratini",
     "imageUrl": "https://images.pokemontcg.io/sm75/35.png",
     "subtype": "Basic",
@@ -1715,7 +1750,8 @@
     ]
   },
   {
-    "id": "sm75-36",
+    "setOrder":80,
+	"id": "sm75-36",
     "name": "Dragonair",
     "imageUrl": "https://images.pokemontcg.io/sm75/36.png",
     "subtype": "Stage 1",
@@ -1774,7 +1810,8 @@
     ]
   },
   {
-    "id": "sm75-37",
+    "setOrder":80,
+	"id": "sm75-37",
     "name": "Dragonite-GX",
     "imageUrl": "https://images.pokemontcg.io/sm75/37.png",
     "subtype": "GX",
@@ -1844,7 +1881,8 @@
     "nationalPokedexNumber": 149
   },
   {
-    "id": "sm75-38",
+    "setOrder":80,
+	"id": "sm75-38",
     "name": "Vibrava",
     "imageUrl": "https://images.pokemontcg.io/sm75/38.png",
     "subtype": "Stage 1",
@@ -1889,7 +1927,8 @@
     ]
   },
   {
-    "id": "sm75-39",
+    "setOrder":80,
+	"id": "sm75-39",
     "name": "Flygon",
     "imageUrl": "https://images.pokemontcg.io/sm75/39.png",
     "subtype": "Stage 2",
@@ -1937,7 +1976,8 @@
     "nationalPokedexNumber": 330
   },
   {
-    "id": "sm75-40",
+    "setOrder":80,
+	"id": "sm75-40",
     "name": "Altaria",
     "imageUrl": "https://images.pokemontcg.io/sm75/40.png",
     "subtype": "Stage 1",
@@ -1984,7 +2024,8 @@
     "nationalPokedexNumber": 334
   },
   {
-    "id": "sm75-41",
+    "setOrder":80,
+	"id": "sm75-41",
     "name": "Altaria-GX",
     "imageUrl": "https://images.pokemontcg.io/sm75/41.png",
     "subtype": "GX",
@@ -2051,7 +2092,8 @@
     "nationalPokedexNumber": 334
   },
   {
-    "id": "sm75-42",
+    "setOrder":80,
+	"id": "sm75-42",
     "name": "Bagon",
     "imageUrl": "https://images.pokemontcg.io/sm75/42.png",
     "subtype": "Basic",
@@ -2104,7 +2146,8 @@
     ]
   },
   {
-    "id": "sm75-43",
+    "setOrder":80,
+	"id": "sm75-43",
     "name": "Shelgon",
     "imageUrl": "https://images.pokemontcg.io/sm75/43.png",
     "subtype": "Stage 1",
@@ -2155,7 +2198,8 @@
     ]
   },
   {
-    "id": "sm75-44",
+    "setOrder":80,
+	"id": "sm75-44",
     "name": "Salamence-GX",
     "imageUrl": "https://images.pokemontcg.io/sm75/44.png",
     "subtype": "GX",
@@ -2220,7 +2264,8 @@
     "nationalPokedexNumber": 373
   },
   {
-    "id": "sm75-45",
+    "setOrder":80,
+	"id": "sm75-45",
     "name": "Druddigon",
     "imageUrl": "https://images.pokemontcg.io/sm75/45.png",
     "subtype": "Basic",
@@ -2267,7 +2312,8 @@
     "nationalPokedexNumber": 621
   },
   {
-    "id": "sm75-46",
+    "setOrder":80,
+	"id": "sm75-46",
     "name": "Zekrom",
     "imageUrl": "https://images.pokemontcg.io/sm75/46.png",
     "subtype": "Basic",
@@ -2323,7 +2369,8 @@
     "nationalPokedexNumber": 644
   },
   {
-    "id": "sm75-47",
+    "setOrder":80,
+	"id": "sm75-47",
     "name": "Kyurem",
     "imageUrl": "https://images.pokemontcg.io/sm75/47.png",
     "subtype": "Basic",
@@ -2376,7 +2423,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "sm75-48",
+    "setOrder":80,
+	"id": "sm75-48",
     "name": "White Kyurem-GX",
     "imageUrl": "https://images.pokemontcg.io/sm75/48.png",
     "subtype": "GX",
@@ -2445,7 +2493,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "sm75-49",
+    "setOrder":80,
+	"id": "sm75-49",
     "name": "Zygarde",
     "imageUrl": "https://images.pokemontcg.io/sm75/49.png",
     "subtype": "Basic",
@@ -2498,7 +2547,8 @@
     "nationalPokedexNumber": 718
   },
   {
-    "id": "sm75-50",
+    "setOrder":80,
+	"id": "sm75-50",
     "name": "Turtonator",
     "imageUrl": "https://images.pokemontcg.io/sm75/50.png",
     "subtype": "Basic",
@@ -2542,7 +2592,8 @@
     "nationalPokedexNumber": 776
   },
   {
-    "id": "sm75-51",
+    "setOrder":80,
+	"id": "sm75-51",
     "name": "Drampa",
     "imageUrl": "https://images.pokemontcg.io/sm75/51.png",
     "subtype": "Basic",
@@ -2593,7 +2644,8 @@
     "nationalPokedexNumber": 780
   },
   {
-    "id": "sm75-52",
+    "setOrder":80,
+	"id": "sm75-52",
     "name": "Jangmo-o",
     "imageUrl": "https://images.pokemontcg.io/sm75/52.png",
     "subtype": "Basic",
@@ -2646,7 +2698,8 @@
     ]
   },
   {
-    "id": "sm75-53",
+    "setOrder":80,
+	"id": "sm75-53",
     "name": "Hakamo-o",
     "imageUrl": "https://images.pokemontcg.io/sm75/53.png",
     "subtype": "Stage 1",
@@ -2703,7 +2756,8 @@
     ]
   },
   {
-    "id": "sm75-54",
+    "setOrder":80,
+	"id": "sm75-54",
     "name": "Kommo-o",
     "imageUrl": "https://images.pokemontcg.io/sm75/54.png",
     "subtype": "Stage 2",
@@ -2757,7 +2811,8 @@
     "nationalPokedexNumber": 784
   },
   {
-    "id": "sm75-55",
+    "setOrder":80,
+	"id": "sm75-55",
     "name": "Kangaskhan",
     "imageUrl": "https://images.pokemontcg.io/sm75/55.png",
     "subtype": "Basic",
@@ -2819,7 +2874,8 @@
     "nationalPokedexNumber": 115
   },
   {
-    "id": "sm75-56",
+    "setOrder":80,
+	"id": "sm75-56",
     "name": "Swablu",
     "imageUrl": "https://images.pokemontcg.io/sm75/56.png",
     "subtype": "Basic",
@@ -2878,7 +2934,8 @@
     ]
   },
   {
-    "id": "sm75-57",
+    "setOrder":80,
+	"id": "sm75-57",
     "name": "Swablu",
     "imageUrl": "https://images.pokemontcg.io/sm75/57.png",
     "subtype": "Basic",
@@ -2927,7 +2984,8 @@
     ]
   },
   {
-    "id": "sm75-58",
+    "setOrder":80,
+	"id": "sm75-58",
     "name": "Blaine's Last Stand",
     "imageUrl": "https://images.pokemontcg.io/sm75/58.png",
     "subtype": "Supporter",
@@ -2945,7 +3003,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm75/58_hires.png"
   },
   {
-    "id": "sm75-59",
+    "setOrder":80,
+	"id": "sm75-59",
     "name": "Dragon Talon",
     "imageUrl": "https://images.pokemontcg.io/sm75/59.png",
     "subtype": "Pokémon Tool",
@@ -2963,7 +3022,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm75/59_hires.png"
   },
   {
-    "id": "sm75-60",
+    "setOrder":80,
+	"id": "sm75-60",
     "name": "Fiery Flint",
     "imageUrl": "https://images.pokemontcg.io/sm75/60.png",
     "subtype": "Item",
@@ -2981,7 +3041,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm75/60_hires.png"
   },
   {
-    "id": "sm75-61",
+    "setOrder":80,
+	"id": "sm75-61",
     "name": "Lance ◇",
     "imageUrl": "https://images.pokemontcg.io/sm75/61.png",
     "subtype": "Supporter",
@@ -3000,7 +3061,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm75/61_hires.png"
   },
   {
-    "id": "sm75-62",
+    "setOrder":80,
+	"id": "sm75-62",
     "name": "Switch Raft",
     "imageUrl": "https://images.pokemontcg.io/sm75/62.png",
     "subtype": "Item",
@@ -3018,7 +3080,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm75/62_hires.png"
   },
   {
-    "id": "sm75-63",
+    "setOrder":80,
+	"id": "sm75-63",
     "name": "Wela Volcano Park",
     "imageUrl": "https://images.pokemontcg.io/sm75/63.png",
     "subtype": "Stadium",
@@ -3036,7 +3099,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm75/63_hires.png"
   },
   {
-    "id": "sm75-64",
+    "setOrder":80,
+	"id": "sm75-64",
     "name": "Zinnia",
     "imageUrl": "https://images.pokemontcg.io/sm75/64.png",
     "subtype": "Supporter",
@@ -3054,7 +3118,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm75/64_hires.png"
   },
   {
-    "id": "sm75-65",
+    "setOrder":80,
+	"id": "sm75-65",
     "name": "Reshiram-GX",
     "imageUrl": "https://images.pokemontcg.io/sm75/65.png",
     "subtype": "GX",
@@ -3123,7 +3188,8 @@
     "nationalPokedexNumber": 643
   },
   {
-    "id": "sm75-66",
+    "setOrder":80,
+	"id": "sm75-66",
     "name": "Kingdra-GX",
     "imageUrl": "https://images.pokemontcg.io/sm75/66.png",
     "subtype": "GX",
@@ -3187,7 +3253,8 @@
     "nationalPokedexNumber": 230
   },
   {
-    "id": "sm75-67",
+    "setOrder":80,
+	"id": "sm75-67",
     "name": "Dragonite-GX",
     "imageUrl": "https://images.pokemontcg.io/sm75/67.png",
     "subtype": "GX",
@@ -3257,7 +3324,8 @@
     "nationalPokedexNumber": 149
   },
   {
-    "id": "sm75-68",
+    "setOrder":80,
+	"id": "sm75-68",
     "name": "Altaria-GX",
     "imageUrl": "https://images.pokemontcg.io/sm75/68.png",
     "subtype": "GX",
@@ -3324,7 +3392,8 @@
     "nationalPokedexNumber": 334
   },
   {
-    "id": "sm75-69",
+    "setOrder":80,
+	"id": "sm75-69",
     "name": "Blaine's Last Stand",
     "imageUrl": "https://images.pokemontcg.io/sm75/69.png",
     "subtype": "Supporter",
@@ -3342,7 +3411,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm75/69_hires.png"
   },
   {
-    "id": "sm75-70",
+    "setOrder":80,
+	"id": "sm75-70",
     "name": "Zinnia",
     "imageUrl": "https://images.pokemontcg.io/sm75/70.png",
     "subtype": "Supporter",

--- a/json/cards/Dragon.json
+++ b/json/cards/Dragon.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "ex3-1",
+    "setOrder":18,
+	"id": "ex3-1",
     "name": "Absol",
     "imageUrl": "https://images.pokemontcg.io/ex3/1.png",
     "subtype": "Basic",
@@ -56,7 +57,8 @@
     "nationalPokedexNumber": 359
   },
   {
-    "id": "ex3-2",
+    "setOrder":18,
+	"id": "ex3-2",
     "name": "Altaria",
     "imageUrl": "https://images.pokemontcg.io/ex3/2.png",
     "subtype": "Stage 1",
@@ -117,7 +119,8 @@
     "nationalPokedexNumber": 334
   },
   {
-    "id": "ex3-3",
+    "setOrder":18,
+	"id": "ex3-3",
     "name": "Crawdaunt",
     "imageUrl": "https://images.pokemontcg.io/ex3/3.png",
     "subtype": "Stage 1",
@@ -166,7 +169,8 @@
     "nationalPokedexNumber": 342
   },
   {
-    "id": "ex3-4",
+    "setOrder":18,
+	"id": "ex3-4",
     "name": "Flygon",
     "imageUrl": "https://images.pokemontcg.io/ex3/4.png",
     "subtype": "Stage 2",
@@ -230,7 +234,8 @@
     "nationalPokedexNumber": 330
   },
   {
-    "id": "ex3-5",
+    "setOrder":18,
+	"id": "ex3-5",
     "name": "Golem",
     "imageUrl": "https://images.pokemontcg.io/ex3/5.png",
     "subtype": "Stage 2",
@@ -289,7 +294,8 @@
     "nationalPokedexNumber": 76
   },
   {
-    "id": "ex3-6",
+    "setOrder":18,
+	"id": "ex3-6",
     "name": "Grumpig",
     "imageUrl": "https://images.pokemontcg.io/ex3/6.png",
     "subtype": "Stage 1",
@@ -342,7 +348,8 @@
     "nationalPokedexNumber": 326
   },
   {
-    "id": "ex3-7",
+    "setOrder":18,
+	"id": "ex3-7",
     "name": "Minun",
     "imageUrl": "https://images.pokemontcg.io/ex3/7.png",
     "subtype": "Basic",
@@ -403,7 +410,8 @@
     "nationalPokedexNumber": 312
   },
   {
-    "id": "ex3-8",
+    "setOrder":18,
+	"id": "ex3-8",
     "name": "Plusle",
     "imageUrl": "https://images.pokemontcg.io/ex3/8.png",
     "subtype": "Basic",
@@ -464,7 +472,8 @@
     "nationalPokedexNumber": 311
   },
   {
-    "id": "ex3-9",
+    "setOrder":18,
+	"id": "ex3-9",
     "name": "Roselia",
     "imageUrl": "https://images.pokemontcg.io/ex3/9.png",
     "subtype": "Basic",
@@ -521,7 +530,8 @@
     ]
   },
   {
-    "id": "ex3-10",
+    "setOrder":18,
+	"id": "ex3-10",
     "name": "Salamence",
     "imageUrl": "https://images.pokemontcg.io/ex3/10.png",
     "subtype": "Stage 2",
@@ -591,7 +601,8 @@
     "nationalPokedexNumber": 373
   },
   {
-    "id": "ex3-11",
+    "setOrder":18,
+	"id": "ex3-11",
     "name": "Shedinja",
     "imageUrl": "https://images.pokemontcg.io/ex3/11.png",
     "subtype": "Stage 1",
@@ -631,7 +642,8 @@
     "nationalPokedexNumber": 292
   },
   {
-    "id": "ex3-12",
+    "setOrder":18,
+	"id": "ex3-12",
     "name": "Torkoal",
     "imageUrl": "https://images.pokemontcg.io/ex3/12.png",
     "subtype": "Basic",
@@ -682,7 +694,8 @@
     "nationalPokedexNumber": 324
   },
   {
-    "id": "ex3-13",
+    "setOrder":18,
+	"id": "ex3-13",
     "name": "Crawdaunt",
     "imageUrl": "https://images.pokemontcg.io/ex3/13.png",
     "subtype": "Stage 1",
@@ -734,7 +747,8 @@
     "nationalPokedexNumber": 342
   },
   {
-    "id": "ex3-14",
+    "setOrder":18,
+	"id": "ex3-14",
     "name": "Dragonair",
     "imageUrl": "https://images.pokemontcg.io/ex3/14.png",
     "subtype": "Stage 1",
@@ -801,7 +815,8 @@
     ]
   },
   {
-    "id": "ex3-15",
+    "setOrder":18,
+	"id": "ex3-15",
     "name": "Flygon",
     "imageUrl": "https://images.pokemontcg.io/ex3/15.png",
     "subtype": "Stage 2",
@@ -844,7 +859,8 @@
     "nationalPokedexNumber": 330
   },
   {
-    "id": "ex3-16",
+    "setOrder":18,
+	"id": "ex3-16",
     "name": "Girafarig",
     "imageUrl": "https://images.pokemontcg.io/ex3/16.png",
     "subtype": "Basic",
@@ -894,7 +910,8 @@
     "nationalPokedexNumber": 203
   },
   {
-    "id": "ex3-17",
+    "setOrder":18,
+	"id": "ex3-17",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/ex3/17.png",
     "subtype": "Stage 1",
@@ -950,7 +967,8 @@
     ]
   },
   {
-    "id": "ex3-18",
+    "setOrder":18,
+	"id": "ex3-18",
     "name": "Ninjask",
     "imageUrl": "https://images.pokemontcg.io/ex3/18.png",
     "subtype": "Stage 1",
@@ -997,7 +1015,8 @@
     ]
   },
   {
-    "id": "ex3-19",
+    "setOrder":18,
+	"id": "ex3-19",
     "name": "Salamence",
     "imageUrl": "https://images.pokemontcg.io/ex3/19.png",
     "subtype": "Stage 2",
@@ -1040,7 +1059,8 @@
     "nationalPokedexNumber": 373
   },
   {
-    "id": "ex3-20",
+    "setOrder":18,
+	"id": "ex3-20",
     "name": "Shelgon",
     "imageUrl": "https://images.pokemontcg.io/ex3/20.png",
     "subtype": "Stage 1",
@@ -1106,7 +1126,8 @@
     ]
   },
   {
-    "id": "ex3-21",
+    "setOrder":18,
+	"id": "ex3-21",
     "name": "Skarmory",
     "imageUrl": "https://images.pokemontcg.io/ex3/21.png",
     "subtype": "Basic",
@@ -1162,7 +1183,8 @@
     "nationalPokedexNumber": 227
   },
   {
-    "id": "ex3-22",
+    "setOrder":18,
+	"id": "ex3-22",
     "name": "Vibrava",
     "imageUrl": "https://images.pokemontcg.io/ex3/22.png",
     "subtype": "Stage 1",
@@ -1226,7 +1248,8 @@
     ]
   },
   {
-    "id": "ex3-23",
+    "setOrder":18,
+	"id": "ex3-23",
     "name": "Bagon",
     "imageUrl": "https://images.pokemontcg.io/ex3/23.png",
     "subtype": "Basic",
@@ -1289,7 +1312,8 @@
     ]
   },
   {
-    "id": "ex3-24",
+    "setOrder":18,
+	"id": "ex3-24",
     "name": "Camerupt",
     "imageUrl": "https://images.pokemontcg.io/ex3/24.png",
     "subtype": "Stage 1",
@@ -1343,7 +1367,8 @@
     "nationalPokedexNumber": 323
   },
   {
-    "id": "ex3-25",
+    "setOrder":18,
+	"id": "ex3-25",
     "name": "Combusken",
     "imageUrl": "https://images.pokemontcg.io/ex3/25.png",
     "subtype": "Stage 1",
@@ -1399,7 +1424,8 @@
     ]
   },
   {
-    "id": "ex3-26",
+    "setOrder":18,
+	"id": "ex3-26",
     "name": "Dratini",
     "imageUrl": "https://images.pokemontcg.io/ex3/26.png",
     "subtype": "Basic",
@@ -1461,7 +1487,8 @@
     ]
   },
   {
-    "id": "ex3-27",
+    "setOrder":18,
+	"id": "ex3-27",
     "name": "Flaaffy",
     "imageUrl": "https://images.pokemontcg.io/ex3/27.png",
     "subtype": "Stage 1",
@@ -1521,7 +1548,8 @@
     ]
   },
   {
-    "id": "ex3-28",
+    "setOrder":18,
+	"id": "ex3-28",
     "name": "Forretress",
     "imageUrl": "https://images.pokemontcg.io/ex3/28.png",
     "subtype": "Stage 1",
@@ -1581,7 +1609,8 @@
     "nationalPokedexNumber": 205
   },
   {
-    "id": "ex3-29",
+    "setOrder":18,
+	"id": "ex3-29",
     "name": "Graveler",
     "imageUrl": "https://images.pokemontcg.io/ex3/29.png",
     "subtype": "Stage 1",
@@ -1639,7 +1668,8 @@
     ]
   },
   {
-    "id": "ex3-30",
+    "setOrder":18,
+	"id": "ex3-30",
     "name": "Graveler",
     "imageUrl": "https://images.pokemontcg.io/ex3/30.png",
     "subtype": "Stage 1",
@@ -1697,7 +1727,8 @@
     ]
   },
   {
-    "id": "ex3-31",
+    "setOrder":18,
+	"id": "ex3-31",
     "name": "Grovyle",
     "imageUrl": "https://images.pokemontcg.io/ex3/31.png",
     "subtype": "Stage 1",
@@ -1748,7 +1779,8 @@
     ]
   },
   {
-    "id": "ex3-32",
+    "setOrder":18,
+	"id": "ex3-32",
     "name": "Gyarados",
     "imageUrl": "https://images.pokemontcg.io/ex3/32.png",
     "subtype": "Stage 1",
@@ -1803,7 +1835,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "ex3-33",
+    "setOrder":18,
+	"id": "ex3-33",
     "name": "Horsea",
     "imageUrl": "https://images.pokemontcg.io/ex3/33.png",
     "subtype": "Basic",
@@ -1855,7 +1888,8 @@
     ]
   },
   {
-    "id": "ex3-34",
+    "setOrder":18,
+	"id": "ex3-34",
     "name": "Houndoom",
     "imageUrl": "https://images.pokemontcg.io/ex3/34.png",
     "subtype": "Stage 1",
@@ -1914,7 +1948,8 @@
     "nationalPokedexNumber": 229
   },
   {
-    "id": "ex3-35",
+    "setOrder":18,
+	"id": "ex3-35",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/ex3/35.png",
     "subtype": "Stage 1",
@@ -1970,7 +2005,8 @@
     ]
   },
   {
-    "id": "ex3-36",
+    "setOrder":18,
+	"id": "ex3-36",
     "name": "Marshtomp",
     "imageUrl": "https://images.pokemontcg.io/ex3/36.png",
     "subtype": "Stage 1",
@@ -2015,7 +2051,8 @@
     ]
   },
   {
-    "id": "ex3-37",
+    "setOrder":18,
+	"id": "ex3-37",
     "name": "Meditite",
     "imageUrl": "https://images.pokemontcg.io/ex3/37.png",
     "subtype": "Basic",
@@ -2069,7 +2106,8 @@
     ]
   },
   {
-    "id": "ex3-38",
+    "setOrder":18,
+	"id": "ex3-38",
     "name": "Ninjask",
     "imageUrl": "https://images.pokemontcg.io/ex3/38.png",
     "subtype": "Stage 1",
@@ -2120,7 +2158,8 @@
     ]
   },
   {
-    "id": "ex3-39",
+    "setOrder":18,
+	"id": "ex3-39",
     "name": "Seadra",
     "imageUrl": "https://images.pokemontcg.io/ex3/39.png",
     "subtype": "Stage 1",
@@ -2175,7 +2214,8 @@
     ]
   },
   {
-    "id": "ex3-40",
+    "setOrder":18,
+	"id": "ex3-40",
     "name": "Seadra",
     "imageUrl": "https://images.pokemontcg.io/ex3/40.png",
     "subtype": "Stage 1",
@@ -2231,7 +2271,8 @@
     ]
   },
   {
-    "id": "ex3-41",
+    "setOrder":18,
+	"id": "ex3-41",
     "name": "Shelgon",
     "imageUrl": "https://images.pokemontcg.io/ex3/41.png",
     "subtype": "Stage 1",
@@ -2276,7 +2317,8 @@
     ]
   },
   {
-    "id": "ex3-42",
+    "setOrder":18,
+	"id": "ex3-42",
     "name": "Shelgon",
     "imageUrl": "https://images.pokemontcg.io/ex3/42.png",
     "subtype": "Stage 1",
@@ -2327,7 +2369,8 @@
     ]
   },
   {
-    "id": "ex3-43",
+    "setOrder":18,
+	"id": "ex3-43",
     "name": "Shuppet",
     "imageUrl": "https://images.pokemontcg.io/ex3/43.png",
     "subtype": "Basic",
@@ -2385,7 +2428,8 @@
     ]
   },
   {
-    "id": "ex3-44",
+    "setOrder":18,
+	"id": "ex3-44",
     "name": "Snorunt",
     "imageUrl": "https://images.pokemontcg.io/ex3/44.png",
     "subtype": "Basic",
@@ -2429,7 +2473,8 @@
     ]
   },
   {
-    "id": "ex3-45",
+    "setOrder":18,
+	"id": "ex3-45",
     "name": "Swellow",
     "imageUrl": "https://images.pokemontcg.io/ex3/45.png",
     "subtype": "Stage 1",
@@ -2483,7 +2528,8 @@
     "nationalPokedexNumber": 277
   },
   {
-    "id": "ex3-46",
+    "setOrder":18,
+	"id": "ex3-46",
     "name": "Vibrava",
     "imageUrl": "https://images.pokemontcg.io/ex3/46.png",
     "subtype": "Stage 1",
@@ -2527,7 +2573,8 @@
     ]
   },
   {
-    "id": "ex3-47",
+    "setOrder":18,
+	"id": "ex3-47",
     "name": "Vibrava",
     "imageUrl": "https://images.pokemontcg.io/ex3/47.png",
     "subtype": "Stage 1",
@@ -2577,7 +2624,8 @@
     ]
   },
   {
-    "id": "ex3-48",
+    "setOrder":18,
+	"id": "ex3-48",
     "name": "Whiscash",
     "imageUrl": "https://images.pokemontcg.io/ex3/48.png",
     "subtype": "Stage 1",
@@ -2637,7 +2685,8 @@
     "nationalPokedexNumber": 340
   },
   {
-    "id": "ex3-49",
+    "setOrder":18,
+	"id": "ex3-49",
     "name": "Bagon",
     "imageUrl": "https://images.pokemontcg.io/ex3/49.png",
     "subtype": "Basic",
@@ -2684,7 +2733,8 @@
     ]
   },
   {
-    "id": "ex3-50",
+    "setOrder":18,
+	"id": "ex3-50",
     "name": "Bagon",
     "imageUrl": "https://images.pokemontcg.io/ex3/50.png",
     "subtype": "Basic",
@@ -2731,7 +2781,8 @@
     ]
   },
   {
-    "id": "ex3-51",
+    "setOrder":18,
+	"id": "ex3-51",
     "name": "Barboach",
     "imageUrl": "https://images.pokemontcg.io/ex3/51.png",
     "subtype": "Basic",
@@ -2784,7 +2835,8 @@
     ]
   },
   {
-    "id": "ex3-52",
+    "setOrder":18,
+	"id": "ex3-52",
     "name": "Corphish",
     "imageUrl": "https://images.pokemontcg.io/ex3/52.png",
     "subtype": "Basic",
@@ -2836,7 +2888,8 @@
     ]
   },
   {
-    "id": "ex3-53",
+    "setOrder":18,
+	"id": "ex3-53",
     "name": "Corphish",
     "imageUrl": "https://images.pokemontcg.io/ex3/53.png",
     "subtype": "Basic",
@@ -2889,7 +2942,8 @@
     ]
   },
   {
-    "id": "ex3-54",
+    "setOrder":18,
+	"id": "ex3-54",
     "name": "Corphish",
     "imageUrl": "https://images.pokemontcg.io/ex3/54.png",
     "subtype": "Basic",
@@ -2942,7 +2996,8 @@
     ]
   },
   {
-    "id": "ex3-55",
+    "setOrder":18,
+	"id": "ex3-55",
     "name": "Geodude",
     "imageUrl": "https://images.pokemontcg.io/ex3/55.png",
     "subtype": "Basic",
@@ -2994,7 +3049,8 @@
     ]
   },
   {
-    "id": "ex3-56",
+    "setOrder":18,
+	"id": "ex3-56",
     "name": "Geodude",
     "imageUrl": "https://images.pokemontcg.io/ex3/56.png",
     "subtype": "Basic",
@@ -3037,7 +3093,8 @@
     ]
   },
   {
-    "id": "ex3-57",
+    "setOrder":18,
+	"id": "ex3-57",
     "name": "Grimer",
     "imageUrl": "https://images.pokemontcg.io/ex3/57.png",
     "subtype": "Basic",
@@ -3089,7 +3146,8 @@
     ]
   },
   {
-    "id": "ex3-58",
+    "setOrder":18,
+	"id": "ex3-58",
     "name": "Horsea",
     "imageUrl": "https://images.pokemontcg.io/ex3/58.png",
     "subtype": "Basic",
@@ -3142,7 +3200,8 @@
     ]
   },
   {
-    "id": "ex3-59",
+    "setOrder":18,
+	"id": "ex3-59",
     "name": "Houndour",
     "imageUrl": "https://images.pokemontcg.io/ex3/59.png",
     "subtype": "Basic",
@@ -3201,7 +3260,8 @@
     ]
   },
   {
-    "id": "ex3-60",
+    "setOrder":18,
+	"id": "ex3-60",
     "name": "Magikarp",
     "imageUrl": "https://images.pokemontcg.io/ex3/60.png",
     "subtype": "Basic",
@@ -3254,7 +3314,8 @@
     ]
   },
   {
-    "id": "ex3-61",
+    "setOrder":18,
+	"id": "ex3-61",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/ex3/61.png",
     "subtype": "Basic",
@@ -3313,7 +3374,8 @@
     ]
   },
   {
-    "id": "ex3-62",
+    "setOrder":18,
+	"id": "ex3-62",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/ex3/62.png",
     "subtype": "Basic",
@@ -3362,7 +3424,8 @@
     ]
   },
   {
-    "id": "ex3-63",
+    "setOrder":18,
+	"id": "ex3-63",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/ex3/63.png",
     "subtype": "Basic",
@@ -3405,7 +3468,8 @@
     ]
   },
   {
-    "id": "ex3-64",
+    "setOrder":18,
+	"id": "ex3-64",
     "name": "Mareep",
     "imageUrl": "https://images.pokemontcg.io/ex3/64.png",
     "subtype": "Basic",
@@ -3454,7 +3518,8 @@
     ]
   },
   {
-    "id": "ex3-65",
+    "setOrder":18,
+	"id": "ex3-65",
     "name": "Mudkip",
     "imageUrl": "https://images.pokemontcg.io/ex3/65.png",
     "subtype": "Basic",
@@ -3497,7 +3562,8 @@
     ]
   },
   {
-    "id": "ex3-66",
+    "setOrder":18,
+	"id": "ex3-66",
     "name": "Nincada",
     "imageUrl": "https://images.pokemontcg.io/ex3/66.png",
     "subtype": "Basic",
@@ -3540,7 +3606,8 @@
     ]
   },
   {
-    "id": "ex3-67",
+    "setOrder":18,
+	"id": "ex3-67",
     "name": "Nincada",
     "imageUrl": "https://images.pokemontcg.io/ex3/67.png",
     "subtype": "Basic",
@@ -3593,7 +3660,8 @@
     ]
   },
   {
-    "id": "ex3-68",
+    "setOrder":18,
+	"id": "ex3-68",
     "name": "Nincada",
     "imageUrl": "https://images.pokemontcg.io/ex3/68.png",
     "subtype": "Basic",
@@ -3636,7 +3704,8 @@
     ]
   },
   {
-    "id": "ex3-69",
+    "setOrder":18,
+	"id": "ex3-69",
     "name": "Numel",
     "imageUrl": "https://images.pokemontcg.io/ex3/69.png",
     "subtype": "Basic",
@@ -3689,7 +3758,8 @@
     ]
   },
   {
-    "id": "ex3-70",
+    "setOrder":18,
+	"id": "ex3-70",
     "name": "Numel",
     "imageUrl": "https://images.pokemontcg.io/ex3/70.png",
     "subtype": "Basic",
@@ -3742,7 +3812,8 @@
     ]
   },
   {
-    "id": "ex3-71",
+    "setOrder":18,
+	"id": "ex3-71",
     "name": "Pineco",
     "imageUrl": "https://images.pokemontcg.io/ex3/71.png",
     "subtype": "Basic",
@@ -3791,7 +3862,8 @@
     ]
   },
   {
-    "id": "ex3-72",
+    "setOrder":18,
+	"id": "ex3-72",
     "name": "Slugma",
     "imageUrl": "https://images.pokemontcg.io/ex3/72.png",
     "subtype": "Basic",
@@ -3844,7 +3916,8 @@
     ]
   },
   {
-    "id": "ex3-73",
+    "setOrder":18,
+	"id": "ex3-73",
     "name": "Spoink",
     "imageUrl": "https://images.pokemontcg.io/ex3/73.png",
     "subtype": "Basic",
@@ -3887,7 +3960,8 @@
     ]
   },
   {
-    "id": "ex3-74",
+    "setOrder":18,
+	"id": "ex3-74",
     "name": "Spoink",
     "imageUrl": "https://images.pokemontcg.io/ex3/74.png",
     "subtype": "Basic",
@@ -3940,7 +4014,8 @@
     ]
   },
   {
-    "id": "ex3-75",
+    "setOrder":18,
+	"id": "ex3-75",
     "name": "Swablu",
     "imageUrl": "https://images.pokemontcg.io/ex3/75.png",
     "subtype": "Basic",
@@ -3998,7 +4073,8 @@
     ]
   },
   {
-    "id": "ex3-76",
+    "setOrder":18,
+	"id": "ex3-76",
     "name": "Taillow",
     "imageUrl": "https://images.pokemontcg.io/ex3/76.png",
     "subtype": "Basic",
@@ -4047,7 +4123,8 @@
     ]
   },
   {
-    "id": "ex3-77",
+    "setOrder":18,
+	"id": "ex3-77",
     "name": "Torchic",
     "imageUrl": "https://images.pokemontcg.io/ex3/77.png",
     "subtype": "Basic",
@@ -4091,7 +4168,8 @@
     ]
   },
   {
-    "id": "ex3-78",
+    "setOrder":18,
+	"id": "ex3-78",
     "name": "Trapinch",
     "imageUrl": "https://images.pokemontcg.io/ex3/78.png",
     "subtype": "Basic",
@@ -4134,7 +4212,8 @@
     ]
   },
   {
-    "id": "ex3-79",
+    "setOrder":18,
+	"id": "ex3-79",
     "name": "Trapinch",
     "imageUrl": "https://images.pokemontcg.io/ex3/79.png",
     "subtype": "Basic",
@@ -4187,7 +4266,8 @@
     ]
   },
   {
-    "id": "ex3-80",
+    "setOrder":18,
+	"id": "ex3-80",
     "name": "Treecko",
     "imageUrl": "https://images.pokemontcg.io/ex3/80.png",
     "subtype": "Basic",
@@ -4237,7 +4317,8 @@
     ]
   },
   {
-    "id": "ex3-81",
+    "setOrder":18,
+	"id": "ex3-81",
     "name": "Wurmple",
     "imageUrl": "https://images.pokemontcg.io/ex3/81.png",
     "subtype": "Basic",
@@ -4290,7 +4371,8 @@
     ]
   },
   {
-    "id": "ex3-82",
+    "setOrder":18,
+	"id": "ex3-82",
     "name": "Balloon Berry",
     "imageUrl": "https://images.pokemontcg.io/ex3/82.png",
     "subtype": "Pokémon Tool",
@@ -4309,7 +4391,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex3/82_hires.png"
   },
   {
-    "id": "ex3-83",
+    "setOrder":18,
+	"id": "ex3-83",
     "name": "Buffer Piece",
     "imageUrl": "https://images.pokemontcg.io/ex3/83.png",
     "subtype": "Pokémon Tool",
@@ -4328,7 +4411,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex3/83_hires.png"
   },
   {
-    "id": "ex3-84",
+    "setOrder":18,
+	"id": "ex3-84",
     "name": "Energy Recycle System",
     "imageUrl": "https://images.pokemontcg.io/ex3/84.png",
     "subtype": "Item",
@@ -4346,7 +4430,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex3/84_hires.png"
   },
   {
-    "id": "ex3-85",
+    "setOrder":18,
+	"id": "ex3-85",
     "name": "High Pressure System",
     "imageUrl": "https://images.pokemontcg.io/ex3/85.png",
     "subtype": "Stadium",
@@ -4365,7 +4450,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex3/85_hires.png"
   },
   {
-    "id": "ex3-86",
+    "setOrder":18,
+	"id": "ex3-86",
     "name": "Low Pressure System",
     "imageUrl": "https://images.pokemontcg.io/ex3/86.png",
     "subtype": "Stadium",
@@ -4384,7 +4470,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex3/86_hires.png"
   },
   {
-    "id": "ex3-87",
+    "setOrder":18,
+	"id": "ex3-87",
     "name": "Mr. Briney's Compassion",
     "imageUrl": "https://images.pokemontcg.io/ex3/87.png",
     "subtype": "Supporter",
@@ -4403,7 +4490,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex3/87_hires.png"
   },
   {
-    "id": "ex3-88",
+    "setOrder":18,
+	"id": "ex3-88",
     "name": "TV Reporter",
     "imageUrl": "https://images.pokemontcg.io/ex3/88.png",
     "subtype": "Supporter",
@@ -4422,7 +4510,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex3/88_hires.png"
   },
   {
-    "id": "ex3-89",
+    "setOrder":18,
+	"id": "ex3-89",
     "name": "Ampharos ex",
     "imageUrl": "https://images.pokemontcg.io/ex3/89.png",
     "subtype": "EX",
@@ -4482,7 +4571,8 @@
     "nationalPokedexNumber": 181
   },
   {
-    "id": "ex3-90",
+    "setOrder":18,
+	"id": "ex3-90",
     "name": "Dragonite ex",
     "imageUrl": "https://images.pokemontcg.io/ex3/90.png",
     "subtype": "EX",
@@ -4556,7 +4646,8 @@
     "nationalPokedexNumber": 149
   },
   {
-    "id": "ex3-91",
+    "setOrder":18,
+	"id": "ex3-91",
     "name": "Golem ex",
     "imageUrl": "https://images.pokemontcg.io/ex3/91.png",
     "subtype": "EX",
@@ -4624,7 +4715,8 @@
     "nationalPokedexNumber": 76
   },
   {
-    "id": "ex3-92",
+    "setOrder":18,
+	"id": "ex3-92",
     "name": "Kingdra ex",
     "imageUrl": "https://images.pokemontcg.io/ex3/92.png",
     "subtype": "EX",
@@ -4686,7 +4778,8 @@
     "nationalPokedexNumber": 230
   },
   {
-    "id": "ex3-93",
+    "setOrder":18,
+	"id": "ex3-93",
     "name": "Latias ex",
     "imageUrl": "https://images.pokemontcg.io/ex3/93.png",
     "subtype": "EX",
@@ -4752,7 +4845,8 @@
     "nationalPokedexNumber": 380
   },
   {
-    "id": "ex3-94",
+    "setOrder":18,
+	"id": "ex3-94",
     "name": "Latios ex",
     "imageUrl": "https://images.pokemontcg.io/ex3/94.png",
     "subtype": "EX",
@@ -4818,7 +4912,8 @@
     "nationalPokedexNumber": 381
   },
   {
-    "id": "ex3-95",
+    "setOrder":18,
+	"id": "ex3-95",
     "name": "Magcargo ex",
     "imageUrl": "https://images.pokemontcg.io/ex3/95.png",
     "subtype": "EX",
@@ -4876,7 +4971,8 @@
     "nationalPokedexNumber": 219
   },
   {
-    "id": "ex3-96",
+    "setOrder":18,
+	"id": "ex3-96",
     "name": "Muk ex",
     "imageUrl": "https://images.pokemontcg.io/ex3/96.png",
     "subtype": "EX",
@@ -4938,7 +5034,8 @@
     "nationalPokedexNumber": 89
   },
   {
-    "id": "ex3-97",
+    "setOrder":18,
+	"id": "ex3-97",
     "name": "Rayquaza ex",
     "imageUrl": "https://images.pokemontcg.io/ex3/97.png",
     "subtype": "EX",

--- a/json/cards/Dragons Exalted.json
+++ b/json/cards/Dragons Exalted.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "bw6-1",
+    "setOrder":53,
+	"id": "bw6-1",
     "name": "Hoppip",
     "imageUrl": "https://images.pokemontcg.io/bw6/1.png",
     "subtype": "Basic",
@@ -49,7 +50,8 @@
     ]
   },
   {
-    "id": "bw6-2",
+    "setOrder":53,
+	"id": "bw6-2",
     "name": "Skiploom",
     "imageUrl": "https://images.pokemontcg.io/bw6/2.png",
     "subtype": "Stage 1",
@@ -96,7 +98,8 @@
     ]
   },
   {
-    "id": "bw6-3",
+    "setOrder":53,
+	"id": "bw6-3",
     "name": "Jumpluff",
     "imageUrl": "https://images.pokemontcg.io/bw6/3.png",
     "subtype": "Stage 2",
@@ -145,7 +148,8 @@
     "nationalPokedexNumber": 189
   },
   {
-    "id": "bw6-4",
+    "setOrder":53,
+	"id": "bw6-4",
     "name": "Yanma",
     "imageUrl": "https://images.pokemontcg.io/bw6/4.png",
     "subtype": "Basic",
@@ -195,7 +199,8 @@
     ]
   },
   {
-    "id": "bw6-5",
+    "setOrder":53,
+	"id": "bw6-5",
     "name": "Yanmega",
     "imageUrl": "https://images.pokemontcg.io/bw6/5.png",
     "subtype": "Stage 1",
@@ -251,7 +256,8 @@
     "nationalPokedexNumber": 469
   },
   {
-    "id": "bw6-6",
+    "setOrder":53,
+	"id": "bw6-6",
     "name": "Wurmple",
     "imageUrl": "https://images.pokemontcg.io/bw6/6.png",
     "subtype": "Basic",
@@ -295,7 +301,8 @@
     ]
   },
   {
-    "id": "bw6-7",
+    "setOrder":53,
+	"id": "bw6-7",
     "name": "Silcoon",
     "imageUrl": "https://images.pokemontcg.io/bw6/7.png",
     "subtype": "Stage 1",
@@ -352,7 +359,8 @@
     ]
   },
   {
-    "id": "bw6-8",
+    "setOrder":53,
+	"id": "bw6-8",
     "name": "Beautifly",
     "imageUrl": "https://images.pokemontcg.io/bw6/8.png",
     "subtype": "Stage 2",
@@ -404,7 +412,8 @@
     "nationalPokedexNumber": 267
   },
   {
-    "id": "bw6-9",
+    "setOrder":53,
+	"id": "bw6-9",
     "name": "Cascoon",
     "imageUrl": "https://images.pokemontcg.io/bw6/9.png",
     "subtype": "Stage 1",
@@ -460,7 +469,8 @@
     ]
   },
   {
-    "id": "bw6-10",
+    "setOrder":53,
+	"id": "bw6-10",
     "name": "Nincada",
     "imageUrl": "https://images.pokemontcg.io/bw6/10.png",
     "subtype": "Basic",
@@ -503,7 +513,8 @@
     ]
   },
   {
-    "id": "bw6-11",
+    "setOrder":53,
+	"id": "bw6-11",
     "name": "Ninjask",
     "imageUrl": "https://images.pokemontcg.io/bw6/11.png",
     "subtype": "Stage 1",
@@ -553,7 +564,8 @@
     ]
   },
   {
-    "id": "bw6-12",
+    "setOrder":53,
+	"id": "bw6-12",
     "name": "Roselia",
     "imageUrl": "https://images.pokemontcg.io/bw6/12.png",
     "subtype": "Basic",
@@ -611,7 +623,8 @@
     ]
   },
   {
-    "id": "bw6-13",
+    "setOrder":53,
+	"id": "bw6-13",
     "name": "Roselia",
     "imageUrl": "https://images.pokemontcg.io/bw6/13.png",
     "subtype": "Basic",
@@ -661,7 +674,8 @@
     ]
   },
   {
-    "id": "bw6-14",
+    "setOrder":53,
+	"id": "bw6-14",
     "name": "Roserade",
     "imageUrl": "https://images.pokemontcg.io/bw6/14.png",
     "subtype": "Stage 1",
@@ -719,7 +733,8 @@
     "nationalPokedexNumber": 407
   },
   {
-    "id": "bw6-15",
+    "setOrder":53,
+	"id": "bw6-15",
     "name": "Roserade",
     "imageUrl": "https://images.pokemontcg.io/bw6/15.png",
     "subtype": "Stage 1",
@@ -772,7 +787,8 @@
     "nationalPokedexNumber": 407
   },
   {
-    "id": "bw6-16",
+    "setOrder":53,
+	"id": "bw6-16",
     "name": "Maractus",
     "imageUrl": "https://images.pokemontcg.io/bw6/16.png",
     "subtype": "Basic",
@@ -831,7 +847,8 @@
     "nationalPokedexNumber": 556
   },
   {
-    "id": "bw6-17",
+    "setOrder":53,
+	"id": "bw6-17",
     "name": "Foongus",
     "imageUrl": "https://images.pokemontcg.io/bw6/17.png",
     "subtype": "Basic",
@@ -880,7 +897,8 @@
     ]
   },
   {
-    "id": "bw6-18",
+    "setOrder":53,
+	"id": "bw6-18",
     "name": "Vulpix",
     "imageUrl": "https://images.pokemontcg.io/bw6/18.png",
     "subtype": "Basic",
@@ -923,7 +941,8 @@
     ]
   },
   {
-    "id": "bw6-19",
+    "setOrder":53,
+	"id": "bw6-19",
     "name": "Ninetales",
     "imageUrl": "https://images.pokemontcg.io/bw6/19.png",
     "subtype": "Stage 1",
@@ -969,7 +988,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "bw6-20",
+    "setOrder":53,
+	"id": "bw6-20",
     "name": "Magmar",
     "imageUrl": "https://images.pokemontcg.io/bw6/20.png",
     "subtype": "Basic",
@@ -1024,7 +1044,8 @@
     ]
   },
   {
-    "id": "bw6-21",
+    "setOrder":53,
+	"id": "bw6-21",
     "name": "Magmortar",
     "imageUrl": "https://images.pokemontcg.io/bw6/21.png",
     "subtype": "Stage 1",
@@ -1078,7 +1099,8 @@
     "nationalPokedexNumber": 467
   },
   {
-    "id": "bw6-22",
+    "setOrder":53,
+	"id": "bw6-22",
     "name": "Ho-Oh-EX",
     "imageUrl": "https://images.pokemontcg.io/bw6/22.png",
     "subtype": "EX",
@@ -1135,7 +1157,8 @@
     "nationalPokedexNumber": 250
   },
   {
-    "id": "bw6-23",
+    "setOrder":53,
+	"id": "bw6-23",
     "name": "Magikarp",
     "imageUrl": "https://images.pokemontcg.io/bw6/23.png",
     "subtype": "Basic",
@@ -1178,7 +1201,8 @@
     ]
   },
   {
-    "id": "bw6-24",
+    "setOrder":53,
+	"id": "bw6-24",
     "name": "Gyarados",
     "imageUrl": "https://images.pokemontcg.io/bw6/24.png",
     "subtype": "Stage 1",
@@ -1235,7 +1259,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "bw6-25",
+    "setOrder":53,
+	"id": "bw6-25",
     "name": "Wailmer",
     "imageUrl": "https://images.pokemontcg.io/bw6/25.png",
     "subtype": "Basic",
@@ -1291,7 +1316,8 @@
     ]
   },
   {
-    "id": "bw6-26",
+    "setOrder":53,
+	"id": "bw6-26",
     "name": "Wailord",
     "imageUrl": "https://images.pokemontcg.io/bw6/26.png",
     "subtype": "Stage 1",
@@ -1347,7 +1373,8 @@
     "nationalPokedexNumber": 321
   },
   {
-    "id": "bw6-27",
+    "setOrder":53,
+	"id": "bw6-27",
     "name": "Feebas",
     "imageUrl": "https://images.pokemontcg.io/bw6/27.png",
     "subtype": "Basic",
@@ -1390,7 +1417,8 @@
     ]
   },
   {
-    "id": "bw6-28",
+    "setOrder":53,
+	"id": "bw6-28",
     "name": "Milotic",
     "imageUrl": "https://images.pokemontcg.io/bw6/28.png",
     "subtype": "Stage 1",
@@ -1442,7 +1470,8 @@
     "nationalPokedexNumber": 350
   },
   {
-    "id": "bw6-29",
+    "setOrder":53,
+	"id": "bw6-29",
     "name": "Spheal",
     "imageUrl": "https://images.pokemontcg.io/bw6/29.png",
     "subtype": "Basic",
@@ -1487,7 +1516,8 @@
     ]
   },
   {
-    "id": "bw6-30",
+    "setOrder":53,
+	"id": "bw6-30",
     "name": "Sealeo",
     "imageUrl": "https://images.pokemontcg.io/bw6/30.png",
     "subtype": "Stage 1",
@@ -1545,7 +1575,8 @@
     ]
   },
   {
-    "id": "bw6-31",
+    "setOrder":53,
+	"id": "bw6-31",
     "name": "Walrein",
     "imageUrl": "https://images.pokemontcg.io/bw6/31.png",
     "subtype": "Stage 2",
@@ -1603,7 +1634,8 @@
     "nationalPokedexNumber": 365
   },
   {
-    "id": "bw6-32",
+    "setOrder":53,
+	"id": "bw6-32",
     "name": "Buizel",
     "imageUrl": "https://images.pokemontcg.io/bw6/32.png",
     "subtype": "Basic",
@@ -1646,7 +1678,8 @@
     ]
   },
   {
-    "id": "bw6-33",
+    "setOrder":53,
+	"id": "bw6-33",
     "name": "Floatzel",
     "imageUrl": "https://images.pokemontcg.io/bw6/33.png",
     "subtype": "Stage 1",
@@ -1697,7 +1730,8 @@
     "nationalPokedexNumber": 419
   },
   {
-    "id": "bw6-34",
+    "setOrder":53,
+	"id": "bw6-34",
     "name": "Tympole",
     "imageUrl": "https://images.pokemontcg.io/bw6/34.png",
     "subtype": "Basic",
@@ -1740,7 +1774,8 @@
     ]
   },
   {
-    "id": "bw6-35",
+    "setOrder":53,
+	"id": "bw6-35",
     "name": "Palpitoad",
     "imageUrl": "https://images.pokemontcg.io/bw6/35.png",
     "subtype": "Stage 1",
@@ -1795,7 +1830,8 @@
     ]
   },
   {
-    "id": "bw6-36",
+    "setOrder":53,
+	"id": "bw6-36",
     "name": "Seismitoad",
     "imageUrl": "https://images.pokemontcg.io/bw6/36.png",
     "subtype": "Stage 2",
@@ -1851,7 +1887,8 @@
     "nationalPokedexNumber": 537
   },
   {
-    "id": "bw6-37",
+    "setOrder":53,
+	"id": "bw6-37",
     "name": "Alomomola",
     "imageUrl": "https://images.pokemontcg.io/bw6/37.png",
     "subtype": "Basic",
@@ -1904,7 +1941,8 @@
     "nationalPokedexNumber": 594
   },
   {
-    "id": "bw6-38",
+    "setOrder":53,
+	"id": "bw6-38",
     "name": "Mareep",
     "imageUrl": "https://images.pokemontcg.io/bw6/38.png",
     "subtype": "Basic",
@@ -1957,7 +1995,8 @@
     ]
   },
   {
-    "id": "bw6-39",
+    "setOrder":53,
+	"id": "bw6-39",
     "name": "Flaaffy",
     "imageUrl": "https://images.pokemontcg.io/bw6/39.png",
     "subtype": "Stage 1",
@@ -2012,7 +2051,8 @@
     ]
   },
   {
-    "id": "bw6-40",
+    "setOrder":53,
+	"id": "bw6-40",
     "name": "Ampharos",
     "imageUrl": "https://images.pokemontcg.io/bw6/40.png",
     "subtype": "Stage 2",
@@ -2061,7 +2101,8 @@
     "nationalPokedexNumber": 181
   },
   {
-    "id": "bw6-41",
+    "setOrder":53,
+	"id": "bw6-41",
     "name": "Electrike",
     "imageUrl": "https://images.pokemontcg.io/bw6/41.png",
     "subtype": "Basic",
@@ -2114,7 +2155,8 @@
     ]
   },
   {
-    "id": "bw6-42",
+    "setOrder":53,
+	"id": "bw6-42",
     "name": "Electrike",
     "imageUrl": "https://images.pokemontcg.io/bw6/42.png",
     "subtype": "Basic",
@@ -2158,7 +2200,8 @@
     ]
   },
   {
-    "id": "bw6-43",
+    "setOrder":53,
+	"id": "bw6-43",
     "name": "Manectric",
     "imageUrl": "https://images.pokemontcg.io/bw6/43.png",
     "subtype": "Stage 1",
@@ -2207,7 +2250,8 @@
     "nationalPokedexNumber": 310
   },
   {
-    "id": "bw6-44",
+    "setOrder":53,
+	"id": "bw6-44",
     "name": "Manectric",
     "imageUrl": "https://images.pokemontcg.io/bw6/44.png",
     "subtype": "Stage 1",
@@ -2258,7 +2302,8 @@
     "nationalPokedexNumber": 310
   },
   {
-    "id": "bw6-45",
+    "setOrder":53,
+	"id": "bw6-45",
     "name": "Emolga",
     "imageUrl": "https://images.pokemontcg.io/bw6/45.png",
     "subtype": "Basic",
@@ -2310,7 +2355,8 @@
     "nationalPokedexNumber": 587
   },
   {
-    "id": "bw6-46",
+    "setOrder":53,
+	"id": "bw6-46",
     "name": "Mew-EX",
     "imageUrl": "https://images.pokemontcg.io/bw6/46.png",
     "subtype": "EX",
@@ -2358,7 +2404,8 @@
     "nationalPokedexNumber": 151
   },
   {
-    "id": "bw6-47",
+    "setOrder":53,
+	"id": "bw6-47",
     "name": "Dustox",
     "imageUrl": "https://images.pokemontcg.io/bw6/47.png",
     "subtype": "Stage 2",
@@ -2410,7 +2457,8 @@
     "nationalPokedexNumber": 269
   },
   {
-    "id": "bw6-48",
+    "setOrder":53,
+	"id": "bw6-48",
     "name": "Shedinja",
     "imageUrl": "https://images.pokemontcg.io/bw6/48.png",
     "subtype": "Stage 1",
@@ -2447,7 +2495,8 @@
     "nationalPokedexNumber": 292
   },
   {
-    "id": "bw6-49",
+    "setOrder":53,
+	"id": "bw6-49",
     "name": "Drifloon",
     "imageUrl": "https://images.pokemontcg.io/bw6/49.png",
     "subtype": "Basic",
@@ -2490,7 +2539,8 @@
     ]
   },
   {
-    "id": "bw6-50",
+    "setOrder":53,
+	"id": "bw6-50",
     "name": "Drifloon",
     "imageUrl": "https://images.pokemontcg.io/bw6/50.png",
     "subtype": "Basic",
@@ -2543,7 +2593,8 @@
     ]
   },
   {
-    "id": "bw6-51",
+    "setOrder":53,
+	"id": "bw6-51",
     "name": "Drifblim",
     "imageUrl": "https://images.pokemontcg.io/bw6/51.png",
     "subtype": "Stage 1",
@@ -2594,7 +2645,8 @@
     "nationalPokedexNumber": 426
   },
   {
-    "id": "bw6-52",
+    "setOrder":53,
+	"id": "bw6-52",
     "name": "Sigilyph",
     "imageUrl": "https://images.pokemontcg.io/bw6/52.png",
     "subtype": "Basic",
@@ -2641,7 +2693,8 @@
     "nationalPokedexNumber": 561
   },
   {
-    "id": "bw6-53",
+    "setOrder":53,
+	"id": "bw6-53",
     "name": "Trubbish",
     "imageUrl": "https://images.pokemontcg.io/bw6/53.png",
     "subtype": "Basic",
@@ -2697,7 +2750,8 @@
     ]
   },
   {
-    "id": "bw6-54",
+    "setOrder":53,
+	"id": "bw6-54",
     "name": "Garbodor",
     "imageUrl": "https://images.pokemontcg.io/bw6/54.png",
     "subtype": "Stage 1",
@@ -2747,7 +2801,8 @@
     "nationalPokedexNumber": 569
   },
   {
-    "id": "bw6-55",
+    "setOrder":53,
+	"id": "bw6-55",
     "name": "Gothita",
     "imageUrl": "https://images.pokemontcg.io/bw6/55.png",
     "subtype": "Basic",
@@ -2790,7 +2845,8 @@
     ]
   },
   {
-    "id": "bw6-56",
+    "setOrder":53,
+	"id": "bw6-56",
     "name": "Gothorita",
     "imageUrl": "https://images.pokemontcg.io/bw6/56.png",
     "subtype": "Stage 1",
@@ -2845,7 +2901,8 @@
     ]
   },
   {
-    "id": "bw6-57",
+    "setOrder":53,
+	"id": "bw6-57",
     "name": "Gothitelle",
     "imageUrl": "https://images.pokemontcg.io/bw6/57.png",
     "subtype": "Stage 2",
@@ -2899,7 +2956,8 @@
     "nationalPokedexNumber": 576
   },
   {
-    "id": "bw6-58",
+    "setOrder":53,
+	"id": "bw6-58",
     "name": "Golett",
     "imageUrl": "https://images.pokemontcg.io/bw6/58.png",
     "subtype": "Basic",
@@ -2956,7 +3014,8 @@
     ]
   },
   {
-    "id": "bw6-59",
+    "setOrder":53,
+	"id": "bw6-59",
     "name": "Golurk",
     "imageUrl": "https://images.pokemontcg.io/bw6/59.png",
     "subtype": "Stage 1",
@@ -3014,7 +3073,8 @@
     "nationalPokedexNumber": 623
   },
   {
-    "id": "bw6-60",
+    "setOrder":53,
+	"id": "bw6-60",
     "name": "Cubone",
     "imageUrl": "https://images.pokemontcg.io/bw6/60.png",
     "subtype": "Basic",
@@ -3073,7 +3133,8 @@
     ]
   },
   {
-    "id": "bw6-61",
+    "setOrder":53,
+	"id": "bw6-61",
     "name": "Marowak",
     "imageUrl": "https://images.pokemontcg.io/bw6/61.png",
     "subtype": "Stage 1",
@@ -3131,7 +3192,8 @@
     "nationalPokedexNumber": 105
   },
   {
-    "id": "bw6-62",
+    "setOrder":53,
+	"id": "bw6-62",
     "name": "Nosepass",
     "imageUrl": "https://images.pokemontcg.io/bw6/62.png",
     "subtype": "Basic",
@@ -3176,7 +3238,8 @@
     ]
   },
   {
-    "id": "bw6-63",
+    "setOrder":53,
+	"id": "bw6-63",
     "name": "Baltoy",
     "imageUrl": "https://images.pokemontcg.io/bw6/63.png",
     "subtype": "Basic",
@@ -3229,7 +3292,8 @@
     ]
   },
   {
-    "id": "bw6-64",
+    "setOrder":53,
+	"id": "bw6-64",
     "name": "Claydol",
     "imageUrl": "https://images.pokemontcg.io/bw6/64.png",
     "subtype": "Stage 1",
@@ -3284,7 +3348,8 @@
     "nationalPokedexNumber": 344
   },
   {
-    "id": "bw6-65",
+    "setOrder":53,
+	"id": "bw6-65",
     "name": "Roggenrola",
     "imageUrl": "https://images.pokemontcg.io/bw6/65.png",
     "subtype": "Basic",
@@ -3341,7 +3406,8 @@
     ]
   },
   {
-    "id": "bw6-66",
+    "setOrder":53,
+	"id": "bw6-66",
     "name": "Boldore",
     "imageUrl": "https://images.pokemontcg.io/bw6/66.png",
     "subtype": "Stage 1",
@@ -3398,7 +3464,8 @@
     ]
   },
   {
-    "id": "bw6-67",
+    "setOrder":53,
+	"id": "bw6-67",
     "name": "Gigalith",
     "imageUrl": "https://images.pokemontcg.io/bw6/67.png",
     "subtype": "Stage 2",
@@ -3456,7 +3523,8 @@
     "nationalPokedexNumber": 526
   },
   {
-    "id": "bw6-68",
+    "setOrder":53,
+	"id": "bw6-68",
     "name": "Throh",
     "imageUrl": "https://images.pokemontcg.io/bw6/68.png",
     "subtype": "Basic",
@@ -3512,7 +3580,8 @@
     "nationalPokedexNumber": 538
   },
   {
-    "id": "bw6-69",
+    "setOrder":53,
+	"id": "bw6-69",
     "name": "Sawk",
     "imageUrl": "https://images.pokemontcg.io/bw6/69.png",
     "subtype": "Basic",
@@ -3563,7 +3632,8 @@
     "nationalPokedexNumber": 539
   },
   {
-    "id": "bw6-70",
+    "setOrder":53,
+	"id": "bw6-70",
     "name": "Stunfisk",
     "imageUrl": "https://images.pokemontcg.io/bw6/70.png",
     "subtype": "Basic",
@@ -3621,7 +3691,8 @@
     "nationalPokedexNumber": 618
   },
   {
-    "id": "bw6-71",
+    "setOrder":53,
+	"id": "bw6-71",
     "name": "Terrakion-EX",
     "imageUrl": "https://images.pokemontcg.io/bw6/71.png",
     "subtype": "EX",
@@ -3678,7 +3749,8 @@
     "nationalPokedexNumber": 639
   },
   {
-    "id": "bw6-72",
+    "setOrder":53,
+	"id": "bw6-72",
     "name": "Murkrow",
     "imageUrl": "https://images.pokemontcg.io/bw6/72.png",
     "subtype": "Basic",
@@ -3737,7 +3809,8 @@
     ]
   },
   {
-    "id": "bw6-73",
+    "setOrder":53,
+	"id": "bw6-73",
     "name": "Honchkrow",
     "imageUrl": "https://images.pokemontcg.io/bw6/73.png",
     "subtype": "Stage 1",
@@ -3797,7 +3870,8 @@
     "nationalPokedexNumber": 430
   },
   {
-    "id": "bw6-74",
+    "setOrder":53,
+	"id": "bw6-74",
     "name": "Houndour",
     "imageUrl": "https://images.pokemontcg.io/bw6/74.png",
     "subtype": "Basic",
@@ -3857,7 +3931,8 @@
     ]
   },
   {
-    "id": "bw6-75",
+    "setOrder":53,
+	"id": "bw6-75",
     "name": "Houndoom",
     "imageUrl": "https://images.pokemontcg.io/bw6/75.png",
     "subtype": "Stage 1",
@@ -3915,7 +3990,8 @@
     "nationalPokedexNumber": 229
   },
   {
-    "id": "bw6-76",
+    "setOrder":53,
+	"id": "bw6-76",
     "name": "Stunky",
     "imageUrl": "https://images.pokemontcg.io/bw6/76.png",
     "subtype": "Basic",
@@ -3964,7 +4040,8 @@
     ]
   },
   {
-    "id": "bw6-77",
+    "setOrder":53,
+	"id": "bw6-77",
     "name": "Skuntank",
     "imageUrl": "https://images.pokemontcg.io/bw6/77.png",
     "subtype": "Stage 1",
@@ -4022,7 +4099,8 @@
     "nationalPokedexNumber": 435
   },
   {
-    "id": "bw6-78",
+    "setOrder":53,
+	"id": "bw6-78",
     "name": "Aron",
     "imageUrl": "https://images.pokemontcg.io/bw6/78.png",
     "subtype": "Basic",
@@ -4073,7 +4151,8 @@
     ]
   },
   {
-    "id": "bw6-79",
+    "setOrder":53,
+	"id": "bw6-79",
     "name": "Lairon",
     "imageUrl": "https://images.pokemontcg.io/bw6/79.png",
     "subtype": "Stage 1",
@@ -4137,7 +4216,8 @@
     ]
   },
   {
-    "id": "bw6-80",
+    "setOrder":53,
+	"id": "bw6-80",
     "name": "Aggron",
     "imageUrl": "https://images.pokemontcg.io/bw6/80.png",
     "subtype": "Stage 2",
@@ -4194,7 +4274,8 @@
     "nationalPokedexNumber": 306
   },
   {
-    "id": "bw6-81",
+    "setOrder":53,
+	"id": "bw6-81",
     "name": "Registeel-EX",
     "imageUrl": "https://images.pokemontcg.io/bw6/81.png",
     "subtype": "EX",
@@ -4260,7 +4341,8 @@
     "nationalPokedexNumber": 379
   },
   {
-    "id": "bw6-82",
+    "setOrder":53,
+	"id": "bw6-82",
     "name": "Probopass",
     "imageUrl": "https://images.pokemontcg.io/bw6/82.png",
     "subtype": "Stage 1",
@@ -4322,7 +4404,8 @@
     "nationalPokedexNumber": 476
   },
   {
-    "id": "bw6-83",
+    "setOrder":53,
+	"id": "bw6-83",
     "name": "Durant",
     "imageUrl": "https://images.pokemontcg.io/bw6/83.png",
     "subtype": "Basic",
@@ -4378,7 +4461,8 @@
     "nationalPokedexNumber": 632
   },
   {
-    "id": "bw6-84",
+    "setOrder":53,
+	"id": "bw6-84",
     "name": "Altaria",
     "imageUrl": "https://images.pokemontcg.io/bw6/84.png",
     "subtype": "Stage 1",
@@ -4426,7 +4510,8 @@
     "nationalPokedexNumber": 334
   },
   {
-    "id": "bw6-85",
+    "setOrder":53,
+	"id": "bw6-85",
     "name": "Rayquaza-EX",
     "imageUrl": "https://images.pokemontcg.io/bw6/85.png",
     "subtype": "EX",
@@ -4480,7 +4565,8 @@
     "evolvesTo": "M Rayquaza-EX"
   },
   {
-    "id": "bw6-86",
+    "setOrder":53,
+	"id": "bw6-86",
     "name": "Gible",
     "imageUrl": "https://images.pokemontcg.io/bw6/86.png",
     "subtype": "Basic",
@@ -4533,7 +4619,8 @@
     ]
   },
   {
-    "id": "bw6-87",
+    "setOrder":53,
+	"id": "bw6-87",
     "name": "Gible",
     "imageUrl": "https://images.pokemontcg.io/bw6/87.png",
     "subtype": "Basic",
@@ -4586,7 +4673,8 @@
     ]
   },
   {
-    "id": "bw6-88",
+    "setOrder":53,
+	"id": "bw6-88",
     "name": "Gabite",
     "imageUrl": "https://images.pokemontcg.io/bw6/88.png",
     "subtype": "Stage 1",
@@ -4640,7 +4728,8 @@
     ]
   },
   {
-    "id": "bw6-89",
+    "setOrder":53,
+	"id": "bw6-89",
     "name": "Gabite",
     "imageUrl": "https://images.pokemontcg.io/bw6/89.png",
     "subtype": "Stage 1",
@@ -4690,7 +4779,8 @@
     ]
   },
   {
-    "id": "bw6-90",
+    "setOrder":53,
+	"id": "bw6-90",
     "name": "Garchomp",
     "imageUrl": "https://images.pokemontcg.io/bw6/90.png",
     "subtype": "Stage 2",
@@ -4741,7 +4831,8 @@
     "nationalPokedexNumber": 445
   },
   {
-    "id": "bw6-91",
+    "setOrder":53,
+	"id": "bw6-91",
     "name": "Garchomp",
     "imageUrl": "https://images.pokemontcg.io/bw6/91.png",
     "subtype": "Stage 2",
@@ -4790,7 +4881,8 @@
     "nationalPokedexNumber": 445
   },
   {
-    "id": "bw6-92",
+    "setOrder":53,
+	"id": "bw6-92",
     "name": "Giratina-EX",
     "imageUrl": "https://images.pokemontcg.io/bw6/92.png",
     "subtype": "EX",
@@ -4849,7 +4941,8 @@
     "nationalPokedexNumber": 487
   },
   {
-    "id": "bw6-93",
+    "setOrder":53,
+	"id": "bw6-93",
     "name": "Deino",
     "imageUrl": "https://images.pokemontcg.io/bw6/93.png",
     "subtype": "Basic",
@@ -4903,7 +4996,8 @@
     ]
   },
   {
-    "id": "bw6-94",
+    "setOrder":53,
+	"id": "bw6-94",
     "name": "Deino",
     "imageUrl": "https://images.pokemontcg.io/bw6/94.png",
     "subtype": "Basic",
@@ -4958,7 +5052,8 @@
     ]
   },
   {
-    "id": "bw6-95",
+    "setOrder":53,
+	"id": "bw6-95",
     "name": "Zweilous",
     "imageUrl": "https://images.pokemontcg.io/bw6/95.png",
     "subtype": "Stage 1",
@@ -5015,7 +5110,8 @@
     ]
   },
   {
-    "id": "bw6-96",
+    "setOrder":53,
+	"id": "bw6-96",
     "name": "Zweilous",
     "imageUrl": "https://images.pokemontcg.io/bw6/96.png",
     "subtype": "Stage 1",
@@ -5072,7 +5168,8 @@
     ]
   },
   {
-    "id": "bw6-97",
+    "setOrder":53,
+	"id": "bw6-97",
     "name": "Hydreigon",
     "imageUrl": "https://images.pokemontcg.io/bw6/97.png",
     "subtype": "Stage 2",
@@ -5123,7 +5220,8 @@
     "nationalPokedexNumber": 635
   },
   {
-    "id": "bw6-98",
+    "setOrder":53,
+	"id": "bw6-98",
     "name": "Hydreigon",
     "imageUrl": "https://images.pokemontcg.io/bw6/98.png",
     "subtype": "Stage 2",
@@ -5180,7 +5278,8 @@
     "nationalPokedexNumber": 635
   },
   {
-    "id": "bw6-99",
+    "setOrder":53,
+	"id": "bw6-99",
     "name": "Aipom",
     "imageUrl": "https://images.pokemontcg.io/bw6/99.png",
     "subtype": "Basic",
@@ -5223,7 +5322,8 @@
     ]
   },
   {
-    "id": "bw6-100",
+    "setOrder":53,
+	"id": "bw6-100",
     "name": "Ambipom",
     "imageUrl": "https://images.pokemontcg.io/bw6/100.png",
     "subtype": "Stage 1",
@@ -5274,7 +5374,8 @@
     "nationalPokedexNumber": 424
   },
   {
-    "id": "bw6-101",
+    "setOrder":53,
+	"id": "bw6-101",
     "name": "Slakoth",
     "imageUrl": "https://images.pokemontcg.io/bw6/101.png",
     "subtype": "Basic",
@@ -5318,7 +5419,8 @@
     ]
   },
   {
-    "id": "bw6-102",
+    "setOrder":53,
+	"id": "bw6-102",
     "name": "Vigoroth",
     "imageUrl": "https://images.pokemontcg.io/bw6/102.png",
     "subtype": "Stage 1",
@@ -5363,7 +5465,8 @@
     ]
   },
   {
-    "id": "bw6-103",
+    "setOrder":53,
+	"id": "bw6-103",
     "name": "Slaking",
     "imageUrl": "https://images.pokemontcg.io/bw6/103.png",
     "subtype": "Stage 2",
@@ -5415,7 +5518,8 @@
     "nationalPokedexNumber": 289
   },
   {
-    "id": "bw6-104",
+    "setOrder":53,
+	"id": "bw6-104",
     "name": "Swablu",
     "imageUrl": "https://images.pokemontcg.io/bw6/104.png",
     "subtype": "Basic",
@@ -5474,7 +5578,8 @@
     ]
   },
   {
-    "id": "bw6-105",
+    "setOrder":53,
+	"id": "bw6-105",
     "name": "Swablu",
     "imageUrl": "https://images.pokemontcg.io/bw6/105.png",
     "subtype": "Basic",
@@ -5523,7 +5628,8 @@
     ]
   },
   {
-    "id": "bw6-106",
+    "setOrder":53,
+	"id": "bw6-106",
     "name": "Bidoof",
     "imageUrl": "https://images.pokemontcg.io/bw6/106.png",
     "subtype": "Basic",
@@ -5568,7 +5674,8 @@
     ]
   },
   {
-    "id": "bw6-107",
+    "setOrder":53,
+	"id": "bw6-107",
     "name": "Bibarel",
     "imageUrl": "https://images.pokemontcg.io/bw6/107.png",
     "subtype": "Stage 1",
@@ -5624,7 +5731,8 @@
     "nationalPokedexNumber": 400
   },
   {
-    "id": "bw6-108",
+    "setOrder":53,
+	"id": "bw6-108",
     "name": "Audino",
     "imageUrl": "https://images.pokemontcg.io/bw6/108.png",
     "subtype": "Basic",
@@ -5677,7 +5785,8 @@
     "nationalPokedexNumber": 531
   },
   {
-    "id": "bw6-109",
+    "setOrder":53,
+	"id": "bw6-109",
     "name": "Minccino",
     "imageUrl": "https://images.pokemontcg.io/bw6/109.png",
     "subtype": "Basic",
@@ -5730,7 +5839,8 @@
     ]
   },
   {
-    "id": "bw6-110",
+    "setOrder":53,
+	"id": "bw6-110",
     "name": "Bouffalant",
     "imageUrl": "https://images.pokemontcg.io/bw6/110.png",
     "subtype": "Basic",
@@ -5778,7 +5888,8 @@
     "nationalPokedexNumber": 626
   },
   {
-    "id": "bw6-111",
+    "setOrder":53,
+	"id": "bw6-111",
     "name": "Rufflet",
     "imageUrl": "https://images.pokemontcg.io/bw6/111.png",
     "subtype": "Basic",
@@ -5837,7 +5948,8 @@
     ]
   },
   {
-    "id": "bw6-112",
+    "setOrder":53,
+	"id": "bw6-112",
     "name": "Braviary",
     "imageUrl": "https://images.pokemontcg.io/bw6/112.png",
     "subtype": "Stage 1",
@@ -5892,7 +6004,8 @@
     "nationalPokedexNumber": 628
   },
   {
-    "id": "bw6-113",
+    "setOrder":53,
+	"id": "bw6-113",
     "name": "Devolution Spray",
     "imageUrl": "https://images.pokemontcg.io/bw6/113.png",
     "subtype": "Item",
@@ -5909,7 +6022,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw6/113_hires.png"
   },
   {
-    "id": "bw6-114",
+    "setOrder":53,
+	"id": "bw6-114",
     "name": "Giant Cape",
     "imageUrl": "https://images.pokemontcg.io/bw6/114.png",
     "subtype": "Pokémon Tool",
@@ -5926,7 +6040,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw6/114_hires.png"
   },
   {
-    "id": "bw6-115",
+    "setOrder":53,
+	"id": "bw6-115",
     "name": "Rescue Scarf",
     "imageUrl": "https://images.pokemontcg.io/bw6/115.png",
     "subtype": "Pokémon Tool",
@@ -5943,7 +6058,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw6/115_hires.png"
   },
   {
-    "id": "bw6-116",
+    "setOrder":53,
+	"id": "bw6-116",
     "name": "Tool Scrapper",
     "imageUrl": "https://images.pokemontcg.io/bw6/116.png",
     "subtype": "Item",
@@ -5960,7 +6076,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw6/116_hires.png"
   },
   {
-    "id": "bw6-117",
+    "setOrder":53,
+	"id": "bw6-117",
     "name": "Blend Energy GrassFirePsychicDarkness",
     "imageUrl": "https://images.pokemontcg.io/bw6/117.png",
     "subtype": "Special",
@@ -5977,7 +6094,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw6/117_hires.png"
   },
   {
-    "id": "bw6-118",
+    "setOrder":53,
+	"id": "bw6-118",
     "name": "Blend Energy WaterLightningFightingMetal",
     "imageUrl": "https://images.pokemontcg.io/bw6/118.png",
     "subtype": "Special",
@@ -5994,7 +6112,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw6/118_hires.png"
   },
   {
-    "id": "bw6-119",
+    "setOrder":53,
+	"id": "bw6-119",
     "name": "Ho-Oh-EX",
     "imageUrl": "https://images.pokemontcg.io/bw6/119.png",
     "subtype": "EX",
@@ -6051,7 +6170,8 @@
     "nationalPokedexNumber": 250
   },
   {
-    "id": "bw6-120",
+    "setOrder":53,
+	"id": "bw6-120",
     "name": "Mew-EX",
     "imageUrl": "https://images.pokemontcg.io/bw6/120.png",
     "subtype": "EX",
@@ -6099,7 +6219,8 @@
     "nationalPokedexNumber": 151
   },
   {
-    "id": "bw6-121",
+    "setOrder":53,
+	"id": "bw6-121",
     "name": "Terrakion-EX",
     "imageUrl": "https://images.pokemontcg.io/bw6/121.png",
     "subtype": "EX",
@@ -6156,7 +6277,8 @@
     "nationalPokedexNumber": 639
   },
   {
-    "id": "bw6-122",
+    "setOrder":53,
+	"id": "bw6-122",
     "name": "Registeel-EX",
     "imageUrl": "https://images.pokemontcg.io/bw6/122.png",
     "subtype": "EX",
@@ -6222,7 +6344,8 @@
     "nationalPokedexNumber": 379
   },
   {
-    "id": "bw6-123",
+    "setOrder":53,
+	"id": "bw6-123",
     "name": "Rayquaza-EX",
     "imageUrl": "https://images.pokemontcg.io/bw6/123.png",
     "subtype": "EX",
@@ -6276,7 +6399,8 @@
     "evolvesTo": "M Rayquaza-EX"
   },
   {
-    "id": "bw6-124",
+    "setOrder":53,
+	"id": "bw6-124",
     "name": "Giratina-EX",
     "imageUrl": "https://images.pokemontcg.io/bw6/124.png",
     "subtype": "EX",
@@ -6335,7 +6459,8 @@
     "nationalPokedexNumber": 487
   },
   {
-    "id": "bw6-125",
+    "setOrder":53,
+	"id": "bw6-125",
     "name": "Serperior",
     "imageUrl": "https://images.pokemontcg.io/bw6/125.png",
     "subtype": "Stage 2",
@@ -6388,7 +6513,8 @@
     "nationalPokedexNumber": 497
   },
   {
-    "id": "bw6-126",
+    "setOrder":53,
+	"id": "bw6-126",
     "name": "Reuniclus",
     "imageUrl": "https://images.pokemontcg.io/bw6/126.png",
     "subtype": "Stage 2",
@@ -6437,7 +6563,8 @@
     "nationalPokedexNumber": 579
   },
   {
-    "id": "bw6-127",
+    "setOrder":53,
+	"id": "bw6-127",
     "name": "Krookodile",
     "imageUrl": "https://images.pokemontcg.io/bw6/127.png",
     "subtype": "Stage 2",
@@ -6500,7 +6627,8 @@
     "nationalPokedexNumber": 553
   },
   {
-    "id": "bw6-128",
+    "setOrder":53,
+	"id": "bw6-128",
     "name": "Rayquaza",
     "imageUrl": "https://images.pokemontcg.io/bw6/128.png",
     "subtype": "Basic",

--- a/json/cards/Emerald.json
+++ b/json/cards/Emerald.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "ex9-1",
+    "setOrder":24,
+	"id": "ex9-1",
     "name": "Blaziken",
     "imageUrl": "https://images.pokemontcg.io/ex9/1.png",
     "subtype": "Stage 2",
@@ -56,7 +57,8 @@
     "nationalPokedexNumber": 257
   },
   {
-    "id": "ex9-2",
+    "setOrder":24,
+	"id": "ex9-2",
     "name": "Deoxys",
     "imageUrl": "https://images.pokemontcg.io/ex9/2.png",
     "subtype": "Basic",
@@ -102,7 +104,8 @@
     "nationalPokedexNumber": 386
   },
   {
-    "id": "ex9-3",
+    "setOrder":24,
+	"id": "ex9-3",
     "name": "Exploud",
     "imageUrl": "https://images.pokemontcg.io/ex9/3.png",
     "subtype": "Stage 2",
@@ -178,7 +181,8 @@
     "nationalPokedexNumber": 295
   },
   {
-    "id": "ex9-4",
+    "setOrder":24,
+	"id": "ex9-4",
     "name": "Gardevoir",
     "imageUrl": "https://images.pokemontcg.io/ex9/4.png",
     "subtype": "Stage 2",
@@ -238,7 +242,8 @@
     "nationalPokedexNumber": 282
   },
   {
-    "id": "ex9-5",
+    "setOrder":24,
+	"id": "ex9-5",
     "name": "Groudon",
     "imageUrl": "https://images.pokemontcg.io/ex9/5.png",
     "subtype": "Basic",
@@ -289,7 +294,8 @@
     "nationalPokedexNumber": 383
   },
   {
-    "id": "ex9-6",
+    "setOrder":24,
+	"id": "ex9-6",
     "name": "Kyogre",
     "imageUrl": "https://images.pokemontcg.io/ex9/6.png",
     "subtype": "Basic",
@@ -341,7 +347,8 @@
     "nationalPokedexNumber": 382
   },
   {
-    "id": "ex9-7",
+    "setOrder":24,
+	"id": "ex9-7",
     "name": "Manectric",
     "imageUrl": "https://images.pokemontcg.io/ex9/7.png",
     "subtype": "Stage 1",
@@ -400,7 +407,8 @@
     "nationalPokedexNumber": 310
   },
   {
-    "id": "ex9-8",
+    "setOrder":24,
+	"id": "ex9-8",
     "name": "Milotic",
     "imageUrl": "https://images.pokemontcg.io/ex9/8.png",
     "subtype": "Stage 1",
@@ -453,7 +461,8 @@
     "nationalPokedexNumber": 350
   },
   {
-    "id": "ex9-9",
+    "setOrder":24,
+	"id": "ex9-9",
     "name": "Rayquaza",
     "imageUrl": "https://images.pokemontcg.io/ex9/9.png",
     "subtype": "Basic",
@@ -506,7 +515,8 @@
     "nationalPokedexNumber": 384
   },
   {
-    "id": "ex9-10",
+    "setOrder":24,
+	"id": "ex9-10",
     "name": "Sceptile",
     "imageUrl": "https://images.pokemontcg.io/ex9/10.png",
     "subtype": "Stage 2",
@@ -571,7 +581,8 @@
     "nationalPokedexNumber": 254
   },
   {
-    "id": "ex9-11",
+    "setOrder":24,
+	"id": "ex9-11",
     "name": "Swampert",
     "imageUrl": "https://images.pokemontcg.io/ex9/11.png",
     "subtype": "Stage 2",
@@ -629,7 +640,8 @@
     "nationalPokedexNumber": 260
   },
   {
-    "id": "ex9-12",
+    "setOrder":24,
+	"id": "ex9-12",
     "name": "Chimecho",
     "imageUrl": "https://images.pokemontcg.io/ex9/12.png",
     "subtype": "Basic",
@@ -679,7 +691,8 @@
     "nationalPokedexNumber": 358
   },
   {
-    "id": "ex9-13",
+    "setOrder":24,
+	"id": "ex9-13",
     "name": "Glalie",
     "imageUrl": "https://images.pokemontcg.io/ex9/13.png",
     "subtype": "Stage 1",
@@ -731,7 +744,8 @@
     "nationalPokedexNumber": 362
   },
   {
-    "id": "ex9-14",
+    "setOrder":24,
+	"id": "ex9-14",
     "name": "Groudon",
     "imageUrl": "https://images.pokemontcg.io/ex9/14.png",
     "subtype": "Basic",
@@ -785,7 +799,8 @@
     "nationalPokedexNumber": 383
   },
   {
-    "id": "ex9-15",
+    "setOrder":24,
+	"id": "ex9-15",
     "name": "Kyogre",
     "imageUrl": "https://images.pokemontcg.io/ex9/15.png",
     "subtype": "Basic",
@@ -837,7 +852,8 @@
     "nationalPokedexNumber": 382
   },
   {
-    "id": "ex9-16",
+    "setOrder":24,
+	"id": "ex9-16",
     "name": "Manectric",
     "imageUrl": "https://images.pokemontcg.io/ex9/16.png",
     "subtype": "Stage 1",
@@ -894,7 +910,8 @@
     "nationalPokedexNumber": 310
   },
   {
-    "id": "ex9-17",
+    "setOrder":24,
+	"id": "ex9-17",
     "name": "Nosepass",
     "imageUrl": "https://images.pokemontcg.io/ex9/17.png",
     "subtype": "Basic",
@@ -947,7 +964,8 @@
     ]
   },
   {
-    "id": "ex9-18",
+    "setOrder":24,
+	"id": "ex9-18",
     "name": "Relicanth",
     "imageUrl": "https://images.pokemontcg.io/ex9/18.png",
     "subtype": "Basic",
@@ -997,7 +1015,8 @@
     "nationalPokedexNumber": 369
   },
   {
-    "id": "ex9-19",
+    "setOrder":24,
+	"id": "ex9-19",
     "name": "Rhydon",
     "imageUrl": "https://images.pokemontcg.io/ex9/19.png",
     "subtype": "Stage 1",
@@ -1054,7 +1073,8 @@
     ]
   },
   {
-    "id": "ex9-20",
+    "setOrder":24,
+	"id": "ex9-20",
     "name": "Seviper",
     "imageUrl": "https://images.pokemontcg.io/ex9/20.png",
     "subtype": "Basic",
@@ -1105,7 +1125,8 @@
     "nationalPokedexNumber": 336
   },
   {
-    "id": "ex9-21",
+    "setOrder":24,
+	"id": "ex9-21",
     "name": "Zangoose",
     "imageUrl": "https://images.pokemontcg.io/ex9/21.png",
     "subtype": "Basic",
@@ -1155,7 +1176,8 @@
     "nationalPokedexNumber": 335
   },
   {
-    "id": "ex9-22",
+    "setOrder":24,
+	"id": "ex9-22",
     "name": "Breloom",
     "imageUrl": "https://images.pokemontcg.io/ex9/22.png",
     "subtype": "Stage 1",
@@ -1207,7 +1229,8 @@
     "nationalPokedexNumber": 286
   },
   {
-    "id": "ex9-23",
+    "setOrder":24,
+	"id": "ex9-23",
     "name": "Camerupt",
     "imageUrl": "https://images.pokemontcg.io/ex9/23.png",
     "subtype": "Stage 1",
@@ -1261,7 +1284,8 @@
     "nationalPokedexNumber": 323
   },
   {
-    "id": "ex9-24",
+    "setOrder":24,
+	"id": "ex9-24",
     "name": "Claydol",
     "imageUrl": "https://images.pokemontcg.io/ex9/24.png",
     "subtype": "Stage 1",
@@ -1309,7 +1333,8 @@
     "nationalPokedexNumber": 344
   },
   {
-    "id": "ex9-25",
+    "setOrder":24,
+	"id": "ex9-25",
     "name": "Combusken",
     "imageUrl": "https://images.pokemontcg.io/ex9/25.png",
     "subtype": "Stage 1",
@@ -1365,7 +1390,8 @@
     ]
   },
   {
-    "id": "ex9-26",
+    "setOrder":24,
+	"id": "ex9-26",
     "name": "Dodrio",
     "imageUrl": "https://images.pokemontcg.io/ex9/26.png",
     "subtype": "Stage 1",
@@ -1424,7 +1450,8 @@
     "nationalPokedexNumber": 85
   },
   {
-    "id": "ex9-27",
+    "setOrder":24,
+	"id": "ex9-27",
     "name": "Electrode",
     "imageUrl": "https://images.pokemontcg.io/ex9/27.png",
     "subtype": "Stage 1",
@@ -1476,7 +1503,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "ex9-28",
+    "setOrder":24,
+	"id": "ex9-28",
     "name": "Grovyle",
     "imageUrl": "https://images.pokemontcg.io/ex9/28.png",
     "subtype": "Stage 1",
@@ -1537,7 +1565,8 @@
     ]
   },
   {
-    "id": "ex9-29",
+    "setOrder":24,
+	"id": "ex9-29",
     "name": "Grumpig",
     "imageUrl": "https://images.pokemontcg.io/ex9/29.png",
     "subtype": "Stage 1",
@@ -1590,7 +1619,8 @@
     "nationalPokedexNumber": 326
   },
   {
-    "id": "ex9-30",
+    "setOrder":24,
+	"id": "ex9-30",
     "name": "Grumpig",
     "imageUrl": "https://images.pokemontcg.io/ex9/30.png",
     "subtype": "Stage 1",
@@ -1641,7 +1671,8 @@
     "nationalPokedexNumber": 326
   },
   {
-    "id": "ex9-31",
+    "setOrder":24,
+	"id": "ex9-31",
     "name": "Hariyama",
     "imageUrl": "https://images.pokemontcg.io/ex9/31.png",
     "subtype": "Stage 1",
@@ -1694,7 +1725,8 @@
     "nationalPokedexNumber": 297
   },
   {
-    "id": "ex9-32",
+    "setOrder":24,
+	"id": "ex9-32",
     "name": "Illumise",
     "imageUrl": "https://images.pokemontcg.io/ex9/32.png",
     "subtype": "Basic",
@@ -1744,7 +1776,8 @@
     "nationalPokedexNumber": 314
   },
   {
-    "id": "ex9-33",
+    "setOrder":24,
+	"id": "ex9-33",
     "name": "Kirlia",
     "imageUrl": "https://images.pokemontcg.io/ex9/33.png",
     "subtype": "Stage 1",
@@ -1801,7 +1834,8 @@
     ]
   },
   {
-    "id": "ex9-34",
+    "setOrder":24,
+	"id": "ex9-34",
     "name": "Linoone",
     "imageUrl": "https://images.pokemontcg.io/ex9/34.png",
     "subtype": "Stage 1",
@@ -1849,7 +1883,8 @@
     "nationalPokedexNumber": 264
   },
   {
-    "id": "ex9-35",
+    "setOrder":24,
+	"id": "ex9-35",
     "name": "Loudred",
     "imageUrl": "https://images.pokemontcg.io/ex9/35.png",
     "subtype": "Stage 1",
@@ -1905,7 +1940,8 @@
     ]
   },
   {
-    "id": "ex9-36",
+    "setOrder":24,
+	"id": "ex9-36",
     "name": "Marshtomp",
     "imageUrl": "https://images.pokemontcg.io/ex9/36.png",
     "subtype": "Stage 1",
@@ -1960,7 +1996,8 @@
     ]
   },
   {
-    "id": "ex9-37",
+    "setOrder":24,
+	"id": "ex9-37",
     "name": "Minun",
     "imageUrl": "https://images.pokemontcg.io/ex9/37.png",
     "subtype": "Basic",
@@ -2012,7 +2049,8 @@
     "nationalPokedexNumber": 312
   },
   {
-    "id": "ex9-38",
+    "setOrder":24,
+	"id": "ex9-38",
     "name": "Ninetales",
     "imageUrl": "https://images.pokemontcg.io/ex9/38.png",
     "subtype": "Stage 1",
@@ -2064,7 +2102,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "ex9-39",
+    "setOrder":24,
+	"id": "ex9-39",
     "name": "Plusle",
     "imageUrl": "https://images.pokemontcg.io/ex9/39.png",
     "subtype": "Basic",
@@ -2121,7 +2160,8 @@
     "nationalPokedexNumber": 311
   },
   {
-    "id": "ex9-40",
+    "setOrder":24,
+	"id": "ex9-40",
     "name": "Swalot",
     "imageUrl": "https://images.pokemontcg.io/ex9/40.png",
     "subtype": "Stage 1",
@@ -2175,7 +2215,8 @@
     "nationalPokedexNumber": 317
   },
   {
-    "id": "ex9-41",
+    "setOrder":24,
+	"id": "ex9-41",
     "name": "Swellow",
     "imageUrl": "https://images.pokemontcg.io/ex9/41.png",
     "subtype": "Stage 1",
@@ -2231,7 +2272,8 @@
     "nationalPokedexNumber": 277
   },
   {
-    "id": "ex9-42",
+    "setOrder":24,
+	"id": "ex9-42",
     "name": "Volbeat",
     "imageUrl": "https://images.pokemontcg.io/ex9/42.png",
     "subtype": "Basic",
@@ -2281,7 +2323,8 @@
     "nationalPokedexNumber": 313
   },
   {
-    "id": "ex9-43",
+    "setOrder":24,
+	"id": "ex9-43",
     "name": "Baltoy",
     "imageUrl": "https://images.pokemontcg.io/ex9/43.png",
     "subtype": "Basic",
@@ -2335,7 +2378,8 @@
     ]
   },
   {
-    "id": "ex9-44",
+    "setOrder":24,
+	"id": "ex9-44",
     "name": "Cacnea",
     "imageUrl": "https://images.pokemontcg.io/ex9/44.png",
     "subtype": "Basic",
@@ -2378,7 +2422,8 @@
     ]
   },
   {
-    "id": "ex9-45",
+    "setOrder":24,
+	"id": "ex9-45",
     "name": "Doduo",
     "imageUrl": "https://images.pokemontcg.io/ex9/45.png",
     "subtype": "Basic",
@@ -2427,7 +2472,8 @@
     ]
   },
   {
-    "id": "ex9-46",
+    "setOrder":24,
+	"id": "ex9-46",
     "name": "Duskull",
     "imageUrl": "https://images.pokemontcg.io/ex9/46.png",
     "subtype": "Basic",
@@ -2476,7 +2522,8 @@
     ]
   },
   {
-    "id": "ex9-47",
+    "setOrder":24,
+	"id": "ex9-47",
     "name": "Electrike",
     "imageUrl": "https://images.pokemontcg.io/ex9/47.png",
     "subtype": "Basic",
@@ -2525,7 +2572,8 @@
     ]
   },
   {
-    "id": "ex9-48",
+    "setOrder":24,
+	"id": "ex9-48",
     "name": "Electrike",
     "imageUrl": "https://images.pokemontcg.io/ex9/48.png",
     "subtype": "Basic",
@@ -2584,7 +2632,8 @@
     ]
   },
   {
-    "id": "ex9-49",
+    "setOrder":24,
+	"id": "ex9-49",
     "name": "Feebas",
     "imageUrl": "https://images.pokemontcg.io/ex9/49.png",
     "subtype": "Basic",
@@ -2633,7 +2682,8 @@
     ]
   },
   {
-    "id": "ex9-50",
+    "setOrder":24,
+	"id": "ex9-50",
     "name": "Feebas",
     "imageUrl": "https://images.pokemontcg.io/ex9/50.png",
     "subtype": "Basic",
@@ -2676,7 +2726,8 @@
     ]
   },
   {
-    "id": "ex9-51",
+    "setOrder":24,
+	"id": "ex9-51",
     "name": "Gulpin",
     "imageUrl": "https://images.pokemontcg.io/ex9/51.png",
     "subtype": "Basic",
@@ -2729,7 +2780,8 @@
     ]
   },
   {
-    "id": "ex9-52",
+    "setOrder":24,
+	"id": "ex9-52",
     "name": "Larvitar",
     "imageUrl": "https://images.pokemontcg.io/ex9/52.png",
     "subtype": "Basic",
@@ -2773,7 +2825,8 @@
     ]
   },
   {
-    "id": "ex9-53",
+    "setOrder":24,
+	"id": "ex9-53",
     "name": "Luvdisc",
     "imageUrl": "https://images.pokemontcg.io/ex9/53.png",
     "subtype": "Basic",
@@ -2823,7 +2876,8 @@
     "nationalPokedexNumber": 370
   },
   {
-    "id": "ex9-54",
+    "setOrder":24,
+	"id": "ex9-54",
     "name": "Makuhita",
     "imageUrl": "https://images.pokemontcg.io/ex9/54.png",
     "subtype": "Basic",
@@ -2866,7 +2920,8 @@
     ]
   },
   {
-    "id": "ex9-55",
+    "setOrder":24,
+	"id": "ex9-55",
     "name": "Meditite",
     "imageUrl": "https://images.pokemontcg.io/ex9/55.png",
     "subtype": "Basic",
@@ -2919,7 +2974,8 @@
     ]
   },
   {
-    "id": "ex9-56",
+    "setOrder":24,
+	"id": "ex9-56",
     "name": "Mudkip",
     "imageUrl": "https://images.pokemontcg.io/ex9/56.png",
     "subtype": "Basic",
@@ -2962,7 +3018,8 @@
     ]
   },
   {
-    "id": "ex9-57",
+    "setOrder":24,
+	"id": "ex9-57",
     "name": "Numel",
     "imageUrl": "https://images.pokemontcg.io/ex9/57.png",
     "subtype": "Basic",
@@ -3014,7 +3071,8 @@
     ]
   },
   {
-    "id": "ex9-58",
+    "setOrder":24,
+	"id": "ex9-58",
     "name": "Numel",
     "imageUrl": "https://images.pokemontcg.io/ex9/58.png",
     "subtype": "Basic",
@@ -3068,7 +3126,8 @@
     ]
   },
   {
-    "id": "ex9-59",
+    "setOrder":24,
+	"id": "ex9-59",
     "name": "Pichu",
     "imageUrl": "https://images.pokemontcg.io/ex9/59.png",
     "subtype": "Basic",
@@ -3116,7 +3175,8 @@
     ]
   },
   {
-    "id": "ex9-60",
+    "setOrder":24,
+	"id": "ex9-60",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/ex9/60.png",
     "subtype": "Basic",
@@ -3169,7 +3229,8 @@
     ]
   },
   {
-    "id": "ex9-61",
+    "setOrder":24,
+	"id": "ex9-61",
     "name": "Ralts",
     "imageUrl": "https://images.pokemontcg.io/ex9/61.png",
     "subtype": "Basic",
@@ -3212,7 +3273,8 @@
     ]
   },
   {
-    "id": "ex9-62",
+    "setOrder":24,
+	"id": "ex9-62",
     "name": "Rhyhorn",
     "imageUrl": "https://images.pokemontcg.io/ex9/62.png",
     "subtype": "Basic",
@@ -3265,7 +3327,8 @@
     ]
   },
   {
-    "id": "ex9-63",
+    "setOrder":24,
+	"id": "ex9-63",
     "name": "Shroomish",
     "imageUrl": "https://images.pokemontcg.io/ex9/63.png",
     "subtype": "Basic",
@@ -3324,7 +3387,8 @@
     ]
   },
   {
-    "id": "ex9-64",
+    "setOrder":24,
+	"id": "ex9-64",
     "name": "Snorunt",
     "imageUrl": "https://images.pokemontcg.io/ex9/64.png",
     "subtype": "Basic",
@@ -3368,7 +3432,8 @@
     ]
   },
   {
-    "id": "ex9-65",
+    "setOrder":24,
+	"id": "ex9-65",
     "name": "Spoink",
     "imageUrl": "https://images.pokemontcg.io/ex9/65.png",
     "subtype": "Basic",
@@ -3411,7 +3476,8 @@
     ]
   },
   {
-    "id": "ex9-66",
+    "setOrder":24,
+	"id": "ex9-66",
     "name": "Spoink",
     "imageUrl": "https://images.pokemontcg.io/ex9/66.png",
     "subtype": "Basic",
@@ -3454,7 +3520,8 @@
     ]
   },
   {
-    "id": "ex9-67",
+    "setOrder":24,
+	"id": "ex9-67",
     "name": "Swablu",
     "imageUrl": "https://images.pokemontcg.io/ex9/67.png",
     "subtype": "Basic",
@@ -3508,7 +3575,8 @@
     ]
   },
   {
-    "id": "ex9-68",
+    "setOrder":24,
+	"id": "ex9-68",
     "name": "Taillow",
     "imageUrl": "https://images.pokemontcg.io/ex9/68.png",
     "subtype": "Basic",
@@ -3557,7 +3625,8 @@
     ]
   },
   {
-    "id": "ex9-69",
+    "setOrder":24,
+	"id": "ex9-69",
     "name": "Torchic",
     "imageUrl": "https://images.pokemontcg.io/ex9/69.png",
     "subtype": "Basic",
@@ -3600,7 +3669,8 @@
     ]
   },
   {
-    "id": "ex9-70",
+    "setOrder":24,
+	"id": "ex9-70",
     "name": "Treecko",
     "imageUrl": "https://images.pokemontcg.io/ex9/70.png",
     "subtype": "Basic",
@@ -3649,7 +3719,8 @@
     ]
   },
   {
-    "id": "ex9-71",
+    "setOrder":24,
+	"id": "ex9-71",
     "name": "Voltorb",
     "imageUrl": "https://images.pokemontcg.io/ex9/71.png",
     "subtype": "Basic",
@@ -3703,7 +3774,8 @@
     ]
   },
   {
-    "id": "ex9-72",
+    "setOrder":24,
+	"id": "ex9-72",
     "name": "Vulpix",
     "imageUrl": "https://images.pokemontcg.io/ex9/72.png",
     "subtype": "Basic",
@@ -3756,7 +3828,8 @@
     ]
   },
   {
-    "id": "ex9-73",
+    "setOrder":24,
+	"id": "ex9-73",
     "name": "Whismur",
     "imageUrl": "https://images.pokemontcg.io/ex9/73.png",
     "subtype": "Basic",
@@ -3809,7 +3882,8 @@
     ]
   },
   {
-    "id": "ex9-74",
+    "setOrder":24,
+	"id": "ex9-74",
     "name": "Zigzagoon",
     "imageUrl": "https://images.pokemontcg.io/ex9/74.png",
     "subtype": "Basic",
@@ -3862,7 +3936,8 @@
     ]
   },
   {
-    "id": "ex9-75",
+    "setOrder":24,
+	"id": "ex9-75",
     "name": "Battle Frontier",
     "imageUrl": "https://images.pokemontcg.io/ex9/75.png",
     "subtype": "Stadium",
@@ -3880,7 +3955,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex9/75_hires.png"
   },
   {
-    "id": "ex9-76",
+    "setOrder":24,
+	"id": "ex9-76",
     "name": "Double Full Heal",
     "imageUrl": "https://images.pokemontcg.io/ex9/76.png",
     "subtype": "Item",
@@ -3898,7 +3974,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex9/76_hires.png"
   },
   {
-    "id": "ex9-77",
+    "setOrder":24,
+	"id": "ex9-77",
     "name": "Lanette's Net Search",
     "imageUrl": "https://images.pokemontcg.io/ex9/77.png",
     "subtype": "Supporter",
@@ -3917,7 +3994,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex9/77_hires.png"
   },
   {
-    "id": "ex9-78",
+    "setOrder":24,
+	"id": "ex9-78",
     "name": "Lum Berry",
     "imageUrl": "https://images.pokemontcg.io/ex9/78.png",
     "subtype": "Pokémon Tool",
@@ -3936,7 +4014,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex9/78_hires.png"
   },
   {
-    "id": "ex9-79",
+    "setOrder":24,
+	"id": "ex9-79",
     "name": "Mr. Stone's Project",
     "imageUrl": "https://images.pokemontcg.io/ex9/79.png",
     "subtype": "Supporter",
@@ -3955,7 +4034,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex9/79_hires.png"
   },
   {
-    "id": "ex9-80",
+    "setOrder":24,
+	"id": "ex9-80",
     "name": "Oran Berry",
     "imageUrl": "https://images.pokemontcg.io/ex9/80.png",
     "subtype": "Pokémon Tool",
@@ -3974,7 +4054,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex9/80_hires.png"
   },
   {
-    "id": "ex9-81",
+    "setOrder":24,
+	"id": "ex9-81",
     "name": "PokéNav",
     "imageUrl": "https://images.pokemontcg.io/ex9/81.png",
     "subtype": "Item",
@@ -3992,7 +4073,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex9/81_hires.png"
   },
   {
-    "id": "ex9-82",
+    "setOrder":24,
+	"id": "ex9-82",
     "name": "Professor Birch",
     "imageUrl": "https://images.pokemontcg.io/ex9/82.png",
     "subtype": "Supporter",
@@ -4011,7 +4093,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex9/82_hires.png"
   },
   {
-    "id": "ex9-83",
+    "setOrder":24,
+	"id": "ex9-83",
     "name": "Rare Candy",
     "imageUrl": "https://images.pokemontcg.io/ex9/83.png",
     "subtype": "Item",
@@ -4029,7 +4112,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex9/83_hires.png"
   },
   {
-    "id": "ex9-84",
+    "setOrder":24,
+	"id": "ex9-84",
     "name": "Scott",
     "imageUrl": "https://images.pokemontcg.io/ex9/84.png",
     "subtype": "Supporter",
@@ -4048,7 +4132,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex9/84_hires.png"
   },
   {
-    "id": "ex9-85",
+    "setOrder":24,
+	"id": "ex9-85",
     "name": "Wally's Training",
     "imageUrl": "https://images.pokemontcg.io/ex9/85.png",
     "subtype": "Supporter",
@@ -4067,7 +4152,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex9/85_hires.png"
   },
   {
-    "id": "ex9-86",
+    "setOrder":24,
+	"id": "ex9-86",
     "name": "Darkness Energy",
     "imageUrl": "https://images.pokemontcg.io/ex9/86.png",
     "subtype": "Special",
@@ -4084,7 +4170,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex9/86_hires.png"
   },
   {
-    "id": "ex9-87",
+    "setOrder":24,
+	"id": "ex9-87",
     "name": "Double Rainbow Energy",
     "imageUrl": "https://images.pokemontcg.io/ex9/87.png",
     "subtype": "Special",
@@ -4101,7 +4188,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex9/87_hires.png"
   },
   {
-    "id": "ex9-88",
+    "setOrder":24,
+	"id": "ex9-88",
     "name": "Metal Energy",
     "imageUrl": "https://images.pokemontcg.io/ex9/88.png",
     "subtype": "Special",
@@ -4118,7 +4206,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex9/88_hires.png"
   },
   {
-    "id": "ex9-89",
+    "setOrder":24,
+	"id": "ex9-89",
     "name": "Multi Energy",
     "imageUrl": "https://images.pokemontcg.io/ex9/89.png",
     "subtype": "Special",
@@ -4135,7 +4224,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex9/89_hires.png"
   },
   {
-    "id": "ex9-90",
+    "setOrder":24,
+	"id": "ex9-90",
     "name": "Altaria ex",
     "imageUrl": "https://images.pokemontcg.io/ex9/90.png",
     "subtype": "EX",
@@ -4190,7 +4280,8 @@
     "nationalPokedexNumber": 334
   },
   {
-    "id": "ex9-91",
+    "setOrder":24,
+	"id": "ex9-91",
     "name": "Cacturne ex",
     "imageUrl": "https://images.pokemontcg.io/ex9/91.png",
     "subtype": "EX",
@@ -4251,7 +4342,8 @@
     "nationalPokedexNumber": 332
   },
   {
-    "id": "ex9-92",
+    "setOrder":24,
+	"id": "ex9-92",
     "name": "Camerupt ex",
     "imageUrl": "https://images.pokemontcg.io/ex9/92.png",
     "subtype": "EX",
@@ -4314,7 +4406,8 @@
     "nationalPokedexNumber": 323
   },
   {
-    "id": "ex9-93",
+    "setOrder":24,
+	"id": "ex9-93",
     "name": "Deoxys ex",
     "imageUrl": "https://images.pokemontcg.io/ex9/93.png",
     "subtype": "EX",
@@ -4365,7 +4458,8 @@
     "nationalPokedexNumber": 386
   },
   {
-    "id": "ex9-94",
+    "setOrder":24,
+	"id": "ex9-94",
     "name": "Dusclops ex",
     "imageUrl": "https://images.pokemontcg.io/ex9/94.png",
     "subtype": "EX",
@@ -4429,7 +4523,8 @@
     ]
   },
   {
-    "id": "ex9-95",
+    "setOrder":24,
+	"id": "ex9-95",
     "name": "Medicham ex",
     "imageUrl": "https://images.pokemontcg.io/ex9/95.png",
     "subtype": "EX",
@@ -4491,7 +4586,8 @@
     "nationalPokedexNumber": 308
   },
   {
-    "id": "ex9-96",
+    "setOrder":24,
+	"id": "ex9-96",
     "name": "Milotic ex",
     "imageUrl": "https://images.pokemontcg.io/ex9/96.png",
     "subtype": "EX",
@@ -4553,7 +4649,8 @@
     "nationalPokedexNumber": 350
   },
   {
-    "id": "ex9-97",
+    "setOrder":24,
+	"id": "ex9-97",
     "name": "Raichu ex",
     "imageUrl": "https://images.pokemontcg.io/ex9/97.png",
     "subtype": "EX",
@@ -4613,7 +4710,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "ex9-98",
+    "setOrder":24,
+	"id": "ex9-98",
     "name": "Regice ex",
     "imageUrl": "https://images.pokemontcg.io/ex9/98.png",
     "subtype": "EX",
@@ -4670,7 +4768,8 @@
     "nationalPokedexNumber": 378
   },
   {
-    "id": "ex9-99",
+    "setOrder":24,
+	"id": "ex9-99",
     "name": "Regirock ex",
     "imageUrl": "https://images.pokemontcg.io/ex9/99.png",
     "subtype": "EX",
@@ -4727,7 +4826,8 @@
     "nationalPokedexNumber": 377
   },
   {
-    "id": "ex9-100",
+    "setOrder":24,
+	"id": "ex9-100",
     "name": "Registeel ex",
     "imageUrl": "https://images.pokemontcg.io/ex9/100.png",
     "subtype": "EX",
@@ -4783,7 +4883,8 @@
     "nationalPokedexNumber": 379
   },
   {
-    "id": "ex9-101",
+    "setOrder":24,
+	"id": "ex9-101",
     "name": "Grass Energy",
     "imageUrl": "https://images.pokemontcg.io/ex9/101.png",
     "subtype": "Basic",
@@ -4797,7 +4898,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex9/101_hires.png"
   },
   {
-    "id": "ex9-102",
+    "setOrder":24,
+	"id": "ex9-102",
     "name": "Fire Energy",
     "imageUrl": "https://images.pokemontcg.io/ex9/102.png",
     "subtype": "Basic",
@@ -4811,7 +4913,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex9/102_hires.png"
   },
   {
-    "id": "ex9-103",
+    "setOrder":24,
+	"id": "ex9-103",
     "name": "Water Energy",
     "imageUrl": "https://images.pokemontcg.io/ex9/103.png",
     "subtype": "Basic",
@@ -4825,7 +4928,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex9/103_hires.png"
   },
   {
-    "id": "ex9-104",
+    "setOrder":24,
+	"id": "ex9-104",
     "name": "Lightning Energy",
     "imageUrl": "https://images.pokemontcg.io/ex9/104.png",
     "subtype": "Basic",
@@ -4839,7 +4943,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex9/104_hires.png"
   },
   {
-    "id": "ex9-105",
+    "setOrder":24,
+	"id": "ex9-105",
     "name": "Psychic Energy",
     "imageUrl": "https://images.pokemontcg.io/ex9/105.png",
     "subtype": "Basic",
@@ -4853,7 +4958,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex9/105_hires.png"
   },
   {
-    "id": "ex9-106",
+    "setOrder":24,
+	"id": "ex9-106",
     "name": "Fighting Energy",
     "imageUrl": "https://images.pokemontcg.io/ex9/106.png",
     "subtype": "Basic",

--- a/json/cards/Emerging Powers.json
+++ b/json/cards/Emerging Powers.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "bw2-1",
+    "setOrder":49,
+	"id": "bw2-1",
     "name": "Pansage",
     "imageUrl": "https://images.pokemontcg.io/bw2/1.png",
     "subtype": "Basic",
@@ -59,7 +60,8 @@
     ]
   },
   {
-    "id": "bw2-2",
+    "setOrder":49,
+	"id": "bw2-2",
     "name": "Simisage",
     "imageUrl": "https://images.pokemontcg.io/bw2/2.png",
     "subtype": "Stage 1",
@@ -119,7 +121,8 @@
     "nationalPokedexNumber": 512
   },
   {
-    "id": "bw2-3",
+    "setOrder":49,
+	"id": "bw2-3",
     "name": "Sewaddle",
     "imageUrl": "https://images.pokemontcg.io/bw2/3.png",
     "subtype": "Basic",
@@ -171,7 +174,8 @@
     ]
   },
   {
-    "id": "bw2-4",
+    "setOrder":49,
+	"id": "bw2-4",
     "name": "Sewaddle",
     "imageUrl": "https://images.pokemontcg.io/bw2/4.png",
     "subtype": "Basic",
@@ -224,7 +228,8 @@
     ]
   },
   {
-    "id": "bw2-5",
+    "setOrder":49,
+	"id": "bw2-5",
     "name": "Swadloon",
     "imageUrl": "https://images.pokemontcg.io/bw2/5.png",
     "subtype": "Stage 1",
@@ -279,7 +284,8 @@
     ]
   },
   {
-    "id": "bw2-6",
+    "setOrder":49,
+	"id": "bw2-6",
     "name": "Swadloon",
     "imageUrl": "https://images.pokemontcg.io/bw2/6.png",
     "subtype": "Stage 1",
@@ -334,7 +340,8 @@
     ]
   },
   {
-    "id": "bw2-7",
+    "setOrder":49,
+	"id": "bw2-7",
     "name": "Leavanny",
     "imageUrl": "https://images.pokemontcg.io/bw2/7.png",
     "subtype": "Stage 2",
@@ -385,7 +392,8 @@
     "nationalPokedexNumber": 542
   },
   {
-    "id": "bw2-8",
+    "setOrder":49,
+	"id": "bw2-8",
     "name": "Leavanny",
     "imageUrl": "https://images.pokemontcg.io/bw2/8.png",
     "subtype": "Stage 2",
@@ -437,7 +445,8 @@
     "nationalPokedexNumber": 542
   },
   {
-    "id": "bw2-9",
+    "setOrder":49,
+	"id": "bw2-9",
     "name": "Cottonee",
     "imageUrl": "https://images.pokemontcg.io/bw2/9.png",
     "subtype": "Basic",
@@ -486,7 +495,8 @@
     ]
   },
   {
-    "id": "bw2-10",
+    "setOrder":49,
+	"id": "bw2-10",
     "name": "Cottonee",
     "imageUrl": "https://images.pokemontcg.io/bw2/10.png",
     "subtype": "Basic",
@@ -535,7 +545,8 @@
     ]
   },
   {
-    "id": "bw2-11",
+    "setOrder":49,
+	"id": "bw2-11",
     "name": "Whimsicott",
     "imageUrl": "https://images.pokemontcg.io/bw2/11.png",
     "subtype": "Stage 1",
@@ -588,7 +599,8 @@
     "nationalPokedexNumber": 547
   },
   {
-    "id": "bw2-12",
+    "setOrder":49,
+	"id": "bw2-12",
     "name": "Whimsicott",
     "imageUrl": "https://images.pokemontcg.io/bw2/12.png",
     "subtype": "Stage 1",
@@ -645,7 +657,8 @@
     "nationalPokedexNumber": 547
   },
   {
-    "id": "bw2-13",
+    "setOrder":49,
+	"id": "bw2-13",
     "name": "Petilil",
     "imageUrl": "https://images.pokemontcg.io/bw2/13.png",
     "subtype": "Basic",
@@ -704,7 +717,8 @@
     ]
   },
   {
-    "id": "bw2-14",
+    "setOrder":49,
+	"id": "bw2-14",
     "name": "Lilligant",
     "imageUrl": "https://images.pokemontcg.io/bw2/14.png",
     "subtype": "Stage 1",
@@ -762,7 +776,8 @@
     "nationalPokedexNumber": 549
   },
   {
-    "id": "bw2-15",
+    "setOrder":49,
+	"id": "bw2-15",
     "name": "Deerling",
     "imageUrl": "https://images.pokemontcg.io/bw2/15.png",
     "subtype": "Basic",
@@ -821,7 +836,8 @@
     ]
   },
   {
-    "id": "bw2-16",
+    "setOrder":49,
+	"id": "bw2-16",
     "name": "Sawsbuck",
     "imageUrl": "https://images.pokemontcg.io/bw2/16.png",
     "subtype": "Stage 1",
@@ -880,7 +896,8 @@
     "nationalPokedexNumber": 586
   },
   {
-    "id": "bw2-17",
+    "setOrder":49,
+	"id": "bw2-17",
     "name": "Virizion",
     "imageUrl": "https://images.pokemontcg.io/bw2/17.png",
     "subtype": "Basic",
@@ -938,7 +955,8 @@
     "nationalPokedexNumber": 640
   },
   {
-    "id": "bw2-18",
+    "setOrder":49,
+	"id": "bw2-18",
     "name": "Pansear",
     "imageUrl": "https://images.pokemontcg.io/bw2/18.png",
     "subtype": "Basic",
@@ -991,7 +1009,8 @@
     ]
   },
   {
-    "id": "bw2-19",
+    "setOrder":49,
+	"id": "bw2-19",
     "name": "Simisear",
     "imageUrl": "https://images.pokemontcg.io/bw2/19.png",
     "subtype": "Stage 1",
@@ -1044,7 +1063,8 @@
     "nationalPokedexNumber": 514
   },
   {
-    "id": "bw2-20",
+    "setOrder":49,
+	"id": "bw2-20",
     "name": "Darumaka",
     "imageUrl": "https://images.pokemontcg.io/bw2/20.png",
     "subtype": "Basic",
@@ -1099,7 +1119,8 @@
     ]
   },
   {
-    "id": "bw2-21",
+    "setOrder":49,
+	"id": "bw2-21",
     "name": "Darmanitan",
     "imageUrl": "https://images.pokemontcg.io/bw2/21.png",
     "subtype": "Stage 1",
@@ -1155,7 +1176,8 @@
     "nationalPokedexNumber": 555
   },
   {
-    "id": "bw2-22",
+    "setOrder":49,
+	"id": "bw2-22",
     "name": "Panpour",
     "imageUrl": "https://images.pokemontcg.io/bw2/22.png",
     "subtype": "Basic",
@@ -1208,7 +1230,8 @@
     ]
   },
   {
-    "id": "bw2-23",
+    "setOrder":49,
+	"id": "bw2-23",
     "name": "Simipour",
     "imageUrl": "https://images.pokemontcg.io/bw2/23.png",
     "subtype": "Stage 1",
@@ -1261,7 +1284,8 @@
     "nationalPokedexNumber": 516
   },
   {
-    "id": "bw2-24",
+    "setOrder":49,
+	"id": "bw2-24",
     "name": "Basculin",
     "imageUrl": "https://images.pokemontcg.io/bw2/24.png",
     "subtype": "Basic",
@@ -1312,7 +1336,8 @@
     "nationalPokedexNumber": 550
   },
   {
-    "id": "bw2-25",
+    "setOrder":49,
+	"id": "bw2-25",
     "name": "Basculin",
     "imageUrl": "https://images.pokemontcg.io/bw2/25.png",
     "subtype": "Basic",
@@ -1362,7 +1387,8 @@
     "nationalPokedexNumber": 550
   },
   {
-    "id": "bw2-26",
+    "setOrder":49,
+	"id": "bw2-26",
     "name": "Ducklett",
     "imageUrl": "https://images.pokemontcg.io/bw2/26.png",
     "subtype": "Basic",
@@ -1421,7 +1447,8 @@
     ]
   },
   {
-    "id": "bw2-27",
+    "setOrder":49,
+	"id": "bw2-27",
     "name": "Swanna",
     "imageUrl": "https://images.pokemontcg.io/bw2/27.png",
     "subtype": "Stage 1",
@@ -1480,7 +1507,8 @@
     "nationalPokedexNumber": 581
   },
   {
-    "id": "bw2-28",
+    "setOrder":49,
+	"id": "bw2-28",
     "name": "Cubchoo",
     "imageUrl": "https://images.pokemontcg.io/bw2/28.png",
     "subtype": "Basic",
@@ -1534,7 +1562,8 @@
     ]
   },
   {
-    "id": "bw2-29",
+    "setOrder":49,
+	"id": "bw2-29",
     "name": "Cubchoo",
     "imageUrl": "https://images.pokemontcg.io/bw2/29.png",
     "subtype": "Basic",
@@ -1579,7 +1608,8 @@
     ]
   },
   {
-    "id": "bw2-30",
+    "setOrder":49,
+	"id": "bw2-30",
     "name": "Beartic",
     "imageUrl": "https://images.pokemontcg.io/bw2/30.png",
     "subtype": "Stage 1",
@@ -1636,7 +1666,8 @@
     "nationalPokedexNumber": 614
   },
   {
-    "id": "bw2-31",
+    "setOrder":49,
+	"id": "bw2-31",
     "name": "Beartic",
     "imageUrl": "https://images.pokemontcg.io/bw2/31.png",
     "subtype": "Stage 1",
@@ -1689,7 +1720,8 @@
     "nationalPokedexNumber": 614
   },
   {
-    "id": "bw2-32",
+    "setOrder":49,
+	"id": "bw2-32",
     "name": "Emolga",
     "imageUrl": "https://images.pokemontcg.io/bw2/32.png",
     "subtype": "Basic",
@@ -1736,7 +1768,8 @@
     "nationalPokedexNumber": 587
   },
   {
-    "id": "bw2-33",
+    "setOrder":49,
+	"id": "bw2-33",
     "name": "Joltik",
     "imageUrl": "https://images.pokemontcg.io/bw2/33.png",
     "subtype": "Basic",
@@ -1779,7 +1812,8 @@
     ]
   },
   {
-    "id": "bw2-34",
+    "setOrder":49,
+	"id": "bw2-34",
     "name": "Galvantula",
     "imageUrl": "https://images.pokemontcg.io/bw2/34.png",
     "subtype": "Stage 1",
@@ -1827,7 +1861,8 @@
     "nationalPokedexNumber": 596
   },
   {
-    "id": "bw2-35",
+    "setOrder":49,
+	"id": "bw2-35",
     "name": "Thundurus",
     "imageUrl": "https://images.pokemontcg.io/bw2/35.png",
     "subtype": "Basic",
@@ -1878,7 +1913,8 @@
     "nationalPokedexNumber": 642
   },
   {
-    "id": "bw2-36",
+    "setOrder":49,
+	"id": "bw2-36",
     "name": "Woobat",
     "imageUrl": "https://images.pokemontcg.io/bw2/36.png",
     "subtype": "Basic",
@@ -1922,7 +1958,8 @@
     ]
   },
   {
-    "id": "bw2-37",
+    "setOrder":49,
+	"id": "bw2-37",
     "name": "Swoobat",
     "imageUrl": "https://images.pokemontcg.io/bw2/37.png",
     "subtype": "Stage 1",
@@ -1979,7 +2016,8 @@
     "nationalPokedexNumber": 528
   },
   {
-    "id": "bw2-38",
+    "setOrder":49,
+	"id": "bw2-38",
     "name": "Venipede",
     "imageUrl": "https://images.pokemontcg.io/bw2/38.png",
     "subtype": "Basic",
@@ -2033,7 +2071,8 @@
     ]
   },
   {
-    "id": "bw2-39",
+    "setOrder":49,
+	"id": "bw2-39",
     "name": "Whirlipede",
     "imageUrl": "https://images.pokemontcg.io/bw2/39.png",
     "subtype": "Stage 1",
@@ -2090,7 +2129,8 @@
     ]
   },
   {
-    "id": "bw2-40",
+    "setOrder":49,
+	"id": "bw2-40",
     "name": "Scolipede",
     "imageUrl": "https://images.pokemontcg.io/bw2/40.png",
     "subtype": "Stage 2",
@@ -2144,7 +2184,8 @@
     "nationalPokedexNumber": 545
   },
   {
-    "id": "bw2-41",
+    "setOrder":49,
+	"id": "bw2-41",
     "name": "Sigilyph",
     "imageUrl": "https://images.pokemontcg.io/bw2/41.png",
     "subtype": "Basic",
@@ -2201,7 +2242,8 @@
     "nationalPokedexNumber": 561
   },
   {
-    "id": "bw2-42",
+    "setOrder":49,
+	"id": "bw2-42",
     "name": "Sigilyph",
     "imageUrl": "https://images.pokemontcg.io/bw2/42.png",
     "subtype": "Basic",
@@ -2258,7 +2300,8 @@
     "nationalPokedexNumber": 561
   },
   {
-    "id": "bw2-43",
+    "setOrder":49,
+	"id": "bw2-43",
     "name": "Gothita",
     "imageUrl": "https://images.pokemontcg.io/bw2/43.png",
     "subtype": "Basic",
@@ -2311,7 +2354,8 @@
     ]
   },
   {
-    "id": "bw2-44",
+    "setOrder":49,
+	"id": "bw2-44",
     "name": "Gothita",
     "imageUrl": "https://images.pokemontcg.io/bw2/44.png",
     "subtype": "Basic",
@@ -2355,7 +2399,8 @@
     ]
   },
   {
-    "id": "bw2-45",
+    "setOrder":49,
+	"id": "bw2-45",
     "name": "Gothorita",
     "imageUrl": "https://images.pokemontcg.io/bw2/45.png",
     "subtype": "Stage 1",
@@ -2409,7 +2454,8 @@
     ]
   },
   {
-    "id": "bw2-46",
+    "setOrder":49,
+	"id": "bw2-46",
     "name": "Gothorita",
     "imageUrl": "https://images.pokemontcg.io/bw2/46.png",
     "subtype": "Stage 1",
@@ -2464,7 +2510,8 @@
     ]
   },
   {
-    "id": "bw2-47",
+    "setOrder":49,
+	"id": "bw2-47",
     "name": "Gothitelle",
     "imageUrl": "https://images.pokemontcg.io/bw2/47.png",
     "subtype": "Stage 2",
@@ -2513,7 +2560,8 @@
     "nationalPokedexNumber": 576
   },
   {
-    "id": "bw2-48",
+    "setOrder":49,
+	"id": "bw2-48",
     "name": "Gothitelle",
     "imageUrl": "https://images.pokemontcg.io/bw2/48.png",
     "subtype": "Stage 2",
@@ -2565,7 +2613,8 @@
     "nationalPokedexNumber": 576
   },
   {
-    "id": "bw2-49",
+    "setOrder":49,
+	"id": "bw2-49",
     "name": "Roggenrola",
     "imageUrl": "https://images.pokemontcg.io/bw2/49.png",
     "subtype": "Basic",
@@ -2620,7 +2669,8 @@
     ]
   },
   {
-    "id": "bw2-50",
+    "setOrder":49,
+	"id": "bw2-50",
     "name": "Roggenrola",
     "imageUrl": "https://images.pokemontcg.io/bw2/50.png",
     "subtype": "Basic",
@@ -2674,7 +2724,8 @@
     ]
   },
   {
-    "id": "bw2-51",
+    "setOrder":49,
+	"id": "bw2-51",
     "name": "Boldore",
     "imageUrl": "https://images.pokemontcg.io/bw2/51.png",
     "subtype": "Stage 1",
@@ -2733,7 +2784,8 @@
     ]
   },
   {
-    "id": "bw2-52",
+    "setOrder":49,
+	"id": "bw2-52",
     "name": "Boldore",
     "imageUrl": "https://images.pokemontcg.io/bw2/52.png",
     "subtype": "Stage 1",
@@ -2791,7 +2843,8 @@
     ]
   },
   {
-    "id": "bw2-53",
+    "setOrder":49,
+	"id": "bw2-53",
     "name": "Gigalith",
     "imageUrl": "https://images.pokemontcg.io/bw2/53.png",
     "subtype": "Stage 2",
@@ -2847,7 +2900,8 @@
     "nationalPokedexNumber": 526
   },
   {
-    "id": "bw2-54",
+    "setOrder":49,
+	"id": "bw2-54",
     "name": "Drilbur",
     "imageUrl": "https://images.pokemontcg.io/bw2/54.png",
     "subtype": "Basic",
@@ -2906,7 +2960,8 @@
     ]
   },
   {
-    "id": "bw2-55",
+    "setOrder":49,
+	"id": "bw2-55",
     "name": "Drilbur",
     "imageUrl": "https://images.pokemontcg.io/bw2/55.png",
     "subtype": "Basic",
@@ -2957,7 +3012,8 @@
     ]
   },
   {
-    "id": "bw2-56",
+    "setOrder":49,
+	"id": "bw2-56",
     "name": "Excadrill",
     "imageUrl": "https://images.pokemontcg.io/bw2/56.png",
     "subtype": "Stage 1",
@@ -3016,7 +3072,8 @@
     "nationalPokedexNumber": 530
   },
   {
-    "id": "bw2-57",
+    "setOrder":49,
+	"id": "bw2-57",
     "name": "Excadrill",
     "imageUrl": "https://images.pokemontcg.io/bw2/57.png",
     "subtype": "Stage 1",
@@ -3076,7 +3133,8 @@
     "nationalPokedexNumber": 530
   },
   {
-    "id": "bw2-58",
+    "setOrder":49,
+	"id": "bw2-58",
     "name": "Throh",
     "imageUrl": "https://images.pokemontcg.io/bw2/58.png",
     "subtype": "Basic",
@@ -3118,7 +3176,8 @@
     "nationalPokedexNumber": 538
   },
   {
-    "id": "bw2-59",
+    "setOrder":49,
+	"id": "bw2-59",
     "name": "Sawk",
     "imageUrl": "https://images.pokemontcg.io/bw2/59.png",
     "subtype": "Basic",
@@ -3159,7 +3218,8 @@
     "nationalPokedexNumber": 539
   },
   {
-    "id": "bw2-60",
+    "setOrder":49,
+	"id": "bw2-60",
     "name": "Sandile",
     "imageUrl": "https://images.pokemontcg.io/bw2/60.png",
     "subtype": "Basic",
@@ -3204,7 +3264,8 @@
     ]
   },
   {
-    "id": "bw2-61",
+    "setOrder":49,
+	"id": "bw2-61",
     "name": "Krokorok",
     "imageUrl": "https://images.pokemontcg.io/bw2/61.png",
     "subtype": "Stage 1",
@@ -3260,7 +3321,8 @@
     ]
   },
   {
-    "id": "bw2-62",
+    "setOrder":49,
+	"id": "bw2-62",
     "name": "Krookodile",
     "imageUrl": "https://images.pokemontcg.io/bw2/62.png",
     "subtype": "Stage 2",
@@ -3316,7 +3378,8 @@
     "nationalPokedexNumber": 553
   },
   {
-    "id": "bw2-63",
+    "setOrder":49,
+	"id": "bw2-63",
     "name": "Terrakion",
     "imageUrl": "https://images.pokemontcg.io/bw2/63.png",
     "subtype": "Basic",
@@ -3371,7 +3434,8 @@
     "nationalPokedexNumber": 639
   },
   {
-    "id": "bw2-64",
+    "setOrder":49,
+	"id": "bw2-64",
     "name": "Purrloin",
     "imageUrl": "https://images.pokemontcg.io/bw2/64.png",
     "subtype": "Basic",
@@ -3421,7 +3485,8 @@
     ]
   },
   {
-    "id": "bw2-65",
+    "setOrder":49,
+	"id": "bw2-65",
     "name": "Liepard",
     "imageUrl": "https://images.pokemontcg.io/bw2/65.png",
     "subtype": "Stage 1",
@@ -3479,7 +3544,8 @@
     "nationalPokedexNumber": 510
   },
   {
-    "id": "bw2-66",
+    "setOrder":49,
+	"id": "bw2-66",
     "name": "Zorua",
     "imageUrl": "https://images.pokemontcg.io/bw2/66.png",
     "subtype": "Basic",
@@ -3538,7 +3604,8 @@
     ]
   },
   {
-    "id": "bw2-67",
+    "setOrder":49,
+	"id": "bw2-67",
     "name": "Zoroark",
     "imageUrl": "https://images.pokemontcg.io/bw2/67.png",
     "subtype": "Stage 1",
@@ -3597,7 +3664,8 @@
     "nationalPokedexNumber": 571
   },
   {
-    "id": "bw2-68",
+    "setOrder":49,
+	"id": "bw2-68",
     "name": "Vullaby",
     "imageUrl": "https://images.pokemontcg.io/bw2/68.png",
     "subtype": "Basic",
@@ -3656,7 +3724,8 @@
     ]
   },
   {
-    "id": "bw2-69",
+    "setOrder":49,
+	"id": "bw2-69",
     "name": "Mandibuzz",
     "imageUrl": "https://images.pokemontcg.io/bw2/69.png",
     "subtype": "Stage 1",
@@ -3713,7 +3782,8 @@
     "nationalPokedexNumber": 630
   },
   {
-    "id": "bw2-70",
+    "setOrder":49,
+	"id": "bw2-70",
     "name": "Ferroseed",
     "imageUrl": "https://images.pokemontcg.io/bw2/70.png",
     "subtype": "Basic",
@@ -3764,7 +3834,8 @@
     ]
   },
   {
-    "id": "bw2-71",
+    "setOrder":49,
+	"id": "bw2-71",
     "name": "Ferroseed",
     "imageUrl": "https://images.pokemontcg.io/bw2/71.png",
     "subtype": "Basic",
@@ -3815,7 +3886,8 @@
     ]
   },
   {
-    "id": "bw2-72",
+    "setOrder":49,
+	"id": "bw2-72",
     "name": "Ferrothorn",
     "imageUrl": "https://images.pokemontcg.io/bw2/72.png",
     "subtype": "Stage 1",
@@ -3874,7 +3946,8 @@
     "nationalPokedexNumber": 598
   },
   {
-    "id": "bw2-73",
+    "setOrder":49,
+	"id": "bw2-73",
     "name": "Ferrothorn",
     "imageUrl": "https://images.pokemontcg.io/bw2/73.png",
     "subtype": "Stage 1",
@@ -3933,7 +4006,8 @@
     "nationalPokedexNumber": 598
   },
   {
-    "id": "bw2-74",
+    "setOrder":49,
+	"id": "bw2-74",
     "name": "Klink",
     "imageUrl": "https://images.pokemontcg.io/bw2/74.png",
     "subtype": "Basic",
@@ -3993,7 +4067,8 @@
     ]
   },
   {
-    "id": "bw2-75",
+    "setOrder":49,
+	"id": "bw2-75",
     "name": "Klang",
     "imageUrl": "https://images.pokemontcg.io/bw2/75.png",
     "subtype": "Stage 1",
@@ -4054,7 +4129,8 @@
     ]
   },
   {
-    "id": "bw2-76",
+    "setOrder":49,
+	"id": "bw2-76",
     "name": "Klinklang",
     "imageUrl": "https://images.pokemontcg.io/bw2/76.png",
     "subtype": "Stage 2",
@@ -4115,7 +4191,8 @@
     "nationalPokedexNumber": 601
   },
   {
-    "id": "bw2-77",
+    "setOrder":49,
+	"id": "bw2-77",
     "name": "Cobalion",
     "imageUrl": "https://images.pokemontcg.io/bw2/77.png",
     "subtype": "Basic",
@@ -4174,7 +4251,8 @@
     "nationalPokedexNumber": 638
   },
   {
-    "id": "bw2-78",
+    "setOrder":49,
+	"id": "bw2-78",
     "name": "Patrat",
     "imageUrl": "https://images.pokemontcg.io/bw2/78.png",
     "subtype": "Basic",
@@ -4217,7 +4295,8 @@
     ]
   },
   {
-    "id": "bw2-79",
+    "setOrder":49,
+	"id": "bw2-79",
     "name": "Watchog",
     "imageUrl": "https://images.pokemontcg.io/bw2/79.png",
     "subtype": "Stage 1",
@@ -4268,7 +4347,8 @@
     "nationalPokedexNumber": 505
   },
   {
-    "id": "bw2-80",
+    "setOrder":49,
+	"id": "bw2-80",
     "name": "Pidove",
     "imageUrl": "https://images.pokemontcg.io/bw2/80.png",
     "subtype": "Basic",
@@ -4318,7 +4398,8 @@
     ]
   },
   {
-    "id": "bw2-81",
+    "setOrder":49,
+	"id": "bw2-81",
     "name": "Tranquill",
     "imageUrl": "https://images.pokemontcg.io/bw2/81.png",
     "subtype": "Stage 1",
@@ -4379,7 +4460,8 @@
     ]
   },
   {
-    "id": "bw2-82",
+    "setOrder":49,
+	"id": "bw2-82",
     "name": "Unfezant",
     "imageUrl": "https://images.pokemontcg.io/bw2/82.png",
     "subtype": "Stage 2",
@@ -4434,7 +4516,8 @@
     "nationalPokedexNumber": 521
   },
   {
-    "id": "bw2-83",
+    "setOrder":49,
+	"id": "bw2-83",
     "name": "Audino",
     "imageUrl": "https://images.pokemontcg.io/bw2/83.png",
     "subtype": "Basic",
@@ -4486,7 +4569,8 @@
     "nationalPokedexNumber": 531
   },
   {
-    "id": "bw2-84",
+    "setOrder":49,
+	"id": "bw2-84",
     "name": "Minccino",
     "imageUrl": "https://images.pokemontcg.io/bw2/84.png",
     "subtype": "Basic",
@@ -4529,7 +4613,8 @@
     ]
   },
   {
-    "id": "bw2-85",
+    "setOrder":49,
+	"id": "bw2-85",
     "name": "Cinccino",
     "imageUrl": "https://images.pokemontcg.io/bw2/85.png",
     "subtype": "Stage 1",
@@ -4580,7 +4665,8 @@
     "nationalPokedexNumber": 573
   },
   {
-    "id": "bw2-86",
+    "setOrder":49,
+	"id": "bw2-86",
     "name": "Rufflet",
     "imageUrl": "https://images.pokemontcg.io/bw2/86.png",
     "subtype": "Basic",
@@ -4639,7 +4725,8 @@
     ]
   },
   {
-    "id": "bw2-87",
+    "setOrder":49,
+	"id": "bw2-87",
     "name": "Rufflet",
     "imageUrl": "https://images.pokemontcg.io/bw2/87.png",
     "subtype": "Basic",
@@ -4698,7 +4785,8 @@
     ]
   },
   {
-    "id": "bw2-88",
+    "setOrder":49,
+	"id": "bw2-88",
     "name": "Braviary",
     "imageUrl": "https://images.pokemontcg.io/bw2/88.png",
     "subtype": "Stage 1",
@@ -4757,7 +4845,8 @@
     "nationalPokedexNumber": 628
   },
   {
-    "id": "bw2-89",
+    "setOrder":49,
+	"id": "bw2-89",
     "name": "Tornadus",
     "imageUrl": "https://images.pokemontcg.io/bw2/89.png",
     "subtype": "Basic",
@@ -4814,7 +4903,8 @@
     "nationalPokedexNumber": 641
   },
   {
-    "id": "bw2-90",
+    "setOrder":49,
+	"id": "bw2-90",
     "name": "Bianca",
     "imageUrl": "https://images.pokemontcg.io/bw2/90.png",
     "subtype": "Supporter",
@@ -4831,7 +4921,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw2/90_hires.png"
   },
   {
-    "id": "bw2-91",
+    "setOrder":49,
+	"id": "bw2-91",
     "name": "Cheren",
     "imageUrl": "https://images.pokemontcg.io/bw2/91.png",
     "subtype": "Supporter",
@@ -4848,7 +4939,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw2/91_hires.png"
   },
   {
-    "id": "bw2-92",
+    "setOrder":49,
+	"id": "bw2-92",
     "name": "Crushing Hammer",
     "imageUrl": "https://images.pokemontcg.io/bw2/92.png",
     "subtype": "Item",
@@ -4865,7 +4957,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw2/92_hires.png"
   },
   {
-    "id": "bw2-93",
+    "setOrder":49,
+	"id": "bw2-93",
     "name": "Great Ball",
     "imageUrl": "https://images.pokemontcg.io/bw2/93.png",
     "subtype": "Item",
@@ -4882,7 +4975,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw2/93_hires.png"
   },
   {
-    "id": "bw2-94",
+    "setOrder":49,
+	"id": "bw2-94",
     "name": "Max Potion",
     "imageUrl": "https://images.pokemontcg.io/bw2/94.png",
     "subtype": "Item",
@@ -4899,7 +4993,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw2/94_hires.png"
   },
   {
-    "id": "bw2-95",
+    "setOrder":49,
+	"id": "bw2-95",
     "name": "Pokémon Catcher",
     "imageUrl": "https://images.pokemontcg.io/bw2/95.png",
     "subtype": "Item",
@@ -4916,7 +5011,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw2/95_hires.png"
   },
   {
-    "id": "bw2-96",
+    "setOrder":49,
+	"id": "bw2-96",
     "name": "Recycle",
     "imageUrl": "https://images.pokemontcg.io/bw2/96.png",
     "subtype": "Item",
@@ -4933,7 +5029,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw2/96_hires.png"
   },
   {
-    "id": "bw2-97",
+    "setOrder":49,
+	"id": "bw2-97",
     "name": "Thundurus",
     "imageUrl": "https://images.pokemontcg.io/bw2/97.png",
     "subtype": "Basic",
@@ -4984,7 +5081,8 @@
     "nationalPokedexNumber": 642
   },
   {
-    "id": "bw2-98",
+    "setOrder":49,
+	"id": "bw2-98",
     "name": "Tornadus",
     "imageUrl": "https://images.pokemontcg.io/bw2/98.png",
     "subtype": "Basic",

--- a/json/cards/Evolutions.json
+++ b/json/cards/Evolutions.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "xy12-1",
+    "setOrder":71,
+	"id": "xy12-1",
     "name": "Venusaur-EX",
     "imageUrl": "https://images.pokemontcg.io/xy12/1.png",
     "subtype": "EX",
@@ -61,7 +62,8 @@
     "evolvesTo": "M Venusaur-EX"
   },
   {
-    "id": "xy12-2",
+    "setOrder":71,
+	"id": "xy12-2",
     "name": "M Venusaur-EX",
     "imageUrl": "https://images.pokemontcg.io/xy12/2.png",
     "subtype": "MEGA",
@@ -112,7 +114,8 @@
     "nationalPokedexNumber": 3
   },
   {
-    "id": "xy12-3",
+    "setOrder":71,
+	"id": "xy12-3",
     "name": "Caterpie",
     "imageUrl": "https://images.pokemontcg.io/xy12/3.png",
     "subtype": "Basic",
@@ -155,7 +158,8 @@
     ]
   },
   {
-    "id": "xy12-4",
+    "setOrder":71,
+	"id": "xy12-4",
     "name": "Metapod",
     "imageUrl": "https://images.pokemontcg.io/xy12/4.png",
     "subtype": "Stage 1",
@@ -211,7 +215,8 @@
     ]
   },
   {
-    "id": "xy12-5",
+    "setOrder":71,
+	"id": "xy12-5",
     "name": "Weedle",
     "imageUrl": "https://images.pokemontcg.io/xy12/5.png",
     "subtype": "Basic",
@@ -254,7 +259,8 @@
     ]
   },
   {
-    "id": "xy12-6",
+    "setOrder":71,
+	"id": "xy12-6",
     "name": "Kakuna",
     "imageUrl": "https://images.pokemontcg.io/xy12/6.png",
     "subtype": "Stage 1",
@@ -310,7 +316,8 @@
     ]
   },
   {
-    "id": "xy12-7",
+    "setOrder":71,
+	"id": "xy12-7",
     "name": "Beedrill",
     "imageUrl": "https://images.pokemontcg.io/xy12/7.png",
     "subtype": "Stage 2",
@@ -358,7 +365,8 @@
     "nationalPokedexNumber": 15
   },
   {
-    "id": "xy12-8",
+    "setOrder":71,
+	"id": "xy12-8",
     "name": "Tangela",
     "imageUrl": "https://images.pokemontcg.io/xy12/8.png",
     "subtype": "Basic",
@@ -414,7 +422,8 @@
     ]
   },
   {
-    "id": "xy12-9",
+    "setOrder":71,
+	"id": "xy12-9",
     "name": "Charmander",
     "imageUrl": "https://images.pokemontcg.io/xy12/9.png",
     "subtype": "Basic",
@@ -467,7 +476,8 @@
     ]
   },
   {
-    "id": "xy12-10",
+    "setOrder":71,
+	"id": "xy12-10",
     "name": "Charmeleon",
     "imageUrl": "https://images.pokemontcg.io/xy12/10.png",
     "subtype": "Stage 1",
@@ -524,7 +534,8 @@
     ]
   },
   {
-    "id": "xy12-11",
+    "setOrder":71,
+	"id": "xy12-11",
     "name": "Charizard",
     "imageUrl": "https://images.pokemontcg.io/xy12/11.png",
     "subtype": "Stage 2",
@@ -581,7 +592,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "xy12-12",
+    "setOrder":71,
+	"id": "xy12-12",
     "name": "Charizard-EX",
     "imageUrl": "https://images.pokemontcg.io/xy12/12.png",
     "subtype": "EX",
@@ -640,7 +652,8 @@
     "evolvesTo": "M Charizard-EX"
   },
   {
-    "id": "xy12-13",
+    "setOrder":71,
+	"id": "xy12-13",
     "name": "M Charizard-EX",
     "imageUrl": "https://images.pokemontcg.io/xy12/13.png",
     "subtype": "MEGA",
@@ -689,7 +702,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "xy12-14",
+    "setOrder":71,
+	"id": "xy12-14",
     "name": "Vulpix",
     "imageUrl": "https://images.pokemontcg.io/xy12/14.png",
     "subtype": "Basic",
@@ -733,7 +747,8 @@
     ]
   },
   {
-    "id": "xy12-15",
+    "setOrder":71,
+	"id": "xy12-15",
     "name": "Ninetales",
     "imageUrl": "https://images.pokemontcg.io/xy12/15.png",
     "subtype": "Stage 1",
@@ -785,7 +800,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "xy12-16",
+    "setOrder":71,
+	"id": "xy12-16",
     "name": "Ninetales BREAK",
     "imageUrl": "https://images.pokemontcg.io/xy12/16.png",
     "subtype": "BREAK",
@@ -821,7 +837,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "xy12-17",
+    "setOrder":71,
+	"id": "xy12-17",
     "name": "Growlithe",
     "imageUrl": "https://images.pokemontcg.io/xy12/17.png",
     "subtype": "Basic",
@@ -875,7 +892,8 @@
     ]
   },
   {
-    "id": "xy12-18",
+    "setOrder":71,
+	"id": "xy12-18",
     "name": "Arcanine",
     "imageUrl": "https://images.pokemontcg.io/xy12/18.png",
     "subtype": "Stage 1",
@@ -925,7 +943,8 @@
     "nationalPokedexNumber": 59
   },
   {
-    "id": "xy12-19",
+    "setOrder":71,
+	"id": "xy12-19",
     "name": "Ponyta",
     "imageUrl": "https://images.pokemontcg.io/xy12/19.png",
     "subtype": "Basic",
@@ -979,7 +998,8 @@
     ]
   },
   {
-    "id": "xy12-20",
+    "setOrder":71,
+	"id": "xy12-20",
     "name": "Magmar",
     "imageUrl": "https://images.pokemontcg.io/xy12/20.png",
     "subtype": "Basic",
@@ -1035,7 +1055,8 @@
     ]
   },
   {
-    "id": "xy12-21",
+    "setOrder":71,
+	"id": "xy12-21",
     "name": "Blastoise-EX",
     "imageUrl": "https://images.pokemontcg.io/xy12/21.png",
     "subtype": "EX",
@@ -1093,7 +1114,8 @@
     "evolvesTo": "M Blastoise-EX"
   },
   {
-    "id": "xy12-22",
+    "setOrder":71,
+	"id": "xy12-22",
     "name": "M Blastoise-EX",
     "imageUrl": "https://images.pokemontcg.io/xy12/22.png",
     "subtype": "MEGA",
@@ -1142,7 +1164,8 @@
     "nationalPokedexNumber": 9
   },
   {
-    "id": "xy12-23",
+    "setOrder":71,
+	"id": "xy12-23",
     "name": "Poliwag",
     "imageUrl": "https://images.pokemontcg.io/xy12/23.png",
     "subtype": "Basic",
@@ -1186,7 +1209,8 @@
     ]
   },
   {
-    "id": "xy12-24",
+    "setOrder":71,
+	"id": "xy12-24",
     "name": "Poliwhirl",
     "imageUrl": "https://images.pokemontcg.io/xy12/24.png",
     "subtype": "Stage 1",
@@ -1243,7 +1267,8 @@
     ]
   },
   {
-    "id": "xy12-25",
+    "setOrder":71,
+	"id": "xy12-25",
     "name": "Poliwrath",
     "imageUrl": "https://images.pokemontcg.io/xy12/25.png",
     "subtype": "Stage 2",
@@ -1296,7 +1321,8 @@
     "nationalPokedexNumber": 62
   },
   {
-    "id": "xy12-26",
+    "setOrder":71,
+	"id": "xy12-26",
     "name": "Slowbro-EX",
     "imageUrl": "https://images.pokemontcg.io/xy12/26.png",
     "subtype": "EX",
@@ -1354,7 +1380,8 @@
     "evolvesTo": "M Slowbro-EX"
   },
   {
-    "id": "xy12-27",
+    "setOrder":71,
+	"id": "xy12-27",
     "name": "M Slowbro-EX",
     "imageUrl": "https://images.pokemontcg.io/xy12/27.png",
     "subtype": "MEGA",
@@ -1403,7 +1430,8 @@
     "nationalPokedexNumber": 80
   },
   {
-    "id": "xy12-28",
+    "setOrder":71,
+	"id": "xy12-28",
     "name": "Seel",
     "imageUrl": "https://images.pokemontcg.io/xy12/28.png",
     "subtype": "Basic",
@@ -1457,7 +1485,8 @@
     ]
   },
   {
-    "id": "xy12-29",
+    "setOrder":71,
+	"id": "xy12-29",
     "name": "Dewgong",
     "imageUrl": "https://images.pokemontcg.io/xy12/29.png",
     "subtype": "Stage 1",
@@ -1511,7 +1540,8 @@
     "nationalPokedexNumber": 87
   },
   {
-    "id": "xy12-30",
+    "setOrder":71,
+	"id": "xy12-30",
     "name": "Staryu",
     "imageUrl": "https://images.pokemontcg.io/xy12/30.png",
     "subtype": "Basic",
@@ -1554,7 +1584,8 @@
     ]
   },
   {
-    "id": "xy12-31",
+    "setOrder":71,
+	"id": "xy12-31",
     "name": "Starmie",
     "imageUrl": "https://images.pokemontcg.io/xy12/31.png",
     "subtype": "Stage 1",
@@ -1601,7 +1632,8 @@
     "nationalPokedexNumber": 121
   },
   {
-    "id": "xy12-32",
+    "setOrder":71,
+	"id": "xy12-32",
     "name": "Starmie BREAK",
     "imageUrl": "https://images.pokemontcg.io/xy12/32.png",
     "subtype": "BREAK",
@@ -1636,7 +1668,8 @@
     "nationalPokedexNumber": 121
   },
   {
-    "id": "xy12-33",
+    "setOrder":71,
+	"id": "xy12-33",
     "name": "Magikarp",
     "imageUrl": "https://images.pokemontcg.io/xy12/33.png",
     "subtype": "Basic",
@@ -1679,7 +1712,8 @@
     ]
   },
   {
-    "id": "xy12-34",
+    "setOrder":71,
+	"id": "xy12-34",
     "name": "Gyarados",
     "imageUrl": "https://images.pokemontcg.io/xy12/34.png",
     "subtype": "Stage 1",
@@ -1736,7 +1770,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "xy12-35",
+    "setOrder":71,
+	"id": "xy12-35",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/xy12/35.png",
     "subtype": "Basic",
@@ -1795,7 +1830,8 @@
     ]
   },
   {
-    "id": "xy12-36",
+    "setOrder":71,
+	"id": "xy12-36",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/xy12/36.png",
     "subtype": "Stage 1",
@@ -1853,7 +1889,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "xy12-37",
+    "setOrder":71,
+	"id": "xy12-37",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/xy12/37.png",
     "subtype": "Basic",
@@ -1912,7 +1949,8 @@
     ]
   },
   {
-    "id": "xy12-38",
+    "setOrder":71,
+	"id": "xy12-38",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/xy12/38.png",
     "subtype": "Stage 1",
@@ -1974,7 +2012,8 @@
     ]
   },
   {
-    "id": "xy12-39",
+    "setOrder":71,
+	"id": "xy12-39",
     "name": "Voltorb",
     "imageUrl": "https://images.pokemontcg.io/xy12/39.png",
     "subtype": "Basic",
@@ -2023,7 +2062,8 @@
     ]
   },
   {
-    "id": "xy12-40",
+    "setOrder":71,
+	"id": "xy12-40",
     "name": "Electrode",
     "imageUrl": "https://images.pokemontcg.io/xy12/40.png",
     "subtype": "Stage 1",
@@ -2077,7 +2117,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "xy12-41",
+    "setOrder":71,
+	"id": "xy12-41",
     "name": "Electabuzz",
     "imageUrl": "https://images.pokemontcg.io/xy12/41.png",
     "subtype": "Basic",
@@ -2137,7 +2178,8 @@
     ]
   },
   {
-    "id": "xy12-42",
+    "setOrder":71,
+	"id": "xy12-42",
     "name": "Zapdos",
     "imageUrl": "https://images.pokemontcg.io/xy12/42.png",
     "subtype": "Basic",
@@ -2193,7 +2235,8 @@
     "nationalPokedexNumber": 145
   },
   {
-    "id": "xy12-43",
+    "setOrder":71,
+	"id": "xy12-43",
     "name": "Nidoran♂",
     "imageUrl": "https://images.pokemontcg.io/xy12/43.png",
     "subtype": "Basic",
@@ -2236,7 +2279,8 @@
     ]
   },
   {
-    "id": "xy12-44",
+    "setOrder":71,
+	"id": "xy12-44",
     "name": "Nidorino",
     "imageUrl": "https://images.pokemontcg.io/xy12/44.png",
     "subtype": "Stage 1",
@@ -2292,7 +2336,8 @@
     ]
   },
   {
-    "id": "xy12-45",
+    "setOrder":71,
+	"id": "xy12-45",
     "name": "Nidoking",
     "imageUrl": "https://images.pokemontcg.io/xy12/45.png",
     "subtype": "Stage 2",
@@ -2347,7 +2392,8 @@
     "nationalPokedexNumber": 34
   },
   {
-    "id": "xy12-46",
+    "setOrder":71,
+	"id": "xy12-46",
     "name": "Nidoking BREAK",
     "imageUrl": "https://images.pokemontcg.io/xy12/46.png",
     "subtype": "BREAK",
@@ -2384,7 +2430,8 @@
     "nationalPokedexNumber": 34
   },
   {
-    "id": "xy12-47",
+    "setOrder":71,
+	"id": "xy12-47",
     "name": "Gastly",
     "imageUrl": "https://images.pokemontcg.io/xy12/47.png",
     "subtype": "Basic",
@@ -2443,7 +2490,8 @@
     ]
   },
   {
-    "id": "xy12-48",
+    "setOrder":71,
+	"id": "xy12-48",
     "name": "Haunter",
     "imageUrl": "https://images.pokemontcg.io/xy12/48.png",
     "subtype": "Stage 1",
@@ -2503,7 +2551,8 @@
     ]
   },
   {
-    "id": "xy12-49",
+    "setOrder":71,
+	"id": "xy12-49",
     "name": "Drowzee",
     "imageUrl": "https://images.pokemontcg.io/xy12/49.png",
     "subtype": "Basic",
@@ -2556,7 +2605,8 @@
     ]
   },
   {
-    "id": "xy12-50",
+    "setOrder":71,
+	"id": "xy12-50",
     "name": "Koffing",
     "imageUrl": "https://images.pokemontcg.io/xy12/50.png",
     "subtype": "Basic",
@@ -2600,7 +2650,8 @@
     ]
   },
   {
-    "id": "xy12-51",
+    "setOrder":71,
+	"id": "xy12-51",
     "name": "Mewtwo",
     "imageUrl": "https://images.pokemontcg.io/xy12/51.png",
     "subtype": "Basic",
@@ -2652,7 +2703,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "xy12-52",
+    "setOrder":71,
+	"id": "xy12-52",
     "name": "Mewtwo-EX",
     "imageUrl": "https://images.pokemontcg.io/xy12/52.png",
     "subtype": "EX",
@@ -2718,7 +2770,8 @@
     "evolvesTo": "M Mewtwo-EX"
   },
   {
-    "id": "xy12-53",
+    "setOrder":71,
+	"id": "xy12-53",
     "name": "Mew",
     "imageUrl": "https://images.pokemontcg.io/xy12/53.png",
     "subtype": "Basic",
@@ -2764,7 +2817,8 @@
     "nationalPokedexNumber": 151
   },
   {
-    "id": "xy12-54",
+    "setOrder":71,
+	"id": "xy12-54",
     "name": "Sandshrew",
     "imageUrl": "https://images.pokemontcg.io/xy12/54.png",
     "subtype": "Basic",
@@ -2807,7 +2861,8 @@
     ]
   },
   {
-    "id": "xy12-55",
+    "setOrder":71,
+	"id": "xy12-55",
     "name": "Diglett",
     "imageUrl": "https://images.pokemontcg.io/xy12/55.png",
     "subtype": "Basic",
@@ -2856,7 +2911,8 @@
     ]
   },
   {
-    "id": "xy12-56",
+    "setOrder":71,
+	"id": "xy12-56",
     "name": "Dugtrio",
     "imageUrl": "https://images.pokemontcg.io/xy12/56.png",
     "subtype": "Stage 1",
@@ -2909,7 +2965,8 @@
     "nationalPokedexNumber": 51
   },
   {
-    "id": "xy12-57",
+    "setOrder":71,
+	"id": "xy12-57",
     "name": "Machop",
     "imageUrl": "https://images.pokemontcg.io/xy12/57.png",
     "subtype": "Basic",
@@ -2954,7 +3011,8 @@
     ]
   },
   {
-    "id": "xy12-58",
+    "setOrder":71,
+	"id": "xy12-58",
     "name": "Machoke",
     "imageUrl": "https://images.pokemontcg.io/xy12/58.png",
     "subtype": "Stage 1",
@@ -3011,7 +3069,8 @@
     ]
   },
   {
-    "id": "xy12-59",
+    "setOrder":71,
+	"id": "xy12-59",
     "name": "Machamp",
     "imageUrl": "https://images.pokemontcg.io/xy12/59.png",
     "subtype": "Stage 2",
@@ -3060,7 +3119,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "xy12-60",
+    "setOrder":71,
+	"id": "xy12-60",
     "name": "Machamp BREAK",
     "imageUrl": "https://images.pokemontcg.io/xy12/60.png",
     "subtype": "BREAK",
@@ -3097,7 +3157,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "xy12-61",
+    "setOrder":71,
+	"id": "xy12-61",
     "name": "Onix",
     "imageUrl": "https://images.pokemontcg.io/xy12/61.png",
     "subtype": "Basic",
@@ -3152,7 +3213,8 @@
     ]
   },
   {
-    "id": "xy12-62",
+    "setOrder":71,
+	"id": "xy12-62",
     "name": "Hitmonchan",
     "imageUrl": "https://images.pokemontcg.io/xy12/62.png",
     "subtype": "Basic",
@@ -3204,7 +3266,8 @@
     "nationalPokedexNumber": 107
   },
   {
-    "id": "xy12-63",
+    "setOrder":71,
+	"id": "xy12-63",
     "name": "Clefairy",
     "imageUrl": "https://images.pokemontcg.io/xy12/63.png",
     "subtype": "Basic",
@@ -3264,7 +3327,8 @@
     ]
   },
   {
-    "id": "xy12-64",
+    "setOrder":71,
+	"id": "xy12-64",
     "name": "Pidgeot-EX",
     "imageUrl": "https://images.pokemontcg.io/xy12/64.png",
     "subtype": "EX",
@@ -3325,7 +3389,8 @@
     "evolvesTo": "M Pidgeot-EX"
   },
   {
-    "id": "xy12-65",
+    "setOrder":71,
+	"id": "xy12-65",
     "name": "M Pidgeot-EX",
     "imageUrl": "https://images.pokemontcg.io/xy12/65.png",
     "subtype": "MEGA",
@@ -3375,7 +3440,8 @@
     "nationalPokedexNumber": 18
   },
   {
-    "id": "xy12-66",
+    "setOrder":71,
+	"id": "xy12-66",
     "name": "Rattata",
     "imageUrl": "https://images.pokemontcg.io/xy12/66.png",
     "subtype": "Basic",
@@ -3423,7 +3489,8 @@
     ]
   },
   {
-    "id": "xy12-67",
+    "setOrder":71,
+	"id": "xy12-67",
     "name": "Raticate",
     "imageUrl": "https://images.pokemontcg.io/xy12/67.png",
     "subtype": "Stage 1",
@@ -3473,7 +3540,8 @@
     "nationalPokedexNumber": 20
   },
   {
-    "id": "xy12-68",
+    "setOrder":71,
+	"id": "xy12-68",
     "name": "Farfetch'd",
     "imageUrl": "https://images.pokemontcg.io/xy12/68.png",
     "subtype": "Basic",
@@ -3530,7 +3598,8 @@
     "nationalPokedexNumber": 83
   },
   {
-    "id": "xy12-69",
+    "setOrder":71,
+	"id": "xy12-69",
     "name": "Doduo",
     "imageUrl": "https://images.pokemontcg.io/xy12/69.png",
     "subtype": "Basic",
@@ -3579,7 +3648,8 @@
     ]
   },
   {
-    "id": "xy12-70",
+    "setOrder":71,
+	"id": "xy12-70",
     "name": "Chansey",
     "imageUrl": "https://images.pokemontcg.io/xy12/70.png",
     "subtype": "Basic",
@@ -3637,7 +3707,8 @@
     ]
   },
   {
-    "id": "xy12-71",
+    "setOrder":71,
+	"id": "xy12-71",
     "name": "Porygon",
     "imageUrl": "https://images.pokemontcg.io/xy12/71.png",
     "subtype": "Basic",
@@ -3680,7 +3751,8 @@
     ]
   },
   {
-    "id": "xy12-72",
+    "setOrder":71,
+	"id": "xy12-72",
     "name": "Dragonite-EX",
     "imageUrl": "https://images.pokemontcg.io/xy12/72.png",
     "subtype": "EX",
@@ -3739,7 +3811,8 @@
     "nationalPokedexNumber": 149
   },
   {
-    "id": "xy12-73",
+    "setOrder":71,
+	"id": "xy12-73",
     "name": "Blastoise Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xy12/73.png",
     "subtype": "Pokémon Tool",
@@ -3756,7 +3829,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/73_hires.png"
   },
   {
-    "id": "xy12-74",
+    "setOrder":71,
+	"id": "xy12-74",
     "name": "Brock's Grit",
     "imageUrl": "https://images.pokemontcg.io/xy12/74.png",
     "subtype": "Supporter",
@@ -3773,7 +3847,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/74_hires.png"
   },
   {
-    "id": "xy12-75",
+    "setOrder":71,
+	"id": "xy12-75",
     "name": "Charizard Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xy12/75.png",
     "subtype": "Pokémon Tool",
@@ -3790,7 +3865,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/75_hires.png"
   },
   {
-    "id": "xy12-76",
+    "setOrder":71,
+	"id": "xy12-76",
     "name": "Devolution Spray",
     "imageUrl": "https://images.pokemontcg.io/xy12/76.png",
     "subtype": "Item",
@@ -3807,7 +3883,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/76_hires.png"
   },
   {
-    "id": "xy12-77",
+    "setOrder":71,
+	"id": "xy12-77",
     "name": "Energy Retrieval",
     "imageUrl": "https://images.pokemontcg.io/xy12/77.png",
     "subtype": "Item",
@@ -3824,7 +3901,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/77_hires.png"
   },
   {
-    "id": "xy12-78",
+    "setOrder":71,
+	"id": "xy12-78",
     "name": "Full Heal",
     "imageUrl": "https://images.pokemontcg.io/xy12/78.png",
     "subtype": "Item",
@@ -3841,7 +3919,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/78_hires.png"
   },
   {
-    "id": "xy12-79",
+    "setOrder":71,
+	"id": "xy12-79",
     "name": "Maintenance",
     "imageUrl": "https://images.pokemontcg.io/xy12/79.png",
     "subtype": "Item",
@@ -3858,7 +3937,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/79_hires.png"
   },
   {
-    "id": "xy12-80",
+    "setOrder":71,
+	"id": "xy12-80",
     "name": "Misty's Determination",
     "imageUrl": "https://images.pokemontcg.io/xy12/80.png",
     "subtype": "Supporter",
@@ -3875,7 +3955,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/80_hires.png"
   },
   {
-    "id": "xy12-81",
+    "setOrder":71,
+	"id": "xy12-81",
     "name": "Pidgeot Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xy12/81.png",
     "subtype": "Pokémon Tool",
@@ -3892,7 +3973,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/81_hires.png"
   },
   {
-    "id": "xy12-82",
+    "setOrder":71,
+	"id": "xy12-82",
     "name": "Pokédex",
     "imageUrl": "https://images.pokemontcg.io/xy12/82.png",
     "subtype": "Item",
@@ -3909,7 +3991,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/82_hires.png"
   },
   {
-    "id": "xy12-83",
+    "setOrder":71,
+	"id": "xy12-83",
     "name": "Potion",
     "imageUrl": "https://images.pokemontcg.io/xy12/83.png",
     "subtype": "Item",
@@ -3926,7 +4009,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/83_hires.png"
   },
   {
-    "id": "xy12-84",
+    "setOrder":71,
+	"id": "xy12-84",
     "name": "Professor Oak's Hint",
     "imageUrl": "https://images.pokemontcg.io/xy12/84.png",
     "subtype": "Supporter",
@@ -3943,7 +4027,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/84_hires.png"
   },
   {
-    "id": "xy12-85",
+    "setOrder":71,
+	"id": "xy12-85",
     "name": "Revive",
     "imageUrl": "https://images.pokemontcg.io/xy12/85.png",
     "subtype": "Item",
@@ -3960,7 +4045,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/85_hires.png"
   },
   {
-    "id": "xy12-86",
+    "setOrder":71,
+	"id": "xy12-86",
     "name": "Slowbro Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xy12/86.png",
     "subtype": "Pokémon Tool",
@@ -3977,7 +4063,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/86_hires.png"
   },
   {
-    "id": "xy12-87",
+    "setOrder":71,
+	"id": "xy12-87",
     "name": "Super Potion",
     "imageUrl": "https://images.pokemontcg.io/xy12/87.png",
     "subtype": "Item",
@@ -3994,7 +4081,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/87_hires.png"
   },
   {
-    "id": "xy12-88",
+    "setOrder":71,
+	"id": "xy12-88",
     "name": "Switch",
     "imageUrl": "https://images.pokemontcg.io/xy12/88.png",
     "subtype": "Item",
@@ -4011,7 +4099,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/88_hires.png"
   },
   {
-    "id": "xy12-89",
+    "setOrder":71,
+	"id": "xy12-89",
     "name": "Venusaur Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xy12/89.png",
     "subtype": "Pokémon Tool",
@@ -4028,7 +4117,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/89_hires.png"
   },
   {
-    "id": "xy12-90",
+    "setOrder":71,
+	"id": "xy12-90",
     "name": "Double Colorless Energy",
     "imageUrl": "https://images.pokemontcg.io/xy12/90.png",
     "subtype": "Special",
@@ -4045,7 +4135,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/90_hires.png"
   },
   {
-    "id": "xy12-91",
+    "setOrder":71,
+	"id": "xy12-91",
     "name": "Basic Grass Energy",
     "imageUrl": "https://images.pokemontcg.io/xy12/91.png",
     "subtype": "Basic",
@@ -4059,7 +4150,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/91_hires.png"
   },
   {
-    "id": "xy12-92",
+    "setOrder":71,
+	"id": "xy12-92",
     "name": "Basic Fire Energy",
     "imageUrl": "https://images.pokemontcg.io/xy12/92.png",
     "subtype": "Basic",
@@ -4073,7 +4165,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/92_hires.png"
   },
   {
-    "id": "xy12-93",
+    "setOrder":71,
+	"id": "xy12-93",
     "name": "Basic Water Energy",
     "imageUrl": "https://images.pokemontcg.io/xy12/93.png",
     "subtype": "Basic",
@@ -4087,7 +4180,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/93_hires.png"
   },
   {
-    "id": "xy12-94",
+    "setOrder":71,
+	"id": "xy12-94",
     "name": "Basic Lightning Energy",
     "imageUrl": "https://images.pokemontcg.io/xy12/94.png",
     "subtype": "Basic",
@@ -4101,7 +4195,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/94_hires.png"
   },
   {
-    "id": "xy12-95",
+    "setOrder":71,
+	"id": "xy12-95",
     "name": "Basic Psychic Energy",
     "imageUrl": "https://images.pokemontcg.io/xy12/95.png",
     "subtype": "Basic",
@@ -4115,7 +4210,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/95_hires.png"
   },
   {
-    "id": "xy12-96",
+    "setOrder":71,
+	"id": "xy12-96",
     "name": "Basic Fighting Energy",
     "imageUrl": "https://images.pokemontcg.io/xy12/96.png",
     "subtype": "Basic",
@@ -4129,7 +4225,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/96_hires.png"
   },
   {
-    "id": "xy12-97",
+    "setOrder":71,
+	"id": "xy12-97",
     "name": "Basic Darkness Energy",
     "imageUrl": "https://images.pokemontcg.io/xy12/97.png",
     "subtype": "Basic",
@@ -4143,7 +4240,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/97_hires.png"
   },
   {
-    "id": "xy12-98",
+    "setOrder":71,
+	"id": "xy12-98",
     "name": "Basic Metal Energy",
     "imageUrl": "https://images.pokemontcg.io/xy12/98.png",
     "subtype": "Basic",
@@ -4157,7 +4255,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/98_hires.png"
   },
   {
-    "id": "xy12-99",
+    "setOrder":71,
+	"id": "xy12-99",
     "name": "Basic Fairy Energy",
     "imageUrl": "https://images.pokemontcg.io/xy12/99.png",
     "subtype": "Basic",
@@ -4171,7 +4270,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/99_hires.png"
   },
   {
-    "id": "xy12-100",
+    "setOrder":71,
+	"id": "xy12-100",
     "name": "M Venusaur-EX",
     "imageUrl": "https://images.pokemontcg.io/xy12/100.png",
     "subtype": "MEGA",
@@ -4222,7 +4322,8 @@
     "nationalPokedexNumber": 3
   },
   {
-    "id": "xy12-101",
+    "setOrder":71,
+	"id": "xy12-101",
     "name": "M Charizard-EX",
     "imageUrl": "https://images.pokemontcg.io/xy12/101.png",
     "subtype": "MEGA",
@@ -4271,7 +4372,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "xy12-102",
+    "setOrder":71,
+	"id": "xy12-102",
     "name": "M Blastoise-EX",
     "imageUrl": "https://images.pokemontcg.io/xy12/102.png",
     "subtype": "MEGA",
@@ -4320,7 +4422,8 @@
     "nationalPokedexNumber": 9
   },
   {
-    "id": "xy12-103",
+    "setOrder":71,
+	"id": "xy12-103",
     "name": "Mewtwo-EX",
     "imageUrl": "https://images.pokemontcg.io/xy12/103.png",
     "subtype": "EX",
@@ -4386,7 +4489,8 @@
     "evolvesTo": "M Mewtwo-EX"
   },
   {
-    "id": "xy12-104",
+    "setOrder":71,
+	"id": "xy12-104",
     "name": "Pidgeot-EX",
     "imageUrl": "https://images.pokemontcg.io/xy12/104.png",
     "subtype": "EX",
@@ -4447,7 +4551,8 @@
     "evolvesTo": "M Pidgeot-EX"
   },
   {
-    "id": "xy12-105",
+    "setOrder":71,
+	"id": "xy12-105",
     "name": "M Pidgeot-EX",
     "imageUrl": "https://images.pokemontcg.io/xy12/105.png",
     "subtype": "MEGA",
@@ -4497,7 +4602,8 @@
     "nationalPokedexNumber": 18
   },
   {
-    "id": "xy12-106",
+    "setOrder":71,
+	"id": "xy12-106",
     "name": "Dragonite-EX",
     "imageUrl": "https://images.pokemontcg.io/xy12/106.png",
     "subtype": "EX",
@@ -4556,7 +4662,8 @@
     "nationalPokedexNumber": 149
   },
   {
-    "id": "xy12-107",
+    "setOrder":71,
+	"id": "xy12-107",
     "name": "Brock's Grit",
     "imageUrl": "https://images.pokemontcg.io/xy12/107.png",
     "subtype": "Supporter",
@@ -4573,7 +4680,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/107_hires.png"
   },
   {
-    "id": "xy12-108",
+    "setOrder":71,
+	"id": "xy12-108",
     "name": "Misty's Determination",
     "imageUrl": "https://images.pokemontcg.io/xy12/108.png",
     "subtype": "Supporter",
@@ -4590,7 +4698,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy12/108_hires.png"
   },
   {
-    "id": "xy12-109",
+    "setOrder":71,
+	"id": "xy12-109",
     "name": "ナッシー[Exeggutor]",
     "imageUrl": "https://images.pokemontcg.io/xy12/109.png",
     "subtype": "Stage 1",

--- a/json/cards/Expedition Base Set.json
+++ b/json/cards/Expedition Base Set.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "ecard1-1",
+    "setOrder":13,
+	"id": "ecard1-1",
     "name": "Alakazam",
     "imageUrl": "https://images.pokemontcg.io/ecard1/1.png",
     "subtype": "Stage 2",
@@ -49,7 +50,8 @@
     "nationalPokedexNumber": 65
   },
   {
-    "id": "ecard1-2",
+    "setOrder":13,
+	"id": "ecard1-2",
     "name": "Ampharos",
     "imageUrl": "https://images.pokemontcg.io/ecard1/2.png",
     "subtype": "Stage 2",
@@ -99,7 +101,8 @@
     "nationalPokedexNumber": 181
   },
   {
-    "id": "ecard1-3",
+    "setOrder":13,
+	"id": "ecard1-3",
     "name": "Arbok",
     "imageUrl": "https://images.pokemontcg.io/ecard1/3.png",
     "subtype": "Stage 1",
@@ -150,7 +153,8 @@
     "nationalPokedexNumber": 24
   },
   {
-    "id": "ecard1-4",
+    "setOrder":13,
+	"id": "ecard1-4",
     "name": "Blastoise",
     "imageUrl": "https://images.pokemontcg.io/ecard1/4.png",
     "subtype": "Stage 2",
@@ -199,7 +203,8 @@
     "nationalPokedexNumber": 9
   },
   {
-    "id": "ecard1-5",
+    "setOrder":13,
+	"id": "ecard1-5",
     "name": "Butterfree",
     "imageUrl": "https://images.pokemontcg.io/ecard1/5.png",
     "subtype": "Stage 2",
@@ -244,7 +249,8 @@
     "nationalPokedexNumber": 12
   },
   {
-    "id": "ecard1-6",
+    "setOrder":13,
+	"id": "ecard1-6",
     "name": "Charizard",
     "imageUrl": "https://images.pokemontcg.io/ecard1/6.png",
     "subtype": "Stage 2",
@@ -295,7 +301,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "ecard1-7",
+    "setOrder":13,
+	"id": "ecard1-7",
     "name": "Clefable",
     "imageUrl": "https://images.pokemontcg.io/ecard1/7.png",
     "subtype": "Stage 1",
@@ -342,7 +349,8 @@
     "nationalPokedexNumber": 36
   },
   {
-    "id": "ecard1-8",
+    "setOrder":13,
+	"id": "ecard1-8",
     "name": "Cloyster",
     "imageUrl": "https://images.pokemontcg.io/ecard1/8.png",
     "subtype": "Stage 1",
@@ -396,7 +404,8 @@
     "nationalPokedexNumber": 91
   },
   {
-    "id": "ecard1-9",
+    "setOrder":13,
+	"id": "ecard1-9",
     "name": "Dragonite",
     "imageUrl": "https://images.pokemontcg.io/ecard1/9.png",
     "subtype": "Stage 2",
@@ -439,7 +448,8 @@
     "nationalPokedexNumber": 149
   },
   {
-    "id": "ecard1-10",
+    "setOrder":13,
+	"id": "ecard1-10",
     "name": "Dugtrio",
     "imageUrl": "https://images.pokemontcg.io/ecard1/10.png",
     "subtype": "Stage 1",
@@ -497,7 +507,8 @@
     "nationalPokedexNumber": 51
   },
   {
-    "id": "ecard1-11",
+    "setOrder":13,
+	"id": "ecard1-11",
     "name": "Fearow",
     "imageUrl": "https://images.pokemontcg.io/ecard1/11.png",
     "subtype": "Stage 1",
@@ -553,7 +564,8 @@
     "nationalPokedexNumber": 22
   },
   {
-    "id": "ecard1-12",
+    "setOrder":13,
+	"id": "ecard1-12",
     "name": "Feraligatr",
     "imageUrl": "https://images.pokemontcg.io/ecard1/12.png",
     "subtype": "Stage 2",
@@ -604,7 +616,8 @@
     "nationalPokedexNumber": 160
   },
   {
-    "id": "ecard1-13",
+    "setOrder":13,
+	"id": "ecard1-13",
     "name": "Gengar",
     "imageUrl": "https://images.pokemontcg.io/ecard1/13.png",
     "subtype": "Stage 2",
@@ -658,7 +671,8 @@
     "nationalPokedexNumber": 94
   },
   {
-    "id": "ecard1-14",
+    "setOrder":13,
+	"id": "ecard1-14",
     "name": "Golem",
     "imageUrl": "https://images.pokemontcg.io/ecard1/14.png",
     "subtype": "Stage 2",
@@ -710,7 +724,8 @@
     "nationalPokedexNumber": 76
   },
   {
-    "id": "ecard1-15",
+    "setOrder":13,
+	"id": "ecard1-15",
     "name": "Kingler",
     "imageUrl": "https://images.pokemontcg.io/ecard1/15.png",
     "subtype": "Stage 1",
@@ -763,7 +778,8 @@
     "nationalPokedexNumber": 99
   },
   {
-    "id": "ecard1-16",
+    "setOrder":13,
+	"id": "ecard1-16",
     "name": "Machamp",
     "imageUrl": "https://images.pokemontcg.io/ecard1/16.png",
     "subtype": "Stage 2",
@@ -813,7 +829,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "ecard1-17",
+    "setOrder":13,
+	"id": "ecard1-17",
     "name": "Magby",
     "imageUrl": "https://images.pokemontcg.io/ecard1/17.png",
     "subtype": "Basic",
@@ -853,7 +870,8 @@
     ]
   },
   {
-    "id": "ecard1-18",
+    "setOrder":13,
+	"id": "ecard1-18",
     "name": "Meganium",
     "imageUrl": "https://images.pokemontcg.io/ecard1/18.png",
     "subtype": "Stage 2",
@@ -909,7 +927,8 @@
     "nationalPokedexNumber": 154
   },
   {
-    "id": "ecard1-19",
+    "setOrder":13,
+	"id": "ecard1-19",
     "name": "Mew",
     "imageUrl": "https://images.pokemontcg.io/ecard1/19.png",
     "subtype": "Basic",
@@ -950,7 +969,8 @@
     "nationalPokedexNumber": 151
   },
   {
-    "id": "ecard1-20",
+    "setOrder":13,
+	"id": "ecard1-20",
     "name": "Mewtwo",
     "imageUrl": "https://images.pokemontcg.io/ecard1/20.png",
     "subtype": "Basic",
@@ -1002,7 +1022,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "ecard1-21",
+    "setOrder":13,
+	"id": "ecard1-21",
     "name": "Ninetales",
     "imageUrl": "https://images.pokemontcg.io/ecard1/21.png",
     "subtype": "Stage 1",
@@ -1055,7 +1076,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "ecard1-22",
+    "setOrder":13,
+	"id": "ecard1-22",
     "name": "Pichu",
     "imageUrl": "https://images.pokemontcg.io/ecard1/22.png",
     "subtype": "Basic",
@@ -1095,7 +1117,8 @@
     ]
   },
   {
-    "id": "ecard1-23",
+    "setOrder":13,
+	"id": "ecard1-23",
     "name": "Pidgeot",
     "imageUrl": "https://images.pokemontcg.io/ecard1/23.png",
     "subtype": "Stage 2",
@@ -1146,7 +1169,8 @@
     "nationalPokedexNumber": 18
   },
   {
-    "id": "ecard1-24",
+    "setOrder":13,
+	"id": "ecard1-24",
     "name": "Poliwrath",
     "imageUrl": "https://images.pokemontcg.io/ecard1/24.png",
     "subtype": "Stage 2",
@@ -1196,7 +1220,8 @@
     "nationalPokedexNumber": 62
   },
   {
-    "id": "ecard1-25",
+    "setOrder":13,
+	"id": "ecard1-25",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/ecard1/25.png",
     "subtype": "Stage 1",
@@ -1248,7 +1273,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "ecard1-26",
+    "setOrder":13,
+	"id": "ecard1-26",
     "name": "Rapidash",
     "imageUrl": "https://images.pokemontcg.io/ecard1/26.png",
     "subtype": "Stage 1",
@@ -1298,7 +1324,8 @@
     "nationalPokedexNumber": 78
   },
   {
-    "id": "ecard1-27",
+    "setOrder":13,
+	"id": "ecard1-27",
     "name": "Skarmory",
     "imageUrl": "https://images.pokemontcg.io/ecard1/27.png",
     "subtype": "Basic",
@@ -1357,7 +1384,8 @@
     "nationalPokedexNumber": 227
   },
   {
-    "id": "ecard1-28",
+    "setOrder":13,
+	"id": "ecard1-28",
     "name": "Typhlosion",
     "imageUrl": "https://images.pokemontcg.io/ecard1/28.png",
     "subtype": "Stage 2",
@@ -1407,7 +1435,8 @@
     "nationalPokedexNumber": 157
   },
   {
-    "id": "ecard1-29",
+    "setOrder":13,
+	"id": "ecard1-29",
     "name": "Tyranitar",
     "imageUrl": "https://images.pokemontcg.io/ecard1/29.png",
     "subtype": "Stage 2",
@@ -1465,7 +1494,8 @@
     "nationalPokedexNumber": 248
   },
   {
-    "id": "ecard1-30",
+    "setOrder":13,
+	"id": "ecard1-30",
     "name": "Venusaur",
     "imageUrl": "https://images.pokemontcg.io/ecard1/30.png",
     "subtype": "Stage 2",
@@ -1515,7 +1545,8 @@
     "nationalPokedexNumber": 3
   },
   {
-    "id": "ecard1-31",
+    "setOrder":13,
+	"id": "ecard1-31",
     "name": "Vileplume",
     "imageUrl": "https://images.pokemontcg.io/ecard1/31.png",
     "subtype": "Stage 2",
@@ -1563,7 +1594,8 @@
     "nationalPokedexNumber": 45
   },
   {
-    "id": "ecard1-32",
+    "setOrder":13,
+	"id": "ecard1-32",
     "name": "Weezing",
     "imageUrl": "https://images.pokemontcg.io/ecard1/32.png",
     "subtype": "Stage 1",
@@ -1617,7 +1649,8 @@
     "nationalPokedexNumber": 110
   },
   {
-    "id": "ecard1-33",
+    "setOrder":13,
+	"id": "ecard1-33",
     "name": "Alakazam",
     "imageUrl": "https://images.pokemontcg.io/ecard1/33.png",
     "subtype": "Stage 2",
@@ -1666,7 +1699,8 @@
     "nationalPokedexNumber": 65
   },
   {
-    "id": "ecard1-34",
+    "setOrder":13,
+	"id": "ecard1-34",
     "name": "Ampharos",
     "imageUrl": "https://images.pokemontcg.io/ecard1/34.png",
     "subtype": "Stage 2",
@@ -1716,7 +1750,8 @@
     "nationalPokedexNumber": 181
   },
   {
-    "id": "ecard1-35",
+    "setOrder":13,
+	"id": "ecard1-35",
     "name": "Arbok",
     "imageUrl": "https://images.pokemontcg.io/ecard1/35.png",
     "subtype": "Stage 1",
@@ -1766,7 +1801,8 @@
     "nationalPokedexNumber": 24
   },
   {
-    "id": "ecard1-36",
+    "setOrder":13,
+	"id": "ecard1-36",
     "name": "Blastoise",
     "imageUrl": "https://images.pokemontcg.io/ecard1/36.png",
     "subtype": "Stage 2",
@@ -1819,7 +1855,8 @@
     "nationalPokedexNumber": 9
   },
   {
-    "id": "ecard1-37",
+    "setOrder":13,
+	"id": "ecard1-37",
     "name": "Blastoise",
     "imageUrl": "https://images.pokemontcg.io/ecard1/37.png",
     "subtype": "Stage 2",
@@ -1867,7 +1904,8 @@
     "nationalPokedexNumber": 9
   },
   {
-    "id": "ecard1-38",
+    "setOrder":13,
+	"id": "ecard1-38",
     "name": "Butterfree",
     "imageUrl": "https://images.pokemontcg.io/ecard1/38.png",
     "subtype": "Stage 2",
@@ -1912,7 +1950,8 @@
     "nationalPokedexNumber": 12
   },
   {
-    "id": "ecard1-39",
+    "setOrder":13,
+	"id": "ecard1-39",
     "name": "Charizard",
     "imageUrl": "https://images.pokemontcg.io/ecard1/39.png",
     "subtype": "Stage 2",
@@ -1965,7 +2004,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "ecard1-40",
+    "setOrder":13,
+	"id": "ecard1-40",
     "name": "Charizard",
     "imageUrl": "https://images.pokemontcg.io/ecard1/40.png",
     "subtype": "Stage 2",
@@ -2016,7 +2056,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "ecard1-41",
+    "setOrder":13,
+	"id": "ecard1-41",
     "name": "Clefable",
     "imageUrl": "https://images.pokemontcg.io/ecard1/41.png",
     "subtype": "Stage 1",
@@ -2063,7 +2104,8 @@
     "nationalPokedexNumber": 36
   },
   {
-    "id": "ecard1-42",
+    "setOrder":13,
+	"id": "ecard1-42",
     "name": "Cloyster",
     "imageUrl": "https://images.pokemontcg.io/ecard1/42.png",
     "subtype": "Stage 1",
@@ -2117,7 +2159,8 @@
     "nationalPokedexNumber": 91
   },
   {
-    "id": "ecard1-43",
+    "setOrder":13,
+	"id": "ecard1-43",
     "name": "Dragonite",
     "imageUrl": "https://images.pokemontcg.io/ecard1/43.png",
     "subtype": "Stage 2",
@@ -2160,7 +2203,8 @@
     "nationalPokedexNumber": 149
   },
   {
-    "id": "ecard1-44",
+    "setOrder":13,
+	"id": "ecard1-44",
     "name": "Dugtrio",
     "imageUrl": "https://images.pokemontcg.io/ecard1/44.png",
     "subtype": "Stage 1",
@@ -2218,7 +2262,8 @@
     "nationalPokedexNumber": 51
   },
   {
-    "id": "ecard1-45",
+    "setOrder":13,
+	"id": "ecard1-45",
     "name": "Fearow",
     "imageUrl": "https://images.pokemontcg.io/ecard1/45.png",
     "subtype": "Stage 1",
@@ -2274,7 +2319,8 @@
     "nationalPokedexNumber": 22
   },
   {
-    "id": "ecard1-46",
+    "setOrder":13,
+	"id": "ecard1-46",
     "name": "Feraligatr",
     "imageUrl": "https://images.pokemontcg.io/ecard1/46.png",
     "subtype": "Stage 2",
@@ -2327,7 +2373,8 @@
     "nationalPokedexNumber": 160
   },
   {
-    "id": "ecard1-47",
+    "setOrder":13,
+	"id": "ecard1-47",
     "name": "Feraligatr",
     "imageUrl": "https://images.pokemontcg.io/ecard1/47.png",
     "subtype": "Stage 2",
@@ -2378,7 +2425,8 @@
     "nationalPokedexNumber": 160
   },
   {
-    "id": "ecard1-48",
+    "setOrder":13,
+	"id": "ecard1-48",
     "name": "Gengar",
     "imageUrl": "https://images.pokemontcg.io/ecard1/48.png",
     "subtype": "Stage 2",
@@ -2432,7 +2480,8 @@
     "nationalPokedexNumber": 94
   },
   {
-    "id": "ecard1-49",
+    "setOrder":13,
+	"id": "ecard1-49",
     "name": "Golem",
     "imageUrl": "https://images.pokemontcg.io/ecard1/49.png",
     "subtype": "Stage 2",
@@ -2484,7 +2533,8 @@
     "nationalPokedexNumber": 76
   },
   {
-    "id": "ecard1-50",
+    "setOrder":13,
+	"id": "ecard1-50",
     "name": "Kingler",
     "imageUrl": "https://images.pokemontcg.io/ecard1/50.png",
     "subtype": "Stage 1",
@@ -2537,7 +2587,8 @@
     "nationalPokedexNumber": 99
   },
   {
-    "id": "ecard1-51",
+    "setOrder":13,
+	"id": "ecard1-51",
     "name": "Machamp",
     "imageUrl": "https://images.pokemontcg.io/ecard1/51.png",
     "subtype": "Stage 2",
@@ -2587,7 +2638,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "ecard1-52",
+    "setOrder":13,
+	"id": "ecard1-52",
     "name": "Magby",
     "imageUrl": "https://images.pokemontcg.io/ecard1/52.png",
     "subtype": "Basic",
@@ -2627,7 +2679,8 @@
     ]
   },
   {
-    "id": "ecard1-53",
+    "setOrder":13,
+	"id": "ecard1-53",
     "name": "Meganium",
     "imageUrl": "https://images.pokemontcg.io/ecard1/53.png",
     "subtype": "Stage 2",
@@ -2687,7 +2740,8 @@
     "nationalPokedexNumber": 154
   },
   {
-    "id": "ecard1-54",
+    "setOrder":13,
+	"id": "ecard1-54",
     "name": "Meganium",
     "imageUrl": "https://images.pokemontcg.io/ecard1/54.png",
     "subtype": "Stage 2",
@@ -2743,7 +2797,8 @@
     "nationalPokedexNumber": 154
   },
   {
-    "id": "ecard1-55",
+    "setOrder":13,
+	"id": "ecard1-55",
     "name": "Mew",
     "imageUrl": "https://images.pokemontcg.io/ecard1/55.png",
     "subtype": "Basic",
@@ -2784,7 +2839,8 @@
     "nationalPokedexNumber": 151
   },
   {
-    "id": "ecard1-56",
+    "setOrder":13,
+	"id": "ecard1-56",
     "name": "Mewtwo",
     "imageUrl": "https://images.pokemontcg.io/ecard1/56.png",
     "subtype": "Basic",
@@ -2836,7 +2892,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "ecard1-57",
+    "setOrder":13,
+	"id": "ecard1-57",
     "name": "Ninetales",
     "imageUrl": "https://images.pokemontcg.io/ecard1/57.png",
     "subtype": "Stage 1",
@@ -2889,7 +2946,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "ecard1-58",
+    "setOrder":13,
+	"id": "ecard1-58",
     "name": "Pichu",
     "imageUrl": "https://images.pokemontcg.io/ecard1/58.png",
     "subtype": "Basic",
@@ -2929,7 +2987,8 @@
     ]
   },
   {
-    "id": "ecard1-59",
+    "setOrder":13,
+	"id": "ecard1-59",
     "name": "Pidgeot",
     "imageUrl": "https://images.pokemontcg.io/ecard1/59.png",
     "subtype": "Stage 2",
@@ -2980,7 +3039,8 @@
     "nationalPokedexNumber": 18
   },
   {
-    "id": "ecard1-60",
+    "setOrder":13,
+	"id": "ecard1-60",
     "name": "Poliwrath",
     "imageUrl": "https://images.pokemontcg.io/ecard1/60.png",
     "subtype": "Stage 2",
@@ -3030,7 +3090,8 @@
     "nationalPokedexNumber": 62
   },
   {
-    "id": "ecard1-61",
+    "setOrder":13,
+	"id": "ecard1-61",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/ecard1/61.png",
     "subtype": "Stage 1",
@@ -3082,7 +3143,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "ecard1-62",
+    "setOrder":13,
+	"id": "ecard1-62",
     "name": "Rapidash",
     "imageUrl": "https://images.pokemontcg.io/ecard1/62.png",
     "subtype": "Stage 1",
@@ -3132,7 +3194,8 @@
     "nationalPokedexNumber": 78
   },
   {
-    "id": "ecard1-63",
+    "setOrder":13,
+	"id": "ecard1-63",
     "name": "Skarmory",
     "imageUrl": "https://images.pokemontcg.io/ecard1/63.png",
     "subtype": "Basic",
@@ -3191,7 +3254,8 @@
     "nationalPokedexNumber": 227
   },
   {
-    "id": "ecard1-64",
+    "setOrder":13,
+	"id": "ecard1-64",
     "name": "Typhlosion",
     "imageUrl": "https://images.pokemontcg.io/ecard1/64.png",
     "subtype": "Stage 2",
@@ -3244,7 +3308,8 @@
     "nationalPokedexNumber": 157
   },
   {
-    "id": "ecard1-65",
+    "setOrder":13,
+	"id": "ecard1-65",
     "name": "Typhlosion",
     "imageUrl": "https://images.pokemontcg.io/ecard1/65.png",
     "subtype": "Stage 2",
@@ -3294,7 +3359,8 @@
     "nationalPokedexNumber": 157
   },
   {
-    "id": "ecard1-66",
+    "setOrder":13,
+	"id": "ecard1-66",
     "name": "Tyranitar",
     "imageUrl": "https://images.pokemontcg.io/ecard1/66.png",
     "subtype": "Stage 2",
@@ -3352,7 +3418,8 @@
     "nationalPokedexNumber": 248
   },
   {
-    "id": "ecard1-67",
+    "setOrder":13,
+	"id": "ecard1-67",
     "name": "Venusaur",
     "imageUrl": "https://images.pokemontcg.io/ecard1/67.png",
     "subtype": "Stage 2",
@@ -3405,7 +3472,8 @@
     "nationalPokedexNumber": 3
   },
   {
-    "id": "ecard1-68",
+    "setOrder":13,
+	"id": "ecard1-68",
     "name": "Venusaur",
     "imageUrl": "https://images.pokemontcg.io/ecard1/68.png",
     "subtype": "Stage 2",
@@ -3455,7 +3523,8 @@
     "nationalPokedexNumber": 3
   },
   {
-    "id": "ecard1-69",
+    "setOrder":13,
+	"id": "ecard1-69",
     "name": "Vileplume",
     "imageUrl": "https://images.pokemontcg.io/ecard1/69.png",
     "subtype": "Stage 2",
@@ -3503,7 +3572,8 @@
     "nationalPokedexNumber": 45
   },
   {
-    "id": "ecard1-70",
+    "setOrder":13,
+	"id": "ecard1-70",
     "name": "Weezing",
     "imageUrl": "https://images.pokemontcg.io/ecard1/70.png",
     "subtype": "Stage 1",
@@ -3557,7 +3627,8 @@
     "nationalPokedexNumber": 110
   },
   {
-    "id": "ecard1-71",
+    "setOrder":13,
+	"id": "ecard1-71",
     "name": "Bayleef",
     "imageUrl": "https://images.pokemontcg.io/ecard1/71.png",
     "subtype": "Stage 1",
@@ -3617,7 +3688,8 @@
     ]
   },
   {
-    "id": "ecard1-72",
+    "setOrder":13,
+	"id": "ecard1-72",
     "name": "Chansey",
     "imageUrl": "https://images.pokemontcg.io/ecard1/72.png",
     "subtype": "Basic",
@@ -3673,7 +3745,8 @@
     ]
   },
   {
-    "id": "ecard1-73",
+    "setOrder":13,
+	"id": "ecard1-73",
     "name": "Charmeleon",
     "imageUrl": "https://images.pokemontcg.io/ecard1/73.png",
     "subtype": "Stage 1",
@@ -3729,7 +3802,8 @@
     ]
   },
   {
-    "id": "ecard1-74",
+    "setOrder":13,
+	"id": "ecard1-74",
     "name": "Croconaw",
     "imageUrl": "https://images.pokemontcg.io/ecard1/74.png",
     "subtype": "Stage 1",
@@ -3785,7 +3859,8 @@
     ]
   },
   {
-    "id": "ecard1-75",
+    "setOrder":13,
+	"id": "ecard1-75",
     "name": "Dragonair",
     "imageUrl": "https://images.pokemontcg.io/ecard1/75.png",
     "subtype": "Stage 1",
@@ -3825,7 +3900,8 @@
     ]
   },
   {
-    "id": "ecard1-76",
+    "setOrder":13,
+	"id": "ecard1-76",
     "name": "Electabuzz",
     "imageUrl": "https://images.pokemontcg.io/ecard1/76.png",
     "subtype": "Basic",
@@ -3879,7 +3955,8 @@
     ]
   },
   {
-    "id": "ecard1-77",
+    "setOrder":13,
+	"id": "ecard1-77",
     "name": "Flaaffy",
     "imageUrl": "https://images.pokemontcg.io/ecard1/77.png",
     "subtype": "Stage 1",
@@ -3935,7 +4012,8 @@
     ]
   },
   {
-    "id": "ecard1-78",
+    "setOrder":13,
+	"id": "ecard1-78",
     "name": "Gloom",
     "imageUrl": "https://images.pokemontcg.io/ecard1/78.png",
     "subtype": "Stage 1",
@@ -3992,7 +4070,8 @@
     ]
   },
   {
-    "id": "ecard1-79",
+    "setOrder":13,
+	"id": "ecard1-79",
     "name": "Graveler",
     "imageUrl": "https://images.pokemontcg.io/ecard1/79.png",
     "subtype": "Stage 1",
@@ -4050,7 +4129,8 @@
     ]
   },
   {
-    "id": "ecard1-80",
+    "setOrder":13,
+	"id": "ecard1-80",
     "name": "Haunter",
     "imageUrl": "https://images.pokemontcg.io/ecard1/80.png",
     "subtype": "Stage 1",
@@ -4111,7 +4191,8 @@
     ]
   },
   {
-    "id": "ecard1-81",
+    "setOrder":13,
+	"id": "ecard1-81",
     "name": "Hitmonlee",
     "imageUrl": "https://images.pokemontcg.io/ecard1/81.png",
     "subtype": "Basic",
@@ -4163,7 +4244,8 @@
     "nationalPokedexNumber": 106
   },
   {
-    "id": "ecard1-82",
+    "setOrder":13,
+	"id": "ecard1-82",
     "name": "Ivysaur",
     "imageUrl": "https://images.pokemontcg.io/ecard1/82.png",
     "subtype": "Stage 1",
@@ -4219,7 +4301,8 @@
     ]
   },
   {
-    "id": "ecard1-83",
+    "setOrder":13,
+	"id": "ecard1-83",
     "name": "Jynx",
     "imageUrl": "https://images.pokemontcg.io/ecard1/83.png",
     "subtype": "Basic",
@@ -4271,7 +4354,8 @@
     "nationalPokedexNumber": 124
   },
   {
-    "id": "ecard1-84",
+    "setOrder":13,
+	"id": "ecard1-84",
     "name": "Kadabra",
     "imageUrl": "https://images.pokemontcg.io/ecard1/84.png",
     "subtype": "Stage 1",
@@ -4325,7 +4409,8 @@
     ]
   },
   {
-    "id": "ecard1-85",
+    "setOrder":13,
+	"id": "ecard1-85",
     "name": "Machoke",
     "imageUrl": "https://images.pokemontcg.io/ecard1/85.png",
     "subtype": "Stage 1",
@@ -4381,7 +4466,8 @@
     ]
   },
   {
-    "id": "ecard1-86",
+    "setOrder":13,
+	"id": "ecard1-86",
     "name": "Magmar",
     "imageUrl": "https://images.pokemontcg.io/ecard1/86.png",
     "subtype": "Basic",
@@ -4436,7 +4522,8 @@
     ]
   },
   {
-    "id": "ecard1-87",
+    "setOrder":13,
+	"id": "ecard1-87",
     "name": "Metapod",
     "imageUrl": "https://images.pokemontcg.io/ecard1/87.png",
     "subtype": "Stage 1",
@@ -4486,7 +4573,8 @@
     ]
   },
   {
-    "id": "ecard1-88",
+    "setOrder":13,
+	"id": "ecard1-88",
     "name": "Pidgeotto",
     "imageUrl": "https://images.pokemontcg.io/ecard1/88.png",
     "subtype": "Stage 1",
@@ -4534,7 +4622,8 @@
     ]
   },
   {
-    "id": "ecard1-89",
+    "setOrder":13,
+	"id": "ecard1-89",
     "name": "Poliwhirl",
     "imageUrl": "https://images.pokemontcg.io/ecard1/89.png",
     "subtype": "Stage 1",
@@ -4591,7 +4680,8 @@
     ]
   },
   {
-    "id": "ecard1-90",
+    "setOrder":13,
+	"id": "ecard1-90",
     "name": "Pupitar",
     "imageUrl": "https://images.pokemontcg.io/ecard1/90.png",
     "subtype": "Stage 1",
@@ -4635,7 +4725,8 @@
     ]
   },
   {
-    "id": "ecard1-91",
+    "setOrder":13,
+	"id": "ecard1-91",
     "name": "Quilava",
     "imageUrl": "https://images.pokemontcg.io/ecard1/91.png",
     "subtype": "Stage 1",
@@ -4691,7 +4782,8 @@
     ]
   },
   {
-    "id": "ecard1-92",
+    "setOrder":13,
+	"id": "ecard1-92",
     "name": "Wartortle",
     "imageUrl": "https://images.pokemontcg.io/ecard1/92.png",
     "subtype": "Stage 1",
@@ -4745,7 +4837,8 @@
     ]
   },
   {
-    "id": "ecard1-93",
+    "setOrder":13,
+	"id": "ecard1-93",
     "name": "Abra",
     "imageUrl": "https://images.pokemontcg.io/ecard1/93.png",
     "subtype": "Basic",
@@ -4797,7 +4890,8 @@
     ]
   },
   {
-    "id": "ecard1-94",
+    "setOrder":13,
+	"id": "ecard1-94",
     "name": "Bulbasaur",
     "imageUrl": "https://images.pokemontcg.io/ecard1/94.png",
     "subtype": "Basic",
@@ -4850,7 +4944,8 @@
     ]
   },
   {
-    "id": "ecard1-95",
+    "setOrder":13,
+	"id": "ecard1-95",
     "name": "Bulbasaur",
     "imageUrl": "https://images.pokemontcg.io/ecard1/95.png",
     "subtype": "Basic",
@@ -4903,7 +4998,8 @@
     ]
   },
   {
-    "id": "ecard1-96",
+    "setOrder":13,
+	"id": "ecard1-96",
     "name": "Caterpie",
     "imageUrl": "https://images.pokemontcg.io/ecard1/96.png",
     "subtype": "Basic",
@@ -4956,7 +5052,8 @@
     ]
   },
   {
-    "id": "ecard1-97",
+    "setOrder":13,
+	"id": "ecard1-97",
     "name": "Charmander",
     "imageUrl": "https://images.pokemontcg.io/ecard1/97.png",
     "subtype": "Basic",
@@ -5009,7 +5106,8 @@
     ]
   },
   {
-    "id": "ecard1-98",
+    "setOrder":13,
+	"id": "ecard1-98",
     "name": "Charmander",
     "imageUrl": "https://images.pokemontcg.io/ecard1/98.png",
     "subtype": "Basic",
@@ -5062,7 +5160,8 @@
     ]
   },
   {
-    "id": "ecard1-99",
+    "setOrder":13,
+	"id": "ecard1-99",
     "name": "Chikorita",
     "imageUrl": "https://images.pokemontcg.io/ecard1/99.png",
     "subtype": "Basic",
@@ -5121,7 +5220,8 @@
     ]
   },
   {
-    "id": "ecard1-100",
+    "setOrder":13,
+	"id": "ecard1-100",
     "name": "Chikorita",
     "imageUrl": "https://images.pokemontcg.io/ecard1/100.png",
     "subtype": "Basic",
@@ -5180,7 +5280,8 @@
     ]
   },
   {
-    "id": "ecard1-101",
+    "setOrder":13,
+	"id": "ecard1-101",
     "name": "Clefairy",
     "imageUrl": "https://images.pokemontcg.io/ecard1/101.png",
     "subtype": "Basic",
@@ -5232,7 +5333,8 @@
     ]
   },
   {
-    "id": "ecard1-102",
+    "setOrder":13,
+	"id": "ecard1-102",
     "name": "Corsola",
     "imageUrl": "https://images.pokemontcg.io/ecard1/102.png",
     "subtype": "Basic",
@@ -5285,7 +5387,8 @@
     "nationalPokedexNumber": 222
   },
   {
-    "id": "ecard1-103",
+    "setOrder":13,
+	"id": "ecard1-103",
     "name": "Cubone",
     "imageUrl": "https://images.pokemontcg.io/ecard1/103.png",
     "subtype": "Basic",
@@ -5344,7 +5447,8 @@
     ]
   },
   {
-    "id": "ecard1-104",
+    "setOrder":13,
+	"id": "ecard1-104",
     "name": "Cyndaquil",
     "imageUrl": "https://images.pokemontcg.io/ecard1/104.png",
     "subtype": "Basic",
@@ -5397,7 +5501,8 @@
     ]
   },
   {
-    "id": "ecard1-105",
+    "setOrder":13,
+	"id": "ecard1-105",
     "name": "Cyndaquil",
     "imageUrl": "https://images.pokemontcg.io/ecard1/105.png",
     "subtype": "Basic",
@@ -5450,7 +5555,8 @@
     ]
   },
   {
-    "id": "ecard1-106",
+    "setOrder":13,
+	"id": "ecard1-106",
     "name": "Diglett",
     "imageUrl": "https://images.pokemontcg.io/ecard1/106.png",
     "subtype": "Basic",
@@ -5499,7 +5605,8 @@
     ]
   },
   {
-    "id": "ecard1-107",
+    "setOrder":13,
+	"id": "ecard1-107",
     "name": "Dratini",
     "imageUrl": "https://images.pokemontcg.io/ecard1/107.png",
     "subtype": "Basic",
@@ -5534,7 +5641,8 @@
     ]
   },
   {
-    "id": "ecard1-108",
+    "setOrder":13,
+	"id": "ecard1-108",
     "name": "Ekans",
     "imageUrl": "https://images.pokemontcg.io/ecard1/108.png",
     "subtype": "Basic",
@@ -5577,7 +5685,8 @@
     ]
   },
   {
-    "id": "ecard1-109",
+    "setOrder":13,
+	"id": "ecard1-109",
     "name": "Gastly",
     "imageUrl": "https://images.pokemontcg.io/ecard1/109.png",
     "subtype": "Basic",
@@ -5626,7 +5735,8 @@
     ]
   },
   {
-    "id": "ecard1-110",
+    "setOrder":13,
+	"id": "ecard1-110",
     "name": "Geodude",
     "imageUrl": "https://images.pokemontcg.io/ecard1/110.png",
     "subtype": "Basic",
@@ -5669,7 +5779,8 @@
     ]
   },
   {
-    "id": "ecard1-111",
+    "setOrder":13,
+	"id": "ecard1-111",
     "name": "Goldeen",
     "imageUrl": "https://images.pokemontcg.io/ecard1/111.png",
     "subtype": "Basic",
@@ -5712,7 +5823,8 @@
     ]
   },
   {
-    "id": "ecard1-112",
+    "setOrder":13,
+	"id": "ecard1-112",
     "name": "Hoppip",
     "imageUrl": "https://images.pokemontcg.io/ecard1/112.png",
     "subtype": "Basic",
@@ -5761,7 +5873,8 @@
     ]
   },
   {
-    "id": "ecard1-113",
+    "setOrder":13,
+	"id": "ecard1-113",
     "name": "Houndour",
     "imageUrl": "https://images.pokemontcg.io/ecard1/113.png",
     "subtype": "Basic",
@@ -5810,7 +5923,8 @@
     ]
   },
   {
-    "id": "ecard1-114",
+    "setOrder":13,
+	"id": "ecard1-114",
     "name": "Koffing",
     "imageUrl": "https://images.pokemontcg.io/ecard1/114.png",
     "subtype": "Basic",
@@ -5862,7 +5976,8 @@
     ]
   },
   {
-    "id": "ecard1-115",
+    "setOrder":13,
+	"id": "ecard1-115",
     "name": "Krabby",
     "imageUrl": "https://images.pokemontcg.io/ecard1/115.png",
     "subtype": "Basic",
@@ -5907,7 +6022,8 @@
     ]
   },
   {
-    "id": "ecard1-116",
+    "setOrder":13,
+	"id": "ecard1-116",
     "name": "Larvitar",
     "imageUrl": "https://images.pokemontcg.io/ecard1/116.png",
     "subtype": "Basic",
@@ -5960,7 +6076,8 @@
     ]
   },
   {
-    "id": "ecard1-117",
+    "setOrder":13,
+	"id": "ecard1-117",
     "name": "Machop",
     "imageUrl": "https://images.pokemontcg.io/ecard1/117.png",
     "subtype": "Basic",
@@ -6013,7 +6130,8 @@
     ]
   },
   {
-    "id": "ecard1-118",
+    "setOrder":13,
+	"id": "ecard1-118",
     "name": "Magikarp",
     "imageUrl": "https://images.pokemontcg.io/ecard1/118.png",
     "subtype": "Basic",
@@ -6056,7 +6174,8 @@
     ]
   },
   {
-    "id": "ecard1-119",
+    "setOrder":13,
+	"id": "ecard1-119",
     "name": "Mareep",
     "imageUrl": "https://images.pokemontcg.io/ecard1/119.png",
     "subtype": "Basic",
@@ -6099,7 +6218,8 @@
     ]
   },
   {
-    "id": "ecard1-120",
+    "setOrder":13,
+	"id": "ecard1-120",
     "name": "Marill",
     "imageUrl": "https://images.pokemontcg.io/ecard1/120.png",
     "subtype": "Basic",
@@ -6152,7 +6272,8 @@
     ]
   },
   {
-    "id": "ecard1-121",
+    "setOrder":13,
+	"id": "ecard1-121",
     "name": "Meowth",
     "imageUrl": "https://images.pokemontcg.io/ecard1/121.png",
     "subtype": "Basic",
@@ -6205,7 +6326,8 @@
     ]
   },
   {
-    "id": "ecard1-122",
+    "setOrder":13,
+	"id": "ecard1-122",
     "name": "Oddish",
     "imageUrl": "https://images.pokemontcg.io/ecard1/122.png",
     "subtype": "Basic",
@@ -6258,7 +6380,8 @@
     ]
   },
   {
-    "id": "ecard1-123",
+    "setOrder":13,
+	"id": "ecard1-123",
     "name": "Pidgey",
     "imageUrl": "https://images.pokemontcg.io/ecard1/123.png",
     "subtype": "Basic",
@@ -6317,7 +6440,8 @@
     ]
   },
   {
-    "id": "ecard1-124",
+    "setOrder":13,
+	"id": "ecard1-124",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/ecard1/124.png",
     "subtype": "Basic",
@@ -6370,7 +6494,8 @@
     ]
   },
   {
-    "id": "ecard1-125",
+    "setOrder":13,
+	"id": "ecard1-125",
     "name": "Poliwag",
     "imageUrl": "https://images.pokemontcg.io/ecard1/125.png",
     "subtype": "Basic",
@@ -6423,7 +6548,8 @@
     ]
   },
   {
-    "id": "ecard1-126",
+    "setOrder":13,
+	"id": "ecard1-126",
     "name": "Ponyta",
     "imageUrl": "https://images.pokemontcg.io/ecard1/126.png",
     "subtype": "Basic",
@@ -6476,7 +6602,8 @@
     ]
   },
   {
-    "id": "ecard1-127",
+    "setOrder":13,
+	"id": "ecard1-127",
     "name": "Qwilfish",
     "imageUrl": "https://images.pokemontcg.io/ecard1/127.png",
     "subtype": "Basic",
@@ -6517,7 +6644,8 @@
     "nationalPokedexNumber": 211
   },
   {
-    "id": "ecard1-128",
+    "setOrder":13,
+	"id": "ecard1-128",
     "name": "Rattata",
     "imageUrl": "https://images.pokemontcg.io/ecard1/128.png",
     "subtype": "Basic",
@@ -6560,7 +6688,8 @@
     ]
   },
   {
-    "id": "ecard1-129",
+    "setOrder":13,
+	"id": "ecard1-129",
     "name": "Shellder",
     "imageUrl": "https://images.pokemontcg.io/ecard1/129.png",
     "subtype": "Basic",
@@ -6613,7 +6742,8 @@
     ]
   },
   {
-    "id": "ecard1-130",
+    "setOrder":13,
+	"id": "ecard1-130",
     "name": "Spearow",
     "imageUrl": "https://images.pokemontcg.io/ecard1/130.png",
     "subtype": "Basic",
@@ -6662,7 +6792,8 @@
     ]
   },
   {
-    "id": "ecard1-131",
+    "setOrder":13,
+	"id": "ecard1-131",
     "name": "Squirtle",
     "imageUrl": "https://images.pokemontcg.io/ecard1/131.png",
     "subtype": "Basic",
@@ -6715,7 +6846,8 @@
     ]
   },
   {
-    "id": "ecard1-132",
+    "setOrder":13,
+	"id": "ecard1-132",
     "name": "Squirtle",
     "imageUrl": "https://images.pokemontcg.io/ecard1/132.png",
     "subtype": "Basic",
@@ -6768,7 +6900,8 @@
     ]
   },
   {
-    "id": "ecard1-133",
+    "setOrder":13,
+	"id": "ecard1-133",
     "name": "Tauros",
     "imageUrl": "https://images.pokemontcg.io/ecard1/133.png",
     "subtype": "Basic",
@@ -6820,7 +6953,8 @@
     "nationalPokedexNumber": 128
   },
   {
-    "id": "ecard1-134",
+    "setOrder":13,
+	"id": "ecard1-134",
     "name": "Totodile",
     "imageUrl": "https://images.pokemontcg.io/ecard1/134.png",
     "subtype": "Basic",
@@ -6873,7 +7007,8 @@
     ]
   },
   {
-    "id": "ecard1-135",
+    "setOrder":13,
+	"id": "ecard1-135",
     "name": "Totodile",
     "imageUrl": "https://images.pokemontcg.io/ecard1/135.png",
     "subtype": "Basic",
@@ -6926,7 +7061,8 @@
     ]
   },
   {
-    "id": "ecard1-136",
+    "setOrder":13,
+	"id": "ecard1-136",
     "name": "Vulpix",
     "imageUrl": "https://images.pokemontcg.io/ecard1/136.png",
     "subtype": "Basic",
@@ -6979,7 +7115,8 @@
     ]
   },
   {
-    "id": "ecard1-137",
+    "setOrder":13,
+	"id": "ecard1-137",
     "name": "Bill's Maintenance",
     "imageUrl": "https://images.pokemontcg.io/ecard1/137.png",
     "subtype": "",
@@ -6996,7 +7133,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/137_hires.png"
   },
   {
-    "id": "ecard1-138",
+    "setOrder":13,
+	"id": "ecard1-138",
     "name": "Copycat",
     "imageUrl": "https://images.pokemontcg.io/ecard1/138.png",
     "subtype": "",
@@ -7013,7 +7151,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/138_hires.png"
   },
   {
-    "id": "ecard1-139",
+    "setOrder":13,
+	"id": "ecard1-139",
     "name": "Dual Ball",
     "imageUrl": "https://images.pokemontcg.io/ecard1/139.png",
     "subtype": "",
@@ -7030,7 +7169,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/139_hires.png"
   },
   {
-    "id": "ecard1-140",
+    "setOrder":13,
+	"id": "ecard1-140",
     "name": "Energy Removal 2",
     "imageUrl": "https://images.pokemontcg.io/ecard1/140.png",
     "subtype": "",
@@ -7047,7 +7187,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/140_hires.png"
   },
   {
-    "id": "ecard1-141",
+    "setOrder":13,
+	"id": "ecard1-141",
     "name": "Energy Restore",
     "imageUrl": "https://images.pokemontcg.io/ecard1/141.png",
     "subtype": "",
@@ -7064,7 +7205,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/141_hires.png"
   },
   {
-    "id": "ecard1-142",
+    "setOrder":13,
+	"id": "ecard1-142",
     "name": "Mary's Impulse",
     "imageUrl": "https://images.pokemontcg.io/ecard1/142.png",
     "subtype": "",
@@ -7081,7 +7223,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/142_hires.png"
   },
   {
-    "id": "ecard1-143",
+    "setOrder":13,
+	"id": "ecard1-143",
     "name": "Master Ball",
     "imageUrl": "https://images.pokemontcg.io/ecard1/143.png",
     "subtype": "",
@@ -7098,7 +7241,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/143_hires.png"
   },
   {
-    "id": "ecard1-144",
+    "setOrder":13,
+	"id": "ecard1-144",
     "name": "Multi Technical Machine 01",
     "imageUrl": "https://images.pokemontcg.io/ecard1/144.png",
     "subtype": "",
@@ -7115,7 +7259,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/144_hires.png"
   },
   {
-    "id": "ecard1-145",
+    "setOrder":13,
+	"id": "ecard1-145",
     "name": "Pokémon Nurse",
     "imageUrl": "https://images.pokemontcg.io/ecard1/145.png",
     "subtype": "",
@@ -7132,7 +7277,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/145_hires.png"
   },
   {
-    "id": "ecard1-146",
+    "setOrder":13,
+	"id": "ecard1-146",
     "name": "Pokémon Reversal",
     "imageUrl": "https://images.pokemontcg.io/ecard1/146.png",
     "subtype": "",
@@ -7149,7 +7295,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/146_hires.png"
   },
   {
-    "id": "ecard1-147",
+    "setOrder":13,
+	"id": "ecard1-147",
     "name": "Power Charge",
     "imageUrl": "https://images.pokemontcg.io/ecard1/147.png",
     "subtype": "",
@@ -7166,7 +7313,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/147_hires.png"
   },
   {
-    "id": "ecard1-148",
+    "setOrder":13,
+	"id": "ecard1-148",
     "name": "Professor Elm's Training Method",
     "imageUrl": "https://images.pokemontcg.io/ecard1/148.png",
     "subtype": "",
@@ -7183,7 +7331,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/148_hires.png"
   },
   {
-    "id": "ecard1-149",
+    "setOrder":13,
+	"id": "ecard1-149",
     "name": "Professor Oak's Research",
     "imageUrl": "https://images.pokemontcg.io/ecard1/149.png",
     "subtype": "",
@@ -7200,7 +7349,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/149_hires.png"
   },
   {
-    "id": "ecard1-150",
+    "setOrder":13,
+	"id": "ecard1-150",
     "name": "Strength Charm",
     "imageUrl": "https://images.pokemontcg.io/ecard1/150.png",
     "subtype": "",
@@ -7217,7 +7367,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/150_hires.png"
   },
   {
-    "id": "ecard1-151",
+    "setOrder":13,
+	"id": "ecard1-151",
     "name": "Super Scoop Up",
     "imageUrl": "https://images.pokemontcg.io/ecard1/151.png",
     "subtype": "",
@@ -7234,7 +7385,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/151_hires.png"
   },
   {
-    "id": "ecard1-152",
+    "setOrder":13,
+	"id": "ecard1-152",
     "name": "Warp Point",
     "imageUrl": "https://images.pokemontcg.io/ecard1/152.png",
     "subtype": "",
@@ -7251,7 +7403,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/152_hires.png"
   },
   {
-    "id": "ecard1-153",
+    "setOrder":13,
+	"id": "ecard1-153",
     "name": "Energy Search",
     "imageUrl": "https://images.pokemontcg.io/ecard1/153.png",
     "subtype": "",
@@ -7268,7 +7421,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/153_hires.png"
   },
   {
-    "id": "ecard1-154",
+    "setOrder":13,
+	"id": "ecard1-154",
     "name": "Full Heal",
     "imageUrl": "https://images.pokemontcg.io/ecard1/154.png",
     "subtype": "",
@@ -7285,7 +7439,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/154_hires.png"
   },
   {
-    "id": "ecard1-155",
+    "setOrder":13,
+	"id": "ecard1-155",
     "name": "Moo-Moo Milk",
     "imageUrl": "https://images.pokemontcg.io/ecard1/155.png",
     "subtype": "",
@@ -7302,7 +7457,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/155_hires.png"
   },
   {
-    "id": "ecard1-156",
+    "setOrder":13,
+	"id": "ecard1-156",
     "name": "Potion",
     "imageUrl": "https://images.pokemontcg.io/ecard1/156.png",
     "subtype": "",
@@ -7319,7 +7475,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/156_hires.png"
   },
   {
-    "id": "ecard1-157",
+    "setOrder":13,
+	"id": "ecard1-157",
     "name": "Switch",
     "imageUrl": "https://images.pokemontcg.io/ecard1/157.png",
     "subtype": "",
@@ -7336,7 +7493,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/157_hires.png"
   },
   {
-    "id": "ecard1-158",
+    "setOrder":13,
+	"id": "ecard1-158",
     "name": "Darkness Energy",
     "imageUrl": "https://images.pokemontcg.io/ecard1/158.png",
     "subtype": "Special",
@@ -7353,7 +7511,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/158_hires.png"
   },
   {
-    "id": "ecard1-159",
+    "setOrder":13,
+	"id": "ecard1-159",
     "name": "Metal Energy",
     "imageUrl": "https://images.pokemontcg.io/ecard1/159.png",
     "subtype": "Special",
@@ -7370,7 +7529,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/159_hires.png"
   },
   {
-    "id": "ecard1-160",
+    "setOrder":13,
+	"id": "ecard1-160",
     "name": "Fighting Energy",
     "imageUrl": "https://images.pokemontcg.io/ecard1/160.png",
     "subtype": "Basic",
@@ -7384,7 +7544,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/160_hires.png"
   },
   {
-    "id": "ecard1-161",
+    "setOrder":13,
+	"id": "ecard1-161",
     "name": "Fire Energy",
     "imageUrl": "https://images.pokemontcg.io/ecard1/161.png",
     "subtype": "Basic",
@@ -7398,7 +7559,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/161_hires.png"
   },
   {
-    "id": "ecard1-162",
+    "setOrder":13,
+	"id": "ecard1-162",
     "name": "Grass Energy",
     "imageUrl": "https://images.pokemontcg.io/ecard1/162.png",
     "subtype": "Basic",
@@ -7412,7 +7574,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/162_hires.png"
   },
   {
-    "id": "ecard1-163",
+    "setOrder":13,
+	"id": "ecard1-163",
     "name": "Lightning Energy",
     "imageUrl": "https://images.pokemontcg.io/ecard1/163.png",
     "subtype": "Basic",
@@ -7426,7 +7589,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/163_hires.png"
   },
   {
-    "id": "ecard1-164",
+    "setOrder":13,
+	"id": "ecard1-164",
     "name": "Psychic Energy",
     "imageUrl": "https://images.pokemontcg.io/ecard1/164.png",
     "subtype": "Basic",
@@ -7440,7 +7604,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard1/164_hires.png"
   },
   {
-    "id": "ecard1-165",
+    "setOrder":13,
+	"id": "ecard1-165",
     "name": "Water Energy",
     "imageUrl": "https://images.pokemontcg.io/ecard1/165.png",
     "subtype": "Basic",

--- a/json/cards/Fates Collide.json
+++ b/json/cards/Fates Collide.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "xy10-1",
+    "setOrder":69,
+	"id": "xy10-1",
     "name": "Shuckle",
     "imageUrl": "https://images.pokemontcg.io/xy10/1.png",
     "subtype": "Basic",
@@ -50,7 +51,8 @@
     "nationalPokedexNumber": 213
   },
   {
-    "id": "xy10-2",
+    "setOrder":69,
+	"id": "xy10-2",
     "name": "Burmy",
     "imageUrl": "https://images.pokemontcg.io/xy10/2.png",
     "subtype": "Basic",
@@ -93,7 +95,8 @@
     ]
   },
   {
-    "id": "xy10-3",
+    "setOrder":69,
+	"id": "xy10-3",
     "name": "Wormadam",
     "imageUrl": "https://images.pokemontcg.io/xy10/3.png",
     "subtype": "Stage 1",
@@ -149,7 +152,8 @@
     ]
   },
   {
-    "id": "xy10-4",
+    "setOrder":69,
+	"id": "xy10-4",
     "name": "Mothim",
     "imageUrl": "https://images.pokemontcg.io/xy10/4.png",
     "subtype": "Stage 1",
@@ -203,7 +207,8 @@
     ]
   },
   {
-    "id": "xy10-5",
+    "setOrder":69,
+	"id": "xy10-5",
     "name": "Snivy",
     "imageUrl": "https://images.pokemontcg.io/xy10/5.png",
     "subtype": "Basic",
@@ -246,7 +251,8 @@
     ]
   },
   {
-    "id": "xy10-6",
+    "setOrder":69,
+	"id": "xy10-6",
     "name": "Servine",
     "imageUrl": "https://images.pokemontcg.io/xy10/6.png",
     "subtype": "Stage 1",
@@ -295,7 +301,8 @@
     ]
   },
   {
-    "id": "xy10-7",
+    "setOrder":69,
+	"id": "xy10-7",
     "name": "Serperior",
     "imageUrl": "https://images.pokemontcg.io/xy10/7.png",
     "subtype": "Stage 2",
@@ -346,7 +353,8 @@
     "nationalPokedexNumber": 497
   },
   {
-    "id": "xy10-8",
+    "setOrder":69,
+	"id": "xy10-8",
     "name": "Deerling",
     "imageUrl": "https://images.pokemontcg.io/xy10/8.png",
     "subtype": "Basic",
@@ -389,7 +397,8 @@
     ]
   },
   {
-    "id": "xy10-9",
+    "setOrder":69,
+	"id": "xy10-9",
     "name": "Moltres",
     "imageUrl": "https://images.pokemontcg.io/xy10/9.png",
     "subtype": "Basic",
@@ -447,7 +456,8 @@
     "nationalPokedexNumber": 146
   },
   {
-    "id": "xy10-10",
+    "setOrder":69,
+	"id": "xy10-10",
     "name": "Fennekin",
     "imageUrl": "https://images.pokemontcg.io/xy10/10.png",
     "subtype": "Basic",
@@ -500,7 +510,8 @@
     ]
   },
   {
-    "id": "xy10-11",
+    "setOrder":69,
+	"id": "xy10-11",
     "name": "Fennekin",
     "imageUrl": "https://images.pokemontcg.io/xy10/11.png",
     "subtype": "Basic",
@@ -543,7 +554,8 @@
     ]
   },
   {
-    "id": "xy10-12",
+    "setOrder":69,
+	"id": "xy10-12",
     "name": "Braixen",
     "imageUrl": "https://images.pokemontcg.io/xy10/12.png",
     "subtype": "Stage 1",
@@ -597,7 +609,8 @@
     ]
   },
   {
-    "id": "xy10-13",
+    "setOrder":69,
+	"id": "xy10-13",
     "name": "Delphox",
     "imageUrl": "https://images.pokemontcg.io/xy10/13.png",
     "subtype": "Stage 2",
@@ -650,7 +663,8 @@
     "nationalPokedexNumber": 655
   },
   {
-    "id": "xy10-14",
+    "setOrder":69,
+	"id": "xy10-14",
     "name": "Delphox BREAK",
     "imageUrl": "https://images.pokemontcg.io/xy10/14.png",
     "subtype": "BREAK",
@@ -679,7 +693,8 @@
     "nationalPokedexNumber": 655
   },
   {
-    "id": "xy10-15",
+    "setOrder":69,
+	"id": "xy10-15",
     "name": "Seel",
     "imageUrl": "https://images.pokemontcg.io/xy10/15.png",
     "subtype": "Basic",
@@ -723,7 +738,8 @@
     ]
   },
   {
-    "id": "xy10-16",
+    "setOrder":69,
+	"id": "xy10-16",
     "name": "Dewgong",
     "imageUrl": "https://images.pokemontcg.io/xy10/16.png",
     "subtype": "Stage 1",
@@ -778,7 +794,8 @@
     "nationalPokedexNumber": 87
   },
   {
-    "id": "xy10-17",
+    "setOrder":69,
+	"id": "xy10-17",
     "name": "Omanyte",
     "imageUrl": "https://images.pokemontcg.io/xy10/17.png",
     "subtype": "Restored",
@@ -825,7 +842,8 @@
     ]
   },
   {
-    "id": "xy10-18",
+    "setOrder":69,
+	"id": "xy10-18",
     "name": "Omastar",
     "imageUrl": "https://images.pokemontcg.io/xy10/18.png",
     "subtype": "Stage 1",
@@ -873,7 +891,8 @@
     "nationalPokedexNumber": 139
   },
   {
-    "id": "xy10-19",
+    "setOrder":69,
+	"id": "xy10-19",
     "name": "Omastar BREAK",
     "imageUrl": "https://images.pokemontcg.io/xy10/19.png",
     "subtype": "BREAK",
@@ -902,7 +921,8 @@
     "nationalPokedexNumber": 139
   },
   {
-    "id": "xy10-20",
+    "setOrder":69,
+	"id": "xy10-20",
     "name": "Glaceon-EX",
     "imageUrl": "https://images.pokemontcg.io/xy10/20.png",
     "subtype": "EX",
@@ -958,7 +978,8 @@
     "nationalPokedexNumber": 471
   },
   {
-    "id": "xy10-21",
+    "setOrder":69,
+	"id": "xy10-21",
     "name": "White Kyurem",
     "imageUrl": "https://images.pokemontcg.io/xy10/21.png",
     "subtype": "Basic",
@@ -1012,7 +1033,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "xy10-22",
+    "setOrder":69,
+	"id": "xy10-22",
     "name": "Binacle",
     "imageUrl": "https://images.pokemontcg.io/xy10/22.png",
     "subtype": "Basic",
@@ -1057,7 +1079,8 @@
     ]
   },
   {
-    "id": "xy10-23",
+    "setOrder":69,
+	"id": "xy10-23",
     "name": "Barbaracle",
     "imageUrl": "https://images.pokemontcg.io/xy10/23.png",
     "subtype": "Stage 1",
@@ -1107,7 +1130,8 @@
     "nationalPokedexNumber": 689
   },
   {
-    "id": "xy10-24",
+    "setOrder":69,
+	"id": "xy10-24",
     "name": "Rotom",
     "imageUrl": "https://images.pokemontcg.io/xy10/24.png",
     "subtype": "Basic",
@@ -1163,7 +1187,8 @@
     "nationalPokedexNumber": 479
   },
   {
-    "id": "xy10-25",
+    "setOrder":69,
+	"id": "xy10-25",
     "name": "Alakazam-EX",
     "imageUrl": "https://images.pokemontcg.io/xy10/25.png",
     "subtype": "EX",
@@ -1214,7 +1239,8 @@
     "evolvesTo": "M Alakazam-EX"
   },
   {
-    "id": "xy10-26",
+    "setOrder":69,
+	"id": "xy10-26",
     "name": "M Alakazam-EX",
     "imageUrl": "https://images.pokemontcg.io/xy10/26.png",
     "subtype": "MEGA",
@@ -1260,7 +1286,8 @@
     "nationalPokedexNumber": 65
   },
   {
-    "id": "xy10-27",
+    "setOrder":69,
+	"id": "xy10-27",
     "name": "Koffing",
     "imageUrl": "https://images.pokemontcg.io/xy10/27.png",
     "subtype": "Basic",
@@ -1304,7 +1331,8 @@
     ]
   },
   {
-    "id": "xy10-28",
+    "setOrder":69,
+	"id": "xy10-28",
     "name": "Weezing",
     "imageUrl": "https://images.pokemontcg.io/xy10/28.png",
     "subtype": "Stage 1",
@@ -1359,7 +1387,8 @@
     "nationalPokedexNumber": 110
   },
   {
-    "id": "xy10-29",
+    "setOrder":69,
+	"id": "xy10-29",
     "name": "Mew",
     "imageUrl": "https://images.pokemontcg.io/xy10/29.png",
     "subtype": "Basic",
@@ -1401,7 +1430,8 @@
     "nationalPokedexNumber": 151
   },
   {
-    "id": "xy10-30",
+    "setOrder":69,
+	"id": "xy10-30",
     "name": "Spoink",
     "imageUrl": "https://images.pokemontcg.io/xy10/30.png",
     "subtype": "Basic",
@@ -1444,7 +1474,8 @@
     ]
   },
   {
-    "id": "xy10-31",
+    "setOrder":69,
+	"id": "xy10-31",
     "name": "Grumpig",
     "imageUrl": "https://images.pokemontcg.io/xy10/31.png",
     "subtype": "Stage 1",
@@ -1496,7 +1527,8 @@
     "nationalPokedexNumber": 326
   },
   {
-    "id": "xy10-32",
+    "setOrder":69,
+	"id": "xy10-32",
     "name": "Gothita",
     "imageUrl": "https://images.pokemontcg.io/xy10/32.png",
     "subtype": "Basic",
@@ -1540,7 +1572,8 @@
     ]
   },
   {
-    "id": "xy10-33",
+    "setOrder":69,
+	"id": "xy10-33",
     "name": "Solosis",
     "imageUrl": "https://images.pokemontcg.io/xy10/33.png",
     "subtype": "Basic",
@@ -1584,7 +1617,8 @@
     ]
   },
   {
-    "id": "xy10-34",
+    "setOrder":69,
+	"id": "xy10-34",
     "name": "Duosion",
     "imageUrl": "https://images.pokemontcg.io/xy10/34.png",
     "subtype": "Stage 1",
@@ -1629,7 +1663,8 @@
     ]
   },
   {
-    "id": "xy10-35",
+    "setOrder":69,
+	"id": "xy10-35",
     "name": "Reuniclus",
     "imageUrl": "https://images.pokemontcg.io/xy10/35.png",
     "subtype": "Stage 2",
@@ -1671,7 +1706,8 @@
     "nationalPokedexNumber": 579
   },
   {
-    "id": "xy10-36",
+    "setOrder":69,
+	"id": "xy10-36",
     "name": "Diglett",
     "imageUrl": "https://images.pokemontcg.io/xy10/36.png",
     "subtype": "Basic",
@@ -1711,7 +1747,8 @@
     ]
   },
   {
-    "id": "xy10-37",
+    "setOrder":69,
+	"id": "xy10-37",
     "name": "Marowak",
     "imageUrl": "https://images.pokemontcg.io/xy10/37.png",
     "subtype": "Stage 1",
@@ -1759,7 +1796,8 @@
     "nationalPokedexNumber": 105
   },
   {
-    "id": "xy10-38",
+    "setOrder":69,
+	"id": "xy10-38",
     "name": "Kabuto",
     "imageUrl": "https://images.pokemontcg.io/xy10/38.png",
     "subtype": "Restored",
@@ -1805,7 +1843,8 @@
     ]
   },
   {
-    "id": "xy10-39",
+    "setOrder":69,
+	"id": "xy10-39",
     "name": "Kabutops",
     "imageUrl": "https://images.pokemontcg.io/xy10/39.png",
     "subtype": "Stage 1",
@@ -1859,7 +1898,8 @@
     "nationalPokedexNumber": 141
   },
   {
-    "id": "xy10-40",
+    "setOrder":69,
+	"id": "xy10-40",
     "name": "Larvitar",
     "imageUrl": "https://images.pokemontcg.io/xy10/40.png",
     "subtype": "Basic",
@@ -1902,7 +1942,8 @@
     ]
   },
   {
-    "id": "xy10-41",
+    "setOrder":69,
+	"id": "xy10-41",
     "name": "Larvitar",
     "imageUrl": "https://images.pokemontcg.io/xy10/41.png",
     "subtype": "Basic",
@@ -1955,7 +1996,8 @@
     ]
   },
   {
-    "id": "xy10-42",
+    "setOrder":69,
+	"id": "xy10-42",
     "name": "Pupitar",
     "imageUrl": "https://images.pokemontcg.io/xy10/42.png",
     "subtype": "Stage 1",
@@ -1999,7 +2041,8 @@
     ]
   },
   {
-    "id": "xy10-43",
+    "setOrder":69,
+	"id": "xy10-43",
     "name": "Regirock-EX",
     "imageUrl": "https://images.pokemontcg.io/xy10/43.png",
     "subtype": "EX",
@@ -2051,7 +2094,8 @@
     "nationalPokedexNumber": 377
   },
   {
-    "id": "xy10-43a",
+    "setOrder":69,
+	"id": "xy10-43a",
     "name": "Regirock-EX",
     "imageUrl": "https://images.pokemontcg.io/xy10/43a.png",
     "subtype": "EX",
@@ -2103,7 +2147,8 @@
     "nationalPokedexNumber": 377
   },
   {
-    "id": "xy10-44",
+    "setOrder":69,
+	"id": "xy10-44",
     "name": "Wormadam",
     "imageUrl": "https://images.pokemontcg.io/xy10/44.png",
     "subtype": "Stage 1",
@@ -2159,7 +2204,8 @@
     ]
   },
   {
-    "id": "xy10-45",
+    "setOrder":69,
+	"id": "xy10-45",
     "name": "Riolu",
     "imageUrl": "https://images.pokemontcg.io/xy10/45.png",
     "subtype": "Basic",
@@ -2202,7 +2248,8 @@
     ]
   },
   {
-    "id": "xy10-46",
+    "setOrder":69,
+	"id": "xy10-46",
     "name": "Riolu",
     "imageUrl": "https://images.pokemontcg.io/xy10/46.png",
     "subtype": "Basic",
@@ -2245,7 +2292,8 @@
     ]
   },
   {
-    "id": "xy10-47",
+    "setOrder":69,
+	"id": "xy10-47",
     "name": "Lucario",
     "imageUrl": "https://images.pokemontcg.io/xy10/47.png",
     "subtype": "Stage 1",
@@ -2297,7 +2345,8 @@
     "nationalPokedexNumber": 448
   },
   {
-    "id": "xy10-48",
+    "setOrder":69,
+	"id": "xy10-48",
     "name": "Hawlucha",
     "imageUrl": "https://images.pokemontcg.io/xy10/48.png",
     "subtype": "Basic",
@@ -2353,7 +2402,8 @@
     "nationalPokedexNumber": 701
   },
   {
-    "id": "xy10-49",
+    "setOrder":69,
+	"id": "xy10-49",
     "name": "Carbink",
     "imageUrl": "https://images.pokemontcg.io/xy10/49.png",
     "subtype": "Basic",
@@ -2400,7 +2450,8 @@
     "nationalPokedexNumber": 703
   },
   {
-    "id": "xy10-50",
+    "setOrder":69,
+	"id": "xy10-50",
     "name": "Carbink",
     "imageUrl": "https://images.pokemontcg.io/xy10/50.png",
     "subtype": "Basic",
@@ -2446,7 +2497,8 @@
     "nationalPokedexNumber": 703
   },
   {
-    "id": "xy10-51",
+    "setOrder":69,
+	"id": "xy10-51",
     "name": "Carbink BREAK",
     "imageUrl": "https://images.pokemontcg.io/xy10/51.png",
     "subtype": "BREAK",
@@ -2481,7 +2533,8 @@
     "nationalPokedexNumber": 703
   },
   {
-    "id": "xy10-52",
+    "setOrder":69,
+	"id": "xy10-52",
     "name": "Zygarde",
     "imageUrl": "https://images.pokemontcg.io/xy10/52.png",
     "subtype": "Basic",
@@ -2532,7 +2585,8 @@
     "nationalPokedexNumber": 718
   },
   {
-    "id": "xy10-53",
+    "setOrder":69,
+	"id": "xy10-53",
     "name": "Zygarde",
     "imageUrl": "https://images.pokemontcg.io/xy10/53.png",
     "subtype": "Basic",
@@ -2585,7 +2639,8 @@
     "nationalPokedexNumber": 718
   },
   {
-    "id": "xy10-54",
+    "setOrder":69,
+	"id": "xy10-54",
     "name": "Zygarde-EX",
     "imageUrl": "https://images.pokemontcg.io/xy10/54.png",
     "subtype": "EX",
@@ -2651,7 +2706,8 @@
     "nationalPokedexNumber": 718
   },
   {
-    "id": "xy10-54a",
+    "setOrder":69,
+	"id": "xy10-54a",
     "name": "Zygarde-EX",
     "imageUrl": "https://images.pokemontcg.io/xy10/54a.png",
     "subtype": "EX",
@@ -2717,7 +2773,8 @@
     "nationalPokedexNumber": 718
   },
   {
-    "id": "xy10-55",
+    "setOrder":69,
+	"id": "xy10-55",
     "name": "Umbreon-EX",
     "imageUrl": "https://images.pokemontcg.io/xy10/55.png",
     "subtype": "EX",
@@ -2777,7 +2834,8 @@
     "nationalPokedexNumber": 197
   },
   {
-    "id": "xy10-56",
+    "setOrder":69,
+	"id": "xy10-56",
     "name": "Tyranitar",
     "imageUrl": "https://images.pokemontcg.io/xy10/56.png",
     "subtype": "Stage 2",
@@ -2836,7 +2894,8 @@
     "nationalPokedexNumber": 248
   },
   {
-    "id": "xy10-57",
+    "setOrder":69,
+	"id": "xy10-57",
     "name": "Vullaby",
     "imageUrl": "https://images.pokemontcg.io/xy10/57.png",
     "subtype": "Basic",
@@ -2896,7 +2955,8 @@
     ]
   },
   {
-    "id": "xy10-58",
+    "setOrder":69,
+	"id": "xy10-58",
     "name": "Mandibuzz",
     "imageUrl": "https://images.pokemontcg.io/xy10/58.png",
     "subtype": "Stage 1",
@@ -2954,7 +3014,8 @@
     "nationalPokedexNumber": 630
   },
   {
-    "id": "xy10-59",
+    "setOrder":69,
+	"id": "xy10-59",
     "name": "Wormadam",
     "imageUrl": "https://images.pokemontcg.io/xy10/59.png",
     "subtype": "Stage 1",
@@ -3016,7 +3077,8 @@
     ]
   },
   {
-    "id": "xy10-60",
+    "setOrder":69,
+	"id": "xy10-60",
     "name": "Bronzor",
     "imageUrl": "https://images.pokemontcg.io/xy10/60.png",
     "subtype": "Basic",
@@ -3076,7 +3138,8 @@
     ]
   },
   {
-    "id": "xy10-61",
+    "setOrder":69,
+	"id": "xy10-61",
     "name": "Bronzong",
     "imageUrl": "https://images.pokemontcg.io/xy10/61.png",
     "subtype": "Stage 1",
@@ -3132,7 +3195,8 @@
     "nationalPokedexNumber": 437
   },
   {
-    "id": "xy10-62",
+    "setOrder":69,
+	"id": "xy10-62",
     "name": "Bronzong BREAK",
     "imageUrl": "https://images.pokemontcg.io/xy10/62.png",
     "subtype": "BREAK",
@@ -3168,7 +3232,8 @@
     "nationalPokedexNumber": 437
   },
   {
-    "id": "xy10-63",
+    "setOrder":69,
+	"id": "xy10-63",
     "name": "Lucario",
     "imageUrl": "https://images.pokemontcg.io/xy10/63.png",
     "subtype": "Stage 1",
@@ -3226,7 +3291,8 @@
     "nationalPokedexNumber": 448
   },
   {
-    "id": "xy10-64",
+    "setOrder":69,
+	"id": "xy10-64",
     "name": "Genesect-EX",
     "imageUrl": "https://images.pokemontcg.io/xy10/64.png",
     "subtype": "EX",
@@ -3283,7 +3349,8 @@
     "nationalPokedexNumber": 649
   },
   {
-    "id": "xy10-65",
+    "setOrder":69,
+	"id": "xy10-65",
     "name": "Jigglypuff",
     "imageUrl": "https://images.pokemontcg.io/xy10/65.png",
     "subtype": "Basic",
@@ -3343,7 +3410,8 @@
     ]
   },
   {
-    "id": "xy10-66",
+    "setOrder":69,
+	"id": "xy10-66",
     "name": "Wigglytuff",
     "imageUrl": "https://images.pokemontcg.io/xy10/66.png",
     "subtype": "Stage 1",
@@ -3403,7 +3471,8 @@
     "nationalPokedexNumber": 40
   },
   {
-    "id": "xy10-67",
+    "setOrder":69,
+	"id": "xy10-67",
     "name": "Mr. Mime",
     "imageUrl": "https://images.pokemontcg.io/xy10/67.png",
     "subtype": "Basic",
@@ -3459,7 +3528,8 @@
     "nationalPokedexNumber": 122
   },
   {
-    "id": "xy10-68",
+    "setOrder":69,
+	"id": "xy10-68",
     "name": "Snubbull",
     "imageUrl": "https://images.pokemontcg.io/xy10/68.png",
     "subtype": "Basic",
@@ -3510,7 +3580,8 @@
     ]
   },
   {
-    "id": "xy10-69",
+    "setOrder":69,
+	"id": "xy10-69",
     "name": "M Altaria-EX",
     "imageUrl": "https://images.pokemontcg.io/xy10/69.png",
     "subtype": "MEGA",
@@ -3564,7 +3635,8 @@
     "nationalPokedexNumber": 334
   },
   {
-    "id": "xy10-70",
+    "setOrder":69,
+	"id": "xy10-70",
     "name": "Cottonee",
     "imageUrl": "https://images.pokemontcg.io/xy10/70.png",
     "subtype": "Basic",
@@ -3613,7 +3685,8 @@
     ]
   },
   {
-    "id": "xy10-71",
+    "setOrder":69,
+	"id": "xy10-71",
     "name": "Whimsicott",
     "imageUrl": "https://images.pokemontcg.io/xy10/71.png",
     "subtype": "Stage 1",
@@ -3657,7 +3730,8 @@
     "nationalPokedexNumber": 547
   },
   {
-    "id": "xy10-72",
+    "setOrder":69,
+	"id": "xy10-72",
     "name": "Diancie-EX",
     "imageUrl": "https://images.pokemontcg.io/xy10/72.png",
     "subtype": "EX",
@@ -3715,7 +3789,8 @@
     "evolvesTo": "M Diancie-EX"
   },
   {
-    "id": "xy10-73",
+    "setOrder":69,
+	"id": "xy10-73",
     "name": "Kingdra-EX",
     "imageUrl": "https://images.pokemontcg.io/xy10/73.png",
     "subtype": "EX",
@@ -3770,7 +3845,8 @@
     "nationalPokedexNumber": 230
   },
   {
-    "id": "xy10-74",
+    "setOrder":69,
+	"id": "xy10-74",
     "name": "Meowth",
     "imageUrl": "https://images.pokemontcg.io/xy10/74.png",
     "subtype": "Basic",
@@ -3814,7 +3890,8 @@
     ]
   },
   {
-    "id": "xy10-75",
+    "setOrder":69,
+	"id": "xy10-75",
     "name": "Kangaskhan",
     "imageUrl": "https://images.pokemontcg.io/xy10/75.png",
     "subtype": "Basic",
@@ -3869,7 +3946,8 @@
     "nationalPokedexNumber": 115
   },
   {
-    "id": "xy10-76",
+    "setOrder":69,
+	"id": "xy10-76",
     "name": "Aerodactyl",
     "imageUrl": "https://images.pokemontcg.io/xy10/76.png",
     "subtype": "Restored",
@@ -3925,7 +4003,8 @@
     "nationalPokedexNumber": 142
   },
   {
-    "id": "xy10-77",
+    "setOrder":69,
+	"id": "xy10-77",
     "name": "Snorlax",
     "imageUrl": "https://images.pokemontcg.io/xy10/77.png",
     "subtype": "Basic",
@@ -3982,7 +4061,8 @@
     "nationalPokedexNumber": 143
   },
   {
-    "id": "xy10-78",
+    "setOrder":69,
+	"id": "xy10-78",
     "name": "Lugia",
     "imageUrl": "https://images.pokemontcg.io/xy10/78.png",
     "subtype": "Basic",
@@ -4036,7 +4116,8 @@
     "nationalPokedexNumber": 249
   },
   {
-    "id": "xy10-79",
+    "setOrder":69,
+	"id": "xy10-79",
     "name": "Lugia BREAK",
     "imageUrl": "https://images.pokemontcg.io/xy10/79.png",
     "subtype": "BREAK",
@@ -4074,7 +4155,8 @@
     "nationalPokedexNumber": 249
   },
   {
-    "id": "xy10-80",
+    "setOrder":69,
+	"id": "xy10-80",
     "name": "Whismur",
     "imageUrl": "https://images.pokemontcg.io/xy10/80.png",
     "subtype": "Basic",
@@ -4128,7 +4210,8 @@
     ]
   },
   {
-    "id": "xy10-81",
+    "setOrder":69,
+	"id": "xy10-81",
     "name": "Loudred",
     "imageUrl": "https://images.pokemontcg.io/xy10/81.png",
     "subtype": "Stage 1",
@@ -4184,7 +4267,8 @@
     ]
   },
   {
-    "id": "xy10-82",
+    "setOrder":69,
+	"id": "xy10-82",
     "name": "Exploud",
     "imageUrl": "https://images.pokemontcg.io/xy10/82.png",
     "subtype": "Stage 2",
@@ -4240,7 +4324,8 @@
     "nationalPokedexNumber": 295
   },
   {
-    "id": "xy10-83",
+    "setOrder":69,
+	"id": "xy10-83",
     "name": "Altaria-EX",
     "imageUrl": "https://images.pokemontcg.io/xy10/83.png",
     "subtype": "EX",
@@ -4302,7 +4387,8 @@
     "evolvesTo": "M Altaria-EX"
   },
   {
-    "id": "xy10-84",
+    "setOrder":69,
+	"id": "xy10-84",
     "name": "Audino-EX",
     "imageUrl": "https://images.pokemontcg.io/xy10/84.png",
     "subtype": "EX",
@@ -4359,7 +4445,8 @@
     "evolvesTo": "M Audino-EX"
   },
   {
-    "id": "xy10-85",
+    "setOrder":69,
+	"id": "xy10-85",
     "name": "M Audino-EX",
     "imageUrl": "https://images.pokemontcg.io/xy10/85.png",
     "subtype": "MEGA",
@@ -4408,7 +4495,8 @@
     "nationalPokedexNumber": 531
   },
   {
-    "id": "xy10-86",
+    "setOrder":69,
+	"id": "xy10-86",
     "name": "Minccino",
     "imageUrl": "https://images.pokemontcg.io/xy10/86.png",
     "subtype": "Basic",
@@ -4451,7 +4539,8 @@
     ]
   },
   {
-    "id": "xy10-87",
+    "setOrder":69,
+	"id": "xy10-87",
     "name": "Minccino",
     "imageUrl": "https://images.pokemontcg.io/xy10/87.png",
     "subtype": "Basic",
@@ -4494,7 +4583,8 @@
     ]
   },
   {
-    "id": "xy10-88",
+    "setOrder":69,
+	"id": "xy10-88",
     "name": "Cinccino",
     "imageUrl": "https://images.pokemontcg.io/xy10/88.png",
     "subtype": "Stage 1",
@@ -4544,7 +4634,8 @@
     "nationalPokedexNumber": 573
   },
   {
-    "id": "xy10-89",
+    "setOrder":69,
+	"id": "xy10-89",
     "name": "Cinccino",
     "imageUrl": "https://images.pokemontcg.io/xy10/89.png",
     "subtype": "Stage 1",
@@ -4595,7 +4686,8 @@
     "nationalPokedexNumber": 573
   },
   {
-    "id": "xy10-90",
+    "setOrder":69,
+	"id": "xy10-90",
     "name": "Alakazam Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xy10/90.png",
     "subtype": "Pokémon Tool",
@@ -4612,7 +4704,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/90_hires.png"
   },
   {
-    "id": "xy10-91",
+    "setOrder":69,
+	"id": "xy10-91",
     "name": "Altaria Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xy10/91.png",
     "subtype": "Pokémon Tool",
@@ -4629,7 +4722,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/91_hires.png"
   },
   {
-    "id": "xy10-92",
+    "setOrder":69,
+	"id": "xy10-92",
     "name": "Audino Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xy10/92.png",
     "subtype": "Pokémon Tool",
@@ -4646,7 +4740,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/92_hires.png"
   },
   {
-    "id": "xy10-93",
+    "setOrder":69,
+	"id": "xy10-93",
     "name": "Bent Spoon",
     "imageUrl": "https://images.pokemontcg.io/xy10/93.png",
     "subtype": "Pokémon Tool",
@@ -4663,7 +4758,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/93_hires.png"
   },
   {
-    "id": "xy10-94",
+    "setOrder":69,
+	"id": "xy10-94",
     "name": "Chaos Tower",
     "imageUrl": "https://images.pokemontcg.io/xy10/94.png",
     "subtype": "Stadium",
@@ -4681,7 +4777,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/94_hires.png"
   },
   {
-    "id": "xy10-95",
+    "setOrder":69,
+	"id": "xy10-95",
     "name": "Devolution Spray",
     "imageUrl": "https://images.pokemontcg.io/xy10/95.png",
     "subtype": "Item",
@@ -4698,7 +4795,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/95_hires.png"
   },
   {
-    "id": "xy10-96",
+    "setOrder":69,
+	"id": "xy10-96",
     "name": "Dome Fossil Kabuto",
     "imageUrl": "https://images.pokemontcg.io/xy10/96.png",
     "subtype": "Item",
@@ -4715,7 +4813,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/96_hires.png"
   },
   {
-    "id": "xy10-97",
+    "setOrder":69,
+	"id": "xy10-97",
     "name": "Energy Pouch",
     "imageUrl": "https://images.pokemontcg.io/xy10/97.png",
     "subtype": "Pokémon Tool",
@@ -4732,7 +4831,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/97_hires.png"
   },
   {
-    "id": "xy10-98",
+    "setOrder":69,
+	"id": "xy10-98",
     "name": "Energy Reset",
     "imageUrl": "https://images.pokemontcg.io/xy10/98.png",
     "subtype": "Item",
@@ -4749,7 +4849,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/98_hires.png"
   },
   {
-    "id": "xy10-99",
+    "setOrder":69,
+	"id": "xy10-99",
     "name": "Fairy Drop",
     "imageUrl": "https://images.pokemontcg.io/xy10/99.png",
     "subtype": "Item",
@@ -4766,7 +4867,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/99_hires.png"
   },
   {
-    "id": "xy10-100",
+    "setOrder":69,
+	"id": "xy10-100",
     "name": "Fairy Garden",
     "imageUrl": "https://images.pokemontcg.io/xy10/100.png",
     "subtype": "Stadium",
@@ -4783,7 +4885,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/100_hires.png"
   },
   {
-    "id": "xy10-101",
+    "setOrder":69,
+	"id": "xy10-101",
     "name": "Fossil Excavation Kit",
     "imageUrl": "https://images.pokemontcg.io/xy10/101.png",
     "subtype": "Item",
@@ -4800,7 +4903,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/101_hires.png"
   },
   {
-    "id": "xy10-102",
+    "setOrder":69,
+	"id": "xy10-102",
     "name": "Helix Fossil Omanyte",
     "imageUrl": "https://images.pokemontcg.io/xy10/102.png",
     "subtype": "Item",
@@ -4817,7 +4921,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/102_hires.png"
   },
   {
-    "id": "xy10-103",
+    "setOrder":69,
+	"id": "xy10-103",
     "name": "Lass's Special",
     "imageUrl": "https://images.pokemontcg.io/xy10/103.png",
     "subtype": "Supporter",
@@ -4834,7 +4939,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/103_hires.png"
   },
   {
-    "id": "xy10-104",
+    "setOrder":69,
+	"id": "xy10-104",
     "name": "Mega Catcher",
     "imageUrl": "https://images.pokemontcg.io/xy10/104.png",
     "subtype": "Item",
@@ -4851,7 +4957,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/104_hires.png"
   },
   {
-    "id": "xy10-105",
+    "setOrder":69,
+	"id": "xy10-105",
     "name": "N",
     "imageUrl": "https://images.pokemontcg.io/xy10/105.png",
     "subtype": "Supporter",
@@ -4868,7 +4975,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/105_hires.png"
   },
   {
-    "id": "xy10-105a",
+    "setOrder":69,
+	"id": "xy10-105a",
     "name": "N",
     "imageUrl": "https://images.pokemontcg.io/xy10/105a.png",
     "subtype": "Supporter",
@@ -4885,7 +4993,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/105a_hires.png"
   },
   {
-    "id": "xy10-106",
+    "setOrder":69,
+	"id": "xy10-106",
     "name": "Old Amber Aerodactyl",
     "imageUrl": "https://images.pokemontcg.io/xy10/106.png",
     "subtype": "Item",
@@ -4902,7 +5011,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/106_hires.png"
   },
   {
-    "id": "xy10-107",
+    "setOrder":69,
+	"id": "xy10-107",
     "name": "Pokémon Fan Club",
     "imageUrl": "https://images.pokemontcg.io/xy10/107.png",
     "subtype": "Supporter",
@@ -4919,7 +5029,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/107_hires.png"
   },
   {
-    "id": "xy10-108",
+    "setOrder":69,
+	"id": "xy10-108",
     "name": "Power Memory",
     "imageUrl": "https://images.pokemontcg.io/xy10/108.png",
     "subtype": "Pokémon Tool",
@@ -4936,7 +5047,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/108_hires.png"
   },
   {
-    "id": "xy10-109",
+    "setOrder":69,
+	"id": "xy10-109",
     "name": "Random Receiver",
     "imageUrl": "https://images.pokemontcg.io/xy10/109.png",
     "subtype": "Item",
@@ -4953,7 +5065,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/109_hires.png"
   },
   {
-    "id": "xy10-110",
+    "setOrder":69,
+	"id": "xy10-110",
     "name": "Scorched Earth",
     "imageUrl": "https://images.pokemontcg.io/xy10/110.png",
     "subtype": "Stadium",
@@ -4970,7 +5083,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/110_hires.png"
   },
   {
-    "id": "xy10-111",
+    "setOrder":69,
+	"id": "xy10-111",
     "name": "Shauna",
     "imageUrl": "https://images.pokemontcg.io/xy10/111.png",
     "subtype": "Supporter",
@@ -4987,7 +5101,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/111_hires.png"
   },
   {
-    "id": "xy10-111a",
+    "setOrder":69,
+	"id": "xy10-111a",
     "name": "Shauna",
     "imageUrl": "https://images.pokemontcg.io/xy10/111a.png",
     "subtype": "Supporter",
@@ -5004,7 +5119,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/111a_hires.png"
   },
   {
-    "id": "xy10-112",
+    "setOrder":69,
+	"id": "xy10-112",
     "name": "Team Rocket's Handiwork",
     "imageUrl": "https://images.pokemontcg.io/xy10/112.png",
     "subtype": "Supporter",
@@ -5021,7 +5137,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/112_hires.png"
   },
   {
-    "id": "xy10-113",
+    "setOrder":69,
+	"id": "xy10-113",
     "name": "Ultra Ball",
     "imageUrl": "https://images.pokemontcg.io/xy10/113.png",
     "subtype": "Item",
@@ -5038,7 +5155,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/113_hires.png"
   },
   {
-    "id": "xy10-114",
+    "setOrder":69,
+	"id": "xy10-114",
     "name": "Double Colorless Energy",
     "imageUrl": "https://images.pokemontcg.io/xy10/114.png",
     "subtype": "Special",
@@ -5055,7 +5173,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/114_hires.png"
   },
   {
-    "id": "xy10-115",
+    "setOrder":69,
+	"id": "xy10-115",
     "name": "Strong Energy",
     "imageUrl": "https://images.pokemontcg.io/xy10/115.png",
     "subtype": "Special",
@@ -5072,7 +5191,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/115_hires.png"
   },
   {
-    "id": "xy10-116",
+    "setOrder":69,
+	"id": "xy10-116",
     "name": "Glaceon-EX",
     "imageUrl": "https://images.pokemontcg.io/xy10/116.png",
     "subtype": "EX",
@@ -5128,7 +5248,8 @@
     "nationalPokedexNumber": 471
   },
   {
-    "id": "xy10-117",
+    "setOrder":69,
+	"id": "xy10-117",
     "name": "Alakazam-EX",
     "imageUrl": "https://images.pokemontcg.io/xy10/117.png",
     "subtype": "EX",
@@ -5179,7 +5300,8 @@
     "evolvesTo": "M Alakazam-EX"
   },
   {
-    "id": "xy10-118",
+    "setOrder":69,
+	"id": "xy10-118",
     "name": "M Alakazam-EX",
     "imageUrl": "https://images.pokemontcg.io/xy10/118.png",
     "subtype": "MEGA",
@@ -5225,7 +5347,8 @@
     "nationalPokedexNumber": 65
   },
   {
-    "id": "xy10-119",
+    "setOrder":69,
+	"id": "xy10-119",
     "name": "Umbreon-EX",
     "imageUrl": "https://images.pokemontcg.io/xy10/119.png",
     "subtype": "EX",
@@ -5285,7 +5408,8 @@
     "nationalPokedexNumber": 197
   },
   {
-    "id": "xy10-120",
+    "setOrder":69,
+	"id": "xy10-120",
     "name": "Genesect-EX",
     "imageUrl": "https://images.pokemontcg.io/xy10/120.png",
     "subtype": "EX",
@@ -5342,7 +5466,8 @@
     "nationalPokedexNumber": 649
   },
   {
-    "id": "xy10-121",
+    "setOrder":69,
+	"id": "xy10-121",
     "name": "M Altaria-EX",
     "imageUrl": "https://images.pokemontcg.io/xy10/121.png",
     "subtype": "MEGA",
@@ -5396,7 +5521,8 @@
     "nationalPokedexNumber": 334
   },
   {
-    "id": "xy10-122",
+    "setOrder":69,
+	"id": "xy10-122",
     "name": "Kingdra-EX",
     "imageUrl": "https://images.pokemontcg.io/xy10/122.png",
     "subtype": "EX",
@@ -5451,7 +5577,8 @@
     "nationalPokedexNumber": 230
   },
   {
-    "id": "xy10-123",
+    "setOrder":69,
+	"id": "xy10-123",
     "name": "Altaria-EX",
     "imageUrl": "https://images.pokemontcg.io/xy10/123.png",
     "subtype": "EX",
@@ -5513,7 +5640,8 @@
     "evolvesTo": "M Altaria-EX"
   },
   {
-    "id": "xy10-124",
+    "setOrder":69,
+	"id": "xy10-124",
     "name": "Team Rocket's Handiwork",
     "imageUrl": "https://images.pokemontcg.io/xy10/124.png",
     "subtype": "Supporter",
@@ -5530,7 +5658,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy10/124_hires.png"
   },
   {
-    "id": "xy10-125",
+    "setOrder":69,
+	"id": "xy10-125",
     "name": "Alakazam-EX",
     "imageUrl": "https://images.pokemontcg.io/xy10/125.png",
     "subtype": "EX",

--- a/json/cards/FireRed & LeafGreen.json
+++ b/json/cards/FireRed & LeafGreen.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "ex6-1",
+    "setOrder":21,
+	"id": "ex6-1",
     "name": "Beedrill",
     "imageUrl": "https://images.pokemontcg.io/ex6/1.png",
     "subtype": "Stage 2",
@@ -49,7 +50,8 @@
     "nationalPokedexNumber": 15
   },
   {
-    "id": "ex6-2",
+    "setOrder":21,
+	"id": "ex6-2",
     "name": "Butterfree",
     "imageUrl": "https://images.pokemontcg.io/ex6/2.png",
     "subtype": "Stage 2",
@@ -110,7 +112,8 @@
     "nationalPokedexNumber": 12
   },
   {
-    "id": "ex6-3",
+    "setOrder":21,
+	"id": "ex6-3",
     "name": "Dewgong",
     "imageUrl": "https://images.pokemontcg.io/ex6/3.png",
     "subtype": "Stage 1",
@@ -168,7 +171,8 @@
     "nationalPokedexNumber": 87
   },
   {
-    "id": "ex6-4",
+    "setOrder":21,
+	"id": "ex6-4",
     "name": "Ditto",
     "imageUrl": "https://images.pokemontcg.io/ex6/4.png",
     "subtype": "Basic",
@@ -213,7 +217,8 @@
     "nationalPokedexNumber": 132
   },
   {
-    "id": "ex6-5",
+    "setOrder":21,
+	"id": "ex6-5",
     "name": "Exeggutor",
     "imageUrl": "https://images.pokemontcg.io/ex6/5.png",
     "subtype": "Stage 1",
@@ -265,7 +270,8 @@
     "nationalPokedexNumber": 103
   },
   {
-    "id": "ex6-6",
+    "setOrder":21,
+	"id": "ex6-6",
     "name": "Kangaskhan",
     "imageUrl": "https://images.pokemontcg.io/ex6/6.png",
     "subtype": "Basic",
@@ -327,7 +333,8 @@
     "nationalPokedexNumber": 115
   },
   {
-    "id": "ex6-7",
+    "setOrder":21,
+	"id": "ex6-7",
     "name": "Marowak",
     "imageUrl": "https://images.pokemontcg.io/ex6/7.png",
     "subtype": "Stage 1",
@@ -380,7 +387,8 @@
     "nationalPokedexNumber": 105
   },
   {
-    "id": "ex6-8",
+    "setOrder":21,
+	"id": "ex6-8",
     "name": "Nidoking",
     "imageUrl": "https://images.pokemontcg.io/ex6/8.png",
     "subtype": "Stage 2",
@@ -441,7 +449,8 @@
     "nationalPokedexNumber": 34
   },
   {
-    "id": "ex6-9",
+    "setOrder":21,
+	"id": "ex6-9",
     "name": "Nidoqueen",
     "imageUrl": "https://images.pokemontcg.io/ex6/9.png",
     "subtype": "Stage 2",
@@ -499,7 +508,8 @@
     "nationalPokedexNumber": 31
   },
   {
-    "id": "ex6-10",
+    "setOrder":21,
+	"id": "ex6-10",
     "name": "Pidgeot",
     "imageUrl": "https://images.pokemontcg.io/ex6/10.png",
     "subtype": "Stage 2",
@@ -549,7 +559,8 @@
     "nationalPokedexNumber": 18
   },
   {
-    "id": "ex6-11",
+    "setOrder":21,
+	"id": "ex6-11",
     "name": "Poliwrath",
     "imageUrl": "https://images.pokemontcg.io/ex6/11.png",
     "subtype": "Stage 2",
@@ -608,7 +619,8 @@
     "nationalPokedexNumber": 62
   },
   {
-    "id": "ex6-12",
+    "setOrder":21,
+	"id": "ex6-12",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/ex6/12.png",
     "subtype": "Stage 1",
@@ -660,7 +672,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "ex6-13",
+    "setOrder":21,
+	"id": "ex6-13",
     "name": "Rapidash",
     "imageUrl": "https://images.pokemontcg.io/ex6/13.png",
     "subtype": "Stage 1",
@@ -718,7 +731,8 @@
     "nationalPokedexNumber": 78
   },
   {
-    "id": "ex6-14",
+    "setOrder":21,
+	"id": "ex6-14",
     "name": "Slowbro",
     "imageUrl": "https://images.pokemontcg.io/ex6/14.png",
     "subtype": "Stage 1",
@@ -765,7 +779,8 @@
     "nationalPokedexNumber": 80
   },
   {
-    "id": "ex6-15",
+    "setOrder":21,
+	"id": "ex6-15",
     "name": "Snorlax",
     "imageUrl": "https://images.pokemontcg.io/ex6/15.png",
     "subtype": "Basic",
@@ -823,7 +838,8 @@
     "nationalPokedexNumber": 143
   },
   {
-    "id": "ex6-16",
+    "setOrder":21,
+	"id": "ex6-16",
     "name": "Tauros",
     "imageUrl": "https://images.pokemontcg.io/ex6/16.png",
     "subtype": "Basic",
@@ -874,7 +890,8 @@
     "nationalPokedexNumber": 128
   },
   {
-    "id": "ex6-17",
+    "setOrder":21,
+	"id": "ex6-17",
     "name": "Victreebel",
     "imageUrl": "https://images.pokemontcg.io/ex6/17.png",
     "subtype": "Stage 2",
@@ -923,7 +940,8 @@
     "nationalPokedexNumber": 71
   },
   {
-    "id": "ex6-18",
+    "setOrder":21,
+	"id": "ex6-18",
     "name": "Arcanine",
     "imageUrl": "https://images.pokemontcg.io/ex6/18.png",
     "subtype": "Stage 1",
@@ -977,7 +995,8 @@
     "nationalPokedexNumber": 59
   },
   {
-    "id": "ex6-19",
+    "setOrder":21,
+	"id": "ex6-19",
     "name": "Chansey",
     "imageUrl": "https://images.pokemontcg.io/ex6/19.png",
     "subtype": "Basic",
@@ -1032,7 +1051,8 @@
     ]
   },
   {
-    "id": "ex6-20",
+    "setOrder":21,
+	"id": "ex6-20",
     "name": "Cloyster",
     "imageUrl": "https://images.pokemontcg.io/ex6/20.png",
     "subtype": "Stage 1",
@@ -1090,7 +1110,8 @@
     "nationalPokedexNumber": 91
   },
   {
-    "id": "ex6-21",
+    "setOrder":21,
+	"id": "ex6-21",
     "name": "Dodrio",
     "imageUrl": "https://images.pokemontcg.io/ex6/21.png",
     "subtype": "Stage 1",
@@ -1143,7 +1164,8 @@
     "nationalPokedexNumber": 85
   },
   {
-    "id": "ex6-22",
+    "setOrder":21,
+	"id": "ex6-22",
     "name": "Dugtrio",
     "imageUrl": "https://images.pokemontcg.io/ex6/22.png",
     "subtype": "Stage 1",
@@ -1196,7 +1218,8 @@
     "nationalPokedexNumber": 51
   },
   {
-    "id": "ex6-23",
+    "setOrder":21,
+	"id": "ex6-23",
     "name": "Farfetch'd",
     "imageUrl": "https://images.pokemontcg.io/ex6/23.png",
     "subtype": "Basic",
@@ -1251,7 +1274,8 @@
     "nationalPokedexNumber": 83
   },
   {
-    "id": "ex6-24",
+    "setOrder":21,
+	"id": "ex6-24",
     "name": "Fearow",
     "imageUrl": "https://images.pokemontcg.io/ex6/24.png",
     "subtype": "Stage 1",
@@ -1315,7 +1339,8 @@
     "nationalPokedexNumber": 22
   },
   {
-    "id": "ex6-25",
+    "setOrder":21,
+	"id": "ex6-25",
     "name": "Hypno",
     "imageUrl": "https://images.pokemontcg.io/ex6/25.png",
     "subtype": "Stage 1",
@@ -1362,7 +1387,8 @@
     "nationalPokedexNumber": 97
   },
   {
-    "id": "ex6-26",
+    "setOrder":21,
+	"id": "ex6-26",
     "name": "Kingler",
     "imageUrl": "https://images.pokemontcg.io/ex6/26.png",
     "subtype": "Stage 1",
@@ -1414,7 +1440,8 @@
     "nationalPokedexNumber": 99
   },
   {
-    "id": "ex6-27",
+    "setOrder":21,
+	"id": "ex6-27",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/ex6/27.png",
     "subtype": "Stage 1",
@@ -1476,7 +1503,8 @@
     ]
   },
   {
-    "id": "ex6-28",
+    "setOrder":21,
+	"id": "ex6-28",
     "name": "Primeape",
     "imageUrl": "https://images.pokemontcg.io/ex6/28.png",
     "subtype": "Stage 1",
@@ -1525,7 +1553,8 @@
     "nationalPokedexNumber": 57
   },
   {
-    "id": "ex6-29",
+    "setOrder":21,
+	"id": "ex6-29",
     "name": "Scyther",
     "imageUrl": "https://images.pokemontcg.io/ex6/29.png",
     "subtype": "Basic",
@@ -1574,7 +1603,8 @@
     ]
   },
   {
-    "id": "ex6-30",
+    "setOrder":21,
+	"id": "ex6-30",
     "name": "Tangela",
     "imageUrl": "https://images.pokemontcg.io/ex6/30.png",
     "subtype": "Basic",
@@ -1632,7 +1662,8 @@
     ]
   },
   {
-    "id": "ex6-31",
+    "setOrder":21,
+	"id": "ex6-31",
     "name": "Charmeleon",
     "imageUrl": "https://images.pokemontcg.io/ex6/31.png",
     "subtype": "Stage 1",
@@ -1688,7 +1719,8 @@
     ]
   },
   {
-    "id": "ex6-32",
+    "setOrder":21,
+	"id": "ex6-32",
     "name": "Drowzee",
     "imageUrl": "https://images.pokemontcg.io/ex6/32.png",
     "subtype": "Basic",
@@ -1740,7 +1772,8 @@
     ]
   },
   {
-    "id": "ex6-33",
+    "setOrder":21,
+	"id": "ex6-33",
     "name": "Exeggcute",
     "imageUrl": "https://images.pokemontcg.io/ex6/33.png",
     "subtype": "Basic",
@@ -1793,7 +1826,8 @@
     ]
   },
   {
-    "id": "ex6-34",
+    "setOrder":21,
+	"id": "ex6-34",
     "name": "Haunter",
     "imageUrl": "https://images.pokemontcg.io/ex6/34.png",
     "subtype": "Stage 1",
@@ -1849,7 +1883,8 @@
     ]
   },
   {
-    "id": "ex6-35",
+    "setOrder":21,
+	"id": "ex6-35",
     "name": "Ivysaur",
     "imageUrl": "https://images.pokemontcg.io/ex6/35.png",
     "subtype": "Stage 1",
@@ -1904,7 +1939,8 @@
     ]
   },
   {
-    "id": "ex6-36",
+    "setOrder":21,
+	"id": "ex6-36",
     "name": "Kakuna",
     "imageUrl": "https://images.pokemontcg.io/ex6/36.png",
     "subtype": "Stage 1",
@@ -1954,7 +1990,8 @@
     ]
   },
   {
-    "id": "ex6-37",
+    "setOrder":21,
+	"id": "ex6-37",
     "name": "Lickitung",
     "imageUrl": "https://images.pokemontcg.io/ex6/37.png",
     "subtype": "Basic",
@@ -2008,7 +2045,8 @@
     ]
   },
   {
-    "id": "ex6-38",
+    "setOrder":21,
+	"id": "ex6-38",
     "name": "Mankey",
     "imageUrl": "https://images.pokemontcg.io/ex6/38.png",
     "subtype": "Basic",
@@ -2061,7 +2099,8 @@
     ]
   },
   {
-    "id": "ex6-39",
+    "setOrder":21,
+	"id": "ex6-39",
     "name": "Metapod",
     "imageUrl": "https://images.pokemontcg.io/ex6/39.png",
     "subtype": "Stage 1",
@@ -2112,7 +2151,8 @@
     ]
   },
   {
-    "id": "ex6-40",
+    "setOrder":21,
+	"id": "ex6-40",
     "name": "Nidorina",
     "imageUrl": "https://images.pokemontcg.io/ex6/40.png",
     "subtype": "Stage 1",
@@ -2166,7 +2206,8 @@
     ]
   },
   {
-    "id": "ex6-41",
+    "setOrder":21,
+	"id": "ex6-41",
     "name": "Nidorino",
     "imageUrl": "https://images.pokemontcg.io/ex6/41.png",
     "subtype": "Stage 1",
@@ -2221,7 +2262,8 @@
     ]
   },
   {
-    "id": "ex6-42",
+    "setOrder":21,
+	"id": "ex6-42",
     "name": "Onix",
     "imageUrl": "https://images.pokemontcg.io/ex6/42.png",
     "subtype": "Basic",
@@ -2276,7 +2318,8 @@
     ]
   },
   {
-    "id": "ex6-43",
+    "setOrder":21,
+	"id": "ex6-43",
     "name": "Parasect",
     "imageUrl": "https://images.pokemontcg.io/ex6/43.png",
     "subtype": "Stage 1",
@@ -2327,7 +2370,8 @@
     "nationalPokedexNumber": 47
   },
   {
-    "id": "ex6-44",
+    "setOrder":21,
+	"id": "ex6-44",
     "name": "Persian",
     "imageUrl": "https://images.pokemontcg.io/ex6/44.png",
     "subtype": "Stage 1",
@@ -2383,7 +2427,8 @@
     "nationalPokedexNumber": 53
   },
   {
-    "id": "ex6-45",
+    "setOrder":21,
+	"id": "ex6-45",
     "name": "Pidgeotto",
     "imageUrl": "https://images.pokemontcg.io/ex6/45.png",
     "subtype": "Stage 1",
@@ -2440,7 +2485,8 @@
     ]
   },
   {
-    "id": "ex6-46",
+    "setOrder":21,
+	"id": "ex6-46",
     "name": "Poliwhirl",
     "imageUrl": "https://images.pokemontcg.io/ex6/46.png",
     "subtype": "Stage 1",
@@ -2495,7 +2541,8 @@
     ]
   },
   {
-    "id": "ex6-47",
+    "setOrder":21,
+	"id": "ex6-47",
     "name": "Porygon",
     "imageUrl": "https://images.pokemontcg.io/ex6/47.png",
     "subtype": "Basic",
@@ -2548,7 +2595,8 @@
     ]
   },
   {
-    "id": "ex6-48",
+    "setOrder":21,
+	"id": "ex6-48",
     "name": "Raticate",
     "imageUrl": "https://images.pokemontcg.io/ex6/48.png",
     "subtype": "Stage 1",
@@ -2600,7 +2648,8 @@
     "nationalPokedexNumber": 20
   },
   {
-    "id": "ex6-49",
+    "setOrder":21,
+	"id": "ex6-49",
     "name": "Venomoth",
     "imageUrl": "https://images.pokemontcg.io/ex6/49.png",
     "subtype": "Stage 1",
@@ -2653,7 +2702,8 @@
     "nationalPokedexNumber": 49
   },
   {
-    "id": "ex6-50",
+    "setOrder":21,
+	"id": "ex6-50",
     "name": "Wartortle",
     "imageUrl": "https://images.pokemontcg.io/ex6/50.png",
     "subtype": "Stage 1",
@@ -2709,7 +2759,8 @@
     ]
   },
   {
-    "id": "ex6-51",
+    "setOrder":21,
+	"id": "ex6-51",
     "name": "Weepinbell",
     "imageUrl": "https://images.pokemontcg.io/ex6/51.png",
     "subtype": "Stage 1",
@@ -2763,7 +2814,8 @@
     ]
   },
   {
-    "id": "ex6-52",
+    "setOrder":21,
+	"id": "ex6-52",
     "name": "Wigglytuff",
     "imageUrl": "https://images.pokemontcg.io/ex6/52.png",
     "subtype": "Stage 1",
@@ -2810,7 +2862,8 @@
     "nationalPokedexNumber": 40
   },
   {
-    "id": "ex6-53",
+    "setOrder":21,
+	"id": "ex6-53",
     "name": "Bellsprout",
     "imageUrl": "https://images.pokemontcg.io/ex6/53.png",
     "subtype": "Basic",
@@ -2853,7 +2906,8 @@
     ]
   },
   {
-    "id": "ex6-54",
+    "setOrder":21,
+	"id": "ex6-54",
     "name": "Bulbasaur",
     "imageUrl": "https://images.pokemontcg.io/ex6/54.png",
     "subtype": "Basic",
@@ -2906,7 +2960,8 @@
     ]
   },
   {
-    "id": "ex6-55",
+    "setOrder":21,
+	"id": "ex6-55",
     "name": "Bulbasaur",
     "imageUrl": "https://images.pokemontcg.io/ex6/55.png",
     "subtype": "Basic",
@@ -2959,7 +3014,8 @@
     ]
   },
   {
-    "id": "ex6-56",
+    "setOrder":21,
+	"id": "ex6-56",
     "name": "Caterpie",
     "imageUrl": "https://images.pokemontcg.io/ex6/56.png",
     "subtype": "Basic",
@@ -3011,7 +3067,8 @@
     ]
   },
   {
-    "id": "ex6-57",
+    "setOrder":21,
+	"id": "ex6-57",
     "name": "Charmander",
     "imageUrl": "https://images.pokemontcg.io/ex6/57.png",
     "subtype": "Basic",
@@ -3054,7 +3111,8 @@
     ]
   },
   {
-    "id": "ex6-58",
+    "setOrder":21,
+	"id": "ex6-58",
     "name": "Charmander",
     "imageUrl": "https://images.pokemontcg.io/ex6/58.png",
     "subtype": "Basic",
@@ -3107,7 +3165,8 @@
     ]
   },
   {
-    "id": "ex6-59",
+    "setOrder":21,
+	"id": "ex6-59",
     "name": "Clefairy",
     "imageUrl": "https://images.pokemontcg.io/ex6/59.png",
     "subtype": "Basic",
@@ -3160,7 +3219,8 @@
     ]
   },
   {
-    "id": "ex6-60",
+    "setOrder":21,
+	"id": "ex6-60",
     "name": "Cubone",
     "imageUrl": "https://images.pokemontcg.io/ex6/60.png",
     "subtype": "Basic",
@@ -3213,7 +3273,8 @@
     ]
   },
   {
-    "id": "ex6-61",
+    "setOrder":21,
+	"id": "ex6-61",
     "name": "Diglett",
     "imageUrl": "https://images.pokemontcg.io/ex6/61.png",
     "subtype": "Basic",
@@ -3256,7 +3317,8 @@
     ]
   },
   {
-    "id": "ex6-62",
+    "setOrder":21,
+	"id": "ex6-62",
     "name": "Doduo",
     "imageUrl": "https://images.pokemontcg.io/ex6/62.png",
     "subtype": "Basic",
@@ -3315,7 +3377,8 @@
     ]
   },
   {
-    "id": "ex6-63",
+    "setOrder":21,
+	"id": "ex6-63",
     "name": "Gastly",
     "imageUrl": "https://images.pokemontcg.io/ex6/63.png",
     "subtype": "Basic",
@@ -3364,7 +3427,8 @@
     ]
   },
   {
-    "id": "ex6-64",
+    "setOrder":21,
+	"id": "ex6-64",
     "name": "Growlithe",
     "imageUrl": "https://images.pokemontcg.io/ex6/64.png",
     "subtype": "Basic",
@@ -3419,7 +3483,8 @@
     ]
   },
   {
-    "id": "ex6-65",
+    "setOrder":21,
+	"id": "ex6-65",
     "name": "Jigglypuff",
     "imageUrl": "https://images.pokemontcg.io/ex6/65.png",
     "subtype": "Basic",
@@ -3472,7 +3537,8 @@
     ]
   },
   {
-    "id": "ex6-66",
+    "setOrder":21,
+	"id": "ex6-66",
     "name": "Krabby",
     "imageUrl": "https://images.pokemontcg.io/ex6/66.png",
     "subtype": "Basic",
@@ -3525,7 +3591,8 @@
     ]
   },
   {
-    "id": "ex6-67",
+    "setOrder":21,
+	"id": "ex6-67",
     "name": "Magikarp",
     "imageUrl": "https://images.pokemontcg.io/ex6/67.png",
     "subtype": "Basic",
@@ -3578,7 +3645,8 @@
     ]
   },
   {
-    "id": "ex6-68",
+    "setOrder":21,
+	"id": "ex6-68",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/ex6/68.png",
     "subtype": "Basic",
@@ -3637,7 +3705,8 @@
     ]
   },
   {
-    "id": "ex6-69",
+    "setOrder":21,
+	"id": "ex6-69",
     "name": "Meowth",
     "imageUrl": "https://images.pokemontcg.io/ex6/69.png",
     "subtype": "Basic",
@@ -3690,7 +3759,8 @@
     ]
   },
   {
-    "id": "ex6-70",
+    "setOrder":21,
+	"id": "ex6-70",
     "name": "Nidoran♀",
     "imageUrl": "https://images.pokemontcg.io/ex6/70.png",
     "subtype": "Basic",
@@ -3743,7 +3813,8 @@
     ]
   },
   {
-    "id": "ex6-71",
+    "setOrder":21,
+	"id": "ex6-71",
     "name": "Nidoran♂",
     "imageUrl": "https://images.pokemontcg.io/ex6/71.png",
     "subtype": "Basic",
@@ -3795,7 +3866,8 @@
     ]
   },
   {
-    "id": "ex6-72",
+    "setOrder":21,
+	"id": "ex6-72",
     "name": "Paras",
     "imageUrl": "https://images.pokemontcg.io/ex6/72.png",
     "subtype": "Basic",
@@ -3847,7 +3919,8 @@
     ]
   },
   {
-    "id": "ex6-73",
+    "setOrder":21,
+	"id": "ex6-73",
     "name": "Pidgey",
     "imageUrl": "https://images.pokemontcg.io/ex6/73.png",
     "subtype": "Basic",
@@ -3906,7 +3979,8 @@
     ]
   },
   {
-    "id": "ex6-74",
+    "setOrder":21,
+	"id": "ex6-74",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/ex6/74.png",
     "subtype": "Basic",
@@ -3949,7 +4023,8 @@
     ]
   },
   {
-    "id": "ex6-75",
+    "setOrder":21,
+	"id": "ex6-75",
     "name": "Poliwag",
     "imageUrl": "https://images.pokemontcg.io/ex6/75.png",
     "subtype": "Basic",
@@ -4002,7 +4077,8 @@
     ]
   },
   {
-    "id": "ex6-76",
+    "setOrder":21,
+	"id": "ex6-76",
     "name": "Ponyta",
     "imageUrl": "https://images.pokemontcg.io/ex6/76.png",
     "subtype": "Basic",
@@ -4046,7 +4122,8 @@
     ]
   },
   {
-    "id": "ex6-77",
+    "setOrder":21,
+	"id": "ex6-77",
     "name": "Rattata",
     "imageUrl": "https://images.pokemontcg.io/ex6/77.png",
     "subtype": "Basic",
@@ -4098,7 +4175,8 @@
     ]
   },
   {
-    "id": "ex6-78",
+    "setOrder":21,
+	"id": "ex6-78",
     "name": "Seel",
     "imageUrl": "https://images.pokemontcg.io/ex6/78.png",
     "subtype": "Basic",
@@ -4141,7 +4219,8 @@
     ]
   },
   {
-    "id": "ex6-79",
+    "setOrder":21,
+	"id": "ex6-79",
     "name": "Shellder",
     "imageUrl": "https://images.pokemontcg.io/ex6/79.png",
     "subtype": "Basic",
@@ -4193,7 +4272,8 @@
     ]
   },
   {
-    "id": "ex6-80",
+    "setOrder":21,
+	"id": "ex6-80",
     "name": "Slowpoke",
     "imageUrl": "https://images.pokemontcg.io/ex6/80.png",
     "subtype": "Basic",
@@ -4237,7 +4317,8 @@
     ]
   },
   {
-    "id": "ex6-81",
+    "setOrder":21,
+	"id": "ex6-81",
     "name": "Spearow",
     "imageUrl": "https://images.pokemontcg.io/ex6/81.png",
     "subtype": "Basic",
@@ -4296,7 +4377,8 @@
     ]
   },
   {
-    "id": "ex6-82",
+    "setOrder":21,
+	"id": "ex6-82",
     "name": "Squirtle",
     "imageUrl": "https://images.pokemontcg.io/ex6/82.png",
     "subtype": "Basic",
@@ -4339,7 +4421,8 @@
     ]
   },
   {
-    "id": "ex6-83",
+    "setOrder":21,
+	"id": "ex6-83",
     "name": "Squirtle",
     "imageUrl": "https://images.pokemontcg.io/ex6/83.png",
     "subtype": "Basic",
@@ -4392,7 +4475,8 @@
     ]
   },
   {
-    "id": "ex6-84",
+    "setOrder":21,
+	"id": "ex6-84",
     "name": "Venonat",
     "imageUrl": "https://images.pokemontcg.io/ex6/84.png",
     "subtype": "Basic",
@@ -4444,7 +4528,8 @@
     ]
   },
   {
-    "id": "ex6-85",
+    "setOrder":21,
+	"id": "ex6-85",
     "name": "Voltorb",
     "imageUrl": "https://images.pokemontcg.io/ex6/85.png",
     "subtype": "Basic",
@@ -4493,7 +4578,8 @@
     ]
   },
   {
-    "id": "ex6-86",
+    "setOrder":21,
+	"id": "ex6-86",
     "name": "Weedle",
     "imageUrl": "https://images.pokemontcg.io/ex6/86.png",
     "subtype": "Basic",
@@ -4545,7 +4631,8 @@
     ]
   },
   {
-    "id": "ex6-87",
+    "setOrder":21,
+	"id": "ex6-87",
     "name": "Bill's Maintenance",
     "imageUrl": "https://images.pokemontcg.io/ex6/87.png",
     "subtype": "Supporter",
@@ -4564,7 +4651,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex6/87_hires.png"
   },
   {
-    "id": "ex6-88",
+    "setOrder":21,
+	"id": "ex6-88",
     "name": "Celio's Network",
     "imageUrl": "https://images.pokemontcg.io/ex6/88.png",
     "subtype": "Supporter",
@@ -4583,7 +4671,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex6/88_hires.png"
   },
   {
-    "id": "ex6-89",
+    "setOrder":21,
+	"id": "ex6-89",
     "name": "Energy Removal 2",
     "imageUrl": "https://images.pokemontcg.io/ex6/89.png",
     "subtype": "Item",
@@ -4601,7 +4690,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex6/89_hires.png"
   },
   {
-    "id": "ex6-90",
+    "setOrder":21,
+	"id": "ex6-90",
     "name": "Energy Switch",
     "imageUrl": "https://images.pokemontcg.io/ex6/90.png",
     "subtype": "Item",
@@ -4619,7 +4709,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex6/90_hires.png"
   },
   {
-    "id": "ex6-91",
+    "setOrder":21,
+	"id": "ex6-91",
     "name": "EXP. ALL",
     "imageUrl": "https://images.pokemontcg.io/ex6/91.png",
     "subtype": "Pokémon Tool",
@@ -4638,7 +4729,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex6/91_hires.png"
   },
   {
-    "id": "ex6-92",
+    "setOrder":21,
+	"id": "ex6-92",
     "name": "Great Ball",
     "imageUrl": "https://images.pokemontcg.io/ex6/92.png",
     "subtype": "Item",
@@ -4656,7 +4748,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex6/92_hires.png"
   },
   {
-    "id": "ex6-93",
+    "setOrder":21,
+	"id": "ex6-93",
     "name": "Life Herb",
     "imageUrl": "https://images.pokemontcg.io/ex6/93.png",
     "subtype": "Item",
@@ -4674,7 +4767,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex6/93_hires.png"
   },
   {
-    "id": "ex6-94",
+    "setOrder":21,
+	"id": "ex6-94",
     "name": "Mt. Moon",
     "imageUrl": "https://images.pokemontcg.io/ex6/94.png",
     "subtype": "Stadium",
@@ -4693,7 +4787,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex6/94_hires.png"
   },
   {
-    "id": "ex6-95",
+    "setOrder":21,
+	"id": "ex6-95",
     "name": "Poké Ball",
     "imageUrl": "https://images.pokemontcg.io/ex6/95.png",
     "subtype": "Item",
@@ -4711,7 +4806,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex6/95_hires.png"
   },
   {
-    "id": "ex6-96",
+    "setOrder":21,
+	"id": "ex6-96",
     "name": "PokéDex (HANDY909)",
     "imageUrl": "https://images.pokemontcg.io/ex6/96.png",
     "subtype": "Item",
@@ -4729,7 +4825,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex6/96_hires.png"
   },
   {
-    "id": "ex6-97",
+    "setOrder":21,
+	"id": "ex6-97",
     "name": "Pokémon Reversal",
     "imageUrl": "https://images.pokemontcg.io/ex6/97.png",
     "subtype": "Item",
@@ -4747,7 +4844,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex6/97_hires.png"
   },
   {
-    "id": "ex6-98",
+    "setOrder":21,
+	"id": "ex6-98",
     "name": "Prof. Oak's Research",
     "imageUrl": "https://images.pokemontcg.io/ex6/98.png",
     "subtype": "Supporter",
@@ -4766,7 +4864,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex6/98_hires.png"
   },
   {
-    "id": "ex6-99",
+    "setOrder":21,
+	"id": "ex6-99",
     "name": "Super Scoop Up",
     "imageUrl": "https://images.pokemontcg.io/ex6/99.png",
     "subtype": "Item",
@@ -4784,7 +4883,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex6/99_hires.png"
   },
   {
-    "id": "ex6-100",
+    "setOrder":21,
+	"id": "ex6-100",
     "name": "VS Seeker",
     "imageUrl": "https://images.pokemontcg.io/ex6/100.png",
     "subtype": "Item",
@@ -4802,7 +4902,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex6/100_hires.png"
   },
   {
-    "id": "ex6-101",
+    "setOrder":21,
+	"id": "ex6-101",
     "name": "Potion",
     "imageUrl": "https://images.pokemontcg.io/ex6/101.png",
     "subtype": "Item",
@@ -4820,7 +4921,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex6/101_hires.png"
   },
   {
-    "id": "ex6-102",
+    "setOrder":21,
+	"id": "ex6-102",
     "name": "Switch",
     "imageUrl": "https://images.pokemontcg.io/ex6/102.png",
     "subtype": "Item",
@@ -4838,7 +4940,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex6/102_hires.png"
   },
   {
-    "id": "ex6-103",
+    "setOrder":21,
+	"id": "ex6-103",
     "name": "Multi Energy",
     "imageUrl": "https://images.pokemontcg.io/ex6/103.png",
     "subtype": "Special",
@@ -4856,7 +4959,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex6/103_hires.png"
   },
   {
-    "id": "ex6-104",
+    "setOrder":21,
+	"id": "ex6-104",
     "name": "Blastoise ex",
     "imageUrl": "https://images.pokemontcg.io/ex6/104.png",
     "subtype": "EX",
@@ -4908,7 +5012,8 @@
     "nationalPokedexNumber": 9
   },
   {
-    "id": "ex6-105",
+    "setOrder":21,
+	"id": "ex6-105",
     "name": "Charizard ex",
     "imageUrl": "https://images.pokemontcg.io/ex6/105.png",
     "subtype": "EX",
@@ -4975,7 +5080,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "ex6-106",
+    "setOrder":21,
+	"id": "ex6-106",
     "name": "Clefable ex",
     "imageUrl": "https://images.pokemontcg.io/ex6/106.png",
     "subtype": "EX",
@@ -5029,7 +5135,8 @@
     "nationalPokedexNumber": 36
   },
   {
-    "id": "ex6-107",
+    "setOrder":21,
+	"id": "ex6-107",
     "name": "Electrode ex",
     "imageUrl": "https://images.pokemontcg.io/ex6/107.png",
     "subtype": "EX",
@@ -5077,7 +5184,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "ex6-108",
+    "setOrder":21,
+	"id": "ex6-108",
     "name": "Gengar ex",
     "imageUrl": "https://images.pokemontcg.io/ex6/108.png",
     "subtype": "EX",
@@ -5146,7 +5254,8 @@
     "nationalPokedexNumber": 94
   },
   {
-    "id": "ex6-109",
+    "setOrder":21,
+	"id": "ex6-109",
     "name": "Gyarados ex",
     "imageUrl": "https://images.pokemontcg.io/ex6/109.png",
     "subtype": "EX",
@@ -5204,7 +5313,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "ex6-110",
+    "setOrder":21,
+	"id": "ex6-110",
     "name": "Mr. Mime ex",
     "imageUrl": "https://images.pokemontcg.io/ex6/110.png",
     "subtype": "EX",
@@ -5245,7 +5355,8 @@
     "nationalPokedexNumber": 122
   },
   {
-    "id": "ex6-111",
+    "setOrder":21,
+	"id": "ex6-111",
     "name": "Mr. Mime ex",
     "imageUrl": "https://images.pokemontcg.io/ex6/111.png",
     "subtype": "EX",
@@ -5286,7 +5397,8 @@
     "nationalPokedexNumber": 122
   },
   {
-    "id": "ex6-112",
+    "setOrder":21,
+	"id": "ex6-112",
     "name": "Venusaur ex",
     "imageUrl": "https://images.pokemontcg.io/ex6/112.png",
     "subtype": "EX",

--- a/json/cards/Flashfire.json
+++ b/json/cards/Flashfire.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "xy2-1",
+    "setOrder":60,
+	"id": "xy2-1",
     "name": "Caterpie",
     "imageUrl": "https://images.pokemontcg.io/xy2/1.png",
     "subtype": "Basic",
@@ -48,7 +49,8 @@
     ]
   },
   {
-    "id": "xy2-2",
+    "setOrder":60,
+	"id": "xy2-2",
     "name": "Metapod",
     "imageUrl": "https://images.pokemontcg.io/xy2/2.png",
     "subtype": "Stage 1",
@@ -99,7 +101,8 @@
     ]
   },
   {
-    "id": "xy2-3",
+    "setOrder":60,
+	"id": "xy2-3",
     "name": "Butterfree",
     "imageUrl": "https://images.pokemontcg.io/xy2/3.png",
     "subtype": "Stage 2",
@@ -157,7 +160,8 @@
     "nationalPokedexNumber": 12
   },
   {
-    "id": "xy2-4",
+    "setOrder":60,
+	"id": "xy2-4",
     "name": "Pineco",
     "imageUrl": "https://images.pokemontcg.io/xy2/4.png",
     "subtype": "Basic",
@@ -202,7 +206,8 @@
     ]
   },
   {
-    "id": "xy2-5",
+    "setOrder":60,
+	"id": "xy2-5",
     "name": "Seedot",
     "imageUrl": "https://images.pokemontcg.io/xy2/5.png",
     "subtype": "Basic",
@@ -245,7 +250,8 @@
     ]
   },
   {
-    "id": "xy2-6",
+    "setOrder":60,
+	"id": "xy2-6",
     "name": "Nuzleaf",
     "imageUrl": "https://images.pokemontcg.io/xy2/6.png",
     "subtype": "Stage 1",
@@ -300,7 +306,8 @@
     ]
   },
   {
-    "id": "xy2-7",
+    "setOrder":60,
+	"id": "xy2-7",
     "name": "Shiftry",
     "imageUrl": "https://images.pokemontcg.io/xy2/7.png",
     "subtype": "Stage 2",
@@ -349,7 +356,8 @@
     "nationalPokedexNumber": 275
   },
   {
-    "id": "xy2-8",
+    "setOrder":60,
+	"id": "xy2-8",
     "name": "Roselia",
     "imageUrl": "https://images.pokemontcg.io/xy2/8.png",
     "subtype": "Basic",
@@ -402,7 +410,8 @@
     ]
   },
   {
-    "id": "xy2-9",
+    "setOrder":60,
+	"id": "xy2-9",
     "name": "Roserade",
     "imageUrl": "https://images.pokemontcg.io/xy2/9.png",
     "subtype": "Stage 1",
@@ -454,7 +463,8 @@
     "nationalPokedexNumber": 407
   },
   {
-    "id": "xy2-10",
+    "setOrder":60,
+	"id": "xy2-10",
     "name": "Maractus",
     "imageUrl": "https://images.pokemontcg.io/xy2/10.png",
     "subtype": "Basic",
@@ -504,7 +514,8 @@
     "nationalPokedexNumber": 556
   },
   {
-    "id": "xy2-11",
+    "setOrder":60,
+	"id": "xy2-11",
     "name": "Charizard-EX",
     "imageUrl": "https://images.pokemontcg.io/xy2/11.png",
     "subtype": "EX",
@@ -561,7 +572,8 @@
     "evolvesTo": "M Charizard-EX"
   },
   {
-    "id": "xy2-12",
+    "setOrder":60,
+	"id": "xy2-12",
     "name": "Charizard-EX",
     "imageUrl": "https://images.pokemontcg.io/xy2/12.png",
     "subtype": "EX",
@@ -620,7 +632,8 @@
     "evolvesTo": "M Charizard-EX"
   },
   {
-    "id": "xy2-13",
+    "setOrder":60,
+	"id": "xy2-13",
     "name": "M Charizard-EX",
     "imageUrl": "https://images.pokemontcg.io/xy2/13.png",
     "subtype": "MEGA",
@@ -669,7 +682,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "xy2-14",
+    "setOrder":60,
+	"id": "xy2-14",
     "name": "Ponyta",
     "imageUrl": "https://images.pokemontcg.io/xy2/14.png",
     "subtype": "Basic",
@@ -722,7 +736,8 @@
     ]
   },
   {
-    "id": "xy2-15",
+    "setOrder":60,
+	"id": "xy2-15",
     "name": "Rapidash",
     "imageUrl": "https://images.pokemontcg.io/xy2/15.png",
     "subtype": "Stage 1",
@@ -770,7 +785,8 @@
     "nationalPokedexNumber": 78
   },
   {
-    "id": "xy2-16",
+    "setOrder":60,
+	"id": "xy2-16",
     "name": "Torkoal",
     "imageUrl": "https://images.pokemontcg.io/xy2/16.png",
     "subtype": "Basic",
@@ -822,7 +838,8 @@
     "nationalPokedexNumber": 324
   },
   {
-    "id": "xy2-17",
+    "setOrder":60,
+	"id": "xy2-17",
     "name": "Fletchinder",
     "imageUrl": "https://images.pokemontcg.io/xy2/17.png",
     "subtype": "Stage 1",
@@ -872,7 +889,8 @@
     ]
   },
   {
-    "id": "xy2-18",
+    "setOrder":60,
+	"id": "xy2-18",
     "name": "Litleo",
     "imageUrl": "https://images.pokemontcg.io/xy2/18.png",
     "subtype": "Basic",
@@ -918,7 +936,8 @@
     ]
   },
   {
-    "id": "xy2-19",
+    "setOrder":60,
+	"id": "xy2-19",
     "name": "Litleo",
     "imageUrl": "https://images.pokemontcg.io/xy2/19.png",
     "subtype": "Basic",
@@ -963,7 +982,8 @@
     ]
   },
   {
-    "id": "xy2-20",
+    "setOrder":60,
+	"id": "xy2-20",
     "name": "Pyroar",
     "imageUrl": "https://images.pokemontcg.io/xy2/20.png",
     "subtype": "Stage 1",
@@ -1012,7 +1032,8 @@
     "nationalPokedexNumber": 668
   },
   {
-    "id": "xy2-21",
+    "setOrder":60,
+	"id": "xy2-21",
     "name": "Qwilfish",
     "imageUrl": "https://images.pokemontcg.io/xy2/21.png",
     "subtype": "Basic",
@@ -1058,7 +1079,8 @@
     "nationalPokedexNumber": 211
   },
   {
-    "id": "xy2-22",
+    "setOrder":60,
+	"id": "xy2-22",
     "name": "Feebas",
     "imageUrl": "https://images.pokemontcg.io/xy2/22.png",
     "subtype": "Basic",
@@ -1101,7 +1123,8 @@
     ]
   },
   {
-    "id": "xy2-23",
+    "setOrder":60,
+	"id": "xy2-23",
     "name": "Milotic",
     "imageUrl": "https://images.pokemontcg.io/xy2/23.png",
     "subtype": "Stage 1",
@@ -1150,7 +1173,8 @@
     "nationalPokedexNumber": 350
   },
   {
-    "id": "xy2-24",
+    "setOrder":60,
+	"id": "xy2-24",
     "name": "Spheal",
     "imageUrl": "https://images.pokemontcg.io/xy2/24.png",
     "subtype": "Basic",
@@ -1195,7 +1219,8 @@
     ]
   },
   {
-    "id": "xy2-25",
+    "setOrder":60,
+	"id": "xy2-25",
     "name": "Sealeo",
     "imageUrl": "https://images.pokemontcg.io/xy2/25.png",
     "subtype": "Stage 1",
@@ -1253,7 +1278,8 @@
     ]
   },
   {
-    "id": "xy2-26",
+    "setOrder":60,
+	"id": "xy2-26",
     "name": "Walrein",
     "imageUrl": "https://images.pokemontcg.io/xy2/26.png",
     "subtype": "Stage 2",
@@ -1311,7 +1337,8 @@
     "nationalPokedexNumber": 365
   },
   {
-    "id": "xy2-27",
+    "setOrder":60,
+	"id": "xy2-27",
     "name": "Luvdisc",
     "imageUrl": "https://images.pokemontcg.io/xy2/27.png",
     "subtype": "Basic",
@@ -1361,7 +1388,8 @@
     "nationalPokedexNumber": 370
   },
   {
-    "id": "xy2-28",
+    "setOrder":60,
+	"id": "xy2-28",
     "name": "Buizel",
     "imageUrl": "https://images.pokemontcg.io/xy2/28.png",
     "subtype": "Basic",
@@ -1414,7 +1442,8 @@
     ]
   },
   {
-    "id": "xy2-29",
+    "setOrder":60,
+	"id": "xy2-29",
     "name": "Floatzel",
     "imageUrl": "https://images.pokemontcg.io/xy2/29.png",
     "subtype": "Stage 1",
@@ -1465,7 +1494,8 @@
     "nationalPokedexNumber": 419
   },
   {
-    "id": "xy2-30",
+    "setOrder":60,
+	"id": "xy2-30",
     "name": "Bergmite",
     "imageUrl": "https://images.pokemontcg.io/xy2/30.png",
     "subtype": "Basic",
@@ -1520,7 +1550,8 @@
     ]
   },
   {
-    "id": "xy2-31",
+    "setOrder":60,
+	"id": "xy2-31",
     "name": "Avalugg",
     "imageUrl": "https://images.pokemontcg.io/xy2/31.png",
     "subtype": "Stage 1",
@@ -1578,7 +1609,8 @@
     "nationalPokedexNumber": 713
   },
   {
-    "id": "xy2-32",
+    "setOrder":60,
+	"id": "xy2-32",
     "name": "Shinx",
     "imageUrl": "https://images.pokemontcg.io/xy2/32.png",
     "subtype": "Basic",
@@ -1637,7 +1669,8 @@
     ]
   },
   {
-    "id": "xy2-33",
+    "setOrder":60,
+	"id": "xy2-33",
     "name": "Luxio",
     "imageUrl": "https://images.pokemontcg.io/xy2/33.png",
     "subtype": "Stage 1",
@@ -1698,7 +1731,8 @@
     ]
   },
   {
-    "id": "xy2-34",
+    "setOrder":60,
+	"id": "xy2-34",
     "name": "Luxray",
     "imageUrl": "https://images.pokemontcg.io/xy2/34.png",
     "subtype": "Stage 2",
@@ -1757,7 +1791,8 @@
     "nationalPokedexNumber": 405
   },
   {
-    "id": "xy2-35",
+    "setOrder":60,
+	"id": "xy2-35",
     "name": "Magnezone-EX",
     "imageUrl": "https://images.pokemontcg.io/xy2/35.png",
     "subtype": "EX",
@@ -1820,7 +1855,8 @@
     "nationalPokedexNumber": 462
   },
   {
-    "id": "xy2-36",
+    "setOrder":60,
+	"id": "xy2-36",
     "name": "Helioptile",
     "imageUrl": "https://images.pokemontcg.io/xy2/36.png",
     "subtype": "Basic",
@@ -1879,7 +1915,8 @@
     ]
   },
   {
-    "id": "xy2-37",
+    "setOrder":60,
+	"id": "xy2-37",
     "name": "Heliolisk",
     "imageUrl": "https://images.pokemontcg.io/xy2/37.png",
     "subtype": "Stage 1",
@@ -1937,7 +1974,8 @@
     "nationalPokedexNumber": 695
   },
   {
-    "id": "xy2-38",
+    "setOrder":60,
+	"id": "xy2-38",
     "name": "Duskull",
     "imageUrl": "https://images.pokemontcg.io/xy2/38.png",
     "subtype": "Basic",
@@ -1995,7 +2033,8 @@
     ]
   },
   {
-    "id": "xy2-39",
+    "setOrder":60,
+	"id": "xy2-39",
     "name": "Dusclops",
     "imageUrl": "https://images.pokemontcg.io/xy2/39.png",
     "subtype": "Stage 1",
@@ -2057,7 +2096,8 @@
     ]
   },
   {
-    "id": "xy2-40",
+    "setOrder":60,
+	"id": "xy2-40",
     "name": "Dusknoir",
     "imageUrl": "https://images.pokemontcg.io/xy2/40.png",
     "subtype": "Stage 2",
@@ -2113,7 +2153,8 @@
     "nationalPokedexNumber": 477
   },
   {
-    "id": "xy2-41",
+    "setOrder":60,
+	"id": "xy2-41",
     "name": "Toxicroak-EX",
     "imageUrl": "https://images.pokemontcg.io/xy2/41.png",
     "subtype": "EX",
@@ -2168,7 +2209,8 @@
     "nationalPokedexNumber": 454
   },
   {
-    "id": "xy2-42",
+    "setOrder":60,
+	"id": "xy2-42",
     "name": "Espurr",
     "imageUrl": "https://images.pokemontcg.io/xy2/42.png",
     "subtype": "Basic",
@@ -2221,7 +2263,8 @@
     ]
   },
   {
-    "id": "xy2-43",
+    "setOrder":60,
+	"id": "xy2-43",
     "name": "Meowstic",
     "imageUrl": "https://images.pokemontcg.io/xy2/43.png",
     "subtype": "Stage 1",
@@ -2273,7 +2316,8 @@
     "nationalPokedexNumber": 678
   },
   {
-    "id": "xy2-44",
+    "setOrder":60,
+	"id": "xy2-44",
     "name": "Skrelp",
     "imageUrl": "https://images.pokemontcg.io/xy2/44.png",
     "subtype": "Basic",
@@ -2316,7 +2360,8 @@
     ]
   },
   {
-    "id": "xy2-45",
+    "setOrder":60,
+	"id": "xy2-45",
     "name": "Geodude",
     "imageUrl": "https://images.pokemontcg.io/xy2/45.png",
     "subtype": "Basic",
@@ -2370,7 +2415,8 @@
     ]
   },
   {
-    "id": "xy2-46",
+    "setOrder":60,
+	"id": "xy2-46",
     "name": "Graveler",
     "imageUrl": "https://images.pokemontcg.io/xy2/46.png",
     "subtype": "Stage 1",
@@ -2430,7 +2476,8 @@
     ]
   },
   {
-    "id": "xy2-47",
+    "setOrder":60,
+	"id": "xy2-47",
     "name": "Golem",
     "imageUrl": "https://images.pokemontcg.io/xy2/47.png",
     "subtype": "Stage 2",
@@ -2487,7 +2534,8 @@
     "nationalPokedexNumber": 76
   },
   {
-    "id": "xy2-48",
+    "setOrder":60,
+	"id": "xy2-48",
     "name": "Binacle",
     "imageUrl": "https://images.pokemontcg.io/xy2/48.png",
     "subtype": "Basic",
@@ -2533,7 +2581,8 @@
     ]
   },
   {
-    "id": "xy2-49",
+    "setOrder":60,
+	"id": "xy2-49",
     "name": "Barbaracle",
     "imageUrl": "https://images.pokemontcg.io/xy2/49.png",
     "subtype": "Stage 1",
@@ -2587,7 +2636,8 @@
     "nationalPokedexNumber": 689
   },
   {
-    "id": "xy2-50",
+    "setOrder":60,
+	"id": "xy2-50",
     "name": "Sneasel",
     "imageUrl": "https://images.pokemontcg.io/xy2/50.png",
     "subtype": "Basic",
@@ -2646,7 +2696,8 @@
     ]
   },
   {
-    "id": "xy2-51",
+    "setOrder":60,
+	"id": "xy2-51",
     "name": "Sneasel",
     "imageUrl": "https://images.pokemontcg.io/xy2/51.png",
     "subtype": "Basic",
@@ -2705,7 +2756,8 @@
     ]
   },
   {
-    "id": "xy2-52",
+    "setOrder":60,
+	"id": "xy2-52",
     "name": "Weavile",
     "imageUrl": "https://images.pokemontcg.io/xy2/52.png",
     "subtype": "Stage 1",
@@ -2763,7 +2815,8 @@
     "nationalPokedexNumber": 461
   },
   {
-    "id": "xy2-53",
+    "setOrder":60,
+	"id": "xy2-53",
     "name": "Stunky",
     "imageUrl": "https://images.pokemontcg.io/xy2/53.png",
     "subtype": "Basic",
@@ -2822,7 +2875,8 @@
     ]
   },
   {
-    "id": "xy2-54",
+    "setOrder":60,
+	"id": "xy2-54",
     "name": "Stunky",
     "imageUrl": "https://images.pokemontcg.io/xy2/54.png",
     "subtype": "Basic",
@@ -2882,7 +2936,8 @@
     ]
   },
   {
-    "id": "xy2-55",
+    "setOrder":60,
+	"id": "xy2-55",
     "name": "Skuntank",
     "imageUrl": "https://images.pokemontcg.io/xy2/55.png",
     "subtype": "Stage 1",
@@ -2942,7 +2997,8 @@
     "nationalPokedexNumber": 435
   },
   {
-    "id": "xy2-56",
+    "setOrder":60,
+	"id": "xy2-56",
     "name": "Sandile",
     "imageUrl": "https://images.pokemontcg.io/xy2/56.png",
     "subtype": "Basic",
@@ -2993,7 +3049,8 @@
     ]
   },
   {
-    "id": "xy2-57",
+    "setOrder":60,
+	"id": "xy2-57",
     "name": "Krokorok",
     "imageUrl": "https://images.pokemontcg.io/xy2/57.png",
     "subtype": "Stage 1",
@@ -3055,7 +3112,8 @@
     ]
   },
   {
-    "id": "xy2-58",
+    "setOrder":60,
+	"id": "xy2-58",
     "name": "Scraggy",
     "imageUrl": "https://images.pokemontcg.io/xy2/58.png",
     "subtype": "Basic",
@@ -3106,7 +3164,8 @@
     ]
   },
   {
-    "id": "xy2-59",
+    "setOrder":60,
+	"id": "xy2-59",
     "name": "Scrafty",
     "imageUrl": "https://images.pokemontcg.io/xy2/59.png",
     "subtype": "Stage 1",
@@ -3166,7 +3225,8 @@
     "nationalPokedexNumber": 560
   },
   {
-    "id": "xy2-60",
+    "setOrder":60,
+	"id": "xy2-60",
     "name": "Forretress",
     "imageUrl": "https://images.pokemontcg.io/xy2/60.png",
     "subtype": "Stage 1",
@@ -3221,7 +3281,8 @@
     "nationalPokedexNumber": 205
   },
   {
-    "id": "xy2-61",
+    "setOrder":60,
+	"id": "xy2-61",
     "name": "Durant",
     "imageUrl": "https://images.pokemontcg.io/xy2/61.png",
     "subtype": "Basic",
@@ -3277,7 +3338,8 @@
     "nationalPokedexNumber": 632
   },
   {
-    "id": "xy2-62",
+    "setOrder":60,
+	"id": "xy2-62",
     "name": "Flabébé",
     "imageUrl": "https://images.pokemontcg.io/xy2/62.png",
     "subtype": "Basic",
@@ -3326,7 +3388,8 @@
     ]
   },
   {
-    "id": "xy2-63",
+    "setOrder":60,
+	"id": "xy2-63",
     "name": "Flabébé",
     "imageUrl": "https://images.pokemontcg.io/xy2/63.png",
     "subtype": "Basic",
@@ -3375,7 +3438,8 @@
     ]
   },
   {
-    "id": "xy2-64",
+    "setOrder":60,
+	"id": "xy2-64",
     "name": "Floette",
     "imageUrl": "https://images.pokemontcg.io/xy2/64.png",
     "subtype": "Stage 1",
@@ -3430,7 +3494,8 @@
     ]
   },
   {
-    "id": "xy2-65",
+    "setOrder":60,
+	"id": "xy2-65",
     "name": "Floette",
     "imageUrl": "https://images.pokemontcg.io/xy2/65.png",
     "subtype": "Stage 1",
@@ -3490,7 +3555,8 @@
     ]
   },
   {
-    "id": "xy2-66",
+    "setOrder":60,
+	"id": "xy2-66",
     "name": "Florges",
     "imageUrl": "https://images.pokemontcg.io/xy2/66.png",
     "subtype": "Stage 2",
@@ -3546,7 +3612,8 @@
     "nationalPokedexNumber": 671
   },
   {
-    "id": "xy2-67",
+    "setOrder":60,
+	"id": "xy2-67",
     "name": "Spritzee",
     "imageUrl": "https://images.pokemontcg.io/xy2/67.png",
     "subtype": "Basic",
@@ -3605,7 +3672,8 @@
     ]
   },
   {
-    "id": "xy2-68",
+    "setOrder":60,
+	"id": "xy2-68",
     "name": "Carbink",
     "imageUrl": "https://images.pokemontcg.io/xy2/68.png",
     "subtype": "Basic",
@@ -3663,7 +3731,8 @@
     "nationalPokedexNumber": 703
   },
   {
-    "id": "xy2-69",
+    "setOrder":60,
+	"id": "xy2-69",
     "name": "M Charizard-EX",
     "imageUrl": "https://images.pokemontcg.io/xy2/69.png",
     "subtype": "MEGA",
@@ -3714,7 +3783,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "xy2-70",
+    "setOrder":60,
+	"id": "xy2-70",
     "name": "Druddigon",
     "imageUrl": "https://images.pokemontcg.io/xy2/70.png",
     "subtype": "Basic",
@@ -3768,7 +3838,8 @@
     "nationalPokedexNumber": 621
   },
   {
-    "id": "xy2-71",
+    "setOrder":60,
+	"id": "xy2-71",
     "name": "Dragalge",
     "imageUrl": "https://images.pokemontcg.io/xy2/71.png",
     "subtype": "Stage 1",
@@ -3816,7 +3887,8 @@
     "nationalPokedexNumber": 691
   },
   {
-    "id": "xy2-72",
+    "setOrder":60,
+	"id": "xy2-72",
     "name": "Goomy",
     "imageUrl": "https://images.pokemontcg.io/xy2/72.png",
     "subtype": "Basic",
@@ -3870,7 +3942,8 @@
     ]
   },
   {
-    "id": "xy2-73",
+    "setOrder":60,
+	"id": "xy2-73",
     "name": "Sliggoo",
     "imageUrl": "https://images.pokemontcg.io/xy2/73.png",
     "subtype": "Stage 1",
@@ -3927,7 +4000,8 @@
     ]
   },
   {
-    "id": "xy2-74",
+    "setOrder":60,
+	"id": "xy2-74",
     "name": "Goodra",
     "imageUrl": "https://images.pokemontcg.io/xy2/74.png",
     "subtype": "Stage 2",
@@ -3977,7 +4051,8 @@
     "nationalPokedexNumber": 706
   },
   {
-    "id": "xy2-75",
+    "setOrder":60,
+	"id": "xy2-75",
     "name": "Pidgey",
     "imageUrl": "https://images.pokemontcg.io/xy2/75.png",
     "subtype": "Basic",
@@ -4026,7 +4101,8 @@
     ]
   },
   {
-    "id": "xy2-76",
+    "setOrder":60,
+	"id": "xy2-76",
     "name": "Pidgeotto",
     "imageUrl": "https://images.pokemontcg.io/xy2/76.png",
     "subtype": "Stage 1",
@@ -4086,7 +4162,8 @@
     ]
   },
   {
-    "id": "xy2-77",
+    "setOrder":60,
+	"id": "xy2-77",
     "name": "Pidgeot",
     "imageUrl": "https://images.pokemontcg.io/xy2/77.png",
     "subtype": "Stage 2",
@@ -4145,7 +4222,8 @@
     "nationalPokedexNumber": 18
   },
   {
-    "id": "xy2-78",
+    "setOrder":60,
+	"id": "xy2-78",
     "name": "Kangaskhan-EX",
     "imageUrl": "https://images.pokemontcg.io/xy2/78.png",
     "subtype": "EX",
@@ -4202,7 +4280,8 @@
     "evolvesTo": "M Kangaskhan-EX"
   },
   {
-    "id": "xy2-79",
+    "setOrder":60,
+	"id": "xy2-79",
     "name": "M Kangaskhan-EX",
     "imageUrl": "https://images.pokemontcg.io/xy2/79.png",
     "subtype": "MEGA",
@@ -4251,7 +4330,8 @@
     "nationalPokedexNumber": 115
   },
   {
-    "id": "xy2-80",
+    "setOrder":60,
+	"id": "xy2-80",
     "name": "Snorlax",
     "imageUrl": "https://images.pokemontcg.io/xy2/80.png",
     "subtype": "Basic",
@@ -4302,7 +4382,8 @@
     "nationalPokedexNumber": 143
   },
   {
-    "id": "xy2-81",
+    "setOrder":60,
+	"id": "xy2-81",
     "name": "Sentret",
     "imageUrl": "https://images.pokemontcg.io/xy2/81.png",
     "subtype": "Basic",
@@ -4355,7 +4436,8 @@
     ]
   },
   {
-    "id": "xy2-82",
+    "setOrder":60,
+	"id": "xy2-82",
     "name": "Furret",
     "imageUrl": "https://images.pokemontcg.io/xy2/82.png",
     "subtype": "Stage 1",
@@ -4406,7 +4488,8 @@
     "nationalPokedexNumber": 162
   },
   {
-    "id": "xy2-83",
+    "setOrder":60,
+	"id": "xy2-83",
     "name": "Miltank",
     "imageUrl": "https://images.pokemontcg.io/xy2/83.png",
     "subtype": "Basic",
@@ -4458,7 +4541,8 @@
     "nationalPokedexNumber": 241
   },
   {
-    "id": "xy2-84",
+    "setOrder":60,
+	"id": "xy2-84",
     "name": "Buneary",
     "imageUrl": "https://images.pokemontcg.io/xy2/84.png",
     "subtype": "Basic",
@@ -4502,7 +4586,8 @@
     ]
   },
   {
-    "id": "xy2-85",
+    "setOrder":60,
+	"id": "xy2-85",
     "name": "Lopunny",
     "imageUrl": "https://images.pokemontcg.io/xy2/85.png",
     "subtype": "Stage 1",
@@ -4550,7 +4635,8 @@
     "nationalPokedexNumber": 428
   },
   {
-    "id": "xy2-86",
+    "setOrder":60,
+	"id": "xy2-86",
     "name": "Fletchling",
     "imageUrl": "https://images.pokemontcg.io/xy2/86.png",
     "subtype": "Basic",
@@ -4599,7 +4685,8 @@
     ]
   },
   {
-    "id": "xy2-87",
+    "setOrder":60,
+	"id": "xy2-87",
     "name": "Furfrou",
     "imageUrl": "https://images.pokemontcg.io/xy2/87.png",
     "subtype": "Basic",
@@ -4651,7 +4738,8 @@
     "nationalPokedexNumber": 676
   },
   {
-    "id": "xy2-88",
+    "setOrder":60,
+	"id": "xy2-88",
     "name": "Blacksmith",
     "imageUrl": "https://images.pokemontcg.io/xy2/88.png",
     "subtype": "Supporter",
@@ -4668,7 +4756,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy2/88_hires.png"
   },
   {
-    "id": "xy2-88a",
+    "setOrder":60,
+	"id": "xy2-88a",
     "name": "Blacksmith",
     "imageUrl": "https://images.pokemontcg.io/xy2/88a.png",
     "subtype": "Supporter",
@@ -4685,7 +4774,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy2/88a_hires.png"
   },
   {
-    "id": "xy2-89",
+    "setOrder":60,
+	"id": "xy2-89",
     "name": "Fiery Torch",
     "imageUrl": "https://images.pokemontcg.io/xy2/89.png",
     "subtype": "Item",
@@ -4702,7 +4792,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy2/89_hires.png"
   },
   {
-    "id": "xy2-90",
+    "setOrder":60,
+	"id": "xy2-90",
     "name": "Lysandre",
     "imageUrl": "https://images.pokemontcg.io/xy2/90.png",
     "subtype": "Supporter",
@@ -4719,7 +4810,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy2/90_hires.png"
   },
   {
-    "id": "xy2-91",
+    "setOrder":60,
+	"id": "xy2-91",
     "name": "Magnetic Storm",
     "imageUrl": "https://images.pokemontcg.io/xy2/91.png",
     "subtype": "Stadium",
@@ -4736,7 +4828,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy2/91_hires.png"
   },
   {
-    "id": "xy2-92",
+    "setOrder":60,
+	"id": "xy2-92",
     "name": "Pal Pad",
     "imageUrl": "https://images.pokemontcg.io/xy2/92.png",
     "subtype": "Item",
@@ -4753,7 +4846,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy2/92_hires.png"
   },
   {
-    "id": "xy2-93",
+    "setOrder":60,
+	"id": "xy2-93",
     "name": "Pokémon Center Lady",
     "imageUrl": "https://images.pokemontcg.io/xy2/93.png",
     "subtype": "Supporter",
@@ -4770,7 +4864,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy2/93_hires.png"
   },
   {
-    "id": "xy2-94",
+    "setOrder":60,
+	"id": "xy2-94",
     "name": "Pokémon Fan Club",
     "imageUrl": "https://images.pokemontcg.io/xy2/94.png",
     "subtype": "Supporter",
@@ -4787,7 +4882,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy2/94_hires.png"
   },
   {
-    "id": "xy2-95",
+    "setOrder":60,
+	"id": "xy2-95",
     "name": "Protection Cube",
     "imageUrl": "https://images.pokemontcg.io/xy2/95.png",
     "subtype": "Pokémon Tool",
@@ -4804,7 +4900,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy2/95_hires.png"
   },
   {
-    "id": "xy2-96",
+    "setOrder":60,
+	"id": "xy2-96",
     "name": "Sacred Ash",
     "imageUrl": "https://images.pokemontcg.io/xy2/96.png",
     "subtype": "Item",
@@ -4821,7 +4918,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy2/96_hires.png"
   },
   {
-    "id": "xy2-97",
+    "setOrder":60,
+	"id": "xy2-97",
     "name": "Startling Megaphone",
     "imageUrl": "https://images.pokemontcg.io/xy2/97.png",
     "subtype": "Item",
@@ -4838,7 +4936,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy2/97_hires.png"
   },
   {
-    "id": "xy2-98",
+    "setOrder":60,
+	"id": "xy2-98",
     "name": "Trick Shovel",
     "imageUrl": "https://images.pokemontcg.io/xy2/98.png",
     "subtype": "Item",
@@ -4855,7 +4954,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy2/98_hires.png"
   },
   {
-    "id": "xy2-99",
+    "setOrder":60,
+	"id": "xy2-99",
     "name": "Ultra Ball",
     "imageUrl": "https://images.pokemontcg.io/xy2/99.png",
     "subtype": "Item",
@@ -4872,7 +4972,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy2/99_hires.png"
   },
   {
-    "id": "xy2-100",
+    "setOrder":60,
+	"id": "xy2-100",
     "name": "Charizard-EX",
     "imageUrl": "https://images.pokemontcg.io/xy2/100.png",
     "subtype": "EX",
@@ -4929,7 +5030,8 @@
     "evolvesTo": "M Charizard-EX"
   },
   {
-    "id": "xy2-101",
+    "setOrder":60,
+	"id": "xy2-101",
     "name": "Magnezone-EX",
     "imageUrl": "https://images.pokemontcg.io/xy2/101.png",
     "subtype": "EX",
@@ -4992,7 +5094,8 @@
     "nationalPokedexNumber": 462
   },
   {
-    "id": "xy2-102",
+    "setOrder":60,
+	"id": "xy2-102",
     "name": "Toxicroak-EX",
     "imageUrl": "https://images.pokemontcg.io/xy2/102.png",
     "subtype": "EX",
@@ -5047,7 +5150,8 @@
     "nationalPokedexNumber": 454
   },
   {
-    "id": "xy2-103",
+    "setOrder":60,
+	"id": "xy2-103",
     "name": "Kangaskhan-EX",
     "imageUrl": "https://images.pokemontcg.io/xy2/103.png",
     "subtype": "EX",
@@ -5104,7 +5208,8 @@
     "evolvesTo": "M Kangaskhan-EX"
   },
   {
-    "id": "xy2-104",
+    "setOrder":60,
+	"id": "xy2-104",
     "name": "Lysandre",
     "imageUrl": "https://images.pokemontcg.io/xy2/104.png",
     "subtype": "Supporter",
@@ -5121,7 +5226,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy2/104_hires.png"
   },
   {
-    "id": "xy2-105",
+    "setOrder":60,
+	"id": "xy2-105",
     "name": "Pokémon Center Lady",
     "imageUrl": "https://images.pokemontcg.io/xy2/105.png",
     "subtype": "Supporter",
@@ -5138,7 +5244,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy2/105_hires.png"
   },
   {
-    "id": "xy2-106",
+    "setOrder":60,
+	"id": "xy2-106",
     "name": "Pokémon Fan Club",
     "imageUrl": "https://images.pokemontcg.io/xy2/106.png",
     "subtype": "Supporter",
@@ -5155,7 +5262,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy2/106_hires.png"
   },
   {
-    "id": "xy2-107",
+    "setOrder":60,
+	"id": "xy2-107",
     "name": "M Charizard-EX",
     "imageUrl": "https://images.pokemontcg.io/xy2/107.png",
     "subtype": "MEGA",
@@ -5204,7 +5312,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "xy2-108",
+    "setOrder":60,
+	"id": "xy2-108",
     "name": "M Charizard-EX",
     "imageUrl": "https://images.pokemontcg.io/xy2/108.png",
     "subtype": "MEGA",
@@ -5255,7 +5364,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "xy2-109",
+    "setOrder":60,
+	"id": "xy2-109",
     "name": "M Kangaskhan-EX",
     "imageUrl": "https://images.pokemontcg.io/xy2/109.png",
     "subtype": "MEGA",

--- a/json/cards/Forbidden Light.json
+++ b/json/cards/Forbidden Light.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "sm6-1",
+    "setOrder":78,
+	"id": "sm6-1",
     "name": "Exeggcute",
     "imageUrl": "https://images.pokemontcg.io/sm6/1.png",
     "subtype": "Basic",
@@ -43,7 +44,8 @@
     ]
   },
   {
-    "id": "sm6-2",
+    "setOrder":78,
+	"id": "sm6-2",
     "name": "Alolan Exeggutor",
     "imageUrl": "https://images.pokemontcg.io/sm6/2.png",
     "subtype": "Stage 1",
@@ -86,7 +88,8 @@
     "nationalPokedexNumber": 103
   },
   {
-    "id": "sm6-3",
+    "setOrder":78,
+	"id": "sm6-3",
     "name": "Snover",
     "imageUrl": "https://images.pokemontcg.io/sm6/3.png",
     "subtype": "Basic",
@@ -132,7 +135,8 @@
     ]
   },
   {
-    "id": "sm6-4",
+    "setOrder":78,
+	"id": "sm6-4",
     "name": "Abomasnow",
     "imageUrl": "https://images.pokemontcg.io/sm6/4.png",
     "subtype": "Stage 1",
@@ -183,7 +187,8 @@
     "nationalPokedexNumber": 460
   },
   {
-    "id": "sm6-5",
+    "setOrder":78,
+	"id": "sm6-5",
     "name": "Scatterbug",
     "imageUrl": "https://images.pokemontcg.io/sm6/5.png",
     "subtype": "Basic",
@@ -232,7 +237,8 @@
     ]
   },
   {
-    "id": "sm6-6",
+    "setOrder":78,
+	"id": "sm6-6",
     "name": "Scatterbug",
     "imageUrl": "https://images.pokemontcg.io/sm6/6.png",
     "subtype": "Basic",
@@ -275,7 +281,8 @@
     ]
   },
   {
-    "id": "sm6-7",
+    "setOrder":78,
+	"id": "sm6-7",
     "name": "Spewpa",
     "imageUrl": "https://images.pokemontcg.io/sm6/7.png",
     "subtype": "Stage 1",
@@ -320,7 +327,8 @@
     ]
   },
   {
-    "id": "sm6-8",
+    "setOrder":78,
+	"id": "sm6-8",
     "name": "Vivillon",
     "imageUrl": "https://images.pokemontcg.io/sm6/8.png",
     "subtype": "Stage 2",
@@ -367,7 +375,8 @@
     "nationalPokedexNumber": 666
   },
   {
-    "id": "sm6-9",
+    "setOrder":78,
+	"id": "sm6-9",
     "name": "Skiddo",
     "imageUrl": "https://images.pokemontcg.io/sm6/9.png",
     "subtype": "Basic",
@@ -422,7 +431,8 @@
     ]
   },
   {
-    "id": "sm6-10",
+    "setOrder":78,
+	"id": "sm6-10",
     "name": "Gogoat",
     "imageUrl": "https://images.pokemontcg.io/sm6/10.png",
     "subtype": "Stage 1",
@@ -475,7 +485,8 @@
     "nationalPokedexNumber": 673
   },
   {
-    "id": "sm6-11",
+    "setOrder":78,
+	"id": "sm6-11",
     "name": "Pheromosa",
     "imageUrl": "https://images.pokemontcg.io/sm6/11.png",
     "subtype": "Basic",
@@ -523,7 +534,8 @@
     "nationalPokedexNumber": 795
   },
   {
-    "id": "sm6-12",
+    "setOrder":78,
+	"id": "sm6-12",
     "name": "Alolan Marowak",
     "imageUrl": "https://images.pokemontcg.io/sm6/12.png",
     "subtype": "Stage 1",
@@ -575,7 +587,8 @@
     "nationalPokedexNumber": 105
   },
   {
-    "id": "sm6-13",
+    "setOrder":78,
+	"id": "sm6-13",
     "name": "Heatran",
     "imageUrl": "https://images.pokemontcg.io/sm6/13.png",
     "subtype": "Basic",
@@ -629,7 +642,8 @@
     "nationalPokedexNumber": 485
   },
   {
-    "id": "sm6-14",
+    "setOrder":78,
+	"id": "sm6-14",
     "name": "Fennekin",
     "imageUrl": "https://images.pokemontcg.io/sm6/14.png",
     "subtype": "Basic",
@@ -672,7 +686,8 @@
     ]
   },
   {
-    "id": "sm6-15",
+    "setOrder":78,
+	"id": "sm6-15",
     "name": "Fennekin",
     "imageUrl": "https://images.pokemontcg.io/sm6/15.png",
     "subtype": "Basic",
@@ -725,7 +740,8 @@
     ]
   },
   {
-    "id": "sm6-16",
+    "setOrder":78,
+	"id": "sm6-16",
     "name": "Braixen",
     "imageUrl": "https://images.pokemontcg.io/sm6/16.png",
     "subtype": "Stage 1",
@@ -781,7 +797,8 @@
     ]
   },
   {
-    "id": "sm6-17",
+    "setOrder":78,
+	"id": "sm6-17",
     "name": "Delphox",
     "imageUrl": "https://images.pokemontcg.io/sm6/17.png",
     "subtype": "Stage 2",
@@ -831,7 +848,8 @@
     "nationalPokedexNumber": 655
   },
   {
-    "id": "sm6-18",
+    "setOrder":78,
+	"id": "sm6-18",
     "name": "Litleo",
     "imageUrl": "https://images.pokemontcg.io/sm6/18.png",
     "subtype": "Basic",
@@ -876,7 +894,8 @@
     ]
   },
   {
-    "id": "sm6-19",
+    "setOrder":78,
+	"id": "sm6-19",
     "name": "Pyroar",
     "imageUrl": "https://images.pokemontcg.io/sm6/19.png",
     "subtype": "Stage 1",
@@ -925,7 +944,8 @@
     "nationalPokedexNumber": 668
   },
   {
-    "id": "sm6-20",
+    "setOrder":78,
+	"id": "sm6-20",
     "name": "Palkia-GX",
     "imageUrl": "https://images.pokemontcg.io/sm6/20.png",
     "subtype": "GX",
@@ -994,7 +1014,8 @@
     "nationalPokedexNumber": 484
   },
   {
-    "id": "sm6-21",
+    "setOrder":78,
+	"id": "sm6-21",
     "name": "Froakie",
     "imageUrl": "https://images.pokemontcg.io/sm6/21.png",
     "subtype": "Basic",
@@ -1043,7 +1064,8 @@
     ]
   },
   {
-    "id": "sm6-22",
+    "setOrder":78,
+	"id": "sm6-22",
     "name": "Froakie",
     "imageUrl": "https://images.pokemontcg.io/sm6/22.png",
     "subtype": "Basic",
@@ -1096,7 +1118,8 @@
     ]
   },
   {
-    "id": "sm6-23",
+    "setOrder":78,
+	"id": "sm6-23",
     "name": "Frogadier",
     "imageUrl": "https://images.pokemontcg.io/sm6/23.png",
     "subtype": "Stage 1",
@@ -1145,7 +1168,8 @@
     ]
   },
   {
-    "id": "sm6-24",
+    "setOrder":78,
+	"id": "sm6-24",
     "name": "Greninja-GX",
     "imageUrl": "https://images.pokemontcg.io/sm6/24.png",
     "subtype": "GX",
@@ -1208,7 +1232,8 @@
     "nationalPokedexNumber": 658
   },
   {
-    "id": "sm6-25",
+    "setOrder":78,
+	"id": "sm6-25",
     "name": "Clauncher",
     "imageUrl": "https://images.pokemontcg.io/sm6/25.png",
     "subtype": "Basic",
@@ -1251,7 +1276,8 @@
     ]
   },
   {
-    "id": "sm6-26",
+    "setOrder":78,
+	"id": "sm6-26",
     "name": "Clawitzer",
     "imageUrl": "https://images.pokemontcg.io/sm6/26.png",
     "subtype": "Stage 1",
@@ -1302,7 +1328,8 @@
     "nationalPokedexNumber": 693
   },
   {
-    "id": "sm6-27",
+    "setOrder":78,
+	"id": "sm6-27",
     "name": "Amaura",
     "imageUrl": "https://images.pokemontcg.io/sm6/27.png",
     "subtype": "Stage 1",
@@ -1360,7 +1387,8 @@
     ]
   },
   {
-    "id": "sm6-28",
+    "setOrder":78,
+	"id": "sm6-28",
     "name": "Aurorus",
     "imageUrl": "https://images.pokemontcg.io/sm6/28.png",
     "subtype": "Stage 2",
@@ -1418,7 +1446,8 @@
     "nationalPokedexNumber": 699
   },
   {
-    "id": "sm6-29",
+    "setOrder":78,
+	"id": "sm6-29",
     "name": "Bergmite",
     "imageUrl": "https://images.pokemontcg.io/sm6/29.png",
     "subtype": "Basic",
@@ -1462,7 +1491,8 @@
     ]
   },
   {
-    "id": "sm6-30",
+    "setOrder":78,
+	"id": "sm6-30",
     "name": "Avalugg",
     "imageUrl": "https://images.pokemontcg.io/sm6/30.png",
     "subtype": "Stage 1",
@@ -1520,7 +1550,8 @@
     "nationalPokedexNumber": 713
   },
   {
-    "id": "sm6-31",
+    "setOrder":78,
+	"id": "sm6-31",
     "name": "Volcanion ◇",
     "imageUrl": "https://images.pokemontcg.io/sm6/31.png",
     "subtype": "Basic",
@@ -1572,7 +1603,8 @@
     "nationalPokedexNumber": 721
   },
   {
-    "id": "sm6-32",
+    "setOrder":78,
+	"id": "sm6-32",
     "name": "Dewpider",
     "imageUrl": "https://images.pokemontcg.io/sm6/32.png",
     "subtype": "Basic",
@@ -1624,7 +1656,8 @@
     ]
   },
   {
-    "id": "sm6-33",
+    "setOrder":78,
+	"id": "sm6-33",
     "name": "Araquanid",
     "imageUrl": "https://images.pokemontcg.io/sm6/33.png",
     "subtype": "Stage 1",
@@ -1675,7 +1708,8 @@
     "nationalPokedexNumber": 752
   },
   {
-    "id": "sm6-34",
+    "setOrder":78,
+	"id": "sm6-34",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/sm6/34.png",
     "subtype": "Basic",
@@ -1733,7 +1767,8 @@
     ]
   },
   {
-    "id": "sm6-35",
+    "setOrder":78,
+	"id": "sm6-35",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/sm6/35.png",
     "subtype": "Stage 1",
@@ -1795,7 +1830,8 @@
     ]
   },
   {
-    "id": "sm6-36",
+    "setOrder":78,
+	"id": "sm6-36",
     "name": "Magnezone",
     "imageUrl": "https://images.pokemontcg.io/sm6/36.png",
     "subtype": "Stage 2",
@@ -1851,7 +1887,8 @@
     "nationalPokedexNumber": 462
   },
   {
-    "id": "sm6-37",
+    "setOrder":78,
+	"id": "sm6-37",
     "name": "Helioptile",
     "imageUrl": "https://images.pokemontcg.io/sm6/37.png",
     "subtype": "Basic",
@@ -1910,7 +1947,8 @@
     ]
   },
   {
-    "id": "sm6-38",
+    "setOrder":78,
+	"id": "sm6-38",
     "name": "Heliolisk",
     "imageUrl": "https://images.pokemontcg.io/sm6/38.png",
     "subtype": "Stage 1",
@@ -1968,7 +2006,8 @@
     "nationalPokedexNumber": 695
   },
   {
-    "id": "sm6-39",
+    "setOrder":78,
+	"id": "sm6-39",
     "name": "Xurkitree",
     "imageUrl": "https://images.pokemontcg.io/sm6/39.png",
     "subtype": "Basic",
@@ -2025,7 +2064,8 @@
     "nationalPokedexNumber": 796
   },
   {
-    "id": "sm6-40",
+    "setOrder":78,
+	"id": "sm6-40",
     "name": "Rotom",
     "imageUrl": "https://images.pokemontcg.io/sm6/40.png",
     "subtype": "Basic",
@@ -2078,7 +2118,8 @@
     "nationalPokedexNumber": 479
   },
   {
-    "id": "sm6-41",
+    "setOrder":78,
+	"id": "sm6-41",
     "name": "Uxie",
     "imageUrl": "https://images.pokemontcg.io/sm6/41.png",
     "subtype": "Basic",
@@ -2118,7 +2159,8 @@
     "nationalPokedexNumber": 480
   },
   {
-    "id": "sm6-42",
+    "setOrder":78,
+	"id": "sm6-42",
     "name": "Mesprit",
     "imageUrl": "https://images.pokemontcg.io/sm6/42.png",
     "subtype": "Basic",
@@ -2164,7 +2206,8 @@
     "nationalPokedexNumber": 481
   },
   {
-    "id": "sm6-43",
+    "setOrder":78,
+	"id": "sm6-43",
     "name": "Azelf",
     "imageUrl": "https://images.pokemontcg.io/sm6/43.png",
     "subtype": "Basic",
@@ -2213,7 +2256,8 @@
     "nationalPokedexNumber": 482
   },
   {
-    "id": "sm6-44",
+    "setOrder":78,
+	"id": "sm6-44",
     "name": "Espurr",
     "imageUrl": "https://images.pokemontcg.io/sm6/44.png",
     "subtype": "Basic",
@@ -2256,7 +2300,8 @@
     ]
   },
   {
-    "id": "sm6-45",
+    "setOrder":78,
+	"id": "sm6-45",
     "name": "Meowstic",
     "imageUrl": "https://images.pokemontcg.io/sm6/45.png",
     "subtype": "Stage 1",
@@ -2307,7 +2352,8 @@
     "nationalPokedexNumber": 678
   },
   {
-    "id": "sm6-46",
+    "setOrder":78,
+	"id": "sm6-46",
     "name": "Honedge",
     "imageUrl": "https://images.pokemontcg.io/sm6/46.png",
     "subtype": "Basic",
@@ -2364,7 +2410,8 @@
     ]
   },
   {
-    "id": "sm6-47",
+    "setOrder":78,
+	"id": "sm6-47",
     "name": "Honedge",
     "imageUrl": "https://images.pokemontcg.io/sm6/47.png",
     "subtype": "Basic",
@@ -2414,7 +2461,8 @@
     ]
   },
   {
-    "id": "sm6-48",
+    "setOrder":78,
+	"id": "sm6-48",
     "name": "Doublade",
     "imageUrl": "https://images.pokemontcg.io/sm6/48.png",
     "subtype": "Stage 1",
@@ -2465,7 +2513,8 @@
     ]
   },
   {
-    "id": "sm6-49",
+    "setOrder":78,
+	"id": "sm6-49",
     "name": "Aegislash",
     "imageUrl": "https://images.pokemontcg.io/sm6/49.png",
     "subtype": "Stage 2",
@@ -2524,7 +2573,8 @@
     "nationalPokedexNumber": 681
   },
   {
-    "id": "sm6-50",
+    "setOrder":78,
+	"id": "sm6-50",
     "name": "Inkay",
     "imageUrl": "https://images.pokemontcg.io/sm6/50.png",
     "subtype": "Basic",
@@ -2567,7 +2617,8 @@
     ]
   },
   {
-    "id": "sm6-51",
+    "setOrder":78,
+	"id": "sm6-51",
     "name": "Malamar",
     "imageUrl": "https://images.pokemontcg.io/sm6/51.png",
     "subtype": "Stage 1",
@@ -2616,7 +2667,8 @@
     "nationalPokedexNumber": 687
   },
   {
-    "id": "sm6-52",
+    "setOrder":78,
+	"id": "sm6-52",
     "name": "Skrelp",
     "imageUrl": "https://images.pokemontcg.io/sm6/52.png",
     "subtype": "Basic",
@@ -2659,7 +2711,8 @@
     ]
   },
   {
-    "id": "sm6-53",
+    "setOrder":78,
+	"id": "sm6-53",
     "name": "Dragalge",
     "imageUrl": "https://images.pokemontcg.io/sm6/53.png",
     "subtype": "Stage 1",
@@ -2706,7 +2759,8 @@
     "nationalPokedexNumber": 691
   },
   {
-    "id": "sm6-54",
+    "setOrder":78,
+	"id": "sm6-54",
     "name": "Hoopa",
     "imageUrl": "https://images.pokemontcg.io/sm6/54.png",
     "subtype": "Basic",
@@ -2755,7 +2809,8 @@
     "nationalPokedexNumber": 720
   },
   {
-    "id": "sm6-55",
+    "setOrder":78,
+	"id": "sm6-55",
     "name": "Poipole",
     "imageUrl": "https://images.pokemontcg.io/sm6/55.png",
     "subtype": "Basic",
@@ -2804,7 +2859,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm6/55_hires.png"
   },
   {
-    "id": "sm6-56",
+    "setOrder":78,
+	"id": "sm6-56",
     "name": "Naganadel-GX",
     "imageUrl": "https://images.pokemontcg.io/sm6/56.png",
     "subtype": "GX",
@@ -2869,7 +2925,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm6/56_hires.png"
   },
   {
-    "id": "sm6-57",
+    "setOrder":78,
+	"id": "sm6-57",
     "name": "Cubone",
     "imageUrl": "https://images.pokemontcg.io/sm6/57.png",
     "subtype": "Basic",
@@ -2914,7 +2971,8 @@
     ]
   },
   {
-    "id": "sm6-58",
+    "setOrder":78,
+	"id": "sm6-58",
     "name": "Torterra",
     "imageUrl": "https://images.pokemontcg.io/sm6/58.png",
     "subtype": "Stage 2",
@@ -2972,7 +3030,8 @@
     "nationalPokedexNumber": 389
   },
   {
-    "id": "sm6-59",
+    "setOrder":78,
+	"id": "sm6-59",
     "name": "Infernape",
     "imageUrl": "https://images.pokemontcg.io/sm6/59.png",
     "subtype": "Stage 2",
@@ -3019,7 +3078,8 @@
     "nationalPokedexNumber": 392
   },
   {
-    "id": "sm6-60",
+    "setOrder":78,
+	"id": "sm6-60",
     "name": "Gible",
     "imageUrl": "https://images.pokemontcg.io/sm6/60.png",
     "subtype": "Basic",
@@ -3062,7 +3122,8 @@
     ]
   },
   {
-    "id": "sm6-61",
+    "setOrder":78,
+	"id": "sm6-61",
     "name": "Gabite",
     "imageUrl": "https://images.pokemontcg.io/sm6/61.png",
     "subtype": "Stage 1",
@@ -3116,7 +3177,8 @@
     ]
   },
   {
-    "id": "sm6-62",
+    "setOrder":78,
+	"id": "sm6-62",
     "name": "Garchomp",
     "imageUrl": "https://images.pokemontcg.io/sm6/62.png",
     "subtype": "Stage 2",
@@ -3166,7 +3228,8 @@
     "nationalPokedexNumber": 445
   },
   {
-    "id": "sm6-63",
+    "setOrder":78,
+	"id": "sm6-63",
     "name": "Croagunk",
     "imageUrl": "https://images.pokemontcg.io/sm6/63.png",
     "subtype": "Basic",
@@ -3209,7 +3272,8 @@
     ]
   },
   {
-    "id": "sm6-64",
+    "setOrder":78,
+	"id": "sm6-64",
     "name": "Toxicroak",
     "imageUrl": "https://images.pokemontcg.io/sm6/64.png",
     "subtype": "Stage 1",
@@ -3261,7 +3325,8 @@
     "nationalPokedexNumber": 454
   },
   {
-    "id": "sm6-65",
+    "setOrder":78,
+	"id": "sm6-65",
     "name": "Pancham",
     "imageUrl": "https://images.pokemontcg.io/sm6/65.png",
     "subtype": "Basic",
@@ -3305,7 +3370,8 @@
     ]
   },
   {
-    "id": "sm6-66",
+    "setOrder":78,
+	"id": "sm6-66",
     "name": "Binacle",
     "imageUrl": "https://images.pokemontcg.io/sm6/66.png",
     "subtype": "Basic",
@@ -3350,7 +3416,8 @@
     ]
   },
   {
-    "id": "sm6-67",
+    "setOrder":78,
+	"id": "sm6-67",
     "name": "Barbaracle",
     "imageUrl": "https://images.pokemontcg.io/sm6/67.png",
     "subtype": "Stage 1",
@@ -3405,7 +3472,8 @@
     "nationalPokedexNumber": 689
   },
   {
-    "id": "sm6-68",
+    "setOrder":78,
+	"id": "sm6-68",
     "name": "Tyrunt",
     "imageUrl": "https://images.pokemontcg.io/sm6/68.png",
     "subtype": "Stage 1",
@@ -3460,7 +3528,8 @@
     ]
   },
   {
-    "id": "sm6-69",
+    "setOrder":78,
+	"id": "sm6-69",
     "name": "Tyrantrum",
     "imageUrl": "https://images.pokemontcg.io/sm6/69.png",
     "subtype": "Stage 2",
@@ -3510,7 +3579,8 @@
     "nationalPokedexNumber": 697
   },
   {
-    "id": "sm6-70",
+    "setOrder":78,
+	"id": "sm6-70",
     "name": "Hawlucha",
     "imageUrl": "https://images.pokemontcg.io/sm6/70.png",
     "subtype": "Basic",
@@ -3567,7 +3637,8 @@
     "nationalPokedexNumber": 701
   },
   {
-    "id": "sm6-71",
+    "setOrder":78,
+	"id": "sm6-71",
     "name": "Zygarde",
     "imageUrl": "https://images.pokemontcg.io/sm6/71.png",
     "subtype": "Basic",
@@ -3612,7 +3683,8 @@
     "nationalPokedexNumber": 718
   },
   {
-    "id": "sm6-72",
+    "setOrder":78,
+	"id": "sm6-72",
     "name": "Zygarde",
     "imageUrl": "https://images.pokemontcg.io/sm6/72.png",
     "subtype": "Basic",
@@ -3665,7 +3737,8 @@
     "nationalPokedexNumber": 718
   },
   {
-    "id": "sm6-73",
+    "setOrder":78,
+	"id": "sm6-73",
     "name": "Zygarde-GX",
     "imageUrl": "https://images.pokemontcg.io/sm6/73.png",
     "subtype": "GX",
@@ -3735,7 +3808,8 @@
     "nationalPokedexNumber": 718
   },
   {
-    "id": "sm6-74",
+    "setOrder":78,
+	"id": "sm6-74",
     "name": "Diancie ◇",
     "imageUrl": "https://images.pokemontcg.io/sm6/74.png",
     "subtype": "Basic",
@@ -3786,7 +3860,8 @@
     "nationalPokedexNumber": 719
   },
   {
-    "id": "sm6-75",
+    "setOrder":78,
+	"id": "sm6-75",
     "name": "Rockruff",
     "imageUrl": "https://images.pokemontcg.io/sm6/75.png",
     "subtype": "Basic",
@@ -3830,7 +3905,8 @@
     ]
   },
   {
-    "id": "sm6-76",
+    "setOrder":78,
+	"id": "sm6-76",
     "name": "Lycanroc",
     "imageUrl": "https://images.pokemontcg.io/sm6/76.png",
     "subtype": "Stage 1",
@@ -3884,7 +3960,8 @@
     "nationalPokedexNumber": 745
   },
   {
-    "id": "sm6-77",
+    "setOrder":78,
+	"id": "sm6-77",
     "name": "Buzzwole",
     "imageUrl": "https://images.pokemontcg.io/sm6/77.png",
     "subtype": "Basic",
@@ -3936,7 +4013,8 @@
     "nationalPokedexNumber": 794
   },
   {
-    "id": "sm6-78",
+    "setOrder":78,
+	"id": "sm6-78",
     "name": "Pangoro",
     "imageUrl": "https://images.pokemontcg.io/sm6/78.png",
     "subtype": "Stage 1",
@@ -3997,7 +4075,8 @@
     "nationalPokedexNumber": 675
   },
   {
-    "id": "sm6-79",
+    "setOrder":78,
+	"id": "sm6-79",
     "name": "Yveltal-GX",
     "imageUrl": "https://images.pokemontcg.io/sm6/79.png",
     "subtype": "GX",
@@ -4067,7 +4146,8 @@
     "nationalPokedexNumber": 717
   },
   {
-    "id": "sm6-80",
+    "setOrder":78,
+	"id": "sm6-80",
     "name": "Guzzlord",
     "imageUrl": "https://images.pokemontcg.io/sm6/80.png",
     "subtype": "Basic",
@@ -4119,7 +4199,8 @@
     "nationalPokedexNumber": 799
   },
   {
-    "id": "sm6-81",
+    "setOrder":78,
+	"id": "sm6-81",
     "name": "Empoleon",
     "imageUrl": "https://images.pokemontcg.io/sm6/81.png",
     "subtype": "Stage 2",
@@ -4179,7 +4260,8 @@
     "nationalPokedexNumber": 395
   },
   {
-    "id": "sm6-82",
+    "setOrder":78,
+	"id": "sm6-82",
     "name": "Dialga-GX",
     "imageUrl": "https://images.pokemontcg.io/sm6/82.png",
     "subtype": "GX",
@@ -4254,7 +4336,8 @@
     "nationalPokedexNumber": 483
   },
   {
-    "id": "sm6-83",
+    "setOrder":78,
+	"id": "sm6-83",
     "name": "Flabébé",
     "imageUrl": "https://images.pokemontcg.io/sm6/83.png",
     "subtype": "Basic",
@@ -4308,7 +4391,8 @@
     ]
   },
   {
-    "id": "sm6-84",
+    "setOrder":78,
+	"id": "sm6-84",
     "name": "Flabébé",
     "imageUrl": "https://images.pokemontcg.io/sm6/84.png",
     "subtype": "Basic",
@@ -4357,7 +4441,8 @@
     ]
   },
   {
-    "id": "sm6-85",
+    "setOrder":78,
+	"id": "sm6-85",
     "name": "Floette",
     "imageUrl": "https://images.pokemontcg.io/sm6/85.png",
     "subtype": "Stage 1",
@@ -4407,7 +4492,8 @@
     ]
   },
   {
-    "id": "sm6-86",
+    "setOrder":78,
+	"id": "sm6-86",
     "name": "Florges",
     "imageUrl": "https://images.pokemontcg.io/sm6/86.png",
     "subtype": "Stage 2",
@@ -4462,7 +4548,8 @@
     "nationalPokedexNumber": 671
   },
   {
-    "id": "sm6-87",
+    "setOrder":78,
+	"id": "sm6-87",
     "name": "Sylveon",
     "imageUrl": "https://images.pokemontcg.io/sm6/87.png",
     "subtype": "Stage 1",
@@ -4519,7 +4606,8 @@
     "nationalPokedexNumber": 700
   },
   {
-    "id": "sm6-88",
+    "setOrder":78,
+	"id": "sm6-88",
     "name": "Dedenne",
     "imageUrl": "https://images.pokemontcg.io/sm6/88.png",
     "subtype": "Basic",
@@ -4575,7 +4663,8 @@
     "nationalPokedexNumber": 702
   },
   {
-    "id": "sm6-89",
+    "setOrder":78,
+	"id": "sm6-89",
     "name": "Klefki",
     "imageUrl": "https://images.pokemontcg.io/sm6/89.png",
     "subtype": "Basic",
@@ -4630,7 +4719,8 @@
     "nationalPokedexNumber": 707
   },
   {
-    "id": "sm6-90",
+    "setOrder":78,
+	"id": "sm6-90",
     "name": "Xerneas-GX",
     "imageUrl": "https://images.pokemontcg.io/sm6/90.png",
     "subtype": "GX",
@@ -4702,7 +4792,8 @@
     "nationalPokedexNumber": 716
   },
   {
-    "id": "sm6-91",
+    "setOrder":78,
+	"id": "sm6-91",
     "name": "Goomy",
     "imageUrl": "https://images.pokemontcg.io/sm6/91.png",
     "subtype": "Basic",
@@ -4750,7 +4841,8 @@
     ]
   },
   {
-    "id": "sm6-92",
+    "setOrder":78,
+	"id": "sm6-92",
     "name": "Goomy",
     "imageUrl": "https://images.pokemontcg.io/sm6/92.png",
     "subtype": "Basic",
@@ -4804,7 +4896,8 @@
     ]
   },
   {
-    "id": "sm6-93",
+    "setOrder":78,
+	"id": "sm6-93",
     "name": "Sliggoo",
     "imageUrl": "https://images.pokemontcg.io/sm6/93.png",
     "subtype": "Stage 1",
@@ -4861,7 +4954,8 @@
     ]
   },
   {
-    "id": "sm6-94",
+    "setOrder":78,
+	"id": "sm6-94",
     "name": "Goodra",
     "imageUrl": "https://images.pokemontcg.io/sm6/94.png",
     "subtype": "Stage 2",
@@ -4911,7 +5005,8 @@
     "nationalPokedexNumber": 706
   },
   {
-    "id": "sm6-95",
+    "setOrder":78,
+	"id": "sm6-95",
     "name": "Ultra Necrozma-GX",
     "imageUrl": "https://images.pokemontcg.io/sm6/95.png",
     "subtype": "GX",
@@ -4966,7 +5061,8 @@
     "nationalPokedexNumber": 800
   },
   {
-    "id": "sm6-96",
+    "setOrder":78,
+	"id": "sm6-96",
     "name": "Arceus ◇",
     "imageUrl": "https://images.pokemontcg.io/sm6/96.png",
     "subtype": "Basic",
@@ -5014,7 +5110,8 @@
     "nationalPokedexNumber": 493
   },
   {
-    "id": "sm6-97",
+    "setOrder":78,
+	"id": "sm6-97",
     "name": "Bunnelby",
     "imageUrl": "https://images.pokemontcg.io/sm6/97.png",
     "subtype": "Basic",
@@ -5068,7 +5165,8 @@
     ]
   },
   {
-    "id": "sm6-98",
+    "setOrder":78,
+	"id": "sm6-98",
     "name": "Diggersby",
     "imageUrl": "https://images.pokemontcg.io/sm6/98.png",
     "subtype": "Stage 1",
@@ -5125,7 +5223,8 @@
     "nationalPokedexNumber": 660
   },
   {
-    "id": "sm6-99",
+    "setOrder":78,
+	"id": "sm6-99",
     "name": "Furfrou",
     "imageUrl": "https://images.pokemontcg.io/sm6/99.png",
     "subtype": "Basic",
@@ -5165,7 +5264,8 @@
     "nationalPokedexNumber": 676
   },
   {
-    "id": "sm6-100",
+    "setOrder":78,
+	"id": "sm6-100",
     "name": "Noibat",
     "imageUrl": "https://images.pokemontcg.io/sm6/100.png",
     "subtype": "Basic",
@@ -5224,7 +5324,8 @@
     ]
   },
   {
-    "id": "sm6-101",
+    "setOrder":78,
+	"id": "sm6-101",
     "name": "Noivern",
     "imageUrl": "https://images.pokemontcg.io/sm6/101.png",
     "subtype": "Stage 1",
@@ -5282,7 +5383,8 @@
     "nationalPokedexNumber": 715
   },
   {
-    "id": "sm6-102",
+    "setOrder":78,
+	"id": "sm6-102",
     "name": "Beast Ring",
     "imageUrl": "https://images.pokemontcg.io/sm6/102.png",
     "subtype": "Item",
@@ -5300,7 +5402,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm6/102_hires.png"
   },
   {
-    "id": "sm6-103",
+    "setOrder":78,
+	"id": "sm6-103",
     "name": "Bonnie",
     "imageUrl": "https://images.pokemontcg.io/sm6/103.png",
     "subtype": "Supporter",
@@ -5318,7 +5421,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm6/103_hires.png"
   },
   {
-    "id": "sm6-104",
+    "setOrder":78,
+	"id": "sm6-104",
     "name": "Crasher Wake",
     "imageUrl": "https://images.pokemontcg.io/sm6/104.png",
     "subtype": "Supporter",
@@ -5336,7 +5440,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm6/104_hires.png"
   },
   {
-    "id": "sm6-105",
+    "setOrder":78,
+	"id": "sm6-105",
     "name": "Diantha",
     "imageUrl": "https://images.pokemontcg.io/sm6/105.png",
     "subtype": "Supporter",
@@ -5354,7 +5459,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm6/105_hires.png"
   },
   {
-    "id": "sm6-106",
+    "setOrder":78,
+	"id": "sm6-106",
     "name": "Eneporter",
     "imageUrl": "https://images.pokemontcg.io/sm6/106.png",
     "subtype": "Item",
@@ -5372,7 +5478,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm6/106_hires.png"
   },
   {
-    "id": "sm6-107",
+    "setOrder":78,
+	"id": "sm6-107",
     "name": "Fossil Excavation Map",
     "imageUrl": "https://images.pokemontcg.io/sm6/107.png",
     "subtype": "Item",
@@ -5390,7 +5497,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm6/107_hires.png"
   },
   {
-    "id": "sm6-108",
+    "setOrder":78,
+	"id": "sm6-108",
     "name": "Judge",
     "imageUrl": "https://images.pokemontcg.io/sm6/108.png",
     "subtype": "Supporter",
@@ -5408,7 +5516,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm6/108_hires.png"
   },
   {
-    "id": "sm6-109",
+    "setOrder":78,
+	"id": "sm6-109",
     "name": "Lady",
     "imageUrl": "https://images.pokemontcg.io/sm6/109.png",
     "subtype": "Supporter",
@@ -5426,7 +5535,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm6/109_hires.png"
   },
   {
-    "id": "sm6-110",
+    "setOrder":78,
+	"id": "sm6-110",
     "name": "Lysandre ◇",
     "imageUrl": "https://images.pokemontcg.io/sm6/110.png",
     "subtype": "Supporter",
@@ -5445,7 +5555,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm6/110_hires.png"
   },
   {
-    "id": "sm6-111",
+    "setOrder":78,
+	"id": "sm6-111",
     "name": "Lysandre Labs",
     "imageUrl": "https://images.pokemontcg.io/sm6/111.png",
     "subtype": "Stadium",
@@ -5463,7 +5574,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm6/111_hires.png"
   },
   {
-    "id": "sm6-112",
+    "setOrder":78,
+	"id": "sm6-112",
     "name": "Metal Frying Pan",
     "imageUrl": "https://images.pokemontcg.io/sm6/112.png",
     "subtype": "Pokémon Tool",
@@ -5481,7 +5593,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm6/112_hires.png"
   },
   {
-    "id": "sm6-113",
+    "setOrder":78,
+	"id": "sm6-113",
     "name": "Mysterious Treasure",
     "imageUrl": "https://images.pokemontcg.io/sm6/113.png",
     "subtype": "Item",
@@ -5499,7 +5612,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm6/113_hires.png"
   },
   {
-    "id": "sm6-114",
+    "setOrder":78,
+	"id": "sm6-114",
     "name": "Ultra Recon Squad",
     "imageUrl": "https://images.pokemontcg.io/sm6/114.png",
     "subtype": "Supporter",
@@ -5517,7 +5631,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm6/114_hires.png"
   },
   {
-    "id": "sm6-115",
+    "setOrder":78,
+	"id": "sm6-115",
     "name": "Ultra Space",
     "imageUrl": "https://images.pokemontcg.io/sm6/115.png",
     "subtype": "Stadium",
@@ -5535,7 +5650,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm6/115_hires.png"
   },
   {
-    "id": "sm6-116",
+    "setOrder":78,
+	"id": "sm6-116",
     "name": "Unidentified Fossil",
     "imageUrl": "https://images.pokemontcg.io/sm6/116.png",
     "subtype": "Item",
@@ -5553,7 +5669,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm6/116_hires.png"
   },
   {
-    "id": "sm6-117",
+    "setOrder":78,
+	"id": "sm6-117",
     "name": "Beast Energy ◇",
     "imageUrl": "https://images.pokemontcg.io/sm6/117.png",
     "subtype": "Special",
@@ -5572,7 +5689,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm6/117_hires.png"
   },
   {
-    "id": "sm6-118",
+    "setOrder":78,
+	"id": "sm6-118",
     "name": "Unit Energy FightingDarknessFairy",
     "imageUrl": "https://images.pokemontcg.io/sm6/118.png",
     "subtype": "Special",
@@ -5590,7 +5708,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm6/118_hires.png"
   },
   {
-    "id": "sm6-119",
+    "setOrder":78,
+	"id": "sm6-119",
     "name": "Palkia-GX",
     "imageUrl": "https://images.pokemontcg.io/sm6/119.png",
     "subtype": "GX",
@@ -5659,7 +5778,8 @@
     "nationalPokedexNumber": 484
   },
   {
-    "id": "sm6-120",
+    "setOrder":78,
+	"id": "sm6-120",
     "name": "Greninja-GX",
     "imageUrl": "https://images.pokemontcg.io/sm6/120.png",
     "subtype": "GX",
@@ -5722,7 +5842,8 @@
     "nationalPokedexNumber": 658
   },
   {
-    "id": "sm6-121",
+    "setOrder":78,
+	"id": "sm6-121",
     "name": "Naganadel-GX",
     "imageUrl": "https://images.pokemontcg.io/sm6/121.png",
     "subtype": "GX",
@@ -5787,7 +5908,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm6/121_hires.png"
   },
   {
-    "id": "sm6-122",
+    "setOrder":78,
+	"id": "sm6-122",
     "name": "Lucario-GX",
     "imageUrl": "https://images.pokemontcg.io/sm6/122.png",
     "subtype": "GX",
@@ -5853,7 +5975,8 @@
     "nationalPokedexNumber": 448
   },
   {
-    "id": "sm6-123",
+    "setOrder":78,
+	"id": "sm6-123",
     "name": "Zygarde-GX",
     "imageUrl": "https://images.pokemontcg.io/sm6/123.png",
     "subtype": "GX",
@@ -5923,7 +6046,8 @@
     "nationalPokedexNumber": 718
   },
   {
-    "id": "sm6-124",
+    "setOrder":78,
+	"id": "sm6-124",
     "name": "Yveltal-GX",
     "imageUrl": "https://images.pokemontcg.io/sm6/124.png",
     "subtype": "GX",
@@ -5993,7 +6117,8 @@
     "nationalPokedexNumber": 717
   },
   {
-    "id": "sm6-125",
+    "setOrder":78,
+	"id": "sm6-125",
     "name": "Dialga-GX",
     "imageUrl": "https://images.pokemontcg.io/sm6/125.png",
     "subtype": "GX",
@@ -6068,7 +6193,8 @@
     "nationalPokedexNumber": 483
   },
   {
-    "id": "sm6-126",
+    "setOrder":78,
+	"id": "sm6-126",
     "name": "Xerneas-GX",
     "imageUrl": "https://images.pokemontcg.io/sm6/126.png",
     "subtype": "GX",
@@ -6140,7 +6266,8 @@
     "nationalPokedexNumber": 716
   },
   {
-    "id": "sm6-127",
+    "setOrder":78,
+	"id": "sm6-127",
     "name": "Ultra Necrozma-GX",
     "imageUrl": "https://images.pokemontcg.io/sm6/127.png",
     "subtype": "GX",
@@ -6195,7 +6322,8 @@
     "nationalPokedexNumber": 800
   },
   {
-    "id": "sm6-128",
+    "setOrder":78,
+	"id": "sm6-128",
     "name": "Bonnie",
     "imageUrl": "https://images.pokemontcg.io/sm6/128.png",
     "subtype": "Supporter",
@@ -6213,7 +6341,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm6/128_hires.png"
   },
   {
-    "id": "sm6-129",
+    "setOrder":78,
+	"id": "sm6-129",
     "name": "Crasher Wake",
     "imageUrl": "https://images.pokemontcg.io/sm6/129.png",
     "subtype": "Supporter",
@@ -6231,7 +6360,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm6/129_hires.png"
   },
   {
-    "id": "sm6-130",
+    "setOrder":78,
+	"id": "sm6-130",
     "name": "Diantha",
     "imageUrl": "https://images.pokemontcg.io/sm6/130.png",
     "subtype": "Supporter",
@@ -6249,7 +6379,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm6/130_hires.png"
   },
   {
-    "id": "sm6-131",
+    "setOrder":78,
+	"id": "sm6-131",
     "name": "Ultra Recon Squad",
     "imageUrl": "https://images.pokemontcg.io/sm6/131.png",
     "subtype": "Supporter",

--- a/json/cards/Fossil.json
+++ b/json/cards/Fossil.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "base3-1",
+    "setOrder":3,
+	"id": "base3-1",
     "name": "Aerodactyl",
     "imageUrl": "https://images.pokemontcg.io/base3/1.png",
     "subtype": "Stage 1",
@@ -55,7 +56,8 @@
     "nationalPokedexNumber": 142
   },
   {
-    "id": "base3-2",
+    "setOrder":3,
+	"id": "base3-2",
     "name": "Articuno",
     "imageUrl": "https://images.pokemontcg.io/base3/2.png",
     "subtype": "Basic",
@@ -111,7 +113,8 @@
     "nationalPokedexNumber": 144
   },
   {
-    "id": "base3-3",
+    "setOrder":3,
+	"id": "base3-3",
     "name": "Ditto",
     "imageUrl": "https://images.pokemontcg.io/base3/3.png",
     "subtype": "Basic",
@@ -152,7 +155,8 @@
     "nationalPokedexNumber": 132
   },
   {
-    "id": "base3-4",
+    "setOrder":3,
+	"id": "base3-4",
     "name": "Dragonite",
     "imageUrl": "https://images.pokemontcg.io/base3/4.png",
     "subtype": "Stage 2",
@@ -202,7 +206,8 @@
     "nationalPokedexNumber": 149
   },
   {
-    "id": "base3-5",
+    "setOrder":3,
+	"id": "base3-5",
     "name": "Gengar",
     "imageUrl": "https://images.pokemontcg.io/base3/5.png",
     "subtype": "Stage 2",
@@ -251,7 +256,8 @@
     "nationalPokedexNumber": 94
   },
   {
-    "id": "base3-6",
+    "setOrder":3,
+	"id": "base3-6",
     "name": "Haunter",
     "imageUrl": "https://images.pokemontcg.io/base3/6.png",
     "subtype": "Stage 1",
@@ -299,7 +305,8 @@
     ]
   },
   {
-    "id": "base3-7",
+    "setOrder":3,
+	"id": "base3-7",
     "name": "Hitmonlee",
     "imageUrl": "https://images.pokemontcg.io/base3/7.png",
     "subtype": "Basic",
@@ -352,7 +359,8 @@
     "nationalPokedexNumber": 106
   },
   {
-    "id": "base3-8",
+    "setOrder":3,
+	"id": "base3-8",
     "name": "Hypno",
     "imageUrl": "https://images.pokemontcg.io/base3/8.png",
     "subtype": "Stage 1",
@@ -406,7 +414,8 @@
     "nationalPokedexNumber": 97
   },
   {
-    "id": "base3-9",
+    "setOrder":3,
+	"id": "base3-9",
     "name": "Kabutops",
     "imageUrl": "https://images.pokemontcg.io/base3/9.png",
     "subtype": "Stage 2",
@@ -461,7 +470,8 @@
     "nationalPokedexNumber": 141
   },
   {
-    "id": "base3-10",
+    "setOrder":3,
+	"id": "base3-10",
     "name": "Lapras",
     "imageUrl": "https://images.pokemontcg.io/base3/10.png",
     "subtype": "Basic",
@@ -513,7 +523,8 @@
     "nationalPokedexNumber": 131
   },
   {
-    "id": "base3-11",
+    "setOrder":3,
+	"id": "base3-11",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/base3/11.png",
     "subtype": "Stage 1",
@@ -572,7 +583,8 @@
     ]
   },
   {
-    "id": "base3-12",
+    "setOrder":3,
+	"id": "base3-12",
     "name": "Moltres",
     "imageUrl": "https://images.pokemontcg.io/base3/12.png",
     "subtype": "Basic",
@@ -626,7 +638,8 @@
     "nationalPokedexNumber": 146
   },
   {
-    "id": "base3-13",
+    "setOrder":3,
+	"id": "base3-13",
     "name": "Muk",
     "imageUrl": "https://images.pokemontcg.io/base3/13.png",
     "subtype": "Stage 1",
@@ -676,7 +689,8 @@
     "nationalPokedexNumber": 89
   },
   {
-    "id": "base3-14",
+    "setOrder":3,
+	"id": "base3-14",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/base3/14.png",
     "subtype": "Stage 1",
@@ -721,7 +735,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "base3-15",
+    "setOrder":3,
+	"id": "base3-15",
     "name": "Zapdos",
     "imageUrl": "https://images.pokemontcg.io/base3/15.png",
     "subtype": "Basic",
@@ -766,7 +781,8 @@
     "nationalPokedexNumber": 145
   },
   {
-    "id": "base3-16",
+    "setOrder":3,
+	"id": "base3-16",
     "name": "Aerodactyl",
     "imageUrl": "https://images.pokemontcg.io/base3/16.png",
     "subtype": "Stage 1",
@@ -821,7 +837,8 @@
     "nationalPokedexNumber": 142
   },
   {
-    "id": "base3-17",
+    "setOrder":3,
+	"id": "base3-17",
     "name": "Articuno",
     "imageUrl": "https://images.pokemontcg.io/base3/17.png",
     "subtype": "Basic",
@@ -877,7 +894,8 @@
     "nationalPokedexNumber": 144
   },
   {
-    "id": "base3-18",
+    "setOrder":3,
+	"id": "base3-18",
     "name": "Ditto",
     "imageUrl": "https://images.pokemontcg.io/base3/18.png",
     "subtype": "Basic",
@@ -918,7 +936,8 @@
     "nationalPokedexNumber": 132
   },
   {
-    "id": "base3-19",
+    "setOrder":3,
+	"id": "base3-19",
     "name": "Dragonite",
     "imageUrl": "https://images.pokemontcg.io/base3/19.png",
     "subtype": "Stage 2",
@@ -968,7 +987,8 @@
     "nationalPokedexNumber": 149
   },
   {
-    "id": "base3-20",
+    "setOrder":3,
+	"id": "base3-20",
     "name": "Gengar",
     "imageUrl": "https://images.pokemontcg.io/base3/20.png",
     "subtype": "Stage 2",
@@ -1017,7 +1037,8 @@
     "nationalPokedexNumber": 94
   },
   {
-    "id": "base3-21",
+    "setOrder":3,
+	"id": "base3-21",
     "name": "Haunter",
     "imageUrl": "https://images.pokemontcg.io/base3/21.png",
     "subtype": "Stage 1",
@@ -1065,7 +1086,8 @@
     ]
   },
   {
-    "id": "base3-22",
+    "setOrder":3,
+	"id": "base3-22",
     "name": "Hitmonlee",
     "imageUrl": "https://images.pokemontcg.io/base3/22.png",
     "subtype": "Basic",
@@ -1118,7 +1140,8 @@
     "nationalPokedexNumber": 106
   },
   {
-    "id": "base3-23",
+    "setOrder":3,
+	"id": "base3-23",
     "name": "Hypno",
     "imageUrl": "https://images.pokemontcg.io/base3/23.png",
     "subtype": "Stage 1",
@@ -1172,7 +1195,8 @@
     "nationalPokedexNumber": 97
   },
   {
-    "id": "base3-24",
+    "setOrder":3,
+	"id": "base3-24",
     "name": "Kabutops",
     "imageUrl": "https://images.pokemontcg.io/base3/24.png",
     "subtype": "Stage 2",
@@ -1227,7 +1251,8 @@
     "nationalPokedexNumber": 141
   },
   {
-    "id": "base3-25",
+    "setOrder":3,
+	"id": "base3-25",
     "name": "Lapras",
     "imageUrl": "https://images.pokemontcg.io/base3/25.png",
     "subtype": "Basic",
@@ -1279,7 +1304,8 @@
     "nationalPokedexNumber": 131
   },
   {
-    "id": "base3-26",
+    "setOrder":3,
+	"id": "base3-26",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/base3/26.png",
     "subtype": "Stage 1",
@@ -1338,7 +1364,8 @@
     ]
   },
   {
-    "id": "base3-27",
+    "setOrder":3,
+	"id": "base3-27",
     "name": "Moltres",
     "imageUrl": "https://images.pokemontcg.io/base3/27.png",
     "subtype": "Basic",
@@ -1392,7 +1419,8 @@
     "nationalPokedexNumber": 146
   },
   {
-    "id": "base3-28",
+    "setOrder":3,
+	"id": "base3-28",
     "name": "Muk",
     "imageUrl": "https://images.pokemontcg.io/base3/28.png",
     "subtype": "Stage 1",
@@ -1442,7 +1470,8 @@
     "nationalPokedexNumber": 89
   },
   {
-    "id": "base3-29",
+    "setOrder":3,
+	"id": "base3-29",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/base3/29.png",
     "subtype": "Stage 1",
@@ -1487,7 +1516,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "base3-30",
+    "setOrder":3,
+	"id": "base3-30",
     "name": "Zapdos",
     "imageUrl": "https://images.pokemontcg.io/base3/30.png",
     "subtype": "Basic",
@@ -1532,7 +1562,8 @@
     "nationalPokedexNumber": 145
   },
   {
-    "id": "base3-31",
+    "setOrder":3,
+	"id": "base3-31",
     "name": "Arbok",
     "imageUrl": "https://images.pokemontcg.io/base3/31.png",
     "subtype": "Stage 1",
@@ -1586,7 +1617,8 @@
     "nationalPokedexNumber": 24
   },
   {
-    "id": "base3-32",
+    "setOrder":3,
+	"id": "base3-32",
     "name": "Cloyster",
     "imageUrl": "https://images.pokemontcg.io/base3/32.png",
     "subtype": "Stage 1",
@@ -1640,7 +1672,8 @@
     "nationalPokedexNumber": 91
   },
   {
-    "id": "base3-33",
+    "setOrder":3,
+	"id": "base3-33",
     "name": "Gastly",
     "imageUrl": "https://images.pokemontcg.io/base3/33.png",
     "subtype": "Basic",
@@ -1691,7 +1724,8 @@
     ]
   },
   {
-    "id": "base3-34",
+    "setOrder":3,
+	"id": "base3-34",
     "name": "Golbat",
     "imageUrl": "https://images.pokemontcg.io/base3/34.png",
     "subtype": "Stage 1",
@@ -1752,7 +1786,8 @@
     ]
   },
   {
-    "id": "base3-35",
+    "setOrder":3,
+	"id": "base3-35",
     "name": "Golduck",
     "imageUrl": "https://images.pokemontcg.io/base3/35.png",
     "subtype": "Stage 1",
@@ -1805,7 +1840,8 @@
     "nationalPokedexNumber": 55
   },
   {
-    "id": "base3-36",
+    "setOrder":3,
+	"id": "base3-36",
     "name": "Golem",
     "imageUrl": "https://images.pokemontcg.io/base3/36.png",
     "subtype": "Stage 2",
@@ -1865,7 +1901,8 @@
     "nationalPokedexNumber": 76
   },
   {
-    "id": "base3-37",
+    "setOrder":3,
+	"id": "base3-37",
     "name": "Graveler",
     "imageUrl": "https://images.pokemontcg.io/base3/37.png",
     "subtype": "Stage 1",
@@ -1923,7 +1960,8 @@
     ]
   },
   {
-    "id": "base3-38",
+    "setOrder":3,
+	"id": "base3-38",
     "name": "Kingler",
     "imageUrl": "https://images.pokemontcg.io/base3/38.png",
     "subtype": "Stage 1",
@@ -1978,7 +2016,8 @@
     "nationalPokedexNumber": 99
   },
   {
-    "id": "base3-39",
+    "setOrder":3,
+	"id": "base3-39",
     "name": "Magmar",
     "imageUrl": "https://images.pokemontcg.io/base3/39.png",
     "subtype": "Basic",
@@ -2033,7 +2072,8 @@
     ]
   },
   {
-    "id": "base3-40",
+    "setOrder":3,
+	"id": "base3-40",
     "name": "Omastar",
     "imageUrl": "https://images.pokemontcg.io/base3/40.png",
     "subtype": "Stage 2",
@@ -2086,7 +2126,8 @@
     "nationalPokedexNumber": 139
   },
   {
-    "id": "base3-41",
+    "setOrder":3,
+	"id": "base3-41",
     "name": "Sandslash",
     "imageUrl": "https://images.pokemontcg.io/base3/41.png",
     "subtype": "Stage 1",
@@ -2145,7 +2186,8 @@
     "nationalPokedexNumber": 28
   },
   {
-    "id": "base3-42",
+    "setOrder":3,
+	"id": "base3-42",
     "name": "Seadra",
     "imageUrl": "https://images.pokemontcg.io/base3/42.png",
     "subtype": "Stage 1",
@@ -2202,7 +2244,8 @@
     ]
   },
   {
-    "id": "base3-43",
+    "setOrder":3,
+	"id": "base3-43",
     "name": "Slowbro",
     "imageUrl": "https://images.pokemontcg.io/base3/43.png",
     "subtype": "Stage 1",
@@ -2250,7 +2293,8 @@
     "nationalPokedexNumber": 80
   },
   {
-    "id": "base3-44",
+    "setOrder":3,
+	"id": "base3-44",
     "name": "Tentacruel",
     "imageUrl": "https://images.pokemontcg.io/base3/44.png",
     "subtype": "Stage 1",
@@ -2299,7 +2343,8 @@
     "nationalPokedexNumber": 73
   },
   {
-    "id": "base3-45",
+    "setOrder":3,
+	"id": "base3-45",
     "name": "Weezing",
     "imageUrl": "https://images.pokemontcg.io/base3/45.png",
     "subtype": "Stage 1",
@@ -2353,7 +2398,8 @@
     "nationalPokedexNumber": 110
   },
   {
-    "id": "base3-46",
+    "setOrder":3,
+	"id": "base3-46",
     "name": "Ekans",
     "imageUrl": "https://images.pokemontcg.io/base3/46.png",
     "subtype": "Basic",
@@ -2407,7 +2453,8 @@
     ]
   },
   {
-    "id": "base3-47",
+    "setOrder":3,
+	"id": "base3-47",
     "name": "Geodude",
     "imageUrl": "https://images.pokemontcg.io/base3/47.png",
     "subtype": "Basic",
@@ -2452,7 +2499,8 @@
     ]
   },
   {
-    "id": "base3-48",
+    "setOrder":3,
+	"id": "base3-48",
     "name": "Grimer",
     "imageUrl": "https://images.pokemontcg.io/base3/48.png",
     "subtype": "Basic",
@@ -2505,7 +2553,8 @@
     ]
   },
   {
-    "id": "base3-49",
+    "setOrder":3,
+	"id": "base3-49",
     "name": "Horsea",
     "imageUrl": "https://images.pokemontcg.io/base3/49.png",
     "subtype": "Basic",
@@ -2546,7 +2595,8 @@
     ]
   },
   {
-    "id": "base3-50",
+    "setOrder":3,
+	"id": "base3-50",
     "name": "Kabuto",
     "imageUrl": "https://images.pokemontcg.io/base3/50.png",
     "subtype": "Stage 1",
@@ -2595,7 +2645,8 @@
     ]
   },
   {
-    "id": "base3-51",
+    "setOrder":3,
+	"id": "base3-51",
     "name": "Krabby",
     "imageUrl": "https://images.pokemontcg.io/base3/51.png",
     "subtype": "Basic",
@@ -2650,7 +2701,8 @@
     ]
   },
   {
-    "id": "base3-52",
+    "setOrder":3,
+	"id": "base3-52",
     "name": "Omanyte",
     "imageUrl": "https://images.pokemontcg.io/base3/52.png",
     "subtype": "Stage 1",
@@ -2699,7 +2751,8 @@
     ]
   },
   {
-    "id": "base3-53",
+    "setOrder":3,
+	"id": "base3-53",
     "name": "Psyduck",
     "imageUrl": "https://images.pokemontcg.io/base3/53.png",
     "subtype": "Basic",
@@ -2752,7 +2805,8 @@
     ]
   },
   {
-    "id": "base3-54",
+    "setOrder":3,
+	"id": "base3-54",
     "name": "Shellder",
     "imageUrl": "https://images.pokemontcg.io/base3/54.png",
     "subtype": "Basic",
@@ -2805,7 +2859,8 @@
     ]
   },
   {
-    "id": "base3-55",
+    "setOrder":3,
+	"id": "base3-55",
     "name": "Slowpoke",
     "imageUrl": "https://images.pokemontcg.io/base3/55.png",
     "subtype": "Basic",
@@ -2860,7 +2915,8 @@
     ]
   },
   {
-    "id": "base3-56",
+    "setOrder":3,
+	"id": "base3-56",
     "name": "Tentacool",
     "imageUrl": "https://images.pokemontcg.io/base3/56.png",
     "subtype": "Basic",
@@ -2906,7 +2962,8 @@
     ]
   },
   {
-    "id": "base3-57",
+    "setOrder":3,
+	"id": "base3-57",
     "name": "Zubat",
     "imageUrl": "https://images.pokemontcg.io/base3/57.png",
     "subtype": "Basic",
@@ -2964,7 +3021,8 @@
     ]
   },
   {
-    "id": "base3-58",
+    "setOrder":3,
+	"id": "base3-58",
     "name": "Mr. Fuji",
     "imageUrl": "https://images.pokemontcg.io/base3/58.png",
     "subtype": "",
@@ -2981,7 +3039,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base3/58_hires.png"
   },
   {
-    "id": "base3-59",
+    "setOrder":3,
+	"id": "base3-59",
     "name": "Energy Search",
     "imageUrl": "https://images.pokemontcg.io/base3/59.png",
     "subtype": "",
@@ -2998,7 +3057,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base3/59_hires.png"
   },
   {
-    "id": "base3-60",
+    "setOrder":3,
+	"id": "base3-60",
     "name": "Gambler",
     "imageUrl": "https://images.pokemontcg.io/base3/60.png",
     "subtype": "",
@@ -3015,7 +3075,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base3/60_hires.png"
   },
   {
-    "id": "base3-61",
+    "setOrder":3,
+	"id": "base3-61",
     "name": "Recycle",
     "imageUrl": "https://images.pokemontcg.io/base3/61.png",
     "subtype": "",
@@ -3032,7 +3093,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base3/61_hires.png"
   },
   {
-    "id": "base3-62",
+    "setOrder":3,
+	"id": "base3-62",
     "name": "Mysterious Fossil",
     "imageUrl": "https://images.pokemontcg.io/base3/62.png",
     "subtype": "",

--- a/json/cards/Furious Fists.json
+++ b/json/cards/Furious Fists.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "xy3-1",
+    "setOrder":61,
+	"id": "xy3-1",
     "name": "Bellsprout",
     "imageUrl": "https://images.pokemontcg.io/xy3/1.png",
     "subtype": "Basic",
@@ -53,7 +54,8 @@
     ]
   },
   {
-    "id": "xy3-2",
+    "setOrder":61,
+	"id": "xy3-2",
     "name": "Weepinbell",
     "imageUrl": "https://images.pokemontcg.io/xy3/2.png",
     "subtype": "Stage 1",
@@ -110,7 +112,8 @@
     ]
   },
   {
-    "id": "xy3-3",
+    "setOrder":61,
+	"id": "xy3-3",
     "name": "Victreebel",
     "imageUrl": "https://images.pokemontcg.io/xy3/3.png",
     "subtype": "Stage 2",
@@ -159,7 +162,8 @@
     "nationalPokedexNumber": 71
   },
   {
-    "id": "xy3-4",
+    "setOrder":61,
+	"id": "xy3-4",
     "name": "Heracross-EX",
     "imageUrl": "https://images.pokemontcg.io/xy3/4.png",
     "subtype": "EX",
@@ -217,7 +221,8 @@
     "evolvesTo": "M Heracross-EX"
   },
   {
-    "id": "xy3-5",
+    "setOrder":61,
+	"id": "xy3-5",
     "name": "M Heracross-EX",
     "imageUrl": "https://images.pokemontcg.io/xy3/5.png",
     "subtype": "MEGA",
@@ -266,7 +271,8 @@
     "nationalPokedexNumber": 214
   },
   {
-    "id": "xy3-6",
+    "setOrder":61,
+	"id": "xy3-6",
     "name": "Shroomish",
     "imageUrl": "https://images.pokemontcg.io/xy3/6.png",
     "subtype": "Basic",
@@ -309,7 +315,8 @@
     ]
   },
   {
-    "id": "xy3-7",
+    "setOrder":61,
+	"id": "xy3-7",
     "name": "Leafeon",
     "imageUrl": "https://images.pokemontcg.io/xy3/7.png",
     "subtype": "Stage 1",
@@ -361,7 +368,8 @@
     "nationalPokedexNumber": 470
   },
   {
-    "id": "xy3-8",
+    "setOrder":61,
+	"id": "xy3-8",
     "name": "Shelmet",
     "imageUrl": "https://images.pokemontcg.io/xy3/8.png",
     "subtype": "Basic",
@@ -406,7 +414,8 @@
     ]
   },
   {
-    "id": "xy3-9",
+    "setOrder":61,
+	"id": "xy3-9",
     "name": "Accelgor",
     "imageUrl": "https://images.pokemontcg.io/xy3/9.png",
     "subtype": "Stage 1",
@@ -454,7 +463,8 @@
     "nationalPokedexNumber": 617
   },
   {
-    "id": "xy3-10",
+    "setOrder":61,
+	"id": "xy3-10",
     "name": "Magmar",
     "imageUrl": "https://images.pokemontcg.io/xy3/10.png",
     "subtype": "Basic",
@@ -508,7 +518,8 @@
     ]
   },
   {
-    "id": "xy3-11",
+    "setOrder":61,
+	"id": "xy3-11",
     "name": "Magmortar",
     "imageUrl": "https://images.pokemontcg.io/xy3/11.png",
     "subtype": "Stage 1",
@@ -563,7 +574,8 @@
     "nationalPokedexNumber": 467
   },
   {
-    "id": "xy3-12",
+    "setOrder":61,
+	"id": "xy3-12",
     "name": "Torchic",
     "imageUrl": "https://images.pokemontcg.io/xy3/12.png",
     "subtype": "Basic",
@@ -607,7 +619,8 @@
     ]
   },
   {
-    "id": "xy3-13",
+    "setOrder":61,
+	"id": "xy3-13",
     "name": "Combusken",
     "imageUrl": "https://images.pokemontcg.io/xy3/13.png",
     "subtype": "Stage 1",
@@ -663,7 +676,8 @@
     ]
   },
   {
-    "id": "xy3-14",
+    "setOrder":61,
+	"id": "xy3-14",
     "name": "Blaziken",
     "imageUrl": "https://images.pokemontcg.io/xy3/14.png",
     "subtype": "Stage 2",
@@ -718,7 +732,8 @@
     "nationalPokedexNumber": 257
   },
   {
-    "id": "xy3-15",
+    "setOrder":61,
+	"id": "xy3-15",
     "name": "Poliwag",
     "imageUrl": "https://images.pokemontcg.io/xy3/15.png",
     "subtype": "Basic",
@@ -772,7 +787,8 @@
     ]
   },
   {
-    "id": "xy3-16",
+    "setOrder":61,
+	"id": "xy3-16",
     "name": "Poliwhirl",
     "imageUrl": "https://images.pokemontcg.io/xy3/16.png",
     "subtype": "Stage 1",
@@ -828,7 +844,8 @@
     ]
   },
   {
-    "id": "xy3-17",
+    "setOrder":61,
+	"id": "xy3-17",
     "name": "Poliwrath",
     "imageUrl": "https://images.pokemontcg.io/xy3/17.png",
     "subtype": "Stage 2",
@@ -885,7 +902,8 @@
     "nationalPokedexNumber": 62
   },
   {
-    "id": "xy3-18",
+    "setOrder":61,
+	"id": "xy3-18",
     "name": "Politoed",
     "imageUrl": "https://images.pokemontcg.io/xy3/18.png",
     "subtype": "Stage 2",
@@ -933,7 +951,8 @@
     "nationalPokedexNumber": 186
   },
   {
-    "id": "xy3-19",
+    "setOrder":61,
+	"id": "xy3-19",
     "name": "Glaceon",
     "imageUrl": "https://images.pokemontcg.io/xy3/19.png",
     "subtype": "Stage 1",
@@ -985,7 +1004,8 @@
     "nationalPokedexNumber": 471
   },
   {
-    "id": "xy3-20",
+    "setOrder":61,
+	"id": "xy3-20",
     "name": "Seismitoad-EX",
     "imageUrl": "https://images.pokemontcg.io/xy3/20.png",
     "subtype": "EX",
@@ -1042,7 +1062,8 @@
     "nationalPokedexNumber": 537
   },
   {
-    "id": "xy3-21",
+    "setOrder":61,
+	"id": "xy3-21",
     "name": "Cubchoo",
     "imageUrl": "https://images.pokemontcg.io/xy3/21.png",
     "subtype": "Basic",
@@ -1097,7 +1118,8 @@
     ]
   },
   {
-    "id": "xy3-22",
+    "setOrder":61,
+	"id": "xy3-22",
     "name": "Beartic",
     "imageUrl": "https://images.pokemontcg.io/xy3/22.png",
     "subtype": "Stage 1",
@@ -1154,7 +1176,8 @@
     "nationalPokedexNumber": 614
   },
   {
-    "id": "xy3-23",
+    "setOrder":61,
+	"id": "xy3-23",
     "name": "Clauncher",
     "imageUrl": "https://images.pokemontcg.io/xy3/23.png",
     "subtype": "Basic",
@@ -1208,7 +1231,8 @@
     ]
   },
   {
-    "id": "xy3-24",
+    "setOrder":61,
+	"id": "xy3-24",
     "name": "Clawitzer",
     "imageUrl": "https://images.pokemontcg.io/xy3/24.png",
     "subtype": "Stage 1",
@@ -1261,7 +1285,8 @@
     "nationalPokedexNumber": 693
   },
   {
-    "id": "xy3-25",
+    "setOrder":61,
+	"id": "xy3-25",
     "name": "Amaura",
     "imageUrl": "https://images.pokemontcg.io/xy3/25.png",
     "subtype": "Restored",
@@ -1320,7 +1345,8 @@
     ]
   },
   {
-    "id": "xy3-26",
+    "setOrder":61,
+	"id": "xy3-26",
     "name": "Aurorus",
     "imageUrl": "https://images.pokemontcg.io/xy3/26.png",
     "subtype": "Stage 1",
@@ -1371,7 +1397,8 @@
     "nationalPokedexNumber": 699
   },
   {
-    "id": "xy3-27",
+    "setOrder":61,
+	"id": "xy3-27",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/xy3/27.png",
     "subtype": "Basic",
@@ -1421,7 +1448,8 @@
     ]
   },
   {
-    "id": "xy3-28",
+    "setOrder":61,
+	"id": "xy3-28",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/xy3/28.png",
     "subtype": "Stage 1",
@@ -1480,7 +1508,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "xy3-29",
+    "setOrder":61,
+	"id": "xy3-29",
     "name": "Electabuzz",
     "imageUrl": "https://images.pokemontcg.io/xy3/29.png",
     "subtype": "Basic",
@@ -1540,7 +1569,8 @@
     ]
   },
   {
-    "id": "xy3-30",
+    "setOrder":61,
+	"id": "xy3-30",
     "name": "Electivire",
     "imageUrl": "https://images.pokemontcg.io/xy3/30.png",
     "subtype": "Stage 1",
@@ -1600,7 +1630,8 @@
     "nationalPokedexNumber": 466
   },
   {
-    "id": "xy3-31",
+    "setOrder":61,
+	"id": "xy3-31",
     "name": "Plusle",
     "imageUrl": "https://images.pokemontcg.io/xy3/31.png",
     "subtype": "Basic",
@@ -1656,7 +1687,8 @@
     "nationalPokedexNumber": 311
   },
   {
-    "id": "xy3-32",
+    "setOrder":61,
+	"id": "xy3-32",
     "name": "Minun",
     "imageUrl": "https://images.pokemontcg.io/xy3/32.png",
     "subtype": "Basic",
@@ -1711,7 +1743,8 @@
     "nationalPokedexNumber": 312
   },
   {
-    "id": "xy3-33",
+    "setOrder":61,
+	"id": "xy3-33",
     "name": "Thundurus",
     "imageUrl": "https://images.pokemontcg.io/xy3/33.png",
     "subtype": "Basic",
@@ -1769,7 +1802,8 @@
     "nationalPokedexNumber": 642
   },
   {
-    "id": "xy3-34",
+    "setOrder":61,
+	"id": "xy3-34",
     "name": "Dedenne",
     "imageUrl": "https://images.pokemontcg.io/xy3/34.png",
     "subtype": "Basic",
@@ -1824,7 +1858,8 @@
     "nationalPokedexNumber": 702
   },
   {
-    "id": "xy3-35",
+    "setOrder":61,
+	"id": "xy3-35",
     "name": "Drowzee",
     "imageUrl": "https://images.pokemontcg.io/xy3/35.png",
     "subtype": "Basic",
@@ -1878,7 +1913,8 @@
     ]
   },
   {
-    "id": "xy3-36",
+    "setOrder":61,
+	"id": "xy3-36",
     "name": "Hypno",
     "imageUrl": "https://images.pokemontcg.io/xy3/36.png",
     "subtype": "Stage 1",
@@ -1931,7 +1967,8 @@
     "nationalPokedexNumber": 97
   },
   {
-    "id": "xy3-37",
+    "setOrder":61,
+	"id": "xy3-37",
     "name": "Jynx",
     "imageUrl": "https://images.pokemontcg.io/xy3/37.png",
     "subtype": "Basic",
@@ -1978,7 +2015,8 @@
     "nationalPokedexNumber": 124
   },
   {
-    "id": "xy3-38",
+    "setOrder":61,
+	"id": "xy3-38",
     "name": "Skorupi",
     "imageUrl": "https://images.pokemontcg.io/xy3/38.png",
     "subtype": "Basic",
@@ -2033,7 +2071,8 @@
     ]
   },
   {
-    "id": "xy3-39",
+    "setOrder":61,
+	"id": "xy3-39",
     "name": "Gothita",
     "imageUrl": "https://images.pokemontcg.io/xy3/39.png",
     "subtype": "Basic",
@@ -2086,7 +2125,8 @@
     ]
   },
   {
-    "id": "xy3-40",
+    "setOrder":61,
+	"id": "xy3-40",
     "name": "Gothorita",
     "imageUrl": "https://images.pokemontcg.io/xy3/40.png",
     "subtype": "Stage 1",
@@ -2140,7 +2180,8 @@
     ]
   },
   {
-    "id": "xy3-41",
+    "setOrder":61,
+	"id": "xy3-41",
     "name": "Gothitelle",
     "imageUrl": "https://images.pokemontcg.io/xy3/41.png",
     "subtype": "Stage 2",
@@ -2189,7 +2230,8 @@
     "nationalPokedexNumber": 576
   },
   {
-    "id": "xy3-42",
+    "setOrder":61,
+	"id": "xy3-42",
     "name": "Golett",
     "imageUrl": "https://images.pokemontcg.io/xy3/42.png",
     "subtype": "Basic",
@@ -2252,7 +2294,8 @@
     ]
   },
   {
-    "id": "xy3-43",
+    "setOrder":61,
+	"id": "xy3-43",
     "name": "Golurk",
     "imageUrl": "https://images.pokemontcg.io/xy3/43.png",
     "subtype": "Stage 1",
@@ -2316,7 +2359,8 @@
     "nationalPokedexNumber": 623
   },
   {
-    "id": "xy3-44",
+    "setOrder":61,
+	"id": "xy3-44",
     "name": "Machop",
     "imageUrl": "https://images.pokemontcg.io/xy3/44.png",
     "subtype": "Basic",
@@ -2360,7 +2404,8 @@
     ]
   },
   {
-    "id": "xy3-45",
+    "setOrder":61,
+	"id": "xy3-45",
     "name": "Machoke",
     "imageUrl": "https://images.pokemontcg.io/xy3/45.png",
     "subtype": "Stage 1",
@@ -2406,7 +2451,8 @@
     ]
   },
   {
-    "id": "xy3-46",
+    "setOrder":61,
+	"id": "xy3-46",
     "name": "Machamp",
     "imageUrl": "https://images.pokemontcg.io/xy3/46.png",
     "subtype": "Stage 2",
@@ -2455,7 +2501,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "xy3-47",
+    "setOrder":61,
+	"id": "xy3-47",
     "name": "Hitmonlee",
     "imageUrl": "https://images.pokemontcg.io/xy3/47.png",
     "subtype": "Basic",
@@ -2505,7 +2552,8 @@
     "nationalPokedexNumber": 106
   },
   {
-    "id": "xy3-48",
+    "setOrder":61,
+	"id": "xy3-48",
     "name": "Hitmonchan",
     "imageUrl": "https://images.pokemontcg.io/xy3/48.png",
     "subtype": "Basic",
@@ -2557,7 +2605,8 @@
     "nationalPokedexNumber": 107
   },
   {
-    "id": "xy3-49",
+    "setOrder":61,
+	"id": "xy3-49",
     "name": "Hitmontop",
     "imageUrl": "https://images.pokemontcg.io/xy3/49.png",
     "subtype": "Basic",
@@ -2608,7 +2657,8 @@
     "nationalPokedexNumber": 237
   },
   {
-    "id": "xy3-50",
+    "setOrder":61,
+	"id": "xy3-50",
     "name": "Breloom",
     "imageUrl": "https://images.pokemontcg.io/xy3/50.png",
     "subtype": "Stage 1",
@@ -2662,7 +2712,8 @@
     "nationalPokedexNumber": 286
   },
   {
-    "id": "xy3-51",
+    "setOrder":61,
+	"id": "xy3-51",
     "name": "Makuhita",
     "imageUrl": "https://images.pokemontcg.io/xy3/51.png",
     "subtype": "Basic",
@@ -2718,7 +2769,8 @@
     ]
   },
   {
-    "id": "xy3-52",
+    "setOrder":61,
+	"id": "xy3-52",
     "name": "Hariyama",
     "imageUrl": "https://images.pokemontcg.io/xy3/52.png",
     "subtype": "Stage 1",
@@ -2769,7 +2821,8 @@
     "nationalPokedexNumber": 297
   },
   {
-    "id": "xy3-53",
+    "setOrder":61,
+	"id": "xy3-53",
     "name": "Trapinch",
     "imageUrl": "https://images.pokemontcg.io/xy3/53.png",
     "subtype": "Basic",
@@ -2822,7 +2875,8 @@
     ]
   },
   {
-    "id": "xy3-54",
+    "setOrder":61,
+	"id": "xy3-54",
     "name": "Lucario-EX",
     "imageUrl": "https://images.pokemontcg.io/xy3/54.png",
     "subtype": "EX",
@@ -2888,7 +2942,8 @@
     "evolvesTo": "M Lucario-EX"
   },
   {
-    "id": "xy3-55",
+    "setOrder":61,
+	"id": "xy3-55",
     "name": "M Lucario-EX",
     "imageUrl": "https://images.pokemontcg.io/xy3/55.png",
     "subtype": "MEGA",
@@ -2935,7 +2990,8 @@
     "nationalPokedexNumber": 448
   },
   {
-    "id": "xy3-55a",
+    "setOrder":61,
+	"id": "xy3-55a",
     "name": "M Lucario-EX",
     "imageUrl": "https://images.pokemontcg.io/xy3/55a.png",
     "subtype": "MEGA",
@@ -2982,7 +3038,8 @@
     "nationalPokedexNumber": 448
   },
   {
-    "id": "xy3-56",
+    "setOrder":61,
+	"id": "xy3-56",
     "name": "Mienfoo",
     "imageUrl": "https://images.pokemontcg.io/xy3/56.png",
     "subtype": "Basic",
@@ -3035,7 +3092,8 @@
     ]
   },
   {
-    "id": "xy3-57",
+    "setOrder":61,
+	"id": "xy3-57",
     "name": "Mienshao",
     "imageUrl": "https://images.pokemontcg.io/xy3/57.png",
     "subtype": "Stage 1",
@@ -3086,7 +3144,8 @@
     "nationalPokedexNumber": 620
   },
   {
-    "id": "xy3-58",
+    "setOrder":61,
+	"id": "xy3-58",
     "name": "Landorus",
     "imageUrl": "https://images.pokemontcg.io/xy3/58.png",
     "subtype": "Basic",
@@ -3137,7 +3196,8 @@
     "nationalPokedexNumber": 645
   },
   {
-    "id": "xy3-59",
+    "setOrder":61,
+	"id": "xy3-59",
     "name": "Pancham",
     "imageUrl": "https://images.pokemontcg.io/xy3/59.png",
     "subtype": "Basic",
@@ -3191,7 +3251,8 @@
     ]
   },
   {
-    "id": "xy3-60",
+    "setOrder":61,
+	"id": "xy3-60",
     "name": "Pancham",
     "imageUrl": "https://images.pokemontcg.io/xy3/60.png",
     "subtype": "Basic",
@@ -3236,7 +3297,8 @@
     ]
   },
   {
-    "id": "xy3-61",
+    "setOrder":61,
+	"id": "xy3-61",
     "name": "Tyrunt",
     "imageUrl": "https://images.pokemontcg.io/xy3/61.png",
     "subtype": "Restored",
@@ -3295,7 +3357,8 @@
     ]
   },
   {
-    "id": "xy3-62",
+    "setOrder":61,
+	"id": "xy3-62",
     "name": "Tyrantrum",
     "imageUrl": "https://images.pokemontcg.io/xy3/62.png",
     "subtype": "Stage 1",
@@ -3352,7 +3415,8 @@
     "nationalPokedexNumber": 697
   },
   {
-    "id": "xy3-63",
+    "setOrder":61,
+	"id": "xy3-63",
     "name": "Hawlucha",
     "imageUrl": "https://images.pokemontcg.io/xy3/63.png",
     "subtype": "Basic",
@@ -3400,7 +3464,8 @@
     "nationalPokedexNumber": 701
   },
   {
-    "id": "xy3-64",
+    "setOrder":61,
+	"id": "xy3-64",
     "name": "Hawlucha-EX",
     "imageUrl": "https://images.pokemontcg.io/xy3/64.png",
     "subtype": "EX",
@@ -3456,7 +3521,8 @@
     "nationalPokedexNumber": 701
   },
   {
-    "id": "xy3-65",
+    "setOrder":61,
+	"id": "xy3-65",
     "name": "Drapion",
     "imageUrl": "https://images.pokemontcg.io/xy3/65.png",
     "subtype": "Stage 1",
@@ -3517,7 +3583,8 @@
     "nationalPokedexNumber": 452
   },
   {
-    "id": "xy3-66",
+    "setOrder":61,
+	"id": "xy3-66",
     "name": "Scraggy",
     "imageUrl": "https://images.pokemontcg.io/xy3/66.png",
     "subtype": "Basic",
@@ -3568,7 +3635,8 @@
     ]
   },
   {
-    "id": "xy3-67",
+    "setOrder":61,
+	"id": "xy3-67",
     "name": "Scrafty",
     "imageUrl": "https://images.pokemontcg.io/xy3/67.png",
     "subtype": "Stage 1",
@@ -3627,7 +3695,8 @@
     "nationalPokedexNumber": 560
   },
   {
-    "id": "xy3-68",
+    "setOrder":61,
+	"id": "xy3-68",
     "name": "Pangoro",
     "imageUrl": "https://images.pokemontcg.io/xy3/68.png",
     "subtype": "Stage 1",
@@ -3688,7 +3757,8 @@
     "nationalPokedexNumber": 675
   },
   {
-    "id": "xy3-69",
+    "setOrder":61,
+	"id": "xy3-69",
     "name": "Clefairy",
     "imageUrl": "https://images.pokemontcg.io/xy3/69.png",
     "subtype": "Basic",
@@ -3747,7 +3817,8 @@
     ]
   },
   {
-    "id": "xy3-70",
+    "setOrder":61,
+	"id": "xy3-70",
     "name": "Clefairy",
     "imageUrl": "https://images.pokemontcg.io/xy3/70.png",
     "subtype": "Basic",
@@ -3796,7 +3867,8 @@
     ]
   },
   {
-    "id": "xy3-71",
+    "setOrder":61,
+	"id": "xy3-71",
     "name": "Clefable",
     "imageUrl": "https://images.pokemontcg.io/xy3/71.png",
     "subtype": "Stage 1",
@@ -3854,7 +3926,8 @@
     "nationalPokedexNumber": 36
   },
   {
-    "id": "xy3-72",
+    "setOrder":61,
+	"id": "xy3-72",
     "name": "Sylveon",
     "imageUrl": "https://images.pokemontcg.io/xy3/72.png",
     "subtype": "Stage 1",
@@ -3912,7 +3985,8 @@
     "nationalPokedexNumber": 700
   },
   {
-    "id": "xy3-73",
+    "setOrder":61,
+	"id": "xy3-73",
     "name": "Klefki",
     "imageUrl": "https://images.pokemontcg.io/xy3/73.png",
     "subtype": "Basic",
@@ -3964,7 +4038,8 @@
     "nationalPokedexNumber": 707
   },
   {
-    "id": "xy3-74",
+    "setOrder":61,
+	"id": "xy3-74",
     "name": "Dragonite-EX",
     "imageUrl": "https://images.pokemontcg.io/xy3/74.png",
     "subtype": "EX",
@@ -4016,7 +4091,8 @@
     "nationalPokedexNumber": 149
   },
   {
-    "id": "xy3-75",
+    "setOrder":61,
+	"id": "xy3-75",
     "name": "Vibrava",
     "imageUrl": "https://images.pokemontcg.io/xy3/75.png",
     "subtype": "Stage 1",
@@ -4070,7 +4146,8 @@
     ]
   },
   {
-    "id": "xy3-76",
+    "setOrder":61,
+	"id": "xy3-76",
     "name": "Flygon",
     "imageUrl": "https://images.pokemontcg.io/xy3/76.png",
     "subtype": "Stage 2",
@@ -4122,7 +4199,8 @@
     "nationalPokedexNumber": 330
   },
   {
-    "id": "xy3-77",
+    "setOrder":61,
+	"id": "xy3-77",
     "name": "Noivern",
     "imageUrl": "https://images.pokemontcg.io/xy3/77.png",
     "subtype": "Stage 1",
@@ -4170,7 +4248,8 @@
     "nationalPokedexNumber": 715
   },
   {
-    "id": "xy3-78",
+    "setOrder":61,
+	"id": "xy3-78",
     "name": "Lickitung",
     "imageUrl": "https://images.pokemontcg.io/xy3/78.png",
     "subtype": "Basic",
@@ -4217,7 +4296,8 @@
     ]
   },
   {
-    "id": "xy3-79",
+    "setOrder":61,
+	"id": "xy3-79",
     "name": "Lickilicky",
     "imageUrl": "https://images.pokemontcg.io/xy3/79.png",
     "subtype": "Stage 1",
@@ -4275,7 +4355,8 @@
     "nationalPokedexNumber": 463
   },
   {
-    "id": "xy3-80",
+    "setOrder":61,
+	"id": "xy3-80",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/xy3/80.png",
     "subtype": "Basic",
@@ -4331,7 +4412,8 @@
     ]
   },
   {
-    "id": "xy3-81",
+    "setOrder":61,
+	"id": "xy3-81",
     "name": "Slakoth",
     "imageUrl": "https://images.pokemontcg.io/xy3/81.png",
     "subtype": "Basic",
@@ -4377,7 +4459,8 @@
     ]
   },
   {
-    "id": "xy3-82",
+    "setOrder":61,
+	"id": "xy3-82",
     "name": "Vigoroth",
     "imageUrl": "https://images.pokemontcg.io/xy3/82.png",
     "subtype": "Stage 1",
@@ -4433,7 +4516,8 @@
     ]
   },
   {
-    "id": "xy3-83",
+    "setOrder":61,
+	"id": "xy3-83",
     "name": "Slaking",
     "imageUrl": "https://images.pokemontcg.io/xy3/83.png",
     "subtype": "Stage 2",
@@ -4491,7 +4575,8 @@
     "nationalPokedexNumber": 289
   },
   {
-    "id": "xy3-84",
+    "setOrder":61,
+	"id": "xy3-84",
     "name": "Patrat",
     "imageUrl": "https://images.pokemontcg.io/xy3/84.png",
     "subtype": "Basic",
@@ -4534,7 +4619,8 @@
     ]
   },
   {
-    "id": "xy3-85",
+    "setOrder":61,
+	"id": "xy3-85",
     "name": "Watchog",
     "imageUrl": "https://images.pokemontcg.io/xy3/85.png",
     "subtype": "Stage 1",
@@ -4585,7 +4671,8 @@
     "nationalPokedexNumber": 505
   },
   {
-    "id": "xy3-86",
+    "setOrder":61,
+	"id": "xy3-86",
     "name": "Tornadus",
     "imageUrl": "https://images.pokemontcg.io/xy3/86.png",
     "subtype": "Basic",
@@ -4643,7 +4730,8 @@
     "nationalPokedexNumber": 641
   },
   {
-    "id": "xy3-87",
+    "setOrder":61,
+	"id": "xy3-87",
     "name": "Noibat",
     "imageUrl": "https://images.pokemontcg.io/xy3/87.png",
     "subtype": "Basic",
@@ -4702,7 +4790,8 @@
     ]
   },
   {
-    "id": "xy3-88",
+    "setOrder":61,
+	"id": "xy3-88",
     "name": "Battle Reporter",
     "imageUrl": "https://images.pokemontcg.io/xy3/88.png",
     "subtype": "Supporter",
@@ -4719,7 +4808,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy3/88_hires.png"
   },
   {
-    "id": "xy3-89",
+    "setOrder":61,
+	"id": "xy3-89",
     "name": "Energy Switch",
     "imageUrl": "https://images.pokemontcg.io/xy3/89.png",
     "subtype": "Item",
@@ -4736,7 +4826,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy3/89_hires.png"
   },
   {
-    "id": "xy3-90",
+    "setOrder":61,
+	"id": "xy3-90",
     "name": "Fighting Stadium",
     "imageUrl": "https://images.pokemontcg.io/xy3/90.png",
     "subtype": "Stadium",
@@ -4753,7 +4844,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy3/90_hires.png"
   },
   {
-    "id": "xy3-91",
+    "setOrder":61,
+	"id": "xy3-91",
     "name": "Focus Sash",
     "imageUrl": "https://images.pokemontcg.io/xy3/91.png",
     "subtype": "Pokémon Tool",
@@ -4770,7 +4862,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy3/91_hires.png"
   },
   {
-    "id": "xy3-92",
+    "setOrder":61,
+	"id": "xy3-92",
     "name": "Fossil Researcher",
     "imageUrl": "https://images.pokemontcg.io/xy3/92.png",
     "subtype": "Supporter",
@@ -4787,7 +4880,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy3/92_hires.png"
   },
   {
-    "id": "xy3-93",
+    "setOrder":61,
+	"id": "xy3-93",
     "name": "Full Heal",
     "imageUrl": "https://images.pokemontcg.io/xy3/93.png",
     "subtype": "Item",
@@ -4804,7 +4898,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy3/93_hires.png"
   },
   {
-    "id": "xy3-94",
+    "setOrder":61,
+	"id": "xy3-94",
     "name": "Jaw Fossil",
     "imageUrl": "https://images.pokemontcg.io/xy3/94.png",
     "subtype": "Item",
@@ -4821,7 +4916,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy3/94_hires.png"
   },
   {
-    "id": "xy3-95",
+    "setOrder":61,
+	"id": "xy3-95",
     "name": "Korrina",
     "imageUrl": "https://images.pokemontcg.io/xy3/95.png",
     "subtype": "Supporter",
@@ -4838,7 +4934,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy3/95_hires.png"
   },
   {
-    "id": "xy3-96",
+    "setOrder":61,
+	"id": "xy3-96",
     "name": "Maintenance",
     "imageUrl": "https://images.pokemontcg.io/xy3/96.png",
     "subtype": "Item",
@@ -4855,7 +4952,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy3/96_hires.png"
   },
   {
-    "id": "xy3-97",
+    "setOrder":61,
+	"id": "xy3-97",
     "name": "Mountain Ring",
     "imageUrl": "https://images.pokemontcg.io/xy3/97.png",
     "subtype": "Stadium",
@@ -4872,7 +4970,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy3/97_hires.png"
   },
   {
-    "id": "xy3-98",
+    "setOrder":61,
+	"id": "xy3-98",
     "name": "Sail Fossil",
     "imageUrl": "https://images.pokemontcg.io/xy3/98.png",
     "subtype": "Item",
@@ -4889,7 +4988,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy3/98_hires.png"
   },
   {
-    "id": "xy3-99",
+    "setOrder":61,
+	"id": "xy3-99",
     "name": "Sparkling Robe",
     "imageUrl": "https://images.pokemontcg.io/xy3/99.png",
     "subtype": "Pokémon Tool",
@@ -4906,7 +5006,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy3/99_hires.png"
   },
   {
-    "id": "xy3-100",
+    "setOrder":61,
+	"id": "xy3-100",
     "name": "Super Scoop Up",
     "imageUrl": "https://images.pokemontcg.io/xy3/100.png",
     "subtype": "Item",
@@ -4923,7 +5024,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy3/100_hires.png"
   },
   {
-    "id": "xy3-101",
+    "setOrder":61,
+	"id": "xy3-101",
     "name": "Tool Retriever",
     "imageUrl": "https://images.pokemontcg.io/xy3/101.png",
     "subtype": "Item",
@@ -4940,7 +5042,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy3/101_hires.png"
   },
   {
-    "id": "xy3-102",
+    "setOrder":61,
+	"id": "xy3-102",
     "name": "Training Center",
     "imageUrl": "https://images.pokemontcg.io/xy3/102.png",
     "subtype": "Stadium",
@@ -4957,7 +5060,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy3/102_hires.png"
   },
   {
-    "id": "xy3-103",
+    "setOrder":61,
+	"id": "xy3-103",
     "name": "Herbal Energy",
     "imageUrl": "https://images.pokemontcg.io/xy3/103.png",
     "subtype": "Special",
@@ -4974,7 +5078,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy3/103_hires.png"
   },
   {
-    "id": "xy3-104",
+    "setOrder":61,
+	"id": "xy3-104",
     "name": "Strong Energy",
     "imageUrl": "https://images.pokemontcg.io/xy3/104.png",
     "subtype": "Special",
@@ -4991,7 +5096,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy3/104_hires.png"
   },
   {
-    "id": "xy3-105",
+    "setOrder":61,
+	"id": "xy3-105",
     "name": "Heracross-EX",
     "imageUrl": "https://images.pokemontcg.io/xy3/105.png",
     "subtype": "EX",
@@ -5049,7 +5155,8 @@
     "evolvesTo": "M Heracross-EX"
   },
   {
-    "id": "xy3-106",
+    "setOrder":61,
+	"id": "xy3-106",
     "name": "Seismitoad-EX",
     "imageUrl": "https://images.pokemontcg.io/xy3/106.png",
     "subtype": "EX",
@@ -5106,7 +5213,8 @@
     "nationalPokedexNumber": 537
   },
   {
-    "id": "xy3-107",
+    "setOrder":61,
+	"id": "xy3-107",
     "name": "Lucario-EX",
     "imageUrl": "https://images.pokemontcg.io/xy3/107.png",
     "subtype": "EX",
@@ -5172,7 +5280,8 @@
     "evolvesTo": "M Lucario-EX"
   },
   {
-    "id": "xy3-108",
+    "setOrder":61,
+	"id": "xy3-108",
     "name": "Dragonite-EX",
     "imageUrl": "https://images.pokemontcg.io/xy3/108.png",
     "subtype": "EX",
@@ -5224,7 +5333,8 @@
     "nationalPokedexNumber": 149
   },
   {
-    "id": "xy3-109",
+    "setOrder":61,
+	"id": "xy3-109",
     "name": "Battle Reporter",
     "imageUrl": "https://images.pokemontcg.io/xy3/109.png",
     "subtype": "Supporter",
@@ -5241,7 +5351,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy3/109_hires.png"
   },
   {
-    "id": "xy3-110",
+    "setOrder":61,
+	"id": "xy3-110",
     "name": "Fossil Researcher",
     "imageUrl": "https://images.pokemontcg.io/xy3/110.png",
     "subtype": "Supporter",
@@ -5258,7 +5369,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy3/110_hires.png"
   },
   {
-    "id": "xy3-111",
+    "setOrder":61,
+	"id": "xy3-111",
     "name": "Korrina",
     "imageUrl": "https://images.pokemontcg.io/xy3/111.png",
     "subtype": "Supporter",
@@ -5275,7 +5387,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy3/111_hires.png"
   },
   {
-    "id": "xy3-112",
+    "setOrder":61,
+	"id": "xy3-112",
     "name": "M Heracross-EX",
     "imageUrl": "https://images.pokemontcg.io/xy3/112.png",
     "subtype": "MEGA",
@@ -5324,7 +5437,8 @@
     "nationalPokedexNumber": 214
   },
   {
-    "id": "xy3-113",
+    "setOrder":61,
+	"id": "xy3-113",
     "name": "M Lucario-EX",
     "imageUrl": "https://images.pokemontcg.io/xy3/113.png",
     "subtype": "MEGA",

--- a/json/cards/Generations.json
+++ b/json/cards/Generations.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "g1-1",
+    "setOrder":68,
+	"id": "g1-1",
     "name": "Venusaur-EX",
     "imageUrl": "https://images.pokemontcg.io/g1/1.png",
     "subtype": "EX",
@@ -61,7 +62,8 @@
     "evolvesTo": "M Venusaur-EX"
   },
   {
-    "id": "g1-2",
+    "setOrder":68,
+	"id": "g1-2",
     "name": "M Venusaur-EX",
     "imageUrl": "https://images.pokemontcg.io/g1/2.png",
     "subtype": "MEGA",
@@ -112,7 +114,8 @@
     "nationalPokedexNumber": 3
   },
   {
-    "id": "g1-3",
+    "setOrder":68,
+	"id": "g1-3",
     "name": "Caterpie",
     "imageUrl": "https://images.pokemontcg.io/g1/3.png",
     "subtype": "Basic",
@@ -160,7 +163,8 @@
     ]
   },
   {
-    "id": "g1-4",
+    "setOrder":68,
+	"id": "g1-4",
     "name": "Metapod",
     "imageUrl": "https://images.pokemontcg.io/g1/4.png",
     "subtype": "Stage 1",
@@ -211,7 +215,8 @@
     ]
   },
   {
-    "id": "g1-5",
+    "setOrder":68,
+	"id": "g1-5",
     "name": "Butterfree",
     "imageUrl": "https://images.pokemontcg.io/g1/5.png",
     "subtype": "Stage 2",
@@ -269,7 +274,8 @@
     "nationalPokedexNumber": 12
   },
   {
-    "id": "g1-6",
+    "setOrder":68,
+	"id": "g1-6",
     "name": "Paras",
     "imageUrl": "https://images.pokemontcg.io/g1/6.png",
     "subtype": "Basic",
@@ -312,7 +318,8 @@
     ]
   },
   {
-    "id": "g1-7",
+    "setOrder":68,
+	"id": "g1-7",
     "name": "Parasect",
     "imageUrl": "https://images.pokemontcg.io/g1/7.png",
     "subtype": "Stage 1",
@@ -364,7 +371,8 @@
     "nationalPokedexNumber": 47
   },
   {
-    "id": "g1-8",
+    "setOrder":68,
+	"id": "g1-8",
     "name": "Tangela",
     "imageUrl": "https://images.pokemontcg.io/g1/8.png",
     "subtype": "Basic",
@@ -420,7 +428,8 @@
     ]
   },
   {
-    "id": "g1-9",
+    "setOrder":68,
+	"id": "g1-9",
     "name": "Pinsir",
     "imageUrl": "https://images.pokemontcg.io/g1/9.png",
     "subtype": "Basic",
@@ -472,7 +481,8 @@
     "nationalPokedexNumber": 127
   },
   {
-    "id": "g1-10",
+    "setOrder":68,
+	"id": "g1-10",
     "name": "Leafeon-EX",
     "imageUrl": "https://images.pokemontcg.io/g1/10.png",
     "subtype": "EX",
@@ -528,7 +538,8 @@
     "nationalPokedexNumber": 470
   },
   {
-    "id": "g1-11",
+    "setOrder":68,
+	"id": "g1-11",
     "name": "Charizard-EX",
     "imageUrl": "https://images.pokemontcg.io/g1/11.png",
     "subtype": "EX",
@@ -586,7 +597,8 @@
     "evolvesTo": "M Charizard-EX"
   },
   {
-    "id": "g1-12",
+    "setOrder":68,
+	"id": "g1-12",
     "name": "M Charizard-EX",
     "imageUrl": "https://images.pokemontcg.io/g1/12.png",
     "subtype": "MEGA",
@@ -636,7 +648,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "g1-13",
+    "setOrder":68,
+	"id": "g1-13",
     "name": "Ninetales-EX",
     "imageUrl": "https://images.pokemontcg.io/g1/13.png",
     "subtype": "EX",
@@ -691,7 +704,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "g1-14",
+    "setOrder":68,
+	"id": "g1-14",
     "name": "Ponyta",
     "imageUrl": "https://images.pokemontcg.io/g1/14.png",
     "subtype": "Basic",
@@ -744,7 +758,8 @@
     ]
   },
   {
-    "id": "g1-15",
+    "setOrder":68,
+	"id": "g1-15",
     "name": "Rapidash",
     "imageUrl": "https://images.pokemontcg.io/g1/15.png",
     "subtype": "Stage 1",
@@ -792,7 +807,8 @@
     "nationalPokedexNumber": 78
   },
   {
-    "id": "g1-16",
+    "setOrder":68,
+	"id": "g1-16",
     "name": "Magmar",
     "imageUrl": "https://images.pokemontcg.io/g1/16.png",
     "subtype": "Basic",
@@ -846,7 +862,8 @@
     ]
   },
   {
-    "id": "g1-17",
+    "setOrder":68,
+	"id": "g1-17",
     "name": "Blastoise-EX",
     "imageUrl": "https://images.pokemontcg.io/g1/17.png",
     "subtype": "EX",
@@ -906,7 +923,8 @@
     "evolvesTo": "M Blastoise-EX"
   },
   {
-    "id": "g1-18",
+    "setOrder":68,
+	"id": "g1-18",
     "name": "M Blastoise-EX",
     "imageUrl": "https://images.pokemontcg.io/g1/18.png",
     "subtype": "MEGA",
@@ -956,7 +974,8 @@
     "nationalPokedexNumber": 9
   },
   {
-    "id": "g1-19",
+    "setOrder":68,
+	"id": "g1-19",
     "name": "Shellder",
     "imageUrl": "https://images.pokemontcg.io/g1/19.png",
     "subtype": "Basic",
@@ -1000,7 +1019,8 @@
     ]
   },
   {
-    "id": "g1-20",
+    "setOrder":68,
+	"id": "g1-20",
     "name": "Cloyster",
     "imageUrl": "https://images.pokemontcg.io/g1/20.png",
     "subtype": "Stage 1",
@@ -1055,7 +1075,8 @@
     "nationalPokedexNumber": 91
   },
   {
-    "id": "g1-21",
+    "setOrder":68,
+	"id": "g1-21",
     "name": "Krabby",
     "imageUrl": "https://images.pokemontcg.io/g1/21.png",
     "subtype": "Basic",
@@ -1110,7 +1131,8 @@
     ]
   },
   {
-    "id": "g1-22",
+    "setOrder":68,
+	"id": "g1-22",
     "name": "Magikarp",
     "imageUrl": "https://images.pokemontcg.io/g1/22.png",
     "subtype": "Basic",
@@ -1153,7 +1175,8 @@
     ]
   },
   {
-    "id": "g1-23",
+    "setOrder":68,
+	"id": "g1-23",
     "name": "Gyarados",
     "imageUrl": "https://images.pokemontcg.io/g1/23.png",
     "subtype": "Stage 1",
@@ -1210,7 +1233,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "g1-24",
+    "setOrder":68,
+	"id": "g1-24",
     "name": "Vaporeon-EX",
     "imageUrl": "https://images.pokemontcg.io/g1/24.png",
     "subtype": "EX",
@@ -1267,7 +1291,8 @@
     "nationalPokedexNumber": 134
   },
   {
-    "id": "g1-25",
+    "setOrder":68,
+	"id": "g1-25",
     "name": "Articuno",
     "imageUrl": "https://images.pokemontcg.io/g1/25.png",
     "subtype": "Basic",
@@ -1325,7 +1350,8 @@
     "nationalPokedexNumber": 144
   },
   {
-    "id": "g1-26",
+    "setOrder":68,
+	"id": "g1-26",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/g1/26.png",
     "subtype": "Basic",
@@ -1384,7 +1410,8 @@
     ]
   },
   {
-    "id": "g1-27",
+    "setOrder":68,
+	"id": "g1-27",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/g1/27.png",
     "subtype": "Stage 1",
@@ -1440,7 +1467,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "g1-28",
+    "setOrder":68,
+	"id": "g1-28",
     "name": "Jolteon-EX",
     "imageUrl": "https://images.pokemontcg.io/g1/28.png",
     "subtype": "EX",
@@ -1497,7 +1525,8 @@
     "nationalPokedexNumber": 135
   },
   {
-    "id": "g1-28a",
+    "setOrder":68,
+	"id": "g1-28a",
     "name": "Jolteon-EX",
     "imageUrl": "https://images.pokemontcg.io/g1/28a.png",
     "subtype": "EX",
@@ -1554,7 +1583,8 @@
     "nationalPokedexNumber": 135
   },
   {
-    "id": "g1-29",
+    "setOrder":68,
+	"id": "g1-29",
     "name": "Zapdos",
     "imageUrl": "https://images.pokemontcg.io/g1/29.png",
     "subtype": "Basic",
@@ -1612,7 +1642,8 @@
     "nationalPokedexNumber": 145
   },
   {
-    "id": "g1-30",
+    "setOrder":68,
+	"id": "g1-30",
     "name": "Zubat",
     "imageUrl": "https://images.pokemontcg.io/g1/30.png",
     "subtype": "Basic",
@@ -1661,7 +1692,8 @@
     ]
   },
   {
-    "id": "g1-31",
+    "setOrder":68,
+	"id": "g1-31",
     "name": "Golbat",
     "imageUrl": "https://images.pokemontcg.io/g1/31.png",
     "subtype": "Stage 1",
@@ -1713,7 +1745,8 @@
     ]
   },
   {
-    "id": "g1-32",
+    "setOrder":68,
+	"id": "g1-32",
     "name": "Slowpoke",
     "imageUrl": "https://images.pokemontcg.io/g1/32.png",
     "subtype": "Basic",
@@ -1767,7 +1800,8 @@
     ]
   },
   {
-    "id": "g1-33",
+    "setOrder":68,
+	"id": "g1-33",
     "name": "Gastly",
     "imageUrl": "https://images.pokemontcg.io/g1/33.png",
     "subtype": "Basic",
@@ -1816,7 +1850,8 @@
     ]
   },
   {
-    "id": "g1-34",
+    "setOrder":68,
+	"id": "g1-34",
     "name": "Haunter",
     "imageUrl": "https://images.pokemontcg.io/g1/34.png",
     "subtype": "Stage 1",
@@ -1872,7 +1907,8 @@
     ]
   },
   {
-    "id": "g1-35",
+    "setOrder":68,
+	"id": "g1-35",
     "name": "Gengar",
     "imageUrl": "https://images.pokemontcg.io/g1/35.png",
     "subtype": "Stage 2",
@@ -1926,7 +1962,8 @@
     "nationalPokedexNumber": 94
   },
   {
-    "id": "g1-36",
+    "setOrder":68,
+	"id": "g1-36",
     "name": "Jynx",
     "imageUrl": "https://images.pokemontcg.io/g1/36.png",
     "subtype": "Basic",
@@ -1973,7 +2010,8 @@
     "nationalPokedexNumber": 124
   },
   {
-    "id": "g1-37",
+    "setOrder":68,
+	"id": "g1-37",
     "name": "Meowstic-EX",
     "imageUrl": "https://images.pokemontcg.io/g1/37.png",
     "subtype": "EX",
@@ -2022,7 +2060,8 @@
     "nationalPokedexNumber": 678
   },
   {
-    "id": "g1-38",
+    "setOrder":68,
+	"id": "g1-38",
     "name": "Diglett",
     "imageUrl": "https://images.pokemontcg.io/g1/38.png",
     "subtype": "Basic",
@@ -2075,7 +2114,8 @@
     ]
   },
   {
-    "id": "g1-39",
+    "setOrder":68,
+	"id": "g1-39",
     "name": "Dugtrio",
     "imageUrl": "https://images.pokemontcg.io/g1/39.png",
     "subtype": "Stage 1",
@@ -2127,7 +2167,8 @@
     "nationalPokedexNumber": 51
   },
   {
-    "id": "g1-40",
+    "setOrder":68,
+	"id": "g1-40",
     "name": "Machop",
     "imageUrl": "https://images.pokemontcg.io/g1/40.png",
     "subtype": "Basic",
@@ -2171,7 +2212,8 @@
     ]
   },
   {
-    "id": "g1-41",
+    "setOrder":68,
+	"id": "g1-41",
     "name": "Machoke",
     "imageUrl": "https://images.pokemontcg.io/g1/41.png",
     "subtype": "Stage 1",
@@ -2217,7 +2259,8 @@
     ]
   },
   {
-    "id": "g1-42",
+    "setOrder":68,
+	"id": "g1-42",
     "name": "Machamp",
     "imageUrl": "https://images.pokemontcg.io/g1/42.png",
     "subtype": "Stage 2",
@@ -2266,7 +2309,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "g1-43",
+    "setOrder":68,
+	"id": "g1-43",
     "name": "Geodude",
     "imageUrl": "https://images.pokemontcg.io/g1/43.png",
     "subtype": "Basic",
@@ -2320,7 +2364,8 @@
     ]
   },
   {
-    "id": "g1-44",
+    "setOrder":68,
+	"id": "g1-44",
     "name": "Graveler",
     "imageUrl": "https://images.pokemontcg.io/g1/44.png",
     "subtype": "Stage 1",
@@ -2380,7 +2425,8 @@
     ]
   },
   {
-    "id": "g1-45",
+    "setOrder":68,
+	"id": "g1-45",
     "name": "Golem",
     "imageUrl": "https://images.pokemontcg.io/g1/45.png",
     "subtype": "Stage 2",
@@ -2437,7 +2483,8 @@
     "nationalPokedexNumber": 76
   },
   {
-    "id": "g1-46",
+    "setOrder":68,
+	"id": "g1-46",
     "name": "Golem-EX",
     "imageUrl": "https://images.pokemontcg.io/g1/46.png",
     "subtype": "EX",
@@ -2497,7 +2544,8 @@
     "nationalPokedexNumber": 76
   },
   {
-    "id": "g1-47",
+    "setOrder":68,
+	"id": "g1-47",
     "name": "Hitmonlee",
     "imageUrl": "https://images.pokemontcg.io/g1/47.png",
     "subtype": "Basic",
@@ -2547,7 +2595,8 @@
     "nationalPokedexNumber": 106
   },
   {
-    "id": "g1-48",
+    "setOrder":68,
+	"id": "g1-48",
     "name": "Hitmonchan",
     "imageUrl": "https://images.pokemontcg.io/g1/48.png",
     "subtype": "Basic",
@@ -2599,7 +2648,8 @@
     "nationalPokedexNumber": 107
   },
   {
-    "id": "g1-49",
+    "setOrder":68,
+	"id": "g1-49",
     "name": "Rhyhorn",
     "imageUrl": "https://images.pokemontcg.io/g1/49.png",
     "subtype": "Basic",
@@ -2645,7 +2695,8 @@
     ]
   },
   {
-    "id": "g1-50",
+    "setOrder":68,
+	"id": "g1-50",
     "name": "Clefairy",
     "imageUrl": "https://images.pokemontcg.io/g1/50.png",
     "subtype": "Basic",
@@ -2704,7 +2755,8 @@
     ]
   },
   {
-    "id": "g1-51",
+    "setOrder":68,
+	"id": "g1-51",
     "name": "Clefable",
     "imageUrl": "https://images.pokemontcg.io/g1/51.png",
     "subtype": "Stage 1",
@@ -2762,7 +2814,8 @@
     "nationalPokedexNumber": 36
   },
   {
-    "id": "g1-52",
+    "setOrder":68,
+	"id": "g1-52",
     "name": "Mr. Mime",
     "imageUrl": "https://images.pokemontcg.io/g1/52.png",
     "subtype": "Basic",
@@ -2814,7 +2867,8 @@
     "nationalPokedexNumber": 122
   },
   {
-    "id": "g1-53",
+    "setOrder":68,
+	"id": "g1-53",
     "name": "Meowth",
     "imageUrl": "https://images.pokemontcg.io/g1/53.png",
     "subtype": "Basic",
@@ -2857,7 +2911,8 @@
     ]
   },
   {
-    "id": "g1-54",
+    "setOrder":68,
+	"id": "g1-54",
     "name": "Persian",
     "imageUrl": "https://images.pokemontcg.io/g1/54.png",
     "subtype": "Stage 1",
@@ -2908,7 +2963,8 @@
     "nationalPokedexNumber": 53
   },
   {
-    "id": "g1-55",
+    "setOrder":68,
+	"id": "g1-55",
     "name": "Doduo",
     "imageUrl": "https://images.pokemontcg.io/g1/55.png",
     "subtype": "Basic",
@@ -2967,7 +3023,8 @@
     ]
   },
   {
-    "id": "g1-56",
+    "setOrder":68,
+	"id": "g1-56",
     "name": "Dodrio",
     "imageUrl": "https://images.pokemontcg.io/g1/56.png",
     "subtype": "Stage 1",
@@ -3021,7 +3078,8 @@
     "nationalPokedexNumber": 85
   },
   {
-    "id": "g1-57",
+    "setOrder":68,
+	"id": "g1-57",
     "name": "Tauros",
     "imageUrl": "https://images.pokemontcg.io/g1/57.png",
     "subtype": "Basic",
@@ -3073,7 +3131,8 @@
     "nationalPokedexNumber": 128
   },
   {
-    "id": "g1-58",
+    "setOrder":68,
+	"id": "g1-58",
     "name": "Snorlax",
     "imageUrl": "https://images.pokemontcg.io/g1/58.png",
     "subtype": "Basic",
@@ -3124,7 +3183,8 @@
     "nationalPokedexNumber": 143
   },
   {
-    "id": "g1-59",
+    "setOrder":68,
+	"id": "g1-59",
     "name": "Clemont",
     "imageUrl": "https://images.pokemontcg.io/g1/59.png",
     "subtype": "Supporter",
@@ -3141,7 +3201,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/59_hires.png"
   },
   {
-    "id": "g1-60",
+    "setOrder":68,
+	"id": "g1-60",
     "name": "Crushing Hammer",
     "imageUrl": "https://images.pokemontcg.io/g1/60.png",
     "subtype": "Item",
@@ -3158,7 +3219,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/60_hires.png"
   },
   {
-    "id": "g1-61",
+    "setOrder":68,
+	"id": "g1-61",
     "name": "Energy Switch",
     "imageUrl": "https://images.pokemontcg.io/g1/61.png",
     "subtype": "Item",
@@ -3175,7 +3237,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/61_hires.png"
   },
   {
-    "id": "g1-62",
+    "setOrder":68,
+	"id": "g1-62",
     "name": "Evosoda",
     "imageUrl": "https://images.pokemontcg.io/g1/62.png",
     "subtype": "Item",
@@ -3192,7 +3255,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/62_hires.png"
   },
   {
-    "id": "g1-63",
+    "setOrder":68,
+	"id": "g1-63",
     "name": "Imakuni?",
     "imageUrl": "https://images.pokemontcg.io/g1/63.png",
     "subtype": "Supporter",
@@ -3209,7 +3273,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/63_hires.png"
   },
   {
-    "id": "g1-64",
+    "setOrder":68,
+	"id": "g1-64",
     "name": "Maintenance",
     "imageUrl": "https://images.pokemontcg.io/g1/64.png",
     "subtype": "Item",
@@ -3226,7 +3291,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/64_hires.png"
   },
   {
-    "id": "g1-65",
+    "setOrder":68,
+	"id": "g1-65",
     "name": "Max Revive",
     "imageUrl": "https://images.pokemontcg.io/g1/65.png",
     "subtype": "Item",
@@ -3243,7 +3309,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/65_hires.png"
   },
   {
-    "id": "g1-66",
+    "setOrder":68,
+	"id": "g1-66",
     "name": "Olympia",
     "imageUrl": "https://images.pokemontcg.io/g1/66.png",
     "subtype": "Supporter",
@@ -3260,7 +3327,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/66_hires.png"
   },
   {
-    "id": "g1-67",
+    "setOrder":68,
+	"id": "g1-67",
     "name": "Poké Ball",
     "imageUrl": "https://images.pokemontcg.io/g1/67.png",
     "subtype": "Item",
@@ -3277,7 +3345,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/67_hires.png"
   },
   {
-    "id": "g1-68",
+    "setOrder":68,
+	"id": "g1-68",
     "name": "Pokémon Center Lady",
     "imageUrl": "https://images.pokemontcg.io/g1/68.png",
     "subtype": "Supporter",
@@ -3294,7 +3363,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/68_hires.png"
   },
   {
-    "id": "g1-69",
+    "setOrder":68,
+	"id": "g1-69",
     "name": "Pokémon Fan Club",
     "imageUrl": "https://images.pokemontcg.io/g1/69.png",
     "subtype": "Supporter",
@@ -3311,7 +3381,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/69_hires.png"
   },
   {
-    "id": "g1-70",
+    "setOrder":68,
+	"id": "g1-70",
     "name": "Revitalizer",
     "imageUrl": "https://images.pokemontcg.io/g1/70.png",
     "subtype": "Item",
@@ -3328,7 +3399,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/70_hires.png"
   },
   {
-    "id": "g1-71",
+    "setOrder":68,
+	"id": "g1-71",
     "name": "Red Card",
     "imageUrl": "https://images.pokemontcg.io/g1/71.png",
     "subtype": "Item",
@@ -3345,7 +3417,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/71_hires.png"
   },
   {
-    "id": "g1-72",
+    "setOrder":68,
+	"id": "g1-72",
     "name": "Shauna",
     "imageUrl": "https://images.pokemontcg.io/g1/72.png",
     "subtype": "Supporter",
@@ -3362,7 +3435,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/72_hires.png"
   },
   {
-    "id": "g1-73",
+    "setOrder":68,
+	"id": "g1-73",
     "name": "Team Flare Grunt",
     "imageUrl": "https://images.pokemontcg.io/g1/73.png",
     "subtype": "Supporter",
@@ -3379,7 +3453,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/73_hires.png"
   },
   {
-    "id": "g1-73a",
+    "setOrder":68,
+	"id": "g1-73a",
     "name": "Team Flare Grunt",
     "imageUrl": "https://images.pokemontcg.io/g1/73a.png",
     "subtype": "Supporter",
@@ -3396,7 +3471,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/73a_hires.png"
   },
   {
-    "id": "g1-74",
+    "setOrder":68,
+	"id": "g1-74",
     "name": "Double Colorless Energy",
     "imageUrl": "https://images.pokemontcg.io/g1/74.png",
     "subtype": "Special",
@@ -3413,7 +3489,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/74_hires.png"
   },
   {
-    "id": "g1-75",
+    "setOrder":68,
+	"id": "g1-75",
     "name": "Basic Grass Energy",
     "imageUrl": "https://images.pokemontcg.io/g1/75.png",
     "subtype": "Basic",
@@ -3427,7 +3504,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/75_hires.png"
   },
   {
-    "id": "g1-76",
+    "setOrder":68,
+	"id": "g1-76",
     "name": "Basic Fire Energy",
     "imageUrl": "https://images.pokemontcg.io/g1/76.png",
     "subtype": "Basic",
@@ -3441,7 +3519,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/76_hires.png"
   },
   {
-    "id": "g1-77",
+    "setOrder":68,
+	"id": "g1-77",
     "name": "Basic Water Energy",
     "imageUrl": "https://images.pokemontcg.io/g1/77.png",
     "subtype": "Basic",
@@ -3455,7 +3534,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/77_hires.png"
   },
   {
-    "id": "g1-78",
+    "setOrder":68,
+	"id": "g1-78",
     "name": "Basic Lightning Energy",
     "imageUrl": "https://images.pokemontcg.io/g1/78.png",
     "subtype": "Basic",
@@ -3469,7 +3549,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/78_hires.png"
   },
   {
-    "id": "g1-79",
+    "setOrder":68,
+	"id": "g1-79",
     "name": "Basic Psychic Energy",
     "imageUrl": "https://images.pokemontcg.io/g1/79.png",
     "subtype": "Basic",
@@ -3483,7 +3564,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/79_hires.png"
   },
   {
-    "id": "g1-80",
+    "setOrder":68,
+	"id": "g1-80",
     "name": "Basic Fighting Energy",
     "imageUrl": "https://images.pokemontcg.io/g1/80.png",
     "subtype": "Basic",
@@ -3497,7 +3579,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/80_hires.png"
   },
   {
-    "id": "g1-81",
+    "setOrder":68,
+	"id": "g1-81",
     "name": "Basic Darkness Energy",
     "imageUrl": "https://images.pokemontcg.io/g1/81.png",
     "subtype": "Basic",
@@ -3511,7 +3594,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/81_hires.png"
   },
   {
-    "id": "g1-82",
+    "setOrder":68,
+	"id": "g1-82",
     "name": "Basic Metal Energy",
     "imageUrl": "https://images.pokemontcg.io/g1/82.png",
     "subtype": "Basic",
@@ -3525,7 +3609,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/82_hires.png"
   },
   {
-    "id": "g1-83",
+    "setOrder":68,
+	"id": "g1-83",
     "name": "Basic Fairy Energy",
     "imageUrl": "https://images.pokemontcg.io/g1/83.png",
     "subtype": "Basic",
@@ -3539,7 +3624,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/83_hires.png"
   },
   {
-    "id": "g1-rc1",
+    "setOrder":68,
+	"id": "g1-rc1",
     "name": "Chikorita",
     "imageUrl": "https://images.pokemontcg.io/g1/RC1.png",
     "subtype": "Basic",
@@ -3592,7 +3678,8 @@
     ]
   },
   {
-    "id": "g1-rc2",
+    "setOrder":68,
+	"id": "g1-rc2",
     "name": "Shroomish",
     "imageUrl": "https://images.pokemontcg.io/g1/RC2.png",
     "subtype": "Basic",
@@ -3636,7 +3723,8 @@
     ]
   },
   {
-    "id": "g1-rc3",
+    "setOrder":68,
+	"id": "g1-rc3",
     "name": "Charmander",
     "imageUrl": "https://images.pokemontcg.io/g1/RC3.png",
     "subtype": "Basic",
@@ -3681,7 +3769,8 @@
     ]
   },
   {
-    "id": "g1-rc4",
+    "setOrder":68,
+	"id": "g1-rc4",
     "name": "Charmeleon",
     "imageUrl": "https://images.pokemontcg.io/g1/RC4.png",
     "subtype": "Stage 1",
@@ -3737,7 +3826,8 @@
     ]
   },
   {
-    "id": "g1-rc5",
+    "setOrder":68,
+	"id": "g1-rc5",
     "name": "Charizard",
     "imageUrl": "https://images.pokemontcg.io/g1/RC5.png",
     "subtype": "Stage 2",
@@ -3792,7 +3882,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "g1-rc6",
+    "setOrder":68,
+	"id": "g1-rc6",
     "name": "Flareon-EX",
     "imageUrl": "https://images.pokemontcg.io/g1/RC6.png",
     "subtype": "EX",
@@ -3843,7 +3934,8 @@
     "nationalPokedexNumber": 136
   },
   {
-    "id": "g1-rc7",
+    "setOrder":68,
+	"id": "g1-rc7",
     "name": "Snorunt",
     "imageUrl": "https://images.pokemontcg.io/g1/RC7.png",
     "subtype": "Basic",
@@ -3887,7 +3979,8 @@
     ]
   },
   {
-    "id": "g1-rc8",
+    "setOrder":68,
+	"id": "g1-rc8",
     "name": "Froslass",
     "imageUrl": "https://images.pokemontcg.io/g1/RC8.png",
     "subtype": "Stage 1",
@@ -3936,7 +4029,8 @@
     "nationalPokedexNumber": 478
   },
   {
-    "id": "g1-rc9",
+    "setOrder":68,
+	"id": "g1-rc9",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/g1/RC9.png",
     "subtype": "Stage 1",
@@ -3992,7 +4086,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "g1-rc10",
+    "setOrder":68,
+	"id": "g1-rc10",
     "name": "Dedenne",
     "imageUrl": "https://images.pokemontcg.io/g1/RC10.png",
     "subtype": "Basic",
@@ -4047,7 +4142,8 @@
     "nationalPokedexNumber": 702
   },
   {
-    "id": "g1-rc11",
+    "setOrder":68,
+	"id": "g1-rc11",
     "name": "Wobbuffet",
     "imageUrl": "https://images.pokemontcg.io/g1/RC11.png",
     "subtype": "Basic",
@@ -4094,7 +4190,8 @@
     "nationalPokedexNumber": 202
   },
   {
-    "id": "g1-rc12",
+    "setOrder":68,
+	"id": "g1-rc12",
     "name": "Gulpin",
     "imageUrl": "https://images.pokemontcg.io/g1/RC12.png",
     "subtype": "Basic",
@@ -4139,7 +4236,8 @@
     ]
   },
   {
-    "id": "g1-rc13",
+    "setOrder":68,
+	"id": "g1-rc13",
     "name": "Jirachi",
     "imageUrl": "https://images.pokemontcg.io/g1/RC13.png",
     "subtype": "Basic",
@@ -4190,7 +4288,8 @@
     "nationalPokedexNumber": 385
   },
   {
-    "id": "g1-rc14",
+    "setOrder":68,
+	"id": "g1-rc14",
     "name": "Espurr",
     "imageUrl": "https://images.pokemontcg.io/g1/RC14.png",
     "subtype": "Basic",
@@ -4233,7 +4332,8 @@
     ]
   },
   {
-    "id": "g1-rc15",
+    "setOrder":68,
+	"id": "g1-rc15",
     "name": "Meowstic",
     "imageUrl": "https://images.pokemontcg.io/g1/RC15.png",
     "subtype": "Stage 1",
@@ -4285,7 +4385,8 @@
     "nationalPokedexNumber": 678
   },
   {
-    "id": "g1-rc16",
+    "setOrder":68,
+	"id": "g1-rc16",
     "name": "Yveltal",
     "imageUrl": "https://images.pokemontcg.io/g1/RC16.png",
     "subtype": "Basic",
@@ -4343,7 +4444,8 @@
     "nationalPokedexNumber": 717
   },
   {
-    "id": "g1-rc17",
+    "setOrder":68,
+	"id": "g1-rc17",
     "name": "Flabébé",
     "imageUrl": "https://images.pokemontcg.io/g1/RC17.png",
     "subtype": "Basic",
@@ -4392,7 +4494,8 @@
     ]
   },
   {
-    "id": "g1-rc18",
+    "setOrder":68,
+	"id": "g1-rc18",
     "name": "Floette",
     "imageUrl": "https://images.pokemontcg.io/g1/RC18.png",
     "subtype": "Stage 1",
@@ -4452,7 +4555,8 @@
     ]
   },
   {
-    "id": "g1-rc19",
+    "setOrder":68,
+	"id": "g1-rc19",
     "name": "Swirlix",
     "imageUrl": "https://images.pokemontcg.io/g1/RC19.png",
     "subtype": "Basic",
@@ -4511,7 +4615,8 @@
     ]
   },
   {
-    "id": "g1-rc20",
+    "setOrder":68,
+	"id": "g1-rc20",
     "name": "Slurpuff",
     "imageUrl": "https://images.pokemontcg.io/g1/RC20.png",
     "subtype": "Stage 1",
@@ -4570,7 +4675,8 @@
     "nationalPokedexNumber": 685
   },
   {
-    "id": "g1-rc21",
+    "setOrder":68,
+	"id": "g1-rc21",
     "name": "Sylveon-EX",
     "imageUrl": "https://images.pokemontcg.io/g1/RC21.png",
     "subtype": "EX",
@@ -4632,7 +4738,8 @@
     "nationalPokedexNumber": 700
   },
   {
-    "id": "g1-rc22",
+    "setOrder":68,
+	"id": "g1-rc22",
     "name": "Diancie",
     "imageUrl": "https://images.pokemontcg.io/g1/RC22.png",
     "subtype": "Basic",
@@ -4689,7 +4796,8 @@
     "nationalPokedexNumber": 719
   },
   {
-    "id": "g1-rc23",
+    "setOrder":68,
+	"id": "g1-rc23",
     "name": "Swablu",
     "imageUrl": "https://images.pokemontcg.io/g1/RC23.png",
     "subtype": "Basic",
@@ -4738,7 +4846,8 @@
     ]
   },
   {
-    "id": "g1-rc24",
+    "setOrder":68,
+	"id": "g1-rc24",
     "name": "Altaria",
     "imageUrl": "https://images.pokemontcg.io/g1/RC24.png",
     "subtype": "Stage 1",
@@ -4795,7 +4904,8 @@
     "nationalPokedexNumber": 334
   },
   {
-    "id": "g1-rc25",
+    "setOrder":68,
+	"id": "g1-rc25",
     "name": "Fletchling",
     "imageUrl": "https://images.pokemontcg.io/g1/RC25.png",
     "subtype": "Basic",
@@ -4844,7 +4954,8 @@
     ]
   },
   {
-    "id": "g1-rc26",
+    "setOrder":68,
+	"id": "g1-rc26",
     "name": "Floral Crown",
     "imageUrl": "https://images.pokemontcg.io/g1/RC26.png",
     "subtype": "Pokémon Tool",
@@ -4861,7 +4972,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/RC26_hires.png"
   },
   {
-    "id": "g1-rc27",
+    "setOrder":68,
+	"id": "g1-rc27",
     "name": "Wally",
     "imageUrl": "https://images.pokemontcg.io/g1/RC27.png",
     "subtype": "Supporter",
@@ -4878,7 +4990,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/g1/RC27_hires.png"
   },
   {
-    "id": "g1-rc28",
+    "setOrder":68,
+	"id": "g1-rc28",
     "name": "Flareon-EX",
     "imageUrl": "https://images.pokemontcg.io/g1/RC28.png",
     "subtype": "EX",
@@ -4929,7 +5042,8 @@
     "nationalPokedexNumber": 136
   },
   {
-    "id": "g1-rc29",
+    "setOrder":68,
+	"id": "g1-rc29",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/g1/RC29.png",
     "subtype": "Basic",
@@ -4988,7 +5102,8 @@
     ]
   },
   {
-    "id": "g1-rc30",
+    "setOrder":68,
+	"id": "g1-rc30",
     "name": "Gardevoir-EX",
     "imageUrl": "https://images.pokemontcg.io/g1/RC30.png",
     "subtype": "EX",
@@ -5050,7 +5165,8 @@
     "evolvesTo": "M Gardevoir-EX"
   },
   {
-    "id": "g1-rc31",
+    "setOrder":68,
+	"id": "g1-rc31",
     "name": "M Gardevoir-EX",
     "imageUrl": "https://images.pokemontcg.io/g1/RC31.png",
     "subtype": "MEGA",
@@ -5104,7 +5220,8 @@
     "nationalPokedexNumber": 282
   },
   {
-    "id": "g1-rc32",
+    "setOrder":68,
+	"id": "g1-rc32",
     "name": "Sylveon-EX",
     "imageUrl": "https://images.pokemontcg.io/g1/RC32.png",
     "subtype": "EX",

--- a/json/cards/Great Encounters.json
+++ b/json/cards/Great Encounters.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "dp4-1",
+    "setOrder":35,
+	"id": "dp4-1",
     "name": "Blaziken",
     "imageUrl": "https://images.pokemontcg.io/dp4/1.png",
     "subtype": "Stage 2",
@@ -53,7 +54,8 @@
     "nationalPokedexNumber": 257
   },
   {
-    "id": "dp4-2",
+    "setOrder":35,
+	"id": "dp4-2",
     "name": "Cresselia",
     "imageUrl": "https://images.pokemontcg.io/dp4/2.png",
     "subtype": "Basic",
@@ -105,7 +107,8 @@
     "nationalPokedexNumber": 488
   },
   {
-    "id": "dp4-3",
+    "setOrder":35,
+	"id": "dp4-3",
     "name": "Darkrai",
     "imageUrl": "https://images.pokemontcg.io/dp4/3.png",
     "subtype": "Basic",
@@ -163,7 +166,8 @@
     "nationalPokedexNumber": 491
   },
   {
-    "id": "dp4-4",
+    "setOrder":35,
+	"id": "dp4-4",
     "name": "Darkrai",
     "imageUrl": "https://images.pokemontcg.io/dp4/4.png",
     "subtype": "Basic",
@@ -221,7 +225,8 @@
     "nationalPokedexNumber": 491
   },
   {
-    "id": "dp4-5",
+    "setOrder":35,
+	"id": "dp4-5",
     "name": "Pachirisu",
     "imageUrl": "https://images.pokemontcg.io/dp4/5.png",
     "subtype": "Basic",
@@ -277,7 +282,8 @@
     "nationalPokedexNumber": 417
   },
   {
-    "id": "dp4-6",
+    "setOrder":35,
+	"id": "dp4-6",
     "name": "Porygon-Z",
     "imageUrl": "https://images.pokemontcg.io/dp4/6.png",
     "subtype": "Stage 2",
@@ -326,7 +332,8 @@
     "nationalPokedexNumber": 474
   },
   {
-    "id": "dp4-7",
+    "setOrder":35,
+	"id": "dp4-7",
     "name": "Rotom",
     "imageUrl": "https://images.pokemontcg.io/dp4/7.png",
     "subtype": "Basic",
@@ -384,7 +391,8 @@
     "nationalPokedexNumber": 479
   },
   {
-    "id": "dp4-8",
+    "setOrder":35,
+	"id": "dp4-8",
     "name": "Sceptile",
     "imageUrl": "https://images.pokemontcg.io/dp4/8.png",
     "subtype": "Stage 2",
@@ -442,7 +450,8 @@
     "nationalPokedexNumber": 254
   },
   {
-    "id": "dp4-9",
+    "setOrder":35,
+	"id": "dp4-9",
     "name": "Swampert",
     "imageUrl": "https://images.pokemontcg.io/dp4/9.png",
     "subtype": "Stage 2",
@@ -493,7 +502,8 @@
     "nationalPokedexNumber": 260
   },
   {
-    "id": "dp4-10",
+    "setOrder":35,
+	"id": "dp4-10",
     "name": "Tangrowth",
     "imageUrl": "https://images.pokemontcg.io/dp4/10.png",
     "subtype": "Stage 1",
@@ -554,7 +564,8 @@
     "nationalPokedexNumber": 465
   },
   {
-    "id": "dp4-11",
+    "setOrder":35,
+	"id": "dp4-11",
     "name": "Togekiss",
     "imageUrl": "https://images.pokemontcg.io/dp4/11.png",
     "subtype": "Stage 2",
@@ -609,7 +620,8 @@
     "nationalPokedexNumber": 468
   },
   {
-    "id": "dp4-12",
+    "setOrder":35,
+	"id": "dp4-12",
     "name": "Altaria",
     "imageUrl": "https://images.pokemontcg.io/dp4/12.png",
     "subtype": "Stage 1",
@@ -668,7 +680,8 @@
     "nationalPokedexNumber": 334
   },
   {
-    "id": "dp4-13",
+    "setOrder":35,
+	"id": "dp4-13",
     "name": "Beedrill",
     "imageUrl": "https://images.pokemontcg.io/dp4/13.png",
     "subtype": "Stage 2",
@@ -718,7 +731,8 @@
     "nationalPokedexNumber": 15
   },
   {
-    "id": "dp4-14",
+    "setOrder":35,
+	"id": "dp4-14",
     "name": "Butterfree",
     "imageUrl": "https://images.pokemontcg.io/dp4/14.png",
     "subtype": "Stage 2",
@@ -768,7 +782,8 @@
     "nationalPokedexNumber": 12
   },
   {
-    "id": "dp4-15",
+    "setOrder":35,
+	"id": "dp4-15",
     "name": "Claydol",
     "imageUrl": "https://images.pokemontcg.io/dp4/15.png",
     "subtype": "Stage 1",
@@ -817,7 +832,8 @@
     "nationalPokedexNumber": 344
   },
   {
-    "id": "dp4-16",
+    "setOrder":35,
+	"id": "dp4-16",
     "name": "Dialga",
     "imageUrl": "https://images.pokemontcg.io/dp4/16.png",
     "subtype": "Basic",
@@ -876,7 +892,8 @@
     "nationalPokedexNumber": 483
   },
   {
-    "id": "dp4-17",
+    "setOrder":35,
+	"id": "dp4-17",
     "name": "Exploud",
     "imageUrl": "https://images.pokemontcg.io/dp4/17.png",
     "subtype": "Stage 2",
@@ -933,7 +950,8 @@
     "nationalPokedexNumber": 295
   },
   {
-    "id": "dp4-18",
+    "setOrder":35,
+	"id": "dp4-18",
     "name": "Houndoom",
     "imageUrl": "https://images.pokemontcg.io/dp4/18.png",
     "subtype": "Stage 1",
@@ -991,7 +1009,8 @@
     "nationalPokedexNumber": 229
   },
   {
-    "id": "dp4-19",
+    "setOrder":35,
+	"id": "dp4-19",
     "name": "Hypno",
     "imageUrl": "https://images.pokemontcg.io/dp4/19.png",
     "subtype": "Stage 1",
@@ -1046,7 +1065,8 @@
     "nationalPokedexNumber": 97
   },
   {
-    "id": "dp4-20",
+    "setOrder":35,
+	"id": "dp4-20",
     "name": "Kingler",
     "imageUrl": "https://images.pokemontcg.io/dp4/20.png",
     "subtype": "Stage 1",
@@ -1102,7 +1122,8 @@
     "nationalPokedexNumber": 99
   },
   {
-    "id": "dp4-21",
+    "setOrder":35,
+	"id": "dp4-21",
     "name": "Lapras",
     "imageUrl": "https://images.pokemontcg.io/dp4/21.png",
     "subtype": "Basic",
@@ -1153,7 +1174,8 @@
     "nationalPokedexNumber": 131
   },
   {
-    "id": "dp4-22",
+    "setOrder":35,
+	"id": "dp4-22",
     "name": "Latias",
     "imageUrl": "https://images.pokemontcg.io/dp4/22.png",
     "subtype": "Basic",
@@ -1211,7 +1233,8 @@
     "nationalPokedexNumber": 380
   },
   {
-    "id": "dp4-23",
+    "setOrder":35,
+	"id": "dp4-23",
     "name": "Latios",
     "imageUrl": "https://images.pokemontcg.io/dp4/23.png",
     "subtype": "Basic",
@@ -1271,7 +1294,8 @@
     "nationalPokedexNumber": 381
   },
   {
-    "id": "dp4-24",
+    "setOrder":35,
+	"id": "dp4-24",
     "name": "Mawile",
     "imageUrl": "https://images.pokemontcg.io/dp4/24.png",
     "subtype": "Basic",
@@ -1328,7 +1352,8 @@
     "nationalPokedexNumber": 303
   },
   {
-    "id": "dp4-25",
+    "setOrder":35,
+	"id": "dp4-25",
     "name": "Milotic",
     "imageUrl": "https://images.pokemontcg.io/dp4/25.png",
     "subtype": "Stage 1",
@@ -1378,7 +1403,8 @@
     "nationalPokedexNumber": 350
   },
   {
-    "id": "dp4-26",
+    "setOrder":35,
+	"id": "dp4-26",
     "name": "Palkia",
     "imageUrl": "https://images.pokemontcg.io/dp4/26.png",
     "subtype": "Basic",
@@ -1431,7 +1457,8 @@
     "nationalPokedexNumber": 484
   },
   {
-    "id": "dp4-27",
+    "setOrder":35,
+	"id": "dp4-27",
     "name": "Primeape",
     "imageUrl": "https://images.pokemontcg.io/dp4/27.png",
     "subtype": "Stage 1",
@@ -1480,7 +1507,8 @@
     "nationalPokedexNumber": 57
   },
   {
-    "id": "dp4-28",
+    "setOrder":35,
+	"id": "dp4-28",
     "name": "Slowking",
     "imageUrl": "https://images.pokemontcg.io/dp4/28.png",
     "subtype": "Stage 1",
@@ -1529,7 +1557,8 @@
     "nationalPokedexNumber": 199
   },
   {
-    "id": "dp4-29",
+    "setOrder":35,
+	"id": "dp4-29",
     "name": "Unown H",
     "imageUrl": "https://images.pokemontcg.io/dp4/29.png",
     "subtype": "Basic",
@@ -1575,7 +1604,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp4-30",
+    "setOrder":35,
+	"id": "dp4-30",
     "name": "Wailord",
     "imageUrl": "https://images.pokemontcg.io/dp4/30.png",
     "subtype": "Stage 1",
@@ -1628,7 +1658,8 @@
     "nationalPokedexNumber": 321
   },
   {
-    "id": "dp4-31",
+    "setOrder":35,
+	"id": "dp4-31",
     "name": "Weezing",
     "imageUrl": "https://images.pokemontcg.io/dp4/31.png",
     "subtype": "Stage 1",
@@ -1677,7 +1708,8 @@
     "nationalPokedexNumber": 110
   },
   {
-    "id": "dp4-32",
+    "setOrder":35,
+	"id": "dp4-32",
     "name": "Wigglytuff",
     "imageUrl": "https://images.pokemontcg.io/dp4/32.png",
     "subtype": "Stage 1",
@@ -1725,7 +1757,8 @@
     "nationalPokedexNumber": 40
   },
   {
-    "id": "dp4-33",
+    "setOrder":35,
+	"id": "dp4-33",
     "name": "Arbok",
     "imageUrl": "https://images.pokemontcg.io/dp4/33.png",
     "subtype": "Stage 1",
@@ -1779,7 +1812,8 @@
     "nationalPokedexNumber": 24
   },
   {
-    "id": "dp4-34",
+    "setOrder":35,
+	"id": "dp4-34",
     "name": "Cacturne",
     "imageUrl": "https://images.pokemontcg.io/dp4/34.png",
     "subtype": "Stage 1",
@@ -1839,7 +1873,8 @@
     "nationalPokedexNumber": 332
   },
   {
-    "id": "dp4-35",
+    "setOrder":35,
+	"id": "dp4-35",
     "name": "Combusken",
     "imageUrl": "https://images.pokemontcg.io/dp4/35.png",
     "subtype": "Stage 1",
@@ -1895,7 +1930,8 @@
     ]
   },
   {
-    "id": "dp4-36",
+    "setOrder":35,
+	"id": "dp4-36",
     "name": "Delibird",
     "imageUrl": "https://images.pokemontcg.io/dp4/36.png",
     "subtype": "Basic",
@@ -1945,7 +1981,8 @@
     "nationalPokedexNumber": 225
   },
   {
-    "id": "dp4-37",
+    "setOrder":35,
+	"id": "dp4-37",
     "name": "Floatzel",
     "imageUrl": "https://images.pokemontcg.io/dp4/37.png",
     "subtype": "Stage 1",
@@ -1999,7 +2036,8 @@
     "nationalPokedexNumber": 419
   },
   {
-    "id": "dp4-38",
+    "setOrder":35,
+	"id": "dp4-38",
     "name": "Gorebyss",
     "imageUrl": "https://images.pokemontcg.io/dp4/38.png",
     "subtype": "Stage 1",
@@ -2048,7 +2086,8 @@
     "nationalPokedexNumber": 368
   },
   {
-    "id": "dp4-39",
+    "setOrder":35,
+	"id": "dp4-39",
     "name": "Granbull",
     "imageUrl": "https://images.pokemontcg.io/dp4/39.png",
     "subtype": "Stage 1",
@@ -2104,7 +2143,8 @@
     "nationalPokedexNumber": 210
   },
   {
-    "id": "dp4-40",
+    "setOrder":35,
+	"id": "dp4-40",
     "name": "Grovyle",
     "imageUrl": "https://images.pokemontcg.io/dp4/40.png",
     "subtype": "Stage 1",
@@ -2165,7 +2205,8 @@
     ]
   },
   {
-    "id": "dp4-41",
+    "setOrder":35,
+	"id": "dp4-41",
     "name": "Hariyama",
     "imageUrl": "https://images.pokemontcg.io/dp4/41.png",
     "subtype": "Stage 1",
@@ -2221,7 +2262,8 @@
     "nationalPokedexNumber": 297
   },
   {
-    "id": "dp4-42",
+    "setOrder":35,
+	"id": "dp4-42",
     "name": "Huntail",
     "imageUrl": "https://images.pokemontcg.io/dp4/42.png",
     "subtype": "Stage 1",
@@ -2273,7 +2315,8 @@
     "nationalPokedexNumber": 367
   },
   {
-    "id": "dp4-43",
+    "setOrder":35,
+	"id": "dp4-43",
     "name": "Linoone",
     "imageUrl": "https://images.pokemontcg.io/dp4/43.png",
     "subtype": "Stage 1",
@@ -2323,7 +2366,8 @@
     "nationalPokedexNumber": 264
   },
   {
-    "id": "dp4-44",
+    "setOrder":35,
+	"id": "dp4-44",
     "name": "Loudred",
     "imageUrl": "https://images.pokemontcg.io/dp4/44.png",
     "subtype": "Stage 1",
@@ -2381,7 +2425,8 @@
     ]
   },
   {
-    "id": "dp4-45",
+    "setOrder":35,
+	"id": "dp4-45",
     "name": "Magcargo",
     "imageUrl": "https://images.pokemontcg.io/dp4/45.png",
     "subtype": "Stage 1",
@@ -2432,7 +2477,8 @@
     "nationalPokedexNumber": 219
   },
   {
-    "id": "dp4-46",
+    "setOrder":35,
+	"id": "dp4-46",
     "name": "Marshtomp",
     "imageUrl": "https://images.pokemontcg.io/dp4/46.png",
     "subtype": "Stage 1",
@@ -2490,7 +2536,8 @@
     ]
   },
   {
-    "id": "dp4-47",
+    "setOrder":35,
+	"id": "dp4-47",
     "name": "Metapod",
     "imageUrl": "https://images.pokemontcg.io/dp4/47.png",
     "subtype": "Stage 1",
@@ -2542,7 +2589,8 @@
     ]
   },
   {
-    "id": "dp4-48",
+    "setOrder":35,
+	"id": "dp4-48",
     "name": "Pelipper",
     "imageUrl": "https://images.pokemontcg.io/dp4/48.png",
     "subtype": "Stage 1",
@@ -2601,7 +2649,8 @@
     "nationalPokedexNumber": 279
   },
   {
-    "id": "dp4-49",
+    "setOrder":35,
+	"id": "dp4-49",
     "name": "Porygon2",
     "imageUrl": "https://images.pokemontcg.io/dp4/49.png",
     "subtype": "Stage 1",
@@ -2653,7 +2702,8 @@
     ]
   },
   {
-    "id": "dp4-50",
+    "setOrder":35,
+	"id": "dp4-50",
     "name": "Purugly",
     "imageUrl": "https://images.pokemontcg.io/dp4/50.png",
     "subtype": "Stage 1",
@@ -2708,7 +2758,8 @@
     "nationalPokedexNumber": 432
   },
   {
-    "id": "dp4-51",
+    "setOrder":35,
+	"id": "dp4-51",
     "name": "Relicanth",
     "imageUrl": "https://images.pokemontcg.io/dp4/51.png",
     "subtype": "Basic",
@@ -2759,7 +2810,8 @@
     "nationalPokedexNumber": 369
   },
   {
-    "id": "dp4-52",
+    "setOrder":35,
+	"id": "dp4-52",
     "name": "Seviper",
     "imageUrl": "https://images.pokemontcg.io/dp4/52.png",
     "subtype": "Basic",
@@ -2812,7 +2864,8 @@
     "nationalPokedexNumber": 336
   },
   {
-    "id": "dp4-53",
+    "setOrder":35,
+	"id": "dp4-53",
     "name": "Skarmory",
     "imageUrl": "https://images.pokemontcg.io/dp4/53.png",
     "subtype": "Basic",
@@ -2870,7 +2923,8 @@
     "nationalPokedexNumber": 227
   },
   {
-    "id": "dp4-54",
+    "setOrder":35,
+	"id": "dp4-54",
     "name": "Slowbro",
     "imageUrl": "https://images.pokemontcg.io/dp4/54.png",
     "subtype": "Stage 1",
@@ -2925,7 +2979,8 @@
     "nationalPokedexNumber": 80
   },
   {
-    "id": "dp4-55",
+    "setOrder":35,
+	"id": "dp4-55",
     "name": "Togetic",
     "imageUrl": "https://images.pokemontcg.io/dp4/55.png",
     "subtype": "Stage 1",
@@ -2988,7 +3043,8 @@
     ]
   },
   {
-    "id": "dp4-56",
+    "setOrder":35,
+	"id": "dp4-56",
     "name": "Unown F",
     "imageUrl": "https://images.pokemontcg.io/dp4/56.png",
     "subtype": "Basic",
@@ -3034,7 +3090,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp4-57",
+    "setOrder":35,
+	"id": "dp4-57",
     "name": "Unown G",
     "imageUrl": "https://images.pokemontcg.io/dp4/57.png",
     "subtype": "Basic",
@@ -3081,7 +3138,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp4-58",
+    "setOrder":35,
+	"id": "dp4-58",
     "name": "Wailmer",
     "imageUrl": "https://images.pokemontcg.io/dp4/58.png",
     "subtype": "Basic",
@@ -3139,7 +3197,8 @@
     ]
   },
   {
-    "id": "dp4-59",
+    "setOrder":35,
+	"id": "dp4-59",
     "name": "Zangoose",
     "imageUrl": "https://images.pokemontcg.io/dp4/59.png",
     "subtype": "Basic",
@@ -3191,7 +3250,8 @@
     "nationalPokedexNumber": 335
   },
   {
-    "id": "dp4-60",
+    "setOrder":35,
+	"id": "dp4-60",
     "name": "Baltoy",
     "imageUrl": "https://images.pokemontcg.io/dp4/60.png",
     "subtype": "Basic",
@@ -3245,7 +3305,8 @@
     ]
   },
   {
-    "id": "dp4-61",
+    "setOrder":35,
+	"id": "dp4-61",
     "name": "Buizel",
     "imageUrl": "https://images.pokemontcg.io/dp4/61.png",
     "subtype": "Basic",
@@ -3299,7 +3360,8 @@
     ]
   },
   {
-    "id": "dp4-62",
+    "setOrder":35,
+	"id": "dp4-62",
     "name": "Cacnea",
     "imageUrl": "https://images.pokemontcg.io/dp4/62.png",
     "subtype": "Basic",
@@ -3359,7 +3421,8 @@
     ]
   },
   {
-    "id": "dp4-63",
+    "setOrder":35,
+	"id": "dp4-63",
     "name": "Caterpie",
     "imageUrl": "https://images.pokemontcg.io/dp4/63.png",
     "subtype": "Basic",
@@ -3408,7 +3471,8 @@
     ]
   },
   {
-    "id": "dp4-64",
+    "setOrder":35,
+	"id": "dp4-64",
     "name": "Clamperl",
     "imageUrl": "https://images.pokemontcg.io/dp4/64.png",
     "subtype": "Basic",
@@ -3463,7 +3527,8 @@
     ]
   },
   {
-    "id": "dp4-65",
+    "setOrder":35,
+	"id": "dp4-65",
     "name": "Drowzee",
     "imageUrl": "https://images.pokemontcg.io/dp4/65.png",
     "subtype": "Basic",
@@ -3517,7 +3582,8 @@
     ]
   },
   {
-    "id": "dp4-66",
+    "setOrder":35,
+	"id": "dp4-66",
     "name": "Ekans",
     "imageUrl": "https://images.pokemontcg.io/dp4/66.png",
     "subtype": "Basic",
@@ -3571,7 +3637,8 @@
     ]
   },
   {
-    "id": "dp4-67",
+    "setOrder":35,
+	"id": "dp4-67",
     "name": "Feebas",
     "imageUrl": "https://images.pokemontcg.io/dp4/67.png",
     "subtype": "Basic",
@@ -3624,7 +3691,8 @@
     ]
   },
   {
-    "id": "dp4-68",
+    "setOrder":35,
+	"id": "dp4-68",
     "name": "Glameow",
     "imageUrl": "https://images.pokemontcg.io/dp4/68.png",
     "subtype": "Basic",
@@ -3678,7 +3746,8 @@
     ]
   },
   {
-    "id": "dp4-69",
+    "setOrder":35,
+	"id": "dp4-69",
     "name": "Houndour",
     "imageUrl": "https://images.pokemontcg.io/dp4/69.png",
     "subtype": "Basic",
@@ -3732,7 +3801,8 @@
     ]
   },
   {
-    "id": "dp4-70",
+    "setOrder":35,
+	"id": "dp4-70",
     "name": "Igglybuff",
     "imageUrl": "https://images.pokemontcg.io/dp4/70.png",
     "subtype": "Basic",
@@ -3781,7 +3851,8 @@
     ]
   },
   {
-    "id": "dp4-71",
+    "setOrder":35,
+	"id": "dp4-71",
     "name": "Illumise",
     "imageUrl": "https://images.pokemontcg.io/dp4/71.png",
     "subtype": "Basic",
@@ -3828,7 +3899,8 @@
     "nationalPokedexNumber": 314
   },
   {
-    "id": "dp4-72",
+    "setOrder":35,
+	"id": "dp4-72",
     "name": "Jigglypuff",
     "imageUrl": "https://images.pokemontcg.io/dp4/72.png",
     "subtype": "Basic",
@@ -3882,7 +3954,8 @@
     ]
   },
   {
-    "id": "dp4-73",
+    "setOrder":35,
+	"id": "dp4-73",
     "name": "Kakuna",
     "imageUrl": "https://images.pokemontcg.io/dp4/73.png",
     "subtype": "Stage 1",
@@ -3937,7 +4010,8 @@
     ]
   },
   {
-    "id": "dp4-74",
+    "setOrder":35,
+	"id": "dp4-74",
     "name": "Koffing",
     "imageUrl": "https://images.pokemontcg.io/dp4/74.png",
     "subtype": "Basic",
@@ -3992,7 +4066,8 @@
     ]
   },
   {
-    "id": "dp4-75",
+    "setOrder":35,
+	"id": "dp4-75",
     "name": "Krabby",
     "imageUrl": "https://images.pokemontcg.io/dp4/75.png",
     "subtype": "Basic",
@@ -4047,7 +4122,8 @@
     ]
   },
   {
-    "id": "dp4-76",
+    "setOrder":35,
+	"id": "dp4-76",
     "name": "Lunatone",
     "imageUrl": "https://images.pokemontcg.io/dp4/76.png",
     "subtype": "Basic",
@@ -4093,7 +4169,8 @@
     "nationalPokedexNumber": 337
   },
   {
-    "id": "dp4-77",
+    "setOrder":35,
+	"id": "dp4-77",
     "name": "Luvdisc",
     "imageUrl": "https://images.pokemontcg.io/dp4/77.png",
     "subtype": "Basic",
@@ -4143,7 +4220,8 @@
     "nationalPokedexNumber": 370
   },
   {
-    "id": "dp4-78",
+    "setOrder":35,
+	"id": "dp4-78",
     "name": "Makuhita",
     "imageUrl": "https://images.pokemontcg.io/dp4/78.png",
     "subtype": "Basic",
@@ -4198,7 +4276,8 @@
     ]
   },
   {
-    "id": "dp4-79",
+    "setOrder":35,
+	"id": "dp4-79",
     "name": "Mankey",
     "imageUrl": "https://images.pokemontcg.io/dp4/79.png",
     "subtype": "Basic",
@@ -4252,7 +4331,8 @@
     ]
   },
   {
-    "id": "dp4-80",
+    "setOrder":35,
+	"id": "dp4-80",
     "name": "Mudkip",
     "imageUrl": "https://images.pokemontcg.io/dp4/80.png",
     "subtype": "Basic",
@@ -4307,7 +4387,8 @@
     ]
   },
   {
-    "id": "dp4-81",
+    "setOrder":35,
+	"id": "dp4-81",
     "name": "Porygon",
     "imageUrl": "https://images.pokemontcg.io/dp4/81.png",
     "subtype": "Basic",
@@ -4361,7 +4442,8 @@
     ]
   },
   {
-    "id": "dp4-82",
+    "setOrder":35,
+	"id": "dp4-82",
     "name": "Slowpoke",
     "imageUrl": "https://images.pokemontcg.io/dp4/82.png",
     "subtype": "Basic",
@@ -4416,7 +4498,8 @@
     ]
   },
   {
-    "id": "dp4-83",
+    "setOrder":35,
+	"id": "dp4-83",
     "name": "Slugma",
     "imageUrl": "https://images.pokemontcg.io/dp4/83.png",
     "subtype": "Basic",
@@ -4471,7 +4554,8 @@
     ]
   },
   {
-    "id": "dp4-84",
+    "setOrder":35,
+	"id": "dp4-84",
     "name": "Snubbull",
     "imageUrl": "https://images.pokemontcg.io/dp4/84.png",
     "subtype": "Basic",
@@ -4526,7 +4610,8 @@
     ]
   },
   {
-    "id": "dp4-85",
+    "setOrder":35,
+	"id": "dp4-85",
     "name": "Solrock",
     "imageUrl": "https://images.pokemontcg.io/dp4/85.png",
     "subtype": "Basic",
@@ -4572,7 +4657,8 @@
     "nationalPokedexNumber": 338
   },
   {
-    "id": "dp4-86",
+    "setOrder":35,
+	"id": "dp4-86",
     "name": "Swablu",
     "imageUrl": "https://images.pokemontcg.io/dp4/86.png",
     "subtype": "Basic",
@@ -4632,7 +4718,8 @@
     ]
   },
   {
-    "id": "dp4-87",
+    "setOrder":35,
+	"id": "dp4-87",
     "name": "Tangela",
     "imageUrl": "https://images.pokemontcg.io/dp4/87.png",
     "subtype": "Basic",
@@ -4687,7 +4774,8 @@
     ]
   },
   {
-    "id": "dp4-88",
+    "setOrder":35,
+	"id": "dp4-88",
     "name": "Togepi",
     "imageUrl": "https://images.pokemontcg.io/dp4/88.png",
     "subtype": "Basic",
@@ -4740,7 +4828,8 @@
     ]
   },
   {
-    "id": "dp4-89",
+    "setOrder":35,
+	"id": "dp4-89",
     "name": "Torchic",
     "imageUrl": "https://images.pokemontcg.io/dp4/89.png",
     "subtype": "Basic",
@@ -4793,7 +4882,8 @@
     ]
   },
   {
-    "id": "dp4-90",
+    "setOrder":35,
+	"id": "dp4-90",
     "name": "Treecko",
     "imageUrl": "https://images.pokemontcg.io/dp4/90.png",
     "subtype": "Basic",
@@ -4853,7 +4943,8 @@
     ]
   },
   {
-    "id": "dp4-91",
+    "setOrder":35,
+	"id": "dp4-91",
     "name": "Unown L",
     "imageUrl": "https://images.pokemontcg.io/dp4/91.png",
     "subtype": "Basic",
@@ -4900,7 +4991,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp4-92",
+    "setOrder":35,
+	"id": "dp4-92",
     "name": "Volbeat",
     "imageUrl": "https://images.pokemontcg.io/dp4/92.png",
     "subtype": "Basic",
@@ -4947,7 +5039,8 @@
     "nationalPokedexNumber": 313
   },
   {
-    "id": "dp4-93",
+    "setOrder":35,
+	"id": "dp4-93",
     "name": "Weedle",
     "imageUrl": "https://images.pokemontcg.io/dp4/93.png",
     "subtype": "Basic",
@@ -5000,7 +5093,8 @@
     ]
   },
   {
-    "id": "dp4-94",
+    "setOrder":35,
+	"id": "dp4-94",
     "name": "Whismur",
     "imageUrl": "https://images.pokemontcg.io/dp4/94.png",
     "subtype": "Basic",
@@ -5053,7 +5147,8 @@
     ]
   },
   {
-    "id": "dp4-95",
+    "setOrder":35,
+	"id": "dp4-95",
     "name": "Wingull",
     "imageUrl": "https://images.pokemontcg.io/dp4/95.png",
     "subtype": "Basic",
@@ -5113,7 +5208,8 @@
     ]
   },
   {
-    "id": "dp4-96",
+    "setOrder":35,
+	"id": "dp4-96",
     "name": "Zigzagoon",
     "imageUrl": "https://images.pokemontcg.io/dp4/96.png",
     "subtype": "Basic",
@@ -5166,7 +5262,8 @@
     ]
   },
   {
-    "id": "dp4-97",
+    "setOrder":35,
+	"id": "dp4-97",
     "name": "Amulet Coin",
     "imageUrl": "https://images.pokemontcg.io/dp4/97.png",
     "subtype": "Pokémon Tool",
@@ -5185,7 +5282,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp4/97_hires.png"
   },
   {
-    "id": "dp4-98",
+    "setOrder":35,
+	"id": "dp4-98",
     "name": "Felicity's Drawing",
     "imageUrl": "https://images.pokemontcg.io/dp4/98.png",
     "subtype": "Supporter",
@@ -5204,7 +5302,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp4/98_hires.png"
   },
   {
-    "id": "dp4-99",
+    "setOrder":35,
+	"id": "dp4-99",
     "name": "Leftovers",
     "imageUrl": "https://images.pokemontcg.io/dp4/99.png",
     "subtype": "Pokémon Tool",
@@ -5223,7 +5322,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp4/99_hires.png"
   },
   {
-    "id": "dp4-100",
+    "setOrder":35,
+	"id": "dp4-100",
     "name": "Moonlight Stadium",
     "imageUrl": "https://images.pokemontcg.io/dp4/100.png",
     "subtype": "Stadium",
@@ -5241,7 +5341,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp4/100_hires.png"
   },
   {
-    "id": "dp4-101",
+    "setOrder":35,
+	"id": "dp4-101",
     "name": "Premier Ball",
     "imageUrl": "https://images.pokemontcg.io/dp4/101.png",
     "subtype": "Item",
@@ -5259,7 +5360,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp4/101_hires.png"
   },
   {
-    "id": "dp4-102",
+    "setOrder":35,
+	"id": "dp4-102",
     "name": "Rare Candy",
     "imageUrl": "https://images.pokemontcg.io/dp4/102.png",
     "subtype": "Item",
@@ -5277,7 +5379,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp4/102_hires.png"
   },
   {
-    "id": "dp4-103",
+    "setOrder":35,
+	"id": "dp4-103",
     "name": "Cresselia",
     "imageUrl": "https://images.pokemontcg.io/dp4/103.png",
     "subtype": "Level Up",
@@ -5328,7 +5431,8 @@
     "nationalPokedexNumber": 488
   },
   {
-    "id": "dp4-104",
+    "setOrder":35,
+	"id": "dp4-104",
     "name": "Darkrai",
     "imageUrl": "https://images.pokemontcg.io/dp4/104.png",
     "subtype": "Level Up",
@@ -5385,7 +5489,8 @@
     "nationalPokedexNumber": 491
   },
   {
-    "id": "dp4-105",
+    "setOrder":35,
+	"id": "dp4-105",
     "name": "Dialga",
     "imageUrl": "https://images.pokemontcg.io/dp4/105.png",
     "subtype": "Level Up",
@@ -5444,7 +5549,8 @@
     "nationalPokedexNumber": 483
   },
   {
-    "id": "dp4-106",
+    "setOrder":35,
+	"id": "dp4-106",
     "name": "Palkia",
     "imageUrl": "https://images.pokemontcg.io/dp4/106.png",
     "subtype": "Level Up",

--- a/json/cards/Guardians Rising.json
+++ b/json/cards/Guardians Rising.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "sm2-1",
+    "setOrder":73,
+	"id": "sm2-1",
     "name": "Bellsprout",
     "imageUrl": "https://images.pokemontcg.io/sm2/1.png",
     "subtype": "Basic",
@@ -44,7 +45,8 @@
     ]
   },
   {
-    "id": "sm2-2",
+    "setOrder":73,
+	"id": "sm2-2",
     "name": "Weepinbell",
     "imageUrl": "https://images.pokemontcg.io/sm2/2.png",
     "subtype": "Stage 1",
@@ -90,7 +92,8 @@
     ]
   },
   {
-    "id": "sm2-3",
+    "setOrder":73,
+	"id": "sm2-3",
     "name": "Victreebel",
     "imageUrl": "https://images.pokemontcg.io/sm2/3.png",
     "subtype": "Stage 2",
@@ -143,7 +146,8 @@
     "nationalPokedexNumber": 71
   },
   {
-    "id": "sm2-4",
+    "setOrder":73,
+	"id": "sm2-4",
     "name": "Petilil",
     "imageUrl": "https://images.pokemontcg.io/sm2/4.png",
     "subtype": "Basic",
@@ -186,7 +190,8 @@
     ]
   },
   {
-    "id": "sm2-5",
+    "setOrder":73,
+	"id": "sm2-5",
     "name": "Lilligant",
     "imageUrl": "https://images.pokemontcg.io/sm2/5.png",
     "subtype": "Stage 1",
@@ -237,7 +242,8 @@
     "nationalPokedexNumber": 549
   },
   {
-    "id": "sm2-6",
+    "setOrder":73,
+	"id": "sm2-6",
     "name": "Phantump",
     "imageUrl": "https://images.pokemontcg.io/sm2/6.png",
     "subtype": "Basic",
@@ -291,7 +297,8 @@
     ]
   },
   {
-    "id": "sm2-7",
+    "setOrder":73,
+	"id": "sm2-7",
     "name": "Trevenant",
     "imageUrl": "https://images.pokemontcg.io/sm2/7.png",
     "subtype": "Stage 1",
@@ -345,7 +352,8 @@
     "nationalPokedexNumber": 709
   },
   {
-    "id": "sm2-8",
+    "setOrder":73,
+	"id": "sm2-8",
     "name": "Wimpod",
     "imageUrl": "https://images.pokemontcg.io/sm2/8.png",
     "subtype": "Basic",
@@ -398,7 +406,8 @@
     ]
   },
   {
-    "id": "sm2-9",
+    "setOrder":73,
+	"id": "sm2-9",
     "name": "Golisopod",
     "imageUrl": "https://images.pokemontcg.io/sm2/9.png",
     "subtype": "Stage 1",
@@ -447,7 +456,8 @@
     "nationalPokedexNumber": 768
   },
   {
-    "id": "sm2-10",
+    "setOrder":73,
+	"id": "sm2-10",
     "name": "Victini",
     "imageUrl": "https://images.pokemontcg.io/sm2/10.png",
     "subtype": "Basic",
@@ -493,7 +503,8 @@
     "nationalPokedexNumber": 494
   },
   {
-    "id": "sm2-11",
+    "setOrder":73,
+	"id": "sm2-11",
     "name": "Litwick",
     "imageUrl": "https://images.pokemontcg.io/sm2/11.png",
     "subtype": "Basic",
@@ -536,7 +547,8 @@
     ]
   },
   {
-    "id": "sm2-12",
+    "setOrder":73,
+	"id": "sm2-12",
     "name": "Lampent",
     "imageUrl": "https://images.pokemontcg.io/sm2/12.png",
     "subtype": "Stage 1",
@@ -580,7 +592,8 @@
     ]
   },
   {
-    "id": "sm2-13",
+    "setOrder":73,
+	"id": "sm2-13",
     "name": "Chandelure",
     "imageUrl": "https://images.pokemontcg.io/sm2/13.png",
     "subtype": "Stage 2",
@@ -626,7 +639,8 @@
     "nationalPokedexNumber": 609
   },
   {
-    "id": "sm2-14",
+    "setOrder":73,
+	"id": "sm2-14",
     "name": "Oricorio",
     "imageUrl": "https://images.pokemontcg.io/sm2/14.png",
     "subtype": "Basic",
@@ -676,7 +690,8 @@
     "nationalPokedexNumber": 741
   },
   {
-    "id": "sm2-15",
+    "setOrder":73,
+	"id": "sm2-15",
     "name": "Salandit",
     "imageUrl": "https://images.pokemontcg.io/sm2/15.png",
     "subtype": "Basic",
@@ -729,7 +744,8 @@
     ]
   },
   {
-    "id": "sm2-16",
+    "setOrder":73,
+	"id": "sm2-16",
     "name": "Salazzle",
     "imageUrl": "https://images.pokemontcg.io/sm2/16.png",
     "subtype": "Stage 1",
@@ -777,7 +793,8 @@
     "nationalPokedexNumber": 758
   },
   {
-    "id": "sm2-17",
+    "setOrder":73,
+	"id": "sm2-17",
     "name": "Turtonator",
     "imageUrl": "https://images.pokemontcg.io/sm2/17.png",
     "subtype": "Basic",
@@ -831,7 +848,8 @@
     "nationalPokedexNumber": 776
   },
   {
-    "id": "sm2-18",
+    "setOrder":73,
+	"id": "sm2-18",
     "name": "Turtonator-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/18.png",
     "subtype": "GX",
@@ -898,7 +916,8 @@
     "nationalPokedexNumber": 776
   },
   {
-    "id": "sm2-19",
+    "setOrder":73,
+	"id": "sm2-19",
     "name": "Alolan Sandshrew",
     "imageUrl": "https://images.pokemontcg.io/sm2/19.png",
     "subtype": "Basic",
@@ -952,7 +971,8 @@
     ]
   },
   {
-    "id": "sm2-20",
+    "setOrder":73,
+	"id": "sm2-20",
     "name": "Alolan Sandslash",
     "imageUrl": "https://images.pokemontcg.io/sm2/20.png",
     "subtype": "Stage 1",
@@ -1001,7 +1021,8 @@
     "nationalPokedexNumber": 28
   },
   {
-    "id": "sm2-21",
+    "setOrder":73,
+	"id": "sm2-21",
     "name": "Alolan Vulpix",
     "imageUrl": "https://images.pokemontcg.io/sm2/21.png",
     "subtype": "Basic",
@@ -1054,7 +1075,8 @@
     ]
   },
   {
-    "id": "sm2-22",
+    "setOrder":73,
+	"id": "sm2-22",
     "name": "Alolan Ninetales-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/22.png",
     "subtype": "GX",
@@ -1121,7 +1143,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "sm2-23",
+    "setOrder":73,
+	"id": "sm2-23",
     "name": "Tentacool",
     "imageUrl": "https://images.pokemontcg.io/sm2/23.png",
     "subtype": "Basic",
@@ -1164,7 +1187,8 @@
     ]
   },
   {
-    "id": "sm2-24",
+    "setOrder":73,
+	"id": "sm2-24",
     "name": "Tentacruel",
     "imageUrl": "https://images.pokemontcg.io/sm2/24.png",
     "subtype": "Stage 1",
@@ -1218,7 +1242,8 @@
     "nationalPokedexNumber": 73
   },
   {
-    "id": "sm2-25",
+    "setOrder":73,
+	"id": "sm2-25",
     "name": "Politoed",
     "imageUrl": "https://images.pokemontcg.io/sm2/25.png",
     "subtype": "Stage 2",
@@ -1270,7 +1295,8 @@
     "nationalPokedexNumber": 186
   },
   {
-    "id": "sm2-26",
+    "setOrder":73,
+	"id": "sm2-26",
     "name": "Delibird",
     "imageUrl": "https://images.pokemontcg.io/sm2/26.png",
     "subtype": "Basic",
@@ -1319,7 +1345,8 @@
     "nationalPokedexNumber": 225
   },
   {
-    "id": "sm2-27",
+    "setOrder":73,
+	"id": "sm2-27",
     "name": "Carvanha",
     "imageUrl": "https://images.pokemontcg.io/sm2/27.png",
     "subtype": "Basic",
@@ -1362,7 +1389,8 @@
     ]
   },
   {
-    "id": "sm2-28",
+    "setOrder":73,
+	"id": "sm2-28",
     "name": "Sharpedo",
     "imageUrl": "https://images.pokemontcg.io/sm2/28.png",
     "subtype": "Stage 1",
@@ -1401,7 +1429,8 @@
     "nationalPokedexNumber": 319
   },
   {
-    "id": "sm2-29",
+    "setOrder":73,
+	"id": "sm2-29",
     "name": "Wailmer",
     "imageUrl": "https://images.pokemontcg.io/sm2/29.png",
     "subtype": "Basic",
@@ -1459,7 +1488,8 @@
     ]
   },
   {
-    "id": "sm2-30",
+    "setOrder":73,
+	"id": "sm2-30",
     "name": "Wailord",
     "imageUrl": "https://images.pokemontcg.io/sm2/30.png",
     "subtype": "Stage 1",
@@ -1517,7 +1547,8 @@
     "nationalPokedexNumber": 321
   },
   {
-    "id": "sm2-31",
+    "setOrder":73,
+	"id": "sm2-31",
     "name": "Snorunt",
     "imageUrl": "https://images.pokemontcg.io/sm2/31.png",
     "subtype": "Basic",
@@ -1572,7 +1603,8 @@
     ]
   },
   {
-    "id": "sm2-32",
+    "setOrder":73,
+	"id": "sm2-32",
     "name": "Glalie",
     "imageUrl": "https://images.pokemontcg.io/sm2/32.png",
     "subtype": "Stage 1",
@@ -1627,7 +1659,8 @@
     "nationalPokedexNumber": 362
   },
   {
-    "id": "sm2-33",
+    "setOrder":73,
+	"id": "sm2-33",
     "name": "Vanillite",
     "imageUrl": "https://images.pokemontcg.io/sm2/33.png",
     "subtype": "Basic",
@@ -1670,7 +1703,8 @@
     ]
   },
   {
-    "id": "sm2-34",
+    "setOrder":73,
+	"id": "sm2-34",
     "name": "Vanillish",
     "imageUrl": "https://images.pokemontcg.io/sm2/34.png",
     "subtype": "Stage 1",
@@ -1715,7 +1749,8 @@
     ]
   },
   {
-    "id": "sm2-35",
+    "setOrder":73,
+	"id": "sm2-35",
     "name": "Vanilluxe",
     "imageUrl": "https://images.pokemontcg.io/sm2/35.png",
     "subtype": "Stage 2",
@@ -1768,7 +1803,8 @@
     "nationalPokedexNumber": 584
   },
   {
-    "id": "sm2-36",
+    "setOrder":73,
+	"id": "sm2-36",
     "name": "Alomomola",
     "imageUrl": "https://images.pokemontcg.io/sm2/36.png",
     "subtype": "Basic",
@@ -1820,7 +1856,8 @@
     "nationalPokedexNumber": 594
   },
   {
-    "id": "sm2-37",
+    "setOrder":73,
+	"id": "sm2-37",
     "name": "Wishiwashi",
     "imageUrl": "https://images.pokemontcg.io/sm2/37.png",
     "subtype": "Basic",
@@ -1862,7 +1899,8 @@
     "nationalPokedexNumber": 746
   },
   {
-    "id": "sm2-38",
+    "setOrder":73,
+	"id": "sm2-38",
     "name": "Wishiwashi-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/38.png",
     "subtype": "GX",
@@ -1934,7 +1972,8 @@
     "nationalPokedexNumber": 746
   },
   {
-    "id": "sm2-39",
+    "setOrder":73,
+	"id": "sm2-39",
     "name": "Mareanie",
     "imageUrl": "https://images.pokemontcg.io/sm2/39.png",
     "subtype": "Basic",
@@ -1986,7 +2025,8 @@
     ]
   },
   {
-    "id": "sm2-40",
+    "setOrder":73,
+	"id": "sm2-40",
     "name": "Alolan Geodude",
     "imageUrl": "https://images.pokemontcg.io/sm2/40.png",
     "subtype": "Basic",
@@ -2047,7 +2087,8 @@
     ]
   },
   {
-    "id": "sm2-41",
+    "setOrder":73,
+	"id": "sm2-41",
     "name": "Alolan Graveler",
     "imageUrl": "https://images.pokemontcg.io/sm2/41.png",
     "subtype": "Stage 1",
@@ -2114,7 +2155,8 @@
     ]
   },
   {
-    "id": "sm2-42",
+    "setOrder":73,
+	"id": "sm2-42",
     "name": "Alolan Golem",
     "imageUrl": "https://images.pokemontcg.io/sm2/42.png",
     "subtype": "Stage 2",
@@ -2178,7 +2220,8 @@
     "nationalPokedexNumber": 76
   },
   {
-    "id": "sm2-43",
+    "setOrder":73,
+	"id": "sm2-43",
     "name": "Helioptile",
     "imageUrl": "https://images.pokemontcg.io/sm2/43.png",
     "subtype": "Basic",
@@ -2227,7 +2270,8 @@
     ]
   },
   {
-    "id": "sm2-44",
+    "setOrder":73,
+	"id": "sm2-44",
     "name": "Heliolisk",
     "imageUrl": "https://images.pokemontcg.io/sm2/44.png",
     "subtype": "Stage 1",
@@ -2285,7 +2329,8 @@
     "nationalPokedexNumber": 695
   },
   {
-    "id": "sm2-45",
+    "setOrder":73,
+	"id": "sm2-45",
     "name": "Vikavolt-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/45.png",
     "subtype": "GX",
@@ -2360,7 +2405,8 @@
     "nationalPokedexNumber": 738
   },
   {
-    "id": "sm2-46",
+    "setOrder":73,
+	"id": "sm2-46",
     "name": "Oricorio",
     "imageUrl": "https://images.pokemontcg.io/sm2/46.png",
     "subtype": "Basic",
@@ -2415,7 +2461,8 @@
     "nationalPokedexNumber": 741
   },
   {
-    "id": "sm2-47",
+    "setOrder":73,
+	"id": "sm2-47",
     "name": "Tapu Koko-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/47.png",
     "subtype": "GX",
@@ -2471,7 +2518,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/47_hires.png"
   },
   {
-    "id": "sm2-48",
+    "setOrder":73,
+	"id": "sm2-48",
     "name": "Slowpoke",
     "imageUrl": "https://images.pokemontcg.io/sm2/48.png",
     "subtype": "Basic",
@@ -2528,7 +2576,8 @@
     ]
   },
   {
-    "id": "sm2-49",
+    "setOrder":73,
+	"id": "sm2-49",
     "name": "Slowbro",
     "imageUrl": "https://images.pokemontcg.io/sm2/49.png",
     "subtype": "Stage 1",
@@ -2582,7 +2631,8 @@
     "nationalPokedexNumber": 80
   },
   {
-    "id": "sm2-50",
+    "setOrder":73,
+	"id": "sm2-50",
     "name": "Trubbish",
     "imageUrl": "https://images.pokemontcg.io/sm2/50.png",
     "subtype": "Basic",
@@ -2637,7 +2687,8 @@
     ]
   },
   {
-    "id": "sm2-51",
+    "setOrder":73,
+	"id": "sm2-51",
     "name": "Garbodor",
     "imageUrl": "https://images.pokemontcg.io/sm2/51.png",
     "subtype": "Stage 1",
@@ -2691,7 +2742,8 @@
     "nationalPokedexNumber": 569
   },
   {
-    "id": "sm2-52",
+    "setOrder":73,
+	"id": "sm2-52",
     "name": "Gothita",
     "imageUrl": "https://images.pokemontcg.io/sm2/52.png",
     "subtype": "Basic",
@@ -2734,7 +2786,8 @@
     ]
   },
   {
-    "id": "sm2-53",
+    "setOrder":73,
+	"id": "sm2-53",
     "name": "Gothorita",
     "imageUrl": "https://images.pokemontcg.io/sm2/53.png",
     "subtype": "Stage 1",
@@ -2789,7 +2842,8 @@
     ]
   },
   {
-    "id": "sm2-54",
+    "setOrder":73,
+	"id": "sm2-54",
     "name": "Gothitelle",
     "imageUrl": "https://images.pokemontcg.io/sm2/54.png",
     "subtype": "Stage 2",
@@ -2841,7 +2895,8 @@
     "nationalPokedexNumber": 576
   },
   {
-    "id": "sm2-55",
+    "setOrder":73,
+	"id": "sm2-55",
     "name": "Oricorio",
     "imageUrl": "https://images.pokemontcg.io/sm2/55.png",
     "subtype": "Basic",
@@ -2887,7 +2942,8 @@
     "nationalPokedexNumber": 741
   },
   {
-    "id": "sm2-56",
+    "setOrder":73,
+	"id": "sm2-56",
     "name": "Oricorio",
     "imageUrl": "https://images.pokemontcg.io/sm2/56.png",
     "subtype": "Basic",
@@ -2942,7 +2998,8 @@
     "nationalPokedexNumber": 741
   },
   {
-    "id": "sm2-57",
+    "setOrder":73,
+	"id": "sm2-57",
     "name": "Toxapex-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/57.png",
     "subtype": "GX",
@@ -3011,7 +3068,8 @@
     "nationalPokedexNumber": 748
   },
   {
-    "id": "sm2-58",
+    "setOrder":73,
+	"id": "sm2-58",
     "name": "Mimikyu",
     "imageUrl": "https://images.pokemontcg.io/sm2/58.png",
     "subtype": "Basic",
@@ -3055,7 +3113,8 @@
     "nationalPokedexNumber": 778
   },
   {
-    "id": "sm2-59",
+    "setOrder":73,
+	"id": "sm2-59",
     "name": "Dhelmise",
     "imageUrl": "https://images.pokemontcg.io/sm2/59.png",
     "subtype": "Basic",
@@ -3109,7 +3168,8 @@
     "nationalPokedexNumber": 781
   },
   {
-    "id": "sm2-60",
+    "setOrder":73,
+	"id": "sm2-60",
     "name": "Tapu Lele-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/60.png",
     "subtype": "GX",
@@ -3161,7 +3221,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/60_hires.png"
   },
   {
-    "id": "sm2-61",
+    "setOrder":73,
+	"id": "sm2-61",
     "name": "Lunala",
     "imageUrl": "https://images.pokemontcg.io/sm2/61.png",
     "subtype": "Stage 2",
@@ -3220,7 +3281,8 @@
     "nationalPokedexNumber": 792
   },
   {
-    "id": "sm2-62",
+    "setOrder":73,
+	"id": "sm2-62",
     "name": "Machop",
     "imageUrl": "https://images.pokemontcg.io/sm2/62.png",
     "subtype": "Basic",
@@ -3265,7 +3327,8 @@
     ]
   },
   {
-    "id": "sm2-63",
+    "setOrder":73,
+	"id": "sm2-63",
     "name": "Machop",
     "imageUrl": "https://images.pokemontcg.io/sm2/63.png",
     "subtype": "Basic",
@@ -3310,7 +3373,8 @@
     ]
   },
   {
-    "id": "sm2-64",
+    "setOrder":73,
+	"id": "sm2-64",
     "name": "Machoke",
     "imageUrl": "https://images.pokemontcg.io/sm2/64.png",
     "subtype": "Stage 1",
@@ -3362,7 +3426,8 @@
     ]
   },
   {
-    "id": "sm2-65",
+    "setOrder":73,
+	"id": "sm2-65",
     "name": "Machamp",
     "imageUrl": "https://images.pokemontcg.io/sm2/65.png",
     "subtype": "Stage 2",
@@ -3417,7 +3482,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "sm2-66",
+    "setOrder":73,
+	"id": "sm2-66",
     "name": "Sudowoodo",
     "imageUrl": "https://images.pokemontcg.io/sm2/66.png",
     "subtype": "Basic",
@@ -3464,7 +3530,8 @@
     "nationalPokedexNumber": 185
   },
   {
-    "id": "sm2-67",
+    "setOrder":73,
+	"id": "sm2-67",
     "name": "Gligar",
     "imageUrl": "https://images.pokemontcg.io/sm2/67.png",
     "subtype": "Basic",
@@ -3507,7 +3574,8 @@
     ]
   },
   {
-    "id": "sm2-68",
+    "setOrder":73,
+	"id": "sm2-68",
     "name": "Gliscor",
     "imageUrl": "https://images.pokemontcg.io/sm2/68.png",
     "subtype": "Stage 1",
@@ -3559,7 +3627,8 @@
     "nationalPokedexNumber": 472
   },
   {
-    "id": "sm2-69",
+    "setOrder":73,
+	"id": "sm2-69",
     "name": "Nosepass",
     "imageUrl": "https://images.pokemontcg.io/sm2/69.png",
     "subtype": "Basic",
@@ -3616,7 +3685,8 @@
     ]
   },
   {
-    "id": "sm2-70",
+    "setOrder":73,
+	"id": "sm2-70",
     "name": "Barboach",
     "imageUrl": "https://images.pokemontcg.io/sm2/70.png",
     "subtype": "Basic",
@@ -3670,7 +3740,8 @@
     ]
   },
   {
-    "id": "sm2-71",
+    "setOrder":73,
+	"id": "sm2-71",
     "name": "Whiscash",
     "imageUrl": "https://images.pokemontcg.io/sm2/71.png",
     "subtype": "Stage 1",
@@ -3727,7 +3798,8 @@
     "nationalPokedexNumber": 340
   },
   {
-    "id": "sm2-72",
+    "setOrder":73,
+	"id": "sm2-72",
     "name": "Pancham",
     "imageUrl": "https://images.pokemontcg.io/sm2/72.png",
     "subtype": "Basic",
@@ -3772,7 +3844,8 @@
     ]
   },
   {
-    "id": "sm2-73",
+    "setOrder":73,
+	"id": "sm2-73",
     "name": "Rockruff",
     "imageUrl": "https://images.pokemontcg.io/sm2/73.png",
     "subtype": "Basic",
@@ -3825,7 +3898,8 @@
     ]
   },
   {
-    "id": "sm2-74",
+    "setOrder":73,
+	"id": "sm2-74",
     "name": "Lycanroc-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/74.png",
     "subtype": "GX",
@@ -3888,7 +3962,8 @@
     "nationalPokedexNumber": 745
   },
   {
-    "id": "sm2-75",
+    "setOrder":73,
+	"id": "sm2-75",
     "name": "Mudbray",
     "imageUrl": "https://images.pokemontcg.io/sm2/75.png",
     "subtype": "Basic",
@@ -3933,7 +4008,8 @@
     ]
   },
   {
-    "id": "sm2-76",
+    "setOrder":73,
+	"id": "sm2-76",
     "name": "Mudsdale",
     "imageUrl": "https://images.pokemontcg.io/sm2/76.png",
     "subtype": "Stage 1",
@@ -3991,7 +4067,8 @@
     "nationalPokedexNumber": 750
   },
   {
-    "id": "sm2-77",
+    "setOrder":73,
+	"id": "sm2-77",
     "name": "Minior",
     "imageUrl": "https://images.pokemontcg.io/sm2/77.png",
     "subtype": "Basic",
@@ -4048,7 +4125,8 @@
     "nationalPokedexNumber": 774
   },
   {
-    "id": "sm2-78",
+    "setOrder":73,
+	"id": "sm2-78",
     "name": "Murkrow",
     "imageUrl": "https://images.pokemontcg.io/sm2/78.png",
     "subtype": "Basic",
@@ -4097,7 +4175,8 @@
     ]
   },
   {
-    "id": "sm2-79",
+    "setOrder":73,
+	"id": "sm2-79",
     "name": "Honchkrow",
     "imageUrl": "https://images.pokemontcg.io/sm2/79.png",
     "subtype": "Stage 1",
@@ -4154,7 +4233,8 @@
     "nationalPokedexNumber": 430
   },
   {
-    "id": "sm2-80",
+    "setOrder":73,
+	"id": "sm2-80",
     "name": "Sableye",
     "imageUrl": "https://images.pokemontcg.io/sm2/80.png",
     "subtype": "Basic",
@@ -4197,7 +4277,8 @@
     "nationalPokedexNumber": 302
   },
   {
-    "id": "sm2-81",
+    "setOrder":73,
+	"id": "sm2-81",
     "name": "Absol",
     "imageUrl": "https://images.pokemontcg.io/sm2/81.png",
     "subtype": "Basic",
@@ -4253,7 +4334,8 @@
     "nationalPokedexNumber": 359
   },
   {
-    "id": "sm2-82",
+    "setOrder":73,
+	"id": "sm2-82",
     "name": "Pangoro",
     "imageUrl": "https://images.pokemontcg.io/sm2/82.png",
     "subtype": "Stage 1",
@@ -4316,7 +4398,8 @@
     "nationalPokedexNumber": 675
   },
   {
-    "id": "sm2-83",
+    "setOrder":73,
+	"id": "sm2-83",
     "name": "Beldum",
     "imageUrl": "https://images.pokemontcg.io/sm2/83.png",
     "subtype": "Basic",
@@ -4365,7 +4448,8 @@
     ]
   },
   {
-    "id": "sm2-84",
+    "setOrder":73,
+	"id": "sm2-84",
     "name": "Metang",
     "imageUrl": "https://images.pokemontcg.io/sm2/84.png",
     "subtype": "Stage 1",
@@ -4428,7 +4512,8 @@
     ]
   },
   {
-    "id": "sm2-85",
+    "setOrder":73,
+	"id": "sm2-85",
     "name": "Metagross-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/85.png",
     "subtype": "GX",
@@ -4497,7 +4582,8 @@
     "nationalPokedexNumber": 376
   },
   {
-    "id": "sm2-86",
+    "setOrder":73,
+	"id": "sm2-86",
     "name": "Probopass",
     "imageUrl": "https://images.pokemontcg.io/sm2/86.png",
     "subtype": "Stage 1",
@@ -4559,7 +4645,8 @@
     "nationalPokedexNumber": 476
   },
   {
-    "id": "sm2-87",
+    "setOrder":73,
+	"id": "sm2-87",
     "name": "Solgaleo",
     "imageUrl": "https://images.pokemontcg.io/sm2/87.png",
     "subtype": "Stage 2",
@@ -4620,7 +4707,8 @@
     "nationalPokedexNumber": 791
   },
   {
-    "id": "sm2-88",
+    "setOrder":73,
+	"id": "sm2-88",
     "name": "Clefairy",
     "imageUrl": "https://images.pokemontcg.io/sm2/88.png",
     "subtype": "Basic",
@@ -4679,7 +4767,8 @@
     ]
   },
   {
-    "id": "sm2-89",
+    "setOrder":73,
+	"id": "sm2-89",
     "name": "Clefable",
     "imageUrl": "https://images.pokemontcg.io/sm2/89.png",
     "subtype": "Stage 1",
@@ -4737,7 +4826,8 @@
     "nationalPokedexNumber": 36
   },
   {
-    "id": "sm2-90",
+    "setOrder":73,
+	"id": "sm2-90",
     "name": "Cottonee",
     "imageUrl": "https://images.pokemontcg.io/sm2/90.png",
     "subtype": "Basic",
@@ -4786,7 +4876,8 @@
     ]
   },
   {
-    "id": "sm2-91",
+    "setOrder":73,
+	"id": "sm2-91",
     "name": "Whimsicott",
     "imageUrl": "https://images.pokemontcg.io/sm2/91.png",
     "subtype": "Stage 1",
@@ -4839,7 +4930,8 @@
     "nationalPokedexNumber": 547
   },
   {
-    "id": "sm2-92",
+    "setOrder":73,
+	"id": "sm2-92",
     "name": "Sylveon-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/92.png",
     "subtype": "GX",
@@ -4913,7 +5005,8 @@
     "nationalPokedexNumber": 700
   },
   {
-    "id": "sm2-93",
+    "setOrder":73,
+	"id": "sm2-93",
     "name": "Comfey",
     "imageUrl": "https://images.pokemontcg.io/sm2/93.png",
     "subtype": "Basic",
@@ -4965,7 +5058,8 @@
     "nationalPokedexNumber": 764
   },
   {
-    "id": "sm2-94",
+    "setOrder":73,
+	"id": "sm2-94",
     "name": "Goomy",
     "imageUrl": "https://images.pokemontcg.io/sm2/94.png",
     "subtype": "Basic",
@@ -5018,7 +5112,8 @@
     ]
   },
   {
-    "id": "sm2-95",
+    "setOrder":73,
+	"id": "sm2-95",
     "name": "Sliggoo",
     "imageUrl": "https://images.pokemontcg.io/sm2/95.png",
     "subtype": "Stage 1",
@@ -5074,7 +5169,8 @@
     ]
   },
   {
-    "id": "sm2-96",
+    "setOrder":73,
+	"id": "sm2-96",
     "name": "Goodra",
     "imageUrl": "https://images.pokemontcg.io/sm2/96.png",
     "subtype": "Stage 2",
@@ -5128,7 +5224,8 @@
     "nationalPokedexNumber": 706
   },
   {
-    "id": "sm2-97",
+    "setOrder":73,
+	"id": "sm2-97",
     "name": "Drampa",
     "imageUrl": "https://images.pokemontcg.io/sm2/97.png",
     "subtype": "Basic",
@@ -5180,7 +5277,8 @@
     "nationalPokedexNumber": 780
   },
   {
-    "id": "sm2-98",
+    "setOrder":73,
+	"id": "sm2-98",
     "name": "Jangmo-o",
     "imageUrl": "https://images.pokemontcg.io/sm2/98.png",
     "subtype": "Basic",
@@ -5230,7 +5328,8 @@
     ]
   },
   {
-    "id": "sm2-99",
+    "setOrder":73,
+	"id": "sm2-99",
     "name": "Hakamo-o",
     "imageUrl": "https://images.pokemontcg.io/sm2/99.png",
     "subtype": "Stage 1",
@@ -5286,7 +5385,8 @@
     ]
   },
   {
-    "id": "sm2-100",
+    "setOrder":73,
+	"id": "sm2-100",
     "name": "Kommo-o-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/100.png",
     "subtype": "GX",
@@ -5356,7 +5456,8 @@
     "nationalPokedexNumber": 784
   },
   {
-    "id": "sm2-101",
+    "setOrder":73,
+	"id": "sm2-101",
     "name": "Chansey",
     "imageUrl": "https://images.pokemontcg.io/sm2/101.png",
     "subtype": "Basic",
@@ -5413,7 +5514,8 @@
     ]
   },
   {
-    "id": "sm2-102",
+    "setOrder":73,
+	"id": "sm2-102",
     "name": "Blissey",
     "imageUrl": "https://images.pokemontcg.io/sm2/102.png",
     "subtype": "Stage 1",
@@ -5465,7 +5567,8 @@
     "nationalPokedexNumber": 242
   },
   {
-    "id": "sm2-103",
+    "setOrder":73,
+	"id": "sm2-103",
     "name": "Taillow",
     "imageUrl": "https://images.pokemontcg.io/sm2/103.png",
     "subtype": "Basic",
@@ -5514,7 +5617,8 @@
     ]
   },
   {
-    "id": "sm2-104",
+    "setOrder":73,
+	"id": "sm2-104",
     "name": "Swellow",
     "imageUrl": "https://images.pokemontcg.io/sm2/104.png",
     "subtype": "Stage 1",
@@ -5570,7 +5674,8 @@
     "nationalPokedexNumber": 277
   },
   {
-    "id": "sm2-105",
+    "setOrder":73,
+	"id": "sm2-105",
     "name": "Castform",
     "imageUrl": "https://images.pokemontcg.io/sm2/105.png",
     "subtype": "Basic",
@@ -5620,7 +5725,8 @@
     "nationalPokedexNumber": 351
   },
   {
-    "id": "sm2-106",
+    "setOrder":73,
+	"id": "sm2-106",
     "name": "Rayquaza",
     "imageUrl": "https://images.pokemontcg.io/sm2/106.png",
     "subtype": "Basic",
@@ -5678,7 +5784,8 @@
     "nationalPokedexNumber": 384
   },
   {
-    "id": "sm2-107",
+    "setOrder":73,
+	"id": "sm2-107",
     "name": "Patrat",
     "imageUrl": "https://images.pokemontcg.io/sm2/107.png",
     "subtype": "Basic",
@@ -5731,7 +5838,8 @@
     ]
   },
   {
-    "id": "sm2-108",
+    "setOrder":73,
+	"id": "sm2-108",
     "name": "Watchog",
     "imageUrl": "https://images.pokemontcg.io/sm2/108.png",
     "subtype": "Stage 1",
@@ -5783,7 +5891,8 @@
     "nationalPokedexNumber": 505
   },
   {
-    "id": "sm2-109",
+    "setOrder":73,
+	"id": "sm2-109",
     "name": "Fletchling",
     "imageUrl": "https://images.pokemontcg.io/sm2/109.png",
     "subtype": "Basic",
@@ -5842,7 +5951,8 @@
     ]
   },
   {
-    "id": "sm2-110",
+    "setOrder":73,
+	"id": "sm2-110",
     "name": "Fletchinder",
     "imageUrl": "https://images.pokemontcg.io/sm2/110.png",
     "subtype": "Stage 1",
@@ -5902,7 +6012,8 @@
     ]
   },
   {
-    "id": "sm2-111",
+    "setOrder":73,
+	"id": "sm2-111",
     "name": "Talonflame",
     "imageUrl": "https://images.pokemontcg.io/sm2/111.png",
     "subtype": "Stage 2",
@@ -5956,7 +6067,8 @@
     "nationalPokedexNumber": 663
   },
   {
-    "id": "sm2-112",
+    "setOrder":73,
+	"id": "sm2-112",
     "name": "Stufful",
     "imageUrl": "https://images.pokemontcg.io/sm2/112.png",
     "subtype": "Basic",
@@ -6011,7 +6123,8 @@
     ]
   },
   {
-    "id": "sm2-113",
+    "setOrder":73,
+	"id": "sm2-113",
     "name": "Bewear",
     "imageUrl": "https://images.pokemontcg.io/sm2/113.png",
     "subtype": "Stage 1",
@@ -6060,7 +6173,8 @@
     "nationalPokedexNumber": 760
   },
   {
-    "id": "sm2-114",
+    "setOrder":73,
+	"id": "sm2-114",
     "name": "Komala",
     "imageUrl": "https://images.pokemontcg.io/sm2/114.png",
     "subtype": "Basic",
@@ -6108,7 +6222,8 @@
     "nationalPokedexNumber": 775
   },
   {
-    "id": "sm2-115",
+    "setOrder":73,
+	"id": "sm2-115",
     "name": "Drampa-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/115.png",
     "subtype": "GX",
@@ -6173,7 +6288,8 @@
     "nationalPokedexNumber": 780
   },
   {
-    "id": "sm2-116",
+    "setOrder":73,
+	"id": "sm2-116",
     "name": "Aether Paradise Conservation Area",
     "imageUrl": "https://images.pokemontcg.io/sm2/116.png",
     "subtype": "Stadium",
@@ -6190,7 +6306,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/116_hires.png"
   },
   {
-    "id": "sm2-117",
+    "setOrder":73,
+	"id": "sm2-117",
     "name": "Altar of the Moone",
     "imageUrl": "https://images.pokemontcg.io/sm2/117.png",
     "subtype": "Stadium",
@@ -6207,7 +6324,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/117_hires.png"
   },
   {
-    "id": "sm2-118",
+    "setOrder":73,
+	"id": "sm2-118",
     "name": "Altar of the Sunne",
     "imageUrl": "https://images.pokemontcg.io/sm2/118.png",
     "subtype": "Stadium",
@@ -6224,7 +6342,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/118_hires.png"
   },
   {
-    "id": "sm2-119",
+    "setOrder":73,
+	"id": "sm2-119",
     "name": "Aqua Patch",
     "imageUrl": "https://images.pokemontcg.io/sm2/119.png",
     "subtype": "Item",
@@ -6241,7 +6360,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/119_hires.png"
   },
   {
-    "id": "sm2-120",
+    "setOrder":73,
+	"id": "sm2-120",
     "name": "Brooklet Hill",
     "imageUrl": "https://images.pokemontcg.io/sm2/120.png",
     "subtype": "Stadium",
@@ -6258,7 +6378,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/120_hires.png"
   },
   {
-    "id": "sm2-121",
+    "setOrder":73,
+	"id": "sm2-121",
     "name": "Choice Band",
     "imageUrl": "https://images.pokemontcg.io/sm2/121.png",
     "subtype": "Pokémon Tool",
@@ -6275,7 +6396,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/121_hires.png"
   },
   {
-    "id": "sm2-122",
+    "setOrder":73,
+	"id": "sm2-122",
     "name": "Energy Loto",
     "imageUrl": "https://images.pokemontcg.io/sm2/122.png",
     "subtype": "Item",
@@ -6292,7 +6414,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/122_hires.png"
   },
   {
-    "id": "sm2-123",
+    "setOrder":73,
+	"id": "sm2-123",
     "name": "Energy Recycler",
     "imageUrl": "https://images.pokemontcg.io/sm2/123.png",
     "subtype": "Item",
@@ -6309,7 +6432,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/123_hires.png"
   },
   {
-    "id": "sm2-124",
+    "setOrder":73,
+	"id": "sm2-124",
     "name": "Enhanced Hammer",
     "imageUrl": "https://images.pokemontcg.io/sm2/124.png",
     "subtype": "Item",
@@ -6326,7 +6450,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/124_hires.png"
   },
   {
-    "id": "sm2-125",
+    "setOrder":73,
+	"id": "sm2-125",
     "name": "Field Blower",
     "imageUrl": "https://images.pokemontcg.io/sm2/125.png",
     "subtype": "Item",
@@ -6343,7 +6468,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/125_hires.png"
   },
   {
-    "id": "sm2-126",
+    "setOrder":73,
+	"id": "sm2-126",
     "name": "Hala",
     "imageUrl": "https://images.pokemontcg.io/sm2/126.png",
     "subtype": "Supporter",
@@ -6360,7 +6486,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/126_hires.png"
   },
   {
-    "id": "sm2-127",
+    "setOrder":73,
+	"id": "sm2-127",
     "name": "Mallow",
     "imageUrl": "https://images.pokemontcg.io/sm2/127.png",
     "subtype": "Supporter",
@@ -6377,7 +6504,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/127_hires.png"
   },
   {
-    "id": "sm2-128",
+    "setOrder":73,
+	"id": "sm2-128",
     "name": "Max Potion",
     "imageUrl": "https://images.pokemontcg.io/sm2/128.png",
     "subtype": "Item",
@@ -6394,7 +6522,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/128_hires.png"
   },
   {
-    "id": "sm2-129",
+    "setOrder":73,
+	"id": "sm2-129",
     "name": "Multi Switch",
     "imageUrl": "https://images.pokemontcg.io/sm2/129.png",
     "subtype": "Item",
@@ -6411,7 +6540,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/129_hires.png"
   },
   {
-    "id": "sm2-130",
+    "setOrder":73,
+	"id": "sm2-130",
     "name": "Rescue Stretcher",
     "imageUrl": "https://images.pokemontcg.io/sm2/130.png",
     "subtype": "Item",
@@ -6428,7 +6558,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/130_hires.png"
   },
   {
-    "id": "sm2-131",
+    "setOrder":73,
+	"id": "sm2-131",
     "name": "Turtonator-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/131.png",
     "subtype": "GX",
@@ -6495,7 +6626,8 @@
     "nationalPokedexNumber": 776
   },
   {
-    "id": "sm2-132",
+    "setOrder":73,
+	"id": "sm2-132",
     "name": "Alolan Ninetales-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/132.png",
     "subtype": "GX",
@@ -6562,7 +6694,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "sm2-133",
+    "setOrder":73,
+	"id": "sm2-133",
     "name": "Wishiwashi-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/133.png",
     "subtype": "GX",
@@ -6634,7 +6767,8 @@
     "nationalPokedexNumber": 746
   },
   {
-    "id": "sm2-134",
+    "setOrder":73,
+	"id": "sm2-134",
     "name": "Vikavolt-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/134.png",
     "subtype": "GX",
@@ -6709,7 +6843,8 @@
     "nationalPokedexNumber": 738
   },
   {
-    "id": "sm2-135",
+    "setOrder":73,
+	"id": "sm2-135",
     "name": "Tapu Koko-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/135.png",
     "subtype": "GX",
@@ -6765,7 +6900,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/135_hires.png"
   },
   {
-    "id": "sm2-136",
+    "setOrder":73,
+	"id": "sm2-136",
     "name": "Toxapex-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/136.png",
     "subtype": "GX",
@@ -6834,7 +6970,8 @@
     "nationalPokedexNumber": 748
   },
   {
-    "id": "sm2-137",
+    "setOrder":73,
+	"id": "sm2-137",
     "name": "Tapu Lele-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/137.png",
     "subtype": "GX",
@@ -6886,7 +7023,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/137_hires.png"
   },
   {
-    "id": "sm2-138",
+    "setOrder":73,
+	"id": "sm2-138",
     "name": "Lycanroc-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/138.png",
     "subtype": "GX",
@@ -6949,7 +7087,8 @@
     "nationalPokedexNumber": 745
   },
   {
-    "id": "sm2-139",
+    "setOrder":73,
+	"id": "sm2-139",
     "name": "Metagross-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/139.png",
     "subtype": "GX",
@@ -7018,7 +7157,8 @@
     "nationalPokedexNumber": 376
   },
   {
-    "id": "sm2-140",
+    "setOrder":73,
+	"id": "sm2-140",
     "name": "Sylveon-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/140.png",
     "subtype": "GX",
@@ -7092,7 +7232,8 @@
     "nationalPokedexNumber": 700
   },
   {
-    "id": "sm2-141",
+    "setOrder":73,
+	"id": "sm2-141",
     "name": "Kommo-o-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/141.png",
     "subtype": "GX",
@@ -7162,7 +7303,8 @@
     "nationalPokedexNumber": 784
   },
   {
-    "id": "sm2-142",
+    "setOrder":73,
+	"id": "sm2-142",
     "name": "Drampa-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/142.png",
     "subtype": "GX",
@@ -7227,7 +7369,8 @@
     "nationalPokedexNumber": 780
   },
   {
-    "id": "sm2-143",
+    "setOrder":73,
+	"id": "sm2-143",
     "name": "Hala",
     "imageUrl": "https://images.pokemontcg.io/sm2/143.png",
     "subtype": "Supporter",
@@ -7244,7 +7387,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/143_hires.png"
   },
   {
-    "id": "sm2-144",
+    "setOrder":73,
+	"id": "sm2-144",
     "name": "Hau",
     "imageUrl": "https://images.pokemontcg.io/sm2/144.png",
     "subtype": "Supporter",
@@ -7261,7 +7405,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/144_hires.png"
   },
   {
-    "id": "sm2-145",
+    "setOrder":73,
+	"id": "sm2-145",
     "name": "Mallow",
     "imageUrl": "https://images.pokemontcg.io/sm2/145.png",
     "subtype": "Supporter",
@@ -7278,7 +7423,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/145_hires.png"
   },
   {
-    "id": "sm2-146",
+    "setOrder":73,
+	"id": "sm2-146",
     "name": "Decidueye-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/146.png",
     "subtype": "GX",
@@ -7340,7 +7486,8 @@
     "nationalPokedexNumber": 724
   },
   {
-    "id": "sm2-147",
+    "setOrder":73,
+	"id": "sm2-147",
     "name": "Incineroar-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/147.png",
     "subtype": "GX",
@@ -7409,7 +7556,8 @@
     "nationalPokedexNumber": 727
   },
   {
-    "id": "sm2-148",
+    "setOrder":73,
+	"id": "sm2-148",
     "name": "Turtonator-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/148.png",
     "subtype": "GX",
@@ -7476,7 +7624,8 @@
     "nationalPokedexNumber": 776
   },
   {
-    "id": "sm2-149",
+    "setOrder":73,
+	"id": "sm2-149",
     "name": "Primarina-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/149.png",
     "subtype": "GX",
@@ -7545,7 +7694,8 @@
     "nationalPokedexNumber": 730
   },
   {
-    "id": "sm2-150",
+    "setOrder":73,
+	"id": "sm2-150",
     "name": "Alolan Ninetales-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/150.png",
     "subtype": "GX",
@@ -7612,7 +7762,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "sm2-151",
+    "setOrder":73,
+	"id": "sm2-151",
     "name": "Wishiwashi-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/151.png",
     "subtype": "GX",
@@ -7684,7 +7835,8 @@
     "nationalPokedexNumber": 746
   },
   {
-    "id": "sm2-152",
+    "setOrder":73,
+	"id": "sm2-152",
     "name": "Vikavolt-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/152.png",
     "subtype": "GX",
@@ -7759,7 +7911,8 @@
     "nationalPokedexNumber": 738
   },
   {
-    "id": "sm2-153",
+    "setOrder":73,
+	"id": "sm2-153",
     "name": "Tapu Koko-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/153.png",
     "subtype": "GX",
@@ -7815,7 +7968,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/153_hires.png"
   },
   {
-    "id": "sm2-154",
+    "setOrder":73,
+	"id": "sm2-154",
     "name": "Toxapex-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/154.png",
     "subtype": "GX",
@@ -7884,7 +8038,8 @@
     "nationalPokedexNumber": 748
   },
   {
-    "id": "sm2-155",
+    "setOrder":73,
+	"id": "sm2-155",
     "name": "Tapu Lele-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/155.png",
     "subtype": "GX",
@@ -7936,7 +8091,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/155_hires.png"
   },
   {
-    "id": "sm2-156",
+    "setOrder":73,
+	"id": "sm2-156",
     "name": "Lycanroc-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/156.png",
     "subtype": "GX",
@@ -7999,7 +8155,8 @@
     "nationalPokedexNumber": 745
   },
   {
-    "id": "sm2-157",
+    "setOrder":73,
+	"id": "sm2-157",
     "name": "Metagross-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/157.png",
     "subtype": "GX",
@@ -8068,7 +8225,8 @@
     "nationalPokedexNumber": 376
   },
   {
-    "id": "sm2-158",
+    "setOrder":73,
+	"id": "sm2-158",
     "name": "Sylveon-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/158.png",
     "subtype": "GX",
@@ -8142,7 +8300,8 @@
     "nationalPokedexNumber": 700
   },
   {
-    "id": "sm2-159",
+    "setOrder":73,
+	"id": "sm2-159",
     "name": "Kommo-o-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/159.png",
     "subtype": "GX",
@@ -8212,7 +8371,8 @@
     "nationalPokedexNumber": 784
   },
   {
-    "id": "sm2-160",
+    "setOrder":73,
+	"id": "sm2-160",
     "name": "Drampa-GX",
     "imageUrl": "https://images.pokemontcg.io/sm2/160.png",
     "subtype": "GX",
@@ -8277,7 +8437,8 @@
     "nationalPokedexNumber": 780
   },
   {
-    "id": "sm2-161",
+    "setOrder":73,
+	"id": "sm2-161",
     "name": "Aqua Patch",
     "imageUrl": "https://images.pokemontcg.io/sm2/161.png",
     "subtype": "Item",
@@ -8294,7 +8455,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/161_hires.png"
   },
   {
-    "id": "sm2-162",
+    "setOrder":73,
+	"id": "sm2-162",
     "name": "Enhanced Hammer",
     "imageUrl": "https://images.pokemontcg.io/sm2/162.png",
     "subtype": "Item",
@@ -8311,7 +8473,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/162_hires.png"
   },
   {
-    "id": "sm2-163",
+    "setOrder":73,
+	"id": "sm2-163",
     "name": "Field Blower",
     "imageUrl": "https://images.pokemontcg.io/sm2/163.png",
     "subtype": "Item",
@@ -8328,7 +8491,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/163_hires.png"
   },
   {
-    "id": "sm2-164",
+    "setOrder":73,
+	"id": "sm2-164",
     "name": "Max Potion",
     "imageUrl": "https://images.pokemontcg.io/sm2/164.png",
     "subtype": "Item",
@@ -8345,7 +8509,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/164_hires.png"
   },
   {
-    "id": "sm2-165",
+    "setOrder":73,
+	"id": "sm2-165",
     "name": "Rare Candy",
     "imageUrl": "https://images.pokemontcg.io/sm2/165.png",
     "subtype": "Item",
@@ -8362,7 +8527,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/165_hires.png"
   },
   {
-    "id": "sm2-166",
+    "setOrder":73,
+	"id": "sm2-166",
     "name": "Double Colorless Energy",
     "imageUrl": "https://images.pokemontcg.io/sm2/166.png",
     "subtype": "Special",
@@ -8379,7 +8545,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/166_hires.png"
   },
   {
-    "id": "sm2-167",
+    "setOrder":73,
+	"id": "sm2-167",
     "name": "Grass Energy",
     "imageUrl": "https://images.pokemontcg.io/sm2/167.png",
     "subtype": "Basic",
@@ -8393,7 +8560,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/167_hires.png"
   },
   {
-    "id": "sm2-168",
+    "setOrder":73,
+	"id": "sm2-168",
     "name": "Lightning Energy",
     "imageUrl": "https://images.pokemontcg.io/sm2/168.png",
     "subtype": "Basic",
@@ -8407,7 +8575,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm2/168_hires.png"
   },
   {
-    "id": "sm2-169",
+    "setOrder":73,
+	"id": "sm2-169",
     "name": "Fighting Energy",
     "imageUrl": "https://images.pokemontcg.io/sm2/169.png",
     "subtype": "Basic",

--- a/json/cards/Gym Challenge.json
+++ b/json/cards/Gym Challenge.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "gym2-1",
+    "setOrder":7,
+	"id": "gym2-1",
     "name": "Blaine's Arcanine",
     "imageUrl": "https://images.pokemontcg.io/gym2/1.png",
     "subtype": "Stage 1",
@@ -58,7 +59,8 @@
     "nationalPokedexNumber": 59
   },
   {
-    "id": "gym2-2",
+    "setOrder":7,
+	"id": "gym2-2",
     "name": "Blaine's Charizard",
     "imageUrl": "https://images.pokemontcg.io/gym2/2.png",
     "subtype": "Stage 2",
@@ -118,7 +120,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "gym2-3",
+    "setOrder":7,
+	"id": "gym2-3",
     "name": "Brock's Ninetales",
     "imageUrl": "https://images.pokemontcg.io/gym2/3.png",
     "subtype": "Stage 1",
@@ -166,7 +169,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "gym2-4",
+    "setOrder":7,
+	"id": "gym2-4",
     "name": "Erika's Venusaur",
     "imageUrl": "https://images.pokemontcg.io/gym2/4.png",
     "subtype": "Stage 2",
@@ -221,7 +225,8 @@
     "nationalPokedexNumber": 3
   },
   {
-    "id": "gym2-5",
+    "setOrder":7,
+	"id": "gym2-5",
     "name": "Giovanni's Gyarados",
     "imageUrl": "https://images.pokemontcg.io/gym2/5.png",
     "subtype": "Stage 1",
@@ -283,7 +288,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "gym2-6",
+    "setOrder":7,
+	"id": "gym2-6",
     "name": "Giovanni's Machamp",
     "imageUrl": "https://images.pokemontcg.io/gym2/6.png",
     "subtype": "Stage 2",
@@ -335,7 +341,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "gym2-7",
+    "setOrder":7,
+	"id": "gym2-7",
     "name": "Giovanni's Nidoking",
     "imageUrl": "https://images.pokemontcg.io/gym2/7.png",
     "subtype": "Stage 2",
@@ -391,7 +398,8 @@
     "nationalPokedexNumber": 34
   },
   {
-    "id": "gym2-8",
+    "setOrder":7,
+	"id": "gym2-8",
     "name": "Giovanni's Persian",
     "imageUrl": "https://images.pokemontcg.io/gym2/8.png",
     "subtype": "Stage 1",
@@ -443,7 +451,8 @@
     "nationalPokedexNumber": 53
   },
   {
-    "id": "gym2-9",
+    "setOrder":7,
+	"id": "gym2-9",
     "name": "Koga's Beedrill",
     "imageUrl": "https://images.pokemontcg.io/gym2/9.png",
     "subtype": "Stage 2",
@@ -500,7 +509,8 @@
     "nationalPokedexNumber": 15
   },
   {
-    "id": "gym2-10",
+    "setOrder":7,
+	"id": "gym2-10",
     "name": "Koga's Ditto",
     "imageUrl": "https://images.pokemontcg.io/gym2/10.png",
     "subtype": "Basic",
@@ -556,7 +566,8 @@
     "nationalPokedexNumber": 132
   },
   {
-    "id": "gym2-11",
+    "setOrder":7,
+	"id": "gym2-11",
     "name": "Lt. Surge's Raichu",
     "imageUrl": "https://images.pokemontcg.io/gym2/11.png",
     "subtype": "Stage 1",
@@ -612,7 +623,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "gym2-12",
+    "setOrder":7,
+	"id": "gym2-12",
     "name": "Misty's Golduck",
     "imageUrl": "https://images.pokemontcg.io/gym2/12.png",
     "subtype": "Stage 1",
@@ -665,7 +677,8 @@
     "nationalPokedexNumber": 55
   },
   {
-    "id": "gym2-13",
+    "setOrder":7,
+	"id": "gym2-13",
     "name": "Misty's Gyarados",
     "imageUrl": "https://images.pokemontcg.io/gym2/13.png",
     "subtype": "Stage 1",
@@ -723,7 +736,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "gym2-14",
+    "setOrder":7,
+	"id": "gym2-14",
     "name": "Rocket's Mewtwo",
     "imageUrl": "https://images.pokemontcg.io/gym2/14.png",
     "subtype": "Basic",
@@ -787,7 +801,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "gym2-15",
+    "setOrder":7,
+	"id": "gym2-15",
     "name": "Rocket's Zapdos",
     "imageUrl": "https://images.pokemontcg.io/gym2/15.png",
     "subtype": "Basic",
@@ -841,7 +856,8 @@
     "nationalPokedexNumber": 145
   },
   {
-    "id": "gym2-16",
+    "setOrder":7,
+	"id": "gym2-16",
     "name": "Sabrina's Alakazam",
     "imageUrl": "https://images.pokemontcg.io/gym2/16.png",
     "subtype": "Stage 2",
@@ -893,7 +909,8 @@
     "nationalPokedexNumber": 65
   },
   {
-    "id": "gym2-17",
+    "setOrder":7,
+	"id": "gym2-17",
     "name": "Blaine",
     "imageUrl": "https://images.pokemontcg.io/gym2/17.png",
     "subtype": "",
@@ -910,7 +927,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/17_hires.png"
   },
   {
-    "id": "gym2-18",
+    "setOrder":7,
+	"id": "gym2-18",
     "name": "Giovanni",
     "imageUrl": "https://images.pokemontcg.io/gym2/18.png",
     "subtype": "",
@@ -927,7 +945,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/18_hires.png"
   },
   {
-    "id": "gym2-19",
+    "setOrder":7,
+	"id": "gym2-19",
     "name": "Koga",
     "imageUrl": "https://images.pokemontcg.io/gym2/19.png",
     "subtype": "",
@@ -944,7 +963,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/19_hires.png"
   },
   {
-    "id": "gym2-20",
+    "setOrder":7,
+	"id": "gym2-20",
     "name": "Sabrina",
     "imageUrl": "https://images.pokemontcg.io/gym2/20.png",
     "subtype": "",
@@ -961,7 +981,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/20_hires.png"
   },
   {
-    "id": "gym2-21",
+    "setOrder":7,
+	"id": "gym2-21",
     "name": "Blaine's Ninetales",
     "imageUrl": "https://images.pokemontcg.io/gym2/21.png",
     "subtype": "Stage 1",
@@ -1010,7 +1031,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "gym2-22",
+    "setOrder":7,
+	"id": "gym2-22",
     "name": "Brock's Dugtrio",
     "imageUrl": "https://images.pokemontcg.io/gym2/22.png",
     "subtype": "Stage 1",
@@ -1069,7 +1091,8 @@
     "nationalPokedexNumber": 51
   },
   {
-    "id": "gym2-23",
+    "setOrder":7,
+	"id": "gym2-23",
     "name": "Giovanni's Nidoqueen",
     "imageUrl": "https://images.pokemontcg.io/gym2/23.png",
     "subtype": "Stage 2",
@@ -1127,7 +1150,8 @@
     "nationalPokedexNumber": 31
   },
   {
-    "id": "gym2-24",
+    "setOrder":7,
+	"id": "gym2-24",
     "name": "Giovanni's Pinsir",
     "imageUrl": "https://images.pokemontcg.io/gym2/24.png",
     "subtype": "Basic",
@@ -1181,7 +1205,8 @@
     "nationalPokedexNumber": 127
   },
   {
-    "id": "gym2-25",
+    "setOrder":7,
+	"id": "gym2-25",
     "name": "Koga's Arbok",
     "imageUrl": "https://images.pokemontcg.io/gym2/25.png",
     "subtype": "Stage 1",
@@ -1234,7 +1259,8 @@
     "nationalPokedexNumber": 24
   },
   {
-    "id": "gym2-26",
+    "setOrder":7,
+	"id": "gym2-26",
     "name": "Koga's Muk",
     "imageUrl": "https://images.pokemontcg.io/gym2/26.png",
     "subtype": "Stage 1",
@@ -1285,7 +1311,8 @@
     "nationalPokedexNumber": 89
   },
   {
-    "id": "gym2-27",
+    "setOrder":7,
+	"id": "gym2-27",
     "name": "Koga's Pidgeotto",
     "imageUrl": "https://images.pokemontcg.io/gym2/27.png",
     "subtype": "Stage 1",
@@ -1347,7 +1374,8 @@
     ]
   },
   {
-    "id": "gym2-28",
+    "setOrder":7,
+	"id": "gym2-28",
     "name": "Lt. Surge's Jolteon",
     "imageUrl": "https://images.pokemontcg.io/gym2/28.png",
     "subtype": "Stage 1",
@@ -1401,7 +1429,8 @@
     "nationalPokedexNumber": 135
   },
   {
-    "id": "gym2-29",
+    "setOrder":7,
+	"id": "gym2-29",
     "name": "Sabrina's Gengar",
     "imageUrl": "https://images.pokemontcg.io/gym2/29.png",
     "subtype": "Stage 2",
@@ -1456,7 +1485,8 @@
     "nationalPokedexNumber": 94
   },
   {
-    "id": "gym2-30",
+    "setOrder":7,
+	"id": "gym2-30",
     "name": "Sabrina's Golduck",
     "imageUrl": "https://images.pokemontcg.io/gym2/30.png",
     "subtype": "Stage 1",
@@ -1511,7 +1541,8 @@
     "nationalPokedexNumber": 55
   },
   {
-    "id": "gym2-31",
+    "setOrder":7,
+	"id": "gym2-31",
     "name": "Blaine's Charmeleon",
     "imageUrl": "https://images.pokemontcg.io/gym2/31.png",
     "subtype": "Stage 1",
@@ -1569,7 +1600,8 @@
     ]
   },
   {
-    "id": "gym2-32",
+    "setOrder":7,
+	"id": "gym2-32",
     "name": "Blaine's Dodrio",
     "imageUrl": "https://images.pokemontcg.io/gym2/32.png",
     "subtype": "Stage 1",
@@ -1618,7 +1650,8 @@
     "nationalPokedexNumber": 85
   },
   {
-    "id": "gym2-33",
+    "setOrder":7,
+	"id": "gym2-33",
     "name": "Blaine's Rapidash",
     "imageUrl": "https://images.pokemontcg.io/gym2/33.png",
     "subtype": "Stage 1",
@@ -1668,7 +1701,8 @@
     "nationalPokedexNumber": 78
   },
   {
-    "id": "gym2-34",
+    "setOrder":7,
+	"id": "gym2-34",
     "name": "Brock's Graveler",
     "imageUrl": "https://images.pokemontcg.io/gym2/34.png",
     "subtype": "Stage 1",
@@ -1726,7 +1760,8 @@
     ]
   },
   {
-    "id": "gym2-35",
+    "setOrder":7,
+	"id": "gym2-35",
     "name": "Brock's Primeape",
     "imageUrl": "https://images.pokemontcg.io/gym2/35.png",
     "subtype": "Stage 1",
@@ -1775,7 +1810,8 @@
     "nationalPokedexNumber": 57
   },
   {
-    "id": "gym2-36",
+    "setOrder":7,
+	"id": "gym2-36",
     "name": "Brock's Sandslash",
     "imageUrl": "https://images.pokemontcg.io/gym2/36.png",
     "subtype": "Stage 1",
@@ -1834,7 +1870,8 @@
     "nationalPokedexNumber": 28
   },
   {
-    "id": "gym2-37",
+    "setOrder":7,
+	"id": "gym2-37",
     "name": "Brock's Vulpix",
     "imageUrl": "https://images.pokemontcg.io/gym2/37.png",
     "subtype": "Basic",
@@ -1888,7 +1925,8 @@
     ]
   },
   {
-    "id": "gym2-38",
+    "setOrder":7,
+	"id": "gym2-38",
     "name": "Erika's Bellsprout",
     "imageUrl": "https://images.pokemontcg.io/gym2/38.png",
     "subtype": "Basic",
@@ -1937,7 +1975,8 @@
     ]
   },
   {
-    "id": "gym2-39",
+    "setOrder":7,
+	"id": "gym2-39",
     "name": "Erika's Bulbasaur",
     "imageUrl": "https://images.pokemontcg.io/gym2/39.png",
     "subtype": "Basic",
@@ -1991,7 +2030,8 @@
     ]
   },
   {
-    "id": "gym2-40",
+    "setOrder":7,
+	"id": "gym2-40",
     "name": "Erika's Clefairy",
     "imageUrl": "https://images.pokemontcg.io/gym2/40.png",
     "subtype": "Basic",
@@ -2051,7 +2091,8 @@
     ]
   },
   {
-    "id": "gym2-41",
+    "setOrder":7,
+	"id": "gym2-41",
     "name": "Erika's Ivysaur",
     "imageUrl": "https://images.pokemontcg.io/gym2/41.png",
     "subtype": "Stage 1",
@@ -2104,7 +2145,8 @@
     ]
   },
   {
-    "id": "gym2-42",
+    "setOrder":7,
+	"id": "gym2-42",
     "name": "Giovanni's Machoke",
     "imageUrl": "https://images.pokemontcg.io/gym2/42.png",
     "subtype": "Stage 1",
@@ -2161,7 +2203,8 @@
     ]
   },
   {
-    "id": "gym2-43",
+    "setOrder":7,
+	"id": "gym2-43",
     "name": "Giovanni's Meowth",
     "imageUrl": "https://images.pokemontcg.io/gym2/43.png",
     "subtype": "Basic",
@@ -2221,7 +2264,8 @@
     ]
   },
   {
-    "id": "gym2-44",
+    "setOrder":7,
+	"id": "gym2-44",
     "name": "Giovanni's Nidorina",
     "imageUrl": "https://images.pokemontcg.io/gym2/44.png",
     "subtype": "Stage 1",
@@ -2279,7 +2323,8 @@
     ]
   },
   {
-    "id": "gym2-45",
+    "setOrder":7,
+	"id": "gym2-45",
     "name": "Giovanni's Nidorino",
     "imageUrl": "https://images.pokemontcg.io/gym2/45.png",
     "subtype": "Stage 1",
@@ -2327,7 +2372,8 @@
     ]
   },
   {
-    "id": "gym2-46",
+    "setOrder":7,
+	"id": "gym2-46",
     "name": "Koga's Golbat",
     "imageUrl": "https://images.pokemontcg.io/gym2/46.png",
     "subtype": "Stage 1",
@@ -2390,7 +2436,8 @@
     ]
   },
   {
-    "id": "gym2-47",
+    "setOrder":7,
+	"id": "gym2-47",
     "name": "Koga's Kakuna",
     "imageUrl": "https://images.pokemontcg.io/gym2/47.png",
     "subtype": "Stage 1",
@@ -2441,7 +2488,8 @@
     ]
   },
   {
-    "id": "gym2-48",
+    "setOrder":7,
+	"id": "gym2-48",
     "name": "Koga's Koffing",
     "imageUrl": "https://images.pokemontcg.io/gym2/48.png",
     "subtype": "Basic",
@@ -2495,7 +2543,8 @@
     ]
   },
   {
-    "id": "gym2-49",
+    "setOrder":7,
+	"id": "gym2-49",
     "name": "Koga's Pidgey",
     "imageUrl": "https://images.pokemontcg.io/gym2/49.png",
     "subtype": "Basic",
@@ -2555,7 +2604,8 @@
     ]
   },
   {
-    "id": "gym2-50",
+    "setOrder":7,
+	"id": "gym2-50",
     "name": "Koga's Weezing",
     "imageUrl": "https://images.pokemontcg.io/gym2/50.png",
     "subtype": "Stage 1",
@@ -2610,7 +2660,8 @@
     "nationalPokedexNumber": 110
   },
   {
-    "id": "gym2-51",
+    "setOrder":7,
+	"id": "gym2-51",
     "name": "Lt. Surge's Eevee",
     "imageUrl": "https://images.pokemontcg.io/gym2/51.png",
     "subtype": "Basic",
@@ -2677,7 +2728,8 @@
     ]
   },
   {
-    "id": "gym2-52",
+    "setOrder":7,
+	"id": "gym2-52",
     "name": "Lt. Surge's Electrode",
     "imageUrl": "https://images.pokemontcg.io/gym2/52.png",
     "subtype": "Stage 1",
@@ -2727,7 +2779,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "gym2-53",
+    "setOrder":7,
+	"id": "gym2-53",
     "name": "Lt. Surge's Raticate",
     "imageUrl": "https://images.pokemontcg.io/gym2/53.png",
     "subtype": "Stage 1",
@@ -2785,7 +2838,8 @@
     "nationalPokedexNumber": 20
   },
   {
-    "id": "gym2-54",
+    "setOrder":7,
+	"id": "gym2-54",
     "name": "Misty's Dewgong",
     "imageUrl": "https://images.pokemontcg.io/gym2/54.png",
     "subtype": "Stage 1",
@@ -2841,7 +2895,8 @@
     "nationalPokedexNumber": 87
   },
   {
-    "id": "gym2-55",
+    "setOrder":7,
+	"id": "gym2-55",
     "name": "Sabrina's Haunter",
     "imageUrl": "https://images.pokemontcg.io/gym2/55.png",
     "subtype": "Stage 1",
@@ -2895,7 +2950,8 @@
     ]
   },
   {
-    "id": "gym2-56",
+    "setOrder":7,
+	"id": "gym2-56",
     "name": "Sabrina's Hypno",
     "imageUrl": "https://images.pokemontcg.io/gym2/56.png",
     "subtype": "Stage 1",
@@ -2948,7 +3004,8 @@
     "nationalPokedexNumber": 97
   },
   {
-    "id": "gym2-57",
+    "setOrder":7,
+	"id": "gym2-57",
     "name": "Sabrina's Jynx",
     "imageUrl": "https://images.pokemontcg.io/gym2/57.png",
     "subtype": "Basic",
@@ -2999,7 +3056,8 @@
     "nationalPokedexNumber": 124
   },
   {
-    "id": "gym2-58",
+    "setOrder":7,
+	"id": "gym2-58",
     "name": "Sabrina's Kadabra",
     "imageUrl": "https://images.pokemontcg.io/gym2/58.png",
     "subtype": "Stage 1",
@@ -3055,7 +3113,8 @@
     ]
   },
   {
-    "id": "gym2-59",
+    "setOrder":7,
+	"id": "gym2-59",
     "name": "Sabrina's Mr. Mime",
     "imageUrl": "https://images.pokemontcg.io/gym2/59.png",
     "subtype": "Basic",
@@ -3097,7 +3156,8 @@
     "nationalPokedexNumber": 122
   },
   {
-    "id": "gym2-60",
+    "setOrder":7,
+	"id": "gym2-60",
     "name": "Blaine's Charmander",
     "imageUrl": "https://images.pokemontcg.io/gym2/60.png",
     "subtype": "Basic",
@@ -3141,7 +3201,8 @@
     ]
   },
   {
-    "id": "gym2-61",
+    "setOrder":7,
+	"id": "gym2-61",
     "name": "Blaine's Doduo",
     "imageUrl": "https://images.pokemontcg.io/gym2/61.png",
     "subtype": "Basic",
@@ -3198,7 +3259,8 @@
     ]
   },
   {
-    "id": "gym2-62",
+    "setOrder":7,
+	"id": "gym2-62",
     "name": "Blaine's Growlithe",
     "imageUrl": "https://images.pokemontcg.io/gym2/62.png",
     "subtype": "Basic",
@@ -3253,7 +3315,8 @@
     ]
   },
   {
-    "id": "gym2-63",
+    "setOrder":7,
+	"id": "gym2-63",
     "name": "Blaine's Mankey",
     "imageUrl": "https://images.pokemontcg.io/gym2/63.png",
     "subtype": "Basic",
@@ -3303,7 +3366,8 @@
     ]
   },
   {
-    "id": "gym2-64",
+    "setOrder":7,
+	"id": "gym2-64",
     "name": "Blaine's Ponyta",
     "imageUrl": "https://images.pokemontcg.io/gym2/64.png",
     "subtype": "Basic",
@@ -3348,7 +3412,8 @@
     ]
   },
   {
-    "id": "gym2-65",
+    "setOrder":7,
+	"id": "gym2-65",
     "name": "Blaine's Rhyhorn",
     "imageUrl": "https://images.pokemontcg.io/gym2/65.png",
     "subtype": "Basic",
@@ -3410,7 +3475,8 @@
     ]
   },
   {
-    "id": "gym2-66",
+    "setOrder":7,
+	"id": "gym2-66",
     "name": "Blaine's Vulpix",
     "imageUrl": "https://images.pokemontcg.io/gym2/66.png",
     "subtype": "Basic",
@@ -3463,7 +3529,8 @@
     ]
   },
   {
-    "id": "gym2-67",
+    "setOrder":7,
+	"id": "gym2-67",
     "name": "Brock's Diglett",
     "imageUrl": "https://images.pokemontcg.io/gym2/67.png",
     "subtype": "Basic",
@@ -3523,7 +3590,8 @@
     ]
   },
   {
-    "id": "gym2-68",
+    "setOrder":7,
+	"id": "gym2-68",
     "name": "Brock's Geodude",
     "imageUrl": "https://images.pokemontcg.io/gym2/68.png",
     "subtype": "Basic",
@@ -3567,7 +3635,8 @@
     ]
   },
   {
-    "id": "gym2-69",
+    "setOrder":7,
+	"id": "gym2-69",
     "name": "Erika's Jigglypuff",
     "imageUrl": "https://images.pokemontcg.io/gym2/69.png",
     "subtype": "Basic",
@@ -3627,7 +3696,8 @@
     ]
   },
   {
-    "id": "gym2-70",
+    "setOrder":7,
+	"id": "gym2-70",
     "name": "Erika's Oddish",
     "imageUrl": "https://images.pokemontcg.io/gym2/70.png",
     "subtype": "Basic",
@@ -3671,7 +3741,8 @@
     ]
   },
   {
-    "id": "gym2-71",
+    "setOrder":7,
+	"id": "gym2-71",
     "name": "Erika's Paras",
     "imageUrl": "https://images.pokemontcg.io/gym2/71.png",
     "subtype": "Basic",
@@ -3725,7 +3796,8 @@
     ]
   },
   {
-    "id": "gym2-72",
+    "setOrder":7,
+	"id": "gym2-72",
     "name": "Giovanni's Machop",
     "imageUrl": "https://images.pokemontcg.io/gym2/72.png",
     "subtype": "Basic",
@@ -3779,7 +3851,8 @@
     ]
   },
   {
-    "id": "gym2-73",
+    "setOrder":7,
+	"id": "gym2-73",
     "name": "Giovanni's Magikarp",
     "imageUrl": "https://images.pokemontcg.io/gym2/73.png",
     "subtype": "Basic",
@@ -3833,7 +3906,8 @@
     ]
   },
   {
-    "id": "gym2-74",
+    "setOrder":7,
+	"id": "gym2-74",
     "name": "Giovanni's Meowth",
     "imageUrl": "https://images.pokemontcg.io/gym2/74.png",
     "subtype": "Basic",
@@ -3895,7 +3969,8 @@
     ]
   },
   {
-    "id": "gym2-75",
+    "setOrder":7,
+	"id": "gym2-75",
     "name": "Giovanni's Nidoran♀",
     "imageUrl": "https://images.pokemontcg.io/gym2/75.png",
     "subtype": "Basic",
@@ -3949,7 +4024,8 @@
     ]
   },
   {
-    "id": "gym2-76",
+    "setOrder":7,
+	"id": "gym2-76",
     "name": "Giovanni's Nidoran♂",
     "imageUrl": "https://images.pokemontcg.io/gym2/76.png",
     "subtype": "Basic",
@@ -4002,7 +4078,8 @@
     ]
   },
   {
-    "id": "gym2-77",
+    "setOrder":7,
+	"id": "gym2-77",
     "name": "Koga's Ekans",
     "imageUrl": "https://images.pokemontcg.io/gym2/77.png",
     "subtype": "Basic",
@@ -4046,7 +4123,8 @@
     ]
   },
   {
-    "id": "gym2-78",
+    "setOrder":7,
+	"id": "gym2-78",
     "name": "Koga's Grimer",
     "imageUrl": "https://images.pokemontcg.io/gym2/78.png",
     "subtype": "Basic",
@@ -4100,7 +4178,8 @@
     ]
   },
   {
-    "id": "gym2-79",
+    "setOrder":7,
+	"id": "gym2-79",
     "name": "Koga's Koffing",
     "imageUrl": "https://images.pokemontcg.io/gym2/79.png",
     "subtype": "Basic",
@@ -4144,7 +4223,8 @@
     ]
   },
   {
-    "id": "gym2-80",
+    "setOrder":7,
+	"id": "gym2-80",
     "name": "Koga's Pidgey",
     "imageUrl": "https://images.pokemontcg.io/gym2/80.png",
     "subtype": "Basic",
@@ -4205,7 +4285,8 @@
     ]
   },
   {
-    "id": "gym2-81",
+    "setOrder":7,
+	"id": "gym2-81",
     "name": "Koga's Tangela",
     "imageUrl": "https://images.pokemontcg.io/gym2/81.png",
     "subtype": "Basic",
@@ -4260,7 +4341,8 @@
     ]
   },
   {
-    "id": "gym2-82",
+    "setOrder":7,
+	"id": "gym2-82",
     "name": "Koga's Weedle",
     "imageUrl": "https://images.pokemontcg.io/gym2/82.png",
     "subtype": "Basic",
@@ -4314,7 +4396,8 @@
     ]
   },
   {
-    "id": "gym2-83",
+    "setOrder":7,
+	"id": "gym2-83",
     "name": "Koga's Zubat",
     "imageUrl": "https://images.pokemontcg.io/gym2/83.png",
     "subtype": "Basic",
@@ -4362,7 +4445,8 @@
     ]
   },
   {
-    "id": "gym2-84",
+    "setOrder":7,
+	"id": "gym2-84",
     "name": "Lt. Surge's Pikachu",
     "imageUrl": "https://images.pokemontcg.io/gym2/84.png",
     "subtype": "Basic",
@@ -4404,7 +4488,8 @@
     ]
   },
   {
-    "id": "gym2-85",
+    "setOrder":7,
+	"id": "gym2-85",
     "name": "Lt. Surge's Rattata",
     "imageUrl": "https://images.pokemontcg.io/gym2/85.png",
     "subtype": "Basic",
@@ -4461,7 +4546,8 @@
     ]
   },
   {
-    "id": "gym2-86",
+    "setOrder":7,
+	"id": "gym2-86",
     "name": "Lt. Surge's Voltorb",
     "imageUrl": "https://images.pokemontcg.io/gym2/86.png",
     "subtype": "Basic",
@@ -4506,7 +4592,8 @@
     ]
   },
   {
-    "id": "gym2-87",
+    "setOrder":7,
+	"id": "gym2-87",
     "name": "Misty's Horsea",
     "imageUrl": "https://images.pokemontcg.io/gym2/87.png",
     "subtype": "Basic",
@@ -4548,7 +4635,8 @@
     ]
   },
   {
-    "id": "gym2-88",
+    "setOrder":7,
+	"id": "gym2-88",
     "name": "Misty's Magikarp",
     "imageUrl": "https://images.pokemontcg.io/gym2/88.png",
     "subtype": "Basic",
@@ -4601,7 +4689,8 @@
     ]
   },
   {
-    "id": "gym2-89",
+    "setOrder":7,
+	"id": "gym2-89",
     "name": "Misty's Poliwag",
     "imageUrl": "https://images.pokemontcg.io/gym2/89.png",
     "subtype": "Basic",
@@ -4655,7 +4744,8 @@
     ]
   },
   {
-    "id": "gym2-90",
+    "setOrder":7,
+	"id": "gym2-90",
     "name": "Misty's Psyduck",
     "imageUrl": "https://images.pokemontcg.io/gym2/90.png",
     "subtype": "Basic",
@@ -4699,7 +4789,8 @@
     ]
   },
   {
-    "id": "gym2-91",
+    "setOrder":7,
+	"id": "gym2-91",
     "name": "Misty's Seel",
     "imageUrl": "https://images.pokemontcg.io/gym2/91.png",
     "subtype": "Basic",
@@ -4753,7 +4844,8 @@
     ]
   },
   {
-    "id": "gym2-92",
+    "setOrder":7,
+	"id": "gym2-92",
     "name": "Misty's Staryu",
     "imageUrl": "https://images.pokemontcg.io/gym2/92.png",
     "subtype": "Basic",
@@ -4797,7 +4889,8 @@
     ]
   },
   {
-    "id": "gym2-93",
+    "setOrder":7,
+	"id": "gym2-93",
     "name": "Sabrina's Abra",
     "imageUrl": "https://images.pokemontcg.io/gym2/93.png",
     "subtype": "Basic",
@@ -4848,7 +4941,8 @@
     ]
   },
   {
-    "id": "gym2-94",
+    "setOrder":7,
+	"id": "gym2-94",
     "name": "Sabrina's Abra",
     "imageUrl": "https://images.pokemontcg.io/gym2/94.png",
     "subtype": "Basic",
@@ -4901,7 +4995,8 @@
     ]
   },
   {
-    "id": "gym2-95",
+    "setOrder":7,
+	"id": "gym2-95",
     "name": "Sabrina's Drowzee",
     "imageUrl": "https://images.pokemontcg.io/gym2/95.png",
     "subtype": "Basic",
@@ -4955,7 +5050,8 @@
     ]
   },
   {
-    "id": "gym2-96",
+    "setOrder":7,
+	"id": "gym2-96",
     "name": "Sabrina's Gastly",
     "imageUrl": "https://images.pokemontcg.io/gym2/96.png",
     "subtype": "Basic",
@@ -5006,7 +5102,8 @@
     ]
   },
   {
-    "id": "gym2-97",
+    "setOrder":7,
+	"id": "gym2-97",
     "name": "Sabrina's Gastly",
     "imageUrl": "https://images.pokemontcg.io/gym2/97.png",
     "subtype": "Basic",
@@ -5056,7 +5153,8 @@
     ]
   },
   {
-    "id": "gym2-98",
+    "setOrder":7,
+	"id": "gym2-98",
     "name": "Sabrina's Porygon",
     "imageUrl": "https://images.pokemontcg.io/gym2/98.png",
     "subtype": "Basic",
@@ -5116,7 +5214,8 @@
     ]
   },
   {
-    "id": "gym2-99",
+    "setOrder":7,
+	"id": "gym2-99",
     "name": "Sabrina's Psyduck",
     "imageUrl": "https://images.pokemontcg.io/gym2/99.png",
     "subtype": "Basic",
@@ -5169,7 +5268,8 @@
     ]
   },
   {
-    "id": "gym2-100",
+    "setOrder":7,
+	"id": "gym2-100",
     "name": "Blaine",
     "imageUrl": "https://images.pokemontcg.io/gym2/100.png",
     "subtype": "",
@@ -5186,7 +5286,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/100_hires.png"
   },
   {
-    "id": "gym2-101",
+    "setOrder":7,
+	"id": "gym2-101",
     "name": "Brock's Protection",
     "imageUrl": "https://images.pokemontcg.io/gym2/101.png",
     "subtype": "",
@@ -5203,7 +5304,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/101_hires.png"
   },
   {
-    "id": "gym2-102",
+    "setOrder":7,
+	"id": "gym2-102",
     "name": "Chaos Gym",
     "imageUrl": "https://images.pokemontcg.io/gym2/102.png",
     "subtype": "",
@@ -5220,7 +5322,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/102_hires.png"
   },
   {
-    "id": "gym2-103",
+    "setOrder":7,
+	"id": "gym2-103",
     "name": "Erika's Kindness",
     "imageUrl": "https://images.pokemontcg.io/gym2/103.png",
     "subtype": "",
@@ -5237,7 +5340,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/103_hires.png"
   },
   {
-    "id": "gym2-104",
+    "setOrder":7,
+	"id": "gym2-104",
     "name": "Giovanni",
     "imageUrl": "https://images.pokemontcg.io/gym2/104.png",
     "subtype": "",
@@ -5254,7 +5358,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/104_hires.png"
   },
   {
-    "id": "gym2-105",
+    "setOrder":7,
+	"id": "gym2-105",
     "name": "Giovanni's Last Resort",
     "imageUrl": "https://images.pokemontcg.io/gym2/105.png",
     "subtype": "",
@@ -5271,7 +5376,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/105_hires.png"
   },
   {
-    "id": "gym2-106",
+    "setOrder":7,
+	"id": "gym2-106",
     "name": "Koga",
     "imageUrl": "https://images.pokemontcg.io/gym2/106.png",
     "subtype": "",
@@ -5288,7 +5394,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/106_hires.png"
   },
   {
-    "id": "gym2-107",
+    "setOrder":7,
+	"id": "gym2-107",
     "name": "Lt. Surge's Secret Plan",
     "imageUrl": "https://images.pokemontcg.io/gym2/107.png",
     "subtype": "",
@@ -5305,7 +5412,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/107_hires.png"
   },
   {
-    "id": "gym2-108",
+    "setOrder":7,
+	"id": "gym2-108",
     "name": "Misty's Wish",
     "imageUrl": "https://images.pokemontcg.io/gym2/108.png",
     "subtype": "",
@@ -5322,7 +5430,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/108_hires.png"
   },
   {
-    "id": "gym2-109",
+    "setOrder":7,
+	"id": "gym2-109",
     "name": "Resistance Gym",
     "imageUrl": "https://images.pokemontcg.io/gym2/109.png",
     "subtype": "",
@@ -5339,7 +5448,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/109_hires.png"
   },
   {
-    "id": "gym2-110",
+    "setOrder":7,
+	"id": "gym2-110",
     "name": "Sabrina",
     "imageUrl": "https://images.pokemontcg.io/gym2/110.png",
     "subtype": "",
@@ -5356,7 +5466,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/110_hires.png"
   },
   {
-    "id": "gym2-111",
+    "setOrder":7,
+	"id": "gym2-111",
     "name": "Blaine's Quiz #2",
     "imageUrl": "https://images.pokemontcg.io/gym2/111.png",
     "subtype": "",
@@ -5373,7 +5484,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/111_hires.png"
   },
   {
-    "id": "gym2-112",
+    "setOrder":7,
+	"id": "gym2-112",
     "name": "Blaine's Quiz #3",
     "imageUrl": "https://images.pokemontcg.io/gym2/112.png",
     "subtype": "",
@@ -5390,7 +5502,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/112_hires.png"
   },
   {
-    "id": "gym2-113",
+    "setOrder":7,
+	"id": "gym2-113",
     "name": "Cinnabar City Gym",
     "imageUrl": "https://images.pokemontcg.io/gym2/113.png",
     "subtype": "",
@@ -5407,7 +5520,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/113_hires.png"
   },
   {
-    "id": "gym2-114",
+    "setOrder":7,
+	"id": "gym2-114",
     "name": "Fuchsia City Gym",
     "imageUrl": "https://images.pokemontcg.io/gym2/114.png",
     "subtype": "",
@@ -5424,7 +5538,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/114_hires.png"
   },
   {
-    "id": "gym2-115",
+    "setOrder":7,
+	"id": "gym2-115",
     "name": "Koga's Ninja Trick",
     "imageUrl": "https://images.pokemontcg.io/gym2/115.png",
     "subtype": "",
@@ -5441,7 +5556,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/115_hires.png"
   },
   {
-    "id": "gym2-116",
+    "setOrder":7,
+	"id": "gym2-116",
     "name": "Master Ball",
     "imageUrl": "https://images.pokemontcg.io/gym2/116.png",
     "subtype": "",
@@ -5458,7 +5574,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/116_hires.png"
   },
   {
-    "id": "gym2-117",
+    "setOrder":7,
+	"id": "gym2-117",
     "name": "Max Revive",
     "imageUrl": "https://images.pokemontcg.io/gym2/117.png",
     "subtype": "",
@@ -5475,7 +5592,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/117_hires.png"
   },
   {
-    "id": "gym2-118",
+    "setOrder":7,
+	"id": "gym2-118",
     "name": "Misty's Tears",
     "imageUrl": "https://images.pokemontcg.io/gym2/118.png",
     "subtype": "",
@@ -5492,7 +5610,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/118_hires.png"
   },
   {
-    "id": "gym2-119",
+    "setOrder":7,
+	"id": "gym2-119",
     "name": "Rocket's Minefield Gym",
     "imageUrl": "https://images.pokemontcg.io/gym2/119.png",
     "subtype": "",
@@ -5509,7 +5628,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/119_hires.png"
   },
   {
-    "id": "gym2-120",
+    "setOrder":7,
+	"id": "gym2-120",
     "name": "Rocket's Secret Experiment",
     "imageUrl": "https://images.pokemontcg.io/gym2/120.png",
     "subtype": "",
@@ -5526,7 +5646,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/120_hires.png"
   },
   {
-    "id": "gym2-121",
+    "setOrder":7,
+	"id": "gym2-121",
     "name": "Sabrina's Psychic Control",
     "imageUrl": "https://images.pokemontcg.io/gym2/121.png",
     "subtype": "",
@@ -5543,7 +5664,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/121_hires.png"
   },
   {
-    "id": "gym2-122",
+    "setOrder":7,
+	"id": "gym2-122",
     "name": "Saffron City Gym",
     "imageUrl": "https://images.pokemontcg.io/gym2/122.png",
     "subtype": "",
@@ -5560,7 +5682,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/122_hires.png"
   },
   {
-    "id": "gym2-123",
+    "setOrder":7,
+	"id": "gym2-123",
     "name": "Viridian City Gym",
     "imageUrl": "https://images.pokemontcg.io/gym2/123.png",
     "subtype": "",
@@ -5577,7 +5700,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/123_hires.png"
   },
   {
-    "id": "gym2-124",
+    "setOrder":7,
+	"id": "gym2-124",
     "name": "Fervor",
     "imageUrl": "https://images.pokemontcg.io/gym2/124.png",
     "subtype": "",
@@ -5594,7 +5718,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/124_hires.png"
   },
   {
-    "id": "gym2-125",
+    "setOrder":7,
+	"id": "gym2-125",
     "name": "Transparent Walls",
     "imageUrl": "https://images.pokemontcg.io/gym2/125.png",
     "subtype": "",
@@ -5611,7 +5736,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/125_hires.png"
   },
   {
-    "id": "gym2-126",
+    "setOrder":7,
+	"id": "gym2-126",
     "name": "Warp Point",
     "imageUrl": "https://images.pokemontcg.io/gym2/126.png",
     "subtype": "",
@@ -5628,7 +5754,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/126_hires.png"
   },
   {
-    "id": "gym2-127",
+    "setOrder":7,
+	"id": "gym2-127",
     "name": "Fighting Energy",
     "imageUrl": "https://images.pokemontcg.io/gym2/127.png",
     "subtype": "Basic",
@@ -5642,7 +5769,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/127_hires.png"
   },
   {
-    "id": "gym2-128",
+    "setOrder":7,
+	"id": "gym2-128",
     "name": "Fire Energy",
     "imageUrl": "https://images.pokemontcg.io/gym2/128.png",
     "subtype": "Basic",
@@ -5656,7 +5784,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/128_hires.png"
   },
   {
-    "id": "gym2-129",
+    "setOrder":7,
+	"id": "gym2-129",
     "name": "Grass Energy",
     "imageUrl": "https://images.pokemontcg.io/gym2/129.png",
     "subtype": "Basic",
@@ -5670,7 +5799,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/129_hires.png"
   },
   {
-    "id": "gym2-130",
+    "setOrder":7,
+	"id": "gym2-130",
     "name": "Lightning Energy",
     "imageUrl": "https://images.pokemontcg.io/gym2/130.png",
     "subtype": "Basic",
@@ -5684,7 +5814,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/130_hires.png"
   },
   {
-    "id": "gym2-131",
+    "setOrder":7,
+	"id": "gym2-131",
     "name": "Psychic Energy",
     "imageUrl": "https://images.pokemontcg.io/gym2/131.png",
     "subtype": "Basic",
@@ -5698,7 +5829,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym2/131_hires.png"
   },
   {
-    "id": "gym2-132",
+    "setOrder":7,
+	"id": "gym2-132",
     "name": "Water Energy",
     "imageUrl": "https://images.pokemontcg.io/gym2/132.png",
     "subtype": "Basic",

--- a/json/cards/Gym Heroes.json
+++ b/json/cards/Gym Heroes.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "gym1-1",
+    "setOrder":6,
+	"id": "gym1-1",
     "name": "Blaine's Moltres",
     "imageUrl": "https://images.pokemontcg.io/gym1/1.png",
     "subtype": "Basic",
@@ -47,7 +48,8 @@
     "nationalPokedexNumber": 146
   },
   {
-    "id": "gym1-2",
+    "setOrder":6,
+	"id": "gym1-2",
     "name": "Brock's Rhydon",
     "imageUrl": "https://images.pokemontcg.io/gym1/2.png",
     "subtype": "Stage 1",
@@ -108,7 +110,8 @@
     ]
   },
   {
-    "id": "gym1-3",
+    "setOrder":6,
+	"id": "gym1-3",
     "name": "Erika's Clefable",
     "imageUrl": "https://images.pokemontcg.io/gym1/3.png",
     "subtype": "Stage 1",
@@ -168,7 +171,8 @@
     "nationalPokedexNumber": 36
   },
   {
-    "id": "gym1-4",
+    "setOrder":6,
+	"id": "gym1-4",
     "name": "Erika's Dragonair",
     "imageUrl": "https://images.pokemontcg.io/gym1/4.png",
     "subtype": "Stage 1",
@@ -228,7 +232,8 @@
     ]
   },
   {
-    "id": "gym1-5",
+    "setOrder":6,
+	"id": "gym1-5",
     "name": "Erika's Vileplume",
     "imageUrl": "https://images.pokemontcg.io/gym1/5.png",
     "subtype": "Stage 2",
@@ -278,7 +283,8 @@
     "nationalPokedexNumber": 45
   },
   {
-    "id": "gym1-6",
+    "setOrder":6,
+	"id": "gym1-6",
     "name": "Lt. Surge's Electabuzz",
     "imageUrl": "https://images.pokemontcg.io/gym1/6.png",
     "subtype": "Basic",
@@ -333,7 +339,8 @@
     ]
   },
   {
-    "id": "gym1-7",
+    "setOrder":6,
+	"id": "gym1-7",
     "name": "Lt. Surge's Fearow",
     "imageUrl": "https://images.pokemontcg.io/gym1/7.png",
     "subtype": "Stage 1",
@@ -390,7 +397,8 @@
     "nationalPokedexNumber": 22
   },
   {
-    "id": "gym1-8",
+    "setOrder":6,
+	"id": "gym1-8",
     "name": "Lt. Surge's Magneton",
     "imageUrl": "https://images.pokemontcg.io/gym1/8.png",
     "subtype": "Stage 1",
@@ -443,7 +451,8 @@
     ]
   },
   {
-    "id": "gym1-9",
+    "setOrder":6,
+	"id": "gym1-9",
     "name": "Misty's Seadra",
     "imageUrl": "https://images.pokemontcg.io/gym1/9.png",
     "subtype": "Stage 1",
@@ -499,7 +508,8 @@
     ]
   },
   {
-    "id": "gym1-10",
+    "setOrder":6,
+	"id": "gym1-10",
     "name": "Misty's Tentacruel",
     "imageUrl": "https://images.pokemontcg.io/gym1/10.png",
     "subtype": "Stage 1",
@@ -546,7 +556,8 @@
     "nationalPokedexNumber": 73
   },
   {
-    "id": "gym1-11",
+    "setOrder":6,
+	"id": "gym1-11",
     "name": "Rocket's Hitmonchan",
     "imageUrl": "https://images.pokemontcg.io/gym1/11.png",
     "subtype": "Basic",
@@ -599,7 +610,8 @@
     "nationalPokedexNumber": 107
   },
   {
-    "id": "gym1-12",
+    "setOrder":6,
+	"id": "gym1-12",
     "name": "Rocket's Moltres",
     "imageUrl": "https://images.pokemontcg.io/gym1/12.png",
     "subtype": "Basic",
@@ -643,7 +655,8 @@
     "nationalPokedexNumber": 146
   },
   {
-    "id": "gym1-13",
+    "setOrder":6,
+	"id": "gym1-13",
     "name": "Rocket's Scyther",
     "imageUrl": "https://images.pokemontcg.io/gym1/13.png",
     "subtype": "Basic",
@@ -704,7 +717,8 @@
     ]
   },
   {
-    "id": "gym1-14",
+    "setOrder":6,
+	"id": "gym1-14",
     "name": "Sabrina's Gengar",
     "imageUrl": "https://images.pokemontcg.io/gym1/14.png",
     "subtype": "Stage 2",
@@ -757,7 +771,8 @@
     "nationalPokedexNumber": 94
   },
   {
-    "id": "gym1-15",
+    "setOrder":6,
+	"id": "gym1-15",
     "name": "Brock",
     "imageUrl": "https://images.pokemontcg.io/gym1/15.png",
     "subtype": "",
@@ -774,7 +789,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/15_hires.png"
   },
   {
-    "id": "gym1-16",
+    "setOrder":6,
+	"id": "gym1-16",
     "name": "Erika",
     "imageUrl": "https://images.pokemontcg.io/gym1/16.png",
     "subtype": "",
@@ -791,7 +807,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/16_hires.png"
   },
   {
-    "id": "gym1-17",
+    "setOrder":6,
+	"id": "gym1-17",
     "name": "Lt. Surge",
     "imageUrl": "https://images.pokemontcg.io/gym1/17.png",
     "subtype": "",
@@ -808,7 +825,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/17_hires.png"
   },
   {
-    "id": "gym1-18",
+    "setOrder":6,
+	"id": "gym1-18",
     "name": "Misty",
     "imageUrl": "https://images.pokemontcg.io/gym1/18.png",
     "subtype": "",
@@ -825,7 +843,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/18_hires.png"
   },
   {
-    "id": "gym1-19",
+    "setOrder":6,
+	"id": "gym1-19",
     "name": "The Rocket's Trap",
     "imageUrl": "https://images.pokemontcg.io/gym1/19.png",
     "subtype": "",
@@ -842,7 +861,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/19_hires.png"
   },
   {
-    "id": "gym1-20",
+    "setOrder":6,
+	"id": "gym1-20",
     "name": "Brock's Golem",
     "imageUrl": "https://images.pokemontcg.io/gym1/20.png",
     "subtype": "Stage 2",
@@ -901,7 +921,8 @@
     "nationalPokedexNumber": 76
   },
   {
-    "id": "gym1-21",
+    "setOrder":6,
+	"id": "gym1-21",
     "name": "Brock's Onix",
     "imageUrl": "https://images.pokemontcg.io/gym1/21.png",
     "subtype": "Basic",
@@ -958,7 +979,8 @@
     ]
   },
   {
-    "id": "gym1-22",
+    "setOrder":6,
+	"id": "gym1-22",
     "name": "Brock's Rhyhorn",
     "imageUrl": "https://images.pokemontcg.io/gym1/22.png",
     "subtype": "Basic",
@@ -1021,7 +1043,8 @@
     ]
   },
   {
-    "id": "gym1-23",
+    "setOrder":6,
+	"id": "gym1-23",
     "name": "Brock's Sandslash",
     "imageUrl": "https://images.pokemontcg.io/gym1/23.png",
     "subtype": "Stage 1",
@@ -1080,7 +1103,8 @@
     "nationalPokedexNumber": 28
   },
   {
-    "id": "gym1-24",
+    "setOrder":6,
+	"id": "gym1-24",
     "name": "Brock's Zubat",
     "imageUrl": "https://images.pokemontcg.io/gym1/24.png",
     "subtype": "Basic",
@@ -1137,7 +1161,8 @@
     ]
   },
   {
-    "id": "gym1-25",
+    "setOrder":6,
+	"id": "gym1-25",
     "name": "Erika's Clefairy",
     "imageUrl": "https://images.pokemontcg.io/gym1/25.png",
     "subtype": "Basic",
@@ -1198,7 +1223,8 @@
     ]
   },
   {
-    "id": "gym1-26",
+    "setOrder":6,
+	"id": "gym1-26",
     "name": "Erika's Victreebel",
     "imageUrl": "https://images.pokemontcg.io/gym1/26.png",
     "subtype": "Stage 2",
@@ -1248,7 +1274,8 @@
     "nationalPokedexNumber": 71
   },
   {
-    "id": "gym1-27",
+    "setOrder":6,
+	"id": "gym1-27",
     "name": "Lt. Surge's Electabuzz",
     "imageUrl": "https://images.pokemontcg.io/gym1/27.png",
     "subtype": "Basic",
@@ -1304,7 +1331,8 @@
     ]
   },
   {
-    "id": "gym1-28",
+    "setOrder":6,
+	"id": "gym1-28",
     "name": "Lt. Surge's Raichu",
     "imageUrl": "https://images.pokemontcg.io/gym1/28.png",
     "subtype": "Stage 1",
@@ -1360,7 +1388,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "gym1-29",
+    "setOrder":6,
+	"id": "gym1-29",
     "name": "Misty's Cloyster",
     "imageUrl": "https://images.pokemontcg.io/gym1/29.png",
     "subtype": "Stage 1",
@@ -1410,7 +1439,8 @@
     "nationalPokedexNumber": 91
   },
   {
-    "id": "gym1-30",
+    "setOrder":6,
+	"id": "gym1-30",
     "name": "Misty's Goldeen",
     "imageUrl": "https://images.pokemontcg.io/gym1/30.png",
     "subtype": "Basic",
@@ -1451,7 +1481,8 @@
     ]
   },
   {
-    "id": "gym1-31",
+    "setOrder":6,
+	"id": "gym1-31",
     "name": "Misty's Poliwrath",
     "imageUrl": "https://images.pokemontcg.io/gym1/31.png",
     "subtype": "Stage 2",
@@ -1498,7 +1529,8 @@
     "nationalPokedexNumber": 62
   },
   {
-    "id": "gym1-32",
+    "setOrder":6,
+	"id": "gym1-32",
     "name": "Misty's Tentacool",
     "imageUrl": "https://images.pokemontcg.io/gym1/32.png",
     "subtype": "Basic",
@@ -1549,7 +1581,8 @@
     ]
   },
   {
-    "id": "gym1-33",
+    "setOrder":6,
+	"id": "gym1-33",
     "name": "Rocket's Snorlax",
     "imageUrl": "https://images.pokemontcg.io/gym1/33.png",
     "subtype": "Basic",
@@ -1607,7 +1640,8 @@
     "nationalPokedexNumber": 143
   },
   {
-    "id": "gym1-34",
+    "setOrder":6,
+	"id": "gym1-34",
     "name": "Sabrina's Venomoth",
     "imageUrl": "https://images.pokemontcg.io/gym1/34.png",
     "subtype": "Stage 1",
@@ -1665,7 +1699,8 @@
     "nationalPokedexNumber": 49
   },
   {
-    "id": "gym1-35",
+    "setOrder":6,
+	"id": "gym1-35",
     "name": "Blaine's Growlithe",
     "imageUrl": "https://images.pokemontcg.io/gym1/35.png",
     "subtype": "Basic",
@@ -1719,7 +1754,8 @@
     ]
   },
   {
-    "id": "gym1-36",
+    "setOrder":6,
+	"id": "gym1-36",
     "name": "Blaine's Kangaskhan",
     "imageUrl": "https://images.pokemontcg.io/gym1/36.png",
     "subtype": "Basic",
@@ -1779,7 +1815,8 @@
     "nationalPokedexNumber": 115
   },
   {
-    "id": "gym1-37",
+    "setOrder":6,
+	"id": "gym1-37",
     "name": "Blaine's Magmar",
     "imageUrl": "https://images.pokemontcg.io/gym1/37.png",
     "subtype": "Basic",
@@ -1836,7 +1873,8 @@
     ]
   },
   {
-    "id": "gym1-38",
+    "setOrder":6,
+	"id": "gym1-38",
     "name": "Brock's Geodude",
     "imageUrl": "https://images.pokemontcg.io/gym1/38.png",
     "subtype": "Basic",
@@ -1890,7 +1928,8 @@
     ]
   },
   {
-    "id": "gym1-39",
+    "setOrder":6,
+	"id": "gym1-39",
     "name": "Brock's Golbat",
     "imageUrl": "https://images.pokemontcg.io/gym1/39.png",
     "subtype": "Stage 1",
@@ -1952,7 +1991,8 @@
     ]
   },
   {
-    "id": "gym1-40",
+    "setOrder":6,
+	"id": "gym1-40",
     "name": "Brock's Graveler",
     "imageUrl": "https://images.pokemontcg.io/gym1/40.png",
     "subtype": "Stage 1",
@@ -2000,7 +2040,8 @@
     ]
   },
   {
-    "id": "gym1-41",
+    "setOrder":6,
+	"id": "gym1-41",
     "name": "Brock's Lickitung",
     "imageUrl": "https://images.pokemontcg.io/gym1/41.png",
     "subtype": "Basic",
@@ -2064,7 +2105,8 @@
     ]
   },
   {
-    "id": "gym1-42",
+    "setOrder":6,
+	"id": "gym1-42",
     "name": "Erika's Dratini",
     "imageUrl": "https://images.pokemontcg.io/gym1/42.png",
     "subtype": "Basic",
@@ -2114,7 +2156,8 @@
     ]
   },
   {
-    "id": "gym1-43",
+    "setOrder":6,
+	"id": "gym1-43",
     "name": "Erika's Exeggcute",
     "imageUrl": "https://images.pokemontcg.io/gym1/43.png",
     "subtype": "Basic",
@@ -2168,7 +2211,8 @@
     ]
   },
   {
-    "id": "gym1-44",
+    "setOrder":6,
+	"id": "gym1-44",
     "name": "Erika's Exeggutor",
     "imageUrl": "https://images.pokemontcg.io/gym1/44.png",
     "subtype": "Stage 1",
@@ -2222,7 +2266,8 @@
     "nationalPokedexNumber": 103
   },
   {
-    "id": "gym1-45",
+    "setOrder":6,
+	"id": "gym1-45",
     "name": "Erika's Gloom",
     "imageUrl": "https://images.pokemontcg.io/gym1/45.png",
     "subtype": "Stage 1",
@@ -2276,7 +2321,8 @@
     ]
   },
   {
-    "id": "gym1-46",
+    "setOrder":6,
+	"id": "gym1-46",
     "name": "Erika's Gloom",
     "imageUrl": "https://images.pokemontcg.io/gym1/46.png",
     "subtype": "Stage 1",
@@ -2334,7 +2380,8 @@
     ]
   },
   {
-    "id": "gym1-47",
+    "setOrder":6,
+	"id": "gym1-47",
     "name": "Erika's Oddish",
     "imageUrl": "https://images.pokemontcg.io/gym1/47.png",
     "subtype": "Basic",
@@ -2384,7 +2431,8 @@
     ]
   },
   {
-    "id": "gym1-48",
+    "setOrder":6,
+	"id": "gym1-48",
     "name": "Erika's Weepinbell",
     "imageUrl": "https://images.pokemontcg.io/gym1/48.png",
     "subtype": "Stage 1",
@@ -2439,7 +2487,8 @@
     ]
   },
   {
-    "id": "gym1-49",
+    "setOrder":6,
+	"id": "gym1-49",
     "name": "Erika's Weepinbell",
     "imageUrl": "https://images.pokemontcg.io/gym1/49.png",
     "subtype": "Stage 1",
@@ -2497,7 +2546,8 @@
     ]
   },
   {
-    "id": "gym1-50",
+    "setOrder":6,
+	"id": "gym1-50",
     "name": "Lt. Surge's Magnemite",
     "imageUrl": "https://images.pokemontcg.io/gym1/50.png",
     "subtype": "Basic",
@@ -2552,7 +2602,8 @@
     ]
   },
   {
-    "id": "gym1-51",
+    "setOrder":6,
+	"id": "gym1-51",
     "name": "Lt. Surge's Raticate",
     "imageUrl": "https://images.pokemontcg.io/gym1/51.png",
     "subtype": "Stage 1",
@@ -2600,7 +2651,8 @@
     "nationalPokedexNumber": 20
   },
   {
-    "id": "gym1-52",
+    "setOrder":6,
+	"id": "gym1-52",
     "name": "Lt. Surge's Spearow",
     "imageUrl": "https://images.pokemontcg.io/gym1/52.png",
     "subtype": "Basic",
@@ -2647,7 +2699,8 @@
     ]
   },
   {
-    "id": "gym1-53",
+    "setOrder":6,
+	"id": "gym1-53",
     "name": "Misty's Poliwhirl",
     "imageUrl": "https://images.pokemontcg.io/gym1/53.png",
     "subtype": "Stage 1",
@@ -2706,7 +2759,8 @@
     ]
   },
   {
-    "id": "gym1-54",
+    "setOrder":6,
+	"id": "gym1-54",
     "name": "Misty's Psyduck",
     "imageUrl": "https://images.pokemontcg.io/gym1/54.png",
     "subtype": "Basic",
@@ -2759,7 +2813,8 @@
     ]
   },
   {
-    "id": "gym1-55",
+    "setOrder":6,
+	"id": "gym1-55",
     "name": "Misty's Seaking",
     "imageUrl": "https://images.pokemontcg.io/gym1/55.png",
     "subtype": "Stage 1",
@@ -2811,7 +2866,8 @@
     "nationalPokedexNumber": 119
   },
   {
-    "id": "gym1-56",
+    "setOrder":6,
+	"id": "gym1-56",
     "name": "Misty's Starmie",
     "imageUrl": "https://images.pokemontcg.io/gym1/56.png",
     "subtype": "Stage 1",
@@ -2865,7 +2921,8 @@
     "nationalPokedexNumber": 121
   },
   {
-    "id": "gym1-57",
+    "setOrder":6,
+	"id": "gym1-57",
     "name": "Misty's Tentacool",
     "imageUrl": "https://images.pokemontcg.io/gym1/57.png",
     "subtype": "Basic",
@@ -2910,7 +2967,8 @@
     ]
   },
   {
-    "id": "gym1-58",
+    "setOrder":6,
+	"id": "gym1-58",
     "name": "Sabrina's Haunter",
     "imageUrl": "https://images.pokemontcg.io/gym1/58.png",
     "subtype": "Stage 1",
@@ -2953,7 +3011,8 @@
     ]
   },
   {
-    "id": "gym1-59",
+    "setOrder":6,
+	"id": "gym1-59",
     "name": "Sabrina's Jynx",
     "imageUrl": "https://images.pokemontcg.io/gym1/59.png",
     "subtype": "Basic",
@@ -3005,7 +3064,8 @@
     "nationalPokedexNumber": 124
   },
   {
-    "id": "gym1-60",
+    "setOrder":6,
+	"id": "gym1-60",
     "name": "Sabrina's Slowbro",
     "imageUrl": "https://images.pokemontcg.io/gym1/60.png",
     "subtype": "Stage 1",
@@ -3059,7 +3119,8 @@
     "nationalPokedexNumber": 80
   },
   {
-    "id": "gym1-61",
+    "setOrder":6,
+	"id": "gym1-61",
     "name": "Blaine's Charmander",
     "imageUrl": "https://images.pokemontcg.io/gym1/61.png",
     "subtype": "Basic",
@@ -3113,7 +3174,8 @@
     ]
   },
   {
-    "id": "gym1-62",
+    "setOrder":6,
+	"id": "gym1-62",
     "name": "Blaine's Growlithe",
     "imageUrl": "https://images.pokemontcg.io/gym1/62.png",
     "subtype": "Basic",
@@ -3158,7 +3220,8 @@
     ]
   },
   {
-    "id": "gym1-63",
+    "setOrder":6,
+	"id": "gym1-63",
     "name": "Blaine's Ponyta",
     "imageUrl": "https://images.pokemontcg.io/gym1/63.png",
     "subtype": "Basic",
@@ -3200,7 +3263,8 @@
     ]
   },
   {
-    "id": "gym1-64",
+    "setOrder":6,
+	"id": "gym1-64",
     "name": "Blaine's Tauros",
     "imageUrl": "https://images.pokemontcg.io/gym1/64.png",
     "subtype": "Basic",
@@ -3259,7 +3323,8 @@
     "nationalPokedexNumber": 128
   },
   {
-    "id": "gym1-65",
+    "setOrder":6,
+	"id": "gym1-65",
     "name": "Blaine's Vulpix",
     "imageUrl": "https://images.pokemontcg.io/gym1/65.png",
     "subtype": "Basic",
@@ -3310,7 +3375,8 @@
     ]
   },
   {
-    "id": "gym1-66",
+    "setOrder":6,
+	"id": "gym1-66",
     "name": "Brock's Geodude",
     "imageUrl": "https://images.pokemontcg.io/gym1/66.png",
     "subtype": "Basic",
@@ -3364,7 +3430,8 @@
     ]
   },
   {
-    "id": "gym1-67",
+    "setOrder":6,
+	"id": "gym1-67",
     "name": "Brock's Mankey",
     "imageUrl": "https://images.pokemontcg.io/gym1/67.png",
     "subtype": "Basic",
@@ -3414,7 +3481,8 @@
     ]
   },
   {
-    "id": "gym1-68",
+    "setOrder":6,
+	"id": "gym1-68",
     "name": "Brock's Mankey",
     "imageUrl": "https://images.pokemontcg.io/gym1/68.png",
     "subtype": "Basic",
@@ -3465,7 +3533,8 @@
     ]
   },
   {
-    "id": "gym1-69",
+    "setOrder":6,
+	"id": "gym1-69",
     "name": "Brock's Onix",
     "imageUrl": "https://images.pokemontcg.io/gym1/69.png",
     "subtype": "Basic",
@@ -3522,7 +3591,8 @@
     ]
   },
   {
-    "id": "gym1-70",
+    "setOrder":6,
+	"id": "gym1-70",
     "name": "Brock's Rhyhorn",
     "imageUrl": "https://images.pokemontcg.io/gym1/70.png",
     "subtype": "Basic",
@@ -3575,7 +3645,8 @@
     ]
   },
   {
-    "id": "gym1-71",
+    "setOrder":6,
+	"id": "gym1-71",
     "name": "Brock's Sandshrew",
     "imageUrl": "https://images.pokemontcg.io/gym1/71.png",
     "subtype": "Basic",
@@ -3635,7 +3706,8 @@
     ]
   },
   {
-    "id": "gym1-72",
+    "setOrder":6,
+	"id": "gym1-72",
     "name": "Brock's Sandshrew",
     "imageUrl": "https://images.pokemontcg.io/gym1/72.png",
     "subtype": "Basic",
@@ -3686,7 +3758,8 @@
     ]
   },
   {
-    "id": "gym1-73",
+    "setOrder":6,
+	"id": "gym1-73",
     "name": "Brock's Vulpix",
     "imageUrl": "https://images.pokemontcg.io/gym1/73.png",
     "subtype": "Basic",
@@ -3740,7 +3813,8 @@
     ]
   },
   {
-    "id": "gym1-74",
+    "setOrder":6,
+	"id": "gym1-74",
     "name": "Brock's Zubat",
     "imageUrl": "https://images.pokemontcg.io/gym1/74.png",
     "subtype": "Basic",
@@ -3797,7 +3871,8 @@
     ]
   },
   {
-    "id": "gym1-75",
+    "setOrder":6,
+	"id": "gym1-75",
     "name": "Erika's Bellsprout",
     "imageUrl": "https://images.pokemontcg.io/gym1/75.png",
     "subtype": "Basic",
@@ -3851,7 +3926,8 @@
     ]
   },
   {
-    "id": "gym1-76",
+    "setOrder":6,
+	"id": "gym1-76",
     "name": "Erika's Bellsprout",
     "imageUrl": "https://images.pokemontcg.io/gym1/76.png",
     "subtype": "Basic",
@@ -3895,7 +3971,8 @@
     ]
   },
   {
-    "id": "gym1-77",
+    "setOrder":6,
+	"id": "gym1-77",
     "name": "Erika's Exeggcute",
     "imageUrl": "https://images.pokemontcg.io/gym1/77.png",
     "subtype": "Basic",
@@ -3949,7 +4026,8 @@
     ]
   },
   {
-    "id": "gym1-78",
+    "setOrder":6,
+	"id": "gym1-78",
     "name": "Erika's Oddish",
     "imageUrl": "https://images.pokemontcg.io/gym1/78.png",
     "subtype": "Basic",
@@ -4003,7 +4081,8 @@
     ]
   },
   {
-    "id": "gym1-79",
+    "setOrder":6,
+	"id": "gym1-79",
     "name": "Erika's Tangela",
     "imageUrl": "https://images.pokemontcg.io/gym1/79.png",
     "subtype": "Basic",
@@ -4059,7 +4138,8 @@
     ]
   },
   {
-    "id": "gym1-80",
+    "setOrder":6,
+	"id": "gym1-80",
     "name": "Lt. Surge's Magnemite",
     "imageUrl": "https://images.pokemontcg.io/gym1/80.png",
     "subtype": "Basic",
@@ -4113,7 +4193,8 @@
     ]
   },
   {
-    "id": "gym1-81",
+    "setOrder":6,
+	"id": "gym1-81",
     "name": "Lt. Surge's Pikachu",
     "imageUrl": "https://images.pokemontcg.io/gym1/81.png",
     "subtype": "Basic",
@@ -4168,7 +4249,8 @@
     ]
   },
   {
-    "id": "gym1-82",
+    "setOrder":6,
+	"id": "gym1-82",
     "name": "Lt. Surge's Rattata",
     "imageUrl": "https://images.pokemontcg.io/gym1/82.png",
     "subtype": "Basic",
@@ -4228,7 +4310,8 @@
     ]
   },
   {
-    "id": "gym1-83",
+    "setOrder":6,
+	"id": "gym1-83",
     "name": "Lt. Surge's Spearow",
     "imageUrl": "https://images.pokemontcg.io/gym1/83.png",
     "subtype": "Basic",
@@ -4285,7 +4368,8 @@
     ]
   },
   {
-    "id": "gym1-84",
+    "setOrder":6,
+	"id": "gym1-84",
     "name": "Lt. Surge's Voltorb",
     "imageUrl": "https://images.pokemontcg.io/gym1/84.png",
     "subtype": "Basic",
@@ -4339,7 +4423,8 @@
     ]
   },
   {
-    "id": "gym1-85",
+    "setOrder":6,
+	"id": "gym1-85",
     "name": "Misty's Goldeen",
     "imageUrl": "https://images.pokemontcg.io/gym1/85.png",
     "subtype": "Basic",
@@ -4392,7 +4477,8 @@
     ]
   },
   {
-    "id": "gym1-86",
+    "setOrder":6,
+	"id": "gym1-86",
     "name": "Misty's Horsea",
     "imageUrl": "https://images.pokemontcg.io/gym1/86.png",
     "subtype": "Basic",
@@ -4443,7 +4529,8 @@
     ]
   },
   {
-    "id": "gym1-87",
+    "setOrder":6,
+	"id": "gym1-87",
     "name": "Misty's Poliwag",
     "imageUrl": "https://images.pokemontcg.io/gym1/87.png",
     "subtype": "Basic",
@@ -4497,7 +4584,8 @@
     ]
   },
   {
-    "id": "gym1-88",
+    "setOrder":6,
+	"id": "gym1-88",
     "name": "Misty's Seel",
     "imageUrl": "https://images.pokemontcg.io/gym1/88.png",
     "subtype": "Basic",
@@ -4542,7 +4630,8 @@
     ]
   },
   {
-    "id": "gym1-89",
+    "setOrder":6,
+	"id": "gym1-89",
     "name": "Misty's Shellder",
     "imageUrl": "https://images.pokemontcg.io/gym1/89.png",
     "subtype": "Basic",
@@ -4596,7 +4685,8 @@
     ]
   },
   {
-    "id": "gym1-90",
+    "setOrder":6,
+	"id": "gym1-90",
     "name": "Misty's Staryu",
     "imageUrl": "https://images.pokemontcg.io/gym1/90.png",
     "subtype": "Basic",
@@ -4641,7 +4731,8 @@
     ]
   },
   {
-    "id": "gym1-91",
+    "setOrder":6,
+	"id": "gym1-91",
     "name": "Sabrina's Abra",
     "imageUrl": "https://images.pokemontcg.io/gym1/91.png",
     "subtype": "Basic",
@@ -4682,7 +4773,8 @@
     ]
   },
   {
-    "id": "gym1-92",
+    "setOrder":6,
+	"id": "gym1-92",
     "name": "Sabrina's Drowzee",
     "imageUrl": "https://images.pokemontcg.io/gym1/92.png",
     "subtype": "Basic",
@@ -4736,7 +4828,8 @@
     ]
   },
   {
-    "id": "gym1-93",
+    "setOrder":6,
+	"id": "gym1-93",
     "name": "Sabrina's Gastly",
     "imageUrl": "https://images.pokemontcg.io/gym1/93.png",
     "subtype": "Basic",
@@ -4781,7 +4874,8 @@
     ]
   },
   {
-    "id": "gym1-94",
+    "setOrder":6,
+	"id": "gym1-94",
     "name": "Sabrina's Mr. Mime",
     "imageUrl": "https://images.pokemontcg.io/gym1/94.png",
     "subtype": "Basic",
@@ -4833,7 +4927,8 @@
     "nationalPokedexNumber": 122
   },
   {
-    "id": "gym1-95",
+    "setOrder":6,
+	"id": "gym1-95",
     "name": "Sabrina's Slowpoke",
     "imageUrl": "https://images.pokemontcg.io/gym1/95.png",
     "subtype": "Basic",
@@ -4879,7 +4974,8 @@
     ]
   },
   {
-    "id": "gym1-96",
+    "setOrder":6,
+	"id": "gym1-96",
     "name": "Sabrina's Venonat",
     "imageUrl": "https://images.pokemontcg.io/gym1/96.png",
     "subtype": "Basic",
@@ -4933,7 +5029,8 @@
     ]
   },
   {
-    "id": "gym1-97",
+    "setOrder":6,
+	"id": "gym1-97",
     "name": "Blaine's Quiz #1",
     "imageUrl": "https://images.pokemontcg.io/gym1/97.png",
     "subtype": "",
@@ -4950,7 +5047,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/97_hires.png"
   },
   {
-    "id": "gym1-98",
+    "setOrder":6,
+	"id": "gym1-98",
     "name": "Brock",
     "imageUrl": "https://images.pokemontcg.io/gym1/98.png",
     "subtype": "",
@@ -4967,7 +5065,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/98_hires.png"
   },
   {
-    "id": "gym1-99",
+    "setOrder":6,
+	"id": "gym1-99",
     "name": "Charity",
     "imageUrl": "https://images.pokemontcg.io/gym1/99.png",
     "subtype": "",
@@ -4984,7 +5083,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/99_hires.png"
   },
   {
-    "id": "gym1-100",
+    "setOrder":6,
+	"id": "gym1-100",
     "name": "Erika",
     "imageUrl": "https://images.pokemontcg.io/gym1/100.png",
     "subtype": "",
@@ -5001,7 +5101,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/100_hires.png"
   },
   {
-    "id": "gym1-101",
+    "setOrder":6,
+	"id": "gym1-101",
     "name": "Lt. Surge",
     "imageUrl": "https://images.pokemontcg.io/gym1/101.png",
     "subtype": "",
@@ -5018,7 +5119,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/101_hires.png"
   },
   {
-    "id": "gym1-102",
+    "setOrder":6,
+	"id": "gym1-102",
     "name": "Misty",
     "imageUrl": "https://images.pokemontcg.io/gym1/102.png",
     "subtype": "",
@@ -5035,7 +5137,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/102_hires.png"
   },
   {
-    "id": "gym1-103",
+    "setOrder":6,
+	"id": "gym1-103",
     "name": "No Removal Gym",
     "imageUrl": "https://images.pokemontcg.io/gym1/103.png",
     "subtype": "",
@@ -5052,7 +5155,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/103_hires.png"
   },
   {
-    "id": "gym1-104",
+    "setOrder":6,
+	"id": "gym1-104",
     "name": "The Rocket's Training Gym",
     "imageUrl": "https://images.pokemontcg.io/gym1/104.png",
     "subtype": "",
@@ -5069,7 +5173,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/104_hires.png"
   },
   {
-    "id": "gym1-105",
+    "setOrder":6,
+	"id": "gym1-105",
     "name": "Blaine's Last Resort",
     "imageUrl": "https://images.pokemontcg.io/gym1/105.png",
     "subtype": "",
@@ -5086,7 +5191,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/105_hires.png"
   },
   {
-    "id": "gym1-106",
+    "setOrder":6,
+	"id": "gym1-106",
     "name": "Brock's Training Method",
     "imageUrl": "https://images.pokemontcg.io/gym1/106.png",
     "subtype": "",
@@ -5103,7 +5209,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/106_hires.png"
   },
   {
-    "id": "gym1-107",
+    "setOrder":6,
+	"id": "gym1-107",
     "name": "Celadon City Gym",
     "imageUrl": "https://images.pokemontcg.io/gym1/107.png",
     "subtype": "",
@@ -5120,7 +5227,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/107_hires.png"
   },
   {
-    "id": "gym1-108",
+    "setOrder":6,
+	"id": "gym1-108",
     "name": "Cerulean City Gym",
     "imageUrl": "https://images.pokemontcg.io/gym1/108.png",
     "subtype": "",
@@ -5137,7 +5245,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/108_hires.png"
   },
   {
-    "id": "gym1-109",
+    "setOrder":6,
+	"id": "gym1-109",
     "name": "Erika's Maids",
     "imageUrl": "https://images.pokemontcg.io/gym1/109.png",
     "subtype": "",
@@ -5154,7 +5263,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/109_hires.png"
   },
   {
-    "id": "gym1-110",
+    "setOrder":6,
+	"id": "gym1-110",
     "name": "Erika's Perfume",
     "imageUrl": "https://images.pokemontcg.io/gym1/110.png",
     "subtype": "",
@@ -5171,7 +5281,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/110_hires.png"
   },
   {
-    "id": "gym1-111",
+    "setOrder":6,
+	"id": "gym1-111",
     "name": "Good Manners",
     "imageUrl": "https://images.pokemontcg.io/gym1/111.png",
     "subtype": "",
@@ -5188,7 +5299,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/111_hires.png"
   },
   {
-    "id": "gym1-112",
+    "setOrder":6,
+	"id": "gym1-112",
     "name": "Lt. Surge's Treaty",
     "imageUrl": "https://images.pokemontcg.io/gym1/112.png",
     "subtype": "",
@@ -5205,7 +5317,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/112_hires.png"
   },
   {
-    "id": "gym1-113",
+    "setOrder":6,
+	"id": "gym1-113",
     "name": "Minion of Team Rocket",
     "imageUrl": "https://images.pokemontcg.io/gym1/113.png",
     "subtype": "",
@@ -5222,7 +5335,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/113_hires.png"
   },
   {
-    "id": "gym1-114",
+    "setOrder":6,
+	"id": "gym1-114",
     "name": "Misty's Wrath",
     "imageUrl": "https://images.pokemontcg.io/gym1/114.png",
     "subtype": "",
@@ -5239,7 +5353,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/114_hires.png"
   },
   {
-    "id": "gym1-115",
+    "setOrder":6,
+	"id": "gym1-115",
     "name": "Pewter City Gym",
     "imageUrl": "https://images.pokemontcg.io/gym1/115.png",
     "subtype": "",
@@ -5256,7 +5371,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/115_hires.png"
   },
   {
-    "id": "gym1-116",
+    "setOrder":6,
+	"id": "gym1-116",
     "name": "Recall",
     "imageUrl": "https://images.pokemontcg.io/gym1/116.png",
     "subtype": "",
@@ -5273,7 +5389,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/116_hires.png"
   },
   {
-    "id": "gym1-117",
+    "setOrder":6,
+	"id": "gym1-117",
     "name": "Sabrina's ESP",
     "imageUrl": "https://images.pokemontcg.io/gym1/117.png",
     "subtype": "",
@@ -5290,7 +5407,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/117_hires.png"
   },
   {
-    "id": "gym1-118",
+    "setOrder":6,
+	"id": "gym1-118",
     "name": "Secret Mission",
     "imageUrl": "https://images.pokemontcg.io/gym1/118.png",
     "subtype": "",
@@ -5307,7 +5425,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/118_hires.png"
   },
   {
-    "id": "gym1-119",
+    "setOrder":6,
+	"id": "gym1-119",
     "name": "Tickling Machine",
     "imageUrl": "https://images.pokemontcg.io/gym1/119.png",
     "subtype": "",
@@ -5324,7 +5443,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/119_hires.png"
   },
   {
-    "id": "gym1-120",
+    "setOrder":6,
+	"id": "gym1-120",
     "name": "Vermilion City Gym",
     "imageUrl": "https://images.pokemontcg.io/gym1/120.png",
     "subtype": "",
@@ -5341,7 +5461,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/120_hires.png"
   },
   {
-    "id": "gym1-121",
+    "setOrder":6,
+	"id": "gym1-121",
     "name": "Blaine's Gamble",
     "imageUrl": "https://images.pokemontcg.io/gym1/121.png",
     "subtype": "",
@@ -5358,7 +5479,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/121_hires.png"
   },
   {
-    "id": "gym1-122",
+    "setOrder":6,
+	"id": "gym1-122",
     "name": "Energy Flow",
     "imageUrl": "https://images.pokemontcg.io/gym1/122.png",
     "subtype": "",
@@ -5375,7 +5497,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/122_hires.png"
   },
   {
-    "id": "gym1-123",
+    "setOrder":6,
+	"id": "gym1-123",
     "name": "Misty's Duel",
     "imageUrl": "https://images.pokemontcg.io/gym1/123.png",
     "subtype": "",
@@ -5392,7 +5515,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/123_hires.png"
   },
   {
-    "id": "gym1-124",
+    "setOrder":6,
+	"id": "gym1-124",
     "name": "Narrow Gym",
     "imageUrl": "https://images.pokemontcg.io/gym1/124.png",
     "subtype": "",
@@ -5409,7 +5533,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/124_hires.png"
   },
   {
-    "id": "gym1-125",
+    "setOrder":6,
+	"id": "gym1-125",
     "name": "Sabrina's Gaze",
     "imageUrl": "https://images.pokemontcg.io/gym1/125.png",
     "subtype": "",
@@ -5426,7 +5551,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/125_hires.png"
   },
   {
-    "id": "gym1-126",
+    "setOrder":6,
+	"id": "gym1-126",
     "name": "Trash Exchange",
     "imageUrl": "https://images.pokemontcg.io/gym1/126.png",
     "subtype": "",
@@ -5443,7 +5569,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/126_hires.png"
   },
   {
-    "id": "gym1-127",
+    "setOrder":6,
+	"id": "gym1-127",
     "name": "Fighting Energy",
     "imageUrl": "https://images.pokemontcg.io/gym1/127.png",
     "subtype": "Basic",
@@ -5457,7 +5584,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/127_hires.png"
   },
   {
-    "id": "gym1-128",
+    "setOrder":6,
+	"id": "gym1-128",
     "name": "Fire Energy",
     "imageUrl": "https://images.pokemontcg.io/gym1/128.png",
     "subtype": "Basic",
@@ -5471,7 +5599,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/128_hires.png"
   },
   {
-    "id": "gym1-129",
+    "setOrder":6,
+	"id": "gym1-129",
     "name": "Grass Energy",
     "imageUrl": "https://images.pokemontcg.io/gym1/129.png",
     "subtype": "Basic",
@@ -5485,7 +5614,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/129_hires.png"
   },
   {
-    "id": "gym1-130",
+    "setOrder":6,
+	"id": "gym1-130",
     "name": "Lightning Energy",
     "imageUrl": "https://images.pokemontcg.io/gym1/130.png",
     "subtype": "Basic",
@@ -5499,7 +5629,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/130_hires.png"
   },
   {
-    "id": "gym1-131",
+    "setOrder":6,
+	"id": "gym1-131",
     "name": "Psychic Energy",
     "imageUrl": "https://images.pokemontcg.io/gym1/131.png",
     "subtype": "Basic",
@@ -5513,7 +5644,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/gym1/131_hires.png"
   },
   {
-    "id": "gym1-132",
+    "setOrder":6,
+	"id": "gym1-132",
     "name": "Water Energy",
     "imageUrl": "https://images.pokemontcg.io/gym1/132.png",
     "subtype": "Basic",

--- a/json/cards/HS—Triumphant.json
+++ b/json/cards/HS—Triumphant.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "hgss4-1",
+    "setOrder":46,
+	"id": "hgss4-1",
     "name": "Aggron",
     "imageUrl": "https://images.pokemontcg.io/hgss4/1.png",
     "subtype": "Stage 2",
@@ -64,7 +65,8 @@
     "nationalPokedexNumber": 306
   },
   {
-    "id": "hgss4-2",
+    "setOrder":46,
+	"id": "hgss4-2",
     "name": "Altaria",
     "imageUrl": "https://images.pokemontcg.io/hgss4/2.png",
     "subtype": "Stage 1",
@@ -119,7 +121,8 @@
     "nationalPokedexNumber": 334
   },
   {
-    "id": "hgss4-3",
+    "setOrder":46,
+	"id": "hgss4-3",
     "name": "Celebi",
     "imageUrl": "https://images.pokemontcg.io/hgss4/3.png",
     "subtype": "Basic",
@@ -169,7 +172,8 @@
     "nationalPokedexNumber": 251
   },
   {
-    "id": "hgss4-4",
+    "setOrder":46,
+	"id": "hgss4-4",
     "name": "Drapion",
     "imageUrl": "https://images.pokemontcg.io/hgss4/4.png",
     "subtype": "Stage 1",
@@ -232,7 +236,8 @@
     "nationalPokedexNumber": 452
   },
   {
-    "id": "hgss4-5",
+    "setOrder":46,
+	"id": "hgss4-5",
     "name": "Mamoswine",
     "imageUrl": "https://images.pokemontcg.io/hgss4/5.png",
     "subtype": "Stage 2",
@@ -290,7 +295,8 @@
     "nationalPokedexNumber": 473
   },
   {
-    "id": "hgss4-6",
+    "setOrder":46,
+	"id": "hgss4-6",
     "name": "Nidoking",
     "imageUrl": "https://images.pokemontcg.io/hgss4/6.png",
     "subtype": "Stage 2",
@@ -347,7 +353,8 @@
     "nationalPokedexNumber": 34
   },
   {
-    "id": "hgss4-7",
+    "setOrder":46,
+	"id": "hgss4-7",
     "name": "Porygon-Z",
     "imageUrl": "https://images.pokemontcg.io/hgss4/7.png",
     "subtype": "Stage 2",
@@ -396,7 +403,8 @@
     "nationalPokedexNumber": 474
   },
   {
-    "id": "hgss4-8",
+    "setOrder":46,
+	"id": "hgss4-8",
     "name": "Rapidash",
     "imageUrl": "https://images.pokemontcg.io/hgss4/8.png",
     "subtype": "Stage 1",
@@ -444,7 +452,8 @@
     "nationalPokedexNumber": 78
   },
   {
-    "id": "hgss4-9",
+    "setOrder":46,
+	"id": "hgss4-9",
     "name": "Solrock",
     "imageUrl": "https://images.pokemontcg.io/hgss4/9.png",
     "subtype": "Basic",
@@ -489,7 +498,8 @@
     "nationalPokedexNumber": 338
   },
   {
-    "id": "hgss4-10",
+    "setOrder":46,
+	"id": "hgss4-10",
     "name": "Spiritomb",
     "imageUrl": "https://images.pokemontcg.io/hgss4/10.png",
     "subtype": "Basic",
@@ -534,7 +544,8 @@
     "nationalPokedexNumber": 442
   },
   {
-    "id": "hgss4-11",
+    "setOrder":46,
+	"id": "hgss4-11",
     "name": "Venomoth",
     "imageUrl": "https://images.pokemontcg.io/hgss4/11.png",
     "subtype": "Stage 1",
@@ -581,7 +592,8 @@
     "nationalPokedexNumber": 49
   },
   {
-    "id": "hgss4-12",
+    "setOrder":46,
+	"id": "hgss4-12",
     "name": "Victreebel",
     "imageUrl": "https://images.pokemontcg.io/hgss4/12.png",
     "subtype": "Stage 2",
@@ -629,7 +641,8 @@
     "nationalPokedexNumber": 71
   },
   {
-    "id": "hgss4-13",
+    "setOrder":46,
+	"id": "hgss4-13",
     "name": "Ambipom",
     "imageUrl": "https://images.pokemontcg.io/hgss4/13.png",
     "subtype": "Stage 1",
@@ -681,7 +694,8 @@
     "nationalPokedexNumber": 424
   },
   {
-    "id": "hgss4-14",
+    "setOrder":46,
+	"id": "hgss4-14",
     "name": "Banette",
     "imageUrl": "https://images.pokemontcg.io/hgss4/14.png",
     "subtype": "Stage 1",
@@ -739,7 +753,8 @@
     "nationalPokedexNumber": 354
   },
   {
-    "id": "hgss4-15",
+    "setOrder":46,
+	"id": "hgss4-15",
     "name": "Bronzong",
     "imageUrl": "https://images.pokemontcg.io/hgss4/15.png",
     "subtype": "Stage 1",
@@ -798,7 +813,8 @@
     "nationalPokedexNumber": 437
   },
   {
-    "id": "hgss4-16",
+    "setOrder":46,
+	"id": "hgss4-16",
     "name": "Carnivine",
     "imageUrl": "https://images.pokemontcg.io/hgss4/16.png",
     "subtype": "Basic",
@@ -856,7 +872,8 @@
     "nationalPokedexNumber": 455
   },
   {
-    "id": "hgss4-17",
+    "setOrder":46,
+	"id": "hgss4-17",
     "name": "Ditto",
     "imageUrl": "https://images.pokemontcg.io/hgss4/17.png",
     "subtype": "Basic",
@@ -902,7 +919,8 @@
     "nationalPokedexNumber": 132
   },
   {
-    "id": "hgss4-18",
+    "setOrder":46,
+	"id": "hgss4-18",
     "name": "Dragonite",
     "imageUrl": "https://images.pokemontcg.io/hgss4/18.png",
     "subtype": "Stage 2",
@@ -966,7 +984,8 @@
     "nationalPokedexNumber": 149
   },
   {
-    "id": "hgss4-19",
+    "setOrder":46,
+	"id": "hgss4-19",
     "name": "Dugtrio",
     "imageUrl": "https://images.pokemontcg.io/hgss4/19.png",
     "subtype": "Stage 1",
@@ -1021,7 +1040,8 @@
     "nationalPokedexNumber": 51
   },
   {
-    "id": "hgss4-20",
+    "setOrder":46,
+	"id": "hgss4-20",
     "name": "Electivire",
     "imageUrl": "https://images.pokemontcg.io/hgss4/20.png",
     "subtype": "Stage 1",
@@ -1081,7 +1101,8 @@
     "nationalPokedexNumber": 466
   },
   {
-    "id": "hgss4-21",
+    "setOrder":46,
+	"id": "hgss4-21",
     "name": "Elekid",
     "imageUrl": "https://images.pokemontcg.io/hgss4/21.png",
     "subtype": "Basic",
@@ -1120,7 +1141,8 @@
     ]
   },
   {
-    "id": "hgss4-22",
+    "setOrder":46,
+	"id": "hgss4-22",
     "name": "Golduck",
     "imageUrl": "https://images.pokemontcg.io/hgss4/22.png",
     "subtype": "Stage 1",
@@ -1167,7 +1189,8 @@
     "nationalPokedexNumber": 55
   },
   {
-    "id": "hgss4-23",
+    "setOrder":46,
+	"id": "hgss4-23",
     "name": "Grumpig",
     "imageUrl": "https://images.pokemontcg.io/hgss4/23.png",
     "subtype": "Stage 1",
@@ -1221,7 +1244,8 @@
     "nationalPokedexNumber": 326
   },
   {
-    "id": "hgss4-24",
+    "setOrder":46,
+	"id": "hgss4-24",
     "name": "Kricketune",
     "imageUrl": "https://images.pokemontcg.io/hgss4/24.png",
     "subtype": "Stage 1",
@@ -1274,7 +1298,8 @@
     "nationalPokedexNumber": 402
   },
   {
-    "id": "hgss4-25",
+    "setOrder":46,
+	"id": "hgss4-25",
     "name": "Lunatone",
     "imageUrl": "https://images.pokemontcg.io/hgss4/25.png",
     "subtype": "Basic",
@@ -1324,7 +1349,8 @@
     "nationalPokedexNumber": 337
   },
   {
-    "id": "hgss4-26",
+    "setOrder":46,
+	"id": "hgss4-26",
     "name": "Machamp",
     "imageUrl": "https://images.pokemontcg.io/hgss4/26.png",
     "subtype": "Stage 2",
@@ -1377,7 +1403,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "hgss4-27",
+    "setOrder":46,
+	"id": "hgss4-27",
     "name": "Magmortar",
     "imageUrl": "https://images.pokemontcg.io/hgss4/27.png",
     "subtype": "Stage 1",
@@ -1430,7 +1457,8 @@
     "nationalPokedexNumber": 467
   },
   {
-    "id": "hgss4-28",
+    "setOrder":46,
+	"id": "hgss4-28",
     "name": "Nidoqueen",
     "imageUrl": "https://images.pokemontcg.io/hgss4/28.png",
     "subtype": "Stage 2",
@@ -1483,7 +1511,8 @@
     "nationalPokedexNumber": 31
   },
   {
-    "id": "hgss4-29",
+    "setOrder":46,
+	"id": "hgss4-29",
     "name": "Pidgeot",
     "imageUrl": "https://images.pokemontcg.io/hgss4/29.png",
     "subtype": "Stage 2",
@@ -1539,7 +1568,8 @@
     "nationalPokedexNumber": 18
   },
   {
-    "id": "hgss4-30",
+    "setOrder":46,
+	"id": "hgss4-30",
     "name": "Sharpedo",
     "imageUrl": "https://images.pokemontcg.io/hgss4/30.png",
     "subtype": "Stage 1",
@@ -1591,7 +1621,8 @@
     "nationalPokedexNumber": 319
   },
   {
-    "id": "hgss4-31",
+    "setOrder":46,
+	"id": "hgss4-31",
     "name": "Wailord",
     "imageUrl": "https://images.pokemontcg.io/hgss4/31.png",
     "subtype": "Stage 1",
@@ -1648,7 +1679,8 @@
     "nationalPokedexNumber": 321
   },
   {
-    "id": "hgss4-32",
+    "setOrder":46,
+	"id": "hgss4-32",
     "name": "Dragonair",
     "imageUrl": "https://images.pokemontcg.io/hgss4/32.png",
     "subtype": "Stage 1",
@@ -1704,7 +1736,8 @@
     ]
   },
   {
-    "id": "hgss4-33",
+    "setOrder":46,
+	"id": "hgss4-33",
     "name": "Electabuzz",
     "imageUrl": "https://images.pokemontcg.io/hgss4/33.png",
     "subtype": "Basic",
@@ -1765,7 +1798,8 @@
     ]
   },
   {
-    "id": "hgss4-34",
+    "setOrder":46,
+	"id": "hgss4-34",
     "name": "Electrode",
     "imageUrl": "https://images.pokemontcg.io/hgss4/34.png",
     "subtype": "Stage 1",
@@ -1823,7 +1857,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "hgss4-35",
+    "setOrder":46,
+	"id": "hgss4-35",
     "name": "Haunter",
     "imageUrl": "https://images.pokemontcg.io/hgss4/35.png",
     "subtype": "Stage 1",
@@ -1880,7 +1915,8 @@
     ]
   },
   {
-    "id": "hgss4-36",
+    "setOrder":46,
+	"id": "hgss4-36",
     "name": "Kangaskhan",
     "imageUrl": "https://images.pokemontcg.io/hgss4/36.png",
     "subtype": "Basic",
@@ -1934,7 +1970,8 @@
     "nationalPokedexNumber": 115
   },
   {
-    "id": "hgss4-37",
+    "setOrder":46,
+	"id": "hgss4-37",
     "name": "Lairon",
     "imageUrl": "https://images.pokemontcg.io/hgss4/37.png",
     "subtype": "Stage 1",
@@ -1988,7 +2025,8 @@
     ]
   },
   {
-    "id": "hgss4-38",
+    "setOrder":46,
+	"id": "hgss4-38",
     "name": "Lickilicky",
     "imageUrl": "https://images.pokemontcg.io/hgss4/38.png",
     "subtype": "Stage 1",
@@ -2042,7 +2080,8 @@
     "nationalPokedexNumber": 463
   },
   {
-    "id": "hgss4-39",
+    "setOrder":46,
+	"id": "hgss4-39",
     "name": "Luvdisc",
     "imageUrl": "https://images.pokemontcg.io/hgss4/39.png",
     "subtype": "Basic",
@@ -2091,7 +2130,8 @@
     "nationalPokedexNumber": 370
   },
   {
-    "id": "hgss4-40",
+    "setOrder":46,
+	"id": "hgss4-40",
     "name": "Machoke",
     "imageUrl": "https://images.pokemontcg.io/hgss4/40.png",
     "subtype": "Stage 1",
@@ -2147,7 +2187,8 @@
     ]
   },
   {
-    "id": "hgss4-41",
+    "setOrder":46,
+	"id": "hgss4-41",
     "name": "Magby",
     "imageUrl": "https://images.pokemontcg.io/hgss4/41.png",
     "subtype": "Basic",
@@ -2186,7 +2227,8 @@
     ]
   },
   {
-    "id": "hgss4-42",
+    "setOrder":46,
+	"id": "hgss4-42",
     "name": "Magmar",
     "imageUrl": "https://images.pokemontcg.io/hgss4/42.png",
     "subtype": "Basic",
@@ -2241,7 +2283,8 @@
     ]
   },
   {
-    "id": "hgss4-43",
+    "setOrder":46,
+	"id": "hgss4-43",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/hgss4/43.png",
     "subtype": "Stage 1",
@@ -2301,7 +2344,8 @@
     ]
   },
   {
-    "id": "hgss4-44",
+    "setOrder":46,
+	"id": "hgss4-44",
     "name": "Marowak",
     "imageUrl": "https://images.pokemontcg.io/hgss4/44.png",
     "subtype": "Stage 1",
@@ -2359,7 +2403,8 @@
     "nationalPokedexNumber": 105
   },
   {
-    "id": "hgss4-45",
+    "setOrder":46,
+	"id": "hgss4-45",
     "name": "Nidorina",
     "imageUrl": "https://images.pokemontcg.io/hgss4/45.png",
     "subtype": "Stage 1",
@@ -2415,7 +2460,8 @@
     ]
   },
   {
-    "id": "hgss4-46",
+    "setOrder":46,
+	"id": "hgss4-46",
     "name": "Nidorino",
     "imageUrl": "https://images.pokemontcg.io/hgss4/46.png",
     "subtype": "Stage 1",
@@ -2471,7 +2517,8 @@
     ]
   },
   {
-    "id": "hgss4-47",
+    "setOrder":46,
+	"id": "hgss4-47",
     "name": "Pidgeotto",
     "imageUrl": "https://images.pokemontcg.io/hgss4/47.png",
     "subtype": "Stage 1",
@@ -2533,7 +2580,8 @@
     ]
   },
   {
-    "id": "hgss4-48",
+    "setOrder":46,
+	"id": "hgss4-48",
     "name": "Piloswine",
     "imageUrl": "https://images.pokemontcg.io/hgss4/48.png",
     "subtype": "Stage 1",
@@ -2593,7 +2641,8 @@
     ]
   },
   {
-    "id": "hgss4-49",
+    "setOrder":46,
+	"id": "hgss4-49",
     "name": "Porygon2",
     "imageUrl": "https://images.pokemontcg.io/hgss4/49.png",
     "subtype": "Stage 1",
@@ -2643,7 +2692,8 @@
     ]
   },
   {
-    "id": "hgss4-50",
+    "setOrder":46,
+	"id": "hgss4-50",
     "name": "Tentacruel",
     "imageUrl": "https://images.pokemontcg.io/hgss4/50.png",
     "subtype": "Stage 1",
@@ -2696,7 +2746,8 @@
     "nationalPokedexNumber": 73
   },
   {
-    "id": "hgss4-51",
+    "setOrder":46,
+	"id": "hgss4-51",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/hgss4/51.png",
     "subtype": "Basic",
@@ -2741,7 +2792,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "hgss4-52",
+    "setOrder":46,
+	"id": "hgss4-52",
     "name": "Wailmer",
     "imageUrl": "https://images.pokemontcg.io/hgss4/52.png",
     "subtype": "Basic",
@@ -2800,7 +2852,8 @@
     ]
   },
   {
-    "id": "hgss4-53",
+    "setOrder":46,
+	"id": "hgss4-53",
     "name": "Weepinbell",
     "imageUrl": "https://images.pokemontcg.io/hgss4/53.png",
     "subtype": "Stage 1",
@@ -2854,7 +2907,8 @@
     ]
   },
   {
-    "id": "hgss4-54",
+    "setOrder":46,
+	"id": "hgss4-54",
     "name": "Yanmega",
     "imageUrl": "https://images.pokemontcg.io/hgss4/54.png",
     "subtype": "Stage 1",
@@ -2912,7 +2966,8 @@
     "nationalPokedexNumber": 469
   },
   {
-    "id": "hgss4-55",
+    "setOrder":46,
+	"id": "hgss4-55",
     "name": "Aipom",
     "imageUrl": "https://images.pokemontcg.io/hgss4/55.png",
     "subtype": "Basic",
@@ -2964,7 +3019,8 @@
     ]
   },
   {
-    "id": "hgss4-56",
+    "setOrder":46,
+	"id": "hgss4-56",
     "name": "Aron",
     "imageUrl": "https://images.pokemontcg.io/hgss4/56.png",
     "subtype": "Basic",
@@ -3025,7 +3081,8 @@
     ]
   },
   {
-    "id": "hgss4-57",
+    "setOrder":46,
+	"id": "hgss4-57",
     "name": "Bellsprout",
     "imageUrl": "https://images.pokemontcg.io/hgss4/57.png",
     "subtype": "Basic",
@@ -3077,7 +3134,8 @@
     ]
   },
   {
-    "id": "hgss4-58",
+    "setOrder":46,
+	"id": "hgss4-58",
     "name": "Bronzor",
     "imageUrl": "https://images.pokemontcg.io/hgss4/58.png",
     "subtype": "Basic",
@@ -3136,7 +3194,8 @@
     ]
   },
   {
-    "id": "hgss4-59",
+    "setOrder":46,
+	"id": "hgss4-59",
     "name": "Carvanha",
     "imageUrl": "https://images.pokemontcg.io/hgss4/59.png",
     "subtype": "Basic",
@@ -3188,7 +3247,8 @@
     ]
   },
   {
-    "id": "hgss4-60",
+    "setOrder":46,
+	"id": "hgss4-60",
     "name": "Cubone",
     "imageUrl": "https://images.pokemontcg.io/hgss4/60.png",
     "subtype": "Basic",
@@ -3243,7 +3303,8 @@
     ]
   },
   {
-    "id": "hgss4-61",
+    "setOrder":46,
+	"id": "hgss4-61",
     "name": "Diglett",
     "imageUrl": "https://images.pokemontcg.io/hgss4/61.png",
     "subtype": "Basic",
@@ -3302,7 +3363,8 @@
     ]
   },
   {
-    "id": "hgss4-62",
+    "setOrder":46,
+	"id": "hgss4-62",
     "name": "Dratini",
     "imageUrl": "https://images.pokemontcg.io/hgss4/62.png",
     "subtype": "Basic",
@@ -3355,7 +3417,8 @@
     ]
   },
   {
-    "id": "hgss4-63",
+    "setOrder":46,
+	"id": "hgss4-63",
     "name": "Gastly",
     "imageUrl": "https://images.pokemontcg.io/hgss4/63.png",
     "subtype": "Basic",
@@ -3404,7 +3467,8 @@
     ]
   },
   {
-    "id": "hgss4-64",
+    "setOrder":46,
+	"id": "hgss4-64",
     "name": "Illumise",
     "imageUrl": "https://images.pokemontcg.io/hgss4/64.png",
     "subtype": "Basic",
@@ -3453,7 +3517,8 @@
     "nationalPokedexNumber": 314
   },
   {
-    "id": "hgss4-65",
+    "setOrder":46,
+	"id": "hgss4-65",
     "name": "Kricketot",
     "imageUrl": "https://images.pokemontcg.io/hgss4/65.png",
     "subtype": "Basic",
@@ -3497,7 +3562,8 @@
     ]
   },
   {
-    "id": "hgss4-66",
+    "setOrder":46,
+	"id": "hgss4-66",
     "name": "Lickitung",
     "imageUrl": "https://images.pokemontcg.io/hgss4/66.png",
     "subtype": "Basic",
@@ -3552,7 +3618,8 @@
     ]
   },
   {
-    "id": "hgss4-67",
+    "setOrder":46,
+	"id": "hgss4-67",
     "name": "Machop",
     "imageUrl": "https://images.pokemontcg.io/hgss4/67.png",
     "subtype": "Basic",
@@ -3607,7 +3674,8 @@
     ]
   },
   {
-    "id": "hgss4-68",
+    "setOrder":46,
+	"id": "hgss4-68",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/hgss4/68.png",
     "subtype": "Basic",
@@ -3666,7 +3734,8 @@
     ]
   },
   {
-    "id": "hgss4-69",
+    "setOrder":46,
+	"id": "hgss4-69",
     "name": "Nidoran♀",
     "imageUrl": "https://images.pokemontcg.io/hgss4/69.png",
     "subtype": "Basic",
@@ -3719,7 +3788,8 @@
     ]
   },
   {
-    "id": "hgss4-70",
+    "setOrder":46,
+	"id": "hgss4-70",
     "name": "Nidoran♂",
     "imageUrl": "https://images.pokemontcg.io/hgss4/70.png",
     "subtype": "Basic",
@@ -3772,7 +3842,8 @@
     ]
   },
   {
-    "id": "hgss4-71",
+    "setOrder":46,
+	"id": "hgss4-71",
     "name": "Pidgey",
     "imageUrl": "https://images.pokemontcg.io/hgss4/71.png",
     "subtype": "Basic",
@@ -3830,7 +3901,8 @@
     ]
   },
   {
-    "id": "hgss4-72",
+    "setOrder":46,
+	"id": "hgss4-72",
     "name": "Ponyta",
     "imageUrl": "https://images.pokemontcg.io/hgss4/72.png",
     "subtype": "Basic",
@@ -3883,7 +3955,8 @@
     ]
   },
   {
-    "id": "hgss4-73",
+    "setOrder":46,
+	"id": "hgss4-73",
     "name": "Porygon",
     "imageUrl": "https://images.pokemontcg.io/hgss4/73.png",
     "subtype": "Basic",
@@ -3936,7 +4009,8 @@
     ]
   },
   {
-    "id": "hgss4-74",
+    "setOrder":46,
+	"id": "hgss4-74",
     "name": "Psyduck",
     "imageUrl": "https://images.pokemontcg.io/hgss4/74.png",
     "subtype": "Basic",
@@ -3979,7 +4053,8 @@
     ]
   },
   {
-    "id": "hgss4-75",
+    "setOrder":46,
+	"id": "hgss4-75",
     "name": "Shuppet",
     "imageUrl": "https://images.pokemontcg.io/hgss4/75.png",
     "subtype": "Basic",
@@ -4037,7 +4112,8 @@
     ]
   },
   {
-    "id": "hgss4-76",
+    "setOrder":46,
+	"id": "hgss4-76",
     "name": "Skorupi",
     "imageUrl": "https://images.pokemontcg.io/hgss4/76.png",
     "subtype": "Basic",
@@ -4081,7 +4157,8 @@
     ]
   },
   {
-    "id": "hgss4-77",
+    "setOrder":46,
+	"id": "hgss4-77",
     "name": "Spoink",
     "imageUrl": "https://images.pokemontcg.io/hgss4/77.png",
     "subtype": "Basic",
@@ -4124,7 +4201,8 @@
     ]
   },
   {
-    "id": "hgss4-78",
+    "setOrder":46,
+	"id": "hgss4-78",
     "name": "Swablu",
     "imageUrl": "https://images.pokemontcg.io/hgss4/78.png",
     "subtype": "Basic",
@@ -4173,7 +4251,8 @@
     ]
   },
   {
-    "id": "hgss4-79",
+    "setOrder":46,
+	"id": "hgss4-79",
     "name": "Swinub",
     "imageUrl": "https://images.pokemontcg.io/hgss4/79.png",
     "subtype": "Basic",
@@ -4227,7 +4306,8 @@
     ]
   },
   {
-    "id": "hgss4-80",
+    "setOrder":46,
+	"id": "hgss4-80",
     "name": "Tentacool",
     "imageUrl": "https://images.pokemontcg.io/hgss4/80.png",
     "subtype": "Basic",
@@ -4270,7 +4350,8 @@
     ]
   },
   {
-    "id": "hgss4-81",
+    "setOrder":46,
+	"id": "hgss4-81",
     "name": "Venonat",
     "imageUrl": "https://images.pokemontcg.io/hgss4/81.png",
     "subtype": "Basic",
@@ -4314,7 +4395,8 @@
     ]
   },
   {
-    "id": "hgss4-82",
+    "setOrder":46,
+	"id": "hgss4-82",
     "name": "Volbeat",
     "imageUrl": "https://images.pokemontcg.io/hgss4/82.png",
     "subtype": "Basic",
@@ -4365,7 +4447,8 @@
     "nationalPokedexNumber": 313
   },
   {
-    "id": "hgss4-83",
+    "setOrder":46,
+	"id": "hgss4-83",
     "name": "Voltorb",
     "imageUrl": "https://images.pokemontcg.io/hgss4/83.png",
     "subtype": "Basic",
@@ -4414,7 +4497,8 @@
     ]
   },
   {
-    "id": "hgss4-84",
+    "setOrder":46,
+	"id": "hgss4-84",
     "name": "Yanma",
     "imageUrl": "https://images.pokemontcg.io/hgss4/84.png",
     "subtype": "Basic",
@@ -4469,7 +4553,8 @@
     ]
   },
   {
-    "id": "hgss4-85",
+    "setOrder":46,
+	"id": "hgss4-85",
     "name": "Black Belt",
     "imageUrl": "https://images.pokemontcg.io/hgss4/85.png",
     "subtype": "Supporter",
@@ -4487,7 +4572,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss4/85_hires.png"
   },
   {
-    "id": "hgss4-86",
+    "setOrder":46,
+	"id": "hgss4-86",
     "name": "Indigo Plateau",
     "imageUrl": "https://images.pokemontcg.io/hgss4/86.png",
     "subtype": "Stadium",
@@ -4505,7 +4591,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss4/86_hires.png"
   },
   {
-    "id": "hgss4-87",
+    "setOrder":46,
+	"id": "hgss4-87",
     "name": "Junk Arm",
     "imageUrl": "https://images.pokemontcg.io/hgss4/87.png",
     "subtype": "Item",
@@ -4522,7 +4609,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss4/87_hires.png"
   },
   {
-    "id": "hgss4-88",
+    "setOrder":46,
+	"id": "hgss4-88",
     "name": "Seeker",
     "imageUrl": "https://images.pokemontcg.io/hgss4/88.png",
     "subtype": "Supporter",
@@ -4540,7 +4628,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss4/88_hires.png"
   },
   {
-    "id": "hgss4-89",
+    "setOrder":46,
+	"id": "hgss4-89",
     "name": "Twins",
     "imageUrl": "https://images.pokemontcg.io/hgss4/89.png",
     "subtype": "Supporter",
@@ -4558,7 +4647,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss4/89_hires.png"
   },
   {
-    "id": "hgss4-90",
+    "setOrder":46,
+	"id": "hgss4-90",
     "name": "Rescue Energy",
     "imageUrl": "https://images.pokemontcg.io/hgss4/90.png",
     "subtype": "Special",
@@ -4575,7 +4665,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss4/90_hires.png"
   },
   {
-    "id": "hgss4-91",
+    "setOrder":46,
+	"id": "hgss4-91",
     "name": "Absol",
     "imageUrl": "https://images.pokemontcg.io/hgss4/91.png",
     "subtype": "Basic",
@@ -4627,7 +4718,8 @@
     "nationalPokedexNumber": 359
   },
   {
-    "id": "hgss4-92",
+    "setOrder":46,
+	"id": "hgss4-92",
     "name": "Celebi",
     "imageUrl": "https://images.pokemontcg.io/hgss4/92.png",
     "subtype": "Basic",
@@ -4674,7 +4766,8 @@
     "nationalPokedexNumber": 251
   },
   {
-    "id": "hgss4-93",
+    "setOrder":46,
+	"id": "hgss4-93",
     "name": "Electrode",
     "imageUrl": "https://images.pokemontcg.io/hgss4/93.png",
     "subtype": "Stage 1",
@@ -4727,7 +4820,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "hgss4-94",
+    "setOrder":46,
+	"id": "hgss4-94",
     "name": "Gengar",
     "imageUrl": "https://images.pokemontcg.io/hgss4/94.png",
     "subtype": "Stage 2",
@@ -4786,7 +4880,8 @@
     "nationalPokedexNumber": 94
   },
   {
-    "id": "hgss4-95",
+    "setOrder":46,
+	"id": "hgss4-95",
     "name": "Machamp",
     "imageUrl": "https://images.pokemontcg.io/hgss4/95.png",
     "subtype": "Stage 2",
@@ -4848,7 +4943,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "hgss4-96",
+    "setOrder":46,
+	"id": "hgss4-96",
     "name": "Magnezone",
     "imageUrl": "https://images.pokemontcg.io/hgss4/96.png",
     "subtype": "Stage 2",
@@ -4903,7 +4999,8 @@
     "nationalPokedexNumber": 462
   },
   {
-    "id": "hgss4-97",
+    "setOrder":46,
+	"id": "hgss4-97",
     "name": "Mew",
     "imageUrl": "https://images.pokemontcg.io/hgss4/97.png",
     "subtype": "Basic",
@@ -4945,7 +5042,8 @@
     "nationalPokedexNumber": 151
   },
   {
-    "id": "hgss4-98",
+    "setOrder":46,
+	"id": "hgss4-98",
     "name": "Yanmega",
     "imageUrl": "https://images.pokemontcg.io/hgss4/98.png",
     "subtype": "Stage 1",
@@ -5006,7 +5104,8 @@
     "nationalPokedexNumber": 469
   },
   {
-    "id": "hgss4-99",
+    "setOrder":46,
+	"id": "hgss4-99",
     "name": "Darkrai & Cresselia LEGEND",
     "imageUrl": "https://images.pokemontcg.io/hgss4/99.png",
     "subtype": "LEGEND",
@@ -5030,7 +5129,8 @@
     "nationalPokedexNumber": 488
   },
   {
-    "id": "hgss4-100",
+    "setOrder":46,
+	"id": "hgss4-100",
     "name": "Darkrai & Cresselia LEGEND",
     "imageUrl": "https://images.pokemontcg.io/hgss4/100.png",
     "subtype": "LEGEND",
@@ -5091,7 +5191,8 @@
     "nationalPokedexNumber": 488
   },
   {
-    "id": "hgss4-101",
+    "setOrder":46,
+	"id": "hgss4-101",
     "name": "Palkia & Dialga LEGEND",
     "imageUrl": "https://images.pokemontcg.io/hgss4/101.png",
     "subtype": "LEGEND",
@@ -5115,7 +5216,8 @@
     "nationalPokedexNumber": 483
   },
   {
-    "id": "hgss4-102",
+    "setOrder":46,
+	"id": "hgss4-102",
     "name": "Palkia & Dialga LEGEND",
     "imageUrl": "https://images.pokemontcg.io/hgss4/102.png",
     "subtype": "LEGEND",
@@ -5178,7 +5280,8 @@
     "nationalPokedexNumber": 483
   },
   {
-    "id": "hgss4-FOUR",
+    "setOrder":46,
+	"id": "hgss4-FOUR",
     "name": "Alph Lithograph",
     "imageUrl": "https://images.pokemontcg.io/hgss4/FOUR.png",
     "subtype": "Item",

--- a/json/cards/HS—Undaunted.json
+++ b/json/cards/HS—Undaunted.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "hgss3-1",
+    "setOrder":45,
+	"id": "hgss3-1",
     "name": "Bellossom",
     "imageUrl": "https://images.pokemontcg.io/hgss3/1.png",
     "subtype": "Stage 2",
@@ -53,7 +54,8 @@
     "nationalPokedexNumber": 182
   },
   {
-    "id": "hgss3-2",
+    "setOrder":45,
+	"id": "hgss3-2",
     "name": "Espeon",
     "imageUrl": "https://images.pokemontcg.io/hgss3/2.png",
     "subtype": "Stage 1",
@@ -104,7 +106,8 @@
     "nationalPokedexNumber": 196
   },
   {
-    "id": "hgss3-3",
+    "setOrder":45,
+	"id": "hgss3-3",
     "name": "Forretress",
     "imageUrl": "https://images.pokemontcg.io/hgss3/3.png",
     "subtype": "Stage 1",
@@ -165,7 +168,8 @@
     "nationalPokedexNumber": 205
   },
   {
-    "id": "hgss3-4",
+    "setOrder":45,
+	"id": "hgss3-4",
     "name": "Gliscor",
     "imageUrl": "https://images.pokemontcg.io/hgss3/4.png",
     "subtype": "Stage 1",
@@ -223,7 +227,8 @@
     "nationalPokedexNumber": 472
   },
   {
-    "id": "hgss3-5",
+    "setOrder":45,
+	"id": "hgss3-5",
     "name": "Houndoom",
     "imageUrl": "https://images.pokemontcg.io/hgss3/5.png",
     "subtype": "Stage 1",
@@ -280,7 +285,8 @@
     "nationalPokedexNumber": 229
   },
   {
-    "id": "hgss3-6",
+    "setOrder":45,
+	"id": "hgss3-6",
     "name": "Magcargo",
     "imageUrl": "https://images.pokemontcg.io/hgss3/6.png",
     "subtype": "Stage 1",
@@ -335,7 +341,8 @@
     "nationalPokedexNumber": 219
   },
   {
-    "id": "hgss3-7",
+    "setOrder":45,
+	"id": "hgss3-7",
     "name": "Scizor",
     "imageUrl": "https://images.pokemontcg.io/hgss3/7.png",
     "subtype": "Stage 1",
@@ -394,7 +401,8 @@
     "nationalPokedexNumber": 212
   },
   {
-    "id": "hgss3-8",
+    "setOrder":45,
+	"id": "hgss3-8",
     "name": "Smeargle",
     "imageUrl": "https://images.pokemontcg.io/hgss3/8.png",
     "subtype": "Basic",
@@ -440,7 +448,8 @@
     "nationalPokedexNumber": 235
   },
   {
-    "id": "hgss3-9",
+    "setOrder":45,
+	"id": "hgss3-9",
     "name": "Togekiss",
     "imageUrl": "https://images.pokemontcg.io/hgss3/9.png",
     "subtype": "Stage 2",
@@ -499,7 +508,8 @@
     "nationalPokedexNumber": 468
   },
   {
-    "id": "hgss3-10",
+    "setOrder":45,
+	"id": "hgss3-10",
     "name": "Umbreon",
     "imageUrl": "https://images.pokemontcg.io/hgss3/10.png",
     "subtype": "Stage 1",
@@ -556,7 +566,8 @@
     "nationalPokedexNumber": 197
   },
   {
-    "id": "hgss3-11",
+    "setOrder":45,
+	"id": "hgss3-11",
     "name": "Dodrio",
     "imageUrl": "https://images.pokemontcg.io/hgss3/11.png",
     "subtype": "Stage 1",
@@ -609,7 +620,8 @@
     "nationalPokedexNumber": 85
   },
   {
-    "id": "hgss3-12",
+    "setOrder":45,
+	"id": "hgss3-12",
     "name": "Drifblim",
     "imageUrl": "https://images.pokemontcg.io/hgss3/12.png",
     "subtype": "Stage 1",
@@ -665,7 +677,8 @@
     "nationalPokedexNumber": 426
   },
   {
-    "id": "hgss3-13",
+    "setOrder":45,
+	"id": "hgss3-13",
     "name": "Forretress",
     "imageUrl": "https://images.pokemontcg.io/hgss3/13.png",
     "subtype": "Stage 1",
@@ -723,7 +736,8 @@
     "nationalPokedexNumber": 205
   },
   {
-    "id": "hgss3-14",
+    "setOrder":45,
+	"id": "hgss3-14",
     "name": "Hariyama",
     "imageUrl": "https://images.pokemontcg.io/hgss3/14.png",
     "subtype": "Stage 1",
@@ -780,7 +794,8 @@
     "nationalPokedexNumber": 297
   },
   {
-    "id": "hgss3-15",
+    "setOrder":45,
+	"id": "hgss3-15",
     "name": "Honchkrow",
     "imageUrl": "https://images.pokemontcg.io/hgss3/15.png",
     "subtype": "Stage 1",
@@ -839,7 +854,8 @@
     "nationalPokedexNumber": 430
   },
   {
-    "id": "hgss3-16",
+    "setOrder":45,
+	"id": "hgss3-16",
     "name": "Honchkrow",
     "imageUrl": "https://images.pokemontcg.io/hgss3/16.png",
     "subtype": "Stage 1",
@@ -899,7 +915,8 @@
     "nationalPokedexNumber": 430
   },
   {
-    "id": "hgss3-17",
+    "setOrder":45,
+	"id": "hgss3-17",
     "name": "Leafeon",
     "imageUrl": "https://images.pokemontcg.io/hgss3/17.png",
     "subtype": "Stage 1",
@@ -955,7 +972,8 @@
     "nationalPokedexNumber": 470
   },
   {
-    "id": "hgss3-18",
+    "setOrder":45,
+	"id": "hgss3-18",
     "name": "Metagross",
     "imageUrl": "https://images.pokemontcg.io/hgss3/18.png",
     "subtype": "Stage 2",
@@ -1019,7 +1037,8 @@
     "nationalPokedexNumber": 376
   },
   {
-    "id": "hgss3-19",
+    "setOrder":45,
+	"id": "hgss3-19",
     "name": "Mismagius",
     "imageUrl": "https://images.pokemontcg.io/hgss3/19.png",
     "subtype": "Stage 1",
@@ -1076,7 +1095,8 @@
     "nationalPokedexNumber": 429
   },
   {
-    "id": "hgss3-20",
+    "setOrder":45,
+	"id": "hgss3-20",
     "name": "Rotom",
     "imageUrl": "https://images.pokemontcg.io/hgss3/20.png",
     "subtype": "Basic",
@@ -1127,7 +1147,8 @@
     "nationalPokedexNumber": 479
   },
   {
-    "id": "hgss3-21",
+    "setOrder":45,
+	"id": "hgss3-21",
     "name": "Skarmory",
     "imageUrl": "https://images.pokemontcg.io/hgss3/21.png",
     "subtype": "Basic",
@@ -1184,7 +1205,8 @@
     "nationalPokedexNumber": 227
   },
   {
-    "id": "hgss3-22",
+    "setOrder":45,
+	"id": "hgss3-22",
     "name": "Tropius",
     "imageUrl": "https://images.pokemontcg.io/hgss3/22.png",
     "subtype": "Basic",
@@ -1242,7 +1264,8 @@
     "nationalPokedexNumber": 357
   },
   {
-    "id": "hgss3-23",
+    "setOrder":45,
+	"id": "hgss3-23",
     "name": "Vespiquen",
     "imageUrl": "https://images.pokemontcg.io/hgss3/23.png",
     "subtype": "Stage 1",
@@ -1292,7 +1315,8 @@
     "nationalPokedexNumber": 416
   },
   {
-    "id": "hgss3-24",
+    "setOrder":45,
+	"id": "hgss3-24",
     "name": "Vileplume",
     "imageUrl": "https://images.pokemontcg.io/hgss3/24.png",
     "subtype": "Stage 2",
@@ -1341,7 +1365,8 @@
     "nationalPokedexNumber": 45
   },
   {
-    "id": "hgss3-25",
+    "setOrder":45,
+	"id": "hgss3-25",
     "name": "Weavile",
     "imageUrl": "https://images.pokemontcg.io/hgss3/25.png",
     "subtype": "Stage 1",
@@ -1391,7 +1416,8 @@
     "nationalPokedexNumber": 461
   },
   {
-    "id": "hgss3-26",
+    "setOrder":45,
+	"id": "hgss3-26",
     "name": "Flareon",
     "imageUrl": "https://images.pokemontcg.io/hgss3/26.png",
     "subtype": "Stage 1",
@@ -1443,7 +1469,8 @@
     "nationalPokedexNumber": 136
   },
   {
-    "id": "hgss3-27",
+    "setOrder":45,
+	"id": "hgss3-27",
     "name": "Gloom",
     "imageUrl": "https://images.pokemontcg.io/hgss3/27.png",
     "subtype": "Stage 1",
@@ -1489,7 +1516,8 @@
     ]
   },
   {
-    "id": "hgss3-28",
+    "setOrder":45,
+	"id": "hgss3-28",
     "name": "Jolteon",
     "imageUrl": "https://images.pokemontcg.io/hgss3/28.png",
     "subtype": "Stage 1",
@@ -1544,7 +1572,8 @@
     "nationalPokedexNumber": 135
   },
   {
-    "id": "hgss3-29",
+    "setOrder":45,
+	"id": "hgss3-29",
     "name": "Lairon",
     "imageUrl": "https://images.pokemontcg.io/hgss3/29.png",
     "subtype": "Stage 1",
@@ -1607,7 +1636,8 @@
     ]
   },
   {
-    "id": "hgss3-30",
+    "setOrder":45,
+	"id": "hgss3-30",
     "name": "Metang",
     "imageUrl": "https://images.pokemontcg.io/hgss3/30.png",
     "subtype": "Stage 1",
@@ -1670,7 +1700,8 @@
     ]
   },
   {
-    "id": "hgss3-31",
+    "setOrder":45,
+	"id": "hgss3-31",
     "name": "Muk",
     "imageUrl": "https://images.pokemontcg.io/hgss3/31.png",
     "subtype": "Stage 1",
@@ -1724,7 +1755,8 @@
     "nationalPokedexNumber": 89
   },
   {
-    "id": "hgss3-32",
+    "setOrder":45,
+	"id": "hgss3-32",
     "name": "Pinsir",
     "imageUrl": "https://images.pokemontcg.io/hgss3/32.png",
     "subtype": "Basic",
@@ -1775,7 +1807,8 @@
     "nationalPokedexNumber": 127
   },
   {
-    "id": "hgss3-33",
+    "setOrder":45,
+	"id": "hgss3-33",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/hgss3/33.png",
     "subtype": "Stage 1",
@@ -1829,7 +1862,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "hgss3-34",
+    "setOrder":45,
+	"id": "hgss3-34",
     "name": "Raticate",
     "imageUrl": "https://images.pokemontcg.io/hgss3/34.png",
     "subtype": "Stage 1",
@@ -1876,7 +1910,8 @@
     "nationalPokedexNumber": 20
   },
   {
-    "id": "hgss3-35",
+    "setOrder":45,
+	"id": "hgss3-35",
     "name": "Sableye",
     "imageUrl": "https://images.pokemontcg.io/hgss3/35.png",
     "subtype": "Basic",
@@ -1926,7 +1961,8 @@
     "nationalPokedexNumber": 302
   },
   {
-    "id": "hgss3-36",
+    "setOrder":45,
+	"id": "hgss3-36",
     "name": "Scyther",
     "imageUrl": "https://images.pokemontcg.io/hgss3/36.png",
     "subtype": "Basic",
@@ -1970,7 +2006,8 @@
     ]
   },
   {
-    "id": "hgss3-37",
+    "setOrder":45,
+	"id": "hgss3-37",
     "name": "Skuntank",
     "imageUrl": "https://images.pokemontcg.io/hgss3/37.png",
     "subtype": "Stage 1",
@@ -2027,7 +2064,8 @@
     "nationalPokedexNumber": 435
   },
   {
-    "id": "hgss3-38",
+    "setOrder":45,
+	"id": "hgss3-38",
     "name": "Slowbro",
     "imageUrl": "https://images.pokemontcg.io/hgss3/38.png",
     "subtype": "Stage 1",
@@ -2080,7 +2118,8 @@
     "nationalPokedexNumber": 80
   },
   {
-    "id": "hgss3-39",
+    "setOrder":45,
+	"id": "hgss3-39",
     "name": "Togetic",
     "imageUrl": "https://images.pokemontcg.io/hgss3/39.png",
     "subtype": "Stage 1",
@@ -2140,7 +2179,8 @@
     ]
   },
   {
-    "id": "hgss3-40",
+    "setOrder":45,
+	"id": "hgss3-40",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/hgss3/40.png",
     "subtype": "Basic",
@@ -2185,7 +2225,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "hgss3-41",
+    "setOrder":45,
+	"id": "hgss3-41",
     "name": "Vaporeon",
     "imageUrl": "https://images.pokemontcg.io/hgss3/41.png",
     "subtype": "Stage 1",
@@ -2238,7 +2279,8 @@
     "nationalPokedexNumber": 134
   },
   {
-    "id": "hgss3-42",
+    "setOrder":45,
+	"id": "hgss3-42",
     "name": "Aron",
     "imageUrl": "https://images.pokemontcg.io/hgss3/42.png",
     "subtype": "Basic",
@@ -2297,7 +2339,8 @@
     ]
   },
   {
-    "id": "hgss3-43",
+    "setOrder":45,
+	"id": "hgss3-43",
     "name": "Beldum",
     "imageUrl": "https://images.pokemontcg.io/hgss3/43.png",
     "subtype": "Basic",
@@ -2357,7 +2400,8 @@
     ]
   },
   {
-    "id": "hgss3-44",
+    "setOrder":45,
+	"id": "hgss3-44",
     "name": "Combee",
     "imageUrl": "https://images.pokemontcg.io/hgss3/44.png",
     "subtype": "Basic",
@@ -2400,7 +2444,8 @@
     ]
   },
   {
-    "id": "hgss3-45",
+    "setOrder":45,
+	"id": "hgss3-45",
     "name": "Doduo",
     "imageUrl": "https://images.pokemontcg.io/hgss3/45.png",
     "subtype": "Basic",
@@ -2459,7 +2504,8 @@
     ]
   },
   {
-    "id": "hgss3-46",
+    "setOrder":45,
+	"id": "hgss3-46",
     "name": "Drifloon",
     "imageUrl": "https://images.pokemontcg.io/hgss3/46.png",
     "subtype": "Basic",
@@ -2517,7 +2563,8 @@
     ]
   },
   {
-    "id": "hgss3-47",
+    "setOrder":45,
+	"id": "hgss3-47",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/hgss3/47.png",
     "subtype": "Basic",
@@ -2577,7 +2624,8 @@
     ]
   },
   {
-    "id": "hgss3-48",
+    "setOrder":45,
+	"id": "hgss3-48",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/hgss3/48.png",
     "subtype": "Basic",
@@ -2637,7 +2685,8 @@
     ]
   },
   {
-    "id": "hgss3-49",
+    "setOrder":45,
+	"id": "hgss3-49",
     "name": "Gligar",
     "imageUrl": "https://images.pokemontcg.io/hgss3/49.png",
     "subtype": "Basic",
@@ -2687,7 +2736,8 @@
     ]
   },
   {
-    "id": "hgss3-50",
+    "setOrder":45,
+	"id": "hgss3-50",
     "name": "Grimer",
     "imageUrl": "https://images.pokemontcg.io/hgss3/50.png",
     "subtype": "Basic",
@@ -2741,7 +2791,8 @@
     ]
   },
   {
-    "id": "hgss3-51",
+    "setOrder":45,
+	"id": "hgss3-51",
     "name": "Hitmonchan",
     "imageUrl": "https://images.pokemontcg.io/hgss3/51.png",
     "subtype": "Basic",
@@ -2791,7 +2842,8 @@
     "nationalPokedexNumber": 107
   },
   {
-    "id": "hgss3-52",
+    "setOrder":45,
+	"id": "hgss3-52",
     "name": "Hitmonlee",
     "imageUrl": "https://images.pokemontcg.io/hgss3/52.png",
     "subtype": "Basic",
@@ -2843,7 +2895,8 @@
     "nationalPokedexNumber": 106
   },
   {
-    "id": "hgss3-53",
+    "setOrder":45,
+	"id": "hgss3-53",
     "name": "Houndour",
     "imageUrl": "https://images.pokemontcg.io/hgss3/53.png",
     "subtype": "Basic",
@@ -2893,7 +2946,8 @@
     ]
   },
   {
-    "id": "hgss3-54",
+    "setOrder":45,
+	"id": "hgss3-54",
     "name": "Houndour",
     "imageUrl": "https://images.pokemontcg.io/hgss3/54.png",
     "subtype": "Basic",
@@ -2942,7 +2996,8 @@
     ]
   },
   {
-    "id": "hgss3-55",
+    "setOrder":45,
+	"id": "hgss3-55",
     "name": "Makuhita",
     "imageUrl": "https://images.pokemontcg.io/hgss3/55.png",
     "subtype": "Basic",
@@ -2998,7 +3053,8 @@
     ]
   },
   {
-    "id": "hgss3-56",
+    "setOrder":45,
+	"id": "hgss3-56",
     "name": "Mawile",
     "imageUrl": "https://images.pokemontcg.io/hgss3/56.png",
     "subtype": "Basic",
@@ -3055,7 +3111,8 @@
     "nationalPokedexNumber": 303
   },
   {
-    "id": "hgss3-57",
+    "setOrder":45,
+	"id": "hgss3-57",
     "name": "Misdreavus",
     "imageUrl": "https://images.pokemontcg.io/hgss3/57.png",
     "subtype": "Basic",
@@ -3113,7 +3170,8 @@
     ]
   },
   {
-    "id": "hgss3-58",
+    "setOrder":45,
+	"id": "hgss3-58",
     "name": "Murkrow",
     "imageUrl": "https://images.pokemontcg.io/hgss3/58.png",
     "subtype": "Basic",
@@ -3162,7 +3220,8 @@
     ]
   },
   {
-    "id": "hgss3-59",
+    "setOrder":45,
+	"id": "hgss3-59",
     "name": "Murkrow",
     "imageUrl": "https://images.pokemontcg.io/hgss3/59.png",
     "subtype": "Basic",
@@ -3222,7 +3281,8 @@
     ]
   },
   {
-    "id": "hgss3-60",
+    "setOrder":45,
+	"id": "hgss3-60",
     "name": "Oddish",
     "imageUrl": "https://images.pokemontcg.io/hgss3/60.png",
     "subtype": "Basic",
@@ -3274,7 +3334,8 @@
     ]
   },
   {
-    "id": "hgss3-61",
+    "setOrder":45,
+	"id": "hgss3-61",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/hgss3/61.png",
     "subtype": "Basic",
@@ -3323,7 +3384,8 @@
     ]
   },
   {
-    "id": "hgss3-62",
+    "setOrder":45,
+	"id": "hgss3-62",
     "name": "Pineco",
     "imageUrl": "https://images.pokemontcg.io/hgss3/62.png",
     "subtype": "Basic",
@@ -3367,7 +3429,8 @@
     ]
   },
   {
-    "id": "hgss3-63",
+    "setOrder":45,
+	"id": "hgss3-63",
     "name": "Pineco",
     "imageUrl": "https://images.pokemontcg.io/hgss3/63.png",
     "subtype": "Basic",
@@ -3421,7 +3484,8 @@
     ]
   },
   {
-    "id": "hgss3-64",
+    "setOrder":45,
+	"id": "hgss3-64",
     "name": "Rattata",
     "imageUrl": "https://images.pokemontcg.io/hgss3/64.png",
     "subtype": "Basic",
@@ -3464,7 +3528,8 @@
     ]
   },
   {
-    "id": "hgss3-65",
+    "setOrder":45,
+	"id": "hgss3-65",
     "name": "Scyther",
     "imageUrl": "https://images.pokemontcg.io/hgss3/65.png",
     "subtype": "Basic",
@@ -3519,7 +3584,8 @@
     ]
   },
   {
-    "id": "hgss3-66",
+    "setOrder":45,
+	"id": "hgss3-66",
     "name": "Slowpoke",
     "imageUrl": "https://images.pokemontcg.io/hgss3/66.png",
     "subtype": "Basic",
@@ -3574,7 +3640,8 @@
     ]
   },
   {
-    "id": "hgss3-67",
+    "setOrder":45,
+	"id": "hgss3-67",
     "name": "Slugma",
     "imageUrl": "https://images.pokemontcg.io/hgss3/67.png",
     "subtype": "Basic",
@@ -3625,7 +3692,8 @@
     ]
   },
   {
-    "id": "hgss3-68",
+    "setOrder":45,
+	"id": "hgss3-68",
     "name": "Sneasel",
     "imageUrl": "https://images.pokemontcg.io/hgss3/68.png",
     "subtype": "Basic",
@@ -3681,7 +3749,8 @@
     ]
   },
   {
-    "id": "hgss3-69",
+    "setOrder":45,
+	"id": "hgss3-69",
     "name": "Stunky",
     "imageUrl": "https://images.pokemontcg.io/hgss3/69.png",
     "subtype": "Basic",
@@ -3730,7 +3799,8 @@
     ]
   },
   {
-    "id": "hgss3-70",
+    "setOrder":45,
+	"id": "hgss3-70",
     "name": "Togepi",
     "imageUrl": "https://images.pokemontcg.io/hgss3/70.png",
     "subtype": "Basic",
@@ -3773,7 +3843,8 @@
     ]
   },
   {
-    "id": "hgss3-71",
+    "setOrder":45,
+	"id": "hgss3-71",
     "name": "Burned Tower",
     "imageUrl": "https://images.pokemontcg.io/hgss3/71.png",
     "subtype": "Stadium",
@@ -3791,7 +3862,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss3/71_hires.png"
   },
   {
-    "id": "hgss3-72",
+    "setOrder":45,
+	"id": "hgss3-72",
     "name": "Defender",
     "imageUrl": "https://images.pokemontcg.io/hgss3/72.png",
     "subtype": "Item",
@@ -3808,7 +3880,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss3/72_hires.png"
   },
   {
-    "id": "hgss3-73",
+    "setOrder":45,
+	"id": "hgss3-73",
     "name": "Energy Exchanger",
     "imageUrl": "https://images.pokemontcg.io/hgss3/73.png",
     "subtype": "Item",
@@ -3825,7 +3898,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss3/73_hires.png"
   },
   {
-    "id": "hgss3-74",
+    "setOrder":45,
+	"id": "hgss3-74",
     "name": "Flower Shop Lady",
     "imageUrl": "https://images.pokemontcg.io/hgss3/74.png",
     "subtype": "Supporter",
@@ -3843,7 +3917,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss3/74_hires.png"
   },
   {
-    "id": "hgss3-75",
+    "setOrder":45,
+	"id": "hgss3-75",
     "name": "Legend Box",
     "imageUrl": "https://images.pokemontcg.io/hgss3/75.png",
     "subtype": "Item",
@@ -3860,7 +3935,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss3/75_hires.png"
   },
   {
-    "id": "hgss3-76",
+    "setOrder":45,
+	"id": "hgss3-76",
     "name": "Ruins of Alph",
     "imageUrl": "https://images.pokemontcg.io/hgss3/76.png",
     "subtype": "Stadium",
@@ -3878,7 +3954,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss3/76_hires.png"
   },
   {
-    "id": "hgss3-77",
+    "setOrder":45,
+	"id": "hgss3-77",
     "name": "Sage's Training",
     "imageUrl": "https://images.pokemontcg.io/hgss3/77.png",
     "subtype": "Supporter",
@@ -3896,7 +3973,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss3/77_hires.png"
   },
   {
-    "id": "hgss3-78",
+    "setOrder":45,
+	"id": "hgss3-78",
     "name": "Team Rocket's Trickery",
     "imageUrl": "https://images.pokemontcg.io/hgss3/78.png",
     "subtype": "Supporter",
@@ -3914,7 +3992,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss3/78_hires.png"
   },
   {
-    "id": "hgss3-79",
+    "setOrder":45,
+	"id": "hgss3-79",
     "name": "Darkness Energy",
     "imageUrl": "https://images.pokemontcg.io/hgss3/79.png",
     "subtype": "Special",
@@ -3931,7 +4010,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss3/79_hires.png"
   },
   {
-    "id": "hgss3-80",
+    "setOrder":45,
+	"id": "hgss3-80",
     "name": "Metal Energy",
     "imageUrl": "https://images.pokemontcg.io/hgss3/80.png",
     "subtype": "Special",
@@ -3948,7 +4028,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss3/80_hires.png"
   },
   {
-    "id": "hgss3-81",
+    "setOrder":45,
+	"id": "hgss3-81",
     "name": "Espeon",
     "imageUrl": "https://images.pokemontcg.io/hgss3/81.png",
     "subtype": "Stage 1",
@@ -3995,7 +4076,8 @@
     "nationalPokedexNumber": 196
   },
   {
-    "id": "hgss3-82",
+    "setOrder":45,
+	"id": "hgss3-82",
     "name": "Houndoom",
     "imageUrl": "https://images.pokemontcg.io/hgss3/82.png",
     "subtype": "Stage 1",
@@ -4049,7 +4131,8 @@
     "nationalPokedexNumber": 229
   },
   {
-    "id": "hgss3-83",
+    "setOrder":45,
+	"id": "hgss3-83",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/hgss3/83.png",
     "subtype": "Stage 1",
@@ -4103,7 +4186,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "hgss3-84",
+    "setOrder":45,
+	"id": "hgss3-84",
     "name": "Scizor",
     "imageUrl": "https://images.pokemontcg.io/hgss3/84.png",
     "subtype": "Stage 1",
@@ -4157,7 +4241,8 @@
     "nationalPokedexNumber": 212
   },
   {
-    "id": "hgss3-85",
+    "setOrder":45,
+	"id": "hgss3-85",
     "name": "Slowking",
     "imageUrl": "https://images.pokemontcg.io/hgss3/85.png",
     "subtype": "Stage 1",
@@ -4206,7 +4291,8 @@
     "nationalPokedexNumber": 199
   },
   {
-    "id": "hgss3-86",
+    "setOrder":45,
+	"id": "hgss3-86",
     "name": "Umbreon",
     "imageUrl": "https://images.pokemontcg.io/hgss3/86.png",
     "subtype": "Stage 1",
@@ -4260,7 +4346,8 @@
     "nationalPokedexNumber": 197
   },
   {
-    "id": "hgss3-87",
+    "setOrder":45,
+	"id": "hgss3-87",
     "name": "Kyogre & Groudon LEGEND",
     "imageUrl": "https://images.pokemontcg.io/hgss3/87.png",
     "subtype": "LEGEND",
@@ -4284,7 +4371,8 @@
     "nationalPokedexNumber": 382
   },
   {
-    "id": "hgss3-88",
+    "setOrder":45,
+	"id": "hgss3-88",
     "name": "Kyogre & Groudon LEGEND",
     "imageUrl": "https://images.pokemontcg.io/hgss3/88.png",
     "subtype": "LEGEND",
@@ -4349,7 +4437,8 @@
     "nationalPokedexNumber": 382
   },
   {
-    "id": "hgss3-89",
+    "setOrder":45,
+	"id": "hgss3-89",
     "name": "Rayquaza & Deoxys LEGEND",
     "imageUrl": "https://images.pokemontcg.io/hgss3/89.png",
     "subtype": "LEGEND",
@@ -4373,7 +4462,8 @@
     "nationalPokedexNumber": 384
   },
   {
-    "id": "hgss3-90",
+    "setOrder":45,
+	"id": "hgss3-90",
     "name": "Rayquaza & Deoxys LEGEND",
     "imageUrl": "https://images.pokemontcg.io/hgss3/90.png",
     "subtype": "LEGEND",
@@ -4431,7 +4521,8 @@
     "nationalPokedexNumber": 384
   },
   {
-    "id": "hgss3-THREE",
+    "setOrder":45,
+	"id": "hgss3-THREE",
     "name": "Alph Lithograph",
     "imageUrl": "https://images.pokemontcg.io/hgss3/THREE.png",
     "subtype": "Item",

--- a/json/cards/HS—Unleashed.json
+++ b/json/cards/HS—Unleashed.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "hgss2-1",
+    "setOrder":44,
+	"id": "hgss2-1",
     "name": "Jirachi",
     "imageUrl": "https://images.pokemontcg.io/hgss2/1.png",
     "subtype": "Basic",
@@ -45,7 +46,8 @@
     "nationalPokedexNumber": 385
   },
   {
-    "id": "hgss2-2",
+    "setOrder":44,
+	"id": "hgss2-2",
     "name": "Magmortar",
     "imageUrl": "https://images.pokemontcg.io/hgss2/2.png",
     "subtype": "Stage 1",
@@ -101,7 +103,8 @@
     "nationalPokedexNumber": 467
   },
   {
-    "id": "hgss2-3",
+    "setOrder":44,
+	"id": "hgss2-3",
     "name": "Manaphy",
     "imageUrl": "https://images.pokemontcg.io/hgss2/3.png",
     "subtype": "Basic",
@@ -147,7 +150,8 @@
     "nationalPokedexNumber": 490
   },
   {
-    "id": "hgss2-4",
+    "setOrder":44,
+	"id": "hgss2-4",
     "name": "Metagross",
     "imageUrl": "https://images.pokemontcg.io/hgss2/4.png",
     "subtype": "Stage 2",
@@ -208,7 +212,8 @@
     "nationalPokedexNumber": 376
   },
   {
-    "id": "hgss2-5",
+    "setOrder":44,
+	"id": "hgss2-5",
     "name": "Mismagius",
     "imageUrl": "https://images.pokemontcg.io/hgss2/5.png",
     "subtype": "Stage 1",
@@ -260,7 +265,8 @@
     "nationalPokedexNumber": 429
   },
   {
-    "id": "hgss2-6",
+    "setOrder":44,
+	"id": "hgss2-6",
     "name": "Octillery",
     "imageUrl": "https://images.pokemontcg.io/hgss2/6.png",
     "subtype": "Stage 1",
@@ -313,7 +319,8 @@
     "nationalPokedexNumber": 224
   },
   {
-    "id": "hgss2-7",
+    "setOrder":44,
+	"id": "hgss2-7",
     "name": "Politoed",
     "imageUrl": "https://images.pokemontcg.io/hgss2/7.png",
     "subtype": "Stage 2",
@@ -362,7 +369,8 @@
     "nationalPokedexNumber": 186
   },
   {
-    "id": "hgss2-8",
+    "setOrder":44,
+	"id": "hgss2-8",
     "name": "Shaymin",
     "imageUrl": "https://images.pokemontcg.io/hgss2/8.png",
     "subtype": "Basic",
@@ -414,7 +422,8 @@
     "nationalPokedexNumber": 492
   },
   {
-    "id": "hgss2-9",
+    "setOrder":44,
+	"id": "hgss2-9",
     "name": "Sudowoodo",
     "imageUrl": "https://images.pokemontcg.io/hgss2/9.png",
     "subtype": "Basic",
@@ -466,7 +475,8 @@
     "nationalPokedexNumber": 185
   },
   {
-    "id": "hgss2-10",
+    "setOrder":44,
+	"id": "hgss2-10",
     "name": "Torterra",
     "imageUrl": "https://images.pokemontcg.io/hgss2/10.png",
     "subtype": "Stage 2",
@@ -524,7 +534,8 @@
     "nationalPokedexNumber": 389
   },
   {
-    "id": "hgss2-11",
+    "setOrder":44,
+	"id": "hgss2-11",
     "name": "Xatu",
     "imageUrl": "https://images.pokemontcg.io/hgss2/11.png",
     "subtype": "Stage 1",
@@ -582,7 +593,8 @@
     "nationalPokedexNumber": 178
   },
   {
-    "id": "hgss2-12",
+    "setOrder":44,
+	"id": "hgss2-12",
     "name": "Beedrill",
     "imageUrl": "https://images.pokemontcg.io/hgss2/12.png",
     "subtype": "Stage 2",
@@ -630,7 +642,8 @@
     "nationalPokedexNumber": 15
   },
   {
-    "id": "hgss2-13",
+    "setOrder":44,
+	"id": "hgss2-13",
     "name": "Blastoise",
     "imageUrl": "https://images.pokemontcg.io/hgss2/13.png",
     "subtype": "Stage 2",
@@ -681,7 +694,8 @@
     "nationalPokedexNumber": 9
   },
   {
-    "id": "hgss2-14",
+    "setOrder":44,
+	"id": "hgss2-14",
     "name": "Crobat",
     "imageUrl": "https://images.pokemontcg.io/hgss2/14.png",
     "subtype": "Stage 2",
@@ -736,7 +750,8 @@
     "nationalPokedexNumber": 169
   },
   {
-    "id": "hgss2-15",
+    "setOrder":44,
+	"id": "hgss2-15",
     "name": "Fearow",
     "imageUrl": "https://images.pokemontcg.io/hgss2/15.png",
     "subtype": "Stage 1",
@@ -795,7 +810,8 @@
     "nationalPokedexNumber": 22
   },
   {
-    "id": "hgss2-16",
+    "setOrder":44,
+	"id": "hgss2-16",
     "name": "Floatzel",
     "imageUrl": "https://images.pokemontcg.io/hgss2/16.png",
     "subtype": "Stage 1",
@@ -839,7 +855,8 @@
     "nationalPokedexNumber": 419
   },
   {
-    "id": "hgss2-17",
+    "setOrder":44,
+	"id": "hgss2-17",
     "name": "Kingdra",
     "imageUrl": "https://images.pokemontcg.io/hgss2/17.png",
     "subtype": "Stage 2",
@@ -891,7 +908,8 @@
     "nationalPokedexNumber": 230
   },
   {
-    "id": "hgss2-18",
+    "setOrder":44,
+	"id": "hgss2-18",
     "name": "Lanturn",
     "imageUrl": "https://images.pokemontcg.io/hgss2/18.png",
     "subtype": "Stage 1",
@@ -944,7 +962,8 @@
     "nationalPokedexNumber": 171
   },
   {
-    "id": "hgss2-19",
+    "setOrder":44,
+	"id": "hgss2-19",
     "name": "Lucario",
     "imageUrl": "https://images.pokemontcg.io/hgss2/19.png",
     "subtype": "Stage 1",
@@ -995,7 +1014,8 @@
     "nationalPokedexNumber": 448
   },
   {
-    "id": "hgss2-20",
+    "setOrder":44,
+	"id": "hgss2-20",
     "name": "Ninetales",
     "imageUrl": "https://images.pokemontcg.io/hgss2/20.png",
     "subtype": "Stage 1",
@@ -1046,7 +1066,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "hgss2-21",
+    "setOrder":44,
+	"id": "hgss2-21",
     "name": "Poliwrath",
     "imageUrl": "https://images.pokemontcg.io/hgss2/21.png",
     "subtype": "Stage 2",
@@ -1101,7 +1122,8 @@
     "nationalPokedexNumber": 62
   },
   {
-    "id": "hgss2-22",
+    "setOrder":44,
+	"id": "hgss2-22",
     "name": "Primeape",
     "imageUrl": "https://images.pokemontcg.io/hgss2/22.png",
     "subtype": "Stage 1",
@@ -1153,7 +1175,8 @@
     "nationalPokedexNumber": 57
   },
   {
-    "id": "hgss2-23",
+    "setOrder":44,
+	"id": "hgss2-23",
     "name": "Roserade",
     "imageUrl": "https://images.pokemontcg.io/hgss2/23.png",
     "subtype": "Stage 1",
@@ -1200,7 +1223,8 @@
     "nationalPokedexNumber": 407
   },
   {
-    "id": "hgss2-24",
+    "setOrder":44,
+	"id": "hgss2-24",
     "name": "Steelix",
     "imageUrl": "https://images.pokemontcg.io/hgss2/24.png",
     "subtype": "Stage 1",
@@ -1264,7 +1288,8 @@
     "nationalPokedexNumber": 208
   },
   {
-    "id": "hgss2-25",
+    "setOrder":44,
+	"id": "hgss2-25",
     "name": "Torkoal",
     "imageUrl": "https://images.pokemontcg.io/hgss2/25.png",
     "subtype": "Basic",
@@ -1311,7 +1336,8 @@
     "nationalPokedexNumber": 324
   },
   {
-    "id": "hgss2-26",
+    "setOrder":44,
+	"id": "hgss2-26",
     "name": "Tyranitar",
     "imageUrl": "https://images.pokemontcg.io/hgss2/26.png",
     "subtype": "Stage 2",
@@ -1374,7 +1400,8 @@
     "nationalPokedexNumber": 248
   },
   {
-    "id": "hgss2-27",
+    "setOrder":44,
+	"id": "hgss2-27",
     "name": "Ursaring",
     "imageUrl": "https://images.pokemontcg.io/hgss2/27.png",
     "subtype": "Stage 1",
@@ -1428,7 +1455,8 @@
     "nationalPokedexNumber": 217
   },
   {
-    "id": "hgss2-28",
+    "setOrder":44,
+	"id": "hgss2-28",
     "name": "Cherrim",
     "imageUrl": "https://images.pokemontcg.io/hgss2/28.png",
     "subtype": "Stage 1",
@@ -1480,7 +1508,8 @@
     "nationalPokedexNumber": 421
   },
   {
-    "id": "hgss2-29",
+    "setOrder":44,
+	"id": "hgss2-29",
     "name": "Dunsparce",
     "imageUrl": "https://images.pokemontcg.io/hgss2/29.png",
     "subtype": "Basic",
@@ -1520,7 +1549,8 @@
     "nationalPokedexNumber": 206
   },
   {
-    "id": "hgss2-30",
+    "setOrder":44,
+	"id": "hgss2-30",
     "name": "Golbat",
     "imageUrl": "https://images.pokemontcg.io/hgss2/30.png",
     "subtype": "Stage 1",
@@ -1567,7 +1597,8 @@
     ]
   },
   {
-    "id": "hgss2-31",
+    "setOrder":44,
+	"id": "hgss2-31",
     "name": "Grotle",
     "imageUrl": "https://images.pokemontcg.io/hgss2/31.png",
     "subtype": "Stage 1",
@@ -1630,7 +1661,8 @@
     ]
   },
   {
-    "id": "hgss2-32",
+    "setOrder":44,
+	"id": "hgss2-32",
     "name": "Kakuna",
     "imageUrl": "https://images.pokemontcg.io/hgss2/32.png",
     "subtype": "Stage 1",
@@ -1684,7 +1716,8 @@
     ]
   },
   {
-    "id": "hgss2-33",
+    "setOrder":44,
+	"id": "hgss2-33",
     "name": "Metang",
     "imageUrl": "https://images.pokemontcg.io/hgss2/33.png",
     "subtype": "Stage 1",
@@ -1741,7 +1774,8 @@
     ]
   },
   {
-    "id": "hgss2-34",
+    "setOrder":44,
+	"id": "hgss2-34",
     "name": "Minun",
     "imageUrl": "https://images.pokemontcg.io/hgss2/34.png",
     "subtype": "Basic",
@@ -1796,7 +1830,8 @@
     "nationalPokedexNumber": 312
   },
   {
-    "id": "hgss2-35",
+    "setOrder":44,
+	"id": "hgss2-35",
     "name": "Numel",
     "imageUrl": "https://images.pokemontcg.io/hgss2/35.png",
     "subtype": "Basic",
@@ -1850,7 +1885,8 @@
     ]
   },
   {
-    "id": "hgss2-36",
+    "setOrder":44,
+	"id": "hgss2-36",
     "name": "Plusle",
     "imageUrl": "https://images.pokemontcg.io/hgss2/36.png",
     "subtype": "Basic",
@@ -1905,7 +1941,8 @@
     "nationalPokedexNumber": 311
   },
   {
-    "id": "hgss2-37",
+    "setOrder":44,
+	"id": "hgss2-37",
     "name": "Poliwhirl",
     "imageUrl": "https://images.pokemontcg.io/hgss2/37.png",
     "subtype": "Stage 1",
@@ -1960,7 +1997,8 @@
     ]
   },
   {
-    "id": "hgss2-38",
+    "setOrder":44,
+	"id": "hgss2-38",
     "name": "Pupitar",
     "imageUrl": "https://images.pokemontcg.io/hgss2/38.png",
     "subtype": "Stage 1",
@@ -2016,7 +2054,8 @@
     ]
   },
   {
-    "id": "hgss2-39",
+    "setOrder":44,
+	"id": "hgss2-39",
     "name": "Pupitar",
     "imageUrl": "https://images.pokemontcg.io/hgss2/39.png",
     "subtype": "Stage 1",
@@ -2078,7 +2117,8 @@
     ]
   },
   {
-    "id": "hgss2-40",
+    "setOrder":44,
+	"id": "hgss2-40",
     "name": "Seadra",
     "imageUrl": "https://images.pokemontcg.io/hgss2/40.png",
     "subtype": "Stage 1",
@@ -2133,7 +2173,8 @@
     ]
   },
   {
-    "id": "hgss2-41",
+    "setOrder":44,
+	"id": "hgss2-41",
     "name": "Tauros",
     "imageUrl": "https://images.pokemontcg.io/hgss2/41.png",
     "subtype": "Basic",
@@ -2185,7 +2226,8 @@
     "nationalPokedexNumber": 128
   },
   {
-    "id": "hgss2-42",
+    "setOrder":44,
+	"id": "hgss2-42",
     "name": "Wartortle",
     "imageUrl": "https://images.pokemontcg.io/hgss2/42.png",
     "subtype": "Stage 1",
@@ -2240,7 +2282,8 @@
     ]
   },
   {
-    "id": "hgss2-43",
+    "setOrder":44,
+	"id": "hgss2-43",
     "name": "Aipom",
     "imageUrl": "https://images.pokemontcg.io/hgss2/43.png",
     "subtype": "Basic",
@@ -2293,7 +2336,8 @@
     ]
   },
   {
-    "id": "hgss2-44",
+    "setOrder":44,
+	"id": "hgss2-44",
     "name": "Beldum",
     "imageUrl": "https://images.pokemontcg.io/hgss2/44.png",
     "subtype": "Basic",
@@ -2337,7 +2381,8 @@
     ]
   },
   {
-    "id": "hgss2-45",
+    "setOrder":44,
+	"id": "hgss2-45",
     "name": "Buizel",
     "imageUrl": "https://images.pokemontcg.io/hgss2/45.png",
     "subtype": "Basic",
@@ -2380,7 +2425,8 @@
     ]
   },
   {
-    "id": "hgss2-46",
+    "setOrder":44,
+	"id": "hgss2-46",
     "name": "Carnivine",
     "imageUrl": "https://images.pokemontcg.io/hgss2/46.png",
     "subtype": "Basic",
@@ -2435,7 +2481,8 @@
     "nationalPokedexNumber": 455
   },
   {
-    "id": "hgss2-47",
+    "setOrder":44,
+	"id": "hgss2-47",
     "name": "Cherubi",
     "imageUrl": "https://images.pokemontcg.io/hgss2/47.png",
     "subtype": "Basic",
@@ -2484,7 +2531,8 @@
     ]
   },
   {
-    "id": "hgss2-48",
+    "setOrder":44,
+	"id": "hgss2-48",
     "name": "Chinchou",
     "imageUrl": "https://images.pokemontcg.io/hgss2/48.png",
     "subtype": "Basic",
@@ -2537,7 +2585,8 @@
     ]
   },
   {
-    "id": "hgss2-49",
+    "setOrder":44,
+	"id": "hgss2-49",
     "name": "Horsea",
     "imageUrl": "https://images.pokemontcg.io/hgss2/49.png",
     "subtype": "Basic",
@@ -2590,7 +2639,8 @@
     ]
   },
   {
-    "id": "hgss2-50",
+    "setOrder":44,
+	"id": "hgss2-50",
     "name": "Larvitar",
     "imageUrl": "https://images.pokemontcg.io/hgss2/50.png",
     "subtype": "Basic",
@@ -2648,7 +2698,8 @@
     ]
   },
   {
-    "id": "hgss2-51",
+    "setOrder":44,
+	"id": "hgss2-51",
     "name": "Larvitar",
     "imageUrl": "https://images.pokemontcg.io/hgss2/51.png",
     "subtype": "Basic",
@@ -2707,7 +2758,8 @@
     ]
   },
   {
-    "id": "hgss2-52",
+    "setOrder":44,
+	"id": "hgss2-52",
     "name": "Magmar",
     "imageUrl": "https://images.pokemontcg.io/hgss2/52.png",
     "subtype": "Basic",
@@ -2760,7 +2812,8 @@
     ]
   },
   {
-    "id": "hgss2-53",
+    "setOrder":44,
+	"id": "hgss2-53",
     "name": "Mankey",
     "imageUrl": "https://images.pokemontcg.io/hgss2/53.png",
     "subtype": "Basic",
@@ -2813,7 +2866,8 @@
     ]
   },
   {
-    "id": "hgss2-54",
+    "setOrder":44,
+	"id": "hgss2-54",
     "name": "Misdreavus",
     "imageUrl": "https://images.pokemontcg.io/hgss2/54.png",
     "subtype": "Basic",
@@ -2862,7 +2916,8 @@
     ]
   },
   {
-    "id": "hgss2-55",
+    "setOrder":44,
+	"id": "hgss2-55",
     "name": "Natu",
     "imageUrl": "https://images.pokemontcg.io/hgss2/55.png",
     "subtype": "Basic",
@@ -2920,7 +2975,8 @@
     ]
   },
   {
-    "id": "hgss2-56",
+    "setOrder":44,
+	"id": "hgss2-56",
     "name": "Onix",
     "imageUrl": "https://images.pokemontcg.io/hgss2/56.png",
     "subtype": "Basic",
@@ -2974,7 +3030,8 @@
     ]
   },
   {
-    "id": "hgss2-57",
+    "setOrder":44,
+	"id": "hgss2-57",
     "name": "Onix",
     "imageUrl": "https://images.pokemontcg.io/hgss2/57.png",
     "subtype": "Basic",
@@ -3021,7 +3078,8 @@
     ]
   },
   {
-    "id": "hgss2-58",
+    "setOrder":44,
+	"id": "hgss2-58",
     "name": "Poliwag",
     "imageUrl": "https://images.pokemontcg.io/hgss2/58.png",
     "subtype": "Basic",
@@ -3074,7 +3132,8 @@
     ]
   },
   {
-    "id": "hgss2-59",
+    "setOrder":44,
+	"id": "hgss2-59",
     "name": "Remoraid",
     "imageUrl": "https://images.pokemontcg.io/hgss2/59.png",
     "subtype": "Basic",
@@ -3127,7 +3186,8 @@
     ]
   },
   {
-    "id": "hgss2-60",
+    "setOrder":44,
+	"id": "hgss2-60",
     "name": "Riolu",
     "imageUrl": "https://images.pokemontcg.io/hgss2/60.png",
     "subtype": "Basic",
@@ -3180,7 +3240,8 @@
     ]
   },
   {
-    "id": "hgss2-61",
+    "setOrder":44,
+	"id": "hgss2-61",
     "name": "Roselia",
     "imageUrl": "https://images.pokemontcg.io/hgss2/61.png",
     "subtype": "Basic",
@@ -3223,7 +3284,8 @@
     ]
   },
   {
-    "id": "hgss2-62",
+    "setOrder":44,
+	"id": "hgss2-62",
     "name": "Spearow",
     "imageUrl": "https://images.pokemontcg.io/hgss2/62.png",
     "subtype": "Basic",
@@ -3281,7 +3343,8 @@
     ]
   },
   {
-    "id": "hgss2-63",
+    "setOrder":44,
+	"id": "hgss2-63",
     "name": "Squirtle",
     "imageUrl": "https://images.pokemontcg.io/hgss2/63.png",
     "subtype": "Basic",
@@ -3335,7 +3398,8 @@
     ]
   },
   {
-    "id": "hgss2-64",
+    "setOrder":44,
+	"id": "hgss2-64",
     "name": "Stantler",
     "imageUrl": "https://images.pokemontcg.io/hgss2/64.png",
     "subtype": "Basic",
@@ -3386,7 +3450,8 @@
     "nationalPokedexNumber": 234
   },
   {
-    "id": "hgss2-65",
+    "setOrder":44,
+	"id": "hgss2-65",
     "name": "Teddiursa",
     "imageUrl": "https://images.pokemontcg.io/hgss2/65.png",
     "subtype": "Basic",
@@ -3429,7 +3494,8 @@
     ]
   },
   {
-    "id": "hgss2-66",
+    "setOrder":44,
+	"id": "hgss2-66",
     "name": "Tropius",
     "imageUrl": "https://images.pokemontcg.io/hgss2/66.png",
     "subtype": "Basic",
@@ -3485,7 +3551,8 @@
     "nationalPokedexNumber": 357
   },
   {
-    "id": "hgss2-67",
+    "setOrder":44,
+	"id": "hgss2-67",
     "name": "Turtwig",
     "imageUrl": "https://images.pokemontcg.io/hgss2/67.png",
     "subtype": "Basic",
@@ -3544,7 +3611,8 @@
     ]
   },
   {
-    "id": "hgss2-68",
+    "setOrder":44,
+	"id": "hgss2-68",
     "name": "Vulpix",
     "imageUrl": "https://images.pokemontcg.io/hgss2/68.png",
     "subtype": "Basic",
@@ -3587,7 +3655,8 @@
     ]
   },
   {
-    "id": "hgss2-69",
+    "setOrder":44,
+	"id": "hgss2-69",
     "name": "Weedle",
     "imageUrl": "https://images.pokemontcg.io/hgss2/69.png",
     "subtype": "Basic",
@@ -3639,7 +3708,8 @@
     ]
   },
   {
-    "id": "hgss2-70",
+    "setOrder":44,
+	"id": "hgss2-70",
     "name": "Zubat",
     "imageUrl": "https://images.pokemontcg.io/hgss2/70.png",
     "subtype": "Basic",
@@ -3697,7 +3767,8 @@
     ]
   },
   {
-    "id": "hgss2-71",
+    "setOrder":44,
+	"id": "hgss2-71",
     "name": "Cheerleader's Cheer",
     "imageUrl": "https://images.pokemontcg.io/hgss2/71.png",
     "subtype": "Supporter",
@@ -3715,7 +3786,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss2/71_hires.png"
   },
   {
-    "id": "hgss2-72",
+    "setOrder":44,
+	"id": "hgss2-72",
     "name": "Dual Ball",
     "imageUrl": "https://images.pokemontcg.io/hgss2/72.png",
     "subtype": "Item",
@@ -3732,7 +3804,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss2/72_hires.png"
   },
   {
-    "id": "hgss2-73",
+    "setOrder":44,
+	"id": "hgss2-73",
     "name": "Emcee's Chatter",
     "imageUrl": "https://images.pokemontcg.io/hgss2/73.png",
     "subtype": "Supporter",
@@ -3750,7 +3823,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss2/73_hires.png"
   },
   {
-    "id": "hgss2-74",
+    "setOrder":44,
+	"id": "hgss2-74",
     "name": "Energy Returner",
     "imageUrl": "https://images.pokemontcg.io/hgss2/74.png",
     "subtype": "Item",
@@ -3767,7 +3841,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss2/74_hires.png"
   },
   {
-    "id": "hgss2-75",
+    "setOrder":44,
+	"id": "hgss2-75",
     "name": "Engineer's Adjustments",
     "imageUrl": "https://images.pokemontcg.io/hgss2/75.png",
     "subtype": "Supporter",
@@ -3785,7 +3860,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss2/75_hires.png"
   },
   {
-    "id": "hgss2-76",
+    "setOrder":44,
+	"id": "hgss2-76",
     "name": "Good Rod",
     "imageUrl": "https://images.pokemontcg.io/hgss2/76.png",
     "subtype": "Item",
@@ -3802,7 +3878,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss2/76_hires.png"
   },
   {
-    "id": "hgss2-77",
+    "setOrder":44,
+	"id": "hgss2-77",
     "name": "Interviewer's Questions",
     "imageUrl": "https://images.pokemontcg.io/hgss2/77.png",
     "subtype": "Supporter",
@@ -3820,7 +3897,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss2/77_hires.png"
   },
   {
-    "id": "hgss2-78",
+    "setOrder":44,
+	"id": "hgss2-78",
     "name": "Judge",
     "imageUrl": "https://images.pokemontcg.io/hgss2/78.png",
     "subtype": "Supporter",
@@ -3838,7 +3916,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss2/78_hires.png"
   },
   {
-    "id": "hgss2-79",
+    "setOrder":44,
+	"id": "hgss2-79",
     "name": "Life Herb",
     "imageUrl": "https://images.pokemontcg.io/hgss2/79.png",
     "subtype": "Item",
@@ -3855,7 +3934,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss2/79_hires.png"
   },
   {
-    "id": "hgss2-80",
+    "setOrder":44,
+	"id": "hgss2-80",
     "name": "PlusPower",
     "imageUrl": "https://images.pokemontcg.io/hgss2/80.png",
     "subtype": "Item",
@@ -3872,7 +3952,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss2/80_hires.png"
   },
   {
-    "id": "hgss2-81",
+    "setOrder":44,
+	"id": "hgss2-81",
     "name": "Pokémon Circulator",
     "imageUrl": "https://images.pokemontcg.io/hgss2/81.png",
     "subtype": "Item",
@@ -3889,7 +3970,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss2/81_hires.png"
   },
   {
-    "id": "hgss2-82",
+    "setOrder":44,
+	"id": "hgss2-82",
     "name": "Rare Candy",
     "imageUrl": "https://images.pokemontcg.io/hgss2/82.png",
     "subtype": "Item",
@@ -3906,7 +3988,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss2/82_hires.png"
   },
   {
-    "id": "hgss2-83",
+    "setOrder":44,
+	"id": "hgss2-83",
     "name": "Super Scoop Up",
     "imageUrl": "https://images.pokemontcg.io/hgss2/83.png",
     "subtype": "Item",
@@ -3923,7 +4006,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss2/83_hires.png"
   },
   {
-    "id": "hgss2-84",
+    "setOrder":44,
+	"id": "hgss2-84",
     "name": "Crobat",
     "imageUrl": "https://images.pokemontcg.io/hgss2/84.png",
     "subtype": "Stage 2",
@@ -3976,7 +4060,8 @@
     "nationalPokedexNumber": 169
   },
   {
-    "id": "hgss2-85",
+    "setOrder":44,
+	"id": "hgss2-85",
     "name": "Kingdra",
     "imageUrl": "https://images.pokemontcg.io/hgss2/85.png",
     "subtype": "Stage 2",
@@ -4022,7 +4107,8 @@
     "nationalPokedexNumber": 230
   },
   {
-    "id": "hgss2-86",
+    "setOrder":44,
+	"id": "hgss2-86",
     "name": "Lanturn",
     "imageUrl": "https://images.pokemontcg.io/hgss2/86.png",
     "subtype": "Stage 1",
@@ -4071,7 +4157,8 @@
     "nationalPokedexNumber": 171
   },
   {
-    "id": "hgss2-87",
+    "setOrder":44,
+	"id": "hgss2-87",
     "name": "Steelix",
     "imageUrl": "https://images.pokemontcg.io/hgss2/87.png",
     "subtype": "Stage 1",
@@ -4140,7 +4227,8 @@
     "nationalPokedexNumber": 208
   },
   {
-    "id": "hgss2-88",
+    "setOrder":44,
+	"id": "hgss2-88",
     "name": "Tyranitar",
     "imageUrl": "https://images.pokemontcg.io/hgss2/88.png",
     "subtype": "Stage 2",
@@ -4212,7 +4300,8 @@
     "nationalPokedexNumber": 248
   },
   {
-    "id": "hgss2-89",
+    "setOrder":44,
+	"id": "hgss2-89",
     "name": "Ursaring",
     "imageUrl": "https://images.pokemontcg.io/hgss2/89.png",
     "subtype": "Stage 1",
@@ -4274,7 +4363,8 @@
     "nationalPokedexNumber": 217
   },
   {
-    "id": "hgss2-90",
+    "setOrder":44,
+	"id": "hgss2-90",
     "name": "Entei & Raikou LEGEND",
     "imageUrl": "https://images.pokemontcg.io/hgss2/90.png",
     "subtype": "LEGEND",
@@ -4298,7 +4388,8 @@
     "nationalPokedexNumber": 243
   },
   {
-    "id": "hgss2-91",
+    "setOrder":44,
+	"id": "hgss2-91",
     "name": "Entei & Raikou LEGEND",
     "imageUrl": "https://images.pokemontcg.io/hgss2/91.png",
     "subtype": "LEGEND",
@@ -4354,7 +4445,8 @@
     "nationalPokedexNumber": 243
   },
   {
-    "id": "hgss2-92",
+    "setOrder":44,
+	"id": "hgss2-92",
     "name": "Raikou & Suicune LEGEND",
     "imageUrl": "https://images.pokemontcg.io/hgss2/92.png",
     "subtype": "LEGEND",
@@ -4378,7 +4470,8 @@
     "nationalPokedexNumber": 243
   },
   {
-    "id": "hgss2-93",
+    "setOrder":44,
+	"id": "hgss2-93",
     "name": "Raikou & Suicune LEGEND",
     "imageUrl": "https://images.pokemontcg.io/hgss2/93.png",
     "subtype": "LEGEND",
@@ -4439,7 +4532,8 @@
     "nationalPokedexNumber": 243
   },
   {
-    "id": "hgss2-94",
+    "setOrder":44,
+	"id": "hgss2-94",
     "name": "Suicune & Entei LEGEND",
     "imageUrl": "https://images.pokemontcg.io/hgss2/94.png",
     "subtype": "LEGEND",
@@ -4463,7 +4557,8 @@
     "nationalPokedexNumber": 244
   },
   {
-    "id": "hgss2-95",
+    "setOrder":44,
+	"id": "hgss2-95",
     "name": "Suicune & Entei LEGEND",
     "imageUrl": "https://images.pokemontcg.io/hgss2/95.png",
     "subtype": "LEGEND",
@@ -4524,7 +4619,8 @@
     "nationalPokedexNumber": 244
   },
   {
-    "id": "hgss2-TWO",
+    "setOrder":44,
+	"id": "hgss2-TWO",
     "name": "Alph Lithograph",
     "imageUrl": "https://images.pokemontcg.io/hgss2/TWO.png",
     "subtype": "Item",

--- a/json/cards/HeartGold & SoulSilver.json
+++ b/json/cards/HeartGold & SoulSilver.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "hgss1-1",
+    "setOrder":43,
+	"id": "hgss1-1",
     "name": "Arcanine",
     "imageUrl": "https://images.pokemontcg.io/hgss1/1.png",
     "subtype": "Stage 1",
@@ -55,7 +56,8 @@
     "nationalPokedexNumber": 59
   },
   {
-    "id": "hgss1-2",
+    "setOrder":43,
+	"id": "hgss1-2",
     "name": "Azumarill",
     "imageUrl": "https://images.pokemontcg.io/hgss1/2.png",
     "subtype": "Stage 1",
@@ -109,7 +111,8 @@
     "nationalPokedexNumber": 184
   },
   {
-    "id": "hgss1-3",
+    "setOrder":43,
+	"id": "hgss1-3",
     "name": "Clefable",
     "imageUrl": "https://images.pokemontcg.io/hgss1/3.png",
     "subtype": "Stage 1",
@@ -161,7 +164,8 @@
     "nationalPokedexNumber": 36
   },
   {
-    "id": "hgss1-4",
+    "setOrder":43,
+	"id": "hgss1-4",
     "name": "Gyarados",
     "imageUrl": "https://images.pokemontcg.io/hgss1/4.png",
     "subtype": "Stage 1",
@@ -224,7 +228,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "hgss1-5",
+    "setOrder":43,
+	"id": "hgss1-5",
     "name": "Hitmontop",
     "imageUrl": "https://images.pokemontcg.io/hgss1/5.png",
     "subtype": "Basic",
@@ -275,7 +280,8 @@
     "nationalPokedexNumber": 237
   },
   {
-    "id": "hgss1-6",
+    "setOrder":43,
+	"id": "hgss1-6",
     "name": "Jumpluff",
     "imageUrl": "https://images.pokemontcg.io/hgss1/6.png",
     "subtype": "Stage 2",
@@ -328,7 +334,8 @@
     "nationalPokedexNumber": 189
   },
   {
-    "id": "hgss1-7",
+    "setOrder":43,
+	"id": "hgss1-7",
     "name": "Ninetales",
     "imageUrl": "https://images.pokemontcg.io/hgss1/7.png",
     "subtype": "Stage 1",
@@ -376,7 +383,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "hgss1-8",
+    "setOrder":43,
+	"id": "hgss1-8",
     "name": "Noctowl",
     "imageUrl": "https://images.pokemontcg.io/hgss1/8.png",
     "subtype": "Stage 1",
@@ -430,7 +438,8 @@
     "nationalPokedexNumber": 164
   },
   {
-    "id": "hgss1-9",
+    "setOrder":43,
+	"id": "hgss1-9",
     "name": "Quagsire",
     "imageUrl": "https://images.pokemontcg.io/hgss1/9.png",
     "subtype": "Stage 1",
@@ -493,7 +502,8 @@
     "nationalPokedexNumber": 195
   },
   {
-    "id": "hgss1-10",
+    "setOrder":43,
+	"id": "hgss1-10",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/hgss1/10.png",
     "subtype": "Stage 1",
@@ -547,7 +557,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "hgss1-11",
+    "setOrder":43,
+	"id": "hgss1-11",
     "name": "Shuckle",
     "imageUrl": "https://images.pokemontcg.io/hgss1/11.png",
     "subtype": "Basic",
@@ -588,7 +599,8 @@
     "nationalPokedexNumber": 213
   },
   {
-    "id": "hgss1-12",
+    "setOrder":43,
+	"id": "hgss1-12",
     "name": "Slowking",
     "imageUrl": "https://images.pokemontcg.io/hgss1/12.png",
     "subtype": "Stage 1",
@@ -636,7 +648,8 @@
     "nationalPokedexNumber": 199
   },
   {
-    "id": "hgss1-13",
+    "setOrder":43,
+	"id": "hgss1-13",
     "name": "Wobbuffet",
     "imageUrl": "https://images.pokemontcg.io/hgss1/13.png",
     "subtype": "Basic",
@@ -678,7 +691,8 @@
     "nationalPokedexNumber": 202
   },
   {
-    "id": "hgss1-14",
+    "setOrder":43,
+	"id": "hgss1-14",
     "name": "Ampharos",
     "imageUrl": "https://images.pokemontcg.io/hgss1/14.png",
     "subtype": "Stage 2",
@@ -736,7 +750,8 @@
     "nationalPokedexNumber": 181
   },
   {
-    "id": "hgss1-15",
+    "setOrder":43,
+	"id": "hgss1-15",
     "name": "Ariados",
     "imageUrl": "https://images.pokemontcg.io/hgss1/15.png",
     "subtype": "Stage 1",
@@ -789,7 +804,8 @@
     "nationalPokedexNumber": 168
   },
   {
-    "id": "hgss1-16",
+    "setOrder":43,
+	"id": "hgss1-16",
     "name": "Butterfree",
     "imageUrl": "https://images.pokemontcg.io/hgss1/16.png",
     "subtype": "Stage 2",
@@ -844,7 +860,8 @@
     "nationalPokedexNumber": 12
   },
   {
-    "id": "hgss1-17",
+    "setOrder":43,
+	"id": "hgss1-17",
     "name": "Cleffa",
     "imageUrl": "https://images.pokemontcg.io/hgss1/17.png",
     "subtype": "Basic",
@@ -883,7 +900,8 @@
     ]
   },
   {
-    "id": "hgss1-18",
+    "setOrder":43,
+	"id": "hgss1-18",
     "name": "Exeggutor",
     "imageUrl": "https://images.pokemontcg.io/hgss1/18.png",
     "subtype": "Stage 1",
@@ -934,7 +952,8 @@
     "nationalPokedexNumber": 103
   },
   {
-    "id": "hgss1-19",
+    "setOrder":43,
+	"id": "hgss1-19",
     "name": "Farfetch'd",
     "imageUrl": "https://images.pokemontcg.io/hgss1/19.png",
     "subtype": "Basic",
@@ -989,7 +1008,8 @@
     "nationalPokedexNumber": 83
   },
   {
-    "id": "hgss1-20",
+    "setOrder":43,
+	"id": "hgss1-20",
     "name": "Feraligatr",
     "imageUrl": "https://images.pokemontcg.io/hgss1/20.png",
     "subtype": "Stage 2",
@@ -1045,7 +1065,8 @@
     "nationalPokedexNumber": 160
   },
   {
-    "id": "hgss1-21",
+    "setOrder":43,
+	"id": "hgss1-21",
     "name": "Furret",
     "imageUrl": "https://images.pokemontcg.io/hgss1/21.png",
     "subtype": "Stage 1",
@@ -1096,7 +1117,8 @@
     "nationalPokedexNumber": 162
   },
   {
-    "id": "hgss1-22",
+    "setOrder":43,
+	"id": "hgss1-22",
     "name": "Granbull",
     "imageUrl": "https://images.pokemontcg.io/hgss1/22.png",
     "subtype": "Stage 1",
@@ -1152,7 +1174,8 @@
     "nationalPokedexNumber": 210
   },
   {
-    "id": "hgss1-23",
+    "setOrder":43,
+	"id": "hgss1-23",
     "name": "Hypno",
     "imageUrl": "https://images.pokemontcg.io/hgss1/23.png",
     "subtype": "Stage 1",
@@ -1201,7 +1224,8 @@
     "nationalPokedexNumber": 97
   },
   {
-    "id": "hgss1-24",
+    "setOrder":43,
+	"id": "hgss1-24",
     "name": "Lapras",
     "imageUrl": "https://images.pokemontcg.io/hgss1/24.png",
     "subtype": "Basic",
@@ -1253,7 +1277,8 @@
     "nationalPokedexNumber": 131
   },
   {
-    "id": "hgss1-25",
+    "setOrder":43,
+	"id": "hgss1-25",
     "name": "Ledian",
     "imageUrl": "https://images.pokemontcg.io/hgss1/25.png",
     "subtype": "Stage 1",
@@ -1307,7 +1332,8 @@
     "nationalPokedexNumber": 166
   },
   {
-    "id": "hgss1-26",
+    "setOrder":43,
+	"id": "hgss1-26",
     "name": "Meganium",
     "imageUrl": "https://images.pokemontcg.io/hgss1/26.png",
     "subtype": "Stage 2",
@@ -1366,7 +1392,8 @@
     "nationalPokedexNumber": 154
   },
   {
-    "id": "hgss1-27",
+    "setOrder":43,
+	"id": "hgss1-27",
     "name": "Persian",
     "imageUrl": "https://images.pokemontcg.io/hgss1/27.png",
     "subtype": "Stage 1",
@@ -1417,7 +1444,8 @@
     "nationalPokedexNumber": 53
   },
   {
-    "id": "hgss1-28",
+    "setOrder":43,
+	"id": "hgss1-28",
     "name": "Pichu",
     "imageUrl": "https://images.pokemontcg.io/hgss1/28.png",
     "subtype": "Basic",
@@ -1456,7 +1484,8 @@
     ]
   },
   {
-    "id": "hgss1-29",
+    "setOrder":43,
+	"id": "hgss1-29",
     "name": "Sandslash",
     "imageUrl": "https://images.pokemontcg.io/hgss1/29.png",
     "subtype": "Stage 1",
@@ -1512,7 +1541,8 @@
     "nationalPokedexNumber": 28
   },
   {
-    "id": "hgss1-30",
+    "setOrder":43,
+	"id": "hgss1-30",
     "name": "Smoochum",
     "imageUrl": "https://images.pokemontcg.io/hgss1/30.png",
     "subtype": "Basic",
@@ -1546,7 +1576,8 @@
     ]
   },
   {
-    "id": "hgss1-31",
+    "setOrder":43,
+	"id": "hgss1-31",
     "name": "Sunflora",
     "imageUrl": "https://images.pokemontcg.io/hgss1/31.png",
     "subtype": "Stage 1",
@@ -1600,7 +1631,8 @@
     "nationalPokedexNumber": 192
   },
   {
-    "id": "hgss1-32",
+    "setOrder":43,
+	"id": "hgss1-32",
     "name": "Typhlosion",
     "imageUrl": "https://images.pokemontcg.io/hgss1/32.png",
     "subtype": "Stage 2",
@@ -1653,7 +1685,8 @@
     "nationalPokedexNumber": 157
   },
   {
-    "id": "hgss1-33",
+    "setOrder":43,
+	"id": "hgss1-33",
     "name": "Tyrogue",
     "imageUrl": "https://images.pokemontcg.io/hgss1/33.png",
     "subtype": "Basic",
@@ -1694,7 +1727,8 @@
     ]
   },
   {
-    "id": "hgss1-34",
+    "setOrder":43,
+	"id": "hgss1-34",
     "name": "Weezing",
     "imageUrl": "https://images.pokemontcg.io/hgss1/34.png",
     "subtype": "Stage 1",
@@ -1746,7 +1780,8 @@
     "nationalPokedexNumber": 110
   },
   {
-    "id": "hgss1-35",
+    "setOrder":43,
+	"id": "hgss1-35",
     "name": "Bayleef",
     "imageUrl": "https://images.pokemontcg.io/hgss1/35.png",
     "subtype": "Stage 1",
@@ -1808,7 +1843,8 @@
     ]
   },
   {
-    "id": "hgss1-36",
+    "setOrder":43,
+	"id": "hgss1-36",
     "name": "Blissey",
     "imageUrl": "https://images.pokemontcg.io/hgss1/36.png",
     "subtype": "Stage 1",
@@ -1862,7 +1898,8 @@
     "nationalPokedexNumber": 242
   },
   {
-    "id": "hgss1-37",
+    "setOrder":43,
+	"id": "hgss1-37",
     "name": "Corsola",
     "imageUrl": "https://images.pokemontcg.io/hgss1/37.png",
     "subtype": "Basic",
@@ -1912,7 +1949,8 @@
     "nationalPokedexNumber": 222
   },
   {
-    "id": "hgss1-38",
+    "setOrder":43,
+	"id": "hgss1-38",
     "name": "Croconaw",
     "imageUrl": "https://images.pokemontcg.io/hgss1/38.png",
     "subtype": "Stage 1",
@@ -1969,7 +2007,8 @@
     ]
   },
   {
-    "id": "hgss1-39",
+    "setOrder":43,
+	"id": "hgss1-39",
     "name": "Delibird",
     "imageUrl": "https://images.pokemontcg.io/hgss1/39.png",
     "subtype": "Basic",
@@ -2025,7 +2064,8 @@
     "nationalPokedexNumber": 225
   },
   {
-    "id": "hgss1-40",
+    "setOrder":43,
+	"id": "hgss1-40",
     "name": "Donphan",
     "imageUrl": "https://images.pokemontcg.io/hgss1/40.png",
     "subtype": "Stage 1",
@@ -2088,7 +2128,8 @@
     "nationalPokedexNumber": 232
   },
   {
-    "id": "hgss1-41",
+    "setOrder":43,
+	"id": "hgss1-41",
     "name": "Dunsparce",
     "imageUrl": "https://images.pokemontcg.io/hgss1/41.png",
     "subtype": "Basic",
@@ -2137,7 +2178,8 @@
     "nationalPokedexNumber": 206
   },
   {
-    "id": "hgss1-42",
+    "setOrder":43,
+	"id": "hgss1-42",
     "name": "Flaaffy",
     "imageUrl": "https://images.pokemontcg.io/hgss1/42.png",
     "subtype": "Stage 1",
@@ -2198,7 +2240,8 @@
     ]
   },
   {
-    "id": "hgss1-43",
+    "setOrder":43,
+	"id": "hgss1-43",
     "name": "Heracross",
     "imageUrl": "https://images.pokemontcg.io/hgss1/43.png",
     "subtype": "Basic",
@@ -2251,7 +2294,8 @@
     "nationalPokedexNumber": 214
   },
   {
-    "id": "hgss1-44",
+    "setOrder":43,
+	"id": "hgss1-44",
     "name": "Igglybuff",
     "imageUrl": "https://images.pokemontcg.io/hgss1/44.png",
     "subtype": "Basic",
@@ -2285,7 +2329,8 @@
     ]
   },
   {
-    "id": "hgss1-45",
+    "setOrder":43,
+	"id": "hgss1-45",
     "name": "Mantine",
     "imageUrl": "https://images.pokemontcg.io/hgss1/45.png",
     "subtype": "Basic",
@@ -2341,7 +2386,8 @@
     "nationalPokedexNumber": 226
   },
   {
-    "id": "hgss1-46",
+    "setOrder":43,
+	"id": "hgss1-46",
     "name": "Metapod",
     "imageUrl": "https://images.pokemontcg.io/hgss1/46.png",
     "subtype": "Stage 1",
@@ -2387,7 +2433,8 @@
     ]
   },
   {
-    "id": "hgss1-47",
+    "setOrder":43,
+	"id": "hgss1-47",
     "name": "Miltank",
     "imageUrl": "https://images.pokemontcg.io/hgss1/47.png",
     "subtype": "Basic",
@@ -2440,7 +2487,8 @@
     "nationalPokedexNumber": 241
   },
   {
-    "id": "hgss1-48",
+    "setOrder":43,
+	"id": "hgss1-48",
     "name": "Parasect",
     "imageUrl": "https://images.pokemontcg.io/hgss1/48.png",
     "subtype": "Stage 1",
@@ -2493,7 +2541,8 @@
     "nationalPokedexNumber": 47
   },
   {
-    "id": "hgss1-49",
+    "setOrder":43,
+	"id": "hgss1-49",
     "name": "Quilava",
     "imageUrl": "https://images.pokemontcg.io/hgss1/49.png",
     "subtype": "Stage 1",
@@ -2549,7 +2598,8 @@
     ]
   },
   {
-    "id": "hgss1-50",
+    "setOrder":43,
+	"id": "hgss1-50",
     "name": "Qwilfish",
     "imageUrl": "https://images.pokemontcg.io/hgss1/50.png",
     "subtype": "Basic",
@@ -2590,7 +2640,8 @@
     "nationalPokedexNumber": 211
   },
   {
-    "id": "hgss1-51",
+    "setOrder":43,
+	"id": "hgss1-51",
     "name": "Skiploom",
     "imageUrl": "https://images.pokemontcg.io/hgss1/51.png",
     "subtype": "Stage 1",
@@ -2637,7 +2688,8 @@
     ]
   },
   {
-    "id": "hgss1-52",
+    "setOrder":43,
+	"id": "hgss1-52",
     "name": "Slowbro",
     "imageUrl": "https://images.pokemontcg.io/hgss1/52.png",
     "subtype": "Stage 1",
@@ -2690,7 +2742,8 @@
     "nationalPokedexNumber": 80
   },
   {
-    "id": "hgss1-53",
+    "setOrder":43,
+	"id": "hgss1-53",
     "name": "Starmie",
     "imageUrl": "https://images.pokemontcg.io/hgss1/53.png",
     "subtype": "Stage 1",
@@ -2728,7 +2781,8 @@
     "nationalPokedexNumber": 121
   },
   {
-    "id": "hgss1-54",
+    "setOrder":43,
+	"id": "hgss1-54",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/hgss1/54.png",
     "subtype": "Basic",
@@ -2773,7 +2827,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "hgss1-55",
+    "setOrder":43,
+	"id": "hgss1-55",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/hgss1/55.png",
     "subtype": "Basic",
@@ -2818,7 +2873,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "hgss1-56",
+    "setOrder":43,
+	"id": "hgss1-56",
     "name": "Wigglytuff",
     "imageUrl": "https://images.pokemontcg.io/hgss1/56.png",
     "subtype": "Stage 1",
@@ -2872,7 +2928,8 @@
     "nationalPokedexNumber": 40
   },
   {
-    "id": "hgss1-57",
+    "setOrder":43,
+	"id": "hgss1-57",
     "name": "Caterpie",
     "imageUrl": "https://images.pokemontcg.io/hgss1/57.png",
     "subtype": "Basic",
@@ -2915,7 +2972,8 @@
     ]
   },
   {
-    "id": "hgss1-58",
+    "setOrder":43,
+	"id": "hgss1-58",
     "name": "Chansey",
     "imageUrl": "https://images.pokemontcg.io/hgss1/58.png",
     "subtype": "Basic",
@@ -2971,7 +3029,8 @@
     ]
   },
   {
-    "id": "hgss1-59",
+    "setOrder":43,
+	"id": "hgss1-59",
     "name": "Chikorita",
     "imageUrl": "https://images.pokemontcg.io/hgss1/59.png",
     "subtype": "Basic",
@@ -3030,7 +3089,8 @@
     ]
   },
   {
-    "id": "hgss1-60",
+    "setOrder":43,
+	"id": "hgss1-60",
     "name": "Clefairy",
     "imageUrl": "https://images.pokemontcg.io/hgss1/60.png",
     "subtype": "Basic",
@@ -3082,7 +3142,8 @@
     ]
   },
   {
-    "id": "hgss1-61",
+    "setOrder":43,
+	"id": "hgss1-61",
     "name": "Cyndaquil",
     "imageUrl": "https://images.pokemontcg.io/hgss1/61.png",
     "subtype": "Basic",
@@ -3135,7 +3196,8 @@
     ]
   },
   {
-    "id": "hgss1-62",
+    "setOrder":43,
+	"id": "hgss1-62",
     "name": "Drowzee",
     "imageUrl": "https://images.pokemontcg.io/hgss1/62.png",
     "subtype": "Basic",
@@ -3189,7 +3251,8 @@
     ]
   },
   {
-    "id": "hgss1-63",
+    "setOrder":43,
+	"id": "hgss1-63",
     "name": "Exeggcute",
     "imageUrl": "https://images.pokemontcg.io/hgss1/63.png",
     "subtype": "Basic",
@@ -3232,7 +3295,8 @@
     ]
   },
   {
-    "id": "hgss1-64",
+    "setOrder":43,
+	"id": "hgss1-64",
     "name": "Girafarig",
     "imageUrl": "https://images.pokemontcg.io/hgss1/64.png",
     "subtype": "Basic",
@@ -3282,7 +3346,8 @@
     "nationalPokedexNumber": 203
   },
   {
-    "id": "hgss1-65",
+    "setOrder":43,
+	"id": "hgss1-65",
     "name": "Growlithe",
     "imageUrl": "https://images.pokemontcg.io/hgss1/65.png",
     "subtype": "Basic",
@@ -3337,7 +3402,8 @@
     ]
   },
   {
-    "id": "hgss1-66",
+    "setOrder":43,
+	"id": "hgss1-66",
     "name": "Hoothoot",
     "imageUrl": "https://images.pokemontcg.io/hgss1/66.png",
     "subtype": "Basic",
@@ -3396,7 +3462,8 @@
     ]
   },
   {
-    "id": "hgss1-67",
+    "setOrder":43,
+	"id": "hgss1-67",
     "name": "Hoppip",
     "imageUrl": "https://images.pokemontcg.io/hgss1/67.png",
     "subtype": "Basic",
@@ -3445,7 +3512,8 @@
     ]
   },
   {
-    "id": "hgss1-68",
+    "setOrder":43,
+	"id": "hgss1-68",
     "name": "Jigglypuff",
     "imageUrl": "https://images.pokemontcg.io/hgss1/68.png",
     "subtype": "Basic",
@@ -3489,7 +3557,8 @@
     ]
   },
   {
-    "id": "hgss1-69",
+    "setOrder":43,
+	"id": "hgss1-69",
     "name": "Jynx",
     "imageUrl": "https://images.pokemontcg.io/hgss1/69.png",
     "subtype": "Basic",
@@ -3539,7 +3608,8 @@
     "nationalPokedexNumber": 124
   },
   {
-    "id": "hgss1-70",
+    "setOrder":43,
+	"id": "hgss1-70",
     "name": "Koffing",
     "imageUrl": "https://images.pokemontcg.io/hgss1/70.png",
     "subtype": "Basic",
@@ -3592,7 +3662,8 @@
     ]
   },
   {
-    "id": "hgss1-71",
+    "setOrder":43,
+	"id": "hgss1-71",
     "name": "Ledyba",
     "imageUrl": "https://images.pokemontcg.io/hgss1/71.png",
     "subtype": "Basic",
@@ -3651,7 +3722,8 @@
     ]
   },
   {
-    "id": "hgss1-72",
+    "setOrder":43,
+	"id": "hgss1-72",
     "name": "Magikarp",
     "imageUrl": "https://images.pokemontcg.io/hgss1/72.png",
     "subtype": "Basic",
@@ -3694,7 +3766,8 @@
     ]
   },
   {
-    "id": "hgss1-73",
+    "setOrder":43,
+	"id": "hgss1-73",
     "name": "Mareep",
     "imageUrl": "https://images.pokemontcg.io/hgss1/73.png",
     "subtype": "Basic",
@@ -3753,7 +3826,8 @@
     ]
   },
   {
-    "id": "hgss1-74",
+    "setOrder":43,
+	"id": "hgss1-74",
     "name": "Marill",
     "imageUrl": "https://images.pokemontcg.io/hgss1/74.png",
     "subtype": "Basic",
@@ -3807,7 +3881,8 @@
     ]
   },
   {
-    "id": "hgss1-75",
+    "setOrder":43,
+	"id": "hgss1-75",
     "name": "Meowth",
     "imageUrl": "https://images.pokemontcg.io/hgss1/75.png",
     "subtype": "Basic",
@@ -3860,7 +3935,8 @@
     ]
   },
   {
-    "id": "hgss1-76",
+    "setOrder":43,
+	"id": "hgss1-76",
     "name": "Paras",
     "imageUrl": "https://images.pokemontcg.io/hgss1/76.png",
     "subtype": "Basic",
@@ -3913,7 +3989,8 @@
     ]
   },
   {
-    "id": "hgss1-77",
+    "setOrder":43,
+	"id": "hgss1-77",
     "name": "Phanpy",
     "imageUrl": "https://images.pokemontcg.io/hgss1/77.png",
     "subtype": "Basic",
@@ -3963,7 +4040,8 @@
     ]
   },
   {
-    "id": "hgss1-78",
+    "setOrder":43,
+	"id": "hgss1-78",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/hgss1/78.png",
     "subtype": "Basic",
@@ -4022,7 +4100,8 @@
     ]
   },
   {
-    "id": "hgss1-79",
+    "setOrder":43,
+	"id": "hgss1-79",
     "name": "Sandshrew",
     "imageUrl": "https://images.pokemontcg.io/hgss1/79.png",
     "subtype": "Basic",
@@ -4080,7 +4159,8 @@
     ]
   },
   {
-    "id": "hgss1-80",
+    "setOrder":43,
+	"id": "hgss1-80",
     "name": "Sentret",
     "imageUrl": "https://images.pokemontcg.io/hgss1/80.png",
     "subtype": "Basic",
@@ -4132,7 +4212,8 @@
     ]
   },
   {
-    "id": "hgss1-81",
+    "setOrder":43,
+	"id": "hgss1-81",
     "name": "Slowpoke",
     "imageUrl": "https://images.pokemontcg.io/hgss1/81.png",
     "subtype": "Basic",
@@ -4177,7 +4258,8 @@
     ]
   },
   {
-    "id": "hgss1-82",
+    "setOrder":43,
+	"id": "hgss1-82",
     "name": "Snubbull",
     "imageUrl": "https://images.pokemontcg.io/hgss1/82.png",
     "subtype": "Basic",
@@ -4231,7 +4313,8 @@
     ]
   },
   {
-    "id": "hgss1-83",
+    "setOrder":43,
+	"id": "hgss1-83",
     "name": "Spinarak",
     "imageUrl": "https://images.pokemontcg.io/hgss1/83.png",
     "subtype": "Basic",
@@ -4283,7 +4366,8 @@
     ]
   },
   {
-    "id": "hgss1-84",
+    "setOrder":43,
+	"id": "hgss1-84",
     "name": "Staryu",
     "imageUrl": "https://images.pokemontcg.io/hgss1/84.png",
     "subtype": "Basic",
@@ -4326,7 +4410,8 @@
     ]
   },
   {
-    "id": "hgss1-85",
+    "setOrder":43,
+	"id": "hgss1-85",
     "name": "Sunkern",
     "imageUrl": "https://images.pokemontcg.io/hgss1/85.png",
     "subtype": "Basic",
@@ -4385,7 +4470,8 @@
     ]
   },
   {
-    "id": "hgss1-86",
+    "setOrder":43,
+	"id": "hgss1-86",
     "name": "Totodile",
     "imageUrl": "https://images.pokemontcg.io/hgss1/86.png",
     "subtype": "Basic",
@@ -4438,7 +4524,8 @@
     ]
   },
   {
-    "id": "hgss1-87",
+    "setOrder":43,
+	"id": "hgss1-87",
     "name": "Vulpix",
     "imageUrl": "https://images.pokemontcg.io/hgss1/87.png",
     "subtype": "Basic",
@@ -4491,7 +4578,8 @@
     ]
   },
   {
-    "id": "hgss1-88",
+    "setOrder":43,
+	"id": "hgss1-88",
     "name": "Wooper",
     "imageUrl": "https://images.pokemontcg.io/hgss1/88.png",
     "subtype": "Basic",
@@ -4549,7 +4637,8 @@
     ]
   },
   {
-    "id": "hgss1-89",
+    "setOrder":43,
+	"id": "hgss1-89",
     "name": "Bill",
     "imageUrl": "https://images.pokemontcg.io/hgss1/89.png",
     "subtype": "Supporter",
@@ -4567,7 +4656,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss1/89_hires.png"
   },
   {
-    "id": "hgss1-90",
+    "setOrder":43,
+	"id": "hgss1-90",
     "name": "Copycat",
     "imageUrl": "https://images.pokemontcg.io/hgss1/90.png",
     "subtype": "Supporter",
@@ -4585,7 +4675,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss1/90_hires.png"
   },
   {
-    "id": "hgss1-91",
+    "setOrder":43,
+	"id": "hgss1-91",
     "name": "Energy Switch",
     "imageUrl": "https://images.pokemontcg.io/hgss1/91.png",
     "subtype": "Item",
@@ -4602,7 +4693,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss1/91_hires.png"
   },
   {
-    "id": "hgss1-92",
+    "setOrder":43,
+	"id": "hgss1-92",
     "name": "Fisherman",
     "imageUrl": "https://images.pokemontcg.io/hgss1/92.png",
     "subtype": "Supporter",
@@ -4620,7 +4712,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss1/92_hires.png"
   },
   {
-    "id": "hgss1-93",
+    "setOrder":43,
+	"id": "hgss1-93",
     "name": "Full Heal",
     "imageUrl": "https://images.pokemontcg.io/hgss1/93.png",
     "subtype": "Item",
@@ -4637,7 +4730,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss1/93_hires.png"
   },
   {
-    "id": "hgss1-94",
+    "setOrder":43,
+	"id": "hgss1-94",
     "name": "Moomoo Milk",
     "imageUrl": "https://images.pokemontcg.io/hgss1/94.png",
     "subtype": "Item",
@@ -4654,7 +4748,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss1/94_hires.png"
   },
   {
-    "id": "hgss1-95",
+    "setOrder":43,
+	"id": "hgss1-95",
     "name": "Poké Ball",
     "imageUrl": "https://images.pokemontcg.io/hgss1/95.png",
     "subtype": "Item",
@@ -4671,7 +4766,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss1/95_hires.png"
   },
   {
-    "id": "hgss1-96",
+    "setOrder":43,
+	"id": "hgss1-96",
     "name": "Pokégear3.0",
     "imageUrl": "https://images.pokemontcg.io/hgss1/96.png",
     "subtype": "Item",
@@ -4688,7 +4784,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss1/96_hires.png"
   },
   {
-    "id": "hgss1-97",
+    "setOrder":43,
+	"id": "hgss1-97",
     "name": "Pokémon Collector",
     "imageUrl": "https://images.pokemontcg.io/hgss1/97.png",
     "subtype": "Supporter",
@@ -4706,7 +4803,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss1/97_hires.png"
   },
   {
-    "id": "hgss1-98",
+    "setOrder":43,
+	"id": "hgss1-98",
     "name": "Pokémon Communication",
     "imageUrl": "https://images.pokemontcg.io/hgss1/98.png",
     "subtype": "Item",
@@ -4723,7 +4821,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss1/98_hires.png"
   },
   {
-    "id": "hgss1-99",
+    "setOrder":43,
+	"id": "hgss1-99",
     "name": "Pokémon Reversal",
     "imageUrl": "https://images.pokemontcg.io/hgss1/99.png",
     "subtype": "Item",
@@ -4740,7 +4839,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss1/99_hires.png"
   },
   {
-    "id": "hgss1-100",
+    "setOrder":43,
+	"id": "hgss1-100",
     "name": "Professor Elm's Training Method",
     "imageUrl": "https://images.pokemontcg.io/hgss1/100.png",
     "subtype": "Supporter",
@@ -4758,7 +4858,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss1/100_hires.png"
   },
   {
-    "id": "hgss1-101",
+    "setOrder":43,
+	"id": "hgss1-101",
     "name": "Professor Oak's New Theory",
     "imageUrl": "https://images.pokemontcg.io/hgss1/101.png",
     "subtype": "Supporter",
@@ -4776,7 +4877,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss1/101_hires.png"
   },
   {
-    "id": "hgss1-102",
+    "setOrder":43,
+	"id": "hgss1-102",
     "name": "Switch",
     "imageUrl": "https://images.pokemontcg.io/hgss1/102.png",
     "subtype": "Item",
@@ -4793,7 +4895,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss1/102_hires.png"
   },
   {
-    "id": "hgss1-103",
+    "setOrder":43,
+	"id": "hgss1-103",
     "name": "Double Colorless Energy",
     "imageUrl": "https://images.pokemontcg.io/hgss1/103.png",
     "subtype": "Special",
@@ -4810,7 +4913,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss1/103_hires.png"
   },
   {
-    "id": "hgss1-104",
+    "setOrder":43,
+	"id": "hgss1-104",
     "name": "Rainbow Energy",
     "imageUrl": "https://images.pokemontcg.io/hgss1/104.png",
     "subtype": "Special",
@@ -4827,7 +4931,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss1/104_hires.png"
   },
   {
-    "id": "hgss1-105",
+    "setOrder":43,
+	"id": "hgss1-105",
     "name": "Ampharos",
     "imageUrl": "https://images.pokemontcg.io/hgss1/105.png",
     "subtype": "Stage 2",
@@ -4882,7 +4987,8 @@
     "nationalPokedexNumber": 181
   },
   {
-    "id": "hgss1-106",
+    "setOrder":43,
+	"id": "hgss1-106",
     "name": "Blissey",
     "imageUrl": "https://images.pokemontcg.io/hgss1/106.png",
     "subtype": "Stage 1",
@@ -4931,7 +5037,8 @@
     "nationalPokedexNumber": 242
   },
   {
-    "id": "hgss1-107",
+    "setOrder":43,
+	"id": "hgss1-107",
     "name": "Donphan",
     "imageUrl": "https://images.pokemontcg.io/hgss1/107.png",
     "subtype": "Stage 1",
@@ -4997,7 +5104,8 @@
     "nationalPokedexNumber": 232
   },
   {
-    "id": "hgss1-108",
+    "setOrder":43,
+	"id": "hgss1-108",
     "name": "Feraligatr",
     "imageUrl": "https://images.pokemontcg.io/hgss1/108.png",
     "subtype": "Stage 2",
@@ -5048,7 +5156,8 @@
     "nationalPokedexNumber": 160
   },
   {
-    "id": "hgss1-109",
+    "setOrder":43,
+	"id": "hgss1-109",
     "name": "Meganium",
     "imageUrl": "https://images.pokemontcg.io/hgss1/109.png",
     "subtype": "Stage 2",
@@ -5104,7 +5213,8 @@
     "nationalPokedexNumber": 154
   },
   {
-    "id": "hgss1-110",
+    "setOrder":43,
+	"id": "hgss1-110",
     "name": "Typhlosion",
     "imageUrl": "https://images.pokemontcg.io/hgss1/110.png",
     "subtype": "Stage 2",
@@ -5153,7 +5263,8 @@
     "nationalPokedexNumber": 157
   },
   {
-    "id": "hgss1-111",
+    "setOrder":43,
+	"id": "hgss1-111",
     "name": "Ho-Oh LEGEND",
     "imageUrl": "https://images.pokemontcg.io/hgss1/111.png",
     "subtype": "LEGEND",
@@ -5176,7 +5287,8 @@
     "nationalPokedexNumber": 250
   },
   {
-    "id": "hgss1-112",
+    "setOrder":43,
+	"id": "hgss1-112",
     "name": "Ho-Oh LEGEND",
     "imageUrl": "https://images.pokemontcg.io/hgss1/112.png",
     "subtype": "LEGEND",
@@ -5233,7 +5345,8 @@
     "nationalPokedexNumber": 250
   },
   {
-    "id": "hgss1-113",
+    "setOrder":43,
+	"id": "hgss1-113",
     "name": "Lugia LEGEND",
     "imageUrl": "https://images.pokemontcg.io/hgss1/113.png",
     "subtype": "LEGEND",
@@ -5256,7 +5369,8 @@
     "nationalPokedexNumber": 249
   },
   {
-    "id": "hgss1-114",
+    "setOrder":43,
+	"id": "hgss1-114",
     "name": "Lugia LEGEND",
     "imageUrl": "https://images.pokemontcg.io/hgss1/114.png",
     "subtype": "LEGEND",
@@ -5311,7 +5425,8 @@
     "nationalPokedexNumber": 249
   },
   {
-    "id": "hgss1-115",
+    "setOrder":43,
+	"id": "hgss1-115",
     "name": "Grass Energy",
     "imageUrl": "https://images.pokemontcg.io/hgss1/115.png",
     "subtype": "Basic",
@@ -5325,7 +5440,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss1/115_hires.png"
   },
   {
-    "id": "hgss1-116",
+    "setOrder":43,
+	"id": "hgss1-116",
     "name": "Fire Energy",
     "imageUrl": "https://images.pokemontcg.io/hgss1/116.png",
     "subtype": "Basic",
@@ -5339,7 +5455,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss1/116_hires.png"
   },
   {
-    "id": "hgss1-117",
+    "setOrder":43,
+	"id": "hgss1-117",
     "name": "Water Energy",
     "imageUrl": "https://images.pokemontcg.io/hgss1/117.png",
     "subtype": "Basic",
@@ -5353,7 +5470,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss1/117_hires.png"
   },
   {
-    "id": "hgss1-118",
+    "setOrder":43,
+	"id": "hgss1-118",
     "name": "Lightning Energy",
     "imageUrl": "https://images.pokemontcg.io/hgss1/118.png",
     "subtype": "Basic",
@@ -5367,7 +5485,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss1/118_hires.png"
   },
   {
-    "id": "hgss1-119",
+    "setOrder":43,
+	"id": "hgss1-119",
     "name": "Psychic Energy",
     "imageUrl": "https://images.pokemontcg.io/hgss1/119.png",
     "subtype": "Basic",
@@ -5381,7 +5500,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss1/119_hires.png"
   },
   {
-    "id": "hgss1-120",
+    "setOrder":43,
+	"id": "hgss1-120",
     "name": "Fighting Energy",
     "imageUrl": "https://images.pokemontcg.io/hgss1/120.png",
     "subtype": "Basic",
@@ -5395,7 +5515,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss1/120_hires.png"
   },
   {
-    "id": "hgss1-121",
+    "setOrder":43,
+	"id": "hgss1-121",
     "name": "Darkness Energy",
     "imageUrl": "https://images.pokemontcg.io/hgss1/121.png",
     "subtype": "Basic",
@@ -5409,7 +5530,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss1/121_hires.png"
   },
   {
-    "id": "hgss1-122",
+    "setOrder":43,
+	"id": "hgss1-122",
     "name": "Metal Energy",
     "imageUrl": "https://images.pokemontcg.io/hgss1/122.png",
     "subtype": "Basic",
@@ -5423,7 +5545,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/hgss1/122_hires.png"
   },
   {
-    "id": "hgss1-123",
+    "setOrder":43,
+	"id": "hgss1-123",
     "name": "Gyarados",
     "imageUrl": "https://images.pokemontcg.io/hgss1/123.png",
     "subtype": "Stage 1",
@@ -5484,7 +5607,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "hgss1-ONE",
+    "setOrder":43,
+	"id": "hgss1-ONE",
     "name": "Alph Lithograph",
     "imageUrl": "https://images.pokemontcg.io/hgss1/ONE.png",
     "subtype": "Item",

--- a/json/cards/Hidden Legends.json
+++ b/json/cards/Hidden Legends.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "ex5-1",
+    "setOrder":20,
+	"id": "ex5-1",
     "name": "Banette",
     "imageUrl": "https://images.pokemontcg.io/ex5/1.png",
     "subtype": "Stage 1",
@@ -57,7 +58,8 @@
     "nationalPokedexNumber": 354
   },
   {
-    "id": "ex5-2",
+    "setOrder":20,
+	"id": "ex5-2",
     "name": "Claydol",
     "imageUrl": "https://images.pokemontcg.io/ex5/2.png",
     "subtype": "Stage 1",
@@ -103,7 +105,8 @@
     "nationalPokedexNumber": 344
   },
   {
-    "id": "ex5-3",
+    "setOrder":20,
+	"id": "ex5-3",
     "name": "Crobat",
     "imageUrl": "https://images.pokemontcg.io/ex5/3.png",
     "subtype": "Stage 2",
@@ -151,7 +154,8 @@
     "nationalPokedexNumber": 169
   },
   {
-    "id": "ex5-4",
+    "setOrder":20,
+	"id": "ex5-4",
     "name": "Dark Celebi",
     "imageUrl": "https://images.pokemontcg.io/ex5/4.png",
     "subtype": "Basic",
@@ -202,7 +206,8 @@
     "nationalPokedexNumber": 251
   },
   {
-    "id": "ex5-5",
+    "setOrder":20,
+	"id": "ex5-5",
     "name": "Electrode",
     "imageUrl": "https://images.pokemontcg.io/ex5/5.png",
     "subtype": "Stage 1",
@@ -254,7 +259,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "ex5-6",
+    "setOrder":20,
+	"id": "ex5-6",
     "name": "Exploud",
     "imageUrl": "https://images.pokemontcg.io/ex5/6.png",
     "subtype": "Stage 2",
@@ -329,7 +335,8 @@
     "nationalPokedexNumber": 295
   },
   {
-    "id": "ex5-7",
+    "setOrder":20,
+	"id": "ex5-7",
     "name": "Heracross",
     "imageUrl": "https://images.pokemontcg.io/ex5/7.png",
     "subtype": "Basic",
@@ -380,7 +387,8 @@
     "nationalPokedexNumber": 214
   },
   {
-    "id": "ex5-8",
+    "setOrder":20,
+	"id": "ex5-8",
     "name": "Jirachi",
     "imageUrl": "https://images.pokemontcg.io/ex5/8.png",
     "subtype": "Basic",
@@ -431,7 +439,8 @@
     "nationalPokedexNumber": 385
   },
   {
-    "id": "ex5-9",
+    "setOrder":20,
+	"id": "ex5-9",
     "name": "Machamp",
     "imageUrl": "https://images.pokemontcg.io/ex5/9.png",
     "subtype": "Stage 2",
@@ -491,7 +500,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "ex5-10",
+    "setOrder":20,
+	"id": "ex5-10",
     "name": "Medicham",
     "imageUrl": "https://images.pokemontcg.io/ex5/10.png",
     "subtype": "Stage 1",
@@ -544,7 +554,8 @@
     "nationalPokedexNumber": 308
   },
   {
-    "id": "ex5-11",
+    "setOrder":20,
+	"id": "ex5-11",
     "name": "Metagross",
     "imageUrl": "https://images.pokemontcg.io/ex5/11.png",
     "subtype": "Stage 2",
@@ -600,7 +611,8 @@
     "nationalPokedexNumber": 376
   },
   {
-    "id": "ex5-12",
+    "setOrder":20,
+	"id": "ex5-12",
     "name": "Milotic",
     "imageUrl": "https://images.pokemontcg.io/ex5/12.png",
     "subtype": "Stage 1",
@@ -660,7 +672,8 @@
     "nationalPokedexNumber": 350
   },
   {
-    "id": "ex5-13",
+    "setOrder":20,
+	"id": "ex5-13",
     "name": "Pinsir",
     "imageUrl": "https://images.pokemontcg.io/ex5/13.png",
     "subtype": "Basic",
@@ -706,7 +719,8 @@
     "nationalPokedexNumber": 127
   },
   {
-    "id": "ex5-14",
+    "setOrder":20,
+	"id": "ex5-14",
     "name": "Shiftry",
     "imageUrl": "https://images.pokemontcg.io/ex5/14.png",
     "subtype": "Stage 2",
@@ -766,7 +780,8 @@
     "nationalPokedexNumber": 275
   },
   {
-    "id": "ex5-15",
+    "setOrder":20,
+	"id": "ex5-15",
     "name": "Walrein",
     "imageUrl": "https://images.pokemontcg.io/ex5/15.png",
     "subtype": "Stage 2",
@@ -816,7 +831,8 @@
     "nationalPokedexNumber": 365
   },
   {
-    "id": "ex5-16",
+    "setOrder":20,
+	"id": "ex5-16",
     "name": "Bellossom",
     "imageUrl": "https://images.pokemontcg.io/ex5/16.png",
     "subtype": "Stage 2",
@@ -880,7 +896,8 @@
     "nationalPokedexNumber": 182
   },
   {
-    "id": "ex5-17",
+    "setOrder":20,
+	"id": "ex5-17",
     "name": "Chimecho",
     "imageUrl": "https://images.pokemontcg.io/ex5/17.png",
     "subtype": "Basic",
@@ -929,7 +946,8 @@
     "nationalPokedexNumber": 358
   },
   {
-    "id": "ex5-18",
+    "setOrder":20,
+	"id": "ex5-18",
     "name": "Gorebyss",
     "imageUrl": "https://images.pokemontcg.io/ex5/18.png",
     "subtype": "Stage 1",
@@ -977,7 +995,8 @@
     "nationalPokedexNumber": 368
   },
   {
-    "id": "ex5-19",
+    "setOrder":20,
+	"id": "ex5-19",
     "name": "Huntail",
     "imageUrl": "https://images.pokemontcg.io/ex5/19.png",
     "subtype": "Stage 1",
@@ -1030,7 +1049,8 @@
     "nationalPokedexNumber": 367
   },
   {
-    "id": "ex5-20",
+    "setOrder":20,
+	"id": "ex5-20",
     "name": "Masquerain",
     "imageUrl": "https://images.pokemontcg.io/ex5/20.png",
     "subtype": "Stage 1",
@@ -1084,7 +1104,8 @@
     "nationalPokedexNumber": 284
   },
   {
-    "id": "ex5-21",
+    "setOrder":20,
+	"id": "ex5-21",
     "name": "Metang",
     "imageUrl": "https://images.pokemontcg.io/ex5/21.png",
     "subtype": "Stage 1",
@@ -1145,7 +1166,8 @@
     ]
   },
   {
-    "id": "ex5-22",
+    "setOrder":20,
+	"id": "ex5-22",
     "name": "Ninetales",
     "imageUrl": "https://images.pokemontcg.io/ex5/22.png",
     "subtype": "Stage 1",
@@ -1203,7 +1225,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "ex5-23",
+    "setOrder":20,
+	"id": "ex5-23",
     "name": "Rain Castform",
     "imageUrl": "https://images.pokemontcg.io/ex5/23.png",
     "subtype": "Basic",
@@ -1258,7 +1281,8 @@
     "nationalPokedexNumber": 351
   },
   {
-    "id": "ex5-24",
+    "setOrder":20,
+	"id": "ex5-24",
     "name": "Relicanth",
     "imageUrl": "https://images.pokemontcg.io/ex5/24.png",
     "subtype": "Basic",
@@ -1303,7 +1327,8 @@
     "nationalPokedexNumber": 369
   },
   {
-    "id": "ex5-25",
+    "setOrder":20,
+	"id": "ex5-25",
     "name": "Snow-cloud Castform",
     "imageUrl": "https://images.pokemontcg.io/ex5/25.png",
     "subtype": "Basic",
@@ -1361,7 +1386,8 @@
     "nationalPokedexNumber": 351
   },
   {
-    "id": "ex5-26",
+    "setOrder":20,
+	"id": "ex5-26",
     "name": "Sunny Castform",
     "imageUrl": "https://images.pokemontcg.io/ex5/26.png",
     "subtype": "Basic",
@@ -1418,7 +1444,8 @@
     "nationalPokedexNumber": 351
   },
   {
-    "id": "ex5-27",
+    "setOrder":20,
+	"id": "ex5-27",
     "name": "Tropius",
     "imageUrl": "https://images.pokemontcg.io/ex5/27.png",
     "subtype": "Basic",
@@ -1468,7 +1495,8 @@
     "nationalPokedexNumber": 357
   },
   {
-    "id": "ex5-28",
+    "setOrder":20,
+	"id": "ex5-28",
     "name": "Beldum",
     "imageUrl": "https://images.pokemontcg.io/ex5/28.png",
     "subtype": "Basic",
@@ -1523,7 +1551,8 @@
     ]
   },
   {
-    "id": "ex5-29",
+    "setOrder":20,
+	"id": "ex5-29",
     "name": "Beldum",
     "imageUrl": "https://images.pokemontcg.io/ex5/29.png",
     "subtype": "Basic",
@@ -1579,7 +1608,8 @@
     ]
   },
   {
-    "id": "ex5-30",
+    "setOrder":20,
+	"id": "ex5-30",
     "name": "Castform",
     "imageUrl": "https://images.pokemontcg.io/ex5/30.png",
     "subtype": "Basic",
@@ -1634,7 +1664,8 @@
     "nationalPokedexNumber": 351
   },
   {
-    "id": "ex5-31",
+    "setOrder":20,
+	"id": "ex5-31",
     "name": "Claydol",
     "imageUrl": "https://images.pokemontcg.io/ex5/31.png",
     "subtype": "Stage 1",
@@ -1687,7 +1718,8 @@
     "nationalPokedexNumber": 344
   },
   {
-    "id": "ex5-32",
+    "setOrder":20,
+	"id": "ex5-32",
     "name": "Corsola",
     "imageUrl": "https://images.pokemontcg.io/ex5/32.png",
     "subtype": "Basic",
@@ -1738,7 +1770,8 @@
     "nationalPokedexNumber": 222
   },
   {
-    "id": "ex5-33",
+    "setOrder":20,
+	"id": "ex5-33",
     "name": "Dodrio",
     "imageUrl": "https://images.pokemontcg.io/ex5/33.png",
     "subtype": "Stage 1",
@@ -1798,7 +1831,8 @@
     "nationalPokedexNumber": 85
   },
   {
-    "id": "ex5-34",
+    "setOrder":20,
+	"id": "ex5-34",
     "name": "Glalie",
     "imageUrl": "https://images.pokemontcg.io/ex5/34.png",
     "subtype": "Stage 1",
@@ -1846,7 +1880,8 @@
     "nationalPokedexNumber": 362
   },
   {
-    "id": "ex5-35",
+    "setOrder":20,
+	"id": "ex5-35",
     "name": "Gloom",
     "imageUrl": "https://images.pokemontcg.io/ex5/35.png",
     "subtype": "Stage 1",
@@ -1903,7 +1938,8 @@
     ]
   },
   {
-    "id": "ex5-36",
+    "setOrder":20,
+	"id": "ex5-36",
     "name": "Golbat",
     "imageUrl": "https://images.pokemontcg.io/ex5/36.png",
     "subtype": "Stage 1",
@@ -1957,7 +1993,8 @@
     ]
   },
   {
-    "id": "ex5-37",
+    "setOrder":20,
+	"id": "ex5-37",
     "name": "Igglybuff",
     "imageUrl": "https://images.pokemontcg.io/ex5/37.png",
     "subtype": "Basic",
@@ -2005,7 +2042,8 @@
     ]
   },
   {
-    "id": "ex5-38",
+    "setOrder":20,
+	"id": "ex5-38",
     "name": "Lanturn",
     "imageUrl": "https://images.pokemontcg.io/ex5/38.png",
     "subtype": "Stage 1",
@@ -2054,7 +2092,8 @@
     "nationalPokedexNumber": 171
   },
   {
-    "id": "ex5-39",
+    "setOrder":20,
+	"id": "ex5-39",
     "name": "Loudred",
     "imageUrl": "https://images.pokemontcg.io/ex5/39.png",
     "subtype": "Stage 2",
@@ -2111,7 +2150,8 @@
     ]
   },
   {
-    "id": "ex5-40",
+    "setOrder":20,
+	"id": "ex5-40",
     "name": "Luvdisc",
     "imageUrl": "https://images.pokemontcg.io/ex5/40.png",
     "subtype": "Basic",
@@ -2160,7 +2200,8 @@
     "nationalPokedexNumber": 370
   },
   {
-    "id": "ex5-41",
+    "setOrder":20,
+	"id": "ex5-41",
     "name": "Machoke",
     "imageUrl": "https://images.pokemontcg.io/ex5/41.png",
     "subtype": "Stage 1",
@@ -2210,7 +2251,8 @@
     ]
   },
   {
-    "id": "ex5-42",
+    "setOrder":20,
+	"id": "ex5-42",
     "name": "Medicham",
     "imageUrl": "https://images.pokemontcg.io/ex5/42.png",
     "subtype": "Stage 1",
@@ -2261,7 +2303,8 @@
     "nationalPokedexNumber": 308
   },
   {
-    "id": "ex5-43",
+    "setOrder":20,
+	"id": "ex5-43",
     "name": "Metang",
     "imageUrl": "https://images.pokemontcg.io/ex5/43.png",
     "subtype": "Stage 1",
@@ -2318,7 +2361,8 @@
     ]
   },
   {
-    "id": "ex5-44",
+    "setOrder":20,
+	"id": "ex5-44",
     "name": "Metang",
     "imageUrl": "https://images.pokemontcg.io/ex5/44.png",
     "subtype": "Stage 1",
@@ -2375,7 +2419,8 @@
     ]
   },
   {
-    "id": "ex5-45",
+    "setOrder":20,
+	"id": "ex5-45",
     "name": "Nuzleaf",
     "imageUrl": "https://images.pokemontcg.io/ex5/45.png",
     "subtype": "Stage 1",
@@ -2436,7 +2481,8 @@
     ]
   },
   {
-    "id": "ex5-46",
+    "setOrder":20,
+	"id": "ex5-46",
     "name": "Rhydon",
     "imageUrl": "https://images.pokemontcg.io/ex5/46.png",
     "subtype": "Stage 1",
@@ -2497,7 +2543,8 @@
     ]
   },
   {
-    "id": "ex5-47",
+    "setOrder":20,
+	"id": "ex5-47",
     "name": "Sealeo",
     "imageUrl": "https://images.pokemontcg.io/ex5/47.png",
     "subtype": "Stage 1",
@@ -2552,7 +2599,8 @@
     ]
   },
   {
-    "id": "ex5-48",
+    "setOrder":20,
+	"id": "ex5-48",
     "name": "Spinda",
     "imageUrl": "https://images.pokemontcg.io/ex5/48.png",
     "subtype": "Basic",
@@ -2601,7 +2649,8 @@
     "nationalPokedexNumber": 327
   },
   {
-    "id": "ex5-49",
+    "setOrder":20,
+	"id": "ex5-49",
     "name": "Starmie",
     "imageUrl": "https://images.pokemontcg.io/ex5/49.png",
     "subtype": "Stage 1",
@@ -2653,7 +2702,8 @@
     "nationalPokedexNumber": 121
   },
   {
-    "id": "ex5-50",
+    "setOrder":20,
+	"id": "ex5-50",
     "name": "Swalot",
     "imageUrl": "https://images.pokemontcg.io/ex5/50.png",
     "subtype": "Stage 1",
@@ -2706,7 +2756,8 @@
     "nationalPokedexNumber": 317
   },
   {
-    "id": "ex5-51",
+    "setOrder":20,
+	"id": "ex5-51",
     "name": "Tentacruel",
     "imageUrl": "https://images.pokemontcg.io/ex5/51.png",
     "subtype": "Stage 1",
@@ -2754,7 +2805,8 @@
     "nationalPokedexNumber": 73
   },
   {
-    "id": "ex5-52",
+    "setOrder":20,
+	"id": "ex5-52",
     "name": "Baltoy",
     "imageUrl": "https://images.pokemontcg.io/ex5/52.png",
     "subtype": "Basic",
@@ -2797,7 +2849,8 @@
     ]
   },
   {
-    "id": "ex5-53",
+    "setOrder":20,
+	"id": "ex5-53",
     "name": "Baltoy",
     "imageUrl": "https://images.pokemontcg.io/ex5/53.png",
     "subtype": "Basic",
@@ -2849,7 +2902,8 @@
     ]
   },
   {
-    "id": "ex5-54",
+    "setOrder":20,
+	"id": "ex5-54",
     "name": "Beldum",
     "imageUrl": "https://images.pokemontcg.io/ex5/54.png",
     "subtype": "Basic",
@@ -2901,7 +2955,8 @@
     ]
   },
   {
-    "id": "ex5-55",
+    "setOrder":20,
+	"id": "ex5-55",
     "name": "Chikorita",
     "imageUrl": "https://images.pokemontcg.io/ex5/55.png",
     "subtype": "Basic",
@@ -2950,7 +3005,8 @@
     ]
   },
   {
-    "id": "ex5-56",
+    "setOrder":20,
+	"id": "ex5-56",
     "name": "Chinchou",
     "imageUrl": "https://images.pokemontcg.io/ex5/56.png",
     "subtype": "Basic",
@@ -3003,7 +3059,8 @@
     ]
   },
   {
-    "id": "ex5-57",
+    "setOrder":20,
+	"id": "ex5-57",
     "name": "Chinchou",
     "imageUrl": "https://images.pokemontcg.io/ex5/57.png",
     "subtype": "Basic",
@@ -3056,7 +3113,8 @@
     ]
   },
   {
-    "id": "ex5-58",
+    "setOrder":20,
+	"id": "ex5-58",
     "name": "Clamperl",
     "imageUrl": "https://images.pokemontcg.io/ex5/58.png",
     "subtype": "Basic",
@@ -3106,7 +3164,8 @@
     ]
   },
   {
-    "id": "ex5-59",
+    "setOrder":20,
+	"id": "ex5-59",
     "name": "Cyndaquil",
     "imageUrl": "https://images.pokemontcg.io/ex5/59.png",
     "subtype": "Basic",
@@ -3159,7 +3218,8 @@
     ]
   },
   {
-    "id": "ex5-60",
+    "setOrder":20,
+	"id": "ex5-60",
     "name": "Doduo",
     "imageUrl": "https://images.pokemontcg.io/ex5/60.png",
     "subtype": "Basic",
@@ -3208,7 +3268,8 @@
     ]
   },
   {
-    "id": "ex5-61",
+    "setOrder":20,
+	"id": "ex5-61",
     "name": "Feebas",
     "imageUrl": "https://images.pokemontcg.io/ex5/61.png",
     "subtype": "Basic",
@@ -3260,7 +3321,8 @@
     ]
   },
   {
-    "id": "ex5-62",
+    "setOrder":20,
+	"id": "ex5-62",
     "name": "Gulpin",
     "imageUrl": "https://images.pokemontcg.io/ex5/62.png",
     "subtype": "Basic",
@@ -3312,7 +3374,8 @@
     ]
   },
   {
-    "id": "ex5-63",
+    "setOrder":20,
+	"id": "ex5-63",
     "name": "Jigglypuff",
     "imageUrl": "https://images.pokemontcg.io/ex5/63.png",
     "subtype": "Basic",
@@ -3365,7 +3428,8 @@
     ]
   },
   {
-    "id": "ex5-64",
+    "setOrder":20,
+	"id": "ex5-64",
     "name": "Machop",
     "imageUrl": "https://images.pokemontcg.io/ex5/64.png",
     "subtype": "Basic",
@@ -3418,7 +3482,8 @@
     ]
   },
   {
-    "id": "ex5-65",
+    "setOrder":20,
+	"id": "ex5-65",
     "name": "Meditite",
     "imageUrl": "https://images.pokemontcg.io/ex5/65.png",
     "subtype": "Basic",
@@ -3470,7 +3535,8 @@
     ]
   },
   {
-    "id": "ex5-66",
+    "setOrder":20,
+	"id": "ex5-66",
     "name": "Meditite",
     "imageUrl": "https://images.pokemontcg.io/ex5/66.png",
     "subtype": "Basic",
@@ -3523,7 +3589,8 @@
     ]
   },
   {
-    "id": "ex5-67",
+    "setOrder":20,
+	"id": "ex5-67",
     "name": "Minun",
     "imageUrl": "https://images.pokemontcg.io/ex5/67.png",
     "subtype": "Basic",
@@ -3579,7 +3646,8 @@
     "nationalPokedexNumber": 312
   },
   {
-    "id": "ex5-68",
+    "setOrder":20,
+	"id": "ex5-68",
     "name": "Oddish",
     "imageUrl": "https://images.pokemontcg.io/ex5/68.png",
     "subtype": "Basic",
@@ -3631,7 +3699,8 @@
     ]
   },
   {
-    "id": "ex5-69",
+    "setOrder":20,
+	"id": "ex5-69",
     "name": "Plusle",
     "imageUrl": "https://images.pokemontcg.io/ex5/69.png",
     "subtype": "Basic",
@@ -3687,7 +3756,8 @@
     "nationalPokedexNumber": 311
   },
   {
-    "id": "ex5-70",
+    "setOrder":20,
+	"id": "ex5-70",
     "name": "Rhyhorn",
     "imageUrl": "https://images.pokemontcg.io/ex5/70.png",
     "subtype": "Basic",
@@ -3741,7 +3811,8 @@
     ]
   },
   {
-    "id": "ex5-71",
+    "setOrder":20,
+	"id": "ex5-71",
     "name": "Seedot",
     "imageUrl": "https://images.pokemontcg.io/ex5/71.png",
     "subtype": "Basic",
@@ -3794,7 +3865,8 @@
     ]
   },
   {
-    "id": "ex5-72",
+    "setOrder":20,
+	"id": "ex5-72",
     "name": "Shuppet",
     "imageUrl": "https://images.pokemontcg.io/ex5/72.png",
     "subtype": "Basic",
@@ -3843,7 +3915,8 @@
     ]
   },
   {
-    "id": "ex5-73",
+    "setOrder":20,
+	"id": "ex5-73",
     "name": "Snorunt",
     "imageUrl": "https://images.pokemontcg.io/ex5/73.png",
     "subtype": "Basic",
@@ -3897,7 +3970,8 @@
     ]
   },
   {
-    "id": "ex5-74",
+    "setOrder":20,
+	"id": "ex5-74",
     "name": "Spheal",
     "imageUrl": "https://images.pokemontcg.io/ex5/74.png",
     "subtype": "Basic",
@@ -3940,7 +4014,8 @@
     ]
   },
   {
-    "id": "ex5-75",
+    "setOrder":20,
+	"id": "ex5-75",
     "name": "Staryu",
     "imageUrl": "https://images.pokemontcg.io/ex5/75.png",
     "subtype": "Basic",
@@ -3988,7 +4063,8 @@
     ]
   },
   {
-    "id": "ex5-76",
+    "setOrder":20,
+	"id": "ex5-76",
     "name": "Surskit",
     "imageUrl": "https://images.pokemontcg.io/ex5/76.png",
     "subtype": "Basic",
@@ -4031,7 +4107,8 @@
     ]
   },
   {
-    "id": "ex5-77",
+    "setOrder":20,
+	"id": "ex5-77",
     "name": "Tentacool",
     "imageUrl": "https://images.pokemontcg.io/ex5/77.png",
     "subtype": "Basic",
@@ -4079,7 +4156,8 @@
     ]
   },
   {
-    "id": "ex5-78",
+    "setOrder":20,
+	"id": "ex5-78",
     "name": "Togepi",
     "imageUrl": "https://images.pokemontcg.io/ex5/78.png",
     "subtype": "Basic",
@@ -4122,7 +4200,8 @@
     ]
   },
   {
-    "id": "ex5-79",
+    "setOrder":20,
+	"id": "ex5-79",
     "name": "Totodile",
     "imageUrl": "https://images.pokemontcg.io/ex5/79.png",
     "subtype": "Basic",
@@ -4175,7 +4254,8 @@
     ]
   },
   {
-    "id": "ex5-80",
+    "setOrder":20,
+	"id": "ex5-80",
     "name": "Voltorb",
     "imageUrl": "https://images.pokemontcg.io/ex5/80.png",
     "subtype": "Basic",
@@ -4228,7 +4308,8 @@
     ]
   },
   {
-    "id": "ex5-81",
+    "setOrder":20,
+	"id": "ex5-81",
     "name": "Vulpix",
     "imageUrl": "https://images.pokemontcg.io/ex5/81.png",
     "subtype": "Basic",
@@ -4280,7 +4361,8 @@
     ]
   },
   {
-    "id": "ex5-82",
+    "setOrder":20,
+	"id": "ex5-82",
     "name": "Whismur",
     "imageUrl": "https://images.pokemontcg.io/ex5/82.png",
     "subtype": "Basic",
@@ -4323,7 +4405,8 @@
     ]
   },
   {
-    "id": "ex5-83",
+    "setOrder":20,
+	"id": "ex5-83",
     "name": "Zubat",
     "imageUrl": "https://images.pokemontcg.io/ex5/83.png",
     "subtype": "Basic",
@@ -4375,7 +4458,8 @@
     ]
   },
   {
-    "id": "ex5-84",
+    "setOrder":20,
+	"id": "ex5-84",
     "name": "Ancient Technical Machine (Ice)",
     "imageUrl": "https://images.pokemontcg.io/ex5/84.png",
     "subtype": "Pokémon Tool",
@@ -4393,7 +4477,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex5/84_hires.png"
   },
   {
-    "id": "ex5-85",
+    "setOrder":20,
+	"id": "ex5-85",
     "name": "Ancient Technical Machine (Rock)",
     "imageUrl": "https://images.pokemontcg.io/ex5/85.png",
     "subtype": "Pokémon Tool",
@@ -4411,7 +4496,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex5/85_hires.png"
   },
   {
-    "id": "ex5-86",
+    "setOrder":20,
+	"id": "ex5-86",
     "name": "Ancient Technical Machine (Steel)",
     "imageUrl": "https://images.pokemontcg.io/ex5/86.png",
     "subtype": "Pokémon Tool",
@@ -4429,7 +4515,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex5/86_hires.png"
   },
   {
-    "id": "ex5-87",
+    "setOrder":20,
+	"id": "ex5-87",
     "name": "Ancient Tomb",
     "imageUrl": "https://images.pokemontcg.io/ex5/87.png",
     "subtype": "Stadium",
@@ -4448,7 +4535,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex5/87_hires.png"
   },
   {
-    "id": "ex5-88",
+    "setOrder":20,
+	"id": "ex5-88",
     "name": "Desert Ruins",
     "imageUrl": "https://images.pokemontcg.io/ex5/88.png",
     "subtype": "Stadium",
@@ -4467,7 +4555,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex5/88_hires.png"
   },
   {
-    "id": "ex5-89",
+    "setOrder":20,
+	"id": "ex5-89",
     "name": "Island Cave",
     "imageUrl": "https://images.pokemontcg.io/ex5/89.png",
     "subtype": "Stadium",
@@ -4486,7 +4575,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex5/89_hires.png"
   },
   {
-    "id": "ex5-90",
+    "setOrder":20,
+	"id": "ex5-90",
     "name": "Life Herb",
     "imageUrl": "https://images.pokemontcg.io/ex5/90.png",
     "subtype": "Item",
@@ -4504,7 +4594,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex5/90_hires.png"
   },
   {
-    "id": "ex5-91",
+    "setOrder":20,
+	"id": "ex5-91",
     "name": "Magnetic Storm",
     "imageUrl": "https://images.pokemontcg.io/ex5/91.png",
     "subtype": "Stadium",
@@ -4523,7 +4614,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex5/91_hires.png"
   },
   {
-    "id": "ex5-92",
+    "setOrder":20,
+	"id": "ex5-92",
     "name": "Steven's Advice",
     "imageUrl": "https://images.pokemontcg.io/ex5/92.png",
     "subtype": "Supporter",
@@ -4542,7 +4634,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex5/92_hires.png"
   },
   {
-    "id": "ex5-93",
+    "setOrder":20,
+	"id": "ex5-93",
     "name": "Groudon ex",
     "imageUrl": "https://images.pokemontcg.io/ex5/93.png",
     "subtype": "EX",
@@ -4602,7 +4695,8 @@
     "nationalPokedexNumber": 383
   },
   {
-    "id": "ex5-94",
+    "setOrder":20,
+	"id": "ex5-94",
     "name": "Kyogre ex",
     "imageUrl": "https://images.pokemontcg.io/ex5/94.png",
     "subtype": "EX",
@@ -4662,7 +4756,8 @@
     "nationalPokedexNumber": 382
   },
   {
-    "id": "ex5-95",
+    "setOrder":20,
+	"id": "ex5-95",
     "name": "Metagross ex",
     "imageUrl": "https://images.pokemontcg.io/ex5/95.png",
     "subtype": "EX",
@@ -4730,7 +4825,8 @@
     "nationalPokedexNumber": 376
   },
   {
-    "id": "ex5-96",
+    "setOrder":20,
+	"id": "ex5-96",
     "name": "Ninetales ex",
     "imageUrl": "https://images.pokemontcg.io/ex5/96.png",
     "subtype": "EX",
@@ -4784,7 +4880,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "ex5-97",
+    "setOrder":20,
+	"id": "ex5-97",
     "name": "Regice ex",
     "imageUrl": "https://images.pokemontcg.io/ex5/97.png",
     "subtype": "EX",
@@ -4833,7 +4930,8 @@
     "nationalPokedexNumber": 378
   },
   {
-    "id": "ex5-98",
+    "setOrder":20,
+	"id": "ex5-98",
     "name": "Regirock ex",
     "imageUrl": "https://images.pokemontcg.io/ex5/98.png",
     "subtype": "EX",
@@ -4883,7 +4981,8 @@
     "nationalPokedexNumber": 377
   },
   {
-    "id": "ex5-99",
+    "setOrder":20,
+	"id": "ex5-99",
     "name": "Registeel ex",
     "imageUrl": "https://images.pokemontcg.io/ex5/99.png",
     "subtype": "EX",
@@ -4938,7 +5037,8 @@
     "nationalPokedexNumber": 379
   },
   {
-    "id": "ex5-100",
+    "setOrder":20,
+	"id": "ex5-100",
     "name": "Vileplume ex",
     "imageUrl": "https://images.pokemontcg.io/ex5/100.png",
     "subtype": "EX",
@@ -4988,7 +5088,8 @@
     "nationalPokedexNumber": 45
   },
   {
-    "id": "ex5-101",
+    "setOrder":20,
+	"id": "ex5-101",
     "name": "Wigglytuff ex",
     "imageUrl": "https://images.pokemontcg.io/ex5/101.png",
     "subtype": "EX",

--- a/json/cards/Holon Phantoms.json
+++ b/json/cards/Holon Phantoms.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "ex13-1",
+    "setOrder":28,
+	"id": "ex13-1",
     "name": "Armaldo δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/1.png",
     "subtype": "Stage 2",
@@ -56,7 +57,8 @@
     "nationalPokedexNumber": 348
   },
   {
-    "id": "ex13-2",
+    "setOrder":28,
+	"id": "ex13-2",
     "name": "Cradily δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/2.png",
     "subtype": "Stage 2",
@@ -111,7 +113,8 @@
     "nationalPokedexNumber": 346
   },
   {
-    "id": "ex13-3",
+    "setOrder":28,
+	"id": "ex13-3",
     "name": "Deoxys δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/3.png",
     "subtype": "Basic",
@@ -158,7 +161,8 @@
     "nationalPokedexNumber": 386
   },
   {
-    "id": "ex13-4",
+    "setOrder":28,
+	"id": "ex13-4",
     "name": "Deoxys δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/4.png",
     "subtype": "Basic",
@@ -205,7 +209,8 @@
     "nationalPokedexNumber": 386
   },
   {
-    "id": "ex13-5",
+    "setOrder":28,
+	"id": "ex13-5",
     "name": "Deoxys δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/5.png",
     "subtype": "Basic",
@@ -251,7 +256,8 @@
     "nationalPokedexNumber": 386
   },
   {
-    "id": "ex13-6",
+    "setOrder":28,
+	"id": "ex13-6",
     "name": "Deoxys δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/6.png",
     "subtype": "Basic",
@@ -296,7 +302,8 @@
     "nationalPokedexNumber": 386
   },
   {
-    "id": "ex13-7",
+    "setOrder":28,
+	"id": "ex13-7",
     "name": "Flygon δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/7.png",
     "subtype": "Stage 2",
@@ -356,7 +363,8 @@
     "nationalPokedexNumber": 330
   },
   {
-    "id": "ex13-8",
+    "setOrder":28,
+	"id": "ex13-8",
     "name": "Gyarados δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/8.png",
     "subtype": "Stage 1",
@@ -418,7 +426,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "ex13-9",
+    "setOrder":28,
+	"id": "ex13-9",
     "name": "Kabutops δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/9.png",
     "subtype": "Stage 2",
@@ -471,7 +480,8 @@
     "nationalPokedexNumber": 141
   },
   {
-    "id": "ex13-10",
+    "setOrder":28,
+	"id": "ex13-10",
     "name": "Kingdra δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/10.png",
     "subtype": "Stage 2",
@@ -532,7 +542,8 @@
     "nationalPokedexNumber": 230
   },
   {
-    "id": "ex13-11",
+    "setOrder":28,
+	"id": "ex13-11",
     "name": "Latias δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/11.png",
     "subtype": "Basic",
@@ -598,7 +609,8 @@
     "nationalPokedexNumber": 380
   },
   {
-    "id": "ex13-12",
+    "setOrder":28,
+	"id": "ex13-12",
     "name": "Latios δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/12.png",
     "subtype": "Basic",
@@ -664,7 +676,8 @@
     "nationalPokedexNumber": 381
   },
   {
-    "id": "ex13-13",
+    "setOrder":28,
+	"id": "ex13-13",
     "name": "Omastar δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/13.png",
     "subtype": "Stage 2",
@@ -718,7 +731,8 @@
     "nationalPokedexNumber": 139
   },
   {
-    "id": "ex13-14",
+    "setOrder":28,
+	"id": "ex13-14",
     "name": "Pidgeot δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/14.png",
     "subtype": "Stage 2",
@@ -773,7 +787,8 @@
     "nationalPokedexNumber": 18
   },
   {
-    "id": "ex13-15",
+    "setOrder":28,
+	"id": "ex13-15",
     "name": "Raichu δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/15.png",
     "subtype": "Stage 1",
@@ -822,7 +837,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "ex13-16",
+    "setOrder":28,
+	"id": "ex13-16",
     "name": "Rayquaza δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/16.png",
     "subtype": "Basic",
@@ -891,7 +907,8 @@
     "nationalPokedexNumber": 384
   },
   {
-    "id": "ex13-17",
+    "setOrder":28,
+	"id": "ex13-17",
     "name": "Vileplume δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/17.png",
     "subtype": "Stage 2",
@@ -939,7 +956,8 @@
     "nationalPokedexNumber": 45
   },
   {
-    "id": "ex13-18",
+    "setOrder":28,
+	"id": "ex13-18",
     "name": "Absol",
     "imageUrl": "https://images.pokemontcg.io/ex13/18.png",
     "subtype": "Basic",
@@ -995,7 +1013,8 @@
     "nationalPokedexNumber": 359
   },
   {
-    "id": "ex13-19",
+    "setOrder":28,
+	"id": "ex13-19",
     "name": "Bellossom δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/19.png",
     "subtype": "Stage 2",
@@ -1048,7 +1067,8 @@
     "nationalPokedexNumber": 182
   },
   {
-    "id": "ex13-20",
+    "setOrder":28,
+	"id": "ex13-20",
     "name": "Blaziken",
     "imageUrl": "https://images.pokemontcg.io/ex13/20.png",
     "subtype": "Stage 2",
@@ -1101,7 +1121,8 @@
     "nationalPokedexNumber": 257
   },
   {
-    "id": "ex13-21",
+    "setOrder":28,
+	"id": "ex13-21",
     "name": "Latias δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/21.png",
     "subtype": "Basic",
@@ -1163,7 +1184,8 @@
     "nationalPokedexNumber": 380
   },
   {
-    "id": "ex13-22",
+    "setOrder":28,
+	"id": "ex13-22",
     "name": "Latios δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/22.png",
     "subtype": "Basic",
@@ -1226,7 +1248,8 @@
     "nationalPokedexNumber": 381
   },
   {
-    "id": "ex13-23",
+    "setOrder":28,
+	"id": "ex13-23",
     "name": "Mawile",
     "imageUrl": "https://images.pokemontcg.io/ex13/23.png",
     "subtype": "Basic",
@@ -1282,7 +1305,8 @@
     "nationalPokedexNumber": 303
   },
   {
-    "id": "ex13-24",
+    "setOrder":28,
+	"id": "ex13-24",
     "name": "Mewtwo δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/24.png",
     "subtype": "Basic",
@@ -1333,7 +1357,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "ex13-25",
+    "setOrder":28,
+	"id": "ex13-25",
     "name": "Nosepass",
     "imageUrl": "https://images.pokemontcg.io/ex13/25.png",
     "subtype": "Basic",
@@ -1386,7 +1411,8 @@
     ]
   },
   {
-    "id": "ex13-26",
+    "setOrder":28,
+	"id": "ex13-26",
     "name": "Rayquaza δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/26.png",
     "subtype": "Basic",
@@ -1439,7 +1465,8 @@
     "nationalPokedexNumber": 384
   },
   {
-    "id": "ex13-27",
+    "setOrder":28,
+	"id": "ex13-27",
     "name": "Regice",
     "imageUrl": "https://images.pokemontcg.io/ex13/27.png",
     "subtype": "Basic",
@@ -1487,7 +1514,8 @@
     "nationalPokedexNumber": 378
   },
   {
-    "id": "ex13-28",
+    "setOrder":28,
+	"id": "ex13-28",
     "name": "Regirock",
     "imageUrl": "https://images.pokemontcg.io/ex13/28.png",
     "subtype": "Basic",
@@ -1535,7 +1563,8 @@
     "nationalPokedexNumber": 377
   },
   {
-    "id": "ex13-29",
+    "setOrder":28,
+	"id": "ex13-29",
     "name": "Registeel",
     "imageUrl": "https://images.pokemontcg.io/ex13/29.png",
     "subtype": "Basic",
@@ -1589,7 +1618,8 @@
     "nationalPokedexNumber": 379
   },
   {
-    "id": "ex13-30",
+    "setOrder":28,
+	"id": "ex13-30",
     "name": "Relicanth",
     "imageUrl": "https://images.pokemontcg.io/ex13/30.png",
     "subtype": "Basic",
@@ -1635,7 +1665,8 @@
     "nationalPokedexNumber": 369
   },
   {
-    "id": "ex13-31",
+    "setOrder":28,
+	"id": "ex13-31",
     "name": "Sableye",
     "imageUrl": "https://images.pokemontcg.io/ex13/31.png",
     "subtype": "Basic",
@@ -1685,7 +1716,8 @@
     "nationalPokedexNumber": 302
   },
   {
-    "id": "ex13-32",
+    "setOrder":28,
+	"id": "ex13-32",
     "name": "Seviper",
     "imageUrl": "https://images.pokemontcg.io/ex13/32.png",
     "subtype": "Basic",
@@ -1736,7 +1768,8 @@
     "nationalPokedexNumber": 336
   },
   {
-    "id": "ex13-33",
+    "setOrder":28,
+	"id": "ex13-33",
     "name": "Torkoal",
     "imageUrl": "https://images.pokemontcg.io/ex13/33.png",
     "subtype": "Basic",
@@ -1788,7 +1821,8 @@
     "nationalPokedexNumber": 324
   },
   {
-    "id": "ex13-34",
+    "setOrder":28,
+	"id": "ex13-34",
     "name": "Zangoose",
     "imageUrl": "https://images.pokemontcg.io/ex13/34.png",
     "subtype": "Basic",
@@ -1838,7 +1872,8 @@
     "nationalPokedexNumber": 335
   },
   {
-    "id": "ex13-35",
+    "setOrder":28,
+	"id": "ex13-35",
     "name": "Aerodactyl δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/35.png",
     "subtype": "Stage 1",
@@ -1888,7 +1923,8 @@
     "nationalPokedexNumber": 142
   },
   {
-    "id": "ex13-36",
+    "setOrder":28,
+	"id": "ex13-36",
     "name": "Camerupt",
     "imageUrl": "https://images.pokemontcg.io/ex13/36.png",
     "subtype": "Stage 1",
@@ -1942,7 +1978,8 @@
     "nationalPokedexNumber": 323
   },
   {
-    "id": "ex13-37",
+    "setOrder":28,
+	"id": "ex13-37",
     "name": "Chimecho δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/37.png",
     "subtype": "Basic",
@@ -1988,7 +2025,8 @@
     "nationalPokedexNumber": 358
   },
   {
-    "id": "ex13-38",
+    "setOrder":28,
+	"id": "ex13-38",
     "name": "Claydol",
     "imageUrl": "https://images.pokemontcg.io/ex13/38.png",
     "subtype": "Stage 1",
@@ -2040,7 +2078,8 @@
     "nationalPokedexNumber": 344
   },
   {
-    "id": "ex13-39",
+    "setOrder":28,
+	"id": "ex13-39",
     "name": "Combusken",
     "imageUrl": "https://images.pokemontcg.io/ex13/39.png",
     "subtype": "Stage 1",
@@ -2096,7 +2135,8 @@
     ]
   },
   {
-    "id": "ex13-40",
+    "setOrder":28,
+	"id": "ex13-40",
     "name": "Donphan",
     "imageUrl": "https://images.pokemontcg.io/ex13/40.png",
     "subtype": "Stage 1",
@@ -2148,7 +2188,8 @@
     "nationalPokedexNumber": 232
   },
   {
-    "id": "ex13-41",
+    "setOrder":28,
+	"id": "ex13-41",
     "name": "Exeggutor δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/41.png",
     "subtype": "Stage 1",
@@ -2201,7 +2242,8 @@
     "nationalPokedexNumber": 103
   },
   {
-    "id": "ex13-42",
+    "setOrder":28,
+	"id": "ex13-42",
     "name": "Gloom δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/42.png",
     "subtype": "Stage 1",
@@ -2256,7 +2298,8 @@
     ]
   },
   {
-    "id": "ex13-43",
+    "setOrder":28,
+	"id": "ex13-43",
     "name": "Golduck δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/43.png",
     "subtype": "Stage 1",
@@ -2303,7 +2346,8 @@
     "nationalPokedexNumber": 55
   },
   {
-    "id": "ex13-44",
+    "setOrder":28,
+	"id": "ex13-44",
     "name": "Holon's Castform",
     "imageUrl": "https://images.pokemontcg.io/ex13/44.png",
     "subtype": "Basic",
@@ -2346,7 +2390,8 @@
     "nationalPokedexNumber": 351
   },
   {
-    "id": "ex13-45",
+    "setOrder":28,
+	"id": "ex13-45",
     "name": "Lairon",
     "imageUrl": "https://images.pokemontcg.io/ex13/45.png",
     "subtype": "Stage 1",
@@ -2409,7 +2454,8 @@
     ]
   },
   {
-    "id": "ex13-46",
+    "setOrder":28,
+	"id": "ex13-46",
     "name": "Manectric",
     "imageUrl": "https://images.pokemontcg.io/ex13/46.png",
     "subtype": "Stage 1",
@@ -2467,7 +2513,8 @@
     "nationalPokedexNumber": 310
   },
   {
-    "id": "ex13-47",
+    "setOrder":28,
+	"id": "ex13-47",
     "name": "Masquerain",
     "imageUrl": "https://images.pokemontcg.io/ex13/47.png",
     "subtype": "Stage 1",
@@ -2515,7 +2562,8 @@
     "nationalPokedexNumber": 284
   },
   {
-    "id": "ex13-48",
+    "setOrder":28,
+	"id": "ex13-48",
     "name": "Persian δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/48.png",
     "subtype": "Stage 1",
@@ -2565,7 +2613,8 @@
     "nationalPokedexNumber": 53
   },
   {
-    "id": "ex13-49",
+    "setOrder":28,
+	"id": "ex13-49",
     "name": "Pidgeotto δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/49.png",
     "subtype": "Stage 1",
@@ -2616,7 +2665,8 @@
     ]
   },
   {
-    "id": "ex13-50",
+    "setOrder":28,
+	"id": "ex13-50",
     "name": "Primeape δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/50.png",
     "subtype": "Stage 1",
@@ -2666,7 +2716,8 @@
     "nationalPokedexNumber": 57
   },
   {
-    "id": "ex13-51",
+    "setOrder":28,
+	"id": "ex13-51",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/ex13/51.png",
     "subtype": "Stage 1",
@@ -2719,7 +2770,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "ex13-52",
+    "setOrder":28,
+	"id": "ex13-52",
     "name": "Seadra δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/52.png",
     "subtype": "Stage 1",
@@ -2775,7 +2827,8 @@
     ]
   },
   {
-    "id": "ex13-53",
+    "setOrder":28,
+	"id": "ex13-53",
     "name": "Sharpedo δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/53.png",
     "subtype": "Stage 1",
@@ -2825,7 +2878,8 @@
     "nationalPokedexNumber": 319
   },
   {
-    "id": "ex13-54",
+    "setOrder":28,
+	"id": "ex13-54",
     "name": "Vibrava δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/54.png",
     "subtype": "Stage 1",
@@ -2891,7 +2945,8 @@
     ]
   },
   {
-    "id": "ex13-55",
+    "setOrder":28,
+	"id": "ex13-55",
     "name": "Whiscash",
     "imageUrl": "https://images.pokemontcg.io/ex13/55.png",
     "subtype": "Stage 1",
@@ -2943,7 +2998,8 @@
     "nationalPokedexNumber": 340
   },
   {
-    "id": "ex13-56",
+    "setOrder":28,
+	"id": "ex13-56",
     "name": "Wobbuffet",
     "imageUrl": "https://images.pokemontcg.io/ex13/56.png",
     "subtype": "Basic",
@@ -2994,7 +3050,8 @@
     "nationalPokedexNumber": 202
   },
   {
-    "id": "ex13-57",
+    "setOrder":28,
+	"id": "ex13-57",
     "name": "Anorith δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/57.png",
     "subtype": "Stage 1",
@@ -3049,7 +3106,8 @@
     ]
   },
   {
-    "id": "ex13-58",
+    "setOrder":28,
+	"id": "ex13-58",
     "name": "Aron",
     "imageUrl": "https://images.pokemontcg.io/ex13/58.png",
     "subtype": "Basic",
@@ -3108,7 +3166,8 @@
     ]
   },
   {
-    "id": "ex13-59",
+    "setOrder":28,
+	"id": "ex13-59",
     "name": "Baltoy",
     "imageUrl": "https://images.pokemontcg.io/ex13/59.png",
     "subtype": "Basic",
@@ -3161,7 +3220,8 @@
     ]
   },
   {
-    "id": "ex13-60",
+    "setOrder":28,
+	"id": "ex13-60",
     "name": "Barboach",
     "imageUrl": "https://images.pokemontcg.io/ex13/60.png",
     "subtype": "Basic",
@@ -3213,7 +3273,8 @@
     ]
   },
   {
-    "id": "ex13-61",
+    "setOrder":28,
+	"id": "ex13-61",
     "name": "Carvanha δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/61.png",
     "subtype": "Basic",
@@ -3266,7 +3327,8 @@
     ]
   },
   {
-    "id": "ex13-62",
+    "setOrder":28,
+	"id": "ex13-62",
     "name": "Corphish",
     "imageUrl": "https://images.pokemontcg.io/ex13/62.png",
     "subtype": "Basic",
@@ -3320,7 +3382,8 @@
     ]
   },
   {
-    "id": "ex13-63",
+    "setOrder":28,
+	"id": "ex13-63",
     "name": "Corphish",
     "imageUrl": "https://images.pokemontcg.io/ex13/63.png",
     "subtype": "Basic",
@@ -3372,7 +3435,8 @@
     ]
   },
   {
-    "id": "ex13-64",
+    "setOrder":28,
+	"id": "ex13-64",
     "name": "Electrike",
     "imageUrl": "https://images.pokemontcg.io/ex13/64.png",
     "subtype": "Basic",
@@ -3421,7 +3485,8 @@
     ]
   },
   {
-    "id": "ex13-65",
+    "setOrder":28,
+	"id": "ex13-65",
     "name": "Exeggcute δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/65.png",
     "subtype": "Basic",
@@ -3474,7 +3539,8 @@
     ]
   },
   {
-    "id": "ex13-66",
+    "setOrder":28,
+	"id": "ex13-66",
     "name": "Horsea δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/66.png",
     "subtype": "Basic",
@@ -3527,7 +3593,8 @@
     ]
   },
   {
-    "id": "ex13-67",
+    "setOrder":28,
+	"id": "ex13-67",
     "name": "Kabuto δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/67.png",
     "subtype": "Stage 1",
@@ -3582,7 +3649,8 @@
     ]
   },
   {
-    "id": "ex13-68",
+    "setOrder":28,
+	"id": "ex13-68",
     "name": "Lileep δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/68.png",
     "subtype": "Stage 1",
@@ -3637,7 +3705,8 @@
     ]
   },
   {
-    "id": "ex13-69",
+    "setOrder":28,
+	"id": "ex13-69",
     "name": "Magikarp δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/69.png",
     "subtype": "Basic",
@@ -3680,7 +3749,8 @@
     ]
   },
   {
-    "id": "ex13-70",
+    "setOrder":28,
+	"id": "ex13-70",
     "name": "Mankey δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/70.png",
     "subtype": "Basic",
@@ -3733,7 +3803,8 @@
     ]
   },
   {
-    "id": "ex13-71",
+    "setOrder":28,
+	"id": "ex13-71",
     "name": "Meowth δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/71.png",
     "subtype": "Basic",
@@ -3787,7 +3858,8 @@
     ]
   },
   {
-    "id": "ex13-72",
+    "setOrder":28,
+	"id": "ex13-72",
     "name": "Numel",
     "imageUrl": "https://images.pokemontcg.io/ex13/72.png",
     "subtype": "Basic",
@@ -3840,7 +3912,8 @@
     ]
   },
   {
-    "id": "ex13-73",
+    "setOrder":28,
+	"id": "ex13-73",
     "name": "Oddish δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/73.png",
     "subtype": "Basic",
@@ -3892,7 +3965,8 @@
     ]
   },
   {
-    "id": "ex13-74",
+    "setOrder":28,
+	"id": "ex13-74",
     "name": "Omanyte δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/74.png",
     "subtype": "Stage 1",
@@ -3946,7 +4020,8 @@
     ]
   },
   {
-    "id": "ex13-75",
+    "setOrder":28,
+	"id": "ex13-75",
     "name": "Phanpy",
     "imageUrl": "https://images.pokemontcg.io/ex13/75.png",
     "subtype": "Basic",
@@ -3998,7 +4073,8 @@
     ]
   },
   {
-    "id": "ex13-76",
+    "setOrder":28,
+	"id": "ex13-76",
     "name": "Pichu δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/76.png",
     "subtype": "Basic",
@@ -4046,7 +4122,8 @@
     ]
   },
   {
-    "id": "ex13-77",
+    "setOrder":28,
+	"id": "ex13-77",
     "name": "Pidgey δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/77.png",
     "subtype": "Basic",
@@ -4095,7 +4172,8 @@
     ]
   },
   {
-    "id": "ex13-78",
+    "setOrder":28,
+	"id": "ex13-78",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/ex13/78.png",
     "subtype": "Basic",
@@ -4148,7 +4226,8 @@
     ]
   },
   {
-    "id": "ex13-79",
+    "setOrder":28,
+	"id": "ex13-79",
     "name": "Pikachu δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/79.png",
     "subtype": "Basic",
@@ -4202,7 +4281,8 @@
     ]
   },
   {
-    "id": "ex13-80",
+    "setOrder":28,
+	"id": "ex13-80",
     "name": "Poochyena",
     "imageUrl": "https://images.pokemontcg.io/ex13/80.png",
     "subtype": "Basic",
@@ -4261,7 +4341,8 @@
     ]
   },
   {
-    "id": "ex13-81",
+    "setOrder":28,
+	"id": "ex13-81",
     "name": "Psyduck δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/81.png",
     "subtype": "Basic",
@@ -4313,7 +4394,8 @@
     ]
   },
   {
-    "id": "ex13-82",
+    "setOrder":28,
+	"id": "ex13-82",
     "name": "Surskit",
     "imageUrl": "https://images.pokemontcg.io/ex13/82.png",
     "subtype": "Basic",
@@ -4356,7 +4438,8 @@
     ]
   },
   {
-    "id": "ex13-83",
+    "setOrder":28,
+	"id": "ex13-83",
     "name": "Torchic",
     "imageUrl": "https://images.pokemontcg.io/ex13/83.png",
     "subtype": "Basic",
@@ -4409,7 +4492,8 @@
     ]
   },
   {
-    "id": "ex13-84",
+    "setOrder":28,
+	"id": "ex13-84",
     "name": "Trapinch δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/84.png",
     "subtype": "Basic",
@@ -4462,7 +4546,8 @@
     ]
   },
   {
-    "id": "ex13-85",
+    "setOrder":28,
+	"id": "ex13-85",
     "name": "Holon Adventurer",
     "imageUrl": "https://images.pokemontcg.io/ex13/85.png",
     "subtype": "Supporter",
@@ -4481,7 +4566,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/85_hires.png"
   },
   {
-    "id": "ex13-86",
+    "setOrder":28,
+	"id": "ex13-86",
     "name": "Holon Fossil",
     "imageUrl": "https://images.pokemontcg.io/ex13/86.png",
     "subtype": "Item",
@@ -4499,7 +4585,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/86_hires.png"
   },
   {
-    "id": "ex13-87",
+    "setOrder":28,
+	"id": "ex13-87",
     "name": "Holon Lake",
     "imageUrl": "https://images.pokemontcg.io/ex13/87.png",
     "subtype": "Stadium",
@@ -4518,7 +4605,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/87_hires.png"
   },
   {
-    "id": "ex13-88",
+    "setOrder":28,
+	"id": "ex13-88",
     "name": "Mr. Stone's Project",
     "imageUrl": "https://images.pokemontcg.io/ex13/88.png",
     "subtype": "Supporter",
@@ -4537,7 +4625,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/88_hires.png"
   },
   {
-    "id": "ex13-89",
+    "setOrder":28,
+	"id": "ex13-89",
     "name": "Professor Cozmo's Discovery",
     "imageUrl": "https://images.pokemontcg.io/ex13/89.png",
     "subtype": "Supporter",
@@ -4556,7 +4645,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/89_hires.png"
   },
   {
-    "id": "ex13-90",
+    "setOrder":28,
+	"id": "ex13-90",
     "name": "Rare Candy",
     "imageUrl": "https://images.pokemontcg.io/ex13/90.png",
     "subtype": "Item",
@@ -4574,7 +4664,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/90_hires.png"
   },
   {
-    "id": "ex13-91",
+    "setOrder":28,
+	"id": "ex13-91",
     "name": "Claw Fossil",
     "imageUrl": "https://images.pokemontcg.io/ex13/91.png",
     "subtype": "Item",
@@ -4593,7 +4684,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/91_hires.png"
   },
   {
-    "id": "ex13-92",
+    "setOrder":28,
+	"id": "ex13-92",
     "name": "Mysterious Fossil",
     "imageUrl": "https://images.pokemontcg.io/ex13/92.png",
     "subtype": "Item",
@@ -4611,7 +4703,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/92_hires.png"
   },
   {
-    "id": "ex13-93",
+    "setOrder":28,
+	"id": "ex13-93",
     "name": "Root Fossil",
     "imageUrl": "https://images.pokemontcg.io/ex13/93.png",
     "subtype": "Item",
@@ -4630,7 +4723,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/93_hires.png"
   },
   {
-    "id": "ex13-94",
+    "setOrder":28,
+	"id": "ex13-94",
     "name": "Darkness Energy",
     "imageUrl": "https://images.pokemontcg.io/ex13/94.png",
     "subtype": "Special",
@@ -4647,7 +4741,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/94_hires.png"
   },
   {
-    "id": "ex13-95",
+    "setOrder":28,
+	"id": "ex13-95",
     "name": "Metal Energy",
     "imageUrl": "https://images.pokemontcg.io/ex13/95.png",
     "subtype": "Special",
@@ -4664,7 +4759,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/95_hires.png"
   },
   {
-    "id": "ex13-96",
+    "setOrder":28,
+	"id": "ex13-96",
     "name": "Multi Energy",
     "imageUrl": "https://images.pokemontcg.io/ex13/96.png",
     "subtype": "Special",
@@ -4681,7 +4777,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/96_hires.png"
   },
   {
-    "id": "ex13-97",
+    "setOrder":28,
+	"id": "ex13-97",
     "name": "Dark Metal Energy",
     "imageUrl": "https://images.pokemontcg.io/ex13/97.png",
     "subtype": "Special",
@@ -4698,7 +4795,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/97_hires.png"
   },
   {
-    "id": "ex13-98",
+    "setOrder":28,
+	"id": "ex13-98",
     "name": "δ Rainbow Energy",
     "imageUrl": "https://images.pokemontcg.io/ex13/98.png",
     "subtype": "Special",
@@ -4715,7 +4813,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/98_hires.png"
   },
   {
-    "id": "ex13-99",
+    "setOrder":28,
+	"id": "ex13-99",
     "name": "Crawdaunt ex",
     "imageUrl": "https://images.pokemontcg.io/ex13/99.png",
     "subtype": "EX",
@@ -4767,7 +4866,8 @@
     "nationalPokedexNumber": 342
   },
   {
-    "id": "ex13-100",
+    "setOrder":28,
+	"id": "ex13-100",
     "name": "Mew ex",
     "imageUrl": "https://images.pokemontcg.io/ex13/100.png",
     "subtype": "EX",
@@ -4828,7 +4928,8 @@
     "nationalPokedexNumber": 151
   },
   {
-    "id": "ex13-101",
+    "setOrder":28,
+	"id": "ex13-101",
     "name": "Mightyena ex",
     "imageUrl": "https://images.pokemontcg.io/ex13/101.png",
     "subtype": "EX",
@@ -4893,7 +4994,8 @@
     "nationalPokedexNumber": 262
   },
   {
-    "id": "ex13-102",
+    "setOrder":28,
+	"id": "ex13-102",
     "name": "Gyarados Star δ",
     "imageUrl": "https://images.pokemontcg.io/ex13/102.png",
     "subtype": "Basic",
@@ -4950,7 +5052,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "ex13-103",
+    "setOrder":28,
+	"id": "ex13-103",
     "name": "Mewtwo Star",
     "imageUrl": "https://images.pokemontcg.io/ex13/103.png",
     "subtype": "Basic",
@@ -5004,7 +5107,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "ex13-104",
+    "setOrder":28,
+	"id": "ex13-104",
     "name": "Pikachu Star",
     "imageUrl": "https://images.pokemontcg.io/ex13/104.png",
     "subtype": "Basic",
@@ -5060,7 +5164,8 @@
     ]
   },
   {
-    "id": "ex13-105",
+    "setOrder":28,
+	"id": "ex13-105",
     "name": "Grass Energy",
     "imageUrl": "https://images.pokemontcg.io/ex13/105.png",
     "subtype": "Basic",
@@ -5074,7 +5179,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/105_hires.png"
   },
   {
-    "id": "ex13-106",
+    "setOrder":28,
+	"id": "ex13-106",
     "name": "Fire Energy",
     "imageUrl": "https://images.pokemontcg.io/ex13/106.png",
     "subtype": "Basic",
@@ -5088,7 +5194,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/106_hires.png"
   },
   {
-    "id": "ex13-107",
+    "setOrder":28,
+	"id": "ex13-107",
     "name": "Water Energy",
     "imageUrl": "https://images.pokemontcg.io/ex13/107.png",
     "subtype": "Basic",
@@ -5102,7 +5209,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/107_hires.png"
   },
   {
-    "id": "ex13-108",
+    "setOrder":28,
+	"id": "ex13-108",
     "name": "Lightning Energy",
     "imageUrl": "https://images.pokemontcg.io/ex13/108.png",
     "subtype": "Basic",
@@ -5116,7 +5224,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/108_hires.png"
   },
   {
-    "id": "ex13-109",
+    "setOrder":28,
+	"id": "ex13-109",
     "name": "Psychic Energy",
     "imageUrl": "https://images.pokemontcg.io/ex13/109.png",
     "subtype": "Basic",
@@ -5130,7 +5239,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/109_hires.png"
   },
   {
-    "id": "ex13-110",
+    "setOrder":28,
+	"id": "ex13-110",
     "name": "Fighting Energy",
     "imageUrl": "https://images.pokemontcg.io/ex13/110.png",
     "subtype": "Basic",
@@ -5144,7 +5254,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex13/110_hires.png"
   },
   {
-    "id": "ex13-111",
+    "setOrder":28,
+	"id": "ex13-111",
     "name": "Mew",
     "imageUrl": "https://images.pokemontcg.io/ex13/111.png",
     "subtype": "Basic",

--- a/json/cards/Jungle.json
+++ b/json/cards/Jungle.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "base2-1",
+    "setOrder":2,
+	"id": "base2-1",
     "name": "Clefable",
     "imageUrl": "https://images.pokemontcg.io/base2/1.png",
     "subtype": "Stage 1",
@@ -59,7 +60,8 @@
     "nationalPokedexNumber": 36
   },
   {
-    "id": "base2-2",
+    "setOrder":2,
+	"id": "base2-2",
     "name": "Electrode",
     "imageUrl": "https://images.pokemontcg.io/base2/2.png",
     "subtype": "Stage 1",
@@ -113,7 +115,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "base2-3",
+    "setOrder":2,
+	"id": "base2-3",
     "name": "Flareon",
     "imageUrl": "https://images.pokemontcg.io/base2/3.png",
     "subtype": "Stage 1",
@@ -168,7 +171,8 @@
     "nationalPokedexNumber": 136
   },
   {
-    "id": "base2-4",
+    "setOrder":2,
+	"id": "base2-4",
     "name": "Jolteon",
     "imageUrl": "https://images.pokemontcg.io/base2/4.png",
     "subtype": "Stage 1",
@@ -222,7 +226,8 @@
     "nationalPokedexNumber": 135
   },
   {
-    "id": "base2-5",
+    "setOrder":2,
+	"id": "base2-5",
     "name": "Kangaskhan",
     "imageUrl": "https://images.pokemontcg.io/base2/5.png",
     "subtype": "Basic",
@@ -283,7 +288,8 @@
     "nationalPokedexNumber": 115
   },
   {
-    "id": "base2-6",
+    "setOrder":2,
+	"id": "base2-6",
     "name": "Mr. Mime",
     "imageUrl": "https://images.pokemontcg.io/base2/6.png",
     "subtype": "Basic",
@@ -331,7 +337,8 @@
     "nationalPokedexNumber": 122
   },
   {
-    "id": "base2-7",
+    "setOrder":2,
+	"id": "base2-7",
     "name": "Nidoqueen",
     "imageUrl": "https://images.pokemontcg.io/base2/7.png",
     "subtype": "Stage 2",
@@ -388,7 +395,8 @@
     "nationalPokedexNumber": 31
   },
   {
-    "id": "base2-8",
+    "setOrder":2,
+	"id": "base2-8",
     "name": "Pidgeot",
     "imageUrl": "https://images.pokemontcg.io/base2/8.png",
     "subtype": "Stage 2",
@@ -445,7 +453,8 @@
     "nationalPokedexNumber": 18
   },
   {
-    "id": "base2-9",
+    "setOrder":2,
+	"id": "base2-9",
     "name": "Pinsir",
     "imageUrl": "https://images.pokemontcg.io/base2/9.png",
     "subtype": "Basic",
@@ -499,7 +508,8 @@
     "nationalPokedexNumber": 127
   },
   {
-    "id": "base2-10",
+    "setOrder":2,
+	"id": "base2-10",
     "name": "Scyther",
     "imageUrl": "https://images.pokemontcg.io/base2/10.png",
     "subtype": "Basic",
@@ -557,7 +567,8 @@
     ]
   },
   {
-    "id": "base2-11",
+    "setOrder":2,
+	"id": "base2-11",
     "name": "Snorlax",
     "imageUrl": "https://images.pokemontcg.io/base2/11.png",
     "subtype": "Basic",
@@ -616,7 +627,8 @@
     "nationalPokedexNumber": 143
   },
   {
-    "id": "base2-12",
+    "setOrder":2,
+	"id": "base2-12",
     "name": "Vaporeon",
     "imageUrl": "https://images.pokemontcg.io/base2/12.png",
     "subtype": "Stage 1",
@@ -670,7 +682,8 @@
     "nationalPokedexNumber": 134
   },
   {
-    "id": "base2-13",
+    "setOrder":2,
+	"id": "base2-13",
     "name": "Venomoth",
     "imageUrl": "https://images.pokemontcg.io/base2/13.png",
     "subtype": "Stage 1",
@@ -721,7 +734,8 @@
     "nationalPokedexNumber": 49
   },
   {
-    "id": "base2-14",
+    "setOrder":2,
+	"id": "base2-14",
     "name": "Victreebel",
     "imageUrl": "https://images.pokemontcg.io/base2/14.png",
     "subtype": "Stage 2",
@@ -774,7 +788,8 @@
     "nationalPokedexNumber": 71
   },
   {
-    "id": "base2-15",
+    "setOrder":2,
+	"id": "base2-15",
     "name": "Vileplume",
     "imageUrl": "https://images.pokemontcg.io/base2/15.png",
     "subtype": "Stage 2",
@@ -824,7 +839,8 @@
     "nationalPokedexNumber": 45
   },
   {
-    "id": "base2-16",
+    "setOrder":2,
+	"id": "base2-16",
     "name": "Wigglytuff",
     "imageUrl": "https://images.pokemontcg.io/base2/16.png",
     "subtype": "Stage 1",
@@ -884,7 +900,8 @@
     "nationalPokedexNumber": 40
   },
   {
-    "id": "base2-17",
+    "setOrder":2,
+	"id": "base2-17",
     "name": "Clefable",
     "imageUrl": "https://images.pokemontcg.io/base2/17.png",
     "subtype": "Stage 1",
@@ -943,7 +960,8 @@
     "nationalPokedexNumber": 36
   },
   {
-    "id": "base2-18",
+    "setOrder":2,
+	"id": "base2-18",
     "name": "Electrode",
     "imageUrl": "https://images.pokemontcg.io/base2/18.png",
     "subtype": "Stage 1",
@@ -997,7 +1015,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "base2-19",
+    "setOrder":2,
+	"id": "base2-19",
     "name": "Flareon",
     "imageUrl": "https://images.pokemontcg.io/base2/19.png",
     "subtype": "Stage 1",
@@ -1052,7 +1071,8 @@
     "nationalPokedexNumber": 136
   },
   {
-    "id": "base2-20",
+    "setOrder":2,
+	"id": "base2-20",
     "name": "Jolteon",
     "imageUrl": "https://images.pokemontcg.io/base2/20.png",
     "subtype": "Stage 1",
@@ -1106,7 +1126,8 @@
     "nationalPokedexNumber": 135
   },
   {
-    "id": "base2-21",
+    "setOrder":2,
+	"id": "base2-21",
     "name": "Kangaskhan",
     "imageUrl": "https://images.pokemontcg.io/base2/21.png",
     "subtype": "Basic",
@@ -1167,7 +1188,8 @@
     "nationalPokedexNumber": 115
   },
   {
-    "id": "base2-22",
+    "setOrder":2,
+	"id": "base2-22",
     "name": "Mr. Mime",
     "imageUrl": "https://images.pokemontcg.io/base2/22.png",
     "subtype": "Basic",
@@ -1215,7 +1237,8 @@
     "nationalPokedexNumber": 122
   },
   {
-    "id": "base2-23",
+    "setOrder":2,
+	"id": "base2-23",
     "name": "Nidoqueen",
     "imageUrl": "https://images.pokemontcg.io/base2/23.png",
     "subtype": "Stage 2",
@@ -1272,7 +1295,8 @@
     "nationalPokedexNumber": 31
   },
   {
-    "id": "base2-24",
+    "setOrder":2,
+	"id": "base2-24",
     "name": "Pidgeot",
     "imageUrl": "https://images.pokemontcg.io/base2/24.png",
     "subtype": "Stage 2",
@@ -1329,7 +1353,8 @@
     "nationalPokedexNumber": 18
   },
   {
-    "id": "base2-25",
+    "setOrder":2,
+	"id": "base2-25",
     "name": "Pinsir",
     "imageUrl": "https://images.pokemontcg.io/base2/25.png",
     "subtype": "Basic",
@@ -1383,7 +1408,8 @@
     "nationalPokedexNumber": 127
   },
   {
-    "id": "base2-26",
+    "setOrder":2,
+	"id": "base2-26",
     "name": "Scyther",
     "imageUrl": "https://images.pokemontcg.io/base2/26.png",
     "subtype": "Basic",
@@ -1441,7 +1467,8 @@
     ]
   },
   {
-    "id": "base2-27",
+    "setOrder":2,
+	"id": "base2-27",
     "name": "Snorlax",
     "imageUrl": "https://images.pokemontcg.io/base2/27.png",
     "subtype": "Basic",
@@ -1500,7 +1527,8 @@
     "nationalPokedexNumber": 143
   },
   {
-    "id": "base2-28",
+    "setOrder":2,
+	"id": "base2-28",
     "name": "Vaporeon",
     "imageUrl": "https://images.pokemontcg.io/base2/28.png",
     "subtype": "Stage 1",
@@ -1554,7 +1582,8 @@
     "nationalPokedexNumber": 134
   },
   {
-    "id": "base2-29",
+    "setOrder":2,
+	"id": "base2-29",
     "name": "Venomoth",
     "imageUrl": "https://images.pokemontcg.io/base2/29.png",
     "subtype": "Stage 1",
@@ -1605,7 +1634,8 @@
     "nationalPokedexNumber": 49
   },
   {
-    "id": "base2-30",
+    "setOrder":2,
+	"id": "base2-30",
     "name": "Victreebel",
     "imageUrl": "https://images.pokemontcg.io/base2/30.png",
     "subtype": "Stage 2",
@@ -1658,7 +1688,8 @@
     "nationalPokedexNumber": 71
   },
   {
-    "id": "base2-31",
+    "setOrder":2,
+	"id": "base2-31",
     "name": "Vileplume",
     "imageUrl": "https://images.pokemontcg.io/base2/31.png",
     "subtype": "Stage 2",
@@ -1708,7 +1739,8 @@
     "nationalPokedexNumber": 45
   },
   {
-    "id": "base2-32",
+    "setOrder":2,
+	"id": "base2-32",
     "name": "Wigglytuff",
     "imageUrl": "https://images.pokemontcg.io/base2/32.png",
     "subtype": "Stage 1",
@@ -1768,7 +1800,8 @@
     "nationalPokedexNumber": 40
   },
   {
-    "id": "base2-33",
+    "setOrder":2,
+	"id": "base2-33",
     "name": "Butterfree",
     "imageUrl": "https://images.pokemontcg.io/base2/33.png",
     "subtype": "Stage 2",
@@ -1826,7 +1859,8 @@
     "nationalPokedexNumber": 12
   },
   {
-    "id": "base2-34",
+    "setOrder":2,
+	"id": "base2-34",
     "name": "Dodrio",
     "imageUrl": "https://images.pokemontcg.io/base2/34.png",
     "subtype": "Stage 1",
@@ -1878,7 +1912,8 @@
     "nationalPokedexNumber": 85
   },
   {
-    "id": "base2-35",
+    "setOrder":2,
+	"id": "base2-35",
     "name": "Exeggutor",
     "imageUrl": "https://images.pokemontcg.io/base2/35.png",
     "subtype": "Stage 1",
@@ -1931,7 +1966,8 @@
     "nationalPokedexNumber": 103
   },
   {
-    "id": "base2-36",
+    "setOrder":2,
+	"id": "base2-36",
     "name": "Fearow",
     "imageUrl": "https://images.pokemontcg.io/base2/36.png",
     "subtype": "Stage 1",
@@ -1990,7 +2026,8 @@
     "nationalPokedexNumber": 22
   },
   {
-    "id": "base2-37",
+    "setOrder":2,
+	"id": "base2-37",
     "name": "Gloom",
     "imageUrl": "https://images.pokemontcg.io/base2/37.png",
     "subtype": "Stage 1",
@@ -2046,7 +2083,8 @@
     ]
   },
   {
-    "id": "base2-38",
+    "setOrder":2,
+	"id": "base2-38",
     "name": "Lickitung",
     "imageUrl": "https://images.pokemontcg.io/base2/38.png",
     "subtype": "Basic",
@@ -2106,7 +2144,8 @@
     ]
   },
   {
-    "id": "base2-39",
+    "setOrder":2,
+	"id": "base2-39",
     "name": "Marowak",
     "imageUrl": "https://images.pokemontcg.io/base2/39.png",
     "subtype": "Stage 1",
@@ -2166,7 +2205,8 @@
     "nationalPokedexNumber": 105
   },
   {
-    "id": "base2-40",
+    "setOrder":2,
+	"id": "base2-40",
     "name": "Nidorina",
     "imageUrl": "https://images.pokemontcg.io/base2/40.png",
     "subtype": "Stage 1",
@@ -2222,7 +2262,8 @@
     ]
   },
   {
-    "id": "base2-41",
+    "setOrder":2,
+	"id": "base2-41",
     "name": "Parasect",
     "imageUrl": "https://images.pokemontcg.io/base2/41.png",
     "subtype": "Stage 1",
@@ -2276,7 +2317,8 @@
     "nationalPokedexNumber": 47
   },
   {
-    "id": "base2-42",
+    "setOrder":2,
+	"id": "base2-42",
     "name": "Persian",
     "imageUrl": "https://images.pokemontcg.io/base2/42.png",
     "subtype": "Stage 1",
@@ -2333,7 +2375,8 @@
     "nationalPokedexNumber": 53
   },
   {
-    "id": "base2-43",
+    "setOrder":2,
+	"id": "base2-43",
     "name": "Primeape",
     "imageUrl": "https://images.pokemontcg.io/base2/43.png",
     "subtype": "Stage 1",
@@ -2387,7 +2430,8 @@
     "nationalPokedexNumber": 57
   },
   {
-    "id": "base2-44",
+    "setOrder":2,
+	"id": "base2-44",
     "name": "Rapidash",
     "imageUrl": "https://images.pokemontcg.io/base2/44.png",
     "subtype": "Stage 1",
@@ -2438,7 +2482,8 @@
     "nationalPokedexNumber": 78
   },
   {
-    "id": "base2-45",
+    "setOrder":2,
+	"id": "base2-45",
     "name": "Rhydon",
     "imageUrl": "https://images.pokemontcg.io/base2/45.png",
     "subtype": "Stage 1",
@@ -2505,7 +2550,8 @@
     ]
   },
   {
-    "id": "base2-46",
+    "setOrder":2,
+	"id": "base2-46",
     "name": "Seaking",
     "imageUrl": "https://images.pokemontcg.io/base2/46.png",
     "subtype": "Stage 1",
@@ -2557,7 +2603,8 @@
     "nationalPokedexNumber": 119
   },
   {
-    "id": "base2-47",
+    "setOrder":2,
+	"id": "base2-47",
     "name": "Tauros",
     "imageUrl": "https://images.pokemontcg.io/base2/47.png",
     "subtype": "Basic",
@@ -2617,7 +2664,8 @@
     "nationalPokedexNumber": 128
   },
   {
-    "id": "base2-48",
+    "setOrder":2,
+	"id": "base2-48",
     "name": "Weepinbell",
     "imageUrl": "https://images.pokemontcg.io/base2/48.png",
     "subtype": "Stage 1",
@@ -2672,7 +2720,8 @@
     ]
   },
   {
-    "id": "base2-49",
+    "setOrder":2,
+	"id": "base2-49",
     "name": "Bellsprout",
     "imageUrl": "https://images.pokemontcg.io/base2/49.png",
     "subtype": "Basic",
@@ -2725,7 +2774,8 @@
     ]
   },
   {
-    "id": "base2-50",
+    "setOrder":2,
+	"id": "base2-50",
     "name": "Cubone",
     "imageUrl": "https://images.pokemontcg.io/base2/50.png",
     "subtype": "Basic",
@@ -2785,7 +2835,8 @@
     ]
   },
   {
-    "id": "base2-51",
+    "setOrder":2,
+	"id": "base2-51",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/base2/51.png",
     "subtype": "Basic",
@@ -2852,7 +2903,8 @@
     ]
   },
   {
-    "id": "base2-52",
+    "setOrder":2,
+	"id": "base2-52",
     "name": "Exeggcute",
     "imageUrl": "https://images.pokemontcg.io/base2/52.png",
     "subtype": "Basic",
@@ -2906,7 +2958,8 @@
     ]
   },
   {
-    "id": "base2-53",
+    "setOrder":2,
+	"id": "base2-53",
     "name": "Goldeen",
     "imageUrl": "https://images.pokemontcg.io/base2/53.png",
     "subtype": "Basic",
@@ -2947,7 +3000,8 @@
     ]
   },
   {
-    "id": "base2-54",
+    "setOrder":2,
+	"id": "base2-54",
     "name": "Jigglypuff",
     "imageUrl": "https://images.pokemontcg.io/base2/54.png",
     "subtype": "Basic",
@@ -3007,7 +3061,8 @@
     ]
   },
   {
-    "id": "base2-55",
+    "setOrder":2,
+	"id": "base2-55",
     "name": "Mankey",
     "imageUrl": "https://images.pokemontcg.io/base2/55.png",
     "subtype": "Basic",
@@ -3053,7 +3108,8 @@
     ]
   },
   {
-    "id": "base2-56",
+    "setOrder":2,
+	"id": "base2-56",
     "name": "Meowth",
     "imageUrl": "https://images.pokemontcg.io/base2/56.png",
     "subtype": "Basic",
@@ -3104,7 +3160,8 @@
     ]
   },
   {
-    "id": "base2-57",
+    "setOrder":2,
+	"id": "base2-57",
     "name": "Nidoran♀",
     "imageUrl": "https://images.pokemontcg.io/base2/57.png",
     "subtype": "Basic",
@@ -3158,7 +3215,8 @@
     ]
   },
   {
-    "id": "base2-58",
+    "setOrder":2,
+	"id": "base2-58",
     "name": "Oddish",
     "imageUrl": "https://images.pokemontcg.io/base2/58.png",
     "subtype": "Basic",
@@ -3212,7 +3270,8 @@
     ]
   },
   {
-    "id": "base2-59",
+    "setOrder":2,
+	"id": "base2-59",
     "name": "Paras",
     "imageUrl": "https://images.pokemontcg.io/base2/59.png",
     "subtype": "Basic",
@@ -3267,7 +3326,8 @@
     ]
   },
   {
-    "id": "base2-60",
+    "setOrder":2,
+	"id": "base2-60",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/base2/60.png",
     "subtype": "Basic",
@@ -3313,7 +3373,8 @@
     ]
   },
   {
-    "id": "base2-61",
+    "setOrder":2,
+	"id": "base2-61",
     "name": "Rhyhorn",
     "imageUrl": "https://images.pokemontcg.io/base2/61.png",
     "subtype": "Basic",
@@ -3376,7 +3437,8 @@
     ]
   },
   {
-    "id": "base2-62",
+    "setOrder":2,
+	"id": "base2-62",
     "name": "Spearow",
     "imageUrl": "https://images.pokemontcg.io/base2/62.png",
     "subtype": "Basic",
@@ -3434,7 +3496,8 @@
     ]
   },
   {
-    "id": "base2-63",
+    "setOrder":2,
+	"id": "base2-63",
     "name": "Venonat",
     "imageUrl": "https://images.pokemontcg.io/base2/63.png",
     "subtype": "Basic",
@@ -3488,7 +3551,8 @@
     ]
   },
   {
-    "id": "base2-64",
+	"setOrder":2,
+	"id": "base2-64",
     "name": "Poké Ball",
     "imageUrl": "https://images.pokemontcg.io/base2/64.png",
     "subtype": "",

--- a/json/cards/Legend Maker.json
+++ b/json/cards/Legend Maker.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "ex12-1",
+    "setOrder":27,
+	"id": "ex12-1",
     "name": "Aerodactyl",
     "imageUrl": "https://images.pokemontcg.io/ex12/1.png",
     "subtype": "Stage 1",
@@ -60,7 +61,8 @@
     "nationalPokedexNumber": 142
   },
   {
-    "id": "ex12-2",
+    "setOrder":27,
+	"id": "ex12-2",
     "name": "Aggron",
     "imageUrl": "https://images.pokemontcg.io/ex12/2.png",
     "subtype": "Stage 2",
@@ -124,7 +126,8 @@
     "nationalPokedexNumber": 306
   },
   {
-    "id": "ex12-3",
+    "setOrder":27,
+	"id": "ex12-3",
     "name": "Cradily",
     "imageUrl": "https://images.pokemontcg.io/ex12/3.png",
     "subtype": "Stage 2",
@@ -188,7 +191,8 @@
     "nationalPokedexNumber": 346
   },
   {
-    "id": "ex12-4",
+    "setOrder":27,
+	"id": "ex12-4",
     "name": "Delcatty",
     "imageUrl": "https://images.pokemontcg.io/ex12/4.png",
     "subtype": "Stage 1",
@@ -245,7 +249,8 @@
     "nationalPokedexNumber": 301
   },
   {
-    "id": "ex12-5",
+    "setOrder":27,
+	"id": "ex12-5",
     "name": "Gengar",
     "imageUrl": "https://images.pokemontcg.io/ex12/5.png",
     "subtype": "Stage 2",
@@ -308,7 +313,8 @@
     "nationalPokedexNumber": 94
   },
   {
-    "id": "ex12-6",
+    "setOrder":27,
+	"id": "ex12-6",
     "name": "Golem",
     "imageUrl": "https://images.pokemontcg.io/ex12/6.png",
     "subtype": "Stage 2",
@@ -373,7 +379,8 @@
     "nationalPokedexNumber": 76
   },
   {
-    "id": "ex12-7",
+    "setOrder":27,
+	"id": "ex12-7",
     "name": "Kabutops",
     "imageUrl": "https://images.pokemontcg.io/ex12/7.png",
     "subtype": "Stage 2",
@@ -431,7 +438,8 @@
     "nationalPokedexNumber": 141
   },
   {
-    "id": "ex12-8",
+    "setOrder":27,
+	"id": "ex12-8",
     "name": "Lapras",
     "imageUrl": "https://images.pokemontcg.io/ex12/8.png",
     "subtype": "Basic",
@@ -478,7 +486,8 @@
     "nationalPokedexNumber": 131
   },
   {
-    "id": "ex12-9",
+    "setOrder":27,
+	"id": "ex12-9",
     "name": "Machamp",
     "imageUrl": "https://images.pokemontcg.io/ex12/9.png",
     "subtype": "Stage 2",
@@ -532,7 +541,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "ex12-10",
+    "setOrder":27,
+	"id": "ex12-10",
     "name": "Mew",
     "imageUrl": "https://images.pokemontcg.io/ex12/10.png",
     "subtype": "Basic",
@@ -578,7 +588,8 @@
     "nationalPokedexNumber": 151
   },
   {
-    "id": "ex12-11",
+    "setOrder":27,
+	"id": "ex12-11",
     "name": "Muk",
     "imageUrl": "https://images.pokemontcg.io/ex12/11.png",
     "subtype": "Stage 1",
@@ -637,7 +648,8 @@
     "nationalPokedexNumber": 89
   },
   {
-    "id": "ex12-12",
+    "setOrder":27,
+	"id": "ex12-12",
     "name": "Shiftry",
     "imageUrl": "https://images.pokemontcg.io/ex12/12.png",
     "subtype": "Stage 2",
@@ -701,7 +713,8 @@
     "nationalPokedexNumber": 275
   },
   {
-    "id": "ex12-13",
+    "setOrder":27,
+	"id": "ex12-13",
     "name": "Victreebel",
     "imageUrl": "https://images.pokemontcg.io/ex12/13.png",
     "subtype": "Stage 2",
@@ -760,7 +773,8 @@
     "nationalPokedexNumber": 71
   },
   {
-    "id": "ex12-14",
+    "setOrder":27,
+	"id": "ex12-14",
     "name": "Wailord",
     "imageUrl": "https://images.pokemontcg.io/ex12/14.png",
     "subtype": "Stage 1",
@@ -823,7 +837,8 @@
     "nationalPokedexNumber": 321
   },
   {
-    "id": "ex12-15",
+    "setOrder":27,
+	"id": "ex12-15",
     "name": "Absol",
     "imageUrl": "https://images.pokemontcg.io/ex12/15.png",
     "subtype": "Basic",
@@ -884,7 +899,8 @@
     "nationalPokedexNumber": 359
   },
   {
-    "id": "ex12-16",
+    "setOrder":27,
+	"id": "ex12-16",
     "name": "Girafarig",
     "imageUrl": "https://images.pokemontcg.io/ex12/16.png",
     "subtype": "Basic",
@@ -939,7 +955,8 @@
     "nationalPokedexNumber": 203
   },
   {
-    "id": "ex12-17",
+    "setOrder":27,
+	"id": "ex12-17",
     "name": "Gorebyss",
     "imageUrl": "https://images.pokemontcg.io/ex12/17.png",
     "subtype": "Stage 1",
@@ -983,7 +1000,8 @@
     "nationalPokedexNumber": 368
   },
   {
-    "id": "ex12-18",
+    "setOrder":27,
+	"id": "ex12-18",
     "name": "Huntail",
     "imageUrl": "https://images.pokemontcg.io/ex12/18.png",
     "subtype": "Stage 1",
@@ -1031,7 +1049,8 @@
     "nationalPokedexNumber": 367
   },
   {
-    "id": "ex12-19",
+    "setOrder":27,
+	"id": "ex12-19",
     "name": "Lanturn",
     "imageUrl": "https://images.pokemontcg.io/ex12/19.png",
     "subtype": "Stage 1",
@@ -1090,7 +1109,8 @@
     "nationalPokedexNumber": 171
   },
   {
-    "id": "ex12-20",
+    "setOrder":27,
+	"id": "ex12-20",
     "name": "Lunatone",
     "imageUrl": "https://images.pokemontcg.io/ex12/20.png",
     "subtype": "Basic",
@@ -1144,7 +1164,8 @@
     "nationalPokedexNumber": 337
   },
   {
-    "id": "ex12-21",
+    "setOrder":27,
+	"id": "ex12-21",
     "name": "Magmar",
     "imageUrl": "https://images.pokemontcg.io/ex12/21.png",
     "subtype": "Basic",
@@ -1203,7 +1224,8 @@
     ]
   },
   {
-    "id": "ex12-22",
+    "setOrder":27,
+	"id": "ex12-22",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/ex12/22.png",
     "subtype": "Stage 1",
@@ -1271,7 +1293,8 @@
     ]
   },
   {
-    "id": "ex12-23",
+    "setOrder":27,
+	"id": "ex12-23",
     "name": "Omastar",
     "imageUrl": "https://images.pokemontcg.io/ex12/23.png",
     "subtype": "Stage 2",
@@ -1328,7 +1351,8 @@
     "nationalPokedexNumber": 139
   },
   {
-    "id": "ex12-24",
+    "setOrder":27,
+	"id": "ex12-24",
     "name": "Pinsir",
     "imageUrl": "https://images.pokemontcg.io/ex12/24.png",
     "subtype": "Basic",
@@ -1383,7 +1407,8 @@
     "nationalPokedexNumber": 127
   },
   {
-    "id": "ex12-25",
+    "setOrder":27,
+	"id": "ex12-25",
     "name": "Solrock",
     "imageUrl": "https://images.pokemontcg.io/ex12/25.png",
     "subtype": "Basic",
@@ -1437,7 +1462,8 @@
     "nationalPokedexNumber": 338
   },
   {
-    "id": "ex12-26",
+    "setOrder":27,
+	"id": "ex12-26",
     "name": "Spinda",
     "imageUrl": "https://images.pokemontcg.io/ex12/26.png",
     "subtype": "Basic",
@@ -1492,7 +1518,8 @@
     "nationalPokedexNumber": 327
   },
   {
-    "id": "ex12-27",
+    "setOrder":27,
+	"id": "ex12-27",
     "name": "Torkoal",
     "imageUrl": "https://images.pokemontcg.io/ex12/27.png",
     "subtype": "Basic",
@@ -1543,7 +1570,8 @@
     "nationalPokedexNumber": 324
   },
   {
-    "id": "ex12-28",
+    "setOrder":27,
+	"id": "ex12-28",
     "name": "Wobbuffet",
     "imageUrl": "https://images.pokemontcg.io/ex12/28.png",
     "subtype": "Basic",
@@ -1600,7 +1628,8 @@
     "nationalPokedexNumber": 202
   },
   {
-    "id": "ex12-29",
+    "setOrder":27,
+	"id": "ex12-29",
     "name": "Anorith",
     "imageUrl": "https://images.pokemontcg.io/ex12/29.png",
     "subtype": "Stage 1",
@@ -1654,7 +1683,8 @@
     ]
   },
   {
-    "id": "ex12-30",
+    "setOrder":27,
+	"id": "ex12-30",
     "name": "Cascoon",
     "imageUrl": "https://images.pokemontcg.io/ex12/30.png",
     "subtype": "Stage 1",
@@ -1705,7 +1735,8 @@
     ]
   },
   {
-    "id": "ex12-31",
+    "setOrder":27,
+	"id": "ex12-31",
     "name": "Dunsparce",
     "imageUrl": "https://images.pokemontcg.io/ex12/31.png",
     "subtype": "Basic",
@@ -1759,7 +1790,8 @@
     "nationalPokedexNumber": 206
   },
   {
-    "id": "ex12-32",
+    "setOrder":27,
+	"id": "ex12-32",
     "name": "Electrode",
     "imageUrl": "https://images.pokemontcg.io/ex12/32.png",
     "subtype": "Stage 1",
@@ -1809,7 +1841,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "ex12-33",
+    "setOrder":27,
+	"id": "ex12-33",
     "name": "Furret",
     "imageUrl": "https://images.pokemontcg.io/ex12/33.png",
     "subtype": "Stage 1",
@@ -1862,7 +1895,8 @@
     "nationalPokedexNumber": 162
   },
   {
-    "id": "ex12-34",
+    "setOrder":27,
+	"id": "ex12-34",
     "name": "Graveler",
     "imageUrl": "https://images.pokemontcg.io/ex12/34.png",
     "subtype": "Stage 1",
@@ -1913,7 +1947,8 @@
     ]
   },
   {
-    "id": "ex12-35",
+    "setOrder":27,
+	"id": "ex12-35",
     "name": "Haunter",
     "imageUrl": "https://images.pokemontcg.io/ex12/35.png",
     "subtype": "Stage 1",
@@ -1974,7 +2009,8 @@
     ]
   },
   {
-    "id": "ex12-36",
+    "setOrder":27,
+	"id": "ex12-36",
     "name": "Kabuto",
     "imageUrl": "https://images.pokemontcg.io/ex12/36.png",
     "subtype": "Stage 1",
@@ -2025,7 +2061,8 @@
     ]
   },
   {
-    "id": "ex12-37",
+    "setOrder":27,
+	"id": "ex12-37",
     "name": "Kecleon",
     "imageUrl": "https://images.pokemontcg.io/ex12/37.png",
     "subtype": "Basic",
@@ -2080,7 +2117,8 @@
     "nationalPokedexNumber": 352
   },
   {
-    "id": "ex12-38",
+    "setOrder":27,
+	"id": "ex12-38",
     "name": "Lairon",
     "imageUrl": "https://images.pokemontcg.io/ex12/38.png",
     "subtype": "Stage 1",
@@ -2142,7 +2180,8 @@
     ]
   },
   {
-    "id": "ex12-39",
+    "setOrder":27,
+	"id": "ex12-39",
     "name": "Machoke",
     "imageUrl": "https://images.pokemontcg.io/ex12/39.png",
     "subtype": "Stage 1",
@@ -2202,7 +2241,8 @@
     ]
   },
   {
-    "id": "ex12-40",
+    "setOrder":27,
+	"id": "ex12-40",
     "name": "Misdreavus",
     "imageUrl": "https://images.pokemontcg.io/ex12/40.png",
     "subtype": "Basic",
@@ -2265,7 +2305,8 @@
     ]
   },
   {
-    "id": "ex12-41",
+    "setOrder":27,
+	"id": "ex12-41",
     "name": "Nuzleaf",
     "imageUrl": "https://images.pokemontcg.io/ex12/41.png",
     "subtype": "Stage 1",
@@ -2325,7 +2366,8 @@
     ]
   },
   {
-    "id": "ex12-42",
+    "setOrder":27,
+	"id": "ex12-42",
     "name": "Roselia",
     "imageUrl": "https://images.pokemontcg.io/ex12/42.png",
     "subtype": "Basic",
@@ -2373,7 +2415,8 @@
     ]
   },
   {
-    "id": "ex12-43",
+    "setOrder":27,
+	"id": "ex12-43",
     "name": "Sealeo",
     "imageUrl": "https://images.pokemontcg.io/ex12/43.png",
     "subtype": "Stage 1",
@@ -2423,7 +2466,8 @@
     ]
   },
   {
-    "id": "ex12-44",
+    "setOrder":27,
+	"id": "ex12-44",
     "name": "Tangela",
     "imageUrl": "https://images.pokemontcg.io/ex12/44.png",
     "subtype": "Basic",
@@ -2488,7 +2532,8 @@
     ]
   },
   {
-    "id": "ex12-45",
+    "setOrder":27,
+	"id": "ex12-45",
     "name": "Tentacruel",
     "imageUrl": "https://images.pokemontcg.io/ex12/45.png",
     "subtype": "Stage 1",
@@ -2541,7 +2586,8 @@
     "nationalPokedexNumber": 73
   },
   {
-    "id": "ex12-46",
+    "setOrder":27,
+	"id": "ex12-46",
     "name": "Vibrava",
     "imageUrl": "https://images.pokemontcg.io/ex12/46.png",
     "subtype": "Stage 1",
@@ -2595,7 +2641,8 @@
     ]
   },
   {
-    "id": "ex12-47",
+    "setOrder":27,
+	"id": "ex12-47",
     "name": "Weepinbell",
     "imageUrl": "https://images.pokemontcg.io/ex12/47.png",
     "subtype": "Stage 1",
@@ -2651,7 +2698,8 @@
     ]
   },
   {
-    "id": "ex12-48",
+    "setOrder":27,
+	"id": "ex12-48",
     "name": "Aron",
     "imageUrl": "https://images.pokemontcg.io/ex12/48.png",
     "subtype": "Basic",
@@ -2711,7 +2759,8 @@
     ]
   },
   {
-    "id": "ex12-49",
+    "setOrder":27,
+	"id": "ex12-49",
     "name": "Bellsprout",
     "imageUrl": "https://images.pokemontcg.io/ex12/49.png",
     "subtype": "Basic",
@@ -2754,7 +2803,8 @@
     ]
   },
   {
-    "id": "ex12-50",
+    "setOrder":27,
+	"id": "ex12-50",
     "name": "Chinchou",
     "imageUrl": "https://images.pokemontcg.io/ex12/50.png",
     "subtype": "Basic",
@@ -2807,7 +2857,8 @@
     ]
   },
   {
-    "id": "ex12-51",
+    "setOrder":27,
+	"id": "ex12-51",
     "name": "Clamperl",
     "imageUrl": "https://images.pokemontcg.io/ex12/51.png",
     "subtype": "Basic",
@@ -2860,7 +2911,8 @@
     ]
   },
   {
-    "id": "ex12-52",
+    "setOrder":27,
+	"id": "ex12-52",
     "name": "Gastly",
     "imageUrl": "https://images.pokemontcg.io/ex12/52.png",
     "subtype": "Basic",
@@ -2918,7 +2970,8 @@
     ]
   },
   {
-    "id": "ex12-53",
+    "setOrder":27,
+	"id": "ex12-53",
     "name": "Geodude",
     "imageUrl": "https://images.pokemontcg.io/ex12/53.png",
     "subtype": "Basic",
@@ -2962,7 +3015,8 @@
     ]
   },
   {
-    "id": "ex12-54",
+    "setOrder":27,
+	"id": "ex12-54",
     "name": "Grimer",
     "imageUrl": "https://images.pokemontcg.io/ex12/54.png",
     "subtype": "Basic",
@@ -3015,7 +3069,8 @@
     ]
   },
   {
-    "id": "ex12-55",
+    "setOrder":27,
+	"id": "ex12-55",
     "name": "Growlithe",
     "imageUrl": "https://images.pokemontcg.io/ex12/55.png",
     "subtype": "Basic",
@@ -3068,7 +3123,8 @@
     ]
   },
   {
-    "id": "ex12-56",
+    "setOrder":27,
+	"id": "ex12-56",
     "name": "Lileep",
     "imageUrl": "https://images.pokemontcg.io/ex12/56.png",
     "subtype": "Stage 1",
@@ -3123,7 +3179,8 @@
     ]
   },
   {
-    "id": "ex12-57",
+    "setOrder":27,
+	"id": "ex12-57",
     "name": "Machop",
     "imageUrl": "https://images.pokemontcg.io/ex12/57.png",
     "subtype": "Basic",
@@ -3166,7 +3223,8 @@
     ]
   },
   {
-    "id": "ex12-58",
+    "setOrder":27,
+	"id": "ex12-58",
     "name": "Magby",
     "imageUrl": "https://images.pokemontcg.io/ex12/58.png",
     "subtype": "Basic",
@@ -3214,7 +3272,8 @@
     ]
   },
   {
-    "id": "ex12-59",
+    "setOrder":27,
+	"id": "ex12-59",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/ex12/59.png",
     "subtype": "Basic",
@@ -3263,7 +3322,8 @@
     ]
   },
   {
-    "id": "ex12-60",
+    "setOrder":27,
+	"id": "ex12-60",
     "name": "Omanyte",
     "imageUrl": "https://images.pokemontcg.io/ex12/60.png",
     "subtype": "Stage 1",
@@ -3322,7 +3382,8 @@
     ]
   },
   {
-    "id": "ex12-61",
+    "setOrder":27,
+	"id": "ex12-61",
     "name": "Seedot",
     "imageUrl": "https://images.pokemontcg.io/ex12/61.png",
     "subtype": "Basic",
@@ -3374,7 +3435,8 @@
     ]
   },
   {
-    "id": "ex12-62",
+    "setOrder":27,
+	"id": "ex12-62",
     "name": "Sentret",
     "imageUrl": "https://images.pokemontcg.io/ex12/62.png",
     "subtype": "Basic",
@@ -3427,7 +3489,8 @@
     ]
   },
   {
-    "id": "ex12-63",
+    "setOrder":27,
+	"id": "ex12-63",
     "name": "Shuppet",
     "imageUrl": "https://images.pokemontcg.io/ex12/63.png",
     "subtype": "Basic",
@@ -3486,7 +3549,8 @@
     ]
   },
   {
-    "id": "ex12-64",
+    "setOrder":27,
+	"id": "ex12-64",
     "name": "Skitty",
     "imageUrl": "https://images.pokemontcg.io/ex12/64.png",
     "subtype": "Basic",
@@ -3539,7 +3603,8 @@
     ]
   },
   {
-    "id": "ex12-65",
+    "setOrder":27,
+	"id": "ex12-65",
     "name": "Spheal",
     "imageUrl": "https://images.pokemontcg.io/ex12/65.png",
     "subtype": "Basic",
@@ -3583,7 +3648,8 @@
     ]
   },
   {
-    "id": "ex12-66",
+    "setOrder":27,
+	"id": "ex12-66",
     "name": "Tentacool",
     "imageUrl": "https://images.pokemontcg.io/ex12/66.png",
     "subtype": "Basic",
@@ -3626,7 +3692,8 @@
     ]
   },
   {
-    "id": "ex12-67",
+    "setOrder":27,
+	"id": "ex12-67",
     "name": "Trapinch",
     "imageUrl": "https://images.pokemontcg.io/ex12/67.png",
     "subtype": "Basic",
@@ -3679,7 +3746,8 @@
     ]
   },
   {
-    "id": "ex12-68",
+    "setOrder":27,
+	"id": "ex12-68",
     "name": "Voltorb",
     "imageUrl": "https://images.pokemontcg.io/ex12/68.png",
     "subtype": "Basic",
@@ -3732,7 +3800,8 @@
     ]
   },
   {
-    "id": "ex12-69",
+    "setOrder":27,
+	"id": "ex12-69",
     "name": "Wailmer",
     "imageUrl": "https://images.pokemontcg.io/ex12/69.png",
     "subtype": "Basic",
@@ -3789,7 +3858,8 @@
     ]
   },
   {
-    "id": "ex12-70",
+    "setOrder":27,
+	"id": "ex12-70",
     "name": "Wurmple",
     "imageUrl": "https://images.pokemontcg.io/ex12/70.png",
     "subtype": "Basic",
@@ -3838,7 +3908,8 @@
     ]
   },
   {
-    "id": "ex12-71",
+    "setOrder":27,
+	"id": "ex12-71",
     "name": "Wynaut",
     "imageUrl": "https://images.pokemontcg.io/ex12/71.png",
     "subtype": "Basic",
@@ -3886,7 +3957,8 @@
     ]
   },
   {
-    "id": "ex12-72",
+    "setOrder":27,
+	"id": "ex12-72",
     "name": "Cursed Stone",
     "imageUrl": "https://images.pokemontcg.io/ex12/72.png",
     "subtype": "Stadium",
@@ -3905,7 +3977,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex12/72_hires.png"
   },
   {
-    "id": "ex12-73",
+    "setOrder":27,
+	"id": "ex12-73",
     "name": "Fieldworker",
     "imageUrl": "https://images.pokemontcg.io/ex12/73.png",
     "subtype": "Supporter",
@@ -3924,7 +3997,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex12/73_hires.png"
   },
   {
-    "id": "ex12-74",
+    "setOrder":27,
+	"id": "ex12-74",
     "name": "Full Flame",
     "imageUrl": "https://images.pokemontcg.io/ex12/74.png",
     "subtype": "Stadium",
@@ -3943,7 +4017,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex12/74_hires.png"
   },
   {
-    "id": "ex12-75",
+    "setOrder":27,
+	"id": "ex12-75",
     "name": "Giant Stump",
     "imageUrl": "https://images.pokemontcg.io/ex12/75.png",
     "subtype": "Stadium",
@@ -3962,7 +4037,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex12/75_hires.png"
   },
   {
-    "id": "ex12-76",
+    "setOrder":27,
+	"id": "ex12-76",
     "name": "Power Tree",
     "imageUrl": "https://images.pokemontcg.io/ex12/76.png",
     "subtype": "Stadium",
@@ -3981,7 +4057,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex12/76_hires.png"
   },
   {
-    "id": "ex12-77",
+    "setOrder":27,
+	"id": "ex12-77",
     "name": "Strange Cave",
     "imageUrl": "https://images.pokemontcg.io/ex12/77.png",
     "subtype": "Stadium",
@@ -4000,7 +4077,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex12/77_hires.png"
   },
   {
-    "id": "ex12-78",
+    "setOrder":27,
+	"id": "ex12-78",
     "name": "Claw Fossil",
     "imageUrl": "https://images.pokemontcg.io/ex12/78.png",
     "subtype": "Item",
@@ -4019,7 +4097,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex12/78_hires.png"
   },
   {
-    "id": "ex12-79",
+    "setOrder":27,
+	"id": "ex12-79",
     "name": "Mysterious Fossil",
     "imageUrl": "https://images.pokemontcg.io/ex12/79.png",
     "subtype": "Item",
@@ -4037,7 +4116,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex12/79_hires.png"
   },
   {
-    "id": "ex12-80",
+    "setOrder":27,
+	"id": "ex12-80",
     "name": "Root Fossil",
     "imageUrl": "https://images.pokemontcg.io/ex12/80.png",
     "subtype": "Item",
@@ -4056,7 +4136,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex12/80_hires.png"
   },
   {
-    "id": "ex12-81",
+    "setOrder":27,
+	"id": "ex12-81",
     "name": "Rainbow Energy",
     "imageUrl": "https://images.pokemontcg.io/ex12/81.png",
     "subtype": "Special",
@@ -4073,7 +4154,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex12/81_hires.png"
   },
   {
-    "id": "ex12-82",
+    "setOrder":27,
+	"id": "ex12-82",
     "name": "React Energy",
     "imageUrl": "https://images.pokemontcg.io/ex12/82.png",
     "subtype": "Special",
@@ -4090,7 +4172,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex12/82_hires.png"
   },
   {
-    "id": "ex12-83",
+    "setOrder":27,
+	"id": "ex12-83",
     "name": "Arcanine ex",
     "imageUrl": "https://images.pokemontcg.io/ex12/83.png",
     "subtype": "EX",
@@ -4151,7 +4234,8 @@
     "nationalPokedexNumber": 59
   },
   {
-    "id": "ex12-84",
+    "setOrder":27,
+	"id": "ex12-84",
     "name": "Armaldo ex",
     "imageUrl": "https://images.pokemontcg.io/ex12/84.png",
     "subtype": "EX",
@@ -4204,7 +4288,8 @@
     "nationalPokedexNumber": 348
   },
   {
-    "id": "ex12-85",
+    "setOrder":27,
+	"id": "ex12-85",
     "name": "Banette ex",
     "imageUrl": "https://images.pokemontcg.io/ex12/85.png",
     "subtype": "EX",
@@ -4261,7 +4346,8 @@
     "nationalPokedexNumber": 354
   },
   {
-    "id": "ex12-86",
+    "setOrder":27,
+	"id": "ex12-86",
     "name": "Dustox ex",
     "imageUrl": "https://images.pokemontcg.io/ex12/86.png",
     "subtype": "EX",
@@ -4306,7 +4392,8 @@
     "nationalPokedexNumber": 269
   },
   {
-    "id": "ex12-87",
+    "setOrder":27,
+	"id": "ex12-87",
     "name": "Flygon ex",
     "imageUrl": "https://images.pokemontcg.io/ex12/87.png",
     "subtype": "EX",
@@ -4358,7 +4445,8 @@
     "nationalPokedexNumber": 330
   },
   {
-    "id": "ex12-88",
+    "setOrder":27,
+	"id": "ex12-88",
     "name": "Mew ex",
     "imageUrl": "https://images.pokemontcg.io/ex12/88.png",
     "subtype": "EX",
@@ -4408,7 +4496,8 @@
     "nationalPokedexNumber": 151
   },
   {
-    "id": "ex12-89",
+    "setOrder":27,
+	"id": "ex12-89",
     "name": "Walrein ex",
     "imageUrl": "https://images.pokemontcg.io/ex12/89.png",
     "subtype": "EX",
@@ -4455,7 +4544,8 @@
     "nationalPokedexNumber": 365
   },
   {
-    "id": "ex12-90",
+    "setOrder":27,
+	"id": "ex12-90",
     "name": "Regice Star",
     "imageUrl": "https://images.pokemontcg.io/ex12/90.png",
     "subtype": "Basic",
@@ -4511,7 +4601,8 @@
     "nationalPokedexNumber": 378
   },
   {
-    "id": "ex12-91",
+    "setOrder":27,
+	"id": "ex12-91",
     "name": "Regirock Star",
     "imageUrl": "https://images.pokemontcg.io/ex12/91.png",
     "subtype": "Basic",
@@ -4567,7 +4658,8 @@
     "nationalPokedexNumber": 377
   },
   {
-    "id": "ex12-92",
+    "setOrder":27,
+	"id": "ex12-92",
     "name": "Registeel Star",
     "imageUrl": "https://images.pokemontcg.io/ex12/92.png",
     "subtype": "Basic",
@@ -4629,7 +4721,8 @@
     "nationalPokedexNumber": 379
   },
   {
-    "id": "ex12-93",
+    "setOrder":27,
+	"id": "ex12-93",
     "name": "Pikachu δ",
     "imageUrl": "https://images.pokemontcg.io/ex12/93.png",
     "subtype": "Basic",

--- a/json/cards/Legendary Collection.json
+++ b/json/cards/Legendary Collection.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "base6-1",
+    "setOrder":12,
+	"id": "base6-1",
     "name": "Alakazam",
     "imageUrl": "https://images.pokemontcg.io/base6/1.png",
     "subtype": "Stage 2",
@@ -51,7 +52,8 @@
     "nationalPokedexNumber": 65
   },
   {
-    "id": "base6-2",
+    "setOrder":12,
+	"id": "base6-2",
     "name": "Articuno",
     "imageUrl": "https://images.pokemontcg.io/base6/2.png",
     "subtype": "Basic",
@@ -107,7 +109,8 @@
     "nationalPokedexNumber": 144
   },
   {
-    "id": "base6-3",
+    "setOrder":12,
+	"id": "base6-3",
     "name": "Charizard",
     "imageUrl": "https://images.pokemontcg.io/base6/3.png",
     "subtype": "Stage 2",
@@ -165,7 +168,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "base6-4",
+    "setOrder":12,
+	"id": "base6-4",
     "name": "Dark Blastoise",
     "imageUrl": "https://images.pokemontcg.io/base6/4.png",
     "subtype": "Stage 2",
@@ -220,7 +224,8 @@
     "nationalPokedexNumber": 9
   },
   {
-    "id": "base6-5",
+    "setOrder":12,
+	"id": "base6-5",
     "name": "Dark Dragonite",
     "imageUrl": "https://images.pokemontcg.io/base6/5.png",
     "subtype": "Stage 2",
@@ -271,7 +276,8 @@
     "nationalPokedexNumber": 149
   },
   {
-    "id": "base6-6",
+    "setOrder":12,
+	"id": "base6-6",
     "name": "Dark Persian",
     "imageUrl": "https://images.pokemontcg.io/base6/6.png",
     "subtype": "Stage 1",
@@ -326,7 +332,8 @@
     "nationalPokedexNumber": 53
   },
   {
-    "id": "base6-7",
+    "setOrder":12,
+	"id": "base6-7",
     "name": "Dark Raichu",
     "imageUrl": "https://images.pokemontcg.io/base6/7.png",
     "subtype": "Stage 1",
@@ -370,7 +377,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "base6-8",
+    "setOrder":12,
+	"id": "base6-8",
     "name": "Dark Slowbro",
     "imageUrl": "https://images.pokemontcg.io/base6/8.png",
     "subtype": "Stage 1",
@@ -419,7 +427,8 @@
     "nationalPokedexNumber": 80
   },
   {
-    "id": "base6-9",
+    "setOrder":12,
+	"id": "base6-9",
     "name": "Dark Vaporeon",
     "imageUrl": "https://images.pokemontcg.io/base6/9.png",
     "subtype": "Stage 1",
@@ -474,7 +483,8 @@
     "nationalPokedexNumber": 134
   },
   {
-    "id": "base6-10",
+    "setOrder":12,
+	"id": "base6-10",
     "name": "Flareon",
     "imageUrl": "https://images.pokemontcg.io/base6/10.png",
     "subtype": "Stage 1",
@@ -529,7 +539,8 @@
     "nationalPokedexNumber": 136
   },
   {
-    "id": "base6-11",
+    "setOrder":12,
+	"id": "base6-11",
     "name": "Gengar",
     "imageUrl": "https://images.pokemontcg.io/base6/11.png",
     "subtype": "Stage 2",
@@ -578,7 +589,8 @@
     "nationalPokedexNumber": 94
   },
   {
-    "id": "base6-12",
+    "setOrder":12,
+	"id": "base6-12",
     "name": "Gyarados",
     "imageUrl": "https://images.pokemontcg.io/base6/12.png",
     "subtype": "Stage 1",
@@ -642,7 +654,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "base6-13",
+    "setOrder":12,
+	"id": "base6-13",
     "name": "Hitmonlee",
     "imageUrl": "https://images.pokemontcg.io/base6/13.png",
     "subtype": "Basic",
@@ -695,7 +708,8 @@
     "nationalPokedexNumber": 106
   },
   {
-    "id": "base6-14",
+    "setOrder":12,
+	"id": "base6-14",
     "name": "Jolteon",
     "imageUrl": "https://images.pokemontcg.io/base6/14.png",
     "subtype": "Stage 1",
@@ -749,7 +763,8 @@
     "nationalPokedexNumber": 135
   },
   {
-    "id": "base6-15",
+    "setOrder":12,
+	"id": "base6-15",
     "name": "Machamp",
     "imageUrl": "https://images.pokemontcg.io/base6/15.png",
     "subtype": "Stage 2",
@@ -801,7 +816,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "base6-16",
+    "setOrder":12,
+	"id": "base6-16",
     "name": "Muk",
     "imageUrl": "https://images.pokemontcg.io/base6/16.png",
     "subtype": "Stage 1",
@@ -851,7 +867,8 @@
     "nationalPokedexNumber": 89
   },
   {
-    "id": "base6-17",
+    "setOrder":12,
+	"id": "base6-17",
     "name": "Ninetales",
     "imageUrl": "https://images.pokemontcg.io/base6/17.png",
     "subtype": "Stage 1",
@@ -906,7 +923,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "base6-18",
+    "setOrder":12,
+	"id": "base6-18",
     "name": "Venusaur",
     "imageUrl": "https://images.pokemontcg.io/base6/18.png",
     "subtype": "Stage 2",
@@ -957,7 +975,8 @@
     "nationalPokedexNumber": 3
   },
   {
-    "id": "base6-19",
+    "setOrder":12,
+	"id": "base6-19",
     "name": "Zapdos",
     "imageUrl": "https://images.pokemontcg.io/base6/19.png",
     "subtype": "Basic",
@@ -1015,7 +1034,8 @@
     "nationalPokedexNumber": 145
   },
   {
-    "id": "base6-20",
+    "setOrder":12,
+	"id": "base6-20",
     "name": "Beedrill",
     "imageUrl": "https://images.pokemontcg.io/base6/20.png",
     "subtype": "Stage 2",
@@ -1073,7 +1093,8 @@
     "nationalPokedexNumber": 15
   },
   {
-    "id": "base6-21",
+    "setOrder":12,
+	"id": "base6-21",
     "name": "Butterfree",
     "imageUrl": "https://images.pokemontcg.io/base6/21.png",
     "subtype": "Stage 2",
@@ -1131,7 +1152,8 @@
     "nationalPokedexNumber": 12
   },
   {
-    "id": "base6-22",
+    "setOrder":12,
+	"id": "base6-22",
     "name": "Electrode",
     "imageUrl": "https://images.pokemontcg.io/base6/22.png",
     "subtype": "Stage 1",
@@ -1185,7 +1207,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "base6-23",
+    "setOrder":12,
+	"id": "base6-23",
     "name": "Exeggutor",
     "imageUrl": "https://images.pokemontcg.io/base6/23.png",
     "subtype": "Stage 1",
@@ -1238,7 +1261,8 @@
     "nationalPokedexNumber": 103
   },
   {
-    "id": "base6-24",
+    "setOrder":12,
+	"id": "base6-24",
     "name": "Golem",
     "imageUrl": "https://images.pokemontcg.io/base6/24.png",
     "subtype": "Stage 2",
@@ -1298,7 +1322,8 @@
     "nationalPokedexNumber": 76
   },
   {
-    "id": "base6-25",
+    "setOrder":12,
+	"id": "base6-25",
     "name": "Hypno",
     "imageUrl": "https://images.pokemontcg.io/base6/25.png",
     "subtype": "Stage 1",
@@ -1352,7 +1377,8 @@
     "nationalPokedexNumber": 97
   },
   {
-    "id": "base6-26",
+    "setOrder":12,
+	"id": "base6-26",
     "name": "Jynx",
     "imageUrl": "https://images.pokemontcg.io/base6/26.png",
     "subtype": "Basic",
@@ -1405,7 +1431,8 @@
     "nationalPokedexNumber": 124
   },
   {
-    "id": "base6-27",
+    "setOrder":12,
+	"id": "base6-27",
     "name": "Kabutops",
     "imageUrl": "https://images.pokemontcg.io/base6/27.png",
     "subtype": "Stage 2",
@@ -1460,7 +1487,8 @@
     "nationalPokedexNumber": 141
   },
   {
-    "id": "base6-28",
+    "setOrder":12,
+	"id": "base6-28",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/base6/28.png",
     "subtype": "Stage 1",
@@ -1519,7 +1547,8 @@
     ]
   },
   {
-    "id": "base6-29",
+    "setOrder":12,
+	"id": "base6-29",
     "name": "Mewtwo",
     "imageUrl": "https://images.pokemontcg.io/base6/29.png",
     "subtype": "Basic",
@@ -1571,7 +1600,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "base6-30",
+    "setOrder":12,
+	"id": "base6-30",
     "name": "Moltres",
     "imageUrl": "https://images.pokemontcg.io/base6/30.png",
     "subtype": "Basic",
@@ -1625,7 +1655,8 @@
     "nationalPokedexNumber": 146
   },
   {
-    "id": "base6-31",
+    "setOrder":12,
+	"id": "base6-31",
     "name": "Nidoking",
     "imageUrl": "https://images.pokemontcg.io/base6/31.png",
     "subtype": "Stage 2",
@@ -1682,7 +1713,8 @@
     "nationalPokedexNumber": 34
   },
   {
-    "id": "base6-32",
+    "setOrder":12,
+	"id": "base6-32",
     "name": "Nidoqueen",
     "imageUrl": "https://images.pokemontcg.io/base6/32.png",
     "subtype": "Stage 2",
@@ -1739,7 +1771,8 @@
     "nationalPokedexNumber": 31
   },
   {
-    "id": "base6-33",
+    "setOrder":12,
+	"id": "base6-33",
     "name": "Pidgeot",
     "imageUrl": "https://images.pokemontcg.io/base6/33.png",
     "subtype": "Stage 2",
@@ -1796,7 +1829,8 @@
     "nationalPokedexNumber": 18
   },
   {
-    "id": "base6-34",
+    "setOrder":12,
+	"id": "base6-34",
     "name": "Pidgeotto",
     "imageUrl": "https://images.pokemontcg.io/base6/34.png",
     "subtype": "Stage 1",
@@ -1859,7 +1893,8 @@
     ]
   },
   {
-    "id": "base6-35",
+    "setOrder":12,
+	"id": "base6-35",
     "name": "Rhydon",
     "imageUrl": "https://images.pokemontcg.io/base6/35.png",
     "subtype": "Stage 1",
@@ -1926,7 +1961,8 @@
     ]
   },
   {
-    "id": "base6-36",
+    "setOrder":12,
+	"id": "base6-36",
     "name": "Arcanine",
     "imageUrl": "https://images.pokemontcg.io/base6/36.png",
     "subtype": "Stage 1",
@@ -1984,7 +2020,8 @@
     "nationalPokedexNumber": 59
   },
   {
-    "id": "base6-37",
+    "setOrder":12,
+	"id": "base6-37",
     "name": "Charmeleon",
     "imageUrl": "https://images.pokemontcg.io/base6/37.png",
     "subtype": "Stage 1",
@@ -2042,7 +2079,8 @@
     ]
   },
   {
-    "id": "base6-38",
+    "setOrder":12,
+	"id": "base6-38",
     "name": "Dark Dragonair",
     "imageUrl": "https://images.pokemontcg.io/base6/38.png",
     "subtype": "Stage 1",
@@ -2095,7 +2133,8 @@
     ]
   },
   {
-    "id": "base6-39",
+    "setOrder":12,
+	"id": "base6-39",
     "name": "Dark Wartortle",
     "imageUrl": "https://images.pokemontcg.io/base6/39.png",
     "subtype": "Stage 1",
@@ -2150,7 +2189,8 @@
     ]
   },
   {
-    "id": "base6-40",
+    "setOrder":12,
+	"id": "base6-40",
     "name": "Dewgong",
     "imageUrl": "https://images.pokemontcg.io/base6/40.png",
     "subtype": "Stage 1",
@@ -2208,7 +2248,8 @@
     "nationalPokedexNumber": 87
   },
   {
-    "id": "base6-41",
+    "setOrder":12,
+	"id": "base6-41",
     "name": "Dodrio",
     "imageUrl": "https://images.pokemontcg.io/base6/41.png",
     "subtype": "Stage 1",
@@ -2260,7 +2301,8 @@
     "nationalPokedexNumber": 85
   },
   {
-    "id": "base6-42",
+    "setOrder":12,
+	"id": "base6-42",
     "name": "Fearow",
     "imageUrl": "https://images.pokemontcg.io/base6/42.png",
     "subtype": "Stage 1",
@@ -2319,7 +2361,8 @@
     "nationalPokedexNumber": 22
   },
   {
-    "id": "base6-43",
+    "setOrder":12,
+	"id": "base6-43",
     "name": "Golduck",
     "imageUrl": "https://images.pokemontcg.io/base6/43.png",
     "subtype": "Stage 1",
@@ -2372,7 +2415,8 @@
     "nationalPokedexNumber": 55
   },
   {
-    "id": "base6-44",
+    "setOrder":12,
+	"id": "base6-44",
     "name": "Graveler",
     "imageUrl": "https://images.pokemontcg.io/base6/44.png",
     "subtype": "Stage 1",
@@ -2430,7 +2474,8 @@
     ]
   },
   {
-    "id": "base6-45",
+    "setOrder":12,
+	"id": "base6-45",
     "name": "Growlithe",
     "imageUrl": "https://images.pokemontcg.io/base6/45.png",
     "subtype": "Basic",
@@ -2475,7 +2520,8 @@
     ]
   },
   {
-    "id": "base6-46",
+    "setOrder":12,
+	"id": "base6-46",
     "name": "Haunter",
     "imageUrl": "https://images.pokemontcg.io/base6/46.png",
     "subtype": "Stage 1",
@@ -2523,7 +2569,8 @@
     ]
   },
   {
-    "id": "base6-47",
+    "setOrder":12,
+	"id": "base6-47",
     "name": "Ivysaur",
     "imageUrl": "https://images.pokemontcg.io/base6/47.png",
     "subtype": "Stage 1",
@@ -2581,7 +2628,8 @@
     ]
   },
   {
-    "id": "base6-48",
+    "setOrder":12,
+	"id": "base6-48",
     "name": "Kabuto",
     "imageUrl": "https://images.pokemontcg.io/base6/48.png",
     "subtype": "Stage 1",
@@ -2630,7 +2678,8 @@
     ]
   },
   {
-    "id": "base6-49",
+    "setOrder":12,
+	"id": "base6-49",
     "name": "Kadabra",
     "imageUrl": "https://images.pokemontcg.io/base6/49.png",
     "subtype": "Stage 1",
@@ -2689,7 +2738,8 @@
     ]
   },
   {
-    "id": "base6-50",
+    "setOrder":12,
+	"id": "base6-50",
     "name": "Kakuna",
     "imageUrl": "https://images.pokemontcg.io/base6/50.png",
     "subtype": "Stage 1",
@@ -2746,7 +2796,8 @@
     ]
   },
   {
-    "id": "base6-51",
+    "setOrder":12,
+	"id": "base6-51",
     "name": "Machoke",
     "imageUrl": "https://images.pokemontcg.io/base6/51.png",
     "subtype": "Stage 1",
@@ -2807,7 +2858,8 @@
     ]
   },
   {
-    "id": "base6-52",
+    "setOrder":12,
+	"id": "base6-52",
     "name": "Magikarp",
     "imageUrl": "https://images.pokemontcg.io/base6/52.png",
     "subtype": "Basic",
@@ -2860,7 +2912,8 @@
     ]
   },
   {
-    "id": "base6-53",
+    "setOrder":12,
+	"id": "base6-53",
     "name": "Meowth",
     "imageUrl": "https://images.pokemontcg.io/base6/53.png",
     "subtype": "Basic",
@@ -2911,7 +2964,8 @@
     ]
   },
   {
-    "id": "base6-54",
+    "setOrder":12,
+	"id": "base6-54",
     "name": "Metapod",
     "imageUrl": "https://images.pokemontcg.io/base6/54.png",
     "subtype": "Stage 1",
@@ -2968,7 +3022,8 @@
     ]
   },
   {
-    "id": "base6-55",
+    "setOrder":12,
+	"id": "base6-55",
     "name": "Nidorina",
     "imageUrl": "https://images.pokemontcg.io/base6/55.png",
     "subtype": "Stage 1",
@@ -3024,7 +3079,8 @@
     ]
   },
   {
-    "id": "base6-56",
+    "setOrder":12,
+	"id": "base6-56",
     "name": "Nidorino",
     "imageUrl": "https://images.pokemontcg.io/base6/56.png",
     "subtype": "Stage 1",
@@ -3083,7 +3139,8 @@
     ]
   },
   {
-    "id": "base6-57",
+    "setOrder":12,
+	"id": "base6-57",
     "name": "Omanyte",
     "imageUrl": "https://images.pokemontcg.io/base6/57.png",
     "subtype": "Stage 1",
@@ -3132,7 +3189,8 @@
     ]
   },
   {
-    "id": "base6-58",
+    "setOrder":12,
+	"id": "base6-58",
     "name": "Omastar",
     "imageUrl": "https://images.pokemontcg.io/base6/58.png",
     "subtype": "Stage 2",
@@ -3185,7 +3243,8 @@
     "nationalPokedexNumber": 139
   },
   {
-    "id": "base6-59",
+    "setOrder":12,
+	"id": "base6-59",
     "name": "Primeape",
     "imageUrl": "https://images.pokemontcg.io/base6/59.png",
     "subtype": "Stage 1",
@@ -3239,7 +3298,8 @@
     "nationalPokedexNumber": 57
   },
   {
-    "id": "base6-60",
+    "setOrder":12,
+	"id": "base6-60",
     "name": "Rapidash",
     "imageUrl": "https://images.pokemontcg.io/base6/60.png",
     "subtype": "Stage 1",
@@ -3290,7 +3350,8 @@
     "nationalPokedexNumber": 78
   },
   {
-    "id": "base6-61",
+    "setOrder":12,
+	"id": "base6-61",
     "name": "Raticate",
     "imageUrl": "https://images.pokemontcg.io/base6/61.png",
     "subtype": "Stage 1",
@@ -3349,7 +3410,8 @@
     "nationalPokedexNumber": 20
   },
   {
-    "id": "base6-62",
+    "setOrder":12,
+	"id": "base6-62",
     "name": "Sandslash",
     "imageUrl": "https://images.pokemontcg.io/base6/62.png",
     "subtype": "Stage 1",
@@ -3408,7 +3470,8 @@
     "nationalPokedexNumber": 28
   },
   {
-    "id": "base6-63",
+    "setOrder":12,
+	"id": "base6-63",
     "name": "Seadra",
     "imageUrl": "https://images.pokemontcg.io/base6/63.png",
     "subtype": "Stage 1",
@@ -3465,7 +3528,8 @@
     ]
   },
   {
-    "id": "base6-64",
+    "setOrder":12,
+	"id": "base6-64",
     "name": "Snorlax",
     "imageUrl": "https://images.pokemontcg.io/base6/64.png",
     "subtype": "Basic",
@@ -3523,7 +3587,8 @@
     "nationalPokedexNumber": 143
   },
   {
-    "id": "base6-65",
+    "setOrder":12,
+	"id": "base6-65",
     "name": "Tauros",
     "imageUrl": "https://images.pokemontcg.io/base6/65.png",
     "subtype": "Basic",
@@ -3583,7 +3648,8 @@
     "nationalPokedexNumber": 128
   },
   {
-    "id": "base6-66",
+    "setOrder":12,
+	"id": "base6-66",
     "name": "Tentacruel",
     "imageUrl": "https://images.pokemontcg.io/base6/66.png",
     "subtype": "Stage 1",
@@ -3632,7 +3698,8 @@
     "nationalPokedexNumber": 73
   },
   {
-    "id": "base6-67",
+    "setOrder":12,
+	"id": "base6-67",
     "name": "Abra",
     "imageUrl": "https://images.pokemontcg.io/base6/67.png",
     "subtype": "Basic",
@@ -3673,7 +3740,8 @@
     ]
   },
   {
-    "id": "base6-68",
+    "setOrder":12,
+	"id": "base6-68",
     "name": "Bulbasaur",
     "imageUrl": "https://images.pokemontcg.io/base6/68.png",
     "subtype": "Basic",
@@ -3718,7 +3786,8 @@
     ]
   },
   {
-    "id": "base6-69",
+    "setOrder":12,
+	"id": "base6-69",
     "name": "Caterpie",
     "imageUrl": "https://images.pokemontcg.io/base6/69.png",
     "subtype": "Basic",
@@ -3762,7 +3831,8 @@
     ]
   },
   {
-    "id": "base6-70",
+    "setOrder":12,
+	"id": "base6-70",
     "name": "Charmander",
     "imageUrl": "https://images.pokemontcg.io/base6/70.png",
     "subtype": "Basic",
@@ -3816,7 +3886,8 @@
     ]
   },
   {
-    "id": "base6-71",
+    "setOrder":12,
+	"id": "base6-71",
     "name": "Doduo",
     "imageUrl": "https://images.pokemontcg.io/base6/71.png",
     "subtype": "Basic",
@@ -3863,7 +3934,8 @@
     ]
   },
   {
-    "id": "base6-72",
+    "setOrder":12,
+	"id": "base6-72",
     "name": "Dratini",
     "imageUrl": "https://images.pokemontcg.io/base6/72.png",
     "subtype": "Basic",
@@ -3907,7 +3979,8 @@
     ]
   },
   {
-    "id": "base6-73",
+    "setOrder":12,
+	"id": "base6-73",
     "name": "Drowzee",
     "imageUrl": "https://images.pokemontcg.io/base6/73.png",
     "subtype": "Basic",
@@ -3957,7 +4030,8 @@
     ]
   },
   {
-    "id": "base6-74",
+    "setOrder":12,
+	"id": "base6-74",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/base6/74.png",
     "subtype": "Basic",
@@ -4024,7 +4098,8 @@
     ]
   },
   {
-    "id": "base6-75",
+    "setOrder":12,
+	"id": "base6-75",
     "name": "Exeggcute",
     "imageUrl": "https://images.pokemontcg.io/base6/75.png",
     "subtype": "Basic",
@@ -4078,7 +4153,8 @@
     ]
   },
   {
-    "id": "base6-76",
+    "setOrder":12,
+	"id": "base6-76",
     "name": "Gastly",
     "imageUrl": "https://images.pokemontcg.io/base6/76.png",
     "subtype": "Basic",
@@ -4129,7 +4205,8 @@
     ]
   },
   {
-    "id": "base6-77",
+    "setOrder":12,
+	"id": "base6-77",
     "name": "Geodude",
     "imageUrl": "https://images.pokemontcg.io/base6/77.png",
     "subtype": "Basic",
@@ -4174,7 +4251,8 @@
     ]
   },
   {
-    "id": "base6-78",
+    "setOrder":12,
+	"id": "base6-78",
     "name": "Grimer",
     "imageUrl": "https://images.pokemontcg.io/base6/78.png",
     "subtype": "Basic",
@@ -4227,7 +4305,8 @@
     ]
   },
   {
-    "id": "base6-79",
+    "setOrder":12,
+	"id": "base6-79",
     "name": "Machop",
     "imageUrl": "https://images.pokemontcg.io/base6/79.png",
     "subtype": "Basic",
@@ -4283,7 +4362,8 @@
     ]
   },
   {
-    "id": "base6-80",
+    "setOrder":12,
+	"id": "base6-80",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/base6/80.png",
     "subtype": "Basic",
@@ -4337,7 +4417,8 @@
     ]
   },
   {
-    "id": "base6-81",
+    "setOrder":12,
+	"id": "base6-81",
     "name": "Mankey",
     "imageUrl": "https://images.pokemontcg.io/base6/81.png",
     "subtype": "Basic",
@@ -4388,7 +4469,8 @@
     ]
   },
   {
-    "id": "base6-82",
+    "setOrder":12,
+	"id": "base6-82",
     "name": "Nidoran♀",
     "imageUrl": "https://images.pokemontcg.io/base6/82.png",
     "subtype": "Basic",
@@ -4442,7 +4524,8 @@
     ]
   },
   {
-    "id": "base6-83",
+    "setOrder":12,
+	"id": "base6-83",
     "name": "Nidoran♂",
     "imageUrl": "https://images.pokemontcg.io/base6/83.png",
     "subtype": "Basic",
@@ -4486,7 +4569,8 @@
     ]
   },
   {
-    "id": "base6-84",
+    "setOrder":12,
+	"id": "base6-84",
     "name": "Onix",
     "imageUrl": "https://images.pokemontcg.io/base6/84.png",
     "subtype": "Basic",
@@ -4542,7 +4626,8 @@
     ]
   },
   {
-    "id": "base6-85",
+    "setOrder":12,
+	"id": "base6-85",
     "name": "Pidgey",
     "imageUrl": "https://images.pokemontcg.io/base6/85.png",
     "subtype": "Basic",
@@ -4593,7 +4678,8 @@
     ]
   },
   {
-    "id": "base6-86",
+    "setOrder":12,
+	"id": "base6-86",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/base6/86.png",
     "subtype": "Basic",
@@ -4638,7 +4724,8 @@
     ]
   },
   {
-    "id": "base6-87",
+    "setOrder":12,
+	"id": "base6-87",
     "name": "Ponyta",
     "imageUrl": "https://images.pokemontcg.io/base6/87.png",
     "subtype": "Basic",
@@ -4693,7 +4780,8 @@
     ]
   },
   {
-    "id": "base6-88",
+    "setOrder":12,
+	"id": "base6-88",
     "name": "Psyduck",
     "imageUrl": "https://images.pokemontcg.io/base6/88.png",
     "subtype": "Basic",
@@ -4747,7 +4835,8 @@
     ]
   },
   {
-    "id": "base6-89",
+    "setOrder":12,
+	"id": "base6-89",
     "name": "Rattata",
     "imageUrl": "https://images.pokemontcg.io/base6/89.png",
     "subtype": "Basic",
@@ -4794,7 +4883,8 @@
     ]
   },
   {
-    "id": "base6-90",
+    "setOrder":12,
+	"id": "base6-90",
     "name": "Rhyhorn",
     "imageUrl": "https://images.pokemontcg.io/base6/90.png",
     "subtype": "Basic",
@@ -4857,7 +4947,8 @@
     ]
   },
   {
-    "id": "base6-91",
+    "setOrder":12,
+	"id": "base6-91",
     "name": "Sandshrew",
     "imageUrl": "https://images.pokemontcg.io/base6/91.png",
     "subtype": "Basic",
@@ -4907,7 +4998,8 @@
     ]
   },
   {
-    "id": "base6-92",
+    "setOrder":12,
+	"id": "base6-92",
     "name": "Seel",
     "imageUrl": "https://images.pokemontcg.io/base6/92.png",
     "subtype": "Basic",
@@ -4951,7 +5043,8 @@
     ]
   },
   {
-    "id": "base6-93",
+    "setOrder":12,
+	"id": "base6-93",
     "name": "Slowpoke",
     "imageUrl": "https://images.pokemontcg.io/base6/93.png",
     "subtype": "Basic",
@@ -5006,7 +5099,8 @@
     ]
   },
   {
-    "id": "base6-94",
+    "setOrder":12,
+	"id": "base6-94",
     "name": "Spearow",
     "imageUrl": "https://images.pokemontcg.io/base6/94.png",
     "subtype": "Basic",
@@ -5064,7 +5158,8 @@
     ]
   },
   {
-    "id": "base6-95",
+    "setOrder":12,
+	"id": "base6-95",
     "name": "Squirtle",
     "imageUrl": "https://images.pokemontcg.io/base6/95.png",
     "subtype": "Basic",
@@ -5118,7 +5213,8 @@
     ]
   },
   {
-    "id": "base6-96",
+    "setOrder":12,
+	"id": "base6-96",
     "name": "Tentacool",
     "imageUrl": "https://images.pokemontcg.io/base6/96.png",
     "subtype": "Basic",
@@ -5164,7 +5260,8 @@
     ]
   },
   {
-    "id": "base6-97",
+    "setOrder":12,
+	"id": "base6-97",
     "name": "Voltorb",
     "imageUrl": "https://images.pokemontcg.io/base6/97.png",
     "subtype": "Basic",
@@ -5208,7 +5305,8 @@
     ]
   },
   {
-    "id": "base6-98",
+    "setOrder":12,
+	"id": "base6-98",
     "name": "Vulpix",
     "imageUrl": "https://images.pokemontcg.io/base6/98.png",
     "subtype": "Basic",
@@ -5253,7 +5351,8 @@
     ]
   },
   {
-    "id": "base6-99",
+    "setOrder":12,
+	"id": "base6-99",
     "name": "Weedle",
     "imageUrl": "https://images.pokemontcg.io/base6/99.png",
     "subtype": "Basic",
@@ -5297,7 +5396,8 @@
     ]
   },
   {
-    "id": "base6-100",
+    "setOrder":12,
+	"id": "base6-100",
     "name": "Full Heal Energy",
     "imageUrl": "https://images.pokemontcg.io/base6/100.png",
     "subtype": "Special",
@@ -5314,7 +5414,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base6/100_hires.png"
   },
   {
-    "id": "base6-101",
+    "setOrder":12,
+	"id": "base6-101",
     "name": "Potion Energy",
     "imageUrl": "https://images.pokemontcg.io/base6/101.png",
     "subtype": "Special",
@@ -5331,7 +5432,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base6/101_hires.png"
   },
   {
-    "id": "base6-102",
+    "setOrder":12,
+	"id": "base6-102",
     "name": "Pokémon Breeder",
     "imageUrl": "https://images.pokemontcg.io/base6/102.png",
     "subtype": "",
@@ -5348,7 +5450,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base6/102_hires.png"
   },
   {
-    "id": "base6-103",
+    "setOrder":12,
+	"id": "base6-103",
     "name": "Pokémon Trader",
     "imageUrl": "https://images.pokemontcg.io/base6/103.png",
     "subtype": "",
@@ -5365,7 +5468,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base6/103_hires.png"
   },
   {
-    "id": "base6-104",
+    "setOrder":12,
+	"id": "base6-104",
     "name": "Scoop Up",
     "imageUrl": "https://images.pokemontcg.io/base6/104.png",
     "subtype": "",
@@ -5382,7 +5486,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base6/104_hires.png"
   },
   {
-    "id": "base6-105",
+    "setOrder":12,
+	"id": "base6-105",
     "name": "The Boss's Way",
     "imageUrl": "https://images.pokemontcg.io/base6/105.png",
     "subtype": "",
@@ -5399,7 +5504,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base6/105_hires.png"
   },
   {
-    "id": "base6-106",
+    "setOrder":12,
+	"id": "base6-106",
     "name": "Challenge!",
     "imageUrl": "https://images.pokemontcg.io/base6/106.png",
     "subtype": "",
@@ -5416,7 +5522,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base6/106_hires.png"
   },
   {
-    "id": "base6-107",
+    "setOrder":12,
+	"id": "base6-107",
     "name": "Energy Retrieval",
     "imageUrl": "https://images.pokemontcg.io/base6/107.png",
     "subtype": "",
@@ -5433,7 +5540,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base6/107_hires.png"
   },
   {
-    "id": "base6-108",
+    "setOrder":12,
+	"id": "base6-108",
     "name": "Bill",
     "imageUrl": "https://images.pokemontcg.io/base6/108.png",
     "subtype": "",
@@ -5450,7 +5558,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base6/108_hires.png"
   },
   {
-    "id": "base6-109",
+    "setOrder":12,
+	"id": "base6-109",
     "name": "Mysterious Fossil",
     "imageUrl": "https://images.pokemontcg.io/base6/109.png",
     "subtype": "",
@@ -5468,7 +5577,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base6/109_hires.png"
   },
   {
-    "id": "base6-110",
+    "setOrder":12,
+	"id": "base6-110",
     "name": "Potion",
     "imageUrl": "https://images.pokemontcg.io/base6/110.png",
     "subtype": "",

--- a/json/cards/Legendary Treasures.json
+++ b/json/cards/Legendary Treasures.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "bw11-1",
+    "setOrder":58,
+	"id": "bw11-1",
     "name": "Tangela",
     "imageUrl": "https://images.pokemontcg.io/bw11/1.png",
     "subtype": "Basic",
@@ -61,7 +62,8 @@
     ]
   },
   {
-    "id": "bw11-2",
+    "setOrder":58,
+	"id": "bw11-2",
     "name": "Tangrowth",
     "imageUrl": "https://images.pokemontcg.io/bw11/2.png",
     "subtype": "Stage 1",
@@ -123,7 +125,8 @@
     "nationalPokedexNumber": 465
   },
   {
-    "id": "bw11-3",
+    "setOrder":58,
+	"id": "bw11-3",
     "name": "Shuckle",
     "imageUrl": "https://images.pokemontcg.io/bw11/3.png",
     "subtype": "Basic",
@@ -174,7 +177,8 @@
     "nationalPokedexNumber": 213
   },
   {
-    "id": "bw11-4",
+    "setOrder":58,
+	"id": "bw11-4",
     "name": "Cherubi",
     "imageUrl": "https://images.pokemontcg.io/bw11/4.png",
     "subtype": "Basic",
@@ -223,7 +227,8 @@
     ]
   },
   {
-    "id": "bw11-5",
+    "setOrder":58,
+	"id": "bw11-5",
     "name": "Carnivine",
     "imageUrl": "https://images.pokemontcg.io/bw11/5.png",
     "subtype": "Basic",
@@ -271,7 +276,8 @@
     "nationalPokedexNumber": 455
   },
   {
-    "id": "bw11-6",
+    "setOrder":58,
+	"id": "bw11-6",
     "name": "Snivy",
     "imageUrl": "https://images.pokemontcg.io/bw11/6.png",
     "subtype": "Basic",
@@ -321,7 +327,8 @@
     ]
   },
   {
-    "id": "bw11-7",
+    "setOrder":58,
+	"id": "bw11-7",
     "name": "Servine",
     "imageUrl": "https://images.pokemontcg.io/bw11/7.png",
     "subtype": "Stage 1",
@@ -372,7 +379,8 @@
     ]
   },
   {
-    "id": "bw11-8",
+    "setOrder":58,
+	"id": "bw11-8",
     "name": "Serperior",
     "imageUrl": "https://images.pokemontcg.io/bw11/8.png",
     "subtype": "Stage 2",
@@ -425,7 +433,8 @@
     "nationalPokedexNumber": 497
   },
   {
-    "id": "bw11-9",
+    "setOrder":58,
+	"id": "bw11-9",
     "name": "Sewaddle",
     "imageUrl": "https://images.pokemontcg.io/bw11/9.png",
     "subtype": "Basic",
@@ -469,7 +478,8 @@
     ]
   },
   {
-    "id": "bw11-10",
+    "setOrder":58,
+	"id": "bw11-10",
     "name": "Sewaddle",
     "imageUrl": "https://images.pokemontcg.io/bw11/10.png",
     "subtype": "Basic",
@@ -513,7 +523,8 @@
     ]
   },
   {
-    "id": "bw11-11",
+    "setOrder":58,
+	"id": "bw11-11",
     "name": "Swadloon",
     "imageUrl": "https://images.pokemontcg.io/bw11/11.png",
     "subtype": "Stage 1",
@@ -567,7 +578,8 @@
     ]
   },
   {
-    "id": "bw11-12",
+    "setOrder":58,
+	"id": "bw11-12",
     "name": "Leavanny",
     "imageUrl": "https://images.pokemontcg.io/bw11/12.png",
     "subtype": "Stage 2",
@@ -616,7 +628,8 @@
     "nationalPokedexNumber": 542
   },
   {
-    "id": "bw11-13",
+    "setOrder":58,
+	"id": "bw11-13",
     "name": "Dwebble",
     "imageUrl": "https://images.pokemontcg.io/bw11/13.png",
     "subtype": "Basic",
@@ -661,7 +674,8 @@
     ]
   },
   {
-    "id": "bw11-14",
+    "setOrder":58,
+	"id": "bw11-14",
     "name": "Crustle",
     "imageUrl": "https://images.pokemontcg.io/bw11/14.png",
     "subtype": "Stage 1",
@@ -715,7 +729,8 @@
     "nationalPokedexNumber": 558
   },
   {
-    "id": "bw11-15",
+    "setOrder":58,
+	"id": "bw11-15",
     "name": "Virizion",
     "imageUrl": "https://images.pokemontcg.io/bw11/15.png",
     "subtype": "Basic",
@@ -771,7 +786,8 @@
     "nationalPokedexNumber": 640
   },
   {
-    "id": "bw11-16",
+    "setOrder":58,
+	"id": "bw11-16",
     "name": "Genesect",
     "imageUrl": "https://images.pokemontcg.io/bw11/16.png",
     "subtype": "Basic",
@@ -823,7 +839,8 @@
     "nationalPokedexNumber": 649
   },
   {
-    "id": "bw11-17",
+    "setOrder":58,
+	"id": "bw11-17",
     "name": "Charmander",
     "imageUrl": "https://images.pokemontcg.io/bw11/17.png",
     "subtype": "Basic",
@@ -877,7 +894,8 @@
     ]
   },
   {
-    "id": "bw11-18",
+    "setOrder":58,
+	"id": "bw11-18",
     "name": "Charmeleon",
     "imageUrl": "https://images.pokemontcg.io/bw11/18.png",
     "subtype": "Stage 1",
@@ -933,7 +951,8 @@
     ]
   },
   {
-    "id": "bw11-19",
+    "setOrder":58,
+	"id": "bw11-19",
     "name": "Charizard",
     "imageUrl": "https://images.pokemontcg.io/bw11/19.png",
     "subtype": "Stage 2",
@@ -991,7 +1010,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "bw11-20",
+    "setOrder":58,
+	"id": "bw11-20",
     "name": "Vulpix",
     "imageUrl": "https://images.pokemontcg.io/bw11/20.png",
     "subtype": "Basic",
@@ -1035,7 +1055,8 @@
     ]
   },
   {
-    "id": "bw11-21",
+    "setOrder":58,
+	"id": "bw11-21",
     "name": "Ninetales",
     "imageUrl": "https://images.pokemontcg.io/bw11/21.png",
     "subtype": "Stage 1",
@@ -1078,7 +1099,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "bw11-22",
+    "setOrder":58,
+	"id": "bw11-22",
     "name": "Moltres",
     "imageUrl": "https://images.pokemontcg.io/bw11/22.png",
     "subtype": "Basic",
@@ -1139,7 +1161,8 @@
     "nationalPokedexNumber": 146
   },
   {
-    "id": "bw11-23",
+    "setOrder":58,
+	"id": "bw11-23",
     "name": "Victini",
     "imageUrl": "https://images.pokemontcg.io/bw11/23.png",
     "subtype": "Basic",
@@ -1185,7 +1208,8 @@
     "nationalPokedexNumber": 494
   },
   {
-    "id": "bw11-24",
+    "setOrder":58,
+	"id": "bw11-24",
     "name": "Victini-EX",
     "imageUrl": "https://images.pokemontcg.io/bw11/24.png",
     "subtype": "EX",
@@ -1239,7 +1263,8 @@
     "nationalPokedexNumber": 494
   },
   {
-    "id": "bw11-25",
+    "setOrder":58,
+	"id": "bw11-25",
     "name": "Tepig",
     "imageUrl": "https://images.pokemontcg.io/bw11/25.png",
     "subtype": "Basic",
@@ -1284,7 +1309,8 @@
     ]
   },
   {
-    "id": "bw11-26",
+    "setOrder":58,
+	"id": "bw11-26",
     "name": "Pignite",
     "imageUrl": "https://images.pokemontcg.io/bw11/26.png",
     "subtype": "Stage 1",
@@ -1342,7 +1368,8 @@
     ]
   },
   {
-    "id": "bw11-27",
+    "setOrder":58,
+	"id": "bw11-27",
     "name": "Emboar",
     "imageUrl": "https://images.pokemontcg.io/bw11/27.png",
     "subtype": "Stage 2",
@@ -1394,7 +1421,8 @@
     "nationalPokedexNumber": 500
   },
   {
-    "id": "bw11-28",
+    "setOrder":58,
+	"id": "bw11-28",
     "name": "Reshiram",
     "imageUrl": "https://images.pokemontcg.io/bw11/28.png",
     "subtype": "Basic",
@@ -1447,7 +1475,8 @@
     "nationalPokedexNumber": 643
   },
   {
-    "id": "bw11-29",
+    "setOrder":58,
+	"id": "bw11-29",
     "name": "Reshiram-EX",
     "imageUrl": "https://images.pokemontcg.io/bw11/29.png",
     "subtype": "EX",
@@ -1506,7 +1535,8 @@
     "nationalPokedexNumber": 643
   },
   {
-    "id": "bw11-30",
+    "setOrder":58,
+	"id": "bw11-30",
     "name": "Magikarp",
     "imageUrl": "https://images.pokemontcg.io/bw11/30.png",
     "subtype": "Basic",
@@ -1549,7 +1579,8 @@
     ]
   },
   {
-    "id": "bw11-31",
+    "setOrder":58,
+	"id": "bw11-31",
     "name": "Gyarados",
     "imageUrl": "https://images.pokemontcg.io/bw11/31.png",
     "subtype": "Stage 1",
@@ -1606,7 +1637,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "bw11-32",
+    "setOrder":58,
+	"id": "bw11-32",
     "name": "Articuno",
     "imageUrl": "https://images.pokemontcg.io/bw11/32.png",
     "subtype": "Basic",
@@ -1667,7 +1699,8 @@
     "nationalPokedexNumber": 144
   },
   {
-    "id": "bw11-33",
+    "setOrder":58,
+	"id": "bw11-33",
     "name": "Piplup",
     "imageUrl": "https://images.pokemontcg.io/bw11/33.png",
     "subtype": "Basic",
@@ -1711,7 +1744,8 @@
     ]
   },
   {
-    "id": "bw11-34",
+    "setOrder":58,
+	"id": "bw11-34",
     "name": "Prinplup",
     "imageUrl": "https://images.pokemontcg.io/bw11/34.png",
     "subtype": "Stage 1",
@@ -1757,7 +1791,8 @@
     ]
   },
   {
-    "id": "bw11-35",
+    "setOrder":58,
+	"id": "bw11-35",
     "name": "Empoleon",
     "imageUrl": "https://images.pokemontcg.io/bw11/35.png",
     "subtype": "Stage 2",
@@ -1811,7 +1846,8 @@
     "nationalPokedexNumber": 395
   },
   {
-    "id": "bw11-36",
+    "setOrder":58,
+	"id": "bw11-36",
     "name": "Phione",
     "imageUrl": "https://images.pokemontcg.io/bw11/36.png",
     "subtype": "Basic",
@@ -1860,7 +1896,8 @@
     "nationalPokedexNumber": 489
   },
   {
-    "id": "bw11-37",
+    "setOrder":58,
+	"id": "bw11-37",
     "name": "Oshawott",
     "imageUrl": "https://images.pokemontcg.io/bw11/37.png",
     "subtype": "Basic",
@@ -1904,7 +1941,8 @@
     ]
   },
   {
-    "id": "bw11-38",
+    "setOrder":58,
+	"id": "bw11-38",
     "name": "Dewott",
     "imageUrl": "https://images.pokemontcg.io/bw11/38.png",
     "subtype": "Stage 1",
@@ -1949,7 +1987,8 @@
     ]
   },
   {
-    "id": "bw11-39",
+    "setOrder":58,
+	"id": "bw11-39",
     "name": "Samurott",
     "imageUrl": "https://images.pokemontcg.io/bw11/39.png",
     "subtype": "Stage 2",
@@ -1998,7 +2037,8 @@
     "nationalPokedexNumber": 503
   },
   {
-    "id": "bw11-40",
+    "setOrder":58,
+	"id": "bw11-40",
     "name": "Tympole",
     "imageUrl": "https://images.pokemontcg.io/bw11/40.png",
     "subtype": "Basic",
@@ -2051,7 +2091,8 @@
     ]
   },
   {
-    "id": "bw11-41",
+    "setOrder":58,
+	"id": "bw11-41",
     "name": "Palpitoad",
     "imageUrl": "https://images.pokemontcg.io/bw11/41.png",
     "subtype": "Stage 1",
@@ -2107,7 +2148,8 @@
     ]
   },
   {
-    "id": "bw11-42",
+    "setOrder":58,
+	"id": "bw11-42",
     "name": "Seismitoad",
     "imageUrl": "https://images.pokemontcg.io/bw11/42.png",
     "subtype": "Stage 2",
@@ -2162,7 +2204,8 @@
     "nationalPokedexNumber": 537
   },
   {
-    "id": "bw11-43",
+    "setOrder":58,
+	"id": "bw11-43",
     "name": "Kyurem",
     "imageUrl": "https://images.pokemontcg.io/bw11/43.png",
     "subtype": "Basic",
@@ -2215,7 +2258,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "bw11-44",
+    "setOrder":58,
+	"id": "bw11-44",
     "name": "Kyurem-EX",
     "imageUrl": "https://images.pokemontcg.io/bw11/44.png",
     "subtype": "EX",
@@ -2274,7 +2318,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "bw11-45",
+    "setOrder":58,
+	"id": "bw11-45",
     "name": "Keldeo-EX",
     "imageUrl": "https://images.pokemontcg.io/bw11/45.png",
     "subtype": "EX",
@@ -2325,7 +2370,8 @@
     "nationalPokedexNumber": 647
   },
   {
-    "id": "bw11-46",
+    "setOrder":58,
+	"id": "bw11-46",
     "name": "Zapdos",
     "imageUrl": "https://images.pokemontcg.io/bw11/46.png",
     "subtype": "Basic",
@@ -2386,7 +2432,8 @@
     "nationalPokedexNumber": 145
   },
   {
-    "id": "bw11-47",
+    "setOrder":58,
+	"id": "bw11-47",
     "name": "Plusle",
     "imageUrl": "https://images.pokemontcg.io/bw11/47.png",
     "subtype": "Basic",
@@ -2435,7 +2482,8 @@
     "nationalPokedexNumber": 311
   },
   {
-    "id": "bw11-48",
+    "setOrder":58,
+	"id": "bw11-48",
     "name": "Minun",
     "imageUrl": "https://images.pokemontcg.io/bw11/48.png",
     "subtype": "Basic",
@@ -2484,7 +2532,8 @@
     "nationalPokedexNumber": 312
   },
   {
-    "id": "bw11-49",
+    "setOrder":58,
+	"id": "bw11-49",
     "name": "Emolga",
     "imageUrl": "https://images.pokemontcg.io/bw11/49.png",
     "subtype": "Basic",
@@ -2536,7 +2585,8 @@
     "nationalPokedexNumber": 587
   },
   {
-    "id": "bw11-50",
+    "setOrder":58,
+	"id": "bw11-50",
     "name": "Thundurus",
     "imageUrl": "https://images.pokemontcg.io/bw11/50.png",
     "subtype": "Basic",
@@ -2587,7 +2637,8 @@
     "nationalPokedexNumber": 642
   },
   {
-    "id": "bw11-51",
+    "setOrder":58,
+	"id": "bw11-51",
     "name": "Zekrom",
     "imageUrl": "https://images.pokemontcg.io/bw11/51.png",
     "subtype": "Basic",
@@ -2640,7 +2691,8 @@
     "nationalPokedexNumber": 644
   },
   {
-    "id": "bw11-52",
+    "setOrder":58,
+	"id": "bw11-52",
     "name": "Zekrom-EX",
     "imageUrl": "https://images.pokemontcg.io/bw11/52.png",
     "subtype": "EX",
@@ -2699,7 +2751,8 @@
     "nationalPokedexNumber": 644
   },
   {
-    "id": "bw11-53",
+    "setOrder":58,
+	"id": "bw11-53",
     "name": "Mewtwo",
     "imageUrl": "https://images.pokemontcg.io/bw11/53.png",
     "subtype": "Basic",
@@ -2753,7 +2806,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "bw11-54",
+    "setOrder":58,
+	"id": "bw11-54",
     "name": "Mewtwo-EX",
     "imageUrl": "https://images.pokemontcg.io/bw11/54.png",
     "subtype": "EX",
@@ -2810,7 +2864,8 @@
     "evolvesTo": "M Mewtwo-EX"
   },
   {
-    "id": "bw11-55",
+    "setOrder":58,
+	"id": "bw11-55",
     "name": "Natu",
     "imageUrl": "https://images.pokemontcg.io/bw11/55.png",
     "subtype": "Basic",
@@ -2854,7 +2909,8 @@
     ]
   },
   {
-    "id": "bw11-56",
+    "setOrder":58,
+	"id": "bw11-56",
     "name": "Xatu",
     "imageUrl": "https://images.pokemontcg.io/bw11/56.png",
     "subtype": "Stage 1",
@@ -2906,7 +2962,8 @@
     "nationalPokedexNumber": 178
   },
   {
-    "id": "bw11-57",
+    "setOrder":58,
+	"id": "bw11-57",
     "name": "Misdreavus",
     "imageUrl": "https://images.pokemontcg.io/bw11/57.png",
     "subtype": "Basic",
@@ -2950,7 +3007,8 @@
     ]
   },
   {
-    "id": "bw11-58",
+    "setOrder":58,
+	"id": "bw11-58",
     "name": "Mismagius",
     "imageUrl": "https://images.pokemontcg.io/bw11/58.png",
     "subtype": "Stage 1",
@@ -3003,7 +3061,8 @@
     "nationalPokedexNumber": 429
   },
   {
-    "id": "bw11-59",
+    "setOrder":58,
+	"id": "bw11-59",
     "name": "Ralts",
     "imageUrl": "https://images.pokemontcg.io/bw11/59.png",
     "subtype": "Basic",
@@ -3047,7 +3106,8 @@
     ]
   },
   {
-    "id": "bw11-60",
+    "setOrder":58,
+	"id": "bw11-60",
     "name": "Kirlia",
     "imageUrl": "https://images.pokemontcg.io/bw11/60.png",
     "subtype": "Stage 1",
@@ -3104,7 +3164,8 @@
     ]
   },
   {
-    "id": "bw11-61",
+    "setOrder":58,
+	"id": "bw11-61",
     "name": "Sableye",
     "imageUrl": "https://images.pokemontcg.io/bw11/61.png",
     "subtype": "Basic",
@@ -3139,7 +3200,8 @@
     "nationalPokedexNumber": 302
   },
   {
-    "id": "bw11-62",
+    "setOrder":58,
+	"id": "bw11-62",
     "name": "Croagunk",
     "imageUrl": "https://images.pokemontcg.io/bw11/62.png",
     "subtype": "Basic",
@@ -3183,7 +3245,8 @@
     ]
   },
   {
-    "id": "bw11-63",
+    "setOrder":58,
+	"id": "bw11-63",
     "name": "Toxicroak",
     "imageUrl": "https://images.pokemontcg.io/bw11/63.png",
     "subtype": "Stage 1",
@@ -3235,7 +3298,8 @@
     "nationalPokedexNumber": 454
   },
   {
-    "id": "bw11-64",
+    "setOrder":58,
+	"id": "bw11-64",
     "name": "Woobat",
     "imageUrl": "https://images.pokemontcg.io/bw11/64.png",
     "subtype": "Basic",
@@ -3284,7 +3348,8 @@
     ]
   },
   {
-    "id": "bw11-65",
+    "setOrder":58,
+	"id": "bw11-65",
     "name": "Swoobat",
     "imageUrl": "https://images.pokemontcg.io/bw11/65.png",
     "subtype": "Stage 1",
@@ -3340,7 +3405,8 @@
     "nationalPokedexNumber": 528
   },
   {
-    "id": "bw11-66",
+    "setOrder":58,
+	"id": "bw11-66",
     "name": "Sigilyph",
     "imageUrl": "https://images.pokemontcg.io/bw11/66.png",
     "subtype": "Basic",
@@ -3387,7 +3453,8 @@
     "nationalPokedexNumber": 561
   },
   {
-    "id": "bw11-67",
+    "setOrder":58,
+	"id": "bw11-67",
     "name": "Trubbish",
     "imageUrl": "https://images.pokemontcg.io/bw11/67.png",
     "subtype": "Basic",
@@ -3443,7 +3510,8 @@
     ]
   },
   {
-    "id": "bw11-68",
+    "setOrder":58,
+	"id": "bw11-68",
     "name": "Garbodor",
     "imageUrl": "https://images.pokemontcg.io/bw11/68.png",
     "subtype": "Stage 1",
@@ -3493,7 +3561,8 @@
     "nationalPokedexNumber": 569
   },
   {
-    "id": "bw11-69",
+    "setOrder":58,
+	"id": "bw11-69",
     "name": "Gothita",
     "imageUrl": "https://images.pokemontcg.io/bw11/69.png",
     "subtype": "Basic",
@@ -3546,7 +3615,8 @@
     ]
   },
   {
-    "id": "bw11-70",
+    "setOrder":58,
+	"id": "bw11-70",
     "name": "Gothita",
     "imageUrl": "https://images.pokemontcg.io/bw11/70.png",
     "subtype": "Basic",
@@ -3590,7 +3660,8 @@
     ]
   },
   {
-    "id": "bw11-71",
+    "setOrder":58,
+	"id": "bw11-71",
     "name": "Gothorita",
     "imageUrl": "https://images.pokemontcg.io/bw11/71.png",
     "subtype": "Stage 1",
@@ -3644,7 +3715,8 @@
     ]
   },
   {
-    "id": "bw11-72",
+    "setOrder":58,
+	"id": "bw11-72",
     "name": "Gothitelle",
     "imageUrl": "https://images.pokemontcg.io/bw11/72.png",
     "subtype": "Stage 2",
@@ -3693,7 +3765,8 @@
     "nationalPokedexNumber": 576
   },
   {
-    "id": "bw11-73",
+    "setOrder":58,
+	"id": "bw11-73",
     "name": "Solosis",
     "imageUrl": "https://images.pokemontcg.io/bw11/73.png",
     "subtype": "Basic",
@@ -3736,7 +3809,8 @@
     ]
   },
   {
-    "id": "bw11-74",
+    "setOrder":58,
+	"id": "bw11-74",
     "name": "Solosis",
     "imageUrl": "https://images.pokemontcg.io/bw11/74.png",
     "subtype": "Basic",
@@ -3789,7 +3863,8 @@
     ]
   },
   {
-    "id": "bw11-75",
+    "setOrder":58,
+	"id": "bw11-75",
     "name": "Duosion",
     "imageUrl": "https://images.pokemontcg.io/bw11/75.png",
     "subtype": "Stage 1",
@@ -3833,7 +3908,8 @@
     ]
   },
   {
-    "id": "bw11-76",
+    "setOrder":58,
+	"id": "bw11-76",
     "name": "Reuniclus",
     "imageUrl": "https://images.pokemontcg.io/bw11/76.png",
     "subtype": "Stage 2",
@@ -3884,7 +3960,8 @@
     "nationalPokedexNumber": 579
   },
   {
-    "id": "bw11-77",
+    "setOrder":58,
+	"id": "bw11-77",
     "name": "Chandelure-EX",
     "imageUrl": "https://images.pokemontcg.io/bw11/77.png",
     "subtype": "EX",
@@ -3939,7 +4016,8 @@
     "nationalPokedexNumber": 609
   },
   {
-    "id": "bw11-78",
+    "setOrder":58,
+	"id": "bw11-78",
     "name": "Meloetta",
     "imageUrl": "https://images.pokemontcg.io/bw11/78.png",
     "subtype": "Basic",
@@ -3990,7 +4068,8 @@
     "nationalPokedexNumber": 648
   },
   {
-    "id": "bw11-79",
+    "setOrder":58,
+	"id": "bw11-79",
     "name": "Riolu",
     "imageUrl": "https://images.pokemontcg.io/bw11/79.png",
     "subtype": "Basic",
@@ -4043,7 +4122,8 @@
     ]
   },
   {
-    "id": "bw11-80",
+    "setOrder":58,
+	"id": "bw11-80",
     "name": "Lucario",
     "imageUrl": "https://images.pokemontcg.io/bw11/80.png",
     "subtype": "Stage 1",
@@ -4090,7 +4170,8 @@
     "nationalPokedexNumber": 448
   },
   {
-    "id": "bw11-81",
+    "setOrder":58,
+	"id": "bw11-81",
     "name": "Gallade",
     "imageUrl": "https://images.pokemontcg.io/bw11/81.png",
     "subtype": "Stage 2",
@@ -4143,7 +4224,8 @@
     "nationalPokedexNumber": 475
   },
   {
-    "id": "bw11-82",
+    "setOrder":58,
+	"id": "bw11-82",
     "name": "Excadrill-EX",
     "imageUrl": "https://images.pokemontcg.io/bw11/82.png",
     "subtype": "EX",
@@ -4207,7 +4289,8 @@
     "nationalPokedexNumber": 530
   },
   {
-    "id": "bw11-83",
+    "setOrder":58,
+	"id": "bw11-83",
     "name": "Stunfisk",
     "imageUrl": "https://images.pokemontcg.io/bw11/83.png",
     "subtype": "Basic",
@@ -4265,7 +4348,8 @@
     "nationalPokedexNumber": 618
   },
   {
-    "id": "bw11-84",
+    "setOrder":58,
+	"id": "bw11-84",
     "name": "Terrakion",
     "imageUrl": "https://images.pokemontcg.io/bw11/84.png",
     "subtype": "Basic",
@@ -4320,7 +4404,8 @@
     "nationalPokedexNumber": 639
   },
   {
-    "id": "bw11-85",
+    "setOrder":58,
+	"id": "bw11-85",
     "name": "Landorus",
     "imageUrl": "https://images.pokemontcg.io/bw11/85.png",
     "subtype": "Basic",
@@ -4377,7 +4462,8 @@
     "nationalPokedexNumber": 645
   },
   {
-    "id": "bw11-86",
+    "setOrder":58,
+	"id": "bw11-86",
     "name": "Meloetta",
     "imageUrl": "https://images.pokemontcg.io/bw11/86.png",
     "subtype": "Basic",
@@ -4428,7 +4514,8 @@
     "nationalPokedexNumber": 648
   },
   {
-    "id": "bw11-87",
+    "setOrder":58,
+	"id": "bw11-87",
     "name": "Spiritomb",
     "imageUrl": "https://images.pokemontcg.io/bw11/87.png",
     "subtype": "Basic",
@@ -4467,7 +4554,8 @@
     "nationalPokedexNumber": 442
   },
   {
-    "id": "bw11-88",
+    "setOrder":58,
+	"id": "bw11-88",
     "name": "Darkrai-EX",
     "imageUrl": "https://images.pokemontcg.io/bw11/88.png",
     "subtype": "EX",
@@ -4524,7 +4612,8 @@
     "nationalPokedexNumber": 491
   },
   {
-    "id": "bw11-89",
+    "setOrder":58,
+	"id": "bw11-89",
     "name": "Zorua",
     "imageUrl": "https://images.pokemontcg.io/bw11/89.png",
     "subtype": "Basic",
@@ -4583,7 +4672,8 @@
     ]
   },
   {
-    "id": "bw11-90",
+    "setOrder":58,
+	"id": "bw11-90",
     "name": "Zoroark",
     "imageUrl": "https://images.pokemontcg.io/bw11/90.png",
     "subtype": "Stage 1",
@@ -4642,7 +4732,8 @@
     "nationalPokedexNumber": 571
   },
   {
-    "id": "bw11-91",
+    "setOrder":58,
+	"id": "bw11-91",
     "name": "Cobalion",
     "imageUrl": "https://images.pokemontcg.io/bw11/91.png",
     "subtype": "Basic",
@@ -4701,7 +4792,8 @@
     "nationalPokedexNumber": 638
   },
   {
-    "id": "bw11-92",
+    "setOrder":58,
+	"id": "bw11-92",
     "name": "Altaria",
     "imageUrl": "https://images.pokemontcg.io/bw11/92.png",
     "subtype": "Stage 1",
@@ -4754,7 +4846,8 @@
     "nationalPokedexNumber": 334
   },
   {
-    "id": "bw11-93",
+    "setOrder":58,
+	"id": "bw11-93",
     "name": "Rayquaza",
     "imageUrl": "https://images.pokemontcg.io/bw11/93.png",
     "subtype": "Basic",
@@ -4807,7 +4900,8 @@
     "nationalPokedexNumber": 384
   },
   {
-    "id": "bw11-94",
+    "setOrder":58,
+	"id": "bw11-94",
     "name": "Gible",
     "imageUrl": "https://images.pokemontcg.io/bw11/94.png",
     "subtype": "Basic",
@@ -4860,7 +4954,8 @@
     ]
   },
   {
-    "id": "bw11-95",
+    "setOrder":58,
+	"id": "bw11-95",
     "name": "Gabite",
     "imageUrl": "https://images.pokemontcg.io/bw11/95.png",
     "subtype": "Stage 1",
@@ -4914,7 +5009,8 @@
     ]
   },
   {
-    "id": "bw11-96",
+    "setOrder":58,
+	"id": "bw11-96",
     "name": "Garchomp",
     "imageUrl": "https://images.pokemontcg.io/bw11/96.png",
     "subtype": "Stage 2",
@@ -4965,7 +5061,8 @@
     "nationalPokedexNumber": 445
   },
   {
-    "id": "bw11-97",
+    "setOrder":58,
+	"id": "bw11-97",
     "name": "Deino",
     "imageUrl": "https://images.pokemontcg.io/bw11/97.png",
     "subtype": "Basic",
@@ -5019,7 +5116,8 @@
     ]
   },
   {
-    "id": "bw11-98",
+    "setOrder":58,
+	"id": "bw11-98",
     "name": "Zweilous",
     "imageUrl": "https://images.pokemontcg.io/bw11/98.png",
     "subtype": "Stage 1",
@@ -5076,7 +5174,8 @@
     ]
   },
   {
-    "id": "bw11-99",
+    "setOrder":58,
+	"id": "bw11-99",
     "name": "Hydreigon",
     "imageUrl": "https://images.pokemontcg.io/bw11/99.png",
     "subtype": "Stage 2",
@@ -5127,7 +5226,8 @@
     "nationalPokedexNumber": 635
   },
   {
-    "id": "bw11-100",
+    "setOrder":58,
+	"id": "bw11-100",
     "name": "Black Kyurem-EX",
     "imageUrl": "https://images.pokemontcg.io/bw11/100.png",
     "subtype": "EX",
@@ -5186,7 +5286,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "bw11-101",
+    "setOrder":58,
+	"id": "bw11-101",
     "name": "White Kyurem-EX",
     "imageUrl": "https://images.pokemontcg.io/bw11/101.png",
     "subtype": "EX",
@@ -5245,7 +5346,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "bw11-102",
+    "setOrder":58,
+	"id": "bw11-102",
     "name": "Lugia-EX",
     "imageUrl": "https://images.pokemontcg.io/bw11/102.png",
     "subtype": "EX",
@@ -5303,7 +5405,8 @@
     "nationalPokedexNumber": 249
   },
   {
-    "id": "bw11-103",
+    "setOrder":58,
+	"id": "bw11-103",
     "name": "Swablu",
     "imageUrl": "https://images.pokemontcg.io/bw11/103.png",
     "subtype": "Basic",
@@ -5353,7 +5456,8 @@
     ]
   },
   {
-    "id": "bw11-104",
+    "setOrder":58,
+	"id": "bw11-104",
     "name": "Minccino",
     "imageUrl": "https://images.pokemontcg.io/bw11/104.png",
     "subtype": "Basic",
@@ -5406,7 +5510,8 @@
     ]
   },
   {
-    "id": "bw11-105",
+    "setOrder":58,
+	"id": "bw11-105",
     "name": "Cinccino",
     "imageUrl": "https://images.pokemontcg.io/bw11/105.png",
     "subtype": "Stage 1",
@@ -5454,7 +5559,8 @@
     "nationalPokedexNumber": 573
   },
   {
-    "id": "bw11-106",
+    "setOrder":58,
+	"id": "bw11-106",
     "name": "Druddigon",
     "imageUrl": "https://images.pokemontcg.io/bw11/106.png",
     "subtype": "Basic",
@@ -5496,7 +5602,8 @@
     "nationalPokedexNumber": 621
   },
   {
-    "id": "bw11-107",
+    "setOrder":58,
+	"id": "bw11-107",
     "name": "Bouffalant",
     "imageUrl": "https://images.pokemontcg.io/bw11/107.png",
     "subtype": "Basic",
@@ -5550,7 +5657,8 @@
     "nationalPokedexNumber": 626
   },
   {
-    "id": "bw11-108",
+    "setOrder":58,
+	"id": "bw11-108",
     "name": "Tornadus",
     "imageUrl": "https://images.pokemontcg.io/bw11/108.png",
     "subtype": "Basic",
@@ -5607,7 +5715,8 @@
     "nationalPokedexNumber": 641
   },
   {
-    "id": "bw11-109",
+    "setOrder":58,
+	"id": "bw11-109",
     "name": "Bianca",
     "imageUrl": "https://images.pokemontcg.io/bw11/109.png",
     "subtype": "Supporter",
@@ -5624,7 +5733,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw11/109_hires.png"
   },
   {
-    "id": "bw11-110",
+    "setOrder":58,
+	"id": "bw11-110",
     "name": "Cedric Juniper",
     "imageUrl": "https://images.pokemontcg.io/bw11/110.png",
     "subtype": "Supporter",
@@ -5641,7 +5751,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw11/110_hires.png"
   },
   {
-    "id": "bw11-111",
+    "setOrder":58,
+	"id": "bw11-111",
     "name": "Crushing Hammer",
     "imageUrl": "https://images.pokemontcg.io/bw11/111.png",
     "subtype": "Item",
@@ -5658,7 +5769,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw11/111_hires.png"
   },
   {
-    "id": "bw11-112",
+    "setOrder":58,
+	"id": "bw11-112",
     "name": "Energy Switch",
     "imageUrl": "https://images.pokemontcg.io/bw11/112.png",
     "subtype": "Item",
@@ -5675,7 +5787,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw11/112_hires.png"
   },
   {
-    "id": "bw11-113",
+    "setOrder":58,
+	"id": "bw11-113",
     "name": "Double Colorless Energy",
     "imageUrl": "https://images.pokemontcg.io/bw11/113.png",
     "subtype": "Special",
@@ -5692,7 +5805,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw11/113_hires.png"
   },
   {
-    "id": "bw11-114",
+    "setOrder":58,
+	"id": "bw11-114",
     "name": "Reshiram",
     "imageUrl": "https://images.pokemontcg.io/bw11/114.png",
     "subtype": "Basic",
@@ -5745,7 +5859,8 @@
     "nationalPokedexNumber": 643
   },
   {
-    "id": "bw11-115",
+    "setOrder":58,
+	"id": "bw11-115",
     "name": "Zekrom",
     "imageUrl": "https://images.pokemontcg.io/bw11/115.png",
     "subtype": "Basic",
@@ -5798,7 +5913,8 @@
     "nationalPokedexNumber": 644
   },
   {
-    "id": "bw11-RC1",
+    "setOrder":58,
+	"id": "bw11-RC1",
     "name": "Snivy",
     "imageUrl": "https://images.pokemontcg.io/bw11/RC1.png",
     "subtype": "Basic",
@@ -5852,7 +5968,8 @@
     ]
   },
   {
-    "id": "bw11-RC2",
+    "setOrder":58,
+	"id": "bw11-RC2",
     "name": "Servine",
     "imageUrl": "https://images.pokemontcg.io/bw11/RC2.png",
     "subtype": "Stage 1",
@@ -5907,7 +6024,8 @@
     ]
   },
   {
-    "id": "bw11-RC3",
+    "setOrder":58,
+	"id": "bw11-RC3",
     "name": "Serperior",
     "imageUrl": "https://images.pokemontcg.io/bw11/RC3.png",
     "subtype": "Stage 2",
@@ -5956,7 +6074,8 @@
     "nationalPokedexNumber": 497
   },
   {
-    "id": "bw11-RC4",
+    "setOrder":58,
+	"id": "bw11-RC4",
     "name": "Growlithe",
     "imageUrl": "https://images.pokemontcg.io/bw11/RC4.png",
     "subtype": "Basic",
@@ -6012,7 +6131,8 @@
     ]
   },
   {
-    "id": "bw11-RC5",
+    "setOrder":58,
+	"id": "bw11-RC5",
     "name": "Torchic",
     "imageUrl": "https://images.pokemontcg.io/bw11/RC5.png",
     "subtype": "Basic",
@@ -6065,7 +6185,8 @@
     ]
   },
   {
-    "id": "bw11-RC6",
+    "setOrder":58,
+	"id": "bw11-RC6",
     "name": "Piplup",
     "imageUrl": "https://images.pokemontcg.io/bw11/RC6.png",
     "subtype": "Basic",
@@ -6118,7 +6239,8 @@
     ]
   },
   {
-    "id": "bw11-RC7",
+    "setOrder":58,
+	"id": "bw11-RC7",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/bw11/RC7.png",
     "subtype": "Basic",
@@ -6171,7 +6293,8 @@
     ]
   },
   {
-    "id": "bw11-RC8",
+    "setOrder":58,
+	"id": "bw11-RC8",
     "name": "Ralts",
     "imageUrl": "https://images.pokemontcg.io/bw11/RC8.png",
     "subtype": "Basic",
@@ -6224,7 +6347,8 @@
     ]
   },
   {
-    "id": "bw11-RC9",
+    "setOrder":58,
+	"id": "bw11-RC9",
     "name": "Kirlia",
     "imageUrl": "https://images.pokemontcg.io/bw11/RC9.png",
     "subtype": "Stage 1",
@@ -6279,7 +6403,8 @@
     ]
   },
   {
-    "id": "bw11-RC10",
+    "setOrder":58,
+	"id": "bw11-RC10",
     "name": "Gardevoir",
     "imageUrl": "https://images.pokemontcg.io/bw11/RC10.png",
     "subtype": "Stage 2",
@@ -6331,7 +6456,8 @@
     "nationalPokedexNumber": 282
   },
   {
-    "id": "bw11-RC11",
+    "setOrder":58,
+	"id": "bw11-RC11",
     "name": "Meloetta-EX",
     "imageUrl": "https://images.pokemontcg.io/bw11/RC11.png",
     "subtype": "EX",
@@ -6386,7 +6512,8 @@
     "nationalPokedexNumber": 648
   },
   {
-    "id": "bw11-RC12",
+    "setOrder":58,
+	"id": "bw11-RC12",
     "name": "Stunfisk",
     "imageUrl": "https://images.pokemontcg.io/bw11/RC12.png",
     "subtype": "Basic",
@@ -6445,7 +6572,8 @@
     "nationalPokedexNumber": 618
   },
   {
-    "id": "bw11-RC13",
+    "setOrder":58,
+	"id": "bw11-RC13",
     "name": "Purrloin",
     "imageUrl": "https://images.pokemontcg.io/bw11/RC13.png",
     "subtype": "Basic",
@@ -6494,7 +6622,8 @@
     ]
   },
   {
-    "id": "bw11-RC14",
+    "setOrder":58,
+	"id": "bw11-RC14",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/bw11/RC14.png",
     "subtype": "Basic",
@@ -6544,7 +6673,8 @@
     ]
   },
   {
-    "id": "bw11-RC15",
+    "setOrder":58,
+	"id": "bw11-RC15",
     "name": "Teddiursa",
     "imageUrl": "https://images.pokemontcg.io/bw11/RC15.png",
     "subtype": "Basic",
@@ -6599,7 +6729,8 @@
     ]
   },
   {
-    "id": "bw11-RC16",
+    "setOrder":58,
+	"id": "bw11-RC16",
     "name": "Ursaring",
     "imageUrl": "https://images.pokemontcg.io/bw11/RC16.png",
     "subtype": "Stage 1",
@@ -6655,7 +6786,8 @@
     "nationalPokedexNumber": 217
   },
   {
-    "id": "bw11-RC17",
+    "setOrder":58,
+	"id": "bw11-RC17",
     "name": "Audino",
     "imageUrl": "https://images.pokemontcg.io/bw11/RC17.png",
     "subtype": "Basic",
@@ -6698,7 +6830,8 @@
     "nationalPokedexNumber": 531
   },
   {
-    "id": "bw11-RC18",
+    "setOrder":58,
+	"id": "bw11-RC18",
     "name": "Minccino",
     "imageUrl": "https://images.pokemontcg.io/bw11/RC18.png",
     "subtype": "Basic",
@@ -6741,7 +6874,8 @@
     ]
   },
   {
-    "id": "bw11-RC19",
+    "setOrder":58,
+	"id": "bw11-RC19",
     "name": "Cinccino",
     "imageUrl": "https://images.pokemontcg.io/bw11/RC19.png",
     "subtype": "Stage 1",
@@ -6789,7 +6923,8 @@
     "nationalPokedexNumber": 573
   },
   {
-    "id": "bw11-RC20",
+    "setOrder":58,
+	"id": "bw11-RC20",
     "name": "Elesa",
     "imageUrl": "https://images.pokemontcg.io/bw11/RC20.png",
     "subtype": "Supporter",
@@ -6806,7 +6941,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw11/RC20_hires.png"
   },
   {
-    "id": "bw11-RC21",
+    "setOrder":58,
+	"id": "bw11-RC21",
     "name": "Shaymin-EX",
     "imageUrl": "https://images.pokemontcg.io/bw11/RC21.png",
     "subtype": "EX",
@@ -6865,7 +7001,8 @@
     "nationalPokedexNumber": 492
   },
   {
-    "id": "bw11-RC22",
+    "setOrder":58,
+	"id": "bw11-RC22",
     "name": "Reshiram",
     "imageUrl": "https://images.pokemontcg.io/bw11/RC22.png",
     "subtype": "Basic",
@@ -6918,7 +7055,8 @@
     "nationalPokedexNumber": 643
   },
   {
-    "id": "bw11-RC23",
+    "setOrder":58,
+	"id": "bw11-RC23",
     "name": "Emolga",
     "imageUrl": "https://images.pokemontcg.io/bw11/RC23.png",
     "subtype": "Basic",
@@ -6970,7 +7108,8 @@
     "nationalPokedexNumber": 587
   },
   {
-    "id": "bw11-RC24",
+    "setOrder":58,
+	"id": "bw11-RC24",
     "name": "Mew-EX",
     "imageUrl": "https://images.pokemontcg.io/bw11/RC24.png",
     "subtype": "EX",
@@ -7018,7 +7157,8 @@
     "nationalPokedexNumber": 151
   },
   {
-    "id": "bw11-RC25",
+    "setOrder":58,
+	"id": "bw11-RC25",
     "name": "Meloetta-EX",
     "imageUrl": "https://images.pokemontcg.io/bw11/RC25.png",
     "subtype": "EX",

--- a/json/cards/Legends Awakened.json
+++ b/json/cards/Legends Awakened.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "dp6-1",
+    "setOrder":37,
+	"id": "dp6-1",
     "name": "Deoxys Normal Forme",
     "imageUrl": "https://images.pokemontcg.io/dp6/1.png",
     "subtype": "Basic",
@@ -47,7 +48,8 @@
     "nationalPokedexNumber": 386
   },
   {
-    "id": "dp6-2",
+    "setOrder":37,
+	"id": "dp6-2",
     "name": "Dragonite",
     "imageUrl": "https://images.pokemontcg.io/dp6/2.png",
     "subtype": "Stage 2",
@@ -111,7 +113,8 @@
     "nationalPokedexNumber": 149
   },
   {
-    "id": "dp6-3",
+    "setOrder":37,
+	"id": "dp6-3",
     "name": "Froslass",
     "imageUrl": "https://images.pokemontcg.io/dp6/3.png",
     "subtype": "Stage 1",
@@ -163,7 +166,8 @@
     "nationalPokedexNumber": 478
   },
   {
-    "id": "dp6-4",
+    "setOrder":37,
+	"id": "dp6-4",
     "name": "Giratina",
     "imageUrl": "https://images.pokemontcg.io/dp6/4.png",
     "subtype": "Basic",
@@ -225,7 +229,8 @@
     "nationalPokedexNumber": 487
   },
   {
-    "id": "dp6-5",
+    "setOrder":37,
+	"id": "dp6-5",
     "name": "Gliscor",
     "imageUrl": "https://images.pokemontcg.io/dp6/5.png",
     "subtype": "Stage 1",
@@ -283,7 +288,8 @@
     "nationalPokedexNumber": 472
   },
   {
-    "id": "dp6-6",
+    "setOrder":37,
+	"id": "dp6-6",
     "name": "Heatran",
     "imageUrl": "https://images.pokemontcg.io/dp6/6.png",
     "subtype": "Basic",
@@ -335,7 +341,8 @@
     "nationalPokedexNumber": 485
   },
   {
-    "id": "dp6-7",
+    "setOrder":37,
+	"id": "dp6-7",
     "name": "Kingdra",
     "imageUrl": "https://images.pokemontcg.io/dp6/7.png",
     "subtype": "Stage 2",
@@ -386,7 +393,8 @@
     "nationalPokedexNumber": 230
   },
   {
-    "id": "dp6-8",
+    "setOrder":37,
+	"id": "dp6-8",
     "name": "Luxray",
     "imageUrl": "https://images.pokemontcg.io/dp6/8.png",
     "subtype": "Stage 2",
@@ -448,7 +456,8 @@
     "nationalPokedexNumber": 405
   },
   {
-    "id": "dp6-9",
+    "setOrder":37,
+	"id": "dp6-9",
     "name": "Mamoswine",
     "imageUrl": "https://images.pokemontcg.io/dp6/9.png",
     "subtype": "Stage 2",
@@ -513,7 +522,8 @@
     "nationalPokedexNumber": 473
   },
   {
-    "id": "dp6-10",
+    "setOrder":37,
+	"id": "dp6-10",
     "name": "Metagross",
     "imageUrl": "https://images.pokemontcg.io/dp6/10.png",
     "subtype": "Stage 2",
@@ -570,7 +580,8 @@
     "nationalPokedexNumber": 376
   },
   {
-    "id": "dp6-11",
+    "setOrder":37,
+	"id": "dp6-11",
     "name": "Mewtwo",
     "imageUrl": "https://images.pokemontcg.io/dp6/11.png",
     "subtype": "Basic",
@@ -623,7 +634,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "dp6-12",
+    "setOrder":37,
+	"id": "dp6-12",
     "name": "Politoed",
     "imageUrl": "https://images.pokemontcg.io/dp6/12.png",
     "subtype": "Stage 2",
@@ -671,7 +683,8 @@
     "nationalPokedexNumber": 186
   },
   {
-    "id": "dp6-13",
+    "setOrder":37,
+	"id": "dp6-13",
     "name": "Probopass",
     "imageUrl": "https://images.pokemontcg.io/dp6/13.png",
     "subtype": "Stage 1",
@@ -722,7 +735,8 @@
     "nationalPokedexNumber": 476
   },
   {
-    "id": "dp6-14",
+    "setOrder":37,
+	"id": "dp6-14",
     "name": "Rayquaza",
     "imageUrl": "https://images.pokemontcg.io/dp6/14.png",
     "subtype": "Basic",
@@ -779,7 +793,8 @@
     "nationalPokedexNumber": 384
   },
   {
-    "id": "dp6-15",
+    "setOrder":37,
+	"id": "dp6-15",
     "name": "Regigigas",
     "imageUrl": "https://images.pokemontcg.io/dp6/15.png",
     "subtype": "Basic",
@@ -831,7 +846,8 @@
     "nationalPokedexNumber": 486
   },
   {
-    "id": "dp6-16",
+    "setOrder":37,
+	"id": "dp6-16",
     "name": "Spiritomb",
     "imageUrl": "https://images.pokemontcg.io/dp6/16.png",
     "subtype": "Basic",
@@ -878,7 +894,8 @@
     "nationalPokedexNumber": 442
   },
   {
-    "id": "dp6-17",
+    "setOrder":37,
+	"id": "dp6-17",
     "name": "Yanmega",
     "imageUrl": "https://images.pokemontcg.io/dp6/17.png",
     "subtype": "Stage 1",
@@ -935,7 +952,8 @@
     "nationalPokedexNumber": 469
   },
   {
-    "id": "dp6-18",
+    "setOrder":37,
+	"id": "dp6-18",
     "name": "Armaldo",
     "imageUrl": "https://images.pokemontcg.io/dp6/18.png",
     "subtype": "Stage 2",
@@ -985,7 +1003,8 @@
     "nationalPokedexNumber": 348
   },
   {
-    "id": "dp6-19",
+    "setOrder":37,
+	"id": "dp6-19",
     "name": "Azelf",
     "imageUrl": "https://images.pokemontcg.io/dp6/19.png",
     "subtype": "Basic",
@@ -1031,7 +1050,8 @@
     "nationalPokedexNumber": 482
   },
   {
-    "id": "dp6-20",
+    "setOrder":37,
+	"id": "dp6-20",
     "name": "Bellossom",
     "imageUrl": "https://images.pokemontcg.io/dp6/20.png",
     "subtype": "Stage 2",
@@ -1089,7 +1109,8 @@
     "nationalPokedexNumber": 182
   },
   {
-    "id": "dp6-21",
+    "setOrder":37,
+	"id": "dp6-21",
     "name": "Cradily",
     "imageUrl": "https://images.pokemontcg.io/dp6/21.png",
     "subtype": "Stage 2",
@@ -1144,7 +1165,8 @@
     "nationalPokedexNumber": 346
   },
   {
-    "id": "dp6-22",
+    "setOrder":37,
+	"id": "dp6-22",
     "name": "Crawdaunt",
     "imageUrl": "https://images.pokemontcg.io/dp6/22.png",
     "subtype": "Stage 1",
@@ -1205,7 +1227,8 @@
     "nationalPokedexNumber": 342
   },
   {
-    "id": "dp6-23",
+    "setOrder":37,
+	"id": "dp6-23",
     "name": "Delcatty",
     "imageUrl": "https://images.pokemontcg.io/dp6/23.png",
     "subtype": "Stage 1",
@@ -1252,7 +1275,8 @@
     "nationalPokedexNumber": 301
   },
   {
-    "id": "dp6-24",
+    "setOrder":37,
+	"id": "dp6-24",
     "name": "Deoxys Attack Forme",
     "imageUrl": "https://images.pokemontcg.io/dp6/24.png",
     "subtype": "Basic",
@@ -1301,7 +1325,8 @@
     "nationalPokedexNumber": 386
   },
   {
-    "id": "dp6-25",
+    "setOrder":37,
+	"id": "dp6-25",
     "name": "Deoxys Defense Forme",
     "imageUrl": "https://images.pokemontcg.io/dp6/25.png",
     "subtype": "Basic",
@@ -1350,7 +1375,8 @@
     "nationalPokedexNumber": 386
   },
   {
-    "id": "dp6-26",
+    "setOrder":37,
+	"id": "dp6-26",
     "name": "Deoxys Speed Forme",
     "imageUrl": "https://images.pokemontcg.io/dp6/26.png",
     "subtype": "Basic",
@@ -1394,7 +1420,8 @@
     "nationalPokedexNumber": 386
   },
   {
-    "id": "dp6-27",
+    "setOrder":37,
+	"id": "dp6-27",
     "name": "Ditto",
     "imageUrl": "https://images.pokemontcg.io/dp6/27.png",
     "subtype": "Basic",
@@ -1429,7 +1456,8 @@
     "nationalPokedexNumber": 132
   },
   {
-    "id": "dp6-28",
+    "setOrder":37,
+	"id": "dp6-28",
     "name": "Forretress",
     "imageUrl": "https://images.pokemontcg.io/dp6/28.png",
     "subtype": "Stage 1",
@@ -1486,7 +1514,8 @@
     "nationalPokedexNumber": 205
   },
   {
-    "id": "dp6-29",
+    "setOrder":37,
+	"id": "dp6-29",
     "name": "Groudon",
     "imageUrl": "https://images.pokemontcg.io/dp6/29.png",
     "subtype": "Basic",
@@ -1546,7 +1575,8 @@
     "nationalPokedexNumber": 383
   },
   {
-    "id": "dp6-30",
+    "setOrder":37,
+	"id": "dp6-30",
     "name": "Heatran",
     "imageUrl": "https://images.pokemontcg.io/dp6/30.png",
     "subtype": "Basic",
@@ -1596,7 +1626,8 @@
     "nationalPokedexNumber": 485
   },
   {
-    "id": "dp6-31",
+    "setOrder":37,
+	"id": "dp6-31",
     "name": "Jirachi",
     "imageUrl": "https://images.pokemontcg.io/dp6/31.png",
     "subtype": "Basic",
@@ -1653,7 +1684,8 @@
     "nationalPokedexNumber": 385
   },
   {
-    "id": "dp6-32",
+    "setOrder":37,
+	"id": "dp6-32",
     "name": "Kyogre",
     "imageUrl": "https://images.pokemontcg.io/dp6/32.png",
     "subtype": "Basic",
@@ -1707,7 +1739,8 @@
     "nationalPokedexNumber": 382
   },
   {
-    "id": "dp6-33",
+    "setOrder":37,
+	"id": "dp6-33",
     "name": "Lopunny",
     "imageUrl": "https://images.pokemontcg.io/dp6/33.png",
     "subtype": "Stage 1",
@@ -1764,7 +1797,8 @@
     "nationalPokedexNumber": 428
   },
   {
-    "id": "dp6-34",
+    "setOrder":37,
+	"id": "dp6-34",
     "name": "Mesprit",
     "imageUrl": "https://images.pokemontcg.io/dp6/34.png",
     "subtype": "Basic",
@@ -1811,7 +1845,8 @@
     "nationalPokedexNumber": 481
   },
   {
-    "id": "dp6-35",
+    "setOrder":37,
+	"id": "dp6-35",
     "name": "Poliwrath",
     "imageUrl": "https://images.pokemontcg.io/dp6/35.png",
     "subtype": "Stage 2",
@@ -1865,7 +1900,8 @@
     "nationalPokedexNumber": 62
   },
   {
-    "id": "dp6-36",
+    "setOrder":37,
+	"id": "dp6-36",
     "name": "Regice",
     "imageUrl": "https://images.pokemontcg.io/dp6/36.png",
     "subtype": "Basic",
@@ -1915,7 +1951,8 @@
     "nationalPokedexNumber": 378
   },
   {
-    "id": "dp6-37",
+    "setOrder":37,
+	"id": "dp6-37",
     "name": "Regigigas",
     "imageUrl": "https://images.pokemontcg.io/dp6/37.png",
     "subtype": "Basic",
@@ -1966,7 +2003,8 @@
     "nationalPokedexNumber": 486
   },
   {
-    "id": "dp6-38",
+    "setOrder":37,
+	"id": "dp6-38",
     "name": "Regirock",
     "imageUrl": "https://images.pokemontcg.io/dp6/38.png",
     "subtype": "Basic",
@@ -2016,7 +2054,8 @@
     "nationalPokedexNumber": 377
   },
   {
-    "id": "dp6-39",
+    "setOrder":37,
+	"id": "dp6-39",
     "name": "Registeel",
     "imageUrl": "https://images.pokemontcg.io/dp6/39.png",
     "subtype": "Basic",
@@ -2073,7 +2112,8 @@
     "nationalPokedexNumber": 379
   },
   {
-    "id": "dp6-40",
+    "setOrder":37,
+	"id": "dp6-40",
     "name": "Shedinja",
     "imageUrl": "https://images.pokemontcg.io/dp6/40.png",
     "subtype": "Stage 1",
@@ -2111,7 +2151,8 @@
     "nationalPokedexNumber": 292
   },
   {
-    "id": "dp6-41",
+    "setOrder":37,
+	"id": "dp6-41",
     "name": "Torkoal",
     "imageUrl": "https://images.pokemontcg.io/dp6/41.png",
     "subtype": "Basic",
@@ -2159,7 +2200,8 @@
     "nationalPokedexNumber": 324
   },
   {
-    "id": "dp6-42",
+    "setOrder":37,
+	"id": "dp6-42",
     "name": "Unown !",
     "imageUrl": "https://images.pokemontcg.io/dp6/42.png",
     "subtype": "Basic",
@@ -2205,7 +2247,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp6-43",
+    "setOrder":37,
+	"id": "dp6-43",
     "name": "Uxie",
     "imageUrl": "https://images.pokemontcg.io/dp6/43.png",
     "subtype": "Basic",
@@ -2251,7 +2294,8 @@
     "nationalPokedexNumber": 480
   },
   {
-    "id": "dp6-44",
+    "setOrder":37,
+	"id": "dp6-44",
     "name": "Victreebel",
     "imageUrl": "https://images.pokemontcg.io/dp6/44.png",
     "subtype": "Stage 2",
@@ -2306,7 +2350,8 @@
     "nationalPokedexNumber": 71
   },
   {
-    "id": "dp6-45",
+    "setOrder":37,
+	"id": "dp6-45",
     "name": "Vileplume",
     "imageUrl": "https://images.pokemontcg.io/dp6/45.png",
     "subtype": "Stage 2",
@@ -2356,7 +2401,8 @@
     "nationalPokedexNumber": 45
   },
   {
-    "id": "dp6-46",
+    "setOrder":37,
+	"id": "dp6-46",
     "name": "Anorith",
     "imageUrl": "https://images.pokemontcg.io/dp6/46.png",
     "subtype": "Stage 1",
@@ -2411,7 +2457,8 @@
     ]
   },
   {
-    "id": "dp6-47",
+    "setOrder":37,
+	"id": "dp6-47",
     "name": "Camerupt",
     "imageUrl": "https://images.pokemontcg.io/dp6/47.png",
     "subtype": "Stage 1",
@@ -2467,7 +2514,8 @@
     "nationalPokedexNumber": 323
   },
   {
-    "id": "dp6-48",
+    "setOrder":37,
+	"id": "dp6-48",
     "name": "Castform",
     "imageUrl": "https://images.pokemontcg.io/dp6/48.png",
     "subtype": "Basic",
@@ -2514,7 +2562,8 @@
     "nationalPokedexNumber": 351
   },
   {
-    "id": "dp6-49",
+    "setOrder":37,
+	"id": "dp6-49",
     "name": "Castform Rain Form",
     "imageUrl": "https://images.pokemontcg.io/dp6/49.png",
     "subtype": "Basic",
@@ -2561,7 +2610,8 @@
     "nationalPokedexNumber": 351
   },
   {
-    "id": "dp6-50",
+    "setOrder":37,
+	"id": "dp6-50",
     "name": "Castform Snow-cloud Form",
     "imageUrl": "https://images.pokemontcg.io/dp6/50.png",
     "subtype": "Basic",
@@ -2608,7 +2658,8 @@
     "nationalPokedexNumber": 351
   },
   {
-    "id": "dp6-51",
+    "setOrder":37,
+	"id": "dp6-51",
     "name": "Castform Sunny Form",
     "imageUrl": "https://images.pokemontcg.io/dp6/51.png",
     "subtype": "Basic",
@@ -2655,7 +2706,8 @@
     "nationalPokedexNumber": 351
   },
   {
-    "id": "dp6-52",
+    "setOrder":37,
+	"id": "dp6-52",
     "name": "Dragonair",
     "imageUrl": "https://images.pokemontcg.io/dp6/52.png",
     "subtype": "Stage 1",
@@ -2712,7 +2764,8 @@
     ]
   },
   {
-    "id": "dp6-53",
+    "setOrder":37,
+	"id": "dp6-53",
     "name": "Drifblim",
     "imageUrl": "https://images.pokemontcg.io/dp6/53.png",
     "subtype": "Stage 1",
@@ -2768,7 +2821,8 @@
     "nationalPokedexNumber": 426
   },
   {
-    "id": "dp6-54",
+    "setOrder":37,
+	"id": "dp6-54",
     "name": "Exeggutor",
     "imageUrl": "https://images.pokemontcg.io/dp6/54.png",
     "subtype": "Stage 1",
@@ -2819,7 +2873,8 @@
     "nationalPokedexNumber": 103
   },
   {
-    "id": "dp6-55",
+    "setOrder":37,
+	"id": "dp6-55",
     "name": "Gliscor",
     "imageUrl": "https://images.pokemontcg.io/dp6/55.png",
     "subtype": "Stage 1",
@@ -2877,7 +2932,8 @@
     "nationalPokedexNumber": 472
   },
   {
-    "id": "dp6-56",
+    "setOrder":37,
+	"id": "dp6-56",
     "name": "Grumpig",
     "imageUrl": "https://images.pokemontcg.io/dp6/56.png",
     "subtype": "Stage 1",
@@ -2930,7 +2986,8 @@
     "nationalPokedexNumber": 326
   },
   {
-    "id": "dp6-57",
+    "setOrder":37,
+	"id": "dp6-57",
     "name": "Houndoom",
     "imageUrl": "https://images.pokemontcg.io/dp6/57.png",
     "subtype": "Stage 1",
@@ -2987,7 +3044,8 @@
     "nationalPokedexNumber": 229
   },
   {
-    "id": "dp6-58",
+    "setOrder":37,
+	"id": "dp6-58",
     "name": "Lanturn",
     "imageUrl": "https://images.pokemontcg.io/dp6/58.png",
     "subtype": "Stage 1",
@@ -3040,7 +3098,8 @@
     "nationalPokedexNumber": 171
   },
   {
-    "id": "dp6-59",
+    "setOrder":37,
+	"id": "dp6-59",
     "name": "Lanturn",
     "imageUrl": "https://images.pokemontcg.io/dp6/59.png",
     "subtype": "Stage 1",
@@ -3094,7 +3153,8 @@
     "nationalPokedexNumber": 171
   },
   {
-    "id": "dp6-60",
+    "setOrder":37,
+	"id": "dp6-60",
     "name": "Ledian",
     "imageUrl": "https://images.pokemontcg.io/dp6/60.png",
     "subtype": "Stage 1",
@@ -3152,7 +3212,8 @@
     "nationalPokedexNumber": 166
   },
   {
-    "id": "dp6-61",
+    "setOrder":37,
+	"id": "dp6-61",
     "name": "Lucario",
     "imageUrl": "https://images.pokemontcg.io/dp6/61.png",
     "subtype": "Stage 1",
@@ -3205,7 +3266,8 @@
     "nationalPokedexNumber": 448
   },
   {
-    "id": "dp6-62",
+    "setOrder":37,
+	"id": "dp6-62",
     "name": "Luxio",
     "imageUrl": "https://images.pokemontcg.io/dp6/62.png",
     "subtype": "Stage 1",
@@ -3268,7 +3330,8 @@
     ]
   },
   {
-    "id": "dp6-63",
+    "setOrder":37,
+	"id": "dp6-63",
     "name": "Marowak",
     "imageUrl": "https://images.pokemontcg.io/dp6/63.png",
     "subtype": "Stage 1",
@@ -3327,7 +3390,8 @@
     "nationalPokedexNumber": 105
   },
   {
-    "id": "dp6-64",
+    "setOrder":37,
+	"id": "dp6-64",
     "name": "Metang",
     "imageUrl": "https://images.pokemontcg.io/dp6/64.png",
     "subtype": "Stage 1",
@@ -3391,7 +3455,8 @@
     ]
   },
   {
-    "id": "dp6-65",
+    "setOrder":37,
+	"id": "dp6-65",
     "name": "Metang",
     "imageUrl": "https://images.pokemontcg.io/dp6/65.png",
     "subtype": "Stage 1",
@@ -3455,7 +3520,8 @@
     ]
   },
   {
-    "id": "dp6-66",
+    "setOrder":37,
+	"id": "dp6-66",
     "name": "Mightyena",
     "imageUrl": "https://images.pokemontcg.io/dp6/66.png",
     "subtype": "Stage 1",
@@ -3513,7 +3579,8 @@
     "nationalPokedexNumber": 262
   },
   {
-    "id": "dp6-67",
+    "setOrder":37,
+	"id": "dp6-67",
     "name": "Ninjask",
     "imageUrl": "https://images.pokemontcg.io/dp6/67.png",
     "subtype": "Stage 1",
@@ -3566,7 +3633,8 @@
     ]
   },
   {
-    "id": "dp6-68",
+    "setOrder":37,
+	"id": "dp6-68",
     "name": "Persian",
     "imageUrl": "https://images.pokemontcg.io/dp6/68.png",
     "subtype": "Stage 1",
@@ -3616,7 +3684,8 @@
     "nationalPokedexNumber": 53
   },
   {
-    "id": "dp6-69",
+    "setOrder":37,
+	"id": "dp6-69",
     "name": "Piloswine",
     "imageUrl": "https://images.pokemontcg.io/dp6/69.png",
     "subtype": "Stage 1",
@@ -3682,7 +3751,8 @@
     ]
   },
   {
-    "id": "dp6-70",
+    "setOrder":37,
+	"id": "dp6-70",
     "name": "Seadra",
     "imageUrl": "https://images.pokemontcg.io/dp6/70.png",
     "subtype": "Stage 1",
@@ -3738,7 +3808,8 @@
     ]
   },
   {
-    "id": "dp6-71",
+    "setOrder":37,
+	"id": "dp6-71",
     "name": "Starmie",
     "imageUrl": "https://images.pokemontcg.io/dp6/71.png",
     "subtype": "Stage 1",
@@ -3786,7 +3857,8 @@
     "nationalPokedexNumber": 121
   },
   {
-    "id": "dp6-72",
+    "setOrder":37,
+	"id": "dp6-72",
     "name": "Swalot",
     "imageUrl": "https://images.pokemontcg.io/dp6/72.png",
     "subtype": "Stage 1",
@@ -3841,7 +3913,8 @@
     "nationalPokedexNumber": 317
   },
   {
-    "id": "dp6-73",
+    "setOrder":37,
+	"id": "dp6-73",
     "name": "Swellow",
     "imageUrl": "https://images.pokemontcg.io/dp6/73.png",
     "subtype": "Stage 1",
@@ -3895,7 +3968,8 @@
     "nationalPokedexNumber": 277
   },
   {
-    "id": "dp6-74",
+    "setOrder":37,
+	"id": "dp6-74",
     "name": "Tauros",
     "imageUrl": "https://images.pokemontcg.io/dp6/74.png",
     "subtype": "Basic",
@@ -3949,7 +4023,8 @@
     "nationalPokedexNumber": 128
   },
   {
-    "id": "dp6-75",
+    "setOrder":37,
+	"id": "dp6-75",
     "name": "Tentacruel",
     "imageUrl": "https://images.pokemontcg.io/dp6/75.png",
     "subtype": "Stage 1",
@@ -4002,7 +4077,8 @@
     "nationalPokedexNumber": 73
   },
   {
-    "id": "dp6-76",
+    "setOrder":37,
+	"id": "dp6-76",
     "name": "Unown J",
     "imageUrl": "https://images.pokemontcg.io/dp6/76.png",
     "subtype": "Basic",
@@ -4048,7 +4124,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp6-77",
+    "setOrder":37,
+	"id": "dp6-77",
     "name": "Unown R",
     "imageUrl": "https://images.pokemontcg.io/dp6/77.png",
     "subtype": "Basic",
@@ -4094,7 +4171,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp6-78",
+    "setOrder":37,
+	"id": "dp6-78",
     "name": "Unown U",
     "imageUrl": "https://images.pokemontcg.io/dp6/78.png",
     "subtype": "Basic",
@@ -4140,7 +4218,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp6-79",
+    "setOrder":37,
+	"id": "dp6-79",
     "name": "Unown V",
     "imageUrl": "https://images.pokemontcg.io/dp6/79.png",
     "subtype": "Basic",
@@ -4186,7 +4265,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp6-80",
+    "setOrder":37,
+	"id": "dp6-80",
     "name": "Unown W",
     "imageUrl": "https://images.pokemontcg.io/dp6/80.png",
     "subtype": "Basic",
@@ -4236,7 +4316,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp6-81",
+    "setOrder":37,
+	"id": "dp6-81",
     "name": "Unown Y",
     "imageUrl": "https://images.pokemontcg.io/dp6/81.png",
     "subtype": "Basic",
@@ -4283,7 +4364,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp6-82",
+    "setOrder":37,
+	"id": "dp6-82",
     "name": "Unown ?",
     "imageUrl": "https://images.pokemontcg.io/dp6/82.png",
     "subtype": "Basic",
@@ -4329,7 +4411,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp6-83",
+    "setOrder":37,
+	"id": "dp6-83",
     "name": "Beldum",
     "imageUrl": "https://images.pokemontcg.io/dp6/83.png",
     "subtype": "Basic",
@@ -4386,7 +4469,8 @@
     ]
   },
   {
-    "id": "dp6-84",
+    "setOrder":37,
+	"id": "dp6-84",
     "name": "Beldum",
     "imageUrl": "https://images.pokemontcg.io/dp6/84.png",
     "subtype": "Basic",
@@ -4446,7 +4530,8 @@
     ]
   },
   {
-    "id": "dp6-85",
+    "setOrder":37,
+	"id": "dp6-85",
     "name": "Bellsprout",
     "imageUrl": "https://images.pokemontcg.io/dp6/85.png",
     "subtype": "Basic",
@@ -4499,7 +4584,8 @@
     ]
   },
   {
-    "id": "dp6-86",
+    "setOrder":37,
+	"id": "dp6-86",
     "name": "Buneary",
     "imageUrl": "https://images.pokemontcg.io/dp6/86.png",
     "subtype": "Basic",
@@ -4553,7 +4639,8 @@
     ]
   },
   {
-    "id": "dp6-87",
+    "setOrder":37,
+	"id": "dp6-87",
     "name": "Chinchou",
     "imageUrl": "https://images.pokemontcg.io/dp6/87.png",
     "subtype": "Basic",
@@ -4607,7 +4694,8 @@
     ]
   },
   {
-    "id": "dp6-88",
+    "setOrder":37,
+	"id": "dp6-88",
     "name": "Chinchou",
     "imageUrl": "https://images.pokemontcg.io/dp6/88.png",
     "subtype": "Basic",
@@ -4661,7 +4749,8 @@
     ]
   },
   {
-    "id": "dp6-89",
+    "setOrder":37,
+	"id": "dp6-89",
     "name": "Corphish",
     "imageUrl": "https://images.pokemontcg.io/dp6/89.png",
     "subtype": "Basic",
@@ -4715,7 +4804,8 @@
     ]
   },
   {
-    "id": "dp6-90",
+    "setOrder":37,
+	"id": "dp6-90",
     "name": "Cubone",
     "imageUrl": "https://images.pokemontcg.io/dp6/90.png",
     "subtype": "Basic",
@@ -4775,7 +4865,8 @@
     ]
   },
   {
-    "id": "dp6-91",
+    "setOrder":37,
+	"id": "dp6-91",
     "name": "Dratini",
     "imageUrl": "https://images.pokemontcg.io/dp6/91.png",
     "subtype": "Basic",
@@ -4829,7 +4920,8 @@
     ]
   },
   {
-    "id": "dp6-92",
+    "setOrder":37,
+	"id": "dp6-92",
     "name": "Drifloon",
     "imageUrl": "https://images.pokemontcg.io/dp6/92.png",
     "subtype": "Basic",
@@ -4889,7 +4981,8 @@
     ]
   },
   {
-    "id": "dp6-93",
+    "setOrder":37,
+	"id": "dp6-93",
     "name": "Exeggcute",
     "imageUrl": "https://images.pokemontcg.io/dp6/93.png",
     "subtype": "Basic",
@@ -4942,7 +5035,8 @@
     ]
   },
   {
-    "id": "dp6-94",
+    "setOrder":37,
+	"id": "dp6-94",
     "name": "Gligar",
     "imageUrl": "https://images.pokemontcg.io/dp6/94.png",
     "subtype": "Basic",
@@ -5001,7 +5095,8 @@
     ]
   },
   {
-    "id": "dp6-95",
+    "setOrder":37,
+	"id": "dp6-95",
     "name": "Gligar",
     "imageUrl": "https://images.pokemontcg.io/dp6/95.png",
     "subtype": "Basic",
@@ -5061,7 +5156,8 @@
     ]
   },
   {
-    "id": "dp6-96",
+    "setOrder":37,
+	"id": "dp6-96",
     "name": "Gloom",
     "imageUrl": "https://images.pokemontcg.io/dp6/96.png",
     "subtype": "Stage 1",
@@ -5117,7 +5213,8 @@
     ]
   },
   {
-    "id": "dp6-97",
+    "setOrder":37,
+	"id": "dp6-97",
     "name": "Gloom",
     "imageUrl": "https://images.pokemontcg.io/dp6/97.png",
     "subtype": "Stage 1",
@@ -5174,7 +5271,8 @@
     ]
   },
   {
-    "id": "dp6-98",
+    "setOrder":37,
+	"id": "dp6-98",
     "name": "Gulpin",
     "imageUrl": "https://images.pokemontcg.io/dp6/98.png",
     "subtype": "Basic",
@@ -5228,7 +5326,8 @@
     ]
   },
   {
-    "id": "dp6-99",
+    "setOrder":37,
+	"id": "dp6-99",
     "name": "Hitmonchan",
     "imageUrl": "https://images.pokemontcg.io/dp6/99.png",
     "subtype": "Basic",
@@ -5279,7 +5378,8 @@
     "nationalPokedexNumber": 107
   },
   {
-    "id": "dp6-100",
+    "setOrder":37,
+	"id": "dp6-100",
     "name": "Hitmonlee",
     "imageUrl": "https://images.pokemontcg.io/dp6/100.png",
     "subtype": "Basic",
@@ -5332,7 +5432,8 @@
     "nationalPokedexNumber": 106
   },
   {
-    "id": "dp6-101",
+    "setOrder":37,
+	"id": "dp6-101",
     "name": "Hitmontop",
     "imageUrl": "https://images.pokemontcg.io/dp6/101.png",
     "subtype": "Basic",
@@ -5385,7 +5486,8 @@
     "nationalPokedexNumber": 237
   },
   {
-    "id": "dp6-102",
+    "setOrder":37,
+	"id": "dp6-102",
     "name": "Horsea",
     "imageUrl": "https://images.pokemontcg.io/dp6/102.png",
     "subtype": "Basic",
@@ -5438,7 +5540,8 @@
     ]
   },
   {
-    "id": "dp6-103",
+    "setOrder":37,
+	"id": "dp6-103",
     "name": "Houndour",
     "imageUrl": "https://images.pokemontcg.io/dp6/103.png",
     "subtype": "Basic",
@@ -5497,7 +5600,8 @@
     ]
   },
   {
-    "id": "dp6-104",
+    "setOrder":37,
+	"id": "dp6-104",
     "name": "Ledyba",
     "imageUrl": "https://images.pokemontcg.io/dp6/104.png",
     "subtype": "Basic",
@@ -5557,7 +5661,8 @@
     ]
   },
   {
-    "id": "dp6-105",
+    "setOrder":37,
+	"id": "dp6-105",
     "name": "Lileep",
     "imageUrl": "https://images.pokemontcg.io/dp6/105.png",
     "subtype": "Stage 1",
@@ -5613,7 +5718,8 @@
     ]
   },
   {
-    "id": "dp6-106",
+    "setOrder":37,
+	"id": "dp6-106",
     "name": "Meowth",
     "imageUrl": "https://images.pokemontcg.io/dp6/106.png",
     "subtype": "Basic",
@@ -5667,7 +5773,8 @@
     ]
   },
   {
-    "id": "dp6-107",
+    "setOrder":37,
+	"id": "dp6-107",
     "name": "Misdreavus",
     "imageUrl": "https://images.pokemontcg.io/dp6/107.png",
     "subtype": "Basic",
@@ -5726,7 +5833,8 @@
     ]
   },
   {
-    "id": "dp6-108",
+    "setOrder":37,
+	"id": "dp6-108",
     "name": "Nincada",
     "imageUrl": "https://images.pokemontcg.io/dp6/108.png",
     "subtype": "Basic",
@@ -5779,7 +5887,8 @@
     ]
   },
   {
-    "id": "dp6-109",
+    "setOrder":37,
+	"id": "dp6-109",
     "name": "Nosepass",
     "imageUrl": "https://images.pokemontcg.io/dp6/109.png",
     "subtype": "Basic",
@@ -5833,7 +5942,8 @@
     ]
   },
   {
-    "id": "dp6-110",
+    "setOrder":37,
+	"id": "dp6-110",
     "name": "Numel",
     "imageUrl": "https://images.pokemontcg.io/dp6/110.png",
     "subtype": "Basic",
@@ -5889,7 +5999,8 @@
     ]
   },
   {
-    "id": "dp6-111",
+    "setOrder":37,
+	"id": "dp6-111",
     "name": "Oddish",
     "imageUrl": "https://images.pokemontcg.io/dp6/111.png",
     "subtype": "Basic",
@@ -5942,7 +6053,8 @@
     ]
   },
   {
-    "id": "dp6-112",
+    "setOrder":37,
+	"id": "dp6-112",
     "name": "Oddish",
     "imageUrl": "https://images.pokemontcg.io/dp6/112.png",
     "subtype": "Basic",
@@ -5996,7 +6108,8 @@
     ]
   },
   {
-    "id": "dp6-113",
+    "setOrder":37,
+	"id": "dp6-113",
     "name": "Pineco",
     "imageUrl": "https://images.pokemontcg.io/dp6/113.png",
     "subtype": "Basic",
@@ -6050,7 +6163,8 @@
     ]
   },
   {
-    "id": "dp6-114",
+    "setOrder":37,
+	"id": "dp6-114",
     "name": "Poliwag",
     "imageUrl": "https://images.pokemontcg.io/dp6/114.png",
     "subtype": "Basic",
@@ -6103,7 +6217,8 @@
     ]
   },
   {
-    "id": "dp6-115",
+    "setOrder":37,
+	"id": "dp6-115",
     "name": "Poliwhirl",
     "imageUrl": "https://images.pokemontcg.io/dp6/115.png",
     "subtype": "Stage 1",
@@ -6161,7 +6276,8 @@
     ]
   },
   {
-    "id": "dp6-116",
+    "setOrder":37,
+	"id": "dp6-116",
     "name": "Poochyena",
     "imageUrl": "https://images.pokemontcg.io/dp6/116.png",
     "subtype": "Basic",
@@ -6221,7 +6337,8 @@
     ]
   },
   {
-    "id": "dp6-117",
+    "setOrder":37,
+	"id": "dp6-117",
     "name": "Riolu",
     "imageUrl": "https://images.pokemontcg.io/dp6/117.png",
     "subtype": "Basic",
@@ -6275,7 +6392,8 @@
     ]
   },
   {
-    "id": "dp6-118",
+    "setOrder":37,
+	"id": "dp6-118",
     "name": "Shinx",
     "imageUrl": "https://images.pokemontcg.io/dp6/118.png",
     "subtype": "Basic",
@@ -6335,7 +6453,8 @@
     ]
   },
   {
-    "id": "dp6-119",
+    "setOrder":37,
+	"id": "dp6-119",
     "name": "Skitty",
     "imageUrl": "https://images.pokemontcg.io/dp6/119.png",
     "subtype": "Basic",
@@ -6388,7 +6507,8 @@
     ]
   },
   {
-    "id": "dp6-120",
+    "setOrder":37,
+	"id": "dp6-120",
     "name": "Sneasel",
     "imageUrl": "https://images.pokemontcg.io/dp6/120.png",
     "subtype": "Basic",
@@ -6448,7 +6568,8 @@
     ]
   },
   {
-    "id": "dp6-121",
+    "setOrder":37,
+	"id": "dp6-121",
     "name": "Spoink",
     "imageUrl": "https://images.pokemontcg.io/dp6/121.png",
     "subtype": "Basic",
@@ -6502,7 +6623,8 @@
     ]
   },
   {
-    "id": "dp6-122",
+    "setOrder":37,
+	"id": "dp6-122",
     "name": "Staryu",
     "imageUrl": "https://images.pokemontcg.io/dp6/122.png",
     "subtype": "Basic",
@@ -6556,7 +6678,8 @@
     ]
   },
   {
-    "id": "dp6-123",
+    "setOrder":37,
+	"id": "dp6-123",
     "name": "Swinub",
     "imageUrl": "https://images.pokemontcg.io/dp6/123.png",
     "subtype": "Basic",
@@ -6617,7 +6740,8 @@
     ]
   },
   {
-    "id": "dp6-124",
+    "setOrder":37,
+	"id": "dp6-124",
     "name": "Taillow",
     "imageUrl": "https://images.pokemontcg.io/dp6/124.png",
     "subtype": "Basic",
@@ -6676,7 +6800,8 @@
     ]
   },
   {
-    "id": "dp6-125",
+    "setOrder":37,
+	"id": "dp6-125",
     "name": "Tentacool",
     "imageUrl": "https://images.pokemontcg.io/dp6/125.png",
     "subtype": "Basic",
@@ -6729,7 +6854,8 @@
     ]
   },
   {
-    "id": "dp6-126",
+    "setOrder":37,
+	"id": "dp6-126",
     "name": "Tyrogue",
     "imageUrl": "https://images.pokemontcg.io/dp6/126.png",
     "subtype": "Basic",
@@ -6780,7 +6906,8 @@
     ]
   },
   {
-    "id": "dp6-127",
+    "setOrder":37,
+	"id": "dp6-127",
     "name": "Weepinbell",
     "imageUrl": "https://images.pokemontcg.io/dp6/127.png",
     "subtype": "Stage 1",
@@ -6836,7 +6963,8 @@
     ]
   },
   {
-    "id": "dp6-128",
+    "setOrder":37,
+	"id": "dp6-128",
     "name": "Yanma",
     "imageUrl": "https://images.pokemontcg.io/dp6/128.png",
     "subtype": "Basic",
@@ -6896,7 +7024,8 @@
     ]
   },
   {
-    "id": "dp6-129",
+    "setOrder":37,
+	"id": "dp6-129",
     "name": "Bubble Coat",
     "imageUrl": "https://images.pokemontcg.io/dp6/129.png",
     "subtype": "Pokémon Tool",
@@ -6915,7 +7044,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp6/129_hires.png"
   },
   {
-    "id": "dp6-130",
+    "setOrder":37,
+	"id": "dp6-130",
     "name": "Buck's Training",
     "imageUrl": "https://images.pokemontcg.io/dp6/130.png",
     "subtype": "Supporter",
@@ -6934,7 +7064,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp6/130_hires.png"
   },
   {
-    "id": "dp6-131",
+    "setOrder":37,
+	"id": "dp6-131",
     "name": "Cynthia's Feelings",
     "imageUrl": "https://images.pokemontcg.io/dp6/131.png",
     "subtype": "Supporter",
@@ -6953,7 +7084,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp6/131_hires.png"
   },
   {
-    "id": "dp6-132",
+    "setOrder":37,
+	"id": "dp6-132",
     "name": "Energy Pickup",
     "imageUrl": "https://images.pokemontcg.io/dp6/132.png",
     "subtype": "Item",
@@ -6971,7 +7103,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp6/132_hires.png"
   },
   {
-    "id": "dp6-133",
+    "setOrder":37,
+	"id": "dp6-133",
     "name": "Poké Radar",
     "imageUrl": "https://images.pokemontcg.io/dp6/133.png",
     "subtype": "Item",
@@ -6989,7 +7122,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp6/133_hires.png"
   },
   {
-    "id": "dp6-134",
+    "setOrder":37,
+	"id": "dp6-134",
     "name": "Snowpoint Temple",
     "imageUrl": "https://images.pokemontcg.io/dp6/134.png",
     "subtype": "Stadium",
@@ -7007,7 +7141,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp6/134_hires.png"
   },
   {
-    "id": "dp6-135",
+    "setOrder":37,
+	"id": "dp6-135",
     "name": "Stark Mountain",
     "imageUrl": "https://images.pokemontcg.io/dp6/135.png",
     "subtype": "Stadium",
@@ -7025,7 +7160,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp6/135_hires.png"
   },
   {
-    "id": "dp6-136",
+    "setOrder":37,
+	"id": "dp6-136",
     "name": "Technical Machine TS-1",
     "imageUrl": "https://images.pokemontcg.io/dp6/136.png",
     "subtype": "Technical Machine",
@@ -7042,7 +7178,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp6/136_hires.png"
   },
   {
-    "id": "dp6-137",
+    "setOrder":37,
+	"id": "dp6-137",
     "name": "Technical Machine TS-2",
     "imageUrl": "https://images.pokemontcg.io/dp6/137.png",
     "subtype": "Technical Machine",
@@ -7059,7 +7196,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp6/137_hires.png"
   },
   {
-    "id": "dp6-138",
+    "setOrder":37,
+	"id": "dp6-138",
     "name": "Claw Fossil",
     "imageUrl": "https://images.pokemontcg.io/dp6/138.png",
     "subtype": "Item",
@@ -7078,7 +7216,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp6/138_hires.png"
   },
   {
-    "id": "dp6-139",
+    "setOrder":37,
+	"id": "dp6-139",
     "name": "Root Fossil",
     "imageUrl": "https://images.pokemontcg.io/dp6/139.png",
     "subtype": "Item",
@@ -7097,7 +7236,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp6/139_hires.png"
   },
   {
-    "id": "dp6-140",
+    "setOrder":37,
+	"id": "dp6-140",
     "name": "Azelf",
     "imageUrl": "https://images.pokemontcg.io/dp6/140.png",
     "subtype": "Level Up",
@@ -7146,7 +7286,8 @@
     "nationalPokedexNumber": 482
   },
   {
-    "id": "dp6-141",
+    "setOrder":37,
+	"id": "dp6-141",
     "name": "Gliscor",
     "imageUrl": "https://images.pokemontcg.io/dp6/141.png",
     "subtype": "Level Up",
@@ -7199,7 +7340,8 @@
     "nationalPokedexNumber": 472
   },
   {
-    "id": "dp6-142",
+    "setOrder":37,
+	"id": "dp6-142",
     "name": "Magnezone",
     "imageUrl": "https://images.pokemontcg.io/dp6/142.png",
     "subtype": "Level Up",
@@ -7258,7 +7400,8 @@
     "nationalPokedexNumber": 462
   },
   {
-    "id": "dp6-143",
+    "setOrder":37,
+	"id": "dp6-143",
     "name": "Mesprit",
     "imageUrl": "https://images.pokemontcg.io/dp6/143.png",
     "subtype": "Level Up",
@@ -7312,7 +7455,8 @@
     "nationalPokedexNumber": 481
   },
   {
-    "id": "dp6-144",
+    "setOrder":37,
+	"id": "dp6-144",
     "name": "Mewtwo",
     "imageUrl": "https://images.pokemontcg.io/dp6/144.png",
     "subtype": "Level Up",
@@ -7364,7 +7508,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "dp6-145",
+    "setOrder":37,
+	"id": "dp6-145",
     "name": "Rhyperior",
     "imageUrl": "https://images.pokemontcg.io/dp6/145.png",
     "subtype": "Level Up",
@@ -7428,7 +7573,8 @@
     "nationalPokedexNumber": 464
   },
   {
-    "id": "dp6-146",
+    "setOrder":37,
+	"id": "dp6-146",
     "name": "Uxie",
     "imageUrl": "https://images.pokemontcg.io/dp6/146.png",
     "subtype": "Level Up",

--- a/json/cards/Majestic Dawn.json
+++ b/json/cards/Majestic Dawn.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "dp5-1",
+    "setOrder":36,
+	"id": "dp5-1",
     "name": "Articuno",
     "imageUrl": "https://images.pokemontcg.io/dp5/1.png",
     "subtype": "Basic",
@@ -55,7 +56,8 @@
     "nationalPokedexNumber": 144
   },
   {
-    "id": "dp5-2",
+    "setOrder":36,
+	"id": "dp5-2",
     "name": "Cresselia",
     "imageUrl": "https://images.pokemontcg.io/dp5/2.png",
     "subtype": "Basic",
@@ -107,7 +109,8 @@
     "nationalPokedexNumber": 488
   },
   {
-    "id": "dp5-3",
+    "setOrder":36,
+	"id": "dp5-3",
     "name": "Darkrai",
     "imageUrl": "https://images.pokemontcg.io/dp5/3.png",
     "subtype": "Basic",
@@ -171,7 +174,8 @@
     "nationalPokedexNumber": 491
   },
   {
-    "id": "dp5-4",
+    "setOrder":36,
+	"id": "dp5-4",
     "name": "Dialga",
     "imageUrl": "https://images.pokemontcg.io/dp5/4.png",
     "subtype": "Basic",
@@ -235,7 +239,8 @@
     "nationalPokedexNumber": 483
   },
   {
-    "id": "dp5-5",
+    "setOrder":36,
+	"id": "dp5-5",
     "name": "Glaceon",
     "imageUrl": "https://images.pokemontcg.io/dp5/5.png",
     "subtype": "Stage 1",
@@ -288,7 +293,8 @@
     "nationalPokedexNumber": 471
   },
   {
-    "id": "dp5-6",
+    "setOrder":36,
+	"id": "dp5-6",
     "name": "Kabutops",
     "imageUrl": "https://images.pokemontcg.io/dp5/6.png",
     "subtype": "Stage 2",
@@ -338,7 +344,8 @@
     "nationalPokedexNumber": 141
   },
   {
-    "id": "dp5-7",
+    "setOrder":36,
+	"id": "dp5-7",
     "name": "Leafeon",
     "imageUrl": "https://images.pokemontcg.io/dp5/7.png",
     "subtype": "Stage 1",
@@ -398,7 +405,8 @@
     "nationalPokedexNumber": 470
   },
   {
-    "id": "dp5-8",
+    "setOrder":36,
+	"id": "dp5-8",
     "name": "Manaphy",
     "imageUrl": "https://images.pokemontcg.io/dp5/8.png",
     "subtype": "Basic",
@@ -454,7 +462,8 @@
     "nationalPokedexNumber": 490
   },
   {
-    "id": "dp5-9",
+    "setOrder":36,
+	"id": "dp5-9",
     "name": "Mewtwo",
     "imageUrl": "https://images.pokemontcg.io/dp5/9.png",
     "subtype": "Basic",
@@ -516,7 +525,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "dp5-10",
+    "setOrder":36,
+	"id": "dp5-10",
     "name": "Moltres",
     "imageUrl": "https://images.pokemontcg.io/dp5/10.png",
     "subtype": "Basic",
@@ -571,7 +581,8 @@
     "nationalPokedexNumber": 146
   },
   {
-    "id": "dp5-11",
+    "setOrder":36,
+	"id": "dp5-11",
     "name": "Palkia",
     "imageUrl": "https://images.pokemontcg.io/dp5/11.png",
     "subtype": "Basic",
@@ -629,7 +640,8 @@
     "nationalPokedexNumber": 484
   },
   {
-    "id": "dp5-12",
+    "setOrder":36,
+	"id": "dp5-12",
     "name": "Phione",
     "imageUrl": "https://images.pokemontcg.io/dp5/12.png",
     "subtype": "Basic",
@@ -680,7 +692,8 @@
     "nationalPokedexNumber": 489
   },
   {
-    "id": "dp5-13",
+    "setOrder":36,
+	"id": "dp5-13",
     "name": "Rotom",
     "imageUrl": "https://images.pokemontcg.io/dp5/13.png",
     "subtype": "Basic",
@@ -737,7 +750,8 @@
     "nationalPokedexNumber": 479
   },
   {
-    "id": "dp5-14",
+    "setOrder":36,
+	"id": "dp5-14",
     "name": "Zapdos",
     "imageUrl": "https://images.pokemontcg.io/dp5/14.png",
     "subtype": "Basic",
@@ -792,7 +806,8 @@
     "nationalPokedexNumber": 145
   },
   {
-    "id": "dp5-15",
+    "setOrder":36,
+	"id": "dp5-15",
     "name": "Aerodactyl",
     "imageUrl": "https://images.pokemontcg.io/dp5/15.png",
     "subtype": "Stage 1",
@@ -846,7 +861,8 @@
     "nationalPokedexNumber": 142
   },
   {
-    "id": "dp5-16",
+    "setOrder":36,
+	"id": "dp5-16",
     "name": "Bronzong",
     "imageUrl": "https://images.pokemontcg.io/dp5/16.png",
     "subtype": "Stage 1",
@@ -912,7 +928,8 @@
     "nationalPokedexNumber": 437
   },
   {
-    "id": "dp5-17",
+    "setOrder":36,
+	"id": "dp5-17",
     "name": "Empoleon",
     "imageUrl": "https://images.pokemontcg.io/dp5/17.png",
     "subtype": "Stage 2",
@@ -967,7 +984,8 @@
     "nationalPokedexNumber": 395
   },
   {
-    "id": "dp5-18",
+    "setOrder":36,
+	"id": "dp5-18",
     "name": "Espeon",
     "imageUrl": "https://images.pokemontcg.io/dp5/18.png",
     "subtype": "Stage 1",
@@ -1016,7 +1034,8 @@
     "nationalPokedexNumber": 196
   },
   {
-    "id": "dp5-19",
+    "setOrder":36,
+	"id": "dp5-19",
     "name": "Flareon",
     "imageUrl": "https://images.pokemontcg.io/dp5/19.png",
     "subtype": "Stage 1",
@@ -1070,7 +1089,8 @@
     "nationalPokedexNumber": 136
   },
   {
-    "id": "dp5-20",
+    "setOrder":36,
+	"id": "dp5-20",
     "name": "Glaceon",
     "imageUrl": "https://images.pokemontcg.io/dp5/20.png",
     "subtype": "Stage 1",
@@ -1124,7 +1144,8 @@
     "nationalPokedexNumber": 471
   },
   {
-    "id": "dp5-21",
+    "setOrder":36,
+	"id": "dp5-21",
     "name": "Hippowdon",
     "imageUrl": "https://images.pokemontcg.io/dp5/21.png",
     "subtype": "Stage 1",
@@ -1179,7 +1200,8 @@
     "nationalPokedexNumber": 450
   },
   {
-    "id": "dp5-22",
+    "setOrder":36,
+	"id": "dp5-22",
     "name": "Infernape",
     "imageUrl": "https://images.pokemontcg.io/dp5/22.png",
     "subtype": "Stage 2",
@@ -1227,7 +1249,8 @@
     "nationalPokedexNumber": 392
   },
   {
-    "id": "dp5-23",
+    "setOrder":36,
+	"id": "dp5-23",
     "name": "Jolteon",
     "imageUrl": "https://images.pokemontcg.io/dp5/23.png",
     "subtype": "Stage 1",
@@ -1283,7 +1306,8 @@
     "nationalPokedexNumber": 135
   },
   {
-    "id": "dp5-24",
+    "setOrder":36,
+	"id": "dp5-24",
     "name": "Leafeon",
     "imageUrl": "https://images.pokemontcg.io/dp5/24.png",
     "subtype": "Stage 1",
@@ -1343,7 +1367,8 @@
     "nationalPokedexNumber": 470
   },
   {
-    "id": "dp5-25",
+    "setOrder":36,
+	"id": "dp5-25",
     "name": "Minun",
     "imageUrl": "https://images.pokemontcg.io/dp5/25.png",
     "subtype": "Basic",
@@ -1400,7 +1425,8 @@
     "nationalPokedexNumber": 312
   },
   {
-    "id": "dp5-26",
+    "setOrder":36,
+	"id": "dp5-26",
     "name": "Omastar",
     "imageUrl": "https://images.pokemontcg.io/dp5/26.png",
     "subtype": "Stage 2",
@@ -1448,7 +1474,8 @@
     "nationalPokedexNumber": 139
   },
   {
-    "id": "dp5-27",
+    "setOrder":36,
+	"id": "dp5-27",
     "name": "Phione",
     "imageUrl": "https://images.pokemontcg.io/dp5/27.png",
     "subtype": "Basic",
@@ -1499,7 +1526,8 @@
     "nationalPokedexNumber": 489
   },
   {
-    "id": "dp5-28",
+    "setOrder":36,
+	"id": "dp5-28",
     "name": "Plusle",
     "imageUrl": "https://images.pokemontcg.io/dp5/28.png",
     "subtype": "Basic",
@@ -1556,7 +1584,8 @@
     "nationalPokedexNumber": 311
   },
   {
-    "id": "dp5-29",
+    "setOrder":36,
+	"id": "dp5-29",
     "name": "Scizor",
     "imageUrl": "https://images.pokemontcg.io/dp5/29.png",
     "subtype": "Stage 1",
@@ -1615,7 +1644,8 @@
     "nationalPokedexNumber": 212
   },
   {
-    "id": "dp5-30",
+    "setOrder":36,
+	"id": "dp5-30",
     "name": "Torterra",
     "imageUrl": "https://images.pokemontcg.io/dp5/30.png",
     "subtype": "Stage 2",
@@ -1673,7 +1703,8 @@
     "nationalPokedexNumber": 389
   },
   {
-    "id": "dp5-31",
+    "setOrder":36,
+	"id": "dp5-31",
     "name": "Toxicroak",
     "imageUrl": "https://images.pokemontcg.io/dp5/31.png",
     "subtype": "Stage 1",
@@ -1726,7 +1757,8 @@
     "nationalPokedexNumber": 454
   },
   {
-    "id": "dp5-32",
+    "setOrder":36,
+	"id": "dp5-32",
     "name": "Umbreon",
     "imageUrl": "https://images.pokemontcg.io/dp5/32.png",
     "subtype": "Stage 1",
@@ -1781,7 +1813,8 @@
     "nationalPokedexNumber": 197
   },
   {
-    "id": "dp5-33",
+    "setOrder":36,
+	"id": "dp5-33",
     "name": "Unown P",
     "imageUrl": "https://images.pokemontcg.io/dp5/33.png",
     "subtype": "Basic",
@@ -1827,7 +1860,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp5-34",
+    "setOrder":36,
+	"id": "dp5-34",
     "name": "Vaporeon",
     "imageUrl": "https://images.pokemontcg.io/dp5/34.png",
     "subtype": "Stage 1",
@@ -1880,7 +1914,8 @@
     "nationalPokedexNumber": 134
   },
   {
-    "id": "dp5-35",
+    "setOrder":36,
+	"id": "dp5-35",
     "name": "Ambipom",
     "imageUrl": "https://images.pokemontcg.io/dp5/35.png",
     "subtype": "Stage 1",
@@ -1934,7 +1969,8 @@
     "nationalPokedexNumber": 424
   },
   {
-    "id": "dp5-36",
+    "setOrder":36,
+	"id": "dp5-36",
     "name": "Fearow",
     "imageUrl": "https://images.pokemontcg.io/dp5/36.png",
     "subtype": "Stage 1",
@@ -1990,7 +2026,8 @@
     "nationalPokedexNumber": 22
   },
   {
-    "id": "dp5-37",
+    "setOrder":36,
+	"id": "dp5-37",
     "name": "Grotle",
     "imageUrl": "https://images.pokemontcg.io/dp5/37.png",
     "subtype": "Stage 1",
@@ -2054,7 +2091,8 @@
     ]
   },
   {
-    "id": "dp5-38",
+    "setOrder":36,
+	"id": "dp5-38",
     "name": "Kangaskhan",
     "imageUrl": "https://images.pokemontcg.io/dp5/38.png",
     "subtype": "Basic",
@@ -2109,7 +2147,8 @@
     "nationalPokedexNumber": 115
   },
   {
-    "id": "dp5-39",
+    "setOrder":36,
+	"id": "dp5-39",
     "name": "Lickitung",
     "imageUrl": "https://images.pokemontcg.io/dp5/39.png",
     "subtype": "Basic",
@@ -2164,7 +2203,8 @@
     ]
   },
   {
-    "id": "dp5-40",
+    "setOrder":36,
+	"id": "dp5-40",
     "name": "Manectric",
     "imageUrl": "https://images.pokemontcg.io/dp5/40.png",
     "subtype": "Stage 1",
@@ -2219,7 +2259,8 @@
     "nationalPokedexNumber": 310
   },
   {
-    "id": "dp5-41",
+    "setOrder":36,
+	"id": "dp5-41",
     "name": "Monferno",
     "imageUrl": "https://images.pokemontcg.io/dp5/41.png",
     "subtype": "Stage 1",
@@ -2271,7 +2312,8 @@
     ]
   },
   {
-    "id": "dp5-42",
+    "setOrder":36,
+	"id": "dp5-42",
     "name": "Mothim",
     "imageUrl": "https://images.pokemontcg.io/dp5/42.png",
     "subtype": "Stage 1",
@@ -2334,7 +2376,8 @@
     ]
   },
   {
-    "id": "dp5-43",
+    "setOrder":36,
+	"id": "dp5-43",
     "name": "Pachirisu",
     "imageUrl": "https://images.pokemontcg.io/dp5/43.png",
     "subtype": "Basic",
@@ -2391,7 +2434,8 @@
     "nationalPokedexNumber": 417
   },
   {
-    "id": "dp5-44",
+    "setOrder":36,
+	"id": "dp5-44",
     "name": "Prinplup",
     "imageUrl": "https://images.pokemontcg.io/dp5/44.png",
     "subtype": "Stage 1",
@@ -2448,7 +2492,8 @@
     ]
   },
   {
-    "id": "dp5-45",
+    "setOrder":36,
+	"id": "dp5-45",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/dp5/45.png",
     "subtype": "Stage 1",
@@ -2504,7 +2549,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "dp5-46",
+    "setOrder":36,
+	"id": "dp5-46",
     "name": "Scyther",
     "imageUrl": "https://images.pokemontcg.io/dp5/46.png",
     "subtype": "Basic",
@@ -2564,7 +2610,8 @@
     ]
   },
   {
-    "id": "dp5-47",
+    "setOrder":36,
+	"id": "dp5-47",
     "name": "Staravia",
     "imageUrl": "https://images.pokemontcg.io/dp5/47.png",
     "subtype": "Stage 1",
@@ -2623,7 +2670,8 @@
     ]
   },
   {
-    "id": "dp5-48",
+    "setOrder":36,
+	"id": "dp5-48",
     "name": "Sudowoodo",
     "imageUrl": "https://images.pokemontcg.io/dp5/48.png",
     "subtype": "Basic",
@@ -2675,7 +2723,8 @@
     "nationalPokedexNumber": 185
   },
   {
-    "id": "dp5-49",
+    "setOrder":36,
+	"id": "dp5-49",
     "name": "Unown Q",
     "imageUrl": "https://images.pokemontcg.io/dp5/49.png",
     "subtype": "Basic",
@@ -2718,7 +2767,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp5-50",
+    "setOrder":36,
+	"id": "dp5-50",
     "name": "Aipom",
     "imageUrl": "https://images.pokemontcg.io/dp5/50.png",
     "subtype": "Basic",
@@ -2772,7 +2822,8 @@
     ]
   },
   {
-    "id": "dp5-51",
+    "setOrder":36,
+	"id": "dp5-51",
     "name": "Aipom",
     "imageUrl": "https://images.pokemontcg.io/dp5/51.png",
     "subtype": "Basic",
@@ -2826,7 +2877,8 @@
     ]
   },
   {
-    "id": "dp5-52",
+    "setOrder":36,
+	"id": "dp5-52",
     "name": "Bronzor",
     "imageUrl": "https://images.pokemontcg.io/dp5/52.png",
     "subtype": "Basic",
@@ -2885,7 +2937,8 @@
     ]
   },
   {
-    "id": "dp5-53",
+    "setOrder":36,
+	"id": "dp5-53",
     "name": "Buneary",
     "imageUrl": "https://images.pokemontcg.io/dp5/53.png",
     "subtype": "Basic",
@@ -2938,7 +2991,8 @@
     ]
   },
   {
-    "id": "dp5-54",
+    "setOrder":36,
+	"id": "dp5-54",
     "name": "Burmy Sandy Cloak",
     "imageUrl": "https://images.pokemontcg.io/dp5/54.png",
     "subtype": "Basic",
@@ -2992,7 +3046,8 @@
     ]
   },
   {
-    "id": "dp5-55",
+    "setOrder":36,
+	"id": "dp5-55",
     "name": "Chatot",
     "imageUrl": "https://images.pokemontcg.io/dp5/55.png",
     "subtype": "Basic",
@@ -3046,7 +3101,8 @@
     "nationalPokedexNumber": 441
   },
   {
-    "id": "dp5-56",
+    "setOrder":36,
+	"id": "dp5-56",
     "name": "Chimchar",
     "imageUrl": "https://images.pokemontcg.io/dp5/56.png",
     "subtype": "Basic",
@@ -3100,7 +3156,8 @@
     ]
   },
   {
-    "id": "dp5-57",
+    "setOrder":36,
+	"id": "dp5-57",
     "name": "Chimchar",
     "imageUrl": "https://images.pokemontcg.io/dp5/57.png",
     "subtype": "Basic",
@@ -3147,7 +3204,8 @@
     ]
   },
   {
-    "id": "dp5-58",
+    "setOrder":36,
+	"id": "dp5-58",
     "name": "Chingling",
     "imageUrl": "https://images.pokemontcg.io/dp5/58.png",
     "subtype": "Basic",
@@ -3196,7 +3254,8 @@
     ]
   },
   {
-    "id": "dp5-59",
+    "setOrder":36,
+	"id": "dp5-59",
     "name": "Combee",
     "imageUrl": "https://images.pokemontcg.io/dp5/59.png",
     "subtype": "Basic",
@@ -3256,7 +3315,8 @@
     ]
   },
   {
-    "id": "dp5-60",
+    "setOrder":36,
+	"id": "dp5-60",
     "name": "Croagunk",
     "imageUrl": "https://images.pokemontcg.io/dp5/60.png",
     "subtype": "Basic",
@@ -3309,7 +3369,8 @@
     ]
   },
   {
-    "id": "dp5-61",
+    "setOrder":36,
+	"id": "dp5-61",
     "name": "Drifloon",
     "imageUrl": "https://images.pokemontcg.io/dp5/61.png",
     "subtype": "Basic",
@@ -3368,7 +3429,8 @@
     ]
   },
   {
-    "id": "dp5-62",
+    "setOrder":36,
+	"id": "dp5-62",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/dp5/62.png",
     "subtype": "Basic",
@@ -3428,7 +3490,8 @@
     ]
   },
   {
-    "id": "dp5-63",
+    "setOrder":36,
+	"id": "dp5-63",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/dp5/63.png",
     "subtype": "Basic",
@@ -3488,7 +3551,8 @@
     ]
   },
   {
-    "id": "dp5-64",
+    "setOrder":36,
+	"id": "dp5-64",
     "name": "Electrike",
     "imageUrl": "https://images.pokemontcg.io/dp5/64.png",
     "subtype": "Basic",
@@ -3548,7 +3612,8 @@
     ]
   },
   {
-    "id": "dp5-65",
+    "setOrder":36,
+	"id": "dp5-65",
     "name": "Glameow",
     "imageUrl": "https://images.pokemontcg.io/dp5/65.png",
     "subtype": "Basic",
@@ -3602,7 +3667,8 @@
     ]
   },
   {
-    "id": "dp5-66",
+    "setOrder":36,
+	"id": "dp5-66",
     "name": "Hippopotas",
     "imageUrl": "https://images.pokemontcg.io/dp5/66.png",
     "subtype": "Basic",
@@ -3658,7 +3724,8 @@
     ]
   },
   {
-    "id": "dp5-67",
+    "setOrder":36,
+	"id": "dp5-67",
     "name": "Kabuto",
     "imageUrl": "https://images.pokemontcg.io/dp5/67.png",
     "subtype": "Stage 1",
@@ -3708,7 +3775,8 @@
     ]
   },
   {
-    "id": "dp5-68",
+    "setOrder":36,
+	"id": "dp5-68",
     "name": "Munchlax",
     "imageUrl": "https://images.pokemontcg.io/dp5/68.png",
     "subtype": "Basic",
@@ -3759,7 +3827,8 @@
     ]
   },
   {
-    "id": "dp5-69",
+    "setOrder":36,
+	"id": "dp5-69",
     "name": "Omanyte",
     "imageUrl": "https://images.pokemontcg.io/dp5/69.png",
     "subtype": "Stage 1",
@@ -3810,7 +3879,8 @@
     ]
   },
   {
-    "id": "dp5-70",
+    "setOrder":36,
+	"id": "dp5-70",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/dp5/70.png",
     "subtype": "Basic",
@@ -3871,7 +3941,8 @@
     ]
   },
   {
-    "id": "dp5-71",
+    "setOrder":36,
+	"id": "dp5-71",
     "name": "Piplup",
     "imageUrl": "https://images.pokemontcg.io/dp5/71.png",
     "subtype": "Basic",
@@ -3925,7 +3996,8 @@
     ]
   },
   {
-    "id": "dp5-72",
+    "setOrder":36,
+	"id": "dp5-72",
     "name": "Piplup",
     "imageUrl": "https://images.pokemontcg.io/dp5/72.png",
     "subtype": "Basic",
@@ -3972,7 +4044,8 @@
     ]
   },
   {
-    "id": "dp5-73",
+    "setOrder":36,
+	"id": "dp5-73",
     "name": "Shellos East Sea",
     "imageUrl": "https://images.pokemontcg.io/dp5/73.png",
     "subtype": "Basic",
@@ -4027,7 +4100,8 @@
     ]
   },
   {
-    "id": "dp5-74",
+    "setOrder":36,
+	"id": "dp5-74",
     "name": "Spearow",
     "imageUrl": "https://images.pokemontcg.io/dp5/74.png",
     "subtype": "Basic",
@@ -4087,7 +4161,8 @@
     ]
   },
   {
-    "id": "dp5-75",
+    "setOrder":36,
+	"id": "dp5-75",
     "name": "Starly",
     "imageUrl": "https://images.pokemontcg.io/dp5/75.png",
     "subtype": "Basic",
@@ -4147,7 +4222,8 @@
     ]
   },
   {
-    "id": "dp5-76",
+    "setOrder":36,
+	"id": "dp5-76",
     "name": "Stunky",
     "imageUrl": "https://images.pokemontcg.io/dp5/76.png",
     "subtype": "Basic",
@@ -4207,7 +4283,8 @@
     ]
   },
   {
-    "id": "dp5-77",
+    "setOrder":36,
+	"id": "dp5-77",
     "name": "Turtwig",
     "imageUrl": "https://images.pokemontcg.io/dp5/77.png",
     "subtype": "Basic",
@@ -4268,7 +4345,8 @@
     ]
   },
   {
-    "id": "dp5-78",
+    "setOrder":36,
+	"id": "dp5-78",
     "name": "Turtwig",
     "imageUrl": "https://images.pokemontcg.io/dp5/78.png",
     "subtype": "Basic",
@@ -4323,7 +4401,8 @@
     ]
   },
   {
-    "id": "dp5-79",
+    "setOrder":36,
+	"id": "dp5-79",
     "name": "Dawn Stadium",
     "imageUrl": "https://images.pokemontcg.io/dp5/79.png",
     "subtype": "Stadium",
@@ -4341,7 +4420,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp5/79_hires.png"
   },
   {
-    "id": "dp5-80",
+    "setOrder":36,
+	"id": "dp5-80",
     "name": "Dusk Ball",
     "imageUrl": "https://images.pokemontcg.io/dp5/80.png",
     "subtype": "Item",
@@ -4359,7 +4439,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp5/80_hires.png"
   },
   {
-    "id": "dp5-81",
+    "setOrder":36,
+	"id": "dp5-81",
     "name": "Energy Restore",
     "imageUrl": "https://images.pokemontcg.io/dp5/81.png",
     "subtype": "Item",
@@ -4377,7 +4458,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp5/81_hires.png"
   },
   {
-    "id": "dp5-82",
+    "setOrder":36,
+	"id": "dp5-82",
     "name": "Fossil Excavator",
     "imageUrl": "https://images.pokemontcg.io/dp5/82.png",
     "subtype": "Supporter",
@@ -4396,7 +4478,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp5/82_hires.png"
   },
   {
-    "id": "dp5-83",
+    "setOrder":36,
+	"id": "dp5-83",
     "name": "Mom's Kindness",
     "imageUrl": "https://images.pokemontcg.io/dp5/83.png",
     "subtype": "Supporter",
@@ -4415,7 +4498,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp5/83_hires.png"
   },
   {
-    "id": "dp5-84",
+    "setOrder":36,
+	"id": "dp5-84",
     "name": "Old Amber",
     "imageUrl": "https://images.pokemontcg.io/dp5/84.png",
     "subtype": "Item",
@@ -4434,7 +4518,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp5/84_hires.png"
   },
   {
-    "id": "dp5-85",
+    "setOrder":36,
+	"id": "dp5-85",
     "name": "Poké Ball",
     "imageUrl": "https://images.pokemontcg.io/dp5/85.png",
     "subtype": "Item",
@@ -4452,7 +4537,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp5/85_hires.png"
   },
   {
-    "id": "dp5-86",
+    "setOrder":36,
+	"id": "dp5-86",
     "name": "Quick Ball",
     "imageUrl": "https://images.pokemontcg.io/dp5/86.png",
     "subtype": "Item",
@@ -4470,7 +4556,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp5/86_hires.png"
   },
   {
-    "id": "dp5-87",
+    "setOrder":36,
+	"id": "dp5-87",
     "name": "Super Scoop Up",
     "imageUrl": "https://images.pokemontcg.io/dp5/87.png",
     "subtype": "Item",
@@ -4488,7 +4575,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp5/87_hires.png"
   },
   {
-    "id": "dp5-88",
+    "setOrder":36,
+	"id": "dp5-88",
     "name": "Warp Point",
     "imageUrl": "https://images.pokemontcg.io/dp5/88.png",
     "subtype": "Item",
@@ -4506,7 +4594,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp5/88_hires.png"
   },
   {
-    "id": "dp5-89",
+    "setOrder":36,
+	"id": "dp5-89",
     "name": "Dome Fossil",
     "imageUrl": "https://images.pokemontcg.io/dp5/89.png",
     "subtype": "Item",
@@ -4525,7 +4614,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp5/89_hires.png"
   },
   {
-    "id": "dp5-90",
+    "setOrder":36,
+	"id": "dp5-90",
     "name": "Energy Search",
     "imageUrl": "https://images.pokemontcg.io/dp5/90.png",
     "subtype": "Item",
@@ -4543,7 +4633,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp5/90_hires.png"
   },
   {
-    "id": "dp5-91",
+    "setOrder":36,
+	"id": "dp5-91",
     "name": "Helix Fossil",
     "imageUrl": "https://images.pokemontcg.io/dp5/91.png",
     "subtype": "Item",
@@ -4562,7 +4653,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp5/91_hires.png"
   },
   {
-    "id": "dp5-92",
+    "setOrder":36,
+	"id": "dp5-92",
     "name": "Call Energy",
     "imageUrl": "https://images.pokemontcg.io/dp5/92.png",
     "subtype": "Special",
@@ -4579,7 +4671,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp5/92_hires.png"
   },
   {
-    "id": "dp5-93",
+    "setOrder":36,
+	"id": "dp5-93",
     "name": "Darkness Energy",
     "imageUrl": "https://images.pokemontcg.io/dp5/93.png",
     "subtype": "Special",
@@ -4596,7 +4689,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp5/93_hires.png"
   },
   {
-    "id": "dp5-94",
+    "setOrder":36,
+	"id": "dp5-94",
     "name": "Health Energy",
     "imageUrl": "https://images.pokemontcg.io/dp5/94.png",
     "subtype": "Special",
@@ -4613,7 +4707,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp5/94_hires.png"
   },
   {
-    "id": "dp5-95",
+    "setOrder":36,
+	"id": "dp5-95",
     "name": "Metal Energy",
     "imageUrl": "https://images.pokemontcg.io/dp5/95.png",
     "subtype": "Special",
@@ -4630,7 +4725,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp5/95_hires.png"
   },
   {
-    "id": "dp5-96",
+    "setOrder":36,
+	"id": "dp5-96",
     "name": "Recover Energy",
     "imageUrl": "https://images.pokemontcg.io/dp5/96.png",
     "subtype": "Special",
@@ -4647,7 +4743,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp5/96_hires.png"
   },
   {
-    "id": "dp5-97",
+    "setOrder":36,
+	"id": "dp5-97",
     "name": "Garchomp",
     "imageUrl": "https://images.pokemontcg.io/dp5/97.png",
     "subtype": "Level Up",
@@ -4693,7 +4790,8 @@
     "nationalPokedexNumber": 445
   },
   {
-    "id": "dp5-98",
+    "setOrder":36,
+	"id": "dp5-98",
     "name": "Glaceon",
     "imageUrl": "https://images.pokemontcg.io/dp5/98.png",
     "subtype": "Level Up",
@@ -4744,7 +4842,8 @@
     "nationalPokedexNumber": 471
   },
   {
-    "id": "dp5-99",
+    "setOrder":36,
+	"id": "dp5-99",
     "name": "Leafeon",
     "imageUrl": "https://images.pokemontcg.io/dp5/99.png",
     "subtype": "Level Up",
@@ -4801,7 +4900,8 @@
     "nationalPokedexNumber": 470
   },
   {
-    "id": "dp5-100",
+    "setOrder":36,
+	"id": "dp5-100",
     "name": "Porygon-Z",
     "imageUrl": "https://images.pokemontcg.io/dp5/100.png",
     "subtype": "Level Up",

--- a/json/cards/Mysterious Treasures.json
+++ b/json/cards/Mysterious Treasures.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "dp2-1",
+    "setOrder":33,
+	"id": "dp2-1",
     "name": "Aggron",
     "imageUrl": "https://images.pokemontcg.io/dp2/1.png",
     "subtype": "Stage 2",
@@ -64,7 +65,8 @@
     "nationalPokedexNumber": 306
   },
   {
-    "id": "dp2-2",
+    "setOrder":33,
+	"id": "dp2-2",
     "name": "Alakazam",
     "imageUrl": "https://images.pokemontcg.io/dp2/2.png",
     "subtype": "Stage 2",
@@ -113,7 +115,8 @@
     "nationalPokedexNumber": 65
   },
   {
-    "id": "dp2-3",
+    "setOrder":33,
+	"id": "dp2-3",
     "name": "Ambipom",
     "imageUrl": "https://images.pokemontcg.io/dp2/3.png",
     "subtype": "Stage 1",
@@ -166,7 +169,8 @@
     "nationalPokedexNumber": 424
   },
   {
-    "id": "dp2-4",
+    "setOrder":33,
+	"id": "dp2-4",
     "name": "Azelf",
     "imageUrl": "https://images.pokemontcg.io/dp2/4.png",
     "subtype": "Basic",
@@ -212,7 +216,8 @@
     "nationalPokedexNumber": 482
   },
   {
-    "id": "dp2-5",
+    "setOrder":33,
+	"id": "dp2-5",
     "name": "Blissey",
     "imageUrl": "https://images.pokemontcg.io/dp2/5.png",
     "subtype": "Stage 1",
@@ -261,7 +266,8 @@
     "nationalPokedexNumber": 242
   },
   {
-    "id": "dp2-6",
+    "setOrder":33,
+	"id": "dp2-6",
     "name": "Bronzong",
     "imageUrl": "https://images.pokemontcg.io/dp2/6.png",
     "subtype": "Stage 1",
@@ -318,7 +324,8 @@
     "nationalPokedexNumber": 437
   },
   {
-    "id": "dp2-7",
+    "setOrder":33,
+	"id": "dp2-7",
     "name": "Celebi",
     "imageUrl": "https://images.pokemontcg.io/dp2/7.png",
     "subtype": "Basic",
@@ -369,7 +376,8 @@
     "nationalPokedexNumber": 251
   },
   {
-    "id": "dp2-8",
+    "setOrder":33,
+	"id": "dp2-8",
     "name": "Feraligatr",
     "imageUrl": "https://images.pokemontcg.io/dp2/8.png",
     "subtype": "Stage 2",
@@ -424,7 +432,8 @@
     "nationalPokedexNumber": 160
   },
   {
-    "id": "dp2-9",
+    "setOrder":33,
+	"id": "dp2-9",
     "name": "Garchomp",
     "imageUrl": "https://images.pokemontcg.io/dp2/9.png",
     "subtype": "Stage 2",
@@ -470,7 +479,8 @@
     "nationalPokedexNumber": 445
   },
   {
-    "id": "dp2-10",
+    "setOrder":33,
+	"id": "dp2-10",
     "name": "Honchkrow",
     "imageUrl": "https://images.pokemontcg.io/dp2/10.png",
     "subtype": "Stage 1",
@@ -525,7 +535,8 @@
     "nationalPokedexNumber": 430
   },
   {
-    "id": "dp2-11",
+    "setOrder":33,
+	"id": "dp2-11",
     "name": "Lumineon",
     "imageUrl": "https://images.pokemontcg.io/dp2/11.png",
     "subtype": "Stage 1",
@@ -573,7 +584,8 @@
     "nationalPokedexNumber": 457
   },
   {
-    "id": "dp2-12",
+    "setOrder":33,
+	"id": "dp2-12",
     "name": "Magmortar",
     "imageUrl": "https://images.pokemontcg.io/dp2/12.png",
     "subtype": "Stage 1",
@@ -629,7 +641,8 @@
     "nationalPokedexNumber": 467
   },
   {
-    "id": "dp2-13",
+    "setOrder":33,
+	"id": "dp2-13",
     "name": "Meganium",
     "imageUrl": "https://images.pokemontcg.io/dp2/13.png",
     "subtype": "Stage 2",
@@ -689,7 +702,8 @@
     "nationalPokedexNumber": 154
   },
   {
-    "id": "dp2-14",
+    "setOrder":33,
+	"id": "dp2-14",
     "name": "Mesprit",
     "imageUrl": "https://images.pokemontcg.io/dp2/14.png",
     "subtype": "Basic",
@@ -736,7 +750,8 @@
     "nationalPokedexNumber": 481
   },
   {
-    "id": "dp2-15",
+    "setOrder":33,
+	"id": "dp2-15",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/dp2/15.png",
     "subtype": "Stage 1",
@@ -794,7 +809,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "dp2-16",
+    "setOrder":33,
+	"id": "dp2-16",
     "name": "Typhlosion",
     "imageUrl": "https://images.pokemontcg.io/dp2/16.png",
     "subtype": "Stage 2",
@@ -844,7 +860,8 @@
     "nationalPokedexNumber": 157
   },
   {
-    "id": "dp2-17",
+    "setOrder":33,
+	"id": "dp2-17",
     "name": "Tyranitar",
     "imageUrl": "https://images.pokemontcg.io/dp2/17.png",
     "subtype": "Stage 2",
@@ -908,7 +925,8 @@
     "nationalPokedexNumber": 248
   },
   {
-    "id": "dp2-18",
+    "setOrder":33,
+	"id": "dp2-18",
     "name": "Uxie",
     "imageUrl": "https://images.pokemontcg.io/dp2/18.png",
     "subtype": "Basic",
@@ -954,7 +972,8 @@
     "nationalPokedexNumber": 480
   },
   {
-    "id": "dp2-19",
+    "setOrder":33,
+	"id": "dp2-19",
     "name": "Abomasnow",
     "imageUrl": "https://images.pokemontcg.io/dp2/19.png",
     "subtype": "Stage 1",
@@ -1005,7 +1024,8 @@
     "nationalPokedexNumber": 460
   },
   {
-    "id": "dp2-20",
+    "setOrder":33,
+	"id": "dp2-20",
     "name": "Ariados",
     "imageUrl": "https://images.pokemontcg.io/dp2/20.png",
     "subtype": "Stage 1",
@@ -1053,7 +1073,8 @@
     "nationalPokedexNumber": 168
   },
   {
-    "id": "dp2-21",
+    "setOrder":33,
+	"id": "dp2-21",
     "name": "Bastiodon",
     "imageUrl": "https://images.pokemontcg.io/dp2/21.png",
     "subtype": "Stage 2",
@@ -1110,7 +1131,8 @@
     "nationalPokedexNumber": 411
   },
   {
-    "id": "dp2-22",
+    "setOrder":33,
+	"id": "dp2-22",
     "name": "Chimecho",
     "imageUrl": "https://images.pokemontcg.io/dp2/22.png",
     "subtype": "Basic",
@@ -1160,7 +1182,8 @@
     "nationalPokedexNumber": 358
   },
   {
-    "id": "dp2-23",
+    "setOrder":33,
+	"id": "dp2-23",
     "name": "Crobat",
     "imageUrl": "https://images.pokemontcg.io/dp2/23.png",
     "subtype": "Stage 2",
@@ -1211,7 +1234,8 @@
     "nationalPokedexNumber": 169
   },
   {
-    "id": "dp2-24",
+    "setOrder":33,
+	"id": "dp2-24",
     "name": "Exeggutor",
     "imageUrl": "https://images.pokemontcg.io/dp2/24.png",
     "subtype": "Stage 1",
@@ -1263,7 +1287,8 @@
     "nationalPokedexNumber": 103
   },
   {
-    "id": "dp2-25",
+    "setOrder":33,
+	"id": "dp2-25",
     "name": "Glalie",
     "imageUrl": "https://images.pokemontcg.io/dp2/25.png",
     "subtype": "Stage 1",
@@ -1313,7 +1338,8 @@
     "nationalPokedexNumber": 362
   },
   {
-    "id": "dp2-26",
+    "setOrder":33,
+	"id": "dp2-26",
     "name": "Gyarados",
     "imageUrl": "https://images.pokemontcg.io/dp2/26.png",
     "subtype": "Stage 1",
@@ -1371,7 +1397,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "dp2-27",
+    "setOrder":33,
+	"id": "dp2-27",
     "name": "Kricketune",
     "imageUrl": "https://images.pokemontcg.io/dp2/27.png",
     "subtype": "Stage 1",
@@ -1425,7 +1452,8 @@
     "nationalPokedexNumber": 402
   },
   {
-    "id": "dp2-28",
+    "setOrder":33,
+	"id": "dp2-28",
     "name": "Manectric",
     "imageUrl": "https://images.pokemontcg.io/dp2/28.png",
     "subtype": "Stage 1",
@@ -1481,7 +1509,8 @@
     "nationalPokedexNumber": 310
   },
   {
-    "id": "dp2-29",
+    "setOrder":33,
+	"id": "dp2-29",
     "name": "Mantine",
     "imageUrl": "https://images.pokemontcg.io/dp2/29.png",
     "subtype": "Basic",
@@ -1534,7 +1563,8 @@
     "nationalPokedexNumber": 226
   },
   {
-    "id": "dp2-30",
+    "setOrder":33,
+	"id": "dp2-30",
     "name": "Mr. Mime",
     "imageUrl": "https://images.pokemontcg.io/dp2/30.png",
     "subtype": "Basic",
@@ -1581,7 +1611,8 @@
     "nationalPokedexNumber": 122
   },
   {
-    "id": "dp2-31",
+    "setOrder":33,
+	"id": "dp2-31",
     "name": "Nidoqueen",
     "imageUrl": "https://images.pokemontcg.io/dp2/31.png",
     "subtype": "Stage 2",
@@ -1637,7 +1668,8 @@
     "nationalPokedexNumber": 31
   },
   {
-    "id": "dp2-32",
+    "setOrder":33,
+	"id": "dp2-32",
     "name": "Ninetales",
     "imageUrl": "https://images.pokemontcg.io/dp2/32.png",
     "subtype": "Stage 1",
@@ -1685,7 +1717,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "dp2-33",
+    "setOrder":33,
+	"id": "dp2-33",
     "name": "Rampardos",
     "imageUrl": "https://images.pokemontcg.io/dp2/33.png",
     "subtype": "Stage 2",
@@ -1739,7 +1772,8 @@
     "nationalPokedexNumber": 409
   },
   {
-    "id": "dp2-34",
+    "setOrder":33,
+	"id": "dp2-34",
     "name": "Slaking",
     "imageUrl": "https://images.pokemontcg.io/dp2/34.png",
     "subtype": "Stage 2",
@@ -1792,7 +1826,8 @@
     "nationalPokedexNumber": 289
   },
   {
-    "id": "dp2-35",
+    "setOrder":33,
+	"id": "dp2-35",
     "name": "Sudowoodo",
     "imageUrl": "https://images.pokemontcg.io/dp2/35.png",
     "subtype": "Basic",
@@ -1843,7 +1878,8 @@
     "nationalPokedexNumber": 185
   },
   {
-    "id": "dp2-36",
+    "setOrder":33,
+	"id": "dp2-36",
     "name": "Toxicroak",
     "imageUrl": "https://images.pokemontcg.io/dp2/36.png",
     "subtype": "Stage 1",
@@ -1891,7 +1927,8 @@
     "nationalPokedexNumber": 454
   },
   {
-    "id": "dp2-37",
+    "setOrder":33,
+	"id": "dp2-37",
     "name": "Unown I",
     "imageUrl": "https://images.pokemontcg.io/dp2/37.png",
     "subtype": "Basic",
@@ -1937,7 +1974,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp2-38",
+    "setOrder":33,
+	"id": "dp2-38",
     "name": "Ursaring",
     "imageUrl": "https://images.pokemontcg.io/dp2/38.png",
     "subtype": "Stage 1",
@@ -1993,7 +2031,8 @@
     "nationalPokedexNumber": 217
   },
   {
-    "id": "dp2-39",
+    "setOrder":33,
+	"id": "dp2-39",
     "name": "Walrein",
     "imageUrl": "https://images.pokemontcg.io/dp2/39.png",
     "subtype": "Stage 2",
@@ -2044,7 +2083,8 @@
     "nationalPokedexNumber": 365
   },
   {
-    "id": "dp2-40",
+    "setOrder":33,
+	"id": "dp2-40",
     "name": "Whiscash",
     "imageUrl": "https://images.pokemontcg.io/dp2/40.png",
     "subtype": "Stage 1",
@@ -2108,7 +2148,8 @@
     "nationalPokedexNumber": 340
   },
   {
-    "id": "dp2-41",
+    "setOrder":33,
+	"id": "dp2-41",
     "name": "Bayleef",
     "imageUrl": "https://images.pokemontcg.io/dp2/41.png",
     "subtype": "Stage 1",
@@ -2169,7 +2210,8 @@
     ]
   },
   {
-    "id": "dp2-42",
+    "setOrder":33,
+	"id": "dp2-42",
     "name": "Chingling",
     "imageUrl": "https://images.pokemontcg.io/dp2/42.png",
     "subtype": "Basic",
@@ -2218,7 +2260,8 @@
     ]
   },
   {
-    "id": "dp2-43",
+    "setOrder":33,
+	"id": "dp2-43",
     "name": "Cranidos",
     "imageUrl": "https://images.pokemontcg.io/dp2/43.png",
     "subtype": "Stage 1",
@@ -2273,7 +2316,8 @@
     ]
   },
   {
-    "id": "dp2-44",
+    "setOrder":33,
+	"id": "dp2-44",
     "name": "Croconaw",
     "imageUrl": "https://images.pokemontcg.io/dp2/44.png",
     "subtype": "Stage 1",
@@ -2325,7 +2369,8 @@
     ]
   },
   {
-    "id": "dp2-45",
+    "setOrder":33,
+	"id": "dp2-45",
     "name": "Dewgong",
     "imageUrl": "https://images.pokemontcg.io/dp2/45.png",
     "subtype": "Stage 1",
@@ -2375,7 +2420,8 @@
     "nationalPokedexNumber": 87
   },
   {
-    "id": "dp2-46",
+    "setOrder":33,
+	"id": "dp2-46",
     "name": "Dodrio",
     "imageUrl": "https://images.pokemontcg.io/dp2/46.png",
     "subtype": "Stage 1",
@@ -2431,7 +2477,8 @@
     "nationalPokedexNumber": 85
   },
   {
-    "id": "dp2-47",
+    "setOrder":33,
+	"id": "dp2-47",
     "name": "Dunsparce",
     "imageUrl": "https://images.pokemontcg.io/dp2/47.png",
     "subtype": "Basic",
@@ -2481,7 +2528,8 @@
     "nationalPokedexNumber": 206
   },
   {
-    "id": "dp2-48",
+    "setOrder":33,
+	"id": "dp2-48",
     "name": "Gabite",
     "imageUrl": "https://images.pokemontcg.io/dp2/48.png",
     "subtype": "Stage 1",
@@ -2536,7 +2584,8 @@
     ]
   },
   {
-    "id": "dp2-49",
+    "setOrder":33,
+	"id": "dp2-49",
     "name": "Girafarig",
     "imageUrl": "https://images.pokemontcg.io/dp2/49.png",
     "subtype": "Basic",
@@ -2587,7 +2636,8 @@
     "nationalPokedexNumber": 203
   },
   {
-    "id": "dp2-50",
+    "setOrder":33,
+	"id": "dp2-50",
     "name": "Golbat",
     "imageUrl": "https://images.pokemontcg.io/dp2/50.png",
     "subtype": "Stage 1",
@@ -2635,7 +2685,8 @@
     ]
   },
   {
-    "id": "dp2-51",
+    "setOrder":33,
+	"id": "dp2-51",
     "name": "Graveler",
     "imageUrl": "https://images.pokemontcg.io/dp2/51.png",
     "subtype": "Stage 1",
@@ -2700,7 +2751,8 @@
     ]
   },
   {
-    "id": "dp2-52",
+    "setOrder":33,
+	"id": "dp2-52",
     "name": "Happiny",
     "imageUrl": "https://images.pokemontcg.io/dp2/52.png",
     "subtype": "Basic",
@@ -2749,7 +2801,8 @@
     ]
   },
   {
-    "id": "dp2-53",
+    "setOrder":33,
+	"id": "dp2-53",
     "name": "Lairon",
     "imageUrl": "https://images.pokemontcg.io/dp2/53.png",
     "subtype": "Stage 1",
@@ -2813,7 +2866,8 @@
     ]
   },
   {
-    "id": "dp2-54",
+    "setOrder":33,
+	"id": "dp2-54",
     "name": "Magmar",
     "imageUrl": "https://images.pokemontcg.io/dp2/54.png",
     "subtype": "Basic",
@@ -2869,7 +2923,8 @@
     ]
   },
   {
-    "id": "dp2-55",
+    "setOrder":33,
+	"id": "dp2-55",
     "name": "Masquerain",
     "imageUrl": "https://images.pokemontcg.io/dp2/55.png",
     "subtype": "Stage 1",
@@ -2925,7 +2980,8 @@
     "nationalPokedexNumber": 284
   },
   {
-    "id": "dp2-56",
+    "setOrder":33,
+	"id": "dp2-56",
     "name": "Nidorina",
     "imageUrl": "https://images.pokemontcg.io/dp2/56.png",
     "subtype": "Stage 1",
@@ -2980,7 +3036,8 @@
     ]
   },
   {
-    "id": "dp2-57",
+    "setOrder":33,
+	"id": "dp2-57",
     "name": "Octillery",
     "imageUrl": "https://images.pokemontcg.io/dp2/57.png",
     "subtype": "Stage 1",
@@ -3033,7 +3090,8 @@
     "nationalPokedexNumber": 224
   },
   {
-    "id": "dp2-58",
+    "setOrder":33,
+	"id": "dp2-58",
     "name": "Parasect",
     "imageUrl": "https://images.pokemontcg.io/dp2/58.png",
     "subtype": "Stage 1",
@@ -3087,7 +3145,8 @@
     "nationalPokedexNumber": 47
   },
   {
-    "id": "dp2-59",
+    "setOrder":33,
+	"id": "dp2-59",
     "name": "Pupitar",
     "imageUrl": "https://images.pokemontcg.io/dp2/59.png",
     "subtype": "Stage 1",
@@ -3147,7 +3206,8 @@
     ]
   },
   {
-    "id": "dp2-60",
+    "setOrder":33,
+	"id": "dp2-60",
     "name": "Quilava",
     "imageUrl": "https://images.pokemontcg.io/dp2/60.png",
     "subtype": "Stage 1",
@@ -3193,7 +3253,8 @@
     ]
   },
   {
-    "id": "dp2-61",
+    "setOrder":33,
+	"id": "dp2-61",
     "name": "Sandslash",
     "imageUrl": "https://images.pokemontcg.io/dp2/61.png",
     "subtype": "Stage 1",
@@ -3252,7 +3313,8 @@
     "nationalPokedexNumber": 28
   },
   {
-    "id": "dp2-62",
+    "setOrder":33,
+	"id": "dp2-62",
     "name": "Sealeo",
     "imageUrl": "https://images.pokemontcg.io/dp2/62.png",
     "subtype": "Stage 1",
@@ -3299,7 +3361,8 @@
     ]
   },
   {
-    "id": "dp2-63",
+    "setOrder":33,
+	"id": "dp2-63",
     "name": "Shieldon",
     "imageUrl": "https://images.pokemontcg.io/dp2/63.png",
     "subtype": "Stage 1",
@@ -3363,7 +3426,8 @@
     ]
   },
   {
-    "id": "dp2-64",
+    "setOrder":33,
+	"id": "dp2-64",
     "name": "Tropius",
     "imageUrl": "https://images.pokemontcg.io/dp2/64.png",
     "subtype": "Basic",
@@ -3420,7 +3484,8 @@
     "nationalPokedexNumber": 357
   },
   {
-    "id": "dp2-65",
+    "setOrder":33,
+	"id": "dp2-65",
     "name": "Unown E",
     "imageUrl": "https://images.pokemontcg.io/dp2/65.png",
     "subtype": "Basic",
@@ -3467,7 +3532,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp2-66",
+    "setOrder":33,
+	"id": "dp2-66",
     "name": "Unown M",
     "imageUrl": "https://images.pokemontcg.io/dp2/66.png",
     "subtype": "Basic",
@@ -3513,7 +3579,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp2-67",
+    "setOrder":33,
+	"id": "dp2-67",
     "name": "Unown T",
     "imageUrl": "https://images.pokemontcg.io/dp2/67.png",
     "subtype": "Basic",
@@ -3559,7 +3626,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp2-68",
+    "setOrder":33,
+	"id": "dp2-68",
     "name": "Vigoroth",
     "imageUrl": "https://images.pokemontcg.io/dp2/68.png",
     "subtype": "Stage 1",
@@ -3615,7 +3683,8 @@
     ]
   },
   {
-    "id": "dp2-69",
+    "setOrder":33,
+	"id": "dp2-69",
     "name": "Abra",
     "imageUrl": "https://images.pokemontcg.io/dp2/69.png",
     "subtype": "Basic",
@@ -3669,7 +3738,8 @@
     ]
   },
   {
-    "id": "dp2-70",
+    "setOrder":33,
+	"id": "dp2-70",
     "name": "Aipom",
     "imageUrl": "https://images.pokemontcg.io/dp2/70.png",
     "subtype": "Basic",
@@ -3723,7 +3793,8 @@
     ]
   },
   {
-    "id": "dp2-71",
+    "setOrder":33,
+	"id": "dp2-71",
     "name": "Aron",
     "imageUrl": "https://images.pokemontcg.io/dp2/71.png",
     "subtype": "Basic",
@@ -3775,7 +3846,8 @@
     ]
   },
   {
-    "id": "dp2-72",
+    "setOrder":33,
+	"id": "dp2-72",
     "name": "Barboach",
     "imageUrl": "https://images.pokemontcg.io/dp2/72.png",
     "subtype": "Basic",
@@ -3825,7 +3897,8 @@
     ]
   },
   {
-    "id": "dp2-73",
+    "setOrder":33,
+	"id": "dp2-73",
     "name": "Bidoof",
     "imageUrl": "https://images.pokemontcg.io/dp2/73.png",
     "subtype": "Basic",
@@ -3874,7 +3947,8 @@
     ]
   },
   {
-    "id": "dp2-74",
+    "setOrder":33,
+	"id": "dp2-74",
     "name": "Bronzor",
     "imageUrl": "https://images.pokemontcg.io/dp2/74.png",
     "subtype": "Basic",
@@ -3925,7 +3999,8 @@
     ]
   },
   {
-    "id": "dp2-75",
+    "setOrder":33,
+	"id": "dp2-75",
     "name": "Buizel",
     "imageUrl": "https://images.pokemontcg.io/dp2/75.png",
     "subtype": "Basic",
@@ -3973,7 +4048,8 @@
     ]
   },
   {
-    "id": "dp2-76",
+    "setOrder":33,
+	"id": "dp2-76",
     "name": "Chansey",
     "imageUrl": "https://images.pokemontcg.io/dp2/76.png",
     "subtype": "Basic",
@@ -4031,7 +4107,8 @@
     ]
   },
   {
-    "id": "dp2-77",
+    "setOrder":33,
+	"id": "dp2-77",
     "name": "Chikorita",
     "imageUrl": "https://images.pokemontcg.io/dp2/77.png",
     "subtype": "Basic",
@@ -4090,7 +4167,8 @@
     ]
   },
   {
-    "id": "dp2-78",
+    "setOrder":33,
+	"id": "dp2-78",
     "name": "Croagunk",
     "imageUrl": "https://images.pokemontcg.io/dp2/78.png",
     "subtype": "Basic",
@@ -4144,7 +4222,8 @@
     ]
   },
   {
-    "id": "dp2-79",
+    "setOrder":33,
+	"id": "dp2-79",
     "name": "Cyndaquil",
     "imageUrl": "https://images.pokemontcg.io/dp2/79.png",
     "subtype": "Basic",
@@ -4198,7 +4277,8 @@
     ]
   },
   {
-    "id": "dp2-80",
+    "setOrder":33,
+	"id": "dp2-80",
     "name": "Doduo",
     "imageUrl": "https://images.pokemontcg.io/dp2/80.png",
     "subtype": "Basic",
@@ -4258,7 +4338,8 @@
     ]
   },
   {
-    "id": "dp2-81",
+    "setOrder":33,
+	"id": "dp2-81",
     "name": "Electrike",
     "imageUrl": "https://images.pokemontcg.io/dp2/81.png",
     "subtype": "Basic",
@@ -4308,7 +4389,8 @@
     ]
   },
   {
-    "id": "dp2-82",
+    "setOrder":33,
+	"id": "dp2-82",
     "name": "Exeggcute",
     "imageUrl": "https://images.pokemontcg.io/dp2/82.png",
     "subtype": "Basic",
@@ -4352,7 +4434,8 @@
     ]
   },
   {
-    "id": "dp2-83",
+    "setOrder":33,
+	"id": "dp2-83",
     "name": "Finneon",
     "imageUrl": "https://images.pokemontcg.io/dp2/83.png",
     "subtype": "Basic",
@@ -4406,7 +4489,8 @@
     ]
   },
   {
-    "id": "dp2-84",
+    "setOrder":33,
+	"id": "dp2-84",
     "name": "Geodude",
     "imageUrl": "https://images.pokemontcg.io/dp2/84.png",
     "subtype": "Basic",
@@ -4457,7 +4541,8 @@
     ]
   },
   {
-    "id": "dp2-85",
+    "setOrder":33,
+	"id": "dp2-85",
     "name": "Gible",
     "imageUrl": "https://images.pokemontcg.io/dp2/85.png",
     "subtype": "Basic",
@@ -4501,7 +4586,8 @@
     ]
   },
   {
-    "id": "dp2-86",
+    "setOrder":33,
+	"id": "dp2-86",
     "name": "Kricketot",
     "imageUrl": "https://images.pokemontcg.io/dp2/86.png",
     "subtype": "Basic",
@@ -4555,7 +4641,8 @@
     ]
   },
   {
-    "id": "dp2-87",
+    "setOrder":33,
+	"id": "dp2-87",
     "name": "Larvitar",
     "imageUrl": "https://images.pokemontcg.io/dp2/87.png",
     "subtype": "Basic",
@@ -4615,7 +4702,8 @@
     ]
   },
   {
-    "id": "dp2-88",
+    "setOrder":33,
+	"id": "dp2-88",
     "name": "Magby",
     "imageUrl": "https://images.pokemontcg.io/dp2/88.png",
     "subtype": "Basic",
@@ -4664,7 +4752,8 @@
     ]
   },
   {
-    "id": "dp2-89",
+    "setOrder":33,
+	"id": "dp2-89",
     "name": "Magikarp",
     "imageUrl": "https://images.pokemontcg.io/dp2/89.png",
     "subtype": "Basic",
@@ -4718,7 +4807,8 @@
     ]
   },
   {
-    "id": "dp2-90",
+    "setOrder":33,
+	"id": "dp2-90",
     "name": "Murkrow",
     "imageUrl": "https://images.pokemontcg.io/dp2/90.png",
     "subtype": "Basic",
@@ -4778,7 +4868,8 @@
     ]
   },
   {
-    "id": "dp2-91",
+    "setOrder":33,
+	"id": "dp2-91",
     "name": "Nidoran♀",
     "imageUrl": "https://images.pokemontcg.io/dp2/91.png",
     "subtype": "Basic",
@@ -4832,7 +4923,8 @@
     ]
   },
   {
-    "id": "dp2-92",
+    "setOrder":33,
+	"id": "dp2-92",
     "name": "Paras",
     "imageUrl": "https://images.pokemontcg.io/dp2/92.png",
     "subtype": "Basic",
@@ -4886,7 +4978,8 @@
     ]
   },
   {
-    "id": "dp2-93",
+    "setOrder":33,
+	"id": "dp2-93",
     "name": "Pichu",
     "imageUrl": "https://images.pokemontcg.io/dp2/93.png",
     "subtype": "Basic",
@@ -4941,7 +5034,8 @@
     ]
   },
   {
-    "id": "dp2-94",
+    "setOrder":33,
+	"id": "dp2-94",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/dp2/94.png",
     "subtype": "Basic",
@@ -4997,7 +5091,8 @@
     ]
   },
   {
-    "id": "dp2-95",
+    "setOrder":33,
+	"id": "dp2-95",
     "name": "Remoraid",
     "imageUrl": "https://images.pokemontcg.io/dp2/95.png",
     "subtype": "Basic",
@@ -5051,7 +5146,8 @@
     ]
   },
   {
-    "id": "dp2-96",
+    "setOrder":33,
+	"id": "dp2-96",
     "name": "Sandshrew",
     "imageUrl": "https://images.pokemontcg.io/dp2/96.png",
     "subtype": "Basic",
@@ -5111,7 +5207,8 @@
     ]
   },
   {
-    "id": "dp2-97",
+    "setOrder":33,
+	"id": "dp2-97",
     "name": "Seel",
     "imageUrl": "https://images.pokemontcg.io/dp2/97.png",
     "subtype": "Basic",
@@ -5157,7 +5254,8 @@
     ]
   },
   {
-    "id": "dp2-98",
+    "setOrder":33,
+	"id": "dp2-98",
     "name": "Shinx",
     "imageUrl": "https://images.pokemontcg.io/dp2/98.png",
     "subtype": "Basic",
@@ -5210,7 +5308,8 @@
     ]
   },
   {
-    "id": "dp2-99",
+    "setOrder":33,
+	"id": "dp2-99",
     "name": "Slakoth",
     "imageUrl": "https://images.pokemontcg.io/dp2/99.png",
     "subtype": "Basic",
@@ -5254,7 +5353,8 @@
     ]
   },
   {
-    "id": "dp2-100",
+    "setOrder":33,
+	"id": "dp2-100",
     "name": "Snorunt",
     "imageUrl": "https://images.pokemontcg.io/dp2/100.png",
     "subtype": "Basic",
@@ -5308,7 +5408,8 @@
     ]
   },
   {
-    "id": "dp2-101",
+    "setOrder":33,
+	"id": "dp2-101",
     "name": "Snover",
     "imageUrl": "https://images.pokemontcg.io/dp2/101.png",
     "subtype": "Basic",
@@ -5363,7 +5464,8 @@
     ]
   },
   {
-    "id": "dp2-102",
+    "setOrder":33,
+	"id": "dp2-102",
     "name": "Spheal",
     "imageUrl": "https://images.pokemontcg.io/dp2/102.png",
     "subtype": "Basic",
@@ -5417,7 +5519,8 @@
     ]
   },
   {
-    "id": "dp2-103",
+    "setOrder":33,
+	"id": "dp2-103",
     "name": "Spinarak",
     "imageUrl": "https://images.pokemontcg.io/dp2/103.png",
     "subtype": "Basic",
@@ -5471,7 +5574,8 @@
     ]
   },
   {
-    "id": "dp2-104",
+    "setOrder":33,
+	"id": "dp2-104",
     "name": "Surskit",
     "imageUrl": "https://images.pokemontcg.io/dp2/104.png",
     "subtype": "Basic",
@@ -5515,7 +5619,8 @@
     ]
   },
   {
-    "id": "dp2-105",
+    "setOrder":33,
+	"id": "dp2-105",
     "name": "Teddiursa",
     "imageUrl": "https://images.pokemontcg.io/dp2/105.png",
     "subtype": "Basic",
@@ -5569,7 +5674,8 @@
     ]
   },
   {
-    "id": "dp2-106",
+    "setOrder":33,
+	"id": "dp2-106",
     "name": "Totodile",
     "imageUrl": "https://images.pokemontcg.io/dp2/106.png",
     "subtype": "Basic",
@@ -5622,7 +5728,8 @@
     ]
   },
   {
-    "id": "dp2-107",
+    "setOrder":33,
+	"id": "dp2-107",
     "name": "Vulpix",
     "imageUrl": "https://images.pokemontcg.io/dp2/107.png",
     "subtype": "Basic",
@@ -5667,7 +5774,8 @@
     ]
   },
   {
-    "id": "dp2-108",
+    "setOrder":33,
+	"id": "dp2-108",
     "name": "Zubat",
     "imageUrl": "https://images.pokemontcg.io/dp2/108.png",
     "subtype": "Basic",
@@ -5727,7 +5835,8 @@
     ]
   },
   {
-    "id": "dp2-109",
+    "setOrder":33,
+	"id": "dp2-109",
     "name": "Bebe's Search",
     "imageUrl": "https://images.pokemontcg.io/dp2/109.png",
     "subtype": "Supporter",
@@ -5746,7 +5855,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp2/109_hires.png"
   },
   {
-    "id": "dp2-110",
+    "setOrder":33,
+	"id": "dp2-110",
     "name": "Dusk Ball",
     "imageUrl": "https://images.pokemontcg.io/dp2/110.png",
     "subtype": "Item",
@@ -5764,7 +5874,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp2/110_hires.png"
   },
   {
-    "id": "dp2-111",
+    "setOrder":33,
+	"id": "dp2-111",
     "name": "Fossil Excavator",
     "imageUrl": "https://images.pokemontcg.io/dp2/111.png",
     "subtype": "Supporter",
@@ -5783,7 +5894,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp2/111_hires.png"
   },
   {
-    "id": "dp2-112",
+    "setOrder":33,
+	"id": "dp2-112",
     "name": "Lake Boundary",
     "imageUrl": "https://images.pokemontcg.io/dp2/112.png",
     "subtype": "Stadium",
@@ -5801,7 +5913,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp2/112_hires.png"
   },
   {
-    "id": "dp2-113",
+    "setOrder":33,
+	"id": "dp2-113",
     "name": "Night Maintenance",
     "imageUrl": "https://images.pokemontcg.io/dp2/113.png",
     "subtype": "Item",
@@ -5819,7 +5932,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp2/113_hires.png"
   },
   {
-    "id": "dp2-114",
+    "setOrder":33,
+	"id": "dp2-114",
     "name": "Quick Ball",
     "imageUrl": "https://images.pokemontcg.io/dp2/114.png",
     "subtype": "Item",
@@ -5837,7 +5951,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp2/114_hires.png"
   },
   {
-    "id": "dp2-115",
+    "setOrder":33,
+	"id": "dp2-115",
     "name": "Team Galactic's Wager",
     "imageUrl": "https://images.pokemontcg.io/dp2/115.png",
     "subtype": "Supporter",
@@ -5856,7 +5971,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp2/115_hires.png"
   },
   {
-    "id": "dp2-116",
+    "setOrder":33,
+	"id": "dp2-116",
     "name": "Armor Fossil",
     "imageUrl": "https://images.pokemontcg.io/dp2/116.png",
     "subtype": "Item",
@@ -5875,7 +5991,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp2/116_hires.png"
   },
   {
-    "id": "dp2-117",
+    "setOrder":33,
+	"id": "dp2-117",
     "name": "Skull Fossil",
     "imageUrl": "https://images.pokemontcg.io/dp2/117.png",
     "subtype": "Item",
@@ -5894,7 +6011,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp2/117_hires.png"
   },
   {
-    "id": "dp2-118",
+    "setOrder":33,
+	"id": "dp2-118",
     "name": "Multi Energy",
     "imageUrl": "https://images.pokemontcg.io/dp2/118.png",
     "subtype": "Special",
@@ -5911,7 +6029,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp2/118_hires.png"
   },
   {
-    "id": "dp2-119",
+    "setOrder":33,
+	"id": "dp2-119",
     "name": "Darkness Energy",
     "imageUrl": "https://images.pokemontcg.io/dp2/119.png",
     "subtype": "Special",
@@ -5928,7 +6047,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp2/119_hires.png"
   },
   {
-    "id": "dp2-120",
+    "setOrder":33,
+	"id": "dp2-120",
     "name": "Metal Energy",
     "imageUrl": "https://images.pokemontcg.io/dp2/120.png",
     "subtype": "Special",
@@ -5945,7 +6065,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp2/120_hires.png"
   },
   {
-    "id": "dp2-121",
+    "setOrder":33,
+	"id": "dp2-121",
     "name": "Electivire",
     "imageUrl": "https://images.pokemontcg.io/dp2/121.png",
     "subtype": "Level Up",
@@ -6003,7 +6124,8 @@
     "nationalPokedexNumber": 466
   },
   {
-    "id": "dp2-122",
+    "setOrder":33,
+	"id": "dp2-122",
     "name": "Lucario",
     "imageUrl": "https://images.pokemontcg.io/dp2/122.png",
     "subtype": "Level Up",
@@ -6054,7 +6176,8 @@
     "nationalPokedexNumber": 448
   },
   {
-    "id": "dp2-123",
+    "setOrder":33,
+	"id": "dp2-123",
     "name": "Magmortar",
     "imageUrl": "https://images.pokemontcg.io/dp2/123.png",
     "subtype": "Level Up",
@@ -6108,7 +6231,8 @@
     "nationalPokedexNumber": 467
   },
   {
-    "id": "dp2-124",
+    "setOrder":33,
+	"id": "dp2-124",
     "name": "Time-Space Distortion",
     "imageUrl": "https://images.pokemontcg.io/dp2/124.png",
     "subtype": "Item",

--- a/json/cards/Neo Destiny.json
+++ b/json/cards/Neo Destiny.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "neo4-1",
+    "setOrder":11,
+	"id": "neo4-1",
     "name": "Dark Ampharos",
     "imageUrl": "https://images.pokemontcg.io/neo4/1.png",
     "subtype": "Stage 2",
@@ -50,7 +51,8 @@
     "nationalPokedexNumber": 181
   },
   {
-    "id": "neo4-2",
+    "setOrder":11,
+	"id": "neo4-2",
     "name": "Dark Crobat",
     "imageUrl": "https://images.pokemontcg.io/neo4/2.png",
     "subtype": "Stage 2",
@@ -101,7 +103,8 @@
     "nationalPokedexNumber": 169
   },
   {
-    "id": "neo4-3",
+    "setOrder":11,
+	"id": "neo4-3",
     "name": "Dark Donphan",
     "imageUrl": "https://images.pokemontcg.io/neo4/3.png",
     "subtype": "Stage 1",
@@ -163,7 +166,8 @@
     "nationalPokedexNumber": 232
   },
   {
-    "id": "neo4-4",
+    "setOrder":11,
+	"id": "neo4-4",
     "name": "Dark Espeon",
     "imageUrl": "https://images.pokemontcg.io/neo4/4.png",
     "subtype": "Stage 1",
@@ -213,7 +217,8 @@
     "nationalPokedexNumber": 196
   },
   {
-    "id": "neo4-5",
+    "setOrder":11,
+	"id": "neo4-5",
     "name": "Dark Feraligatr",
     "imageUrl": "https://images.pokemontcg.io/neo4/5.png",
     "subtype": "Stage 2",
@@ -264,7 +269,8 @@
     "nationalPokedexNumber": 160
   },
   {
-    "id": "neo4-6",
+    "setOrder":11,
+	"id": "neo4-6",
     "name": "Dark Gengar",
     "imageUrl": "https://images.pokemontcg.io/neo4/6.png",
     "subtype": "Stage 2",
@@ -314,7 +320,8 @@
     "nationalPokedexNumber": 94
   },
   {
-    "id": "neo4-7",
+    "setOrder":11,
+	"id": "neo4-7",
     "name": "Dark Houndoom",
     "imageUrl": "https://images.pokemontcg.io/neo4/7.png",
     "subtype": "Stage 1",
@@ -366,7 +373,8 @@
     "nationalPokedexNumber": 229
   },
   {
-    "id": "neo4-8",
+    "setOrder":11,
+	"id": "neo4-8",
     "name": "Dark Porygon2",
     "imageUrl": "https://images.pokemontcg.io/neo4/8.png",
     "subtype": "Stage 1",
@@ -424,7 +432,8 @@
     ]
   },
   {
-    "id": "neo4-9",
+    "setOrder":11,
+	"id": "neo4-9",
     "name": "Dark Scizor",
     "imageUrl": "https://images.pokemontcg.io/neo4/9.png",
     "subtype": "Stage 1",
@@ -485,7 +494,8 @@
     "nationalPokedexNumber": 212
   },
   {
-    "id": "neo4-10",
+    "setOrder":11,
+	"id": "neo4-10",
     "name": "Dark Typhlosion",
     "imageUrl": "https://images.pokemontcg.io/neo4/10.png",
     "subtype": "Stage 2",
@@ -536,7 +546,8 @@
     "nationalPokedexNumber": 157
   },
   {
-    "id": "neo4-11",
+    "setOrder":11,
+	"id": "neo4-11",
     "name": "Dark Tyranitar",
     "imageUrl": "https://images.pokemontcg.io/neo4/11.png",
     "subtype": "Stage 2",
@@ -598,7 +609,8 @@
     "nationalPokedexNumber": 248
   },
   {
-    "id": "neo4-12",
+    "setOrder":11,
+	"id": "neo4-12",
     "name": "Light Arcanine",
     "imageUrl": "https://images.pokemontcg.io/neo4/12.png",
     "subtype": "Stage 1",
@@ -648,7 +660,8 @@
     "nationalPokedexNumber": 59
   },
   {
-    "id": "neo4-13",
+    "setOrder":11,
+	"id": "neo4-13",
     "name": "Light Azumarill",
     "imageUrl": "https://images.pokemontcg.io/neo4/13.png",
     "subtype": "Stage 1",
@@ -701,7 +714,8 @@
     "nationalPokedexNumber": 184
   },
   {
-    "id": "neo4-14",
+    "setOrder":11,
+	"id": "neo4-14",
     "name": "Light Dragonite",
     "imageUrl": "https://images.pokemontcg.io/neo4/14.png",
     "subtype": "Stage 2",
@@ -751,7 +765,8 @@
     "nationalPokedexNumber": 149
   },
   {
-    "id": "neo4-15",
+    "setOrder":11,
+	"id": "neo4-15",
     "name": "Light Togetic",
     "imageUrl": "https://images.pokemontcg.io/neo4/15.png",
     "subtype": "Stage 1",
@@ -799,7 +814,8 @@
     ]
   },
   {
-    "id": "neo4-16",
+    "setOrder":11,
+	"id": "neo4-16",
     "name": "Miracle Energy",
     "imageUrl": "https://images.pokemontcg.io/neo4/16.png",
     "subtype": "Special",
@@ -816,7 +832,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo4/16_hires.png"
   },
   {
-    "id": "neo4-17",
+    "setOrder":11,
+	"id": "neo4-17",
     "name": "Dark Ariados",
     "imageUrl": "https://images.pokemontcg.io/neo4/17.png",
     "subtype": "Stage 1",
@@ -870,7 +887,8 @@
     "nationalPokedexNumber": 168
   },
   {
-    "id": "neo4-18",
+    "setOrder":11,
+	"id": "neo4-18",
     "name": "Dark Magcargo",
     "imageUrl": "https://images.pokemontcg.io/neo4/18.png",
     "subtype": "Stage 1",
@@ -920,7 +938,8 @@
     "nationalPokedexNumber": 219
   },
   {
-    "id": "neo4-19",
+    "setOrder":11,
+	"id": "neo4-19",
     "name": "Dark Omastar",
     "imageUrl": "https://images.pokemontcg.io/neo4/19.png",
     "subtype": "Stage 2",
@@ -973,7 +992,8 @@
     "nationalPokedexNumber": 139
   },
   {
-    "id": "neo4-20",
+    "setOrder":11,
+	"id": "neo4-20",
     "name": "Dark Slowking",
     "imageUrl": "https://images.pokemontcg.io/neo4/20.png",
     "subtype": "Stage 1",
@@ -1022,7 +1042,8 @@
     "nationalPokedexNumber": 199
   },
   {
-    "id": "neo4-21",
+    "setOrder":11,
+	"id": "neo4-21",
     "name": "Dark Ursaring",
     "imageUrl": "https://images.pokemontcg.io/neo4/21.png",
     "subtype": "Stage 1",
@@ -1081,7 +1102,8 @@
     "nationalPokedexNumber": 217
   },
   {
-    "id": "neo4-22",
+    "setOrder":11,
+	"id": "neo4-22",
     "name": "Light Dragonair",
     "imageUrl": "https://images.pokemontcg.io/neo4/22.png",
     "subtype": "Stage 1",
@@ -1139,7 +1161,8 @@
     ]
   },
   {
-    "id": "neo4-23",
+    "setOrder":11,
+	"id": "neo4-23",
     "name": "Light Lanturn",
     "imageUrl": "https://images.pokemontcg.io/neo4/23.png",
     "subtype": "Stage 1",
@@ -1192,7 +1215,8 @@
     "nationalPokedexNumber": 171
   },
   {
-    "id": "neo4-24",
+    "setOrder":11,
+	"id": "neo4-24",
     "name": "Light Ledian",
     "imageUrl": "https://images.pokemontcg.io/neo4/24.png",
     "subtype": "Stage 1",
@@ -1248,7 +1272,8 @@
     "nationalPokedexNumber": 166
   },
   {
-    "id": "neo4-25",
+    "setOrder":11,
+	"id": "neo4-25",
     "name": "Light Machamp",
     "imageUrl": "https://images.pokemontcg.io/neo4/25.png",
     "subtype": "Stage 2",
@@ -1293,7 +1318,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "neo4-26",
+    "setOrder":11,
+	"id": "neo4-26",
     "name": "Light Piloswine",
     "imageUrl": "https://images.pokemontcg.io/neo4/26.png",
     "subtype": "Stage 1",
@@ -1348,7 +1374,8 @@
     ]
   },
   {
-    "id": "neo4-27",
+    "setOrder":11,
+	"id": "neo4-27",
     "name": "Unown [G]",
     "imageUrl": "https://images.pokemontcg.io/neo4/27.png",
     "subtype": "Basic",
@@ -1394,7 +1421,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "neo4-28",
+    "setOrder":11,
+	"id": "neo4-28",
     "name": "Unown [H]",
     "imageUrl": "https://images.pokemontcg.io/neo4/28.png",
     "subtype": "Basic",
@@ -1440,7 +1468,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "neo4-29",
+    "setOrder":11,
+	"id": "neo4-29",
     "name": "Unown [W]",
     "imageUrl": "https://images.pokemontcg.io/neo4/29.png",
     "subtype": "Basic",
@@ -1486,7 +1515,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "neo4-30",
+    "setOrder":11,
+	"id": "neo4-30",
     "name": "Unown [X]",
     "imageUrl": "https://images.pokemontcg.io/neo4/30.png",
     "subtype": "Basic",
@@ -1532,7 +1562,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "neo4-31",
+    "setOrder":11,
+	"id": "neo4-31",
     "name": "Chansey",
     "imageUrl": "https://images.pokemontcg.io/neo4/31.png",
     "subtype": "Basic",
@@ -1595,7 +1626,8 @@
     ]
   },
   {
-    "id": "neo4-32",
+    "setOrder":11,
+	"id": "neo4-32",
     "name": "Dark Croconaw",
     "imageUrl": "https://images.pokemontcg.io/neo4/32.png",
     "subtype": "Stage 1",
@@ -1642,7 +1674,8 @@
     ]
   },
   {
-    "id": "neo4-33",
+    "setOrder":11,
+	"id": "neo4-33",
     "name": "Dark Exeggutor",
     "imageUrl": "https://images.pokemontcg.io/neo4/33.png",
     "subtype": "Stage 1",
@@ -1695,7 +1728,8 @@
     "nationalPokedexNumber": 103
   },
   {
-    "id": "neo4-34",
+    "setOrder":11,
+	"id": "neo4-34",
     "name": "Dark Flaaffy",
     "imageUrl": "https://images.pokemontcg.io/neo4/34.png",
     "subtype": "Stage 1",
@@ -1750,7 +1784,8 @@
     ]
   },
   {
-    "id": "neo4-35",
+    "setOrder":11,
+	"id": "neo4-35",
     "name": "Dark Forretress",
     "imageUrl": "https://images.pokemontcg.io/neo4/35.png",
     "subtype": "Stage 1",
@@ -1803,7 +1838,8 @@
     "nationalPokedexNumber": 205
   },
   {
-    "id": "neo4-36",
+    "setOrder":11,
+	"id": "neo4-36",
     "name": "Dark Haunter",
     "imageUrl": "https://images.pokemontcg.io/neo4/36.png",
     "subtype": "Stage 1",
@@ -1855,7 +1891,8 @@
     ]
   },
   {
-    "id": "neo4-37",
+    "setOrder":11,
+	"id": "neo4-37",
     "name": "Dark Omanyte",
     "imageUrl": "https://images.pokemontcg.io/neo4/37.png",
     "subtype": "Stage 1",
@@ -1899,7 +1936,8 @@
     ]
   },
   {
-    "id": "neo4-38",
+    "setOrder":11,
+	"id": "neo4-38",
     "name": "Dark Pupitar",
     "imageUrl": "https://images.pokemontcg.io/neo4/38.png",
     "subtype": "Stage 1",
@@ -1962,7 +2000,8 @@
     ]
   },
   {
-    "id": "neo4-39",
+    "setOrder":11,
+	"id": "neo4-39",
     "name": "Dark Quilava",
     "imageUrl": "https://images.pokemontcg.io/neo4/39.png",
     "subtype": "Stage 1",
@@ -2017,7 +2056,8 @@
     ]
   },
   {
-    "id": "neo4-40",
+    "setOrder":11,
+	"id": "neo4-40",
     "name": "Dark Wigglytuff",
     "imageUrl": "https://images.pokemontcg.io/neo4/40.png",
     "subtype": "Stage 1",
@@ -2078,7 +2118,8 @@
     "nationalPokedexNumber": 40
   },
   {
-    "id": "neo4-41",
+    "setOrder":11,
+	"id": "neo4-41",
     "name": "Heracross",
     "imageUrl": "https://images.pokemontcg.io/neo4/41.png",
     "subtype": "Basic",
@@ -2132,7 +2173,8 @@
     "nationalPokedexNumber": 214
   },
   {
-    "id": "neo4-42",
+    "setOrder":11,
+	"id": "neo4-42",
     "name": "Hitmonlee",
     "imageUrl": "https://images.pokemontcg.io/neo4/42.png",
     "subtype": "Basic",
@@ -2185,7 +2227,8 @@
     "nationalPokedexNumber": 106
   },
   {
-    "id": "neo4-43",
+    "setOrder":11,
+	"id": "neo4-43",
     "name": "Houndour",
     "imageUrl": "https://images.pokemontcg.io/neo4/43.png",
     "subtype": "Basic",
@@ -2239,7 +2282,8 @@
     ]
   },
   {
-    "id": "neo4-44",
+    "setOrder":11,
+	"id": "neo4-44",
     "name": "Jigglypuff",
     "imageUrl": "https://images.pokemontcg.io/neo4/44.png",
     "subtype": "Basic",
@@ -2290,7 +2334,8 @@
     ]
   },
   {
-    "id": "neo4-45",
+    "setOrder":11,
+	"id": "neo4-45",
     "name": "Light Dewgong",
     "imageUrl": "https://images.pokemontcg.io/neo4/45.png",
     "subtype": "Stage 1",
@@ -2345,7 +2390,8 @@
     "nationalPokedexNumber": 87
   },
   {
-    "id": "neo4-46",
+    "setOrder":11,
+	"id": "neo4-46",
     "name": "Light Flareon",
     "imageUrl": "https://images.pokemontcg.io/neo4/46.png",
     "subtype": "Stage 1",
@@ -2398,7 +2444,8 @@
     "nationalPokedexNumber": 136
   },
   {
-    "id": "neo4-47",
+    "setOrder":11,
+	"id": "neo4-47",
     "name": "Light Golduck",
     "imageUrl": "https://images.pokemontcg.io/neo4/47.png",
     "subtype": "Stage 1",
@@ -2451,7 +2498,8 @@
     "nationalPokedexNumber": 55
   },
   {
-    "id": "neo4-48",
+    "setOrder":11,
+	"id": "neo4-48",
     "name": "Light Jolteon",
     "imageUrl": "https://images.pokemontcg.io/neo4/48.png",
     "subtype": "Stage 1",
@@ -2501,7 +2549,8 @@
     "nationalPokedexNumber": 135
   },
   {
-    "id": "neo4-49",
+    "setOrder":11,
+	"id": "neo4-49",
     "name": "Light Machoke",
     "imageUrl": "https://images.pokemontcg.io/neo4/49.png",
     "subtype": "Stage 1",
@@ -2557,7 +2606,8 @@
     ]
   },
   {
-    "id": "neo4-50",
+    "setOrder":11,
+	"id": "neo4-50",
     "name": "Light Ninetales",
     "imageUrl": "https://images.pokemontcg.io/neo4/50.png",
     "subtype": "Stage 1",
@@ -2610,7 +2660,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "neo4-51",
+    "setOrder":11,
+	"id": "neo4-51",
     "name": "Light Slowbro",
     "imageUrl": "https://images.pokemontcg.io/neo4/51.png",
     "subtype": "Stage 1",
@@ -2663,7 +2714,8 @@
     "nationalPokedexNumber": 80
   },
   {
-    "id": "neo4-52",
+    "setOrder":11,
+	"id": "neo4-52",
     "name": "Light Vaporeon",
     "imageUrl": "https://images.pokemontcg.io/neo4/52.png",
     "subtype": "Stage 1",
@@ -2716,7 +2768,8 @@
     "nationalPokedexNumber": 134
   },
   {
-    "id": "neo4-53",
+    "setOrder":11,
+	"id": "neo4-53",
     "name": "Light Venomoth",
     "imageUrl": "https://images.pokemontcg.io/neo4/53.png",
     "subtype": "Stage 1",
@@ -2771,7 +2824,8 @@
     "nationalPokedexNumber": 49
   },
   {
-    "id": "neo4-54",
+    "setOrder":11,
+	"id": "neo4-54",
     "name": "Light Wigglytuff",
     "imageUrl": "https://images.pokemontcg.io/neo4/54.png",
     "subtype": "Stage 1",
@@ -2830,7 +2884,8 @@
     "nationalPokedexNumber": 40
   },
   {
-    "id": "neo4-55",
+    "setOrder":11,
+	"id": "neo4-55",
     "name": "Scyther",
     "imageUrl": "https://images.pokemontcg.io/neo4/55.png",
     "subtype": "Basic",
@@ -2892,7 +2947,8 @@
     ]
   },
   {
-    "id": "neo4-56",
+    "setOrder":11,
+	"id": "neo4-56",
     "name": "Togepi",
     "imageUrl": "https://images.pokemontcg.io/neo4/56.png",
     "subtype": "Basic",
@@ -2946,7 +3002,8 @@
     ]
   },
   {
-    "id": "neo4-57",
+    "setOrder":11,
+	"id": "neo4-57",
     "name": "Unown [C]",
     "imageUrl": "https://images.pokemontcg.io/neo4/57.png",
     "subtype": "Basic",
@@ -2992,7 +3049,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "neo4-58",
+    "setOrder":11,
+	"id": "neo4-58",
     "name": "Unown [P]",
     "imageUrl": "https://images.pokemontcg.io/neo4/58.png",
     "subtype": "Basic",
@@ -3033,7 +3091,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "neo4-59",
+    "setOrder":11,
+	"id": "neo4-59",
     "name": "Unown [Q]",
     "imageUrl": "https://images.pokemontcg.io/neo4/59.png",
     "subtype": "Basic",
@@ -3079,7 +3138,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "neo4-60",
+    "setOrder":11,
+	"id": "neo4-60",
     "name": "Unown [Z]",
     "imageUrl": "https://images.pokemontcg.io/neo4/60.png",
     "subtype": "Basic",
@@ -3125,7 +3185,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "neo4-61",
+    "setOrder":11,
+	"id": "neo4-61",
     "name": "Cyndaquil",
     "imageUrl": "https://images.pokemontcg.io/neo4/61.png",
     "subtype": "Basic",
@@ -3169,7 +3230,8 @@
     ]
   },
   {
-    "id": "neo4-62",
+    "setOrder":11,
+	"id": "neo4-62",
     "name": "Dark Octillery",
     "imageUrl": "https://images.pokemontcg.io/neo4/62.png",
     "subtype": "Stage 1",
@@ -3222,7 +3284,8 @@
     "nationalPokedexNumber": 224
   },
   {
-    "id": "neo4-63",
+    "setOrder":11,
+	"id": "neo4-63",
     "name": "Dratini",
     "imageUrl": "https://images.pokemontcg.io/neo4/63.png",
     "subtype": "Basic",
@@ -3275,7 +3338,8 @@
     ]
   },
   {
-    "id": "neo4-64",
+    "setOrder":11,
+	"id": "neo4-64",
     "name": "Exeggcute",
     "imageUrl": "https://images.pokemontcg.io/neo4/64.png",
     "subtype": "Basic",
@@ -3328,7 +3392,8 @@
     ]
   },
   {
-    "id": "neo4-65",
+    "setOrder":11,
+	"id": "neo4-65",
     "name": "Gastly",
     "imageUrl": "https://images.pokemontcg.io/neo4/65.png",
     "subtype": "Basic",
@@ -3369,7 +3434,8 @@
     ]
   },
   {
-    "id": "neo4-66",
+    "setOrder":11,
+	"id": "neo4-66",
     "name": "Girafarig",
     "imageUrl": "https://images.pokemontcg.io/neo4/66.png",
     "subtype": "Basic",
@@ -3415,7 +3481,8 @@
     "nationalPokedexNumber": 203
   },
   {
-    "id": "neo4-67",
+    "setOrder":11,
+	"id": "neo4-67",
     "name": "Gligar",
     "imageUrl": "https://images.pokemontcg.io/neo4/67.png",
     "subtype": "Basic",
@@ -3463,7 +3530,8 @@
     ]
   },
   {
-    "id": "neo4-68",
+    "setOrder":11,
+	"id": "neo4-68",
     "name": "Growlithe",
     "imageUrl": "https://images.pokemontcg.io/neo4/68.png",
     "subtype": "Basic",
@@ -3508,7 +3576,8 @@
     ]
   },
   {
-    "id": "neo4-69",
+    "setOrder":11,
+	"id": "neo4-69",
     "name": "Hitmonchan",
     "imageUrl": "https://images.pokemontcg.io/neo4/69.png",
     "subtype": "Basic",
@@ -3560,7 +3629,8 @@
     "nationalPokedexNumber": 107
   },
   {
-    "id": "neo4-70",
+    "setOrder":11,
+	"id": "neo4-70",
     "name": "Larvitar",
     "imageUrl": "https://images.pokemontcg.io/neo4/70.png",
     "subtype": "Basic",
@@ -3620,7 +3690,8 @@
     ]
   },
   {
-    "id": "neo4-71",
+    "setOrder":11,
+	"id": "neo4-71",
     "name": "Ledyba",
     "imageUrl": "https://images.pokemontcg.io/neo4/71.png",
     "subtype": "Basic",
@@ -3668,7 +3739,8 @@
     ]
   },
   {
-    "id": "neo4-72",
+    "setOrder":11,
+	"id": "neo4-72",
     "name": "Light Sunflora",
     "imageUrl": "https://images.pokemontcg.io/neo4/72.png",
     "subtype": "Stage 1",
@@ -3722,7 +3794,8 @@
     "nationalPokedexNumber": 192
   },
   {
-    "id": "neo4-73",
+    "setOrder":11,
+	"id": "neo4-73",
     "name": "Machop",
     "imageUrl": "https://images.pokemontcg.io/neo4/73.png",
     "subtype": "Basic",
@@ -3776,7 +3849,8 @@
     ]
   },
   {
-    "id": "neo4-74",
+    "setOrder":11,
+	"id": "neo4-74",
     "name": "Mantine",
     "imageUrl": "https://images.pokemontcg.io/neo4/74.png",
     "subtype": "Basic",
@@ -3825,7 +3899,8 @@
     "nationalPokedexNumber": 226
   },
   {
-    "id": "neo4-75",
+    "setOrder":11,
+	"id": "neo4-75",
     "name": "Mareep",
     "imageUrl": "https://images.pokemontcg.io/neo4/75.png",
     "subtype": "Basic",
@@ -3869,7 +3944,8 @@
     ]
   },
   {
-    "id": "neo4-76",
+    "setOrder":11,
+	"id": "neo4-76",
     "name": "Phanpy",
     "imageUrl": "https://images.pokemontcg.io/neo4/76.png",
     "subtype": "Basic",
@@ -3919,7 +3995,8 @@
     ]
   },
   {
-    "id": "neo4-77",
+    "setOrder":11,
+	"id": "neo4-77",
     "name": "Pineco",
     "imageUrl": "https://images.pokemontcg.io/neo4/77.png",
     "subtype": "Basic",
@@ -3965,7 +4042,8 @@
     ]
   },
   {
-    "id": "neo4-78",
+    "setOrder":11,
+	"id": "neo4-78",
     "name": "Porygon",
     "imageUrl": "https://images.pokemontcg.io/neo4/78.png",
     "subtype": "Basic",
@@ -4016,7 +4094,8 @@
     ]
   },
   {
-    "id": "neo4-79",
+    "setOrder":11,
+	"id": "neo4-79",
     "name": "Psyduck",
     "imageUrl": "https://images.pokemontcg.io/neo4/79.png",
     "subtype": "Basic",
@@ -4070,7 +4149,8 @@
     ]
   },
   {
-    "id": "neo4-80",
+    "setOrder":11,
+	"id": "neo4-80",
     "name": "Remoraid",
     "imageUrl": "https://images.pokemontcg.io/neo4/80.png",
     "subtype": "Basic",
@@ -4111,7 +4191,8 @@
     ]
   },
   {
-    "id": "neo4-81",
+    "setOrder":11,
+	"id": "neo4-81",
     "name": "Seel",
     "imageUrl": "https://images.pokemontcg.io/neo4/81.png",
     "subtype": "Basic",
@@ -4156,7 +4237,8 @@
     ]
   },
   {
-    "id": "neo4-82",
+    "setOrder":11,
+	"id": "neo4-82",
     "name": "Slugma",
     "imageUrl": "https://images.pokemontcg.io/neo4/82.png",
     "subtype": "Basic",
@@ -4202,7 +4284,8 @@
     ]
   },
   {
-    "id": "neo4-83",
+    "setOrder":11,
+	"id": "neo4-83",
     "name": "Sunkern",
     "imageUrl": "https://images.pokemontcg.io/neo4/83.png",
     "subtype": "Basic",
@@ -4257,7 +4340,8 @@
     ]
   },
   {
-    "id": "neo4-84",
+    "setOrder":11,
+	"id": "neo4-84",
     "name": "Swinub",
     "imageUrl": "https://images.pokemontcg.io/neo4/84.png",
     "subtype": "Basic",
@@ -4308,7 +4392,8 @@
     ]
   },
   {
-    "id": "neo4-85",
+    "setOrder":11,
+	"id": "neo4-85",
     "name": "Totodile",
     "imageUrl": "https://images.pokemontcg.io/neo4/85.png",
     "subtype": "Basic",
@@ -4352,7 +4437,8 @@
     ]
   },
   {
-    "id": "neo4-86",
+    "setOrder":11,
+	"id": "neo4-86",
     "name": "Unown [L]",
     "imageUrl": "https://images.pokemontcg.io/neo4/86.png",
     "subtype": "Basic",
@@ -4398,7 +4484,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "neo4-87",
+    "setOrder":11,
+	"id": "neo4-87",
     "name": "Unown [S]",
     "imageUrl": "https://images.pokemontcg.io/neo4/87.png",
     "subtype": "Basic",
@@ -4445,7 +4532,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "neo4-88",
+    "setOrder":11,
+	"id": "neo4-88",
     "name": "Unown [T]",
     "imageUrl": "https://images.pokemontcg.io/neo4/88.png",
     "subtype": "Basic",
@@ -4492,7 +4580,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "neo4-89",
+    "setOrder":11,
+	"id": "neo4-89",
     "name": "Unown [V]",
     "imageUrl": "https://images.pokemontcg.io/neo4/89.png",
     "subtype": "Basic",
@@ -4538,7 +4627,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "neo4-90",
+    "setOrder":11,
+	"id": "neo4-90",
     "name": "Venonat",
     "imageUrl": "https://images.pokemontcg.io/neo4/90.png",
     "subtype": "Basic",
@@ -4592,7 +4682,8 @@
     ]
   },
   {
-    "id": "neo4-91",
+    "setOrder":11,
+	"id": "neo4-91",
     "name": "Vulpix",
     "imageUrl": "https://images.pokemontcg.io/neo4/91.png",
     "subtype": "Basic",
@@ -4637,7 +4728,8 @@
     ]
   },
   {
-    "id": "neo4-92",
+    "setOrder":11,
+	"id": "neo4-92",
     "name": "Broken Ground Gym",
     "imageUrl": "https://images.pokemontcg.io/neo4/92.png",
     "subtype": "",
@@ -4654,7 +4746,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo4/92_hires.png"
   },
   {
-    "id": "neo4-93",
+    "setOrder":11,
+	"id": "neo4-93",
     "name": "EXP.ALL",
     "imageUrl": "https://images.pokemontcg.io/neo4/93.png",
     "subtype": "",
@@ -4671,7 +4764,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo4/93_hires.png"
   },
   {
-    "id": "neo4-94",
+    "setOrder":11,
+	"id": "neo4-94",
     "name": "Impostor Professor Oak's Invention",
     "imageUrl": "https://images.pokemontcg.io/neo4/94.png",
     "subtype": "",
@@ -4688,7 +4782,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo4/94_hires.png"
   },
   {
-    "id": "neo4-95",
+    "setOrder":11,
+	"id": "neo4-95",
     "name": "Radio Tower",
     "imageUrl": "https://images.pokemontcg.io/neo4/95.png",
     "subtype": "",
@@ -4705,7 +4800,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo4/95_hires.png"
   },
   {
-    "id": "neo4-96",
+    "setOrder":11,
+	"id": "neo4-96",
     "name": "Thought Wave Machine (Rocket's Secret Machine)",
     "imageUrl": "https://images.pokemontcg.io/neo4/96.png",
     "subtype": "",
@@ -4722,7 +4818,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo4/96_hires.png"
   },
   {
-    "id": "neo4-97",
+    "setOrder":11,
+	"id": "neo4-97",
     "name": "Counterattack Claws",
     "imageUrl": "https://images.pokemontcg.io/neo4/97.png",
     "subtype": "",
@@ -4739,7 +4836,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo4/97_hires.png"
   },
   {
-    "id": "neo4-98",
+    "setOrder":11,
+	"id": "neo4-98",
     "name": "Energy Amplifier",
     "imageUrl": "https://images.pokemontcg.io/neo4/98.png",
     "subtype": "",
@@ -4756,7 +4854,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo4/98_hires.png"
   },
   {
-    "id": "neo4-99",
+    "setOrder":11,
+	"id": "neo4-99",
     "name": "Energy Stadium",
     "imageUrl": "https://images.pokemontcg.io/neo4/99.png",
     "subtype": "",
@@ -4773,7 +4872,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo4/99_hires.png"
   },
   {
-    "id": "neo4-100",
+    "setOrder":11,
+	"id": "neo4-100",
     "name": "Lucky Stadium",
     "imageUrl": "https://images.pokemontcg.io/neo4/100.png",
     "subtype": "",
@@ -4790,7 +4890,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo4/100_hires.png"
   },
   {
-    "id": "neo4-101",
+    "setOrder":11,
+	"id": "neo4-101",
     "name": "Magnifier",
     "imageUrl": "https://images.pokemontcg.io/neo4/101.png",
     "subtype": "",
@@ -4807,7 +4908,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo4/101_hires.png"
   },
   {
-    "id": "neo4-102",
+    "setOrder":11,
+	"id": "neo4-102",
     "name": "Pokémon Personality Test",
     "imageUrl": "https://images.pokemontcg.io/neo4/102.png",
     "subtype": "",
@@ -4824,7 +4926,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo4/102_hires.png"
   },
   {
-    "id": "neo4-103",
+    "setOrder":11,
+	"id": "neo4-103",
     "name": "Team Rocket's Evil Deeds",
     "imageUrl": "https://images.pokemontcg.io/neo4/103.png",
     "subtype": "",
@@ -4841,7 +4944,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo4/103_hires.png"
   },
   {
-    "id": "neo4-104",
+    "setOrder":11,
+	"id": "neo4-104",
     "name": "Heal Powder",
     "imageUrl": "https://images.pokemontcg.io/neo4/104.png",
     "subtype": "",
@@ -4858,7 +4962,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo4/104_hires.png"
   },
   {
-    "id": "neo4-105",
+    "setOrder":11,
+	"id": "neo4-105",
     "name": "Mail from Bill",
     "imageUrl": "https://images.pokemontcg.io/neo4/105.png",
     "subtype": "",
@@ -4875,7 +4980,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo4/105_hires.png"
   },
   {
-    "id": "neo4-106",
+    "setOrder":11,
+	"id": "neo4-106",
     "name": "Shining Celebi",
     "imageUrl": "https://images.pokemontcg.io/neo4/106.png",
     "subtype": "Basic",
@@ -4926,7 +5032,8 @@
     "nationalPokedexNumber": 251
   },
   {
-    "id": "neo4-107",
+    "setOrder":11,
+	"id": "neo4-107",
     "name": "Shining Charizard",
     "imageUrl": "https://images.pokemontcg.io/neo4/107.png",
     "subtype": "Basic",
@@ -4979,7 +5086,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "neo4-108",
+    "setOrder":11,
+	"id": "neo4-108",
     "name": "Shining Kabutops",
     "imageUrl": "https://images.pokemontcg.io/neo4/108.png",
     "subtype": "Basic",
@@ -5035,7 +5143,8 @@
     "nationalPokedexNumber": 141
   },
   {
-    "id": "neo4-109",
+    "setOrder":11,
+	"id": "neo4-109",
     "name": "Shining Mewtwo",
     "imageUrl": "https://images.pokemontcg.io/neo4/109.png",
     "subtype": "Basic",
@@ -5089,7 +5198,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "neo4-110",
+    "setOrder":11,
+	"id": "neo4-110",
     "name": "Shining Noctowl",
     "imageUrl": "https://images.pokemontcg.io/neo4/110.png",
     "subtype": "Basic",
@@ -5138,7 +5248,8 @@
     "nationalPokedexNumber": 164
   },
   {
-    "id": "neo4-111",
+    "setOrder":11,
+	"id": "neo4-111",
     "name": "Shining Raichu",
     "imageUrl": "https://images.pokemontcg.io/neo4/111.png",
     "subtype": "Basic",
@@ -5182,7 +5293,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "neo4-112",
+    "setOrder":11,
+	"id": "neo4-112",
     "name": "Shining Steelix",
     "imageUrl": "https://images.pokemontcg.io/neo4/112.png",
     "subtype": "Basic",
@@ -5235,7 +5347,8 @@
     "nationalPokedexNumber": 208
   },
   {
-    "id": "neo4-113",
+    "setOrder":11,
+	"id": "neo4-113",
     "name": "Shining Tyranitar",
     "imageUrl": "https://images.pokemontcg.io/neo4/113.png",
     "subtype": "Basic",

--- a/json/cards/Neo Discovery.json
+++ b/json/cards/Neo Discovery.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "neo2-1",
+    "setOrder":9,
+	"id": "neo2-1",
     "name": "Espeon",
     "imageUrl": "https://images.pokemontcg.io/neo2/1.png",
     "subtype": "Stage 1",
@@ -51,7 +52,8 @@
     "nationalPokedexNumber": 196
   },
   {
-    "id": "neo2-2",
+    "setOrder":9,
+	"id": "neo2-2",
     "name": "Forretress",
     "imageUrl": "https://images.pokemontcg.io/neo2/2.png",
     "subtype": "Stage 1",
@@ -108,7 +110,8 @@
     "nationalPokedexNumber": 205
   },
   {
-    "id": "neo2-3",
+    "setOrder":9,
+	"id": "neo2-3",
     "name": "Hitmontop",
     "imageUrl": "https://images.pokemontcg.io/neo2/3.png",
     "subtype": "Basic",
@@ -160,7 +163,8 @@
     "nationalPokedexNumber": 237
   },
   {
-    "id": "neo2-4",
+    "setOrder":9,
+	"id": "neo2-4",
     "name": "Houndoom",
     "imageUrl": "https://images.pokemontcg.io/neo2/4.png",
     "subtype": "Stage 1",
@@ -215,7 +219,8 @@
     "nationalPokedexNumber": 229
   },
   {
-    "id": "neo2-5",
+    "setOrder":9,
+	"id": "neo2-5",
     "name": "Houndour",
     "imageUrl": "https://images.pokemontcg.io/neo2/5.png",
     "subtype": "Basic",
@@ -269,7 +274,8 @@
     ]
   },
   {
-    "id": "neo2-6",
+    "setOrder":9,
+	"id": "neo2-6",
     "name": "Kabutops",
     "imageUrl": "https://images.pokemontcg.io/neo2/6.png",
     "subtype": "Stage 2",
@@ -321,7 +327,8 @@
     "nationalPokedexNumber": 141
   },
   {
-    "id": "neo2-7",
+    "setOrder":9,
+	"id": "neo2-7",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/neo2/7.png",
     "subtype": "Basic",
@@ -381,7 +388,8 @@
     ]
   },
   {
-    "id": "neo2-8",
+    "setOrder":9,
+	"id": "neo2-8",
     "name": "Politoed",
     "imageUrl": "https://images.pokemontcg.io/neo2/8.png",
     "subtype": "Stage 2",
@@ -433,7 +441,8 @@
     "nationalPokedexNumber": 186
   },
   {
-    "id": "neo2-9",
+    "setOrder":9,
+	"id": "neo2-9",
     "name": "Poliwrath",
     "imageUrl": "https://images.pokemontcg.io/neo2/9.png",
     "subtype": "Stage 2",
@@ -489,7 +498,8 @@
     "nationalPokedexNumber": 62
   },
   {
-    "id": "neo2-10",
+    "setOrder":9,
+	"id": "neo2-10",
     "name": "Scizor",
     "imageUrl": "https://images.pokemontcg.io/neo2/10.png",
     "subtype": "Stage 1",
@@ -549,7 +559,8 @@
     "nationalPokedexNumber": 212
   },
   {
-    "id": "neo2-11",
+    "setOrder":9,
+	"id": "neo2-11",
     "name": "Smeargle",
     "imageUrl": "https://images.pokemontcg.io/neo2/11.png",
     "subtype": "Basic",
@@ -597,7 +608,8 @@
     "nationalPokedexNumber": 235
   },
   {
-    "id": "neo2-12",
+    "setOrder":9,
+	"id": "neo2-12",
     "name": "Tyranitar",
     "imageUrl": "https://images.pokemontcg.io/neo2/12.png",
     "subtype": "Stage 2",
@@ -655,7 +667,8 @@
     "nationalPokedexNumber": 248
   },
   {
-    "id": "neo2-13",
+    "setOrder":9,
+	"id": "neo2-13",
     "name": "Umbreon",
     "imageUrl": "https://images.pokemontcg.io/neo2/13.png",
     "subtype": "Stage 1",
@@ -709,7 +722,8 @@
     "nationalPokedexNumber": 197
   },
   {
-    "id": "neo2-14",
+    "setOrder":9,
+	"id": "neo2-14",
     "name": "Unown [A]",
     "imageUrl": "https://images.pokemontcg.io/neo2/14.png",
     "subtype": "Basic",
@@ -755,7 +769,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "neo2-15",
+    "setOrder":9,
+	"id": "neo2-15",
     "name": "Ursaring",
     "imageUrl": "https://images.pokemontcg.io/neo2/15.png",
     "subtype": "Stage 1",
@@ -818,7 +833,8 @@
     "nationalPokedexNumber": 217
   },
   {
-    "id": "neo2-16",
+    "setOrder":9,
+	"id": "neo2-16",
     "name": "Wobbuffet",
     "imageUrl": "https://images.pokemontcg.io/neo2/16.png",
     "subtype": "Basic",
@@ -861,7 +877,8 @@
     "nationalPokedexNumber": 202
   },
   {
-    "id": "neo2-17",
+    "setOrder":9,
+	"id": "neo2-17",
     "name": "Yanma",
     "imageUrl": "https://images.pokemontcg.io/neo2/17.png",
     "subtype": "Basic",
@@ -919,7 +936,8 @@
     ]
   },
   {
-    "id": "neo2-18",
+    "setOrder":9,
+	"id": "neo2-18",
     "name": "Beedrill",
     "imageUrl": "https://images.pokemontcg.io/neo2/18.png",
     "subtype": "Stage 2",
@@ -975,7 +993,8 @@
     "nationalPokedexNumber": 15
   },
   {
-    "id": "neo2-19",
+    "setOrder":9,
+	"id": "neo2-19",
     "name": "Butterfree",
     "imageUrl": "https://images.pokemontcg.io/neo2/19.png",
     "subtype": "Stage 2",
@@ -1035,7 +1054,8 @@
     "nationalPokedexNumber": 12
   },
   {
-    "id": "neo2-20",
+    "setOrder":9,
+	"id": "neo2-20",
     "name": "Espeon",
     "imageUrl": "https://images.pokemontcg.io/neo2/20.png",
     "subtype": "Stage 1",
@@ -1089,7 +1109,8 @@
     "nationalPokedexNumber": 196
   },
   {
-    "id": "neo2-21",
+    "setOrder":9,
+	"id": "neo2-21",
     "name": "Forretress",
     "imageUrl": "https://images.pokemontcg.io/neo2/21.png",
     "subtype": "Stage 1",
@@ -1146,7 +1167,8 @@
     "nationalPokedexNumber": 205
   },
   {
-    "id": "neo2-22",
+    "setOrder":9,
+	"id": "neo2-22",
     "name": "Hitmontop",
     "imageUrl": "https://images.pokemontcg.io/neo2/22.png",
     "subtype": "Basic",
@@ -1198,7 +1220,8 @@
     "nationalPokedexNumber": 237
   },
   {
-    "id": "neo2-23",
+    "setOrder":9,
+	"id": "neo2-23",
     "name": "Houndoom",
     "imageUrl": "https://images.pokemontcg.io/neo2/23.png",
     "subtype": "Stage 1",
@@ -1253,7 +1276,8 @@
     "nationalPokedexNumber": 229
   },
   {
-    "id": "neo2-24",
+    "setOrder":9,
+	"id": "neo2-24",
     "name": "Houndour",
     "imageUrl": "https://images.pokemontcg.io/neo2/24.png",
     "subtype": "Basic",
@@ -1307,7 +1331,8 @@
     ]
   },
   {
-    "id": "neo2-25",
+    "setOrder":9,
+	"id": "neo2-25",
     "name": "Kabutops",
     "imageUrl": "https://images.pokemontcg.io/neo2/25.png",
     "subtype": "Stage 2",
@@ -1359,7 +1384,8 @@
     "nationalPokedexNumber": 141
   },
   {
-    "id": "neo2-26",
+    "setOrder":9,
+	"id": "neo2-26",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/neo2/26.png",
     "subtype": "Basic",
@@ -1419,7 +1445,8 @@
     ]
   },
   {
-    "id": "neo2-27",
+    "setOrder":9,
+	"id": "neo2-27",
     "name": "Politoed",
     "imageUrl": "https://images.pokemontcg.io/neo2/27.png",
     "subtype": "Stage 2",
@@ -1471,7 +1498,8 @@
     "nationalPokedexNumber": 186
   },
   {
-    "id": "neo2-28",
+    "setOrder":9,
+	"id": "neo2-28",
     "name": "Poliwrath",
     "imageUrl": "https://images.pokemontcg.io/neo2/28.png",
     "subtype": "Stage 2",
@@ -1527,7 +1555,8 @@
     "nationalPokedexNumber": 62
   },
   {
-    "id": "neo2-29",
+    "setOrder":9,
+	"id": "neo2-29",
     "name": "Scizor",
     "imageUrl": "https://images.pokemontcg.io/neo2/29.png",
     "subtype": "Stage 1",
@@ -1587,7 +1616,8 @@
     "nationalPokedexNumber": 212
   },
   {
-    "id": "neo2-30",
+    "setOrder":9,
+	"id": "neo2-30",
     "name": "Smeargle",
     "imageUrl": "https://images.pokemontcg.io/neo2/30.png",
     "subtype": "Basic",
@@ -1635,7 +1665,8 @@
     "nationalPokedexNumber": 235
   },
   {
-    "id": "neo2-31",
+    "setOrder":9,
+	"id": "neo2-31",
     "name": "Tyranitar",
     "imageUrl": "https://images.pokemontcg.io/neo2/31.png",
     "subtype": "Stage 2",
@@ -1693,7 +1724,8 @@
     "nationalPokedexNumber": 248
   },
   {
-    "id": "neo2-32",
+    "setOrder":9,
+	"id": "neo2-32",
     "name": "Umbreon",
     "imageUrl": "https://images.pokemontcg.io/neo2/32.png",
     "subtype": "Stage 1",
@@ -1747,7 +1779,8 @@
     "nationalPokedexNumber": 197
   },
   {
-    "id": "neo2-33",
+    "setOrder":9,
+	"id": "neo2-33",
     "name": "Unown [A]",
     "imageUrl": "https://images.pokemontcg.io/neo2/33.png",
     "subtype": "Basic",
@@ -1793,7 +1826,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "neo2-34",
+    "setOrder":9,
+	"id": "neo2-34",
     "name": "Ursaring",
     "imageUrl": "https://images.pokemontcg.io/neo2/34.png",
     "subtype": "Stage 1",
@@ -1856,7 +1890,8 @@
     "nationalPokedexNumber": 217
   },
   {
-    "id": "neo2-35",
+    "setOrder":9,
+	"id": "neo2-35",
     "name": "Wobbuffet",
     "imageUrl": "https://images.pokemontcg.io/neo2/35.png",
     "subtype": "Basic",
@@ -1899,7 +1934,8 @@
     "nationalPokedexNumber": 202
   },
   {
-    "id": "neo2-36",
+    "setOrder":9,
+	"id": "neo2-36",
     "name": "Yanma",
     "imageUrl": "https://images.pokemontcg.io/neo2/36.png",
     "subtype": "Basic",
@@ -1957,7 +1993,8 @@
     ]
   },
   {
-    "id": "neo2-37",
+    "setOrder":9,
+	"id": "neo2-37",
     "name": "Corsola",
     "imageUrl": "https://images.pokemontcg.io/neo2/37.png",
     "subtype": "Basic",
@@ -2008,7 +2045,8 @@
     "nationalPokedexNumber": 222
   },
   {
-    "id": "neo2-38",
+    "setOrder":9,
+	"id": "neo2-38",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/neo2/38.png",
     "subtype": "Basic",
@@ -2070,7 +2108,8 @@
     ]
   },
   {
-    "id": "neo2-39",
+    "setOrder":9,
+	"id": "neo2-39",
     "name": "Houndour",
     "imageUrl": "https://images.pokemontcg.io/neo2/39.png",
     "subtype": "Basic",
@@ -2124,7 +2163,8 @@
     ]
   },
   {
-    "id": "neo2-40",
+    "setOrder":9,
+	"id": "neo2-40",
     "name": "Igglybuff",
     "imageUrl": "https://images.pokemontcg.io/neo2/40.png",
     "subtype": "Basic",
@@ -2156,7 +2196,8 @@
     ]
   },
   {
-    "id": "neo2-41",
+    "setOrder":9,
+	"id": "neo2-41",
     "name": "Kakuna",
     "imageUrl": "https://images.pokemontcg.io/neo2/41.png",
     "subtype": "Stage 1",
@@ -2203,7 +2244,8 @@
     ]
   },
   {
-    "id": "neo2-42",
+    "setOrder":9,
+	"id": "neo2-42",
     "name": "Metapod",
     "imageUrl": "https://images.pokemontcg.io/neo2/42.png",
     "subtype": "Stage 1",
@@ -2260,7 +2302,8 @@
     ]
   },
   {
-    "id": "neo2-43",
+    "setOrder":9,
+	"id": "neo2-43",
     "name": "Omastar",
     "imageUrl": "https://images.pokemontcg.io/neo2/43.png",
     "subtype": "Stage 2",
@@ -2314,7 +2357,8 @@
     "nationalPokedexNumber": 139
   },
   {
-    "id": "neo2-44",
+    "setOrder":9,
+	"id": "neo2-44",
     "name": "Poliwhirl",
     "imageUrl": "https://images.pokemontcg.io/neo2/44.png",
     "subtype": "Stage 1",
@@ -2371,7 +2415,8 @@
     ]
   },
   {
-    "id": "neo2-45",
+    "setOrder":9,
+	"id": "neo2-45",
     "name": "Pupitar",
     "imageUrl": "https://images.pokemontcg.io/neo2/45.png",
     "subtype": "Stage 1",
@@ -2433,7 +2478,8 @@
     ]
   },
   {
-    "id": "neo2-46",
+    "setOrder":9,
+	"id": "neo2-46",
     "name": "Scyther",
     "imageUrl": "https://images.pokemontcg.io/neo2/46.png",
     "subtype": "Basic",
@@ -2484,7 +2530,8 @@
     ]
   },
   {
-    "id": "neo2-47",
+    "setOrder":9,
+	"id": "neo2-47",
     "name": "Unown [D]",
     "imageUrl": "https://images.pokemontcg.io/neo2/47.png",
     "subtype": "Basic",
@@ -2530,7 +2577,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "neo2-48",
+    "setOrder":9,
+	"id": "neo2-48",
     "name": "Unown [F]",
     "imageUrl": "https://images.pokemontcg.io/neo2/48.png",
     "subtype": "Basic",
@@ -2576,7 +2624,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "neo2-49",
+    "setOrder":9,
+	"id": "neo2-49",
     "name": "Unown [M]",
     "imageUrl": "https://images.pokemontcg.io/neo2/49.png",
     "subtype": "Basic",
@@ -2617,7 +2666,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "neo2-50",
+    "setOrder":9,
+	"id": "neo2-50",
     "name": "Unown [N]",
     "imageUrl": "https://images.pokemontcg.io/neo2/50.png",
     "subtype": "Basic",
@@ -2658,7 +2708,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "neo2-51",
+    "setOrder":9,
+	"id": "neo2-51",
     "name": "Unown [U]",
     "imageUrl": "https://images.pokemontcg.io/neo2/51.png",
     "subtype": "Basic",
@@ -2704,7 +2755,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "neo2-52",
+    "setOrder":9,
+	"id": "neo2-52",
     "name": "Xatu",
     "imageUrl": "https://images.pokemontcg.io/neo2/52.png",
     "subtype": "Stage 1",
@@ -2763,7 +2815,8 @@
     "nationalPokedexNumber": 178
   },
   {
-    "id": "neo2-53",
+    "setOrder":9,
+	"id": "neo2-53",
     "name": "Caterpie",
     "imageUrl": "https://images.pokemontcg.io/neo2/53.png",
     "subtype": "Basic",
@@ -2807,7 +2860,8 @@
     ]
   },
   {
-    "id": "neo2-54",
+    "setOrder":9,
+	"id": "neo2-54",
     "name": "Dunsparce",
     "imageUrl": "https://images.pokemontcg.io/neo2/54.png",
     "subtype": "Basic",
@@ -2851,7 +2905,8 @@
     "nationalPokedexNumber": 206
   },
   {
-    "id": "neo2-55",
+    "setOrder":9,
+	"id": "neo2-55",
     "name": "Hoppip",
     "imageUrl": "https://images.pokemontcg.io/neo2/55.png",
     "subtype": "Basic",
@@ -2898,7 +2953,8 @@
     ]
   },
   {
-    "id": "neo2-56",
+    "setOrder":9,
+	"id": "neo2-56",
     "name": "Kabuto",
     "imageUrl": "https://images.pokemontcg.io/neo2/56.png",
     "subtype": "Stage 1",
@@ -2948,7 +3004,8 @@
     ]
   },
   {
-    "id": "neo2-57",
+    "setOrder":9,
+	"id": "neo2-57",
     "name": "Larvitar",
     "imageUrl": "https://images.pokemontcg.io/neo2/57.png",
     "subtype": "Basic",
@@ -2998,7 +3055,8 @@
     ]
   },
   {
-    "id": "neo2-58",
+    "setOrder":9,
+	"id": "neo2-58",
     "name": "Mareep",
     "imageUrl": "https://images.pokemontcg.io/neo2/58.png",
     "subtype": "Basic",
@@ -3043,7 +3101,8 @@
     ]
   },
   {
-    "id": "neo2-59",
+    "setOrder":9,
+	"id": "neo2-59",
     "name": "Natu",
     "imageUrl": "https://images.pokemontcg.io/neo2/59.png",
     "subtype": "Basic",
@@ -3093,7 +3152,8 @@
     ]
   },
   {
-    "id": "neo2-60",
+    "setOrder":9,
+	"id": "neo2-60",
     "name": "Omanyte",
     "imageUrl": "https://images.pokemontcg.io/neo2/60.png",
     "subtype": "Stage 1",
@@ -3142,7 +3202,8 @@
     ]
   },
   {
-    "id": "neo2-61",
+    "setOrder":9,
+	"id": "neo2-61",
     "name": "Pineco",
     "imageUrl": "https://images.pokemontcg.io/neo2/61.png",
     "subtype": "Basic",
@@ -3187,7 +3248,8 @@
     ]
   },
   {
-    "id": "neo2-62",
+    "setOrder":9,
+	"id": "neo2-62",
     "name": "Poliwag",
     "imageUrl": "https://images.pokemontcg.io/neo2/62.png",
     "subtype": "Basic",
@@ -3240,7 +3302,8 @@
     ]
   },
   {
-    "id": "neo2-63",
+    "setOrder":9,
+	"id": "neo2-63",
     "name": "Sentret",
     "imageUrl": "https://images.pokemontcg.io/neo2/63.png",
     "subtype": "Basic",
@@ -3300,7 +3363,8 @@
     ]
   },
   {
-    "id": "neo2-64",
+    "setOrder":9,
+	"id": "neo2-64",
     "name": "Spinarak",
     "imageUrl": "https://images.pokemontcg.io/neo2/64.png",
     "subtype": "Basic",
@@ -3345,7 +3409,8 @@
     ]
   },
   {
-    "id": "neo2-65",
+    "setOrder":9,
+	"id": "neo2-65",
     "name": "Teddiursa",
     "imageUrl": "https://images.pokemontcg.io/neo2/65.png",
     "subtype": "Basic",
@@ -3405,7 +3470,8 @@
     ]
   },
   {
-    "id": "neo2-66",
+    "setOrder":9,
+	"id": "neo2-66",
     "name": "Tyrogue",
     "imageUrl": "https://images.pokemontcg.io/neo2/66.png",
     "subtype": "Basic",
@@ -3445,7 +3511,8 @@
     ]
   },
   {
-    "id": "neo2-67",
+    "setOrder":9,
+	"id": "neo2-67",
     "name": "Unown [E]",
     "imageUrl": "https://images.pokemontcg.io/neo2/67.png",
     "subtype": "Basic",
@@ -3491,7 +3558,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "neo2-68",
+    "setOrder":9,
+	"id": "neo2-68",
     "name": "Unown [I]",
     "imageUrl": "https://images.pokemontcg.io/neo2/68.png",
     "subtype": "Basic",
@@ -3532,7 +3600,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "neo2-69",
+    "setOrder":9,
+	"id": "neo2-69",
     "name": "Unown [O]",
     "imageUrl": "https://images.pokemontcg.io/neo2/69.png",
     "subtype": "Basic",
@@ -3578,7 +3647,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "neo2-70",
+    "setOrder":9,
+	"id": "neo2-70",
     "name": "Weedle",
     "imageUrl": "https://images.pokemontcg.io/neo2/70.png",
     "subtype": "Basic",
@@ -3622,7 +3692,8 @@
     ]
   },
   {
-    "id": "neo2-71",
+    "setOrder":9,
+	"id": "neo2-71",
     "name": "Wooper",
     "imageUrl": "https://images.pokemontcg.io/neo2/71.png",
     "subtype": "Basic",
@@ -3682,7 +3753,8 @@
     ]
   },
   {
-    "id": "neo2-72",
+    "setOrder":9,
+	"id": "neo2-72",
     "name": "Fossil Egg",
     "imageUrl": "https://images.pokemontcg.io/neo2/72.png",
     "subtype": "",
@@ -3699,7 +3771,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo2/72_hires.png"
   },
   {
-    "id": "neo2-73",
+    "setOrder":9,
+	"id": "neo2-73",
     "name": "Hyper Devolution Spray",
     "imageUrl": "https://images.pokemontcg.io/neo2/73.png",
     "subtype": "",
@@ -3716,7 +3789,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo2/73_hires.png"
   },
   {
-    "id": "neo2-74",
+    "setOrder":9,
+	"id": "neo2-74",
     "name": "Ruin Wall",
     "imageUrl": "https://images.pokemontcg.io/neo2/74.png",
     "subtype": "",
@@ -3733,7 +3807,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo2/74_hires.png"
   },
   {
-    "id": "neo2-75",
+    "setOrder":9,
+	"id": "neo2-75",
     "name": "Energy Ark",
     "imageUrl": "https://images.pokemontcg.io/neo2/75.png",
     "subtype": "",

--- a/json/cards/Neo Genesis.json
+++ b/json/cards/Neo Genesis.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "neo1-1",
+    "setOrder":8,
+	"id": "neo1-1",
     "name": "Ampharos",
     "imageUrl": "https://images.pokemontcg.io/neo1/1.png",
     "subtype": "Stage 2",
@@ -45,7 +46,8 @@
     "nationalPokedexNumber": 181
   },
   {
-    "id": "neo1-2",
+    "setOrder":8,
+	"id": "neo1-2",
     "name": "Azumarill",
     "imageUrl": "https://images.pokemontcg.io/neo1/2.png",
     "subtype": "Stage 1",
@@ -99,7 +101,8 @@
     "nationalPokedexNumber": 184
   },
   {
-    "id": "neo1-3",
+    "setOrder":8,
+	"id": "neo1-3",
     "name": "Bellossom",
     "imageUrl": "https://images.pokemontcg.io/neo1/3.png",
     "subtype": "Stage 2",
@@ -153,7 +156,8 @@
     "nationalPokedexNumber": 182
   },
   {
-    "id": "neo1-4",
+    "setOrder":8,
+	"id": "neo1-4",
     "name": "Feraligatr",
     "imageUrl": "https://images.pokemontcg.io/neo1/4.png",
     "subtype": "Stage 2",
@@ -205,7 +209,8 @@
     "nationalPokedexNumber": 160
   },
   {
-    "id": "neo1-5",
+    "setOrder":8,
+	"id": "neo1-5",
     "name": "Feraligatr",
     "imageUrl": "https://images.pokemontcg.io/neo1/5.png",
     "subtype": "Stage 2",
@@ -251,7 +256,8 @@
     "nationalPokedexNumber": 160
   },
   {
-    "id": "neo1-6",
+    "setOrder":8,
+	"id": "neo1-6",
     "name": "Heracross",
     "imageUrl": "https://images.pokemontcg.io/neo1/6.png",
     "subtype": "Basic",
@@ -300,7 +306,8 @@
     "nationalPokedexNumber": 214
   },
   {
-    "id": "neo1-7",
+    "setOrder":8,
+	"id": "neo1-7",
     "name": "Jumpluff",
     "imageUrl": "https://images.pokemontcg.io/neo1/7.png",
     "subtype": "Stage 2",
@@ -354,7 +361,8 @@
     "nationalPokedexNumber": 189
   },
   {
-    "id": "neo1-8",
+    "setOrder":8,
+	"id": "neo1-8",
     "name": "Kingdra",
     "imageUrl": "https://images.pokemontcg.io/neo1/8.png",
     "subtype": "Stage 2",
@@ -405,7 +413,8 @@
     "nationalPokedexNumber": 230
   },
   {
-    "id": "neo1-9",
+    "setOrder":8,
+	"id": "neo1-9",
     "name": "Lugia",
     "imageUrl": "https://images.pokemontcg.io/neo1/9.png",
     "subtype": "Basic",
@@ -455,7 +464,8 @@
     "nationalPokedexNumber": 249
   },
   {
-    "id": "neo1-10",
+    "setOrder":8,
+	"id": "neo1-10",
     "name": "Meganium",
     "imageUrl": "https://images.pokemontcg.io/neo1/10.png",
     "subtype": "Stage 2",
@@ -507,7 +517,8 @@
     "nationalPokedexNumber": 154
   },
   {
-    "id": "neo1-11",
+    "setOrder":8,
+	"id": "neo1-11",
     "name": "Meganium",
     "imageUrl": "https://images.pokemontcg.io/neo1/11.png",
     "subtype": "Stage 2",
@@ -559,7 +570,8 @@
     "nationalPokedexNumber": 154
   },
   {
-    "id": "neo1-12",
+    "setOrder":8,
+	"id": "neo1-12",
     "name": "Pichu",
     "imageUrl": "https://images.pokemontcg.io/neo1/12.png",
     "subtype": "Basic",
@@ -597,7 +609,8 @@
     ]
   },
   {
-    "id": "neo1-13",
+    "setOrder":8,
+	"id": "neo1-13",
     "name": "Skarmory",
     "imageUrl": "https://images.pokemontcg.io/neo1/13.png",
     "subtype": "Basic",
@@ -656,7 +669,8 @@
     "nationalPokedexNumber": 227
   },
   {
-    "id": "neo1-14",
+    "setOrder":8,
+	"id": "neo1-14",
     "name": "Slowking",
     "imageUrl": "https://images.pokemontcg.io/neo1/14.png",
     "subtype": "Stage 1",
@@ -707,7 +721,8 @@
     "nationalPokedexNumber": 199
   },
   {
-    "id": "neo1-15",
+    "setOrder":8,
+	"id": "neo1-15",
     "name": "Steelix",
     "imageUrl": "https://images.pokemontcg.io/neo1/15.png",
     "subtype": "Stage 1",
@@ -770,7 +785,8 @@
     "nationalPokedexNumber": 208
   },
   {
-    "id": "neo1-16",
+    "setOrder":8,
+	"id": "neo1-16",
     "name": "Togetic",
     "imageUrl": "https://images.pokemontcg.io/neo1/16.png",
     "subtype": "Stage 1",
@@ -823,7 +839,8 @@
     ]
   },
   {
-    "id": "neo1-17",
+    "setOrder":8,
+	"id": "neo1-17",
     "name": "Typhlosion",
     "imageUrl": "https://images.pokemontcg.io/neo1/17.png",
     "subtype": "Stage 2",
@@ -874,7 +891,8 @@
     "nationalPokedexNumber": 157
   },
   {
-    "id": "neo1-18",
+    "setOrder":8,
+	"id": "neo1-18",
     "name": "Typhlosion",
     "imageUrl": "https://images.pokemontcg.io/neo1/18.png",
     "subtype": "Stage 2",
@@ -925,7 +943,8 @@
     "nationalPokedexNumber": 157
   },
   {
-    "id": "neo1-19",
+    "setOrder":8,
+	"id": "neo1-19",
     "name": "Metal Energy",
     "imageUrl": "https://images.pokemontcg.io/neo1/19.png",
     "subtype": "Special",
@@ -942,7 +961,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/19_hires.png"
   },
   {
-    "id": "neo1-20",
+    "setOrder":8,
+	"id": "neo1-20",
     "name": "Cleffa",
     "imageUrl": "https://images.pokemontcg.io/neo1/20.png",
     "subtype": "Basic",
@@ -980,7 +1000,8 @@
     ]
   },
   {
-    "id": "neo1-21",
+    "setOrder":8,
+	"id": "neo1-21",
     "name": "Donphan",
     "imageUrl": "https://images.pokemontcg.io/neo1/21.png",
     "subtype": "Stage 1",
@@ -1041,7 +1062,8 @@
     "nationalPokedexNumber": 232
   },
   {
-    "id": "neo1-22",
+    "setOrder":8,
+	"id": "neo1-22",
     "name": "Elekid",
     "imageUrl": "https://images.pokemontcg.io/neo1/22.png",
     "subtype": "Basic",
@@ -1073,7 +1095,8 @@
     ]
   },
   {
-    "id": "neo1-23",
+    "setOrder":8,
+	"id": "neo1-23",
     "name": "Magby",
     "imageUrl": "https://images.pokemontcg.io/neo1/23.png",
     "subtype": "Basic",
@@ -1111,7 +1134,8 @@
     ]
   },
   {
-    "id": "neo1-24",
+    "setOrder":8,
+	"id": "neo1-24",
     "name": "Murkrow",
     "imageUrl": "https://images.pokemontcg.io/neo1/24.png",
     "subtype": "Basic",
@@ -1162,7 +1186,8 @@
     ]
   },
   {
-    "id": "neo1-25",
+    "setOrder":8,
+	"id": "neo1-25",
     "name": "Sneasel",
     "imageUrl": "https://images.pokemontcg.io/neo1/25.png",
     "subtype": "Basic",
@@ -1213,7 +1238,8 @@
     ]
   },
   {
-    "id": "neo1-26",
+    "setOrder":8,
+	"id": "neo1-26",
     "name": "Aipom",
     "imageUrl": "https://images.pokemontcg.io/neo1/26.png",
     "subtype": "Basic",
@@ -1269,7 +1295,8 @@
     ]
   },
   {
-    "id": "neo1-27",
+    "setOrder":8,
+	"id": "neo1-27",
     "name": "Ariados",
     "imageUrl": "https://images.pokemontcg.io/neo1/27.png",
     "subtype": "Stage 1",
@@ -1322,7 +1349,8 @@
     "nationalPokedexNumber": 168
   },
   {
-    "id": "neo1-28",
+    "setOrder":8,
+	"id": "neo1-28",
     "name": "Bayleef",
     "imageUrl": "https://images.pokemontcg.io/neo1/28.png",
     "subtype": "Stage 1",
@@ -1376,7 +1404,8 @@
     ]
   },
   {
-    "id": "neo1-29",
+    "setOrder":8,
+	"id": "neo1-29",
     "name": "Bayleef",
     "imageUrl": "https://images.pokemontcg.io/neo1/29.png",
     "subtype": "Stage 1",
@@ -1433,7 +1462,8 @@
     ]
   },
   {
-    "id": "neo1-30",
+    "setOrder":8,
+	"id": "neo1-30",
     "name": "Clefairy",
     "imageUrl": "https://images.pokemontcg.io/neo1/30.png",
     "subtype": "Basic",
@@ -1495,7 +1525,8 @@
     ]
   },
   {
-    "id": "neo1-31",
+    "setOrder":8,
+	"id": "neo1-31",
     "name": "Croconaw",
     "imageUrl": "https://images.pokemontcg.io/neo1/31.png",
     "subtype": "Stage 1",
@@ -1552,7 +1583,8 @@
     ]
   },
   {
-    "id": "neo1-32",
+    "setOrder":8,
+	"id": "neo1-32",
     "name": "Croconaw",
     "imageUrl": "https://images.pokemontcg.io/neo1/32.png",
     "subtype": "Stage 1",
@@ -1610,7 +1642,8 @@
     ]
   },
   {
-    "id": "neo1-33",
+    "setOrder":8,
+	"id": "neo1-33",
     "name": "Electabuzz",
     "imageUrl": "https://images.pokemontcg.io/neo1/33.png",
     "subtype": "Basic",
@@ -1666,7 +1699,8 @@
     ]
   },
   {
-    "id": "neo1-34",
+    "setOrder":8,
+	"id": "neo1-34",
     "name": "Flaaffy",
     "imageUrl": "https://images.pokemontcg.io/neo1/34.png",
     "subtype": "Stage 1",
@@ -1721,7 +1755,8 @@
     ]
   },
   {
-    "id": "neo1-35",
+    "setOrder":8,
+	"id": "neo1-35",
     "name": "Furret",
     "imageUrl": "https://images.pokemontcg.io/neo1/35.png",
     "subtype": "Stage 1",
@@ -1781,7 +1816,8 @@
     "nationalPokedexNumber": 162
   },
   {
-    "id": "neo1-36",
+    "setOrder":8,
+	"id": "neo1-36",
     "name": "Gloom",
     "imageUrl": "https://images.pokemontcg.io/neo1/36.png",
     "subtype": "Stage 1",
@@ -1839,7 +1875,8 @@
     ]
   },
   {
-    "id": "neo1-37",
+    "setOrder":8,
+	"id": "neo1-37",
     "name": "Granbull",
     "imageUrl": "https://images.pokemontcg.io/neo1/37.png",
     "subtype": "Stage 1",
@@ -1900,7 +1937,8 @@
     "nationalPokedexNumber": 210
   },
   {
-    "id": "neo1-38",
+    "setOrder":8,
+	"id": "neo1-38",
     "name": "Lanturn",
     "imageUrl": "https://images.pokemontcg.io/neo1/38.png",
     "subtype": "Stage 1",
@@ -1948,7 +1986,8 @@
     "nationalPokedexNumber": 171
   },
   {
-    "id": "neo1-39",
+    "setOrder":8,
+	"id": "neo1-39",
     "name": "Ledian",
     "imageUrl": "https://images.pokemontcg.io/neo1/39.png",
     "subtype": "Stage 1",
@@ -1994,7 +2033,8 @@
     "nationalPokedexNumber": 166
   },
   {
-    "id": "neo1-40",
+    "setOrder":8,
+	"id": "neo1-40",
     "name": "Magmar",
     "imageUrl": "https://images.pokemontcg.io/neo1/40.png",
     "subtype": "Basic",
@@ -2051,7 +2091,8 @@
     ]
   },
   {
-    "id": "neo1-41",
+    "setOrder":8,
+	"id": "neo1-41",
     "name": "Miltank",
     "imageUrl": "https://images.pokemontcg.io/neo1/41.png",
     "subtype": "Basic",
@@ -2110,7 +2151,8 @@
     "nationalPokedexNumber": 241
   },
   {
-    "id": "neo1-42",
+    "setOrder":8,
+	"id": "neo1-42",
     "name": "Noctowl",
     "imageUrl": "https://images.pokemontcg.io/neo1/42.png",
     "subtype": "Stage 1",
@@ -2162,7 +2204,8 @@
     "nationalPokedexNumber": 164
   },
   {
-    "id": "neo1-43",
+    "setOrder":8,
+	"id": "neo1-43",
     "name": "Phanpy",
     "imageUrl": "https://images.pokemontcg.io/neo1/43.png",
     "subtype": "Basic",
@@ -2221,7 +2264,8 @@
     ]
   },
   {
-    "id": "neo1-44",
+    "setOrder":8,
+	"id": "neo1-44",
     "name": "Piloswine",
     "imageUrl": "https://images.pokemontcg.io/neo1/44.png",
     "subtype": "Stage 1",
@@ -2286,7 +2330,8 @@
     ]
   },
   {
-    "id": "neo1-45",
+    "setOrder":8,
+	"id": "neo1-45",
     "name": "Quagsire",
     "imageUrl": "https://images.pokemontcg.io/neo1/45.png",
     "subtype": "Stage 1",
@@ -2348,7 +2393,8 @@
     "nationalPokedexNumber": 195
   },
   {
-    "id": "neo1-46",
+    "setOrder":8,
+	"id": "neo1-46",
     "name": "Quilava",
     "imageUrl": "https://images.pokemontcg.io/neo1/46.png",
     "subtype": "Stage 1",
@@ -2404,7 +2450,8 @@
     ]
   },
   {
-    "id": "neo1-47",
+    "setOrder":8,
+	"id": "neo1-47",
     "name": "Quilava",
     "imageUrl": "https://images.pokemontcg.io/neo1/47.png",
     "subtype": "Stage 1",
@@ -2461,7 +2508,8 @@
     ]
   },
   {
-    "id": "neo1-48",
+    "setOrder":8,
+	"id": "neo1-48",
     "name": "Seadra",
     "imageUrl": "https://images.pokemontcg.io/neo1/48.png",
     "subtype": "Stage 1",
@@ -2516,7 +2564,8 @@
     ]
   },
   {
-    "id": "neo1-49",
+    "setOrder":8,
+	"id": "neo1-49",
     "name": "Skiploom",
     "imageUrl": "https://images.pokemontcg.io/neo1/49.png",
     "subtype": "Stage 1",
@@ -2573,7 +2622,8 @@
     ]
   },
   {
-    "id": "neo1-50",
+    "setOrder":8,
+	"id": "neo1-50",
     "name": "Sunflora",
     "imageUrl": "https://images.pokemontcg.io/neo1/50.png",
     "subtype": "Stage 1",
@@ -2617,7 +2667,8 @@
     "nationalPokedexNumber": 192
   },
   {
-    "id": "neo1-51",
+    "setOrder":8,
+	"id": "neo1-51",
     "name": "Togepi",
     "imageUrl": "https://images.pokemontcg.io/neo1/51.png",
     "subtype": "Basic",
@@ -2662,7 +2713,8 @@
     ]
   },
   {
-    "id": "neo1-52",
+    "setOrder":8,
+	"id": "neo1-52",
     "name": "Xatu",
     "imageUrl": "https://images.pokemontcg.io/neo1/52.png",
     "subtype": "Stage 1",
@@ -2718,7 +2770,8 @@
     "nationalPokedexNumber": 178
   },
   {
-    "id": "neo1-53",
+    "setOrder":8,
+	"id": "neo1-53",
     "name": "Chikorita",
     "imageUrl": "https://images.pokemontcg.io/neo1/53.png",
     "subtype": "Basic",
@@ -2771,7 +2824,8 @@
     ]
   },
   {
-    "id": "neo1-54",
+    "setOrder":8,
+	"id": "neo1-54",
     "name": "Chikorita",
     "imageUrl": "https://images.pokemontcg.io/neo1/54.png",
     "subtype": "Basic",
@@ -2825,7 +2879,8 @@
     ]
   },
   {
-    "id": "neo1-55",
+    "setOrder":8,
+	"id": "neo1-55",
     "name": "Chinchou",
     "imageUrl": "https://images.pokemontcg.io/neo1/55.png",
     "subtype": "Basic",
@@ -2878,7 +2933,8 @@
     ]
   },
   {
-    "id": "neo1-56",
+    "setOrder":8,
+	"id": "neo1-56",
     "name": "Cyndaquil",
     "imageUrl": "https://images.pokemontcg.io/neo1/56.png",
     "subtype": "Basic",
@@ -2932,7 +2988,8 @@
     ]
   },
   {
-    "id": "neo1-57",
+    "setOrder":8,
+	"id": "neo1-57",
     "name": "Cyndaquil",
     "imageUrl": "https://images.pokemontcg.io/neo1/57.png",
     "subtype": "Basic",
@@ -2986,7 +3043,8 @@
     ]
   },
   {
-    "id": "neo1-58",
+    "setOrder":8,
+	"id": "neo1-58",
     "name": "Girafarig",
     "imageUrl": "https://images.pokemontcg.io/neo1/58.png",
     "subtype": "Basic",
@@ -3029,7 +3087,8 @@
     "nationalPokedexNumber": 203
   },
   {
-    "id": "neo1-59",
+    "setOrder":8,
+	"id": "neo1-59",
     "name": "Gligar",
     "imageUrl": "https://images.pokemontcg.io/neo1/59.png",
     "subtype": "Basic",
@@ -3086,7 +3145,8 @@
     ]
   },
   {
-    "id": "neo1-60",
+    "setOrder":8,
+	"id": "neo1-60",
     "name": "Hoothoot",
     "imageUrl": "https://images.pokemontcg.io/neo1/60.png",
     "subtype": "Basic",
@@ -3146,7 +3206,8 @@
     ]
   },
   {
-    "id": "neo1-61",
+    "setOrder":8,
+	"id": "neo1-61",
     "name": "Hoppip",
     "imageUrl": "https://images.pokemontcg.io/neo1/61.png",
     "subtype": "Basic",
@@ -3202,7 +3263,8 @@
     ]
   },
   {
-    "id": "neo1-62",
+    "setOrder":8,
+	"id": "neo1-62",
     "name": "Horsea",
     "imageUrl": "https://images.pokemontcg.io/neo1/62.png",
     "subtype": "Basic",
@@ -3244,7 +3306,8 @@
     ]
   },
   {
-    "id": "neo1-63",
+    "setOrder":8,
+	"id": "neo1-63",
     "name": "Ledyba",
     "imageUrl": "https://images.pokemontcg.io/neo1/63.png",
     "subtype": "Basic",
@@ -3301,7 +3364,8 @@
     ]
   },
   {
-    "id": "neo1-64",
+    "setOrder":8,
+	"id": "neo1-64",
     "name": "Mantine",
     "imageUrl": "https://images.pokemontcg.io/neo1/64.png",
     "subtype": "Basic",
@@ -3349,7 +3413,8 @@
     "nationalPokedexNumber": 226
   },
   {
-    "id": "neo1-65",
+    "setOrder":8,
+	"id": "neo1-65",
     "name": "Mareep",
     "imageUrl": "https://images.pokemontcg.io/neo1/65.png",
     "subtype": "Basic",
@@ -3403,7 +3468,8 @@
     ]
   },
   {
-    "id": "neo1-66",
+    "setOrder":8,
+	"id": "neo1-66",
     "name": "Marill",
     "imageUrl": "https://images.pokemontcg.io/neo1/66.png",
     "subtype": "Basic",
@@ -3457,7 +3523,8 @@
     ]
   },
   {
-    "id": "neo1-67",
+    "setOrder":8,
+	"id": "neo1-67",
     "name": "Natu",
     "imageUrl": "https://images.pokemontcg.io/neo1/67.png",
     "subtype": "Basic",
@@ -3514,7 +3581,8 @@
     ]
   },
   {
-    "id": "neo1-68",
+    "setOrder":8,
+	"id": "neo1-68",
     "name": "Oddish",
     "imageUrl": "https://images.pokemontcg.io/neo1/68.png",
     "subtype": "Basic",
@@ -3568,7 +3636,8 @@
     ]
   },
   {
-    "id": "neo1-69",
+    "setOrder":8,
+	"id": "neo1-69",
     "name": "Onix",
     "imageUrl": "https://images.pokemontcg.io/neo1/69.png",
     "subtype": "Basic",
@@ -3623,7 +3692,8 @@
     ]
   },
   {
-    "id": "neo1-70",
+    "setOrder":8,
+	"id": "neo1-70",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/neo1/70.png",
     "subtype": "Basic",
@@ -3678,7 +3748,8 @@
     ]
   },
   {
-    "id": "neo1-71",
+    "setOrder":8,
+	"id": "neo1-71",
     "name": "Sentret",
     "imageUrl": "https://images.pokemontcg.io/neo1/71.png",
     "subtype": "Basic",
@@ -3728,7 +3799,8 @@
     ]
   },
   {
-    "id": "neo1-72",
+    "setOrder":8,
+	"id": "neo1-72",
     "name": "Shuckle",
     "imageUrl": "https://images.pokemontcg.io/neo1/72.png",
     "subtype": "Basic",
@@ -3779,7 +3851,8 @@
     "nationalPokedexNumber": 213
   },
   {
-    "id": "neo1-73",
+    "setOrder":8,
+	"id": "neo1-73",
     "name": "Slowpoke",
     "imageUrl": "https://images.pokemontcg.io/neo1/73.png",
     "subtype": "Basic",
@@ -3833,7 +3906,8 @@
     ]
   },
   {
-    "id": "neo1-74",
+    "setOrder":8,
+	"id": "neo1-74",
     "name": "Snubbull",
     "imageUrl": "https://images.pokemontcg.io/neo1/74.png",
     "subtype": "Basic",
@@ -3893,7 +3967,8 @@
     ]
   },
   {
-    "id": "neo1-75",
+    "setOrder":8,
+	"id": "neo1-75",
     "name": "Spinarak",
     "imageUrl": "https://images.pokemontcg.io/neo1/75.png",
     "subtype": "Basic",
@@ -3946,7 +4021,8 @@
     ]
   },
   {
-    "id": "neo1-76",
+    "setOrder":8,
+	"id": "neo1-76",
     "name": "Stantler",
     "imageUrl": "https://images.pokemontcg.io/neo1/76.png",
     "subtype": "Basic",
@@ -4006,7 +4082,8 @@
     "nationalPokedexNumber": 234
   },
   {
-    "id": "neo1-77",
+    "setOrder":8,
+	"id": "neo1-77",
     "name": "Sudowoodo",
     "imageUrl": "https://images.pokemontcg.io/neo1/77.png",
     "subtype": "Basic",
@@ -4059,7 +4136,8 @@
     "nationalPokedexNumber": 185
   },
   {
-    "id": "neo1-78",
+    "setOrder":8,
+	"id": "neo1-78",
     "name": "Sunkern",
     "imageUrl": "https://images.pokemontcg.io/neo1/78.png",
     "subtype": "Basic",
@@ -4115,7 +4193,8 @@
     ]
   },
   {
-    "id": "neo1-79",
+    "setOrder":8,
+	"id": "neo1-79",
     "name": "Swinub",
     "imageUrl": "https://images.pokemontcg.io/neo1/79.png",
     "subtype": "Basic",
@@ -4165,7 +4244,8 @@
     ]
   },
   {
-    "id": "neo1-80",
+    "setOrder":8,
+	"id": "neo1-80",
     "name": "Totodile",
     "imageUrl": "https://images.pokemontcg.io/neo1/80.png",
     "subtype": "Basic",
@@ -4219,7 +4299,8 @@
     ]
   },
   {
-    "id": "neo1-81",
+    "setOrder":8,
+	"id": "neo1-81",
     "name": "Totodile",
     "imageUrl": "https://images.pokemontcg.io/neo1/81.png",
     "subtype": "Basic",
@@ -4272,7 +4353,8 @@
     ]
   },
   {
-    "id": "neo1-82",
+    "setOrder":8,
+	"id": "neo1-82",
     "name": "Wooper",
     "imageUrl": "https://images.pokemontcg.io/neo1/82.png",
     "subtype": "Basic",
@@ -4332,7 +4414,8 @@
     ]
   },
   {
-    "id": "neo1-83",
+    "setOrder":8,
+	"id": "neo1-83",
     "name": "Arcade Game",
     "imageUrl": "https://images.pokemontcg.io/neo1/83.png",
     "subtype": "",
@@ -4349,7 +4432,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/83_hires.png"
   },
   {
-    "id": "neo1-84",
+    "setOrder":8,
+	"id": "neo1-84",
     "name": "Ecogym",
     "imageUrl": "https://images.pokemontcg.io/neo1/84.png",
     "subtype": "",
@@ -4366,7 +4450,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/84_hires.png"
   },
   {
-    "id": "neo1-85",
+    "setOrder":8,
+	"id": "neo1-85",
     "name": "Energy Charge",
     "imageUrl": "https://images.pokemontcg.io/neo1/85.png",
     "subtype": "",
@@ -4383,7 +4468,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/85_hires.png"
   },
   {
-    "id": "neo1-86",
+    "setOrder":8,
+	"id": "neo1-86",
     "name": "Focus Band",
     "imageUrl": "https://images.pokemontcg.io/neo1/86.png",
     "subtype": "",
@@ -4400,7 +4486,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/86_hires.png"
   },
   {
-    "id": "neo1-87",
+    "setOrder":8,
+	"id": "neo1-87",
     "name": "Mary",
     "imageUrl": "https://images.pokemontcg.io/neo1/87.png",
     "subtype": "",
@@ -4417,7 +4504,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/87_hires.png"
   },
   {
-    "id": "neo1-88",
+    "setOrder":8,
+	"id": "neo1-88",
     "name": "PokéGear",
     "imageUrl": "https://images.pokemontcg.io/neo1/88.png",
     "subtype": "",
@@ -4434,7 +4522,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/88_hires.png"
   },
   {
-    "id": "neo1-89",
+    "setOrder":8,
+	"id": "neo1-89",
     "name": "Super Energy Retrieval",
     "imageUrl": "https://images.pokemontcg.io/neo1/89.png",
     "subtype": "",
@@ -4451,7 +4540,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/89_hires.png"
   },
   {
-    "id": "neo1-90",
+    "setOrder":8,
+	"id": "neo1-90",
     "name": "Time Capsule",
     "imageUrl": "https://images.pokemontcg.io/neo1/90.png",
     "subtype": "",
@@ -4468,7 +4558,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/90_hires.png"
   },
   {
-    "id": "neo1-91",
+    "setOrder":8,
+	"id": "neo1-91",
     "name": "Bill's Teleporter",
     "imageUrl": "https://images.pokemontcg.io/neo1/91.png",
     "subtype": "",
@@ -4485,7 +4576,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/91_hires.png"
   },
   {
-    "id": "neo1-92",
+    "setOrder":8,
+	"id": "neo1-92",
     "name": "Card-Flip Game",
     "imageUrl": "https://images.pokemontcg.io/neo1/92.png",
     "subtype": "",
@@ -4502,7 +4594,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/92_hires.png"
   },
   {
-    "id": "neo1-93",
+    "setOrder":8,
+	"id": "neo1-93",
     "name": "Gold Berry",
     "imageUrl": "https://images.pokemontcg.io/neo1/93.png",
     "subtype": "",
@@ -4519,7 +4612,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/93_hires.png"
   },
   {
-    "id": "neo1-94",
+    "setOrder":8,
+	"id": "neo1-94",
     "name": "Miracle Berry",
     "imageUrl": "https://images.pokemontcg.io/neo1/94.png",
     "subtype": "",
@@ -4536,7 +4630,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/94_hires.png"
   },
   {
-    "id": "neo1-95",
+    "setOrder":8,
+	"id": "neo1-95",
     "name": "New Pokédex",
     "imageUrl": "https://images.pokemontcg.io/neo1/95.png",
     "subtype": "",
@@ -4553,7 +4648,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/95_hires.png"
   },
   {
-    "id": "neo1-96",
+    "setOrder":8,
+	"id": "neo1-96",
     "name": "Professor Elm",
     "imageUrl": "https://images.pokemontcg.io/neo1/96.png",
     "subtype": "",
@@ -4570,7 +4666,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/96_hires.png"
   },
   {
-    "id": "neo1-97",
+    "setOrder":8,
+	"id": "neo1-97",
     "name": "Sprout Tower",
     "imageUrl": "https://images.pokemontcg.io/neo1/97.png",
     "subtype": "",
@@ -4587,7 +4684,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/97_hires.png"
   },
   {
-    "id": "neo1-98",
+    "setOrder":8,
+	"id": "neo1-98",
     "name": "Super Scoop Up",
     "imageUrl": "https://images.pokemontcg.io/neo1/98.png",
     "subtype": "",
@@ -4604,7 +4702,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/98_hires.png"
   },
   {
-    "id": "neo1-99",
+    "setOrder":8,
+	"id": "neo1-99",
     "name": "Berry",
     "imageUrl": "https://images.pokemontcg.io/neo1/99.png",
     "subtype": "",
@@ -4621,7 +4720,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/99_hires.png"
   },
   {
-    "id": "neo1-100",
+    "setOrder":8,
+	"id": "neo1-100",
     "name": "Double Gust",
     "imageUrl": "https://images.pokemontcg.io/neo1/100.png",
     "subtype": "",
@@ -4638,7 +4738,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/100_hires.png"
   },
   {
-    "id": "neo1-101",
+    "setOrder":8,
+	"id": "neo1-101",
     "name": "Moo-Moo Milk",
     "imageUrl": "https://images.pokemontcg.io/neo1/101.png",
     "subtype": "",
@@ -4655,7 +4756,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/101_hires.png"
   },
   {
-    "id": "neo1-102",
+    "setOrder":8,
+	"id": "neo1-102",
     "name": "Pokémon March",
     "imageUrl": "https://images.pokemontcg.io/neo1/102.png",
     "subtype": "",
@@ -4672,7 +4774,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/102_hires.png"
   },
   {
-    "id": "neo1-103",
+    "setOrder":8,
+	"id": "neo1-103",
     "name": "Super Rod",
     "imageUrl": "https://images.pokemontcg.io/neo1/103.png",
     "subtype": "",
@@ -4689,7 +4792,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/103_hires.png"
   },
   {
-    "id": "neo1-104",
+    "setOrder":8,
+	"id": "neo1-104",
     "name": "Darkness Energy",
     "imageUrl": "https://images.pokemontcg.io/neo1/104.png",
     "subtype": "Special",
@@ -4706,7 +4810,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/104_hires.png"
   },
   {
-    "id": "neo1-105",
+    "setOrder":8,
+	"id": "neo1-105",
     "name": "Recycle Energy",
     "imageUrl": "https://images.pokemontcg.io/neo1/105.png",
     "subtype": "Special",
@@ -4723,7 +4828,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/105_hires.png"
   },
   {
-    "id": "neo1-106",
+    "setOrder":8,
+	"id": "neo1-106",
     "name": "Fighting Energy",
     "imageUrl": "https://images.pokemontcg.io/neo1/106.png",
     "subtype": "Basic",
@@ -4737,7 +4843,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/106_hires.png"
   },
   {
-    "id": "neo1-107",
+    "setOrder":8,
+	"id": "neo1-107",
     "name": "Fire Energy",
     "imageUrl": "https://images.pokemontcg.io/neo1/107.png",
     "subtype": "Basic",
@@ -4751,7 +4858,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/107_hires.png"
   },
   {
-    "id": "neo1-108",
+    "setOrder":8,
+	"id": "neo1-108",
     "name": "Grass Energy",
     "imageUrl": "https://images.pokemontcg.io/neo1/108.png",
     "subtype": "Basic",
@@ -4765,7 +4873,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/108_hires.png"
   },
   {
-    "id": "neo1-109",
+    "setOrder":8,
+	"id": "neo1-109",
     "name": "Lightning Energy",
     "imageUrl": "https://images.pokemontcg.io/neo1/109.png",
     "subtype": "Basic",
@@ -4779,7 +4888,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/109_hires.png"
   },
   {
-    "id": "neo1-110",
+    "setOrder":8,
+	"id": "neo1-110",
     "name": "Psychic Energy",
     "imageUrl": "https://images.pokemontcg.io/neo1/110.png",
     "subtype": "Basic",
@@ -4793,7 +4903,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo1/110_hires.png"
   },
   {
-    "id": "neo1-111",
+    "setOrder":8,
+	"id": "neo1-111",
     "name": "Water Energy",
     "imageUrl": "https://images.pokemontcg.io/neo1/111.png",
     "subtype": "Basic",

--- a/json/cards/Neo Revelation.json
+++ b/json/cards/Neo Revelation.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "neo3-1",
+    "setOrder":10,
+	"id": "neo3-1",
     "name": "Ampharos",
     "imageUrl": "https://images.pokemontcg.io/neo3/1.png",
     "subtype": "Stage 2",
@@ -56,7 +57,8 @@
     "nationalPokedexNumber": 181
   },
   {
-    "id": "neo3-2",
+    "setOrder":10,
+	"id": "neo3-2",
     "name": "Blissey",
     "imageUrl": "https://images.pokemontcg.io/neo3/2.png",
     "subtype": "Stage 1",
@@ -113,7 +115,8 @@
     "nationalPokedexNumber": 242
   },
   {
-    "id": "neo3-3",
+    "setOrder":10,
+	"id": "neo3-3",
     "name": "Celebi",
     "imageUrl": "https://images.pokemontcg.io/neo3/3.png",
     "subtype": "Basic",
@@ -159,7 +162,8 @@
     "nationalPokedexNumber": 251
   },
   {
-    "id": "neo3-4",
+    "setOrder":10,
+	"id": "neo3-4",
     "name": "Crobat",
     "imageUrl": "https://images.pokemontcg.io/neo3/4.png",
     "subtype": "Stage 2",
@@ -215,7 +219,8 @@
     "nationalPokedexNumber": 169
   },
   {
-    "id": "neo3-5",
+    "setOrder":10,
+	"id": "neo3-5",
     "name": "Delibird",
     "imageUrl": "https://images.pokemontcg.io/neo3/5.png",
     "subtype": "Basic",
@@ -263,7 +268,8 @@
     "nationalPokedexNumber": 225
   },
   {
-    "id": "neo3-6",
+    "setOrder":10,
+	"id": "neo3-6",
     "name": "Entei",
     "imageUrl": "https://images.pokemontcg.io/neo3/6.png",
     "subtype": "Basic",
@@ -311,7 +317,8 @@
     "nationalPokedexNumber": 244
   },
   {
-    "id": "neo3-7",
+    "setOrder":10,
+	"id": "neo3-7",
     "name": "Ho-oh",
     "imageUrl": "https://images.pokemontcg.io/neo3/7.png",
     "subtype": "Basic",
@@ -383,7 +390,8 @@
     "nationalPokedexNumber": 250
   },
   {
-    "id": "neo3-8",
+    "setOrder":10,
+	"id": "neo3-8",
     "name": "Houndoom",
     "imageUrl": "https://images.pokemontcg.io/neo3/8.png",
     "subtype": "Stage 1",
@@ -436,7 +444,8 @@
     "nationalPokedexNumber": 229
   },
   {
-    "id": "neo3-9",
+    "setOrder":10,
+	"id": "neo3-9",
     "name": "Jumpluff",
     "imageUrl": "https://images.pokemontcg.io/neo3/9.png",
     "subtype": "Stage 2",
@@ -490,7 +499,8 @@
     "nationalPokedexNumber": 189
   },
   {
-    "id": "neo3-10",
+    "setOrder":10,
+	"id": "neo3-10",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/neo3/10.png",
     "subtype": "Stage 1",
@@ -549,7 +559,8 @@
     ]
   },
   {
-    "id": "neo3-11",
+    "setOrder":10,
+	"id": "neo3-11",
     "name": "Misdreavus",
     "imageUrl": "https://images.pokemontcg.io/neo3/11.png",
     "subtype": "Basic",
@@ -604,7 +615,8 @@
     ]
   },
   {
-    "id": "neo3-12",
+    "setOrder":10,
+	"id": "neo3-12",
     "name": "Porygon2",
     "imageUrl": "https://images.pokemontcg.io/neo3/12.png",
     "subtype": "Stage 1",
@@ -662,7 +674,8 @@
     ]
   },
   {
-    "id": "neo3-13",
+    "setOrder":10,
+	"id": "neo3-13",
     "name": "Raikou",
     "imageUrl": "https://images.pokemontcg.io/neo3/13.png",
     "subtype": "Basic",
@@ -710,7 +723,8 @@
     "nationalPokedexNumber": 243
   },
   {
-    "id": "neo3-14",
+    "setOrder":10,
+	"id": "neo3-14",
     "name": "Suicune",
     "imageUrl": "https://images.pokemontcg.io/neo3/14.png",
     "subtype": "Basic",
@@ -758,7 +772,8 @@
     "nationalPokedexNumber": 245
   },
   {
-    "id": "neo3-15",
+    "setOrder":10,
+	"id": "neo3-15",
     "name": "Aerodactyl",
     "imageUrl": "https://images.pokemontcg.io/neo3/15.png",
     "subtype": "Stage 1",
@@ -813,7 +828,8 @@
     "nationalPokedexNumber": 142
   },
   {
-    "id": "neo3-16",
+    "setOrder":10,
+	"id": "neo3-16",
     "name": "Celebi",
     "imageUrl": "https://images.pokemontcg.io/neo3/16.png",
     "subtype": "Basic",
@@ -855,7 +871,8 @@
     "nationalPokedexNumber": 251
   },
   {
-    "id": "neo3-17",
+    "setOrder":10,
+	"id": "neo3-17",
     "name": "Entei",
     "imageUrl": "https://images.pokemontcg.io/neo3/17.png",
     "subtype": "Basic",
@@ -900,7 +917,8 @@
     "nationalPokedexNumber": 244
   },
   {
-    "id": "neo3-18",
+    "setOrder":10,
+	"id": "neo3-18",
     "name": "Ho-oh",
     "imageUrl": "https://images.pokemontcg.io/neo3/18.png",
     "subtype": "Basic",
@@ -951,7 +969,8 @@
     "nationalPokedexNumber": 250
   },
   {
-    "id": "neo3-19",
+    "setOrder":10,
+	"id": "neo3-19",
     "name": "Kingdra",
     "imageUrl": "https://images.pokemontcg.io/neo3/19.png",
     "subtype": "Stage 2",
@@ -1000,7 +1019,8 @@
     "nationalPokedexNumber": 230
   },
   {
-    "id": "neo3-20",
+    "setOrder":10,
+	"id": "neo3-20",
     "name": "Lugia",
     "imageUrl": "https://images.pokemontcg.io/neo3/20.png",
     "subtype": "Basic",
@@ -1051,7 +1071,8 @@
     "nationalPokedexNumber": 249
   },
   {
-    "id": "neo3-21",
+    "setOrder":10,
+	"id": "neo3-21",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/neo3/21.png",
     "subtype": "Stage 1",
@@ -1105,7 +1126,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "neo3-22",
+    "setOrder":10,
+	"id": "neo3-22",
     "name": "Raikou",
     "imageUrl": "https://images.pokemontcg.io/neo3/22.png",
     "subtype": "Basic",
@@ -1150,7 +1172,8 @@
     "nationalPokedexNumber": 243
   },
   {
-    "id": "neo3-23",
+    "setOrder":10,
+	"id": "neo3-23",
     "name": "Skarmory",
     "imageUrl": "https://images.pokemontcg.io/neo3/23.png",
     "subtype": "Basic",
@@ -1209,7 +1232,8 @@
     "nationalPokedexNumber": 227
   },
   {
-    "id": "neo3-24",
+    "setOrder":10,
+	"id": "neo3-24",
     "name": "Sneasel",
     "imageUrl": "https://images.pokemontcg.io/neo3/24.png",
     "subtype": "Basic",
@@ -1260,7 +1284,8 @@
     ]
   },
   {
-    "id": "neo3-25",
+    "setOrder":10,
+	"id": "neo3-25",
     "name": "Starmie",
     "imageUrl": "https://images.pokemontcg.io/neo3/25.png",
     "subtype": "Stage 1",
@@ -1313,7 +1338,8 @@
     "nationalPokedexNumber": 121
   },
   {
-    "id": "neo3-26",
+    "setOrder":10,
+	"id": "neo3-26",
     "name": "Sudowoodo",
     "imageUrl": "https://images.pokemontcg.io/neo3/26.png",
     "subtype": "Basic",
@@ -1362,7 +1388,8 @@
     "nationalPokedexNumber": 185
   },
   {
-    "id": "neo3-27",
+    "setOrder":10,
+	"id": "neo3-27",
     "name": "Suicune",
     "imageUrl": "https://images.pokemontcg.io/neo3/27.png",
     "subtype": "Basic",
@@ -1407,7 +1434,8 @@
     "nationalPokedexNumber": 245
   },
   {
-    "id": "neo3-28",
+    "setOrder":10,
+	"id": "neo3-28",
     "name": "Flaaffy",
     "imageUrl": "https://images.pokemontcg.io/neo3/28.png",
     "subtype": "Stage 1",
@@ -1463,7 +1491,8 @@
     ]
   },
   {
-    "id": "neo3-29",
+    "setOrder":10,
+	"id": "neo3-29",
     "name": "Golbat",
     "imageUrl": "https://images.pokemontcg.io/neo3/29.png",
     "subtype": "Stage 1",
@@ -1521,7 +1550,8 @@
     ]
   },
   {
-    "id": "neo3-30",
+    "setOrder":10,
+	"id": "neo3-30",
     "name": "Graveler",
     "imageUrl": "https://images.pokemontcg.io/neo3/30.png",
     "subtype": "Stage 1",
@@ -1579,7 +1609,8 @@
     ]
   },
   {
-    "id": "neo3-31",
+    "setOrder":10,
+	"id": "neo3-31",
     "name": "Jynx",
     "imageUrl": "https://images.pokemontcg.io/neo3/31.png",
     "subtype": "Basic",
@@ -1632,7 +1663,8 @@
     "nationalPokedexNumber": 124
   },
   {
-    "id": "neo3-32",
+    "setOrder":10,
+	"id": "neo3-32",
     "name": "Lanturn",
     "imageUrl": "https://images.pokemontcg.io/neo3/32.png",
     "subtype": "Stage 1",
@@ -1682,7 +1714,8 @@
     "nationalPokedexNumber": 171
   },
   {
-    "id": "neo3-33",
+    "setOrder":10,
+	"id": "neo3-33",
     "name": "Magcargo",
     "imageUrl": "https://images.pokemontcg.io/neo3/33.png",
     "subtype": "Stage 1",
@@ -1733,7 +1766,8 @@
     "nationalPokedexNumber": 219
   },
   {
-    "id": "neo3-34",
+    "setOrder":10,
+	"id": "neo3-34",
     "name": "Octillery",
     "imageUrl": "https://images.pokemontcg.io/neo3/34.png",
     "subtype": "Stage 1",
@@ -1787,7 +1821,8 @@
     "nationalPokedexNumber": 224
   },
   {
-    "id": "neo3-35",
+    "setOrder":10,
+	"id": "neo3-35",
     "name": "Parasect",
     "imageUrl": "https://images.pokemontcg.io/neo3/35.png",
     "subtype": "Stage 1",
@@ -1831,7 +1866,8 @@
     "nationalPokedexNumber": 47
   },
   {
-    "id": "neo3-36",
+    "setOrder":10,
+	"id": "neo3-36",
     "name": "Piloswine",
     "imageUrl": "https://images.pokemontcg.io/neo3/36.png",
     "subtype": "Stage 1",
@@ -1897,7 +1933,8 @@
     ]
   },
   {
-    "id": "neo3-37",
+    "setOrder":10,
+	"id": "neo3-37",
     "name": "Seaking",
     "imageUrl": "https://images.pokemontcg.io/neo3/37.png",
     "subtype": "Stage 1",
@@ -1949,7 +1986,8 @@
     "nationalPokedexNumber": 119
   },
   {
-    "id": "neo3-38",
+    "setOrder":10,
+	"id": "neo3-38",
     "name": "Stantler",
     "imageUrl": "https://images.pokemontcg.io/neo3/38.png",
     "subtype": "Basic",
@@ -2007,7 +2045,8 @@
     "nationalPokedexNumber": 234
   },
   {
-    "id": "neo3-39",
+    "setOrder":10,
+	"id": "neo3-39",
     "name": "Unown [B]",
     "imageUrl": "https://images.pokemontcg.io/neo3/39.png",
     "subtype": "Basic",
@@ -2053,7 +2092,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "neo3-40",
+    "setOrder":10,
+	"id": "neo3-40",
     "name": "Unown [Y]",
     "imageUrl": "https://images.pokemontcg.io/neo3/40.png",
     "subtype": "Basic",
@@ -2099,7 +2139,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "neo3-41",
+    "setOrder":10,
+	"id": "neo3-41",
     "name": "Aipom",
     "imageUrl": "https://images.pokemontcg.io/neo3/41.png",
     "subtype": "Basic",
@@ -2156,7 +2197,8 @@
     ]
   },
   {
-    "id": "neo3-42",
+    "setOrder":10,
+	"id": "neo3-42",
     "name": "Chinchou",
     "imageUrl": "https://images.pokemontcg.io/neo3/42.png",
     "subtype": "Basic",
@@ -2209,7 +2251,8 @@
     ]
   },
   {
-    "id": "neo3-43",
+    "setOrder":10,
+	"id": "neo3-43",
     "name": "Farfetch'd",
     "imageUrl": "https://images.pokemontcg.io/neo3/43.png",
     "subtype": "Basic",
@@ -2267,7 +2310,8 @@
     "nationalPokedexNumber": 83
   },
   {
-    "id": "neo3-44",
+    "setOrder":10,
+	"id": "neo3-44",
     "name": "Geodude",
     "imageUrl": "https://images.pokemontcg.io/neo3/44.png",
     "subtype": "Basic",
@@ -2311,7 +2355,8 @@
     ]
   },
   {
-    "id": "neo3-45",
+    "setOrder":10,
+	"id": "neo3-45",
     "name": "Goldeen",
     "imageUrl": "https://images.pokemontcg.io/neo3/45.png",
     "subtype": "Basic",
@@ -2352,7 +2397,8 @@
     ]
   },
   {
-    "id": "neo3-46",
+    "setOrder":10,
+	"id": "neo3-46",
     "name": "Murkrow",
     "imageUrl": "https://images.pokemontcg.io/neo3/46.png",
     "subtype": "Basic",
@@ -2403,7 +2449,8 @@
     ]
   },
   {
-    "id": "neo3-47",
+    "setOrder":10,
+	"id": "neo3-47",
     "name": "Paras",
     "imageUrl": "https://images.pokemontcg.io/neo3/47.png",
     "subtype": "Basic",
@@ -2457,7 +2504,8 @@
     ]
   },
   {
-    "id": "neo3-48",
+    "setOrder":10,
+	"id": "neo3-48",
     "name": "Quagsire",
     "imageUrl": "https://images.pokemontcg.io/neo3/48.png",
     "subtype": "Stage 1",
@@ -2519,7 +2567,8 @@
     "nationalPokedexNumber": 195
   },
   {
-    "id": "neo3-49",
+    "setOrder":10,
+	"id": "neo3-49",
     "name": "Qwilfish",
     "imageUrl": "https://images.pokemontcg.io/neo3/49.png",
     "subtype": "Basic",
@@ -2570,7 +2619,8 @@
     "nationalPokedexNumber": 211
   },
   {
-    "id": "neo3-50",
+    "setOrder":10,
+	"id": "neo3-50",
     "name": "Remoraid",
     "imageUrl": "https://images.pokemontcg.io/neo3/50.png",
     "subtype": "Basic",
@@ -2611,7 +2661,8 @@
     ]
   },
   {
-    "id": "neo3-51",
+    "setOrder":10,
+	"id": "neo3-51",
     "name": "Shuckle",
     "imageUrl": "https://images.pokemontcg.io/neo3/51.png",
     "subtype": "Basic",
@@ -2658,7 +2709,8 @@
     "nationalPokedexNumber": 213
   },
   {
-    "id": "neo3-52",
+    "setOrder":10,
+	"id": "neo3-52",
     "name": "Skiploom",
     "imageUrl": "https://images.pokemontcg.io/neo3/52.png",
     "subtype": "Stage 1",
@@ -2719,7 +2771,8 @@
     ]
   },
   {
-    "id": "neo3-53",
+    "setOrder":10,
+	"id": "neo3-53",
     "name": "Slugma",
     "imageUrl": "https://images.pokemontcg.io/neo3/53.png",
     "subtype": "Basic",
@@ -2774,7 +2827,8 @@
     ]
   },
   {
-    "id": "neo3-54",
+    "setOrder":10,
+	"id": "neo3-54",
     "name": "Smoochum",
     "imageUrl": "https://images.pokemontcg.io/neo3/54.png",
     "subtype": "Basic",
@@ -2812,7 +2866,8 @@
     ]
   },
   {
-    "id": "neo3-55",
+    "setOrder":10,
+	"id": "neo3-55",
     "name": "Snubbull",
     "imageUrl": "https://images.pokemontcg.io/neo3/55.png",
     "subtype": "Basic",
@@ -2872,7 +2927,8 @@
     ]
   },
   {
-    "id": "neo3-56",
+    "setOrder":10,
+	"id": "neo3-56",
     "name": "Staryu",
     "imageUrl": "https://images.pokemontcg.io/neo3/56.png",
     "subtype": "Basic",
@@ -2925,7 +2981,8 @@
     ]
   },
   {
-    "id": "neo3-57",
+    "setOrder":10,
+	"id": "neo3-57",
     "name": "Swinub",
     "imageUrl": "https://images.pokemontcg.io/neo3/57.png",
     "subtype": "Basic",
@@ -2985,7 +3042,8 @@
     ]
   },
   {
-    "id": "neo3-58",
+    "setOrder":10,
+	"id": "neo3-58",
     "name": "Unown [K]",
     "imageUrl": "https://images.pokemontcg.io/neo3/58.png",
     "subtype": "Basic",
@@ -3031,7 +3089,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "neo3-59",
+    "setOrder":10,
+	"id": "neo3-59",
     "name": "Zubat",
     "imageUrl": "https://images.pokemontcg.io/neo3/59.png",
     "subtype": "Basic",
@@ -3087,7 +3146,8 @@
     ]
   },
   {
-    "id": "neo3-60",
+    "setOrder":10,
+	"id": "neo3-60",
     "name": "Balloon Berry",
     "imageUrl": "https://images.pokemontcg.io/neo3/60.png",
     "subtype": "",
@@ -3104,7 +3164,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo3/60_hires.png"
   },
   {
-    "id": "neo3-61",
+    "setOrder":10,
+	"id": "neo3-61",
     "name": "Healing Field",
     "imageUrl": "https://images.pokemontcg.io/neo3/61.png",
     "subtype": "",
@@ -3121,7 +3182,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo3/61_hires.png"
   },
   {
-    "id": "neo3-62",
+    "setOrder":10,
+	"id": "neo3-62",
     "name": "Pokémon Breeder Fields",
     "imageUrl": "https://images.pokemontcg.io/neo3/62.png",
     "subtype": "",
@@ -3138,7 +3200,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo3/62_hires.png"
   },
   {
-    "id": "neo3-63",
+    "setOrder":10,
+	"id": "neo3-63",
     "name": "Rocket's Hideout",
     "imageUrl": "https://images.pokemontcg.io/neo3/63.png",
     "subtype": "",
@@ -3155,7 +3218,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo3/63_hires.png"
   },
   {
-    "id": "neo3-64",
+    "setOrder":10,
+	"id": "neo3-64",
     "name": "Old Rod",
     "imageUrl": "https://images.pokemontcg.io/neo3/64.png",
     "subtype": "",
@@ -3172,7 +3236,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/neo3/64_hires.png"
   },
   {
-    "id": "neo3-65",
+    "setOrder":10,
+	"id": "neo3-65",
     "name": "Shining Gyarados",
     "imageUrl": "https://images.pokemontcg.io/neo3/65.png",
     "subtype": "Basic",
@@ -3235,7 +3300,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "neo3-66",
+    "setOrder":10,
+	"id": "neo3-66",
     "name": "Shining Magikarp",
     "imageUrl": "https://images.pokemontcg.io/neo3/66.png",
     "subtype": "Basic",

--- a/json/cards/Next Destinies.json
+++ b/json/cards/Next Destinies.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "bw4-1",
+    "setOrder":51,
+	"id": "bw4-1",
     "name": "Pinsir",
     "imageUrl": "https://images.pokemontcg.io/bw4/1.png",
     "subtype": "Basic",
@@ -53,7 +54,8 @@
     "nationalPokedexNumber": 127
   },
   {
-    "id": "bw4-2",
+    "setOrder":51,
+	"id": "bw4-2",
     "name": "Seedot",
     "imageUrl": "https://images.pokemontcg.io/bw4/2.png",
     "subtype": "Basic",
@@ -102,7 +104,8 @@
     ]
   },
   {
-    "id": "bw4-3",
+    "setOrder":51,
+	"id": "bw4-3",
     "name": "Kricketot",
     "imageUrl": "https://images.pokemontcg.io/bw4/3.png",
     "subtype": "Basic",
@@ -155,7 +158,8 @@
     ]
   },
   {
-    "id": "bw4-4",
+    "setOrder":51,
+	"id": "bw4-4",
     "name": "Kricketune",
     "imageUrl": "https://images.pokemontcg.io/bw4/4.png",
     "subtype": "Stage 1",
@@ -206,7 +210,8 @@
     "nationalPokedexNumber": 402
   },
   {
-    "id": "bw4-5",
+    "setOrder":51,
+	"id": "bw4-5",
     "name": "Shaymin-EX",
     "imageUrl": "https://images.pokemontcg.io/bw4/5.png",
     "subtype": "EX",
@@ -265,7 +270,8 @@
     "nationalPokedexNumber": 492
   },
   {
-    "id": "bw4-6",
+    "setOrder":51,
+	"id": "bw4-6",
     "name": "Pansage",
     "imageUrl": "https://images.pokemontcg.io/bw4/6.png",
     "subtype": "Basic",
@@ -315,7 +321,8 @@
     ]
   },
   {
-    "id": "bw4-7",
+    "setOrder":51,
+	"id": "bw4-7",
     "name": "Simisage",
     "imageUrl": "https://images.pokemontcg.io/bw4/7.png",
     "subtype": "Stage 1",
@@ -373,7 +380,8 @@
     "nationalPokedexNumber": 512
   },
   {
-    "id": "bw4-8",
+    "setOrder":51,
+	"id": "bw4-8",
     "name": "Foongus",
     "imageUrl": "https://images.pokemontcg.io/bw4/8.png",
     "subtype": "Basic",
@@ -432,7 +440,8 @@
     ]
   },
   {
-    "id": "bw4-9",
+    "setOrder":51,
+	"id": "bw4-9",
     "name": "Amoonguss",
     "imageUrl": "https://images.pokemontcg.io/bw4/9.png",
     "subtype": "Stage 1",
@@ -486,7 +495,8 @@
     "nationalPokedexNumber": 591
   },
   {
-    "id": "bw4-10",
+    "setOrder":51,
+	"id": "bw4-10",
     "name": "Growlithe",
     "imageUrl": "https://images.pokemontcg.io/bw4/10.png",
     "subtype": "Basic",
@@ -541,7 +551,8 @@
     ]
   },
   {
-    "id": "bw4-11",
+    "setOrder":51,
+	"id": "bw4-11",
     "name": "Growlithe",
     "imageUrl": "https://images.pokemontcg.io/bw4/11.png",
     "subtype": "Basic",
@@ -586,7 +597,8 @@
     ]
   },
   {
-    "id": "bw4-12",
+    "setOrder":51,
+	"id": "bw4-12",
     "name": "Arcanine",
     "imageUrl": "https://images.pokemontcg.io/bw4/12.png",
     "subtype": "Stage 1",
@@ -636,7 +648,8 @@
     "nationalPokedexNumber": 59
   },
   {
-    "id": "bw4-13",
+    "setOrder":51,
+	"id": "bw4-13",
     "name": "Arcanine",
     "imageUrl": "https://images.pokemontcg.io/bw4/13.png",
     "subtype": "Stage 1",
@@ -691,7 +704,8 @@
     "nationalPokedexNumber": 59
   },
   {
-    "id": "bw4-14",
+    "setOrder":51,
+	"id": "bw4-14",
     "name": "Moltres",
     "imageUrl": "https://images.pokemontcg.io/bw4/14.png",
     "subtype": "Basic",
@@ -752,7 +766,8 @@
     "nationalPokedexNumber": 146
   },
   {
-    "id": "bw4-15",
+    "setOrder":51,
+	"id": "bw4-15",
     "name": "Pansear",
     "imageUrl": "https://images.pokemontcg.io/bw4/15.png",
     "subtype": "Basic",
@@ -796,7 +811,8 @@
     ]
   },
   {
-    "id": "bw4-16",
+    "setOrder":51,
+	"id": "bw4-16",
     "name": "Simisear",
     "imageUrl": "https://images.pokemontcg.io/bw4/16.png",
     "subtype": "Stage 1",
@@ -847,7 +863,8 @@
     "nationalPokedexNumber": 514
   },
   {
-    "id": "bw4-17",
+    "setOrder":51,
+	"id": "bw4-17",
     "name": "Darumaka",
     "imageUrl": "https://images.pokemontcg.io/bw4/17.png",
     "subtype": "Basic",
@@ -893,7 +910,8 @@
     ]
   },
   {
-    "id": "bw4-18",
+    "setOrder":51,
+	"id": "bw4-18",
     "name": "Litwick",
     "imageUrl": "https://images.pokemontcg.io/bw4/18.png",
     "subtype": "Basic",
@@ -936,7 +954,8 @@
     ]
   },
   {
-    "id": "bw4-19",
+    "setOrder":51,
+	"id": "bw4-19",
     "name": "Lampent",
     "imageUrl": "https://images.pokemontcg.io/bw4/19.png",
     "subtype": "Stage 1",
@@ -981,7 +1000,8 @@
     ]
   },
   {
-    "id": "bw4-20",
+    "setOrder":51,
+	"id": "bw4-20",
     "name": "Chandelure",
     "imageUrl": "https://images.pokemontcg.io/bw4/20.png",
     "subtype": "Stage 2",
@@ -1033,7 +1053,8 @@
     "nationalPokedexNumber": 609
   },
   {
-    "id": "bw4-21",
+    "setOrder":51,
+	"id": "bw4-21",
     "name": "Reshiram",
     "imageUrl": "https://images.pokemontcg.io/bw4/21.png",
     "subtype": "Basic",
@@ -1086,7 +1107,8 @@
     "nationalPokedexNumber": 643
   },
   {
-    "id": "bw4-22",
+    "setOrder":51,
+	"id": "bw4-22",
     "name": "Reshiram-EX",
     "imageUrl": "https://images.pokemontcg.io/bw4/22.png",
     "subtype": "EX",
@@ -1145,7 +1167,8 @@
     "nationalPokedexNumber": 643
   },
   {
-    "id": "bw4-23",
+    "setOrder":51,
+	"id": "bw4-23",
     "name": "Staryu",
     "imageUrl": "https://images.pokemontcg.io/bw4/23.png",
     "subtype": "Basic",
@@ -1197,7 +1220,8 @@
     ]
   },
   {
-    "id": "bw4-24",
+    "setOrder":51,
+	"id": "bw4-24",
     "name": "Starmie",
     "imageUrl": "https://images.pokemontcg.io/bw4/24.png",
     "subtype": "Stage 1",
@@ -1244,7 +1268,8 @@
     "nationalPokedexNumber": 121
   },
   {
-    "id": "bw4-25",
+    "setOrder":51,
+	"id": "bw4-25",
     "name": "Lapras",
     "imageUrl": "https://images.pokemontcg.io/bw4/25.png",
     "subtype": "Basic",
@@ -1295,7 +1320,8 @@
     "nationalPokedexNumber": 131
   },
   {
-    "id": "bw4-26",
+    "setOrder":51,
+	"id": "bw4-26",
     "name": "Lapras",
     "imageUrl": "https://images.pokemontcg.io/bw4/26.png",
     "subtype": "Basic",
@@ -1348,7 +1374,8 @@
     "nationalPokedexNumber": 131
   },
   {
-    "id": "bw4-27",
+    "setOrder":51,
+	"id": "bw4-27",
     "name": "Articuno",
     "imageUrl": "https://images.pokemontcg.io/bw4/27.png",
     "subtype": "Basic",
@@ -1409,7 +1436,8 @@
     "nationalPokedexNumber": 144
   },
   {
-    "id": "bw4-28",
+    "setOrder":51,
+	"id": "bw4-28",
     "name": "Panpour",
     "imageUrl": "https://images.pokemontcg.io/bw4/28.png",
     "subtype": "Basic",
@@ -1453,7 +1481,8 @@
     ]
   },
   {
-    "id": "bw4-29",
+    "setOrder":51,
+	"id": "bw4-29",
     "name": "Simipour",
     "imageUrl": "https://images.pokemontcg.io/bw4/29.png",
     "subtype": "Stage 1",
@@ -1504,7 +1533,8 @@
     "nationalPokedexNumber": 516
   },
   {
-    "id": "bw4-30",
+    "setOrder":51,
+	"id": "bw4-30",
     "name": "Basculin",
     "imageUrl": "https://images.pokemontcg.io/bw4/30.png",
     "subtype": "Basic",
@@ -1553,7 +1583,8 @@
     "nationalPokedexNumber": 550
   },
   {
-    "id": "bw4-31",
+    "setOrder":51,
+	"id": "bw4-31",
     "name": "Vanillite",
     "imageUrl": "https://images.pokemontcg.io/bw4/31.png",
     "subtype": "Basic",
@@ -1606,7 +1637,8 @@
     ]
   },
   {
-    "id": "bw4-32",
+    "setOrder":51,
+	"id": "bw4-32",
     "name": "Vanillish",
     "imageUrl": "https://images.pokemontcg.io/bw4/32.png",
     "subtype": "Stage 1",
@@ -1662,7 +1694,8 @@
     ]
   },
   {
-    "id": "bw4-33",
+    "setOrder":51,
+	"id": "bw4-33",
     "name": "Vanilluxe",
     "imageUrl": "https://images.pokemontcg.io/bw4/33.png",
     "subtype": "Stage 2",
@@ -1711,7 +1744,8 @@
     "nationalPokedexNumber": 584
   },
   {
-    "id": "bw4-34",
+    "setOrder":51,
+	"id": "bw4-34",
     "name": "Frillish",
     "imageUrl": "https://images.pokemontcg.io/bw4/34.png",
     "subtype": "Basic",
@@ -1765,7 +1799,8 @@
     ]
   },
   {
-    "id": "bw4-35",
+    "setOrder":51,
+	"id": "bw4-35",
     "name": "Jellicent",
     "imageUrl": "https://images.pokemontcg.io/bw4/35.png",
     "subtype": "Stage 1",
@@ -1818,7 +1853,8 @@
     "nationalPokedexNumber": 593
   },
   {
-    "id": "bw4-36",
+    "setOrder":51,
+	"id": "bw4-36",
     "name": "Cubchoo",
     "imageUrl": "https://images.pokemontcg.io/bw4/36.png",
     "subtype": "Basic",
@@ -1873,7 +1909,8 @@
     ]
   },
   {
-    "id": "bw4-37",
+    "setOrder":51,
+	"id": "bw4-37",
     "name": "Beartic",
     "imageUrl": "https://images.pokemontcg.io/bw4/37.png",
     "subtype": "Stage 1",
@@ -1928,7 +1965,8 @@
     "nationalPokedexNumber": 614
   },
   {
-    "id": "bw4-38",
+    "setOrder":51,
+	"id": "bw4-38",
     "name": "Kyurem-EX",
     "imageUrl": "https://images.pokemontcg.io/bw4/38.png",
     "subtype": "EX",
@@ -1987,7 +2025,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "bw4-39",
+    "setOrder":51,
+	"id": "bw4-39",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/bw4/39.png",
     "subtype": "Basic",
@@ -2040,7 +2079,8 @@
     ]
   },
   {
-    "id": "bw4-40",
+    "setOrder":51,
+	"id": "bw4-40",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/bw4/40.png",
     "subtype": "Stage 1",
@@ -2092,7 +2132,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "bw4-41",
+    "setOrder":51,
+	"id": "bw4-41",
     "name": "Zapdos",
     "imageUrl": "https://images.pokemontcg.io/bw4/41.png",
     "subtype": "Basic",
@@ -2153,7 +2194,8 @@
     "nationalPokedexNumber": 145
   },
   {
-    "id": "bw4-42",
+    "setOrder":51,
+	"id": "bw4-42",
     "name": "Shinx",
     "imageUrl": "https://images.pokemontcg.io/bw4/42.png",
     "subtype": "Basic",
@@ -2206,7 +2248,8 @@
     ]
   },
   {
-    "id": "bw4-43",
+    "setOrder":51,
+	"id": "bw4-43",
     "name": "Shinx",
     "imageUrl": "https://images.pokemontcg.io/bw4/43.png",
     "subtype": "Basic",
@@ -2249,7 +2292,8 @@
     ]
   },
   {
-    "id": "bw4-44",
+    "setOrder":51,
+	"id": "bw4-44",
     "name": "Luxio",
     "imageUrl": "https://images.pokemontcg.io/bw4/44.png",
     "subtype": "Stage 1",
@@ -2304,7 +2348,8 @@
     ]
   },
   {
-    "id": "bw4-45",
+    "setOrder":51,
+	"id": "bw4-45",
     "name": "Luxio",
     "imageUrl": "https://images.pokemontcg.io/bw4/45.png",
     "subtype": "Stage 1",
@@ -2355,7 +2400,8 @@
     ]
   },
   {
-    "id": "bw4-46",
+    "setOrder":51,
+	"id": "bw4-46",
     "name": "Luxray",
     "imageUrl": "https://images.pokemontcg.io/bw4/46.png",
     "subtype": "Stage 2",
@@ -2407,7 +2453,8 @@
     "nationalPokedexNumber": 405
   },
   {
-    "id": "bw4-47",
+    "setOrder":51,
+	"id": "bw4-47",
     "name": "Blitzle",
     "imageUrl": "https://images.pokemontcg.io/bw4/47.png",
     "subtype": "Basic",
@@ -2451,7 +2498,8 @@
     ]
   },
   {
-    "id": "bw4-48",
+    "setOrder":51,
+	"id": "bw4-48",
     "name": "Zebstrika",
     "imageUrl": "https://images.pokemontcg.io/bw4/48.png",
     "subtype": "Stage 1",
@@ -2501,7 +2549,8 @@
     "nationalPokedexNumber": 523
   },
   {
-    "id": "bw4-49",
+    "setOrder":51,
+	"id": "bw4-49",
     "name": "Emolga",
     "imageUrl": "https://images.pokemontcg.io/bw4/49.png",
     "subtype": "Basic",
@@ -2542,7 +2591,8 @@
     "nationalPokedexNumber": 587
   },
   {
-    "id": "bw4-50",
+    "setOrder":51,
+	"id": "bw4-50",
     "name": "Zekrom",
     "imageUrl": "https://images.pokemontcg.io/bw4/50.png",
     "subtype": "Basic",
@@ -2595,7 +2645,8 @@
     "nationalPokedexNumber": 644
   },
   {
-    "id": "bw4-51",
+    "setOrder":51,
+	"id": "bw4-51",
     "name": "Zekrom-EX",
     "imageUrl": "https://images.pokemontcg.io/bw4/51.png",
     "subtype": "EX",
@@ -2654,7 +2705,8 @@
     "nationalPokedexNumber": 644
   },
   {
-    "id": "bw4-52",
+    "setOrder":51,
+	"id": "bw4-52",
     "name": "Grimer",
     "imageUrl": "https://images.pokemontcg.io/bw4/52.png",
     "subtype": "Basic",
@@ -2699,7 +2751,8 @@
     ]
   },
   {
-    "id": "bw4-53",
+    "setOrder":51,
+	"id": "bw4-53",
     "name": "Muk",
     "imageUrl": "https://images.pokemontcg.io/bw4/53.png",
     "subtype": "Stage 1",
@@ -2756,7 +2809,8 @@
     "nationalPokedexNumber": 89
   },
   {
-    "id": "bw4-54",
+    "setOrder":51,
+	"id": "bw4-54",
     "name": "Mewtwo-EX",
     "imageUrl": "https://images.pokemontcg.io/bw4/54.png",
     "subtype": "EX",
@@ -2813,7 +2867,8 @@
     "evolvesTo": "M Mewtwo-EX"
   },
   {
-    "id": "bw4-55",
+    "setOrder":51,
+	"id": "bw4-55",
     "name": "Ralts",
     "imageUrl": "https://images.pokemontcg.io/bw4/55.png",
     "subtype": "Basic",
@@ -2866,7 +2921,8 @@
     ]
   },
   {
-    "id": "bw4-56",
+    "setOrder":51,
+	"id": "bw4-56",
     "name": "Kirlia",
     "imageUrl": "https://images.pokemontcg.io/bw4/56.png",
     "subtype": "Stage 1",
@@ -2923,7 +2979,8 @@
     ]
   },
   {
-    "id": "bw4-57",
+    "setOrder":51,
+	"id": "bw4-57",
     "name": "Gardevoir",
     "imageUrl": "https://images.pokemontcg.io/bw4/57.png",
     "subtype": "Stage 2",
@@ -2973,7 +3030,8 @@
     "nationalPokedexNumber": 282
   },
   {
-    "id": "bw4-58",
+    "setOrder":51,
+	"id": "bw4-58",
     "name": "Munna",
     "imageUrl": "https://images.pokemontcg.io/bw4/58.png",
     "subtype": "Basic",
@@ -3018,7 +3076,8 @@
     ]
   },
   {
-    "id": "bw4-59",
+    "setOrder":51,
+	"id": "bw4-59",
     "name": "Musharna",
     "imageUrl": "https://images.pokemontcg.io/bw4/59.png",
     "subtype": "Stage 1",
@@ -3067,7 +3126,8 @@
     "nationalPokedexNumber": 518
   },
   {
-    "id": "bw4-60",
+    "setOrder":51,
+	"id": "bw4-60",
     "name": "Darmanitan",
     "imageUrl": "https://images.pokemontcg.io/bw4/60.png",
     "subtype": "Stage 1",
@@ -3120,7 +3180,8 @@
     "nationalPokedexNumber": 555
   },
   {
-    "id": "bw4-61",
+    "setOrder":51,
+	"id": "bw4-61",
     "name": "Elgyem",
     "imageUrl": "https://images.pokemontcg.io/bw4/61.png",
     "subtype": "Basic",
@@ -3163,7 +3224,8 @@
     ]
   },
   {
-    "id": "bw4-62",
+    "setOrder":51,
+	"id": "bw4-62",
     "name": "Beheeyem",
     "imageUrl": "https://images.pokemontcg.io/bw4/62.png",
     "subtype": "Stage 1",
@@ -3215,7 +3277,8 @@
     "nationalPokedexNumber": 606
   },
   {
-    "id": "bw4-63",
+    "setOrder":51,
+	"id": "bw4-63",
     "name": "Riolu",
     "imageUrl": "https://images.pokemontcg.io/bw4/63.png",
     "subtype": "Basic",
@@ -3268,7 +3331,8 @@
     ]
   },
   {
-    "id": "bw4-64",
+    "setOrder":51,
+	"id": "bw4-64",
     "name": "Lucario",
     "imageUrl": "https://images.pokemontcg.io/bw4/64.png",
     "subtype": "Stage 1",
@@ -3315,7 +3379,8 @@
     "nationalPokedexNumber": 448
   },
   {
-    "id": "bw4-65",
+    "setOrder":51,
+	"id": "bw4-65",
     "name": "Hippopotas",
     "imageUrl": "https://images.pokemontcg.io/bw4/65.png",
     "subtype": "Basic",
@@ -3378,7 +3443,8 @@
     ]
   },
   {
-    "id": "bw4-66",
+    "setOrder":51,
+	"id": "bw4-66",
     "name": "Hippowdon",
     "imageUrl": "https://images.pokemontcg.io/bw4/66.png",
     "subtype": "Stage 1",
@@ -3442,7 +3508,8 @@
     "nationalPokedexNumber": 450
   },
   {
-    "id": "bw4-67",
+    "setOrder":51,
+	"id": "bw4-67",
     "name": "Mienfoo",
     "imageUrl": "https://images.pokemontcg.io/bw4/67.png",
     "subtype": "Basic",
@@ -3485,7 +3552,8 @@
     ]
   },
   {
-    "id": "bw4-68",
+    "setOrder":51,
+	"id": "bw4-68",
     "name": "Mienshao",
     "imageUrl": "https://images.pokemontcg.io/bw4/68.png",
     "subtype": "Stage 1",
@@ -3536,7 +3604,8 @@
     "nationalPokedexNumber": 620
   },
   {
-    "id": "bw4-69",
+    "setOrder":51,
+	"id": "bw4-69",
     "name": "Sneasel",
     "imageUrl": "https://images.pokemontcg.io/bw4/69.png",
     "subtype": "Basic",
@@ -3595,7 +3664,8 @@
     ]
   },
   {
-    "id": "bw4-70",
+    "setOrder":51,
+	"id": "bw4-70",
     "name": "Weavile",
     "imageUrl": "https://images.pokemontcg.io/bw4/70.png",
     "subtype": "Stage 1",
@@ -3653,7 +3723,8 @@
     "nationalPokedexNumber": 461
   },
   {
-    "id": "bw4-71",
+    "setOrder":51,
+	"id": "bw4-71",
     "name": "Nuzleaf",
     "imageUrl": "https://images.pokemontcg.io/bw4/71.png",
     "subtype": "Stage 1",
@@ -3704,7 +3775,8 @@
     ]
   },
   {
-    "id": "bw4-72",
+    "setOrder":51,
+	"id": "bw4-72",
     "name": "Shiftry",
     "imageUrl": "https://images.pokemontcg.io/bw4/72.png",
     "subtype": "Stage 2",
@@ -3758,7 +3830,8 @@
     "nationalPokedexNumber": 275
   },
   {
-    "id": "bw4-73",
+    "setOrder":51,
+	"id": "bw4-73",
     "name": "Scraggy",
     "imageUrl": "https://images.pokemontcg.io/bw4/73.png",
     "subtype": "Basic",
@@ -3818,7 +3891,8 @@
     ]
   },
   {
-    "id": "bw4-74",
+    "setOrder":51,
+	"id": "bw4-74",
     "name": "Scrafty",
     "imageUrl": "https://images.pokemontcg.io/bw4/74.png",
     "subtype": "Stage 1",
@@ -3877,7 +3951,8 @@
     "nationalPokedexNumber": 560
   },
   {
-    "id": "bw4-75",
+    "setOrder":51,
+	"id": "bw4-75",
     "name": "Bronzor",
     "imageUrl": "https://images.pokemontcg.io/bw4/75.png",
     "subtype": "Basic",
@@ -3940,7 +4015,8 @@
     ]
   },
   {
-    "id": "bw4-76",
+    "setOrder":51,
+	"id": "bw4-76",
     "name": "Bronzong",
     "imageUrl": "https://images.pokemontcg.io/bw4/76.png",
     "subtype": "Stage 1",
@@ -3997,7 +4073,8 @@
     "nationalPokedexNumber": 437
   },
   {
-    "id": "bw4-77",
+    "setOrder":51,
+	"id": "bw4-77",
     "name": "Ferroseed",
     "imageUrl": "https://images.pokemontcg.io/bw4/77.png",
     "subtype": "Basic",
@@ -4049,7 +4126,8 @@
     ]
   },
   {
-    "id": "bw4-78",
+    "setOrder":51,
+	"id": "bw4-78",
     "name": "Jigglypuff",
     "imageUrl": "https://images.pokemontcg.io/bw4/78.png",
     "subtype": "Basic",
@@ -4103,7 +4181,8 @@
     ]
   },
   {
-    "id": "bw4-79",
+    "setOrder":51,
+	"id": "bw4-79",
     "name": "Wigglytuff",
     "imageUrl": "https://images.pokemontcg.io/bw4/79.png",
     "subtype": "Stage 1",
@@ -4157,7 +4236,8 @@
     "nationalPokedexNumber": 40
   },
   {
-    "id": "bw4-80",
+    "setOrder":51,
+	"id": "bw4-80",
     "name": "Meowth",
     "imageUrl": "https://images.pokemontcg.io/bw4/80.png",
     "subtype": "Basic",
@@ -4210,7 +4290,8 @@
     ]
   },
   {
-    "id": "bw4-81",
+    "setOrder":51,
+	"id": "bw4-81",
     "name": "Persian",
     "imageUrl": "https://images.pokemontcg.io/bw4/81.png",
     "subtype": "Stage 1",
@@ -4261,7 +4342,8 @@
     "nationalPokedexNumber": 53
   },
   {
-    "id": "bw4-82",
+    "setOrder":51,
+	"id": "bw4-82",
     "name": "Regigigas-EX",
     "imageUrl": "https://images.pokemontcg.io/bw4/82.png",
     "subtype": "EX",
@@ -4321,7 +4403,8 @@
     "nationalPokedexNumber": 486
   },
   {
-    "id": "bw4-83",
+    "setOrder":51,
+	"id": "bw4-83",
     "name": "Pidove",
     "imageUrl": "https://images.pokemontcg.io/bw4/83.png",
     "subtype": "Basic",
@@ -4380,7 +4463,8 @@
     ]
   },
   {
-    "id": "bw4-84",
+    "setOrder":51,
+	"id": "bw4-84",
     "name": "Minccino",
     "imageUrl": "https://images.pokemontcg.io/bw4/84.png",
     "subtype": "Basic",
@@ -4433,7 +4517,8 @@
     ]
   },
   {
-    "id": "bw4-85",
+    "setOrder":51,
+	"id": "bw4-85",
     "name": "Cinccino",
     "imageUrl": "https://images.pokemontcg.io/bw4/85.png",
     "subtype": "Stage 1",
@@ -4481,7 +4566,8 @@
     "nationalPokedexNumber": 573
   },
   {
-    "id": "bw4-86",
+    "setOrder":51,
+	"id": "bw4-86",
     "name": "Cilan",
     "imageUrl": "https://images.pokemontcg.io/bw4/86.png",
     "subtype": "Supporter",
@@ -4498,7 +4584,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw4/86_hires.png"
   },
   {
-    "id": "bw4-87",
+    "setOrder":51,
+	"id": "bw4-87",
     "name": "Exp. Share",
     "imageUrl": "https://images.pokemontcg.io/bw4/87.png",
     "subtype": "Pokémon Tool",
@@ -4515,7 +4602,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw4/87_hires.png"
   },
   {
-    "id": "bw4-88",
+    "setOrder":51,
+	"id": "bw4-88",
     "name": "Heavy Ball",
     "imageUrl": "https://images.pokemontcg.io/bw4/88.png",
     "subtype": "Item",
@@ -4532,7 +4620,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw4/88_hires.png"
   },
   {
-    "id": "bw4-89",
+    "setOrder":51,
+	"id": "bw4-89",
     "name": "Level Ball",
     "imageUrl": "https://images.pokemontcg.io/bw4/89.png",
     "subtype": "Item",
@@ -4549,7 +4638,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw4/89_hires.png"
   },
   {
-    "id": "bw4-90",
+    "setOrder":51,
+	"id": "bw4-90",
     "name": "Pokémon Center",
     "imageUrl": "https://images.pokemontcg.io/bw4/90.png",
     "subtype": "Stadium",
@@ -4567,7 +4657,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw4/90_hires.png"
   },
   {
-    "id": "bw4-91",
+    "setOrder":51,
+	"id": "bw4-91",
     "name": "Skyarrow Bridge",
     "imageUrl": "https://images.pokemontcg.io/bw4/91.png",
     "subtype": "Stadium",
@@ -4584,7 +4675,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw4/91_hires.png"
   },
   {
-    "id": "bw4-92",
+    "setOrder":51,
+	"id": "bw4-92",
     "name": "Double Colorless Energy",
     "imageUrl": "https://images.pokemontcg.io/bw4/92.png",
     "subtype": "Special",
@@ -4601,7 +4693,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw4/92_hires.png"
   },
   {
-    "id": "bw4-93",
+    "setOrder":51,
+	"id": "bw4-93",
     "name": "Prism Energy",
     "imageUrl": "https://images.pokemontcg.io/bw4/93.png",
     "subtype": "Special",
@@ -4618,7 +4711,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw4/93_hires.png"
   },
   {
-    "id": "bw4-94",
+    "setOrder":51,
+	"id": "bw4-94",
     "name": "Shaymin-EX",
     "imageUrl": "https://images.pokemontcg.io/bw4/94.png",
     "subtype": "EX",
@@ -4677,7 +4771,8 @@
     "nationalPokedexNumber": 492
   },
   {
-    "id": "bw4-95",
+    "setOrder":51,
+	"id": "bw4-95",
     "name": "Reshiram-EX",
     "imageUrl": "https://images.pokemontcg.io/bw4/95.png",
     "subtype": "EX",
@@ -4736,7 +4831,8 @@
     "nationalPokedexNumber": 643
   },
   {
-    "id": "bw4-96",
+    "setOrder":51,
+	"id": "bw4-96",
     "name": "Kyurem-EX",
     "imageUrl": "https://images.pokemontcg.io/bw4/96.png",
     "subtype": "EX",
@@ -4795,7 +4891,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "bw4-97",
+    "setOrder":51,
+	"id": "bw4-97",
     "name": "Zekrom-EX",
     "imageUrl": "https://images.pokemontcg.io/bw4/97.png",
     "subtype": "EX",
@@ -4854,7 +4951,8 @@
     "nationalPokedexNumber": 644
   },
   {
-    "id": "bw4-98",
+    "setOrder":51,
+	"id": "bw4-98",
     "name": "Mewtwo-EX",
     "imageUrl": "https://images.pokemontcg.io/bw4/98.png",
     "subtype": "EX",
@@ -4911,7 +5009,8 @@
     "evolvesTo": "M Mewtwo-EX"
   },
   {
-    "id": "bw4-99",
+    "setOrder":51,
+	"id": "bw4-99",
     "name": "Regigigas-EX",
     "imageUrl": "https://images.pokemontcg.io/bw4/99.png",
     "subtype": "EX",
@@ -4971,7 +5070,8 @@
     "nationalPokedexNumber": 486
   },
   {
-    "id": "bw4-100",
+    "setOrder":51,
+	"id": "bw4-100",
     "name": "Emboar",
     "imageUrl": "https://images.pokemontcg.io/bw4/100.png",
     "subtype": "Stage 2",

--- a/json/cards/Noble Victories.json
+++ b/json/cards/Noble Victories.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "bw3-1",
+    "setOrder":50,
+	"id": "bw3-1",
     "name": "Sewaddle",
     "imageUrl": "https://images.pokemontcg.io/bw3/1.png",
     "subtype": "Basic",
@@ -44,7 +45,8 @@
     ]
   },
   {
-    "id": "bw3-2",
+    "setOrder":50,
+	"id": "bw3-2",
     "name": "Swadloon",
     "imageUrl": "https://images.pokemontcg.io/bw3/2.png",
     "subtype": "Stage 1",
@@ -98,7 +100,8 @@
     ]
   },
   {
-    "id": "bw3-3",
+    "setOrder":50,
+	"id": "bw3-3",
     "name": "Leavanny",
     "imageUrl": "https://images.pokemontcg.io/bw3/3.png",
     "subtype": "Stage 2",
@@ -147,7 +150,8 @@
     "nationalPokedexNumber": 542
   },
   {
-    "id": "bw3-4",
+    "setOrder":50,
+	"id": "bw3-4",
     "name": "Petilil",
     "imageUrl": "https://images.pokemontcg.io/bw3/4.png",
     "subtype": "Basic",
@@ -206,7 +210,8 @@
     ]
   },
   {
-    "id": "bw3-5",
+    "setOrder":50,
+	"id": "bw3-5",
     "name": "Lilligant",
     "imageUrl": "https://images.pokemontcg.io/bw3/5.png",
     "subtype": "Stage 1",
@@ -263,7 +268,8 @@
     "nationalPokedexNumber": 549
   },
   {
-    "id": "bw3-6",
+    "setOrder":50,
+	"id": "bw3-6",
     "name": "Dwebble",
     "imageUrl": "https://images.pokemontcg.io/bw3/6.png",
     "subtype": "Basic",
@@ -317,7 +323,8 @@
     ]
   },
   {
-    "id": "bw3-7",
+    "setOrder":50,
+	"id": "bw3-7",
     "name": "Crustle",
     "imageUrl": "https://images.pokemontcg.io/bw3/7.png",
     "subtype": "Stage 1",
@@ -372,7 +379,8 @@
     "nationalPokedexNumber": 558
   },
   {
-    "id": "bw3-8",
+    "setOrder":50,
+	"id": "bw3-8",
     "name": "Karrablast",
     "imageUrl": "https://images.pokemontcg.io/bw3/8.png",
     "subtype": "Basic",
@@ -425,7 +433,8 @@
     ]
   },
   {
-    "id": "bw3-9",
+    "setOrder":50,
+	"id": "bw3-9",
     "name": "Foongus",
     "imageUrl": "https://images.pokemontcg.io/bw3/9.png",
     "subtype": "Basic",
@@ -474,7 +483,8 @@
     ]
   },
   {
-    "id": "bw3-10",
+    "setOrder":50,
+	"id": "bw3-10",
     "name": "Amoonguss",
     "imageUrl": "https://images.pokemontcg.io/bw3/10.png",
     "subtype": "Stage 1",
@@ -532,7 +542,8 @@
     "nationalPokedexNumber": 591
   },
   {
-    "id": "bw3-11",
+    "setOrder":50,
+	"id": "bw3-11",
     "name": "Shelmet",
     "imageUrl": "https://images.pokemontcg.io/bw3/11.png",
     "subtype": "Basic",
@@ -586,7 +597,8 @@
     ]
   },
   {
-    "id": "bw3-12",
+    "setOrder":50,
+	"id": "bw3-12",
     "name": "Accelgor",
     "imageUrl": "https://images.pokemontcg.io/bw3/12.png",
     "subtype": "Stage 1",
@@ -633,7 +645,8 @@
     "nationalPokedexNumber": 617
   },
   {
-    "id": "bw3-13",
+    "setOrder":50,
+	"id": "bw3-13",
     "name": "Virizion",
     "imageUrl": "https://images.pokemontcg.io/bw3/13.png",
     "subtype": "Basic",
@@ -689,7 +702,8 @@
     "nationalPokedexNumber": 640
   },
   {
-    "id": "bw3-14",
+    "setOrder":50,
+	"id": "bw3-14",
     "name": "Victini",
     "imageUrl": "https://images.pokemontcg.io/bw3/14.png",
     "subtype": "Basic",
@@ -735,7 +749,8 @@
     "nationalPokedexNumber": 494
   },
   {
-    "id": "bw3-15",
+    "setOrder":50,
+	"id": "bw3-15",
     "name": "Victini",
     "imageUrl": "https://images.pokemontcg.io/bw3/15.png",
     "subtype": "Basic",
@@ -776,7 +791,8 @@
     "nationalPokedexNumber": 494
   },
   {
-    "id": "bw3-16",
+    "setOrder":50,
+	"id": "bw3-16",
     "name": "Pansear",
     "imageUrl": "https://images.pokemontcg.io/bw3/16.png",
     "subtype": "Basic",
@@ -831,7 +847,8 @@
     ]
   },
   {
-    "id": "bw3-17",
+    "setOrder":50,
+	"id": "bw3-17",
     "name": "Simisear",
     "imageUrl": "https://images.pokemontcg.io/bw3/17.png",
     "subtype": "Stage 1",
@@ -884,7 +901,8 @@
     "nationalPokedexNumber": 514
   },
   {
-    "id": "bw3-18",
+    "setOrder":50,
+	"id": "bw3-18",
     "name": "Heatmor",
     "imageUrl": "https://images.pokemontcg.io/bw3/18.png",
     "subtype": "Basic",
@@ -935,7 +953,8 @@
     "nationalPokedexNumber": 631
   },
   {
-    "id": "bw3-19",
+    "setOrder":50,
+	"id": "bw3-19",
     "name": "Larvesta",
     "imageUrl": "https://images.pokemontcg.io/bw3/19.png",
     "subtype": "Basic",
@@ -979,7 +998,8 @@
     ]
   },
   {
-    "id": "bw3-20",
+    "setOrder":50,
+	"id": "bw3-20",
     "name": "Larvesta",
     "imageUrl": "https://images.pokemontcg.io/bw3/20.png",
     "subtype": "Basic",
@@ -1024,7 +1044,8 @@
     ]
   },
   {
-    "id": "bw3-21",
+    "setOrder":50,
+	"id": "bw3-21",
     "name": "Volcarona",
     "imageUrl": "https://images.pokemontcg.io/bw3/21.png",
     "subtype": "Stage 1",
@@ -1076,7 +1097,8 @@
     "nationalPokedexNumber": 637
   },
   {
-    "id": "bw3-22",
+    "setOrder":50,
+	"id": "bw3-22",
     "name": "Tympole",
     "imageUrl": "https://images.pokemontcg.io/bw3/22.png",
     "subtype": "Basic",
@@ -1129,7 +1151,8 @@
     ]
   },
   {
-    "id": "bw3-23",
+    "setOrder":50,
+	"id": "bw3-23",
     "name": "Palpitoad",
     "imageUrl": "https://images.pokemontcg.io/bw3/23.png",
     "subtype": "Stage 1",
@@ -1185,7 +1208,8 @@
     ]
   },
   {
-    "id": "bw3-24",
+    "setOrder":50,
+	"id": "bw3-24",
     "name": "Seismitoad",
     "imageUrl": "https://images.pokemontcg.io/bw3/24.png",
     "subtype": "Stage 2",
@@ -1240,7 +1264,8 @@
     "nationalPokedexNumber": 537
   },
   {
-    "id": "bw3-25",
+    "setOrder":50,
+	"id": "bw3-25",
     "name": "Tirtouga",
     "imageUrl": "https://images.pokemontcg.io/bw3/25.png",
     "subtype": "Restored",
@@ -1300,7 +1325,8 @@
     ]
   },
   {
-    "id": "bw3-26",
+    "setOrder":50,
+	"id": "bw3-26",
     "name": "Carracosta",
     "imageUrl": "https://images.pokemontcg.io/bw3/26.png",
     "subtype": "Stage 1",
@@ -1352,7 +1378,8 @@
     "nationalPokedexNumber": 565
   },
   {
-    "id": "bw3-27",
+    "setOrder":50,
+	"id": "bw3-27",
     "name": "Vanillite",
     "imageUrl": "https://images.pokemontcg.io/bw3/27.png",
     "subtype": "Basic",
@@ -1395,7 +1422,8 @@
     ]
   },
   {
-    "id": "bw3-28",
+    "setOrder":50,
+	"id": "bw3-28",
     "name": "Vanillish",
     "imageUrl": "https://images.pokemontcg.io/bw3/28.png",
     "subtype": "Stage 1",
@@ -1451,7 +1479,8 @@
     ]
   },
   {
-    "id": "bw3-29",
+    "setOrder":50,
+	"id": "bw3-29",
     "name": "Vanilluxe",
     "imageUrl": "https://images.pokemontcg.io/bw3/29.png",
     "subtype": "Stage 2",
@@ -1504,7 +1533,8 @@
     "nationalPokedexNumber": 584
   },
   {
-    "id": "bw3-30",
+    "setOrder":50,
+	"id": "bw3-30",
     "name": "Frillish",
     "imageUrl": "https://images.pokemontcg.io/bw3/30.png",
     "subtype": "Basic",
@@ -1549,7 +1579,8 @@
     ]
   },
   {
-    "id": "bw3-31",
+    "setOrder":50,
+	"id": "bw3-31",
     "name": "Jellicent",
     "imageUrl": "https://images.pokemontcg.io/bw3/31.png",
     "subtype": "Stage 1",
@@ -1598,7 +1629,8 @@
     "nationalPokedexNumber": 593
   },
   {
-    "id": "bw3-32",
+    "setOrder":50,
+	"id": "bw3-32",
     "name": "Cryogonal",
     "imageUrl": "https://images.pokemontcg.io/bw3/32.png",
     "subtype": "Basic",
@@ -1648,7 +1680,8 @@
     "nationalPokedexNumber": 615
   },
   {
-    "id": "bw3-33",
+    "setOrder":50,
+	"id": "bw3-33",
     "name": "Cryogonal",
     "imageUrl": "https://images.pokemontcg.io/bw3/33.png",
     "subtype": "Basic",
@@ -1698,7 +1731,8 @@
     "nationalPokedexNumber": 615
   },
   {
-    "id": "bw3-34",
+    "setOrder":50,
+	"id": "bw3-34",
     "name": "Kyurem",
     "imageUrl": "https://images.pokemontcg.io/bw3/34.png",
     "subtype": "Basic",
@@ -1751,7 +1785,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "bw3-35",
+    "setOrder":50,
+	"id": "bw3-35",
     "name": "Blitzle",
     "imageUrl": "https://images.pokemontcg.io/bw3/35.png",
     "subtype": "Basic",
@@ -1794,7 +1829,8 @@
     ]
   },
   {
-    "id": "bw3-36",
+    "setOrder":50,
+	"id": "bw3-36",
     "name": "Zebstrika",
     "imageUrl": "https://images.pokemontcg.io/bw3/36.png",
     "subtype": "Stage 1",
@@ -1846,7 +1882,8 @@
     "nationalPokedexNumber": 523
   },
   {
-    "id": "bw3-37",
+    "setOrder":50,
+	"id": "bw3-37",
     "name": "Emolga",
     "imageUrl": "https://images.pokemontcg.io/bw3/37.png",
     "subtype": "Basic",
@@ -1886,7 +1923,8 @@
     "nationalPokedexNumber": 587
   },
   {
-    "id": "bw3-38",
+    "setOrder":50,
+	"id": "bw3-38",
     "name": "Tynamo",
     "imageUrl": "https://images.pokemontcg.io/bw3/38.png",
     "subtype": "Basic",
@@ -1929,7 +1967,8 @@
     ]
   },
   {
-    "id": "bw3-39",
+    "setOrder":50,
+	"id": "bw3-39",
     "name": "Tynamo",
     "imageUrl": "https://images.pokemontcg.io/bw3/39.png",
     "subtype": "Basic",
@@ -1969,7 +2008,8 @@
     ]
   },
   {
-    "id": "bw3-40",
+    "setOrder":50,
+	"id": "bw3-40",
     "name": "Eelektrik",
     "imageUrl": "https://images.pokemontcg.io/bw3/40.png",
     "subtype": "Stage 1",
@@ -2021,7 +2061,8 @@
     ]
   },
   {
-    "id": "bw3-41",
+    "setOrder":50,
+	"id": "bw3-41",
     "name": "Eelektross",
     "imageUrl": "https://images.pokemontcg.io/bw3/41.png",
     "subtype": "Stage 2",
@@ -2076,7 +2117,8 @@
     "nationalPokedexNumber": 604
   },
   {
-    "id": "bw3-42",
+    "setOrder":50,
+	"id": "bw3-42",
     "name": "Stunfisk",
     "imageUrl": "https://images.pokemontcg.io/bw3/42.png",
     "subtype": "Basic",
@@ -2129,7 +2171,8 @@
     "nationalPokedexNumber": 618
   },
   {
-    "id": "bw3-43",
+    "setOrder":50,
+	"id": "bw3-43",
     "name": "Victini",
     "imageUrl": "https://images.pokemontcg.io/bw3/43.png",
     "subtype": "Basic",
@@ -2169,7 +2212,8 @@
     "nationalPokedexNumber": 494
   },
   {
-    "id": "bw3-44",
+    "setOrder":50,
+	"id": "bw3-44",
     "name": "Yamask",
     "imageUrl": "https://images.pokemontcg.io/bw3/44.png",
     "subtype": "Basic",
@@ -2212,7 +2256,8 @@
     ]
   },
   {
-    "id": "bw3-45",
+    "setOrder":50,
+	"id": "bw3-45",
     "name": "Yamask",
     "imageUrl": "https://images.pokemontcg.io/bw3/45.png",
     "subtype": "Basic",
@@ -2255,7 +2300,8 @@
     ]
   },
   {
-    "id": "bw3-46",
+    "setOrder":50,
+	"id": "bw3-46",
     "name": "Cofagrigus",
     "imageUrl": "https://images.pokemontcg.io/bw3/46.png",
     "subtype": "Stage 1",
@@ -2310,7 +2356,8 @@
     "nationalPokedexNumber": 563
   },
   {
-    "id": "bw3-47",
+    "setOrder":50,
+	"id": "bw3-47",
     "name": "Cofagrigus",
     "imageUrl": "https://images.pokemontcg.io/bw3/47.png",
     "subtype": "Stage 1",
@@ -2358,7 +2405,8 @@
     "nationalPokedexNumber": 563
   },
   {
-    "id": "bw3-48",
+    "setOrder":50,
+	"id": "bw3-48",
     "name": "Trubbish",
     "imageUrl": "https://images.pokemontcg.io/bw3/48.png",
     "subtype": "Basic",
@@ -2411,7 +2459,8 @@
     ]
   },
   {
-    "id": "bw3-49",
+    "setOrder":50,
+	"id": "bw3-49",
     "name": "Garbodor",
     "imageUrl": "https://images.pokemontcg.io/bw3/49.png",
     "subtype": "Stage 1",
@@ -2466,7 +2515,8 @@
     "nationalPokedexNumber": 569
   },
   {
-    "id": "bw3-50",
+    "setOrder":50,
+	"id": "bw3-50",
     "name": "Solosis",
     "imageUrl": "https://images.pokemontcg.io/bw3/50.png",
     "subtype": "Basic",
@@ -2509,7 +2559,8 @@
     ]
   },
   {
-    "id": "bw3-51",
+    "setOrder":50,
+	"id": "bw3-51",
     "name": "Duosion",
     "imageUrl": "https://images.pokemontcg.io/bw3/51.png",
     "subtype": "Stage 1",
@@ -2553,7 +2604,8 @@
     ]
   },
   {
-    "id": "bw3-52",
+    "setOrder":50,
+	"id": "bw3-52",
     "name": "Reuniclus",
     "imageUrl": "https://images.pokemontcg.io/bw3/52.png",
     "subtype": "Stage 2",
@@ -2604,7 +2656,8 @@
     "nationalPokedexNumber": 579
   },
   {
-    "id": "bw3-53",
+    "setOrder":50,
+	"id": "bw3-53",
     "name": "Reuniclus",
     "imageUrl": "https://images.pokemontcg.io/bw3/53.png",
     "subtype": "Stage 2",
@@ -2657,7 +2710,8 @@
     "nationalPokedexNumber": 579
   },
   {
-    "id": "bw3-54",
+    "setOrder":50,
+	"id": "bw3-54",
     "name": "Elgyem",
     "imageUrl": "https://images.pokemontcg.io/bw3/54.png",
     "subtype": "Basic",
@@ -2709,7 +2763,8 @@
     ]
   },
   {
-    "id": "bw3-55",
+    "setOrder":50,
+	"id": "bw3-55",
     "name": "Elgyem",
     "imageUrl": "https://images.pokemontcg.io/bw3/55.png",
     "subtype": "Basic",
@@ -2762,7 +2817,8 @@
     ]
   },
   {
-    "id": "bw3-56",
+    "setOrder":50,
+	"id": "bw3-56",
     "name": "Beheeyem",
     "imageUrl": "https://images.pokemontcg.io/bw3/56.png",
     "subtype": "Stage 1",
@@ -2813,7 +2869,8 @@
     "nationalPokedexNumber": 606
   },
   {
-    "id": "bw3-57",
+    "setOrder":50,
+	"id": "bw3-57",
     "name": "Litwick",
     "imageUrl": "https://images.pokemontcg.io/bw3/57.png",
     "subtype": "Basic",
@@ -2857,7 +2914,8 @@
     ]
   },
   {
-    "id": "bw3-58",
+    "setOrder":50,
+	"id": "bw3-58",
     "name": "Litwick",
     "imageUrl": "https://images.pokemontcg.io/bw3/58.png",
     "subtype": "Basic",
@@ -2900,7 +2958,8 @@
     ]
   },
   {
-    "id": "bw3-59",
+    "setOrder":50,
+	"id": "bw3-59",
     "name": "Lampent",
     "imageUrl": "https://images.pokemontcg.io/bw3/59.png",
     "subtype": "Stage 1",
@@ -2954,7 +3013,8 @@
     ]
   },
   {
-    "id": "bw3-60",
+    "setOrder":50,
+	"id": "bw3-60",
     "name": "Chandelure",
     "imageUrl": "https://images.pokemontcg.io/bw3/60.png",
     "subtype": "Stage 2",
@@ -3003,7 +3063,8 @@
     "nationalPokedexNumber": 609
   },
   {
-    "id": "bw3-61",
+    "setOrder":50,
+	"id": "bw3-61",
     "name": "Gigalith",
     "imageUrl": "https://images.pokemontcg.io/bw3/61.png",
     "subtype": "Stage 2",
@@ -3059,7 +3120,8 @@
     "nationalPokedexNumber": 526
   },
   {
-    "id": "bw3-62",
+    "setOrder":50,
+	"id": "bw3-62",
     "name": "Timburr",
     "imageUrl": "https://images.pokemontcg.io/bw3/62.png",
     "subtype": "Basic",
@@ -3103,7 +3165,8 @@
     ]
   },
   {
-    "id": "bw3-63",
+    "setOrder":50,
+	"id": "bw3-63",
     "name": "Gurdurr",
     "imageUrl": "https://images.pokemontcg.io/bw3/63.png",
     "subtype": "Stage 1",
@@ -3161,7 +3224,8 @@
     ]
   },
   {
-    "id": "bw3-64",
+    "setOrder":50,
+	"id": "bw3-64",
     "name": "Conkeldurr",
     "imageUrl": "https://images.pokemontcg.io/bw3/64.png",
     "subtype": "Stage 2",
@@ -3213,7 +3277,8 @@
     "nationalPokedexNumber": 534
   },
   {
-    "id": "bw3-65",
+    "setOrder":50,
+	"id": "bw3-65",
     "name": "Conkeldurr",
     "imageUrl": "https://images.pokemontcg.io/bw3/65.png",
     "subtype": "Stage 2",
@@ -3267,7 +3332,8 @@
     "nationalPokedexNumber": 534
   },
   {
-    "id": "bw3-66",
+    "setOrder":50,
+	"id": "bw3-66",
     "name": "Archen",
     "imageUrl": "https://images.pokemontcg.io/bw3/66.png",
     "subtype": "Restored",
@@ -3323,7 +3389,8 @@
     ]
   },
   {
-    "id": "bw3-67",
+    "setOrder":50,
+	"id": "bw3-67",
     "name": "Archeops",
     "imageUrl": "https://images.pokemontcg.io/bw3/67.png",
     "subtype": "Stage 1",
@@ -3372,7 +3439,8 @@
     "nationalPokedexNumber": 567
   },
   {
-    "id": "bw3-68",
+    "setOrder":50,
+	"id": "bw3-68",
     "name": "Stunfisk",
     "imageUrl": "https://images.pokemontcg.io/bw3/68.png",
     "subtype": "Basic",
@@ -3430,7 +3498,8 @@
     "nationalPokedexNumber": 618
   },
   {
-    "id": "bw3-69",
+    "setOrder":50,
+	"id": "bw3-69",
     "name": "Mienfoo",
     "imageUrl": "https://images.pokemontcg.io/bw3/69.png",
     "subtype": "Basic",
@@ -3483,7 +3552,8 @@
     ]
   },
   {
-    "id": "bw3-70",
+    "setOrder":50,
+	"id": "bw3-70",
     "name": "Mienshao",
     "imageUrl": "https://images.pokemontcg.io/bw3/70.png",
     "subtype": "Stage 1",
@@ -3534,7 +3604,8 @@
     "nationalPokedexNumber": 620
   },
   {
-    "id": "bw3-71",
+    "setOrder":50,
+	"id": "bw3-71",
     "name": "Golett",
     "imageUrl": "https://images.pokemontcg.io/bw3/71.png",
     "subtype": "Basic",
@@ -3586,7 +3657,8 @@
     ]
   },
   {
-    "id": "bw3-72",
+    "setOrder":50,
+	"id": "bw3-72",
     "name": "Golurk",
     "imageUrl": "https://images.pokemontcg.io/bw3/72.png",
     "subtype": "Stage 1",
@@ -3650,7 +3722,8 @@
     "nationalPokedexNumber": 623
   },
   {
-    "id": "bw3-73",
+    "setOrder":50,
+	"id": "bw3-73",
     "name": "Terrakion",
     "imageUrl": "https://images.pokemontcg.io/bw3/73.png",
     "subtype": "Basic",
@@ -3705,7 +3778,8 @@
     "nationalPokedexNumber": 639
   },
   {
-    "id": "bw3-74",
+    "setOrder":50,
+	"id": "bw3-74",
     "name": "Landorus",
     "imageUrl": "https://images.pokemontcg.io/bw3/74.png",
     "subtype": "Basic",
@@ -3762,7 +3836,8 @@
     "nationalPokedexNumber": 645
   },
   {
-    "id": "bw3-75",
+    "setOrder":50,
+	"id": "bw3-75",
     "name": "Pawniard",
     "imageUrl": "https://images.pokemontcg.io/bw3/75.png",
     "subtype": "Basic",
@@ -3811,7 +3886,8 @@
     ]
   },
   {
-    "id": "bw3-76",
+    "setOrder":50,
+	"id": "bw3-76",
     "name": "Bisharp",
     "imageUrl": "https://images.pokemontcg.io/bw3/76.png",
     "subtype": "Stage 1",
@@ -3868,7 +3944,8 @@
     "nationalPokedexNumber": 625
   },
   {
-    "id": "bw3-77",
+    "setOrder":50,
+	"id": "bw3-77",
     "name": "Deino",
     "imageUrl": "https://images.pokemontcg.io/bw3/77.png",
     "subtype": "Basic",
@@ -3928,7 +4005,8 @@
     ]
   },
   {
-    "id": "bw3-78",
+    "setOrder":50,
+	"id": "bw3-78",
     "name": "Zweilous",
     "imageUrl": "https://images.pokemontcg.io/bw3/78.png",
     "subtype": "Stage 1",
@@ -3990,7 +4068,8 @@
     ]
   },
   {
-    "id": "bw3-79",
+    "setOrder":50,
+	"id": "bw3-79",
     "name": "Hydreigon",
     "imageUrl": "https://images.pokemontcg.io/bw3/79.png",
     "subtype": "Stage 2",
@@ -4047,7 +4126,8 @@
     "nationalPokedexNumber": 635
   },
   {
-    "id": "bw3-80",
+    "setOrder":50,
+	"id": "bw3-80",
     "name": "Escavalier",
     "imageUrl": "https://images.pokemontcg.io/bw3/80.png",
     "subtype": "Stage 1",
@@ -4108,7 +4188,8 @@
     "nationalPokedexNumber": 589
   },
   {
-    "id": "bw3-81",
+    "setOrder":50,
+	"id": "bw3-81",
     "name": "Pawniard",
     "imageUrl": "https://images.pokemontcg.io/bw3/81.png",
     "subtype": "Basic",
@@ -4167,7 +4248,8 @@
     ]
   },
   {
-    "id": "bw3-82",
+    "setOrder":50,
+	"id": "bw3-82",
     "name": "Bisharp",
     "imageUrl": "https://images.pokemontcg.io/bw3/82.png",
     "subtype": "Stage 1",
@@ -4226,7 +4308,8 @@
     "nationalPokedexNumber": 625
   },
   {
-    "id": "bw3-83",
+    "setOrder":50,
+	"id": "bw3-83",
     "name": "Durant",
     "imageUrl": "https://images.pokemontcg.io/bw3/83.png",
     "subtype": "Basic",
@@ -4282,7 +4365,8 @@
     "nationalPokedexNumber": 632
   },
   {
-    "id": "bw3-84",
+    "setOrder":50,
+	"id": "bw3-84",
     "name": "Cobalion",
     "imageUrl": "https://images.pokemontcg.io/bw3/84.png",
     "subtype": "Basic",
@@ -4341,7 +4425,8 @@
     "nationalPokedexNumber": 638
   },
   {
-    "id": "bw3-85",
+    "setOrder":50,
+	"id": "bw3-85",
     "name": "Audino",
     "imageUrl": "https://images.pokemontcg.io/bw3/85.png",
     "subtype": "Basic",
@@ -4383,7 +4468,8 @@
     "nationalPokedexNumber": 531
   },
   {
-    "id": "bw3-86",
+    "setOrder":50,
+	"id": "bw3-86",
     "name": "Axew",
     "imageUrl": "https://images.pokemontcg.io/bw3/86.png",
     "subtype": "Basic",
@@ -4420,7 +4506,8 @@
     ]
   },
   {
-    "id": "bw3-87",
+    "setOrder":50,
+	"id": "bw3-87",
     "name": "Fraxure",
     "imageUrl": "https://images.pokemontcg.io/bw3/87.png",
     "subtype": "Stage 1",
@@ -4469,7 +4556,8 @@
     ]
   },
   {
-    "id": "bw3-88",
+    "setOrder":50,
+	"id": "bw3-88",
     "name": "Haxorus",
     "imageUrl": "https://images.pokemontcg.io/bw3/88.png",
     "subtype": "Stage 2",
@@ -4517,7 +4605,8 @@
     "nationalPokedexNumber": 612
   },
   {
-    "id": "bw3-89",
+    "setOrder":50,
+	"id": "bw3-89",
     "name": "Druddigon",
     "imageUrl": "https://images.pokemontcg.io/bw3/89.png",
     "subtype": "Basic",
@@ -4559,7 +4648,8 @@
     "nationalPokedexNumber": 621
   },
   {
-    "id": "bw3-90",
+    "setOrder":50,
+	"id": "bw3-90",
     "name": "Cover Fossil",
     "imageUrl": "https://images.pokemontcg.io/bw3/90.png",
     "subtype": "Item",
@@ -4576,7 +4666,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw3/90_hires.png"
   },
   {
-    "id": "bw3-91",
+    "setOrder":50,
+	"id": "bw3-91",
     "name": "Eviolite",
     "imageUrl": "https://images.pokemontcg.io/bw3/91.png",
     "subtype": "Pokémon Tool",
@@ -4594,7 +4685,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw3/91_hires.png"
   },
   {
-    "id": "bw3-92",
+    "setOrder":50,
+	"id": "bw3-92",
     "name": "N",
     "imageUrl": "https://images.pokemontcg.io/bw3/92.png",
     "subtype": "Supporter",
@@ -4611,7 +4703,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw3/92_hires.png"
   },
   {
-    "id": "bw3-93",
+    "setOrder":50,
+	"id": "bw3-93",
     "name": "Plume Fossil",
     "imageUrl": "https://images.pokemontcg.io/bw3/93.png",
     "subtype": "Item",
@@ -4628,7 +4721,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw3/93_hires.png"
   },
   {
-    "id": "bw3-94",
+    "setOrder":50,
+	"id": "bw3-94",
     "name": "Rocky Helmet",
     "imageUrl": "https://images.pokemontcg.io/bw3/94.png",
     "subtype": "Pokémon Tool",
@@ -4645,7 +4739,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw3/94_hires.png"
   },
   {
-    "id": "bw3-95",
+    "setOrder":50,
+	"id": "bw3-95",
     "name": "Super Rod",
     "imageUrl": "https://images.pokemontcg.io/bw3/95.png",
     "subtype": "Item",
@@ -4662,7 +4757,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw3/95_hires.png"
   },
   {
-    "id": "bw3-96",
+    "setOrder":50,
+	"id": "bw3-96",
     "name": "Xtransceiver",
     "imageUrl": "https://images.pokemontcg.io/bw3/96.png",
     "subtype": "Item",
@@ -4679,7 +4775,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw3/96_hires.png"
   },
   {
-    "id": "bw3-97",
+    "setOrder":50,
+	"id": "bw3-97",
     "name": "Virizion",
     "imageUrl": "https://images.pokemontcg.io/bw3/97.png",
     "subtype": "Basic",
@@ -4735,7 +4832,8 @@
     "nationalPokedexNumber": 640
   },
   {
-    "id": "bw3-98",
+    "setOrder":50,
+	"id": "bw3-98",
     "name": "Victini",
     "imageUrl": "https://images.pokemontcg.io/bw3/98.png",
     "subtype": "Basic",
@@ -4781,7 +4879,8 @@
     "nationalPokedexNumber": 494
   },
   {
-    "id": "bw3-99",
+    "setOrder":50,
+	"id": "bw3-99",
     "name": "Terrakion",
     "imageUrl": "https://images.pokemontcg.io/bw3/99.png",
     "subtype": "Basic",
@@ -4836,7 +4935,8 @@
     "nationalPokedexNumber": 639
   },
   {
-    "id": "bw3-100",
+    "setOrder":50,
+	"id": "bw3-100",
     "name": "Cobalion",
     "imageUrl": "https://images.pokemontcg.io/bw3/100.png",
     "subtype": "Basic",
@@ -4895,7 +4995,8 @@
     "nationalPokedexNumber": 638
   },
   {
-    "id": "bw3-101",
+    "setOrder":50,
+	"id": "bw3-101",
     "name": "N",
     "imageUrl": "https://images.pokemontcg.io/bw3/101.png",
     "subtype": "Supporter",
@@ -4912,7 +5013,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw3/101_hires.png"
   },
   {
-    "id": "bw3-102",
+    "setOrder":50,
+	"id": "bw3-102",
     "name": "Meowth",
     "imageUrl": "https://images.pokemontcg.io/bw3/102.png",
     "subtype": "Basic",

--- a/json/cards/Phantom Forces.json
+++ b/json/cards/Phantom Forces.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "xy4-1",
+    "setOrder":62,
+	"id": "xy4-1",
     "name": "Venonat",
     "imageUrl": "https://images.pokemontcg.io/xy4/1.png",
     "subtype": "Basic",
@@ -44,7 +45,8 @@
     ]
   },
   {
-    "id": "xy4-2",
+    "setOrder":62,
+	"id": "xy4-2",
     "name": "Venomoth",
     "imageUrl": "https://images.pokemontcg.io/xy4/2.png",
     "subtype": "Stage 1",
@@ -96,7 +98,8 @@
     "nationalPokedexNumber": 49
   },
   {
-    "id": "xy4-3",
+    "setOrder":62,
+	"id": "xy4-3",
     "name": "Yanma",
     "imageUrl": "https://images.pokemontcg.io/xy4/3.png",
     "subtype": "Basic",
@@ -146,7 +149,8 @@
     ]
   },
   {
-    "id": "xy4-4",
+    "setOrder":62,
+	"id": "xy4-4",
     "name": "Yanmega",
     "imageUrl": "https://images.pokemontcg.io/xy4/4.png",
     "subtype": "Stage 1",
@@ -201,7 +205,8 @@
     "nationalPokedexNumber": 469
   },
   {
-    "id": "xy4-5",
+    "setOrder":62,
+	"id": "xy4-5",
     "name": "Sewaddle",
     "imageUrl": "https://images.pokemontcg.io/xy4/5.png",
     "subtype": "Basic",
@@ -254,7 +259,8 @@
     ]
   },
   {
-    "id": "xy4-6",
+    "setOrder":62,
+	"id": "xy4-6",
     "name": "Swadloon",
     "imageUrl": "https://images.pokemontcg.io/xy4/6.png",
     "subtype": "Stage 1",
@@ -309,7 +315,8 @@
     ]
   },
   {
-    "id": "xy4-7",
+    "setOrder":62,
+	"id": "xy4-7",
     "name": "Leavanny",
     "imageUrl": "https://images.pokemontcg.io/xy4/7.png",
     "subtype": "Stage 2",
@@ -361,7 +368,8 @@
     "nationalPokedexNumber": 542
   },
   {
-    "id": "xy4-8",
+    "setOrder":62,
+	"id": "xy4-8",
     "name": "Karrablast",
     "imageUrl": "https://images.pokemontcg.io/xy4/8.png",
     "subtype": "Basic",
@@ -414,7 +422,8 @@
     ]
   },
   {
-    "id": "xy4-9",
+    "setOrder":62,
+	"id": "xy4-9",
     "name": "Fletchinder",
     "imageUrl": "https://images.pokemontcg.io/xy4/9.png",
     "subtype": "Stage 1",
@@ -475,7 +484,8 @@
     ]
   },
   {
-    "id": "xy4-10",
+    "setOrder":62,
+	"id": "xy4-10",
     "name": "Talonflame",
     "imageUrl": "https://images.pokemontcg.io/xy4/10.png",
     "subtype": "Stage 2",
@@ -533,7 +543,8 @@
     "nationalPokedexNumber": 663
   },
   {
-    "id": "xy4-11",
+    "setOrder":62,
+	"id": "xy4-11",
     "name": "Litleo",
     "imageUrl": "https://images.pokemontcg.io/xy4/11.png",
     "subtype": "Basic",
@@ -587,7 +598,8 @@
     ]
   },
   {
-    "id": "xy4-12",
+    "setOrder":62,
+	"id": "xy4-12",
     "name": "Pyroar",
     "imageUrl": "https://images.pokemontcg.io/xy4/12.png",
     "subtype": "Stage 1",
@@ -637,7 +649,8 @@
     "nationalPokedexNumber": 668
   },
   {
-    "id": "xy4-13",
+    "setOrder":62,
+	"id": "xy4-13",
     "name": "Krabby",
     "imageUrl": "https://images.pokemontcg.io/xy4/13.png",
     "subtype": "Basic",
@@ -692,7 +705,8 @@
     ]
   },
   {
-    "id": "xy4-14",
+    "setOrder":62,
+	"id": "xy4-14",
     "name": "Kingler",
     "imageUrl": "https://images.pokemontcg.io/xy4/14.png",
     "subtype": "Stage 1",
@@ -747,7 +761,8 @@
     "nationalPokedexNumber": 99
   },
   {
-    "id": "xy4-15",
+    "setOrder":62,
+	"id": "xy4-15",
     "name": "Totodile",
     "imageUrl": "https://images.pokemontcg.io/xy4/15.png",
     "subtype": "Basic",
@@ -790,7 +805,8 @@
     ]
   },
   {
-    "id": "xy4-16",
+    "setOrder":62,
+	"id": "xy4-16",
     "name": "Croconaw",
     "imageUrl": "https://images.pokemontcg.io/xy4/16.png",
     "subtype": "Stage 1",
@@ -847,7 +863,8 @@
     ]
   },
   {
-    "id": "xy4-17",
+    "setOrder":62,
+	"id": "xy4-17",
     "name": "Feraligatr",
     "imageUrl": "https://images.pokemontcg.io/xy4/17.png",
     "subtype": "Stage 2",
@@ -904,7 +921,8 @@
     "nationalPokedexNumber": 160
   },
   {
-    "id": "xy4-18",
+    "setOrder":62,
+	"id": "xy4-18",
     "name": "Finneon",
     "imageUrl": "https://images.pokemontcg.io/xy4/18.png",
     "subtype": "Basic",
@@ -947,7 +965,8 @@
     ]
   },
   {
-    "id": "xy4-19",
+    "setOrder":62,
+	"id": "xy4-19",
     "name": "Lumineon",
     "imageUrl": "https://images.pokemontcg.io/xy4/19.png",
     "subtype": "Stage 1",
@@ -998,7 +1017,8 @@
     "nationalPokedexNumber": 457
   },
   {
-    "id": "xy4-20",
+    "setOrder":62,
+	"id": "xy4-20",
     "name": "Frillish",
     "imageUrl": "https://images.pokemontcg.io/xy4/20.png",
     "subtype": "Basic",
@@ -1042,7 +1062,8 @@
     ]
   },
   {
-    "id": "xy4-21",
+    "setOrder":62,
+	"id": "xy4-21",
     "name": "Jellicent",
     "imageUrl": "https://images.pokemontcg.io/xy4/21.png",
     "subtype": "Stage 1",
@@ -1096,7 +1117,8 @@
     "nationalPokedexNumber": 593
   },
   {
-    "id": "xy4-22",
+    "setOrder":62,
+	"id": "xy4-22",
     "name": "Alomomola",
     "imageUrl": "https://images.pokemontcg.io/xy4/22.png",
     "subtype": "Basic",
@@ -1150,7 +1172,8 @@
     "nationalPokedexNumber": 594
   },
   {
-    "id": "xy4-23",
+    "setOrder":62,
+	"id": "xy4-23",
     "name": "Manectric-EX",
     "imageUrl": "https://images.pokemontcg.io/xy4/23.png",
     "subtype": "EX",
@@ -1207,7 +1230,8 @@
     "evolvesTo": "M Manectric-EX"
   },
   {
-    "id": "xy4-24",
+    "setOrder":62,
+	"id": "xy4-24",
     "name": "M Manectric-EX",
     "imageUrl": "https://images.pokemontcg.io/xy4/24.png",
     "subtype": "MEGA",
@@ -1252,7 +1276,8 @@
     "nationalPokedexNumber": 310
   },
   {
-    "id": "xy4-24a",
+    "setOrder":62,
+	"id": "xy4-24a",
     "name": "M Manectric-EX",
     "imageUrl": "https://images.pokemontcg.io/xy4/24a.png",
     "subtype": "MEGA",
@@ -1297,7 +1322,8 @@
     "nationalPokedexNumber": 310
   },
   {
-    "id": "xy4-25",
+    "setOrder":62,
+	"id": "xy4-25",
     "name": "Pachirisu",
     "imageUrl": "https://images.pokemontcg.io/xy4/25.png",
     "subtype": "Basic",
@@ -1353,7 +1379,8 @@
     "nationalPokedexNumber": 417
   },
   {
-    "id": "xy4-26",
+    "setOrder":62,
+	"id": "xy4-26",
     "name": "Joltik",
     "imageUrl": "https://images.pokemontcg.io/xy4/26.png",
     "subtype": "Basic",
@@ -1412,7 +1439,8 @@
     ]
   },
   {
-    "id": "xy4-27",
+    "setOrder":62,
+	"id": "xy4-27",
     "name": "Galvantula",
     "imageUrl": "https://images.pokemontcg.io/xy4/27.png",
     "subtype": "Stage 1",
@@ -1470,7 +1498,8 @@
     "nationalPokedexNumber": 596
   },
   {
-    "id": "xy4-28",
+    "setOrder":62,
+	"id": "xy4-28",
     "name": "Helioptile",
     "imageUrl": "https://images.pokemontcg.io/xy4/28.png",
     "subtype": "Basic",
@@ -1520,7 +1549,8 @@
     ]
   },
   {
-    "id": "xy4-29",
+    "setOrder":62,
+	"id": "xy4-29",
     "name": "Helioptile",
     "imageUrl": "https://images.pokemontcg.io/xy4/29.png",
     "subtype": "Basic",
@@ -1580,7 +1610,8 @@
     ]
   },
   {
-    "id": "xy4-30",
+    "setOrder":62,
+	"id": "xy4-30",
     "name": "Heliolisk",
     "imageUrl": "https://images.pokemontcg.io/xy4/30.png",
     "subtype": "Stage 1",
@@ -1637,7 +1668,8 @@
     "nationalPokedexNumber": 695
   },
   {
-    "id": "xy4-31",
+    "setOrder":62,
+	"id": "xy4-31",
     "name": "Zubat",
     "imageUrl": "https://images.pokemontcg.io/xy4/31.png",
     "subtype": "Basic",
@@ -1686,7 +1718,8 @@
     ]
   },
   {
-    "id": "xy4-32",
+    "setOrder":62,
+	"id": "xy4-32",
     "name": "Golbat",
     "imageUrl": "https://images.pokemontcg.io/xy4/32.png",
     "subtype": "Stage 1",
@@ -1738,7 +1771,8 @@
     ]
   },
   {
-    "id": "xy4-33",
+    "setOrder":62,
+	"id": "xy4-33",
     "name": "Crobat",
     "imageUrl": "https://images.pokemontcg.io/xy4/33.png",
     "subtype": "Stage 2",
@@ -1787,7 +1821,8 @@
     "nationalPokedexNumber": 169
   },
   {
-    "id": "xy4-34",
+    "setOrder":62,
+	"id": "xy4-34",
     "name": "Gengar-EX",
     "imageUrl": "https://images.pokemontcg.io/xy4/34.png",
     "subtype": "EX",
@@ -1846,7 +1881,8 @@
     "evolvesTo": "M Gengar-EX"
   },
   {
-    "id": "xy4-35",
+    "setOrder":62,
+	"id": "xy4-35",
     "name": "M Gengar-EX",
     "imageUrl": "https://images.pokemontcg.io/xy4/35.png",
     "subtype": "MEGA",
@@ -1898,7 +1934,8 @@
     "nationalPokedexNumber": 94
   },
   {
-    "id": "xy4-36",
+    "setOrder":62,
+	"id": "xy4-36",
     "name": "Wobbuffet",
     "imageUrl": "https://images.pokemontcg.io/xy4/36.png",
     "subtype": "Basic",
@@ -1945,7 +1982,8 @@
     "nationalPokedexNumber": 202
   },
   {
-    "id": "xy4-37",
+    "setOrder":62,
+	"id": "xy4-37",
     "name": "Gulpin",
     "imageUrl": "https://images.pokemontcg.io/xy4/37.png",
     "subtype": "Basic",
@@ -2000,7 +2038,8 @@
     ]
   },
   {
-    "id": "xy4-38",
+    "setOrder":62,
+	"id": "xy4-38",
     "name": "Swalot",
     "imageUrl": "https://images.pokemontcg.io/xy4/38.png",
     "subtype": "Stage 1",
@@ -2055,7 +2094,8 @@
     "nationalPokedexNumber": 317
   },
   {
-    "id": "xy4-39",
+    "setOrder":62,
+	"id": "xy4-39",
     "name": "Munna",
     "imageUrl": "https://images.pokemontcg.io/xy4/39.png",
     "subtype": "Basic",
@@ -2109,7 +2149,8 @@
     ]
   },
   {
-    "id": "xy4-40",
+    "setOrder":62,
+	"id": "xy4-40",
     "name": "Musharna",
     "imageUrl": "https://images.pokemontcg.io/xy4/40.png",
     "subtype": "Stage 1",
@@ -2161,7 +2202,8 @@
     "nationalPokedexNumber": 518
   },
   {
-    "id": "xy4-41",
+    "setOrder":62,
+	"id": "xy4-41",
     "name": "Litwick",
     "imageUrl": "https://images.pokemontcg.io/xy4/41.png",
     "subtype": "Basic",
@@ -2210,7 +2252,8 @@
     ]
   },
   {
-    "id": "xy4-42",
+    "setOrder":62,
+	"id": "xy4-42",
     "name": "Lampent",
     "imageUrl": "https://images.pokemontcg.io/xy4/42.png",
     "subtype": "Stage 1",
@@ -2272,7 +2315,8 @@
     ]
   },
   {
-    "id": "xy4-43",
+    "setOrder":62,
+	"id": "xy4-43",
     "name": "Chandelure",
     "imageUrl": "https://images.pokemontcg.io/xy4/43.png",
     "subtype": "Stage 2",
@@ -2327,7 +2371,8 @@
     "nationalPokedexNumber": 609
   },
   {
-    "id": "xy4-44",
+    "setOrder":62,
+	"id": "xy4-44",
     "name": "Pumpkaboo",
     "imageUrl": "https://images.pokemontcg.io/xy4/44.png",
     "subtype": "Basic",
@@ -2388,7 +2433,8 @@
     ]
   },
   {
-    "id": "xy4-45",
+    "setOrder":62,
+	"id": "xy4-45",
     "name": "Gourgeist",
     "imageUrl": "https://images.pokemontcg.io/xy4/45.png",
     "subtype": "Stage 1",
@@ -2444,7 +2490,8 @@
     "nationalPokedexNumber": 711
   },
   {
-    "id": "xy4-46",
+    "setOrder":62,
+	"id": "xy4-46",
     "name": "Gligar",
     "imageUrl": "https://images.pokemontcg.io/xy4/46.png",
     "subtype": "Basic",
@@ -2488,7 +2535,8 @@
     ]
   },
   {
-    "id": "xy4-47",
+    "setOrder":62,
+	"id": "xy4-47",
     "name": "Gliscor",
     "imageUrl": "https://images.pokemontcg.io/xy4/47.png",
     "subtype": "Stage 1",
@@ -2540,7 +2588,8 @@
     "nationalPokedexNumber": 472
   },
   {
-    "id": "xy4-48",
+    "setOrder":62,
+	"id": "xy4-48",
     "name": "Roggenrola",
     "imageUrl": "https://images.pokemontcg.io/xy4/48.png",
     "subtype": "Basic",
@@ -2586,7 +2635,8 @@
     ]
   },
   {
-    "id": "xy4-49",
+    "setOrder":62,
+	"id": "xy4-49",
     "name": "Boldore",
     "imageUrl": "https://images.pokemontcg.io/xy4/49.png",
     "subtype": "Stage 1",
@@ -2643,7 +2693,8 @@
     ]
   },
   {
-    "id": "xy4-50",
+    "setOrder":62,
+	"id": "xy4-50",
     "name": "Gigalith",
     "imageUrl": "https://images.pokemontcg.io/xy4/50.png",
     "subtype": "Stage 2",
@@ -2694,7 +2745,8 @@
     "nationalPokedexNumber": 526
   },
   {
-    "id": "xy4-51",
+    "setOrder":62,
+	"id": "xy4-51",
     "name": "Murkrow",
     "imageUrl": "https://images.pokemontcg.io/xy4/51.png",
     "subtype": "Basic",
@@ -2754,7 +2806,8 @@
     ]
   },
   {
-    "id": "xy4-52",
+    "setOrder":62,
+	"id": "xy4-52",
     "name": "Honchkrow",
     "imageUrl": "https://images.pokemontcg.io/xy4/52.png",
     "subtype": "Stage 1",
@@ -2812,7 +2865,8 @@
     "nationalPokedexNumber": 430
   },
   {
-    "id": "xy4-53",
+    "setOrder":62,
+	"id": "xy4-53",
     "name": "Poochyena",
     "imageUrl": "https://images.pokemontcg.io/xy4/53.png",
     "subtype": "Basic",
@@ -2871,7 +2925,8 @@
     ]
   },
   {
-    "id": "xy4-54",
+    "setOrder":62,
+	"id": "xy4-54",
     "name": "Mightyena",
     "imageUrl": "https://images.pokemontcg.io/xy4/54.png",
     "subtype": "Stage 1",
@@ -2930,7 +2985,8 @@
     "nationalPokedexNumber": 262
   },
   {
-    "id": "xy4-55",
+    "setOrder":62,
+	"id": "xy4-55",
     "name": "Spiritomb",
     "imageUrl": "https://images.pokemontcg.io/xy4/55.png",
     "subtype": "Basic",
@@ -2974,7 +3030,8 @@
     "nationalPokedexNumber": 442
   },
   {
-    "id": "xy4-56",
+    "setOrder":62,
+	"id": "xy4-56",
     "name": "Purrloin",
     "imageUrl": "https://images.pokemontcg.io/xy4/56.png",
     "subtype": "Basic",
@@ -3023,7 +3080,8 @@
     ]
   },
   {
-    "id": "xy4-57",
+    "setOrder":62,
+	"id": "xy4-57",
     "name": "Liepard",
     "imageUrl": "https://images.pokemontcg.io/xy4/57.png",
     "subtype": "Stage 1",
@@ -3080,7 +3138,8 @@
     "nationalPokedexNumber": 510
   },
   {
-    "id": "xy4-58",
+    "setOrder":62,
+	"id": "xy4-58",
     "name": "Malamar-EX",
     "imageUrl": "https://images.pokemontcg.io/xy4/58.png",
     "subtype": "EX",
@@ -3133,7 +3192,8 @@
     "nationalPokedexNumber": 687
   },
   {
-    "id": "xy4-59",
+    "setOrder":62,
+	"id": "xy4-59",
     "name": "Skarmory",
     "imageUrl": "https://images.pokemontcg.io/xy4/59.png",
     "subtype": "Basic",
@@ -3191,7 +3251,8 @@
     "nationalPokedexNumber": 227
   },
   {
-    "id": "xy4-60",
+    "setOrder":62,
+	"id": "xy4-60",
     "name": "Bronzor",
     "imageUrl": "https://images.pokemontcg.io/xy4/60.png",
     "subtype": "Basic",
@@ -3240,7 +3301,8 @@
     ]
   },
   {
-    "id": "xy4-61",
+    "setOrder":62,
+	"id": "xy4-61",
     "name": "Bronzong",
     "imageUrl": "https://images.pokemontcg.io/xy4/61.png",
     "subtype": "Stage 1",
@@ -3296,7 +3358,8 @@
     "nationalPokedexNumber": 437
   },
   {
-    "id": "xy4-62",
+    "setOrder":62,
+	"id": "xy4-62",
     "name": "Dialga-EX",
     "imageUrl": "https://images.pokemontcg.io/xy4/62.png",
     "subtype": "EX",
@@ -3357,7 +3420,8 @@
     "nationalPokedexNumber": 483
   },
   {
-    "id": "xy4-63",
+    "setOrder":62,
+	"id": "xy4-63",
     "name": "Heatran",
     "imageUrl": "https://images.pokemontcg.io/xy4/63.png",
     "subtype": "Basic",
@@ -3419,7 +3483,8 @@
     "nationalPokedexNumber": 485
   },
   {
-    "id": "xy4-64",
+    "setOrder":62,
+	"id": "xy4-64",
     "name": "Escavalier",
     "imageUrl": "https://images.pokemontcg.io/xy4/64.png",
     "subtype": "Stage 1",
@@ -3479,7 +3544,8 @@
     "nationalPokedexNumber": 589
   },
   {
-    "id": "xy4-65",
+    "setOrder":62,
+	"id": "xy4-65",
     "name": "Aegislash-EX",
     "imageUrl": "https://images.pokemontcg.io/xy4/65.png",
     "subtype": "EX",
@@ -3534,7 +3600,8 @@
     "nationalPokedexNumber": 681
   },
   {
-    "id": "xy4-65a",
+    "setOrder":62,
+	"id": "xy4-65a",
     "name": "Aegislash-EX",
     "imageUrl": "https://images.pokemontcg.io/xy4/65a.png",
     "subtype": "EX",
@@ -3589,7 +3656,8 @@
     "nationalPokedexNumber": 681
   },
   {
-    "id": "xy4-66",
+    "setOrder":62,
+	"id": "xy4-66",
     "name": "Klefki",
     "imageUrl": "https://images.pokemontcg.io/xy4/66.png",
     "subtype": "Basic",
@@ -3645,7 +3713,8 @@
     "nationalPokedexNumber": 707
   },
   {
-    "id": "xy4-67",
+    "setOrder":62,
+	"id": "xy4-67",
     "name": "Florges-EX",
     "imageUrl": "https://images.pokemontcg.io/xy4/67.png",
     "subtype": "EX",
@@ -3702,7 +3771,8 @@
     "nationalPokedexNumber": 671
   },
   {
-    "id": "xy4-68",
+    "setOrder":62,
+	"id": "xy4-68",
     "name": "Swirlix",
     "imageUrl": "https://images.pokemontcg.io/xy4/68.png",
     "subtype": "Basic",
@@ -3761,7 +3831,8 @@
     ]
   },
   {
-    "id": "xy4-69",
+    "setOrder":62,
+	"id": "xy4-69",
     "name": "Slurpuff",
     "imageUrl": "https://images.pokemontcg.io/xy4/69.png",
     "subtype": "Stage 1",
@@ -3815,7 +3886,8 @@
     "nationalPokedexNumber": 685
   },
   {
-    "id": "xy4-70",
+    "setOrder":62,
+	"id": "xy4-70",
     "name": "Dedenne",
     "imageUrl": "https://images.pokemontcg.io/xy4/70.png",
     "subtype": "Basic",
@@ -3872,7 +3944,8 @@
     "nationalPokedexNumber": 702
   },
   {
-    "id": "xy4-71",
+    "setOrder":62,
+	"id": "xy4-71",
     "name": "Diancie",
     "imageUrl": "https://images.pokemontcg.io/xy4/71.png",
     "subtype": "Basic",
@@ -3929,7 +4002,8 @@
     "nationalPokedexNumber": 719
   },
   {
-    "id": "xy4-72",
+    "setOrder":62,
+	"id": "xy4-72",
     "name": "Deino",
     "imageUrl": "https://images.pokemontcg.io/xy4/72.png",
     "subtype": "Basic",
@@ -3973,7 +4047,8 @@
     ]
   },
   {
-    "id": "xy4-73",
+    "setOrder":62,
+	"id": "xy4-73",
     "name": "Zweilous",
     "imageUrl": "https://images.pokemontcg.io/xy4/73.png",
     "subtype": "Stage 1",
@@ -4019,7 +4094,8 @@
     ]
   },
   {
-    "id": "xy4-74",
+    "setOrder":62,
+	"id": "xy4-74",
     "name": "Hydreigon",
     "imageUrl": "https://images.pokemontcg.io/xy4/74.png",
     "subtype": "Stage 2",
@@ -4070,7 +4146,8 @@
     "nationalPokedexNumber": 635
   },
   {
-    "id": "xy4-75",
+    "setOrder":62,
+	"id": "xy4-75",
     "name": "Goomy",
     "imageUrl": "https://images.pokemontcg.io/xy4/75.png",
     "subtype": "Basic",
@@ -4124,7 +4201,8 @@
     ]
   },
   {
-    "id": "xy4-76",
+    "setOrder":62,
+	"id": "xy4-76",
     "name": "Sliggoo",
     "imageUrl": "https://images.pokemontcg.io/xy4/76.png",
     "subtype": "Stage 1",
@@ -4181,7 +4259,8 @@
     ]
   },
   {
-    "id": "xy4-77",
+    "setOrder":62,
+	"id": "xy4-77",
     "name": "Goodra",
     "imageUrl": "https://images.pokemontcg.io/xy4/77.png",
     "subtype": "Stage 2",
@@ -4232,7 +4311,8 @@
     "nationalPokedexNumber": 706
   },
   {
-    "id": "xy4-78",
+    "setOrder":62,
+	"id": "xy4-78",
     "name": "Spearow",
     "imageUrl": "https://images.pokemontcg.io/xy4/78.png",
     "subtype": "Basic",
@@ -4281,7 +4361,8 @@
     ]
   },
   {
-    "id": "xy4-79",
+    "setOrder":62,
+	"id": "xy4-79",
     "name": "Fearow",
     "imageUrl": "https://images.pokemontcg.io/xy4/79.png",
     "subtype": "Stage 1",
@@ -4340,7 +4421,8 @@
     "nationalPokedexNumber": 22
   },
   {
-    "id": "xy4-80",
+    "setOrder":62,
+	"id": "xy4-80",
     "name": "Chansey",
     "imageUrl": "https://images.pokemontcg.io/xy4/80.png",
     "subtype": "Basic",
@@ -4396,7 +4478,8 @@
     ]
   },
   {
-    "id": "xy4-81",
+    "setOrder":62,
+	"id": "xy4-81",
     "name": "Blissey",
     "imageUrl": "https://images.pokemontcg.io/xy4/81.png",
     "subtype": "Stage 1",
@@ -4453,7 +4536,8 @@
     "nationalPokedexNumber": 242
   },
   {
-    "id": "xy4-82",
+    "setOrder":62,
+	"id": "xy4-82",
     "name": "Girafarig",
     "imageUrl": "https://images.pokemontcg.io/xy4/82.png",
     "subtype": "Basic",
@@ -4505,7 +4589,8 @@
     "nationalPokedexNumber": 203
   },
   {
-    "id": "xy4-83",
+    "setOrder":62,
+	"id": "xy4-83",
     "name": "Whismur",
     "imageUrl": "https://images.pokemontcg.io/xy4/83.png",
     "subtype": "Basic",
@@ -4548,7 +4633,8 @@
     ]
   },
   {
-    "id": "xy4-84",
+    "setOrder":62,
+	"id": "xy4-84",
     "name": "Loudred",
     "imageUrl": "https://images.pokemontcg.io/xy4/84.png",
     "subtype": "Stage 1",
@@ -4605,7 +4691,8 @@
     ]
   },
   {
-    "id": "xy4-85",
+    "setOrder":62,
+	"id": "xy4-85",
     "name": "Exploud",
     "imageUrl": "https://images.pokemontcg.io/xy4/85.png",
     "subtype": "Stage 2",
@@ -4661,7 +4748,8 @@
     "nationalPokedexNumber": 295
   },
   {
-    "id": "xy4-86",
+    "setOrder":62,
+	"id": "xy4-86",
     "name": "Regigigas",
     "imageUrl": "https://images.pokemontcg.io/xy4/86.png",
     "subtype": "Basic",
@@ -4718,7 +4806,8 @@
     "nationalPokedexNumber": 486
   },
   {
-    "id": "xy4-87",
+    "setOrder":62,
+	"id": "xy4-87",
     "name": "Bunnelby",
     "imageUrl": "https://images.pokemontcg.io/xy4/87.png",
     "subtype": "Basic",
@@ -4772,7 +4861,8 @@
     ]
   },
   {
-    "id": "xy4-88",
+    "setOrder":62,
+	"id": "xy4-88",
     "name": "Diggersby",
     "imageUrl": "https://images.pokemontcg.io/xy4/88.png",
     "subtype": "Stage 1",
@@ -4826,7 +4916,8 @@
     "nationalPokedexNumber": 660
   },
   {
-    "id": "xy4-89",
+    "setOrder":62,
+	"id": "xy4-89",
     "name": "Fletchling",
     "imageUrl": "https://images.pokemontcg.io/xy4/89.png",
     "subtype": "Basic",
@@ -4885,7 +4976,8 @@
     ]
   },
   {
-    "id": "xy4-90",
+    "setOrder":62,
+	"id": "xy4-90",
     "name": "Furfrou",
     "imageUrl": "https://images.pokemontcg.io/xy4/90.png",
     "subtype": "Basic",
@@ -4937,7 +5029,8 @@
     "nationalPokedexNumber": 676
   },
   {
-    "id": "xy4-91",
+    "setOrder":62,
+	"id": "xy4-91",
     "name": "AZ",
     "imageUrl": "https://images.pokemontcg.io/xy4/91.png",
     "subtype": "Supporter",
@@ -4954,7 +5047,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/91_hires.png"
   },
   {
-    "id": "xy4-92",
+    "setOrder":62,
+	"id": "xy4-92",
     "name": "Battle Compressor Team Flare Gear",
     "imageUrl": "https://images.pokemontcg.io/xy4/92.png",
     "subtype": "Item",
@@ -4971,7 +5065,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/92_hires.png"
   },
   {
-    "id": "xy4-93",
+    "setOrder":62,
+	"id": "xy4-93",
     "name": "Dimension Valley",
     "imageUrl": "https://images.pokemontcg.io/xy4/93.png",
     "subtype": "Stadium",
@@ -4988,7 +5083,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/93_hires.png"
   },
   {
-    "id": "xy4-94",
+    "setOrder":62,
+	"id": "xy4-94",
     "name": "Enhanced Hammer",
     "imageUrl": "https://images.pokemontcg.io/xy4/94.png",
     "subtype": "Item",
@@ -5005,7 +5101,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/94_hires.png"
   },
   {
-    "id": "xy4-95",
+    "setOrder":62,
+	"id": "xy4-95",
     "name": "Gengar Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xy4/95.png",
     "subtype": "Pokémon Tool",
@@ -5022,7 +5119,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/95_hires.png"
   },
   {
-    "id": "xy4-96",
+    "setOrder":62,
+	"id": "xy4-96",
     "name": "Hand Scope",
     "imageUrl": "https://images.pokemontcg.io/xy4/96.png",
     "subtype": "Item",
@@ -5039,7 +5137,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/96_hires.png"
   },
   {
-    "id": "xy4-97",
+    "setOrder":62,
+	"id": "xy4-97",
     "name": "Head Ringer Team Flare Hyper Gear",
     "imageUrl": "https://images.pokemontcg.io/xy4/97.png",
     "subtype": "Pokémon Tool",
@@ -5067,7 +5166,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/97_hires.png"
   },
   {
-    "id": "xy4-98",
+    "setOrder":62,
+	"id": "xy4-98",
     "name": "Jamming Net Team Flare Hyper Gear",
     "imageUrl": "https://images.pokemontcg.io/xy4/98.png",
     "subtype": "Pokémon Tool",
@@ -5084,7 +5184,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/98_hires.png"
   },
   {
-    "id": "xy4-99",
+    "setOrder":62,
+	"id": "xy4-99",
     "name": "Lysandre's Trump Card",
     "imageUrl": "https://images.pokemontcg.io/xy4/99.png",
     "subtype": "Supporter",
@@ -5101,7 +5202,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/99_hires.png"
   },
   {
-    "id": "xy4-100",
+    "setOrder":62,
+	"id": "xy4-100",
     "name": "Manectric Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xy4/100.png",
     "subtype": "Pokémon Tool",
@@ -5118,7 +5220,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/100_hires.png"
   },
   {
-    "id": "xy4-101",
+    "setOrder":62,
+	"id": "xy4-101",
     "name": "Professor Sycamore",
     "imageUrl": "https://images.pokemontcg.io/xy4/101.png",
     "subtype": "Supporter",
@@ -5135,7 +5238,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/101_hires.png"
   },
   {
-    "id": "xy4-102",
+    "setOrder":62,
+	"id": "xy4-102",
     "name": "Robo Substitute Team Flare Gear",
     "imageUrl": "https://images.pokemontcg.io/xy4/102.png",
     "subtype": "Item",
@@ -5152,7 +5256,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/102_hires.png"
   },
   {
-    "id": "xy4-103",
+    "setOrder":62,
+	"id": "xy4-103",
     "name": "Roller Skates",
     "imageUrl": "https://images.pokemontcg.io/xy4/103.png",
     "subtype": "Item",
@@ -5169,7 +5274,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/103_hires.png"
   },
   {
-    "id": "xy4-104",
+    "setOrder":62,
+	"id": "xy4-104",
     "name": "Shauna",
     "imageUrl": "https://images.pokemontcg.io/xy4/104.png",
     "subtype": "Supporter",
@@ -5186,7 +5292,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/104_hires.png"
   },
   {
-    "id": "xy4-105",
+    "setOrder":62,
+	"id": "xy4-105",
     "name": "Steel Shelter",
     "imageUrl": "https://images.pokemontcg.io/xy4/105.png",
     "subtype": "Stadium",
@@ -5203,7 +5310,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/105_hires.png"
   },
   {
-    "id": "xy4-106",
+    "setOrder":62,
+	"id": "xy4-106",
     "name": "Target Whistle Team Flare Gear",
     "imageUrl": "https://images.pokemontcg.io/xy4/106.png",
     "subtype": "Item",
@@ -5220,7 +5328,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/106_hires.png"
   },
   {
-    "id": "xy4-107",
+    "setOrder":62,
+	"id": "xy4-107",
     "name": "Tierno",
     "imageUrl": "https://images.pokemontcg.io/xy4/107.png",
     "subtype": "Supporter",
@@ -5237,7 +5346,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/107_hires.png"
   },
   {
-    "id": "xy4-108",
+    "setOrder":62,
+	"id": "xy4-108",
     "name": "Trick Coin",
     "imageUrl": "https://images.pokemontcg.io/xy4/108.png",
     "subtype": "Pokémon Tool",
@@ -5254,7 +5364,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/108_hires.png"
   },
   {
-    "id": "xy4-109",
+    "setOrder":62,
+	"id": "xy4-109",
     "name": "VS Seeker",
     "imageUrl": "https://images.pokemontcg.io/xy4/109.png",
     "subtype": "Item",
@@ -5271,7 +5382,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/109_hires.png"
   },
   {
-    "id": "xy4-110",
+    "setOrder":62,
+	"id": "xy4-110",
     "name": "Xerosic",
     "imageUrl": "https://images.pokemontcg.io/xy4/110.png",
     "subtype": "Supporter",
@@ -5288,7 +5400,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/110_hires.png"
   },
   {
-    "id": "xy4-111",
+    "setOrder":62,
+	"id": "xy4-111",
     "name": "Double Colorless Energy",
     "imageUrl": "https://images.pokemontcg.io/xy4/111.png",
     "subtype": "Special",
@@ -5305,7 +5418,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/111_hires.png"
   },
   {
-    "id": "xy4-112",
+    "setOrder":62,
+	"id": "xy4-112",
     "name": "Mystery Energy",
     "imageUrl": "https://images.pokemontcg.io/xy4/112.png",
     "subtype": "Special",
@@ -5322,7 +5436,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/112_hires.png"
   },
   {
-    "id": "xy4-113",
+    "setOrder":62,
+	"id": "xy4-113",
     "name": "Manectric-EX",
     "imageUrl": "https://images.pokemontcg.io/xy4/113.png",
     "subtype": "EX",
@@ -5379,7 +5494,8 @@
     "evolvesTo": "M Manectric-EX"
   },
   {
-    "id": "xy4-114",
+    "setOrder":62,
+	"id": "xy4-114",
     "name": "Gengar-EX",
     "imageUrl": "https://images.pokemontcg.io/xy4/114.png",
     "subtype": "EX",
@@ -5438,7 +5554,8 @@
     "evolvesTo": "M Gengar-EX"
   },
   {
-    "id": "xy4-115",
+    "setOrder":62,
+	"id": "xy4-115",
     "name": "Malamar-EX",
     "imageUrl": "https://images.pokemontcg.io/xy4/115.png",
     "subtype": "EX",
@@ -5491,7 +5608,8 @@
     "nationalPokedexNumber": 687
   },
   {
-    "id": "xy4-116",
+    "setOrder":62,
+	"id": "xy4-116",
     "name": "Florges-EX",
     "imageUrl": "https://images.pokemontcg.io/xy4/116.png",
     "subtype": "EX",
@@ -5548,7 +5666,8 @@
     "nationalPokedexNumber": 671
   },
   {
-    "id": "xy4-117",
+    "setOrder":62,
+	"id": "xy4-117",
     "name": "AZ",
     "imageUrl": "https://images.pokemontcg.io/xy4/117.png",
     "subtype": "Supporter",
@@ -5565,7 +5684,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/117_hires.png"
   },
   {
-    "id": "xy4-118",
+    "setOrder":62,
+	"id": "xy4-118",
     "name": "Lysandre's Trump Card",
     "imageUrl": "https://images.pokemontcg.io/xy4/118.png",
     "subtype": "Supporter",
@@ -5582,7 +5702,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy4/118_hires.png"
   },
   {
-    "id": "xy4-119",
+    "setOrder":62,
+	"id": "xy4-119",
     "name": "Xerosic",
     "imageUrl": "https://images.pokemontcg.io/xy4/119.png",
     "subtype": "Supporter",

--- a/json/cards/Plasma Blast.json
+++ b/json/cards/Plasma Blast.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "bw10-1",
+    "setOrder":57,
+	"id": "bw10-1",
     "name": "Surskit",
     "imageUrl": "https://images.pokemontcg.io/bw10/1.png",
     "subtype": "Basic",
@@ -43,7 +44,8 @@
     ]
   },
   {
-    "id": "bw10-2",
+    "setOrder":57,
+	"id": "bw10-2",
     "name": "Masquerain",
     "imageUrl": "https://images.pokemontcg.io/bw10/2.png",
     "subtype": "Stage 1",
@@ -91,7 +93,8 @@
     "nationalPokedexNumber": 284
   },
   {
-    "id": "bw10-3",
+    "setOrder":57,
+	"id": "bw10-3",
     "name": "Lileep",
     "imageUrl": "https://images.pokemontcg.io/bw10/3.png",
     "subtype": "Restored",
@@ -150,7 +153,8 @@
     ]
   },
   {
-    "id": "bw10-4",
+    "setOrder":57,
+	"id": "bw10-4",
     "name": "Cradily",
     "imageUrl": "https://images.pokemontcg.io/bw10/4.png",
     "subtype": "Stage 1",
@@ -209,7 +213,8 @@
     "nationalPokedexNumber": 346
   },
   {
-    "id": "bw10-5",
+    "setOrder":57,
+	"id": "bw10-5",
     "name": "Tropius",
     "imageUrl": "https://images.pokemontcg.io/bw10/5.png",
     "subtype": "Basic",
@@ -265,7 +270,8 @@
     "nationalPokedexNumber": 357
   },
   {
-    "id": "bw10-6",
+    "setOrder":57,
+	"id": "bw10-6",
     "name": "Karrablast",
     "imageUrl": "https://images.pokemontcg.io/bw10/6.png",
     "subtype": "Basic",
@@ -309,7 +315,8 @@
     ]
   },
   {
-    "id": "bw10-7",
+    "setOrder":57,
+	"id": "bw10-7",
     "name": "Shelmet",
     "imageUrl": "https://images.pokemontcg.io/bw10/7.png",
     "subtype": "Basic",
@@ -364,7 +371,8 @@
     ]
   },
   {
-    "id": "bw10-8",
+    "setOrder":57,
+	"id": "bw10-8",
     "name": "Accelgor",
     "imageUrl": "https://images.pokemontcg.io/bw10/8.png",
     "subtype": "Stage 1",
@@ -412,7 +420,8 @@
     "nationalPokedexNumber": 617
   },
   {
-    "id": "bw10-9",
+    "setOrder":57,
+	"id": "bw10-9",
     "name": "Virizion-EX",
     "imageUrl": "https://images.pokemontcg.io/bw10/9.png",
     "subtype": "EX",
@@ -467,7 +476,8 @@
     "nationalPokedexNumber": 640
   },
   {
-    "id": "bw10-10",
+    "setOrder":57,
+	"id": "bw10-10",
     "name": "Genesect",
     "imageUrl": "https://images.pokemontcg.io/bw10/10.png",
     "subtype": "Basic",
@@ -518,7 +528,8 @@
     "nationalPokedexNumber": 649
   },
   {
-    "id": "bw10-11",
+    "setOrder":57,
+	"id": "bw10-11",
     "name": "Genesect-EX",
     "imageUrl": "https://images.pokemontcg.io/bw10/11.png",
     "subtype": "EX",
@@ -568,7 +579,8 @@
     "nationalPokedexNumber": 649
   },
   {
-    "id": "bw10-12",
+    "setOrder":57,
+	"id": "bw10-12",
     "name": "Larvesta",
     "imageUrl": "https://images.pokemontcg.io/bw10/12.png",
     "subtype": "Basic",
@@ -623,7 +635,8 @@
     ]
   },
   {
-    "id": "bw10-13",
+    "setOrder":57,
+	"id": "bw10-13",
     "name": "Volcarona",
     "imageUrl": "https://images.pokemontcg.io/bw10/13.png",
     "subtype": "Stage 1",
@@ -675,7 +688,8 @@
     "nationalPokedexNumber": 637
   },
   {
-    "id": "bw10-14",
+    "setOrder":57,
+	"id": "bw10-14",
     "name": "Squirtle",
     "imageUrl": "https://images.pokemontcg.io/bw10/14.png",
     "subtype": "Basic",
@@ -728,7 +742,8 @@
     ]
   },
   {
-    "id": "bw10-15",
+    "setOrder":57,
+	"id": "bw10-15",
     "name": "Wartortle",
     "imageUrl": "https://images.pokemontcg.io/bw10/15.png",
     "subtype": "Stage 1",
@@ -784,7 +799,8 @@
     ]
   },
   {
-    "id": "bw10-16",
+    "setOrder":57,
+	"id": "bw10-16",
     "name": "Blastoise",
     "imageUrl": "https://images.pokemontcg.io/bw10/16.png",
     "subtype": "Stage 2",
@@ -836,7 +852,8 @@
     "nationalPokedexNumber": 9
   },
   {
-    "id": "bw10-17",
+    "setOrder":57,
+	"id": "bw10-17",
     "name": "Lapras",
     "imageUrl": "https://images.pokemontcg.io/bw10/17.png",
     "subtype": "Basic",
@@ -890,7 +907,8 @@
     "nationalPokedexNumber": 131
   },
   {
-    "id": "bw10-18",
+    "setOrder":57,
+	"id": "bw10-18",
     "name": "Remoraid",
     "imageUrl": "https://images.pokemontcg.io/bw10/18.png",
     "subtype": "Basic",
@@ -934,7 +952,8 @@
     ]
   },
   {
-    "id": "bw10-19",
+    "setOrder":57,
+	"id": "bw10-19",
     "name": "Octillery",
     "imageUrl": "https://images.pokemontcg.io/bw10/19.png",
     "subtype": "Stage 1",
@@ -985,7 +1004,8 @@
     "nationalPokedexNumber": 224
   },
   {
-    "id": "bw10-20",
+    "setOrder":57,
+	"id": "bw10-20",
     "name": "Suicune",
     "imageUrl": "https://images.pokemontcg.io/bw10/20.png",
     "subtype": "Basic",
@@ -1033,7 +1053,8 @@
     "nationalPokedexNumber": 245
   },
   {
-    "id": "bw10-21",
+    "setOrder":57,
+	"id": "bw10-21",
     "name": "Snorunt",
     "imageUrl": "https://images.pokemontcg.io/bw10/21.png",
     "subtype": "Basic",
@@ -1088,7 +1109,8 @@
     ]
   },
   {
-    "id": "bw10-22",
+    "setOrder":57,
+	"id": "bw10-22",
     "name": "Glalie",
     "imageUrl": "https://images.pokemontcg.io/bw10/22.png",
     "subtype": "Stage 1",
@@ -1142,7 +1164,8 @@
     "nationalPokedexNumber": 362
   },
   {
-    "id": "bw10-23",
+    "setOrder":57,
+	"id": "bw10-23",
     "name": "Froslass",
     "imageUrl": "https://images.pokemontcg.io/bw10/23.png",
     "subtype": "Stage 1",
@@ -1189,7 +1212,8 @@
     "nationalPokedexNumber": 478
   },
   {
-    "id": "bw10-24",
+    "setOrder":57,
+	"id": "bw10-24",
     "name": "Relicanth",
     "imageUrl": "https://images.pokemontcg.io/bw10/24.png",
     "subtype": "Basic",
@@ -1239,7 +1263,8 @@
     "nationalPokedexNumber": 369
   },
   {
-    "id": "bw10-25",
+    "setOrder":57,
+	"id": "bw10-25",
     "name": "Snover",
     "imageUrl": "https://images.pokemontcg.io/bw10/25.png",
     "subtype": "Basic",
@@ -1295,7 +1320,8 @@
     ]
   },
   {
-    "id": "bw10-26",
+    "setOrder":57,
+	"id": "bw10-26",
     "name": "Abomasnow",
     "imageUrl": "https://images.pokemontcg.io/bw10/26.png",
     "subtype": "Stage 1",
@@ -1349,7 +1375,8 @@
     "nationalPokedexNumber": 460
   },
   {
-    "id": "bw10-27",
+    "setOrder":57,
+	"id": "bw10-27",
     "name": "Tirtouga",
     "imageUrl": "https://images.pokemontcg.io/bw10/27.png",
     "subtype": "Restored",
@@ -1404,7 +1431,8 @@
     ]
   },
   {
-    "id": "bw10-28",
+    "setOrder":57,
+	"id": "bw10-28",
     "name": "Carracosta",
     "imageUrl": "https://images.pokemontcg.io/bw10/28.png",
     "subtype": "Stage 1",
@@ -1462,7 +1490,8 @@
     "nationalPokedexNumber": 565
   },
   {
-    "id": "bw10-29",
+    "setOrder":57,
+	"id": "bw10-29",
     "name": "Ducklett",
     "imageUrl": "https://images.pokemontcg.io/bw10/29.png",
     "subtype": "Basic",
@@ -1512,7 +1541,8 @@
     ]
   },
   {
-    "id": "bw10-30",
+    "setOrder":57,
+	"id": "bw10-30",
     "name": "Kyurem-EX",
     "imageUrl": "https://images.pokemontcg.io/bw10/30.png",
     "subtype": "EX",
@@ -1570,7 +1600,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "bw10-31",
+    "setOrder":57,
+	"id": "bw10-31",
     "name": "Tynamo",
     "imageUrl": "https://images.pokemontcg.io/bw10/31.png",
     "subtype": "Basic",
@@ -1613,7 +1644,8 @@
     ]
   },
   {
-    "id": "bw10-32",
+    "setOrder":57,
+	"id": "bw10-32",
     "name": "Eelektrik",
     "imageUrl": "https://images.pokemontcg.io/bw10/32.png",
     "subtype": "Stage 1",
@@ -1667,7 +1699,8 @@
     ]
   },
   {
-    "id": "bw10-33",
+    "setOrder":57,
+	"id": "bw10-33",
     "name": "Eelektross",
     "imageUrl": "https://images.pokemontcg.io/bw10/33.png",
     "subtype": "Stage 2",
@@ -1723,7 +1756,8 @@
     "nationalPokedexNumber": 604
   },
   {
-    "id": "bw10-34",
+    "setOrder":57,
+	"id": "bw10-34",
     "name": "Drifloon",
     "imageUrl": "https://images.pokemontcg.io/bw10/34.png",
     "subtype": "Basic",
@@ -1778,7 +1812,8 @@
     ]
   },
   {
-    "id": "bw10-35",
+    "setOrder":57,
+	"id": "bw10-35",
     "name": "Drifblim",
     "imageUrl": "https://images.pokemontcg.io/bw10/35.png",
     "subtype": "Stage 1",
@@ -1823,7 +1858,8 @@
     "nationalPokedexNumber": 426
   },
   {
-    "id": "bw10-36",
+    "setOrder":57,
+	"id": "bw10-36",
     "name": "Uxie",
     "imageUrl": "https://images.pokemontcg.io/bw10/36.png",
     "subtype": "Basic",
@@ -1863,7 +1899,8 @@
     "nationalPokedexNumber": 480
   },
   {
-    "id": "bw10-37",
+    "setOrder":57,
+	"id": "bw10-37",
     "name": "Mesprit",
     "imageUrl": "https://images.pokemontcg.io/bw10/37.png",
     "subtype": "Basic",
@@ -1910,7 +1947,8 @@
     "nationalPokedexNumber": 481
   },
   {
-    "id": "bw10-38",
+    "setOrder":57,
+	"id": "bw10-38",
     "name": "Azelf",
     "imageUrl": "https://images.pokemontcg.io/bw10/38.png",
     "subtype": "Basic",
@@ -1961,7 +1999,8 @@
     "nationalPokedexNumber": 482
   },
   {
-    "id": "bw10-39",
+    "setOrder":57,
+	"id": "bw10-39",
     "name": "Munna",
     "imageUrl": "https://images.pokemontcg.io/bw10/39.png",
     "subtype": "Basic",
@@ -2014,7 +2053,8 @@
     ]
   },
   {
-    "id": "bw10-40",
+    "setOrder":57,
+	"id": "bw10-40",
     "name": "Musharna",
     "imageUrl": "https://images.pokemontcg.io/bw10/40.png",
     "subtype": "Stage 1",
@@ -2068,7 +2108,8 @@
     "nationalPokedexNumber": 518
   },
   {
-    "id": "bw10-41",
+    "setOrder":57,
+	"id": "bw10-41",
     "name": "Sigilyph",
     "imageUrl": "https://images.pokemontcg.io/bw10/41.png",
     "subtype": "Basic",
@@ -2121,7 +2162,8 @@
     "nationalPokedexNumber": 561
   },
   {
-    "id": "bw10-42",
+    "setOrder":57,
+	"id": "bw10-42",
     "name": "Solosis",
     "imageUrl": "https://images.pokemontcg.io/bw10/42.png",
     "subtype": "Basic",
@@ -2164,7 +2206,8 @@
     ]
   },
   {
-    "id": "bw10-43",
+    "setOrder":57,
+	"id": "bw10-43",
     "name": "Duosion",
     "imageUrl": "https://images.pokemontcg.io/bw10/43.png",
     "subtype": "Stage 1",
@@ -2209,7 +2252,8 @@
     ]
   },
   {
-    "id": "bw10-44",
+    "setOrder":57,
+	"id": "bw10-44",
     "name": "Reuniclus",
     "imageUrl": "https://images.pokemontcg.io/bw10/44.png",
     "subtype": "Stage 2",
@@ -2262,7 +2306,8 @@
     "nationalPokedexNumber": 579
   },
   {
-    "id": "bw10-45",
+    "setOrder":57,
+	"id": "bw10-45",
     "name": "Golett",
     "imageUrl": "https://images.pokemontcg.io/bw10/45.png",
     "subtype": "Basic",
@@ -2318,7 +2363,8 @@
     ]
   },
   {
-    "id": "bw10-46",
+    "setOrder":57,
+	"id": "bw10-46",
     "name": "Golurk",
     "imageUrl": "https://images.pokemontcg.io/bw10/46.png",
     "subtype": "Stage 1",
@@ -2375,7 +2421,8 @@
     "nationalPokedexNumber": 623
   },
   {
-    "id": "bw10-47",
+    "setOrder":57,
+	"id": "bw10-47",
     "name": "Machop",
     "imageUrl": "https://images.pokemontcg.io/bw10/47.png",
     "subtype": "Basic",
@@ -2421,7 +2468,8 @@
     ]
   },
   {
-    "id": "bw10-48",
+    "setOrder":57,
+	"id": "bw10-48",
     "name": "Machoke",
     "imageUrl": "https://images.pokemontcg.io/bw10/48.png",
     "subtype": "Stage 1",
@@ -2478,7 +2526,8 @@
     ]
   },
   {
-    "id": "bw10-49",
+    "setOrder":57,
+	"id": "bw10-49",
     "name": "Machamp",
     "imageUrl": "https://images.pokemontcg.io/bw10/49.png",
     "subtype": "Stage 2",
@@ -2529,7 +2578,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "bw10-50",
+    "setOrder":57,
+	"id": "bw10-50",
     "name": "Machamp",
     "imageUrl": "https://images.pokemontcg.io/bw10/50.png",
     "subtype": "Stage 2",
@@ -2586,7 +2636,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "bw10-51",
+    "setOrder":57,
+	"id": "bw10-51",
     "name": "Throh",
     "imageUrl": "https://images.pokemontcg.io/bw10/51.png",
     "subtype": "Basic",
@@ -2640,7 +2691,8 @@
     "nationalPokedexNumber": 538
   },
   {
-    "id": "bw10-52",
+    "setOrder":57,
+	"id": "bw10-52",
     "name": "Sawk",
     "imageUrl": "https://images.pokemontcg.io/bw10/52.png",
     "subtype": "Basic",
@@ -2691,7 +2743,8 @@
     "nationalPokedexNumber": 539
   },
   {
-    "id": "bw10-53",
+    "setOrder":57,
+	"id": "bw10-53",
     "name": "Archen",
     "imageUrl": "https://images.pokemontcg.io/bw10/53.png",
     "subtype": "Restored",
@@ -2743,7 +2796,8 @@
     ]
   },
   {
-    "id": "bw10-54",
+    "setOrder":57,
+	"id": "bw10-54",
     "name": "Archeops",
     "imageUrl": "https://images.pokemontcg.io/bw10/54.png",
     "subtype": "Stage 1",
@@ -2791,7 +2845,8 @@
     "nationalPokedexNumber": 567
   },
   {
-    "id": "bw10-55",
+    "setOrder":57,
+	"id": "bw10-55",
     "name": "Houndour",
     "imageUrl": "https://images.pokemontcg.io/bw10/55.png",
     "subtype": "Basic",
@@ -2850,7 +2905,8 @@
     ]
   },
   {
-    "id": "bw10-56",
+    "setOrder":57,
+	"id": "bw10-56",
     "name": "Houndoom",
     "imageUrl": "https://images.pokemontcg.io/bw10/56.png",
     "subtype": "Stage 1",
@@ -2909,7 +2965,8 @@
     "nationalPokedexNumber": 229
   },
   {
-    "id": "bw10-57",
+    "setOrder":57,
+	"id": "bw10-57",
     "name": "Aron",
     "imageUrl": "https://images.pokemontcg.io/bw10/57.png",
     "subtype": "Basic",
@@ -2970,7 +3027,8 @@
     ]
   },
   {
-    "id": "bw10-58",
+    "setOrder":57,
+	"id": "bw10-58",
     "name": "Lairon",
     "imageUrl": "https://images.pokemontcg.io/bw10/58.png",
     "subtype": "Stage 1",
@@ -3034,7 +3092,8 @@
     ]
   },
   {
-    "id": "bw10-59",
+    "setOrder":57,
+	"id": "bw10-59",
     "name": "Aggron",
     "imageUrl": "https://images.pokemontcg.io/bw10/59.png",
     "subtype": "Stage 2",
@@ -3097,7 +3156,8 @@
     "nationalPokedexNumber": 306
   },
   {
-    "id": "bw10-60",
+    "setOrder":57,
+	"id": "bw10-60",
     "name": "Jirachi-EX",
     "imageUrl": "https://images.pokemontcg.io/bw10/60.png",
     "subtype": "EX",
@@ -3153,7 +3213,8 @@
     "nationalPokedexNumber": 385
   },
   {
-    "id": "bw10-61",
+    "setOrder":57,
+	"id": "bw10-61",
     "name": "Escavalier",
     "imageUrl": "https://images.pokemontcg.io/bw10/61.png",
     "subtype": "Stage 1",
@@ -3214,7 +3275,8 @@
     "nationalPokedexNumber": 589
   },
   {
-    "id": "bw10-62",
+    "setOrder":57,
+	"id": "bw10-62",
     "name": "Bagon",
     "imageUrl": "https://images.pokemontcg.io/bw10/62.png",
     "subtype": "Basic",
@@ -3267,7 +3329,8 @@
     ]
   },
   {
-    "id": "bw10-63",
+    "setOrder":57,
+	"id": "bw10-63",
     "name": "Shelgon",
     "imageUrl": "https://images.pokemontcg.io/bw10/63.png",
     "subtype": "Stage 1",
@@ -3324,7 +3387,8 @@
     ]
   },
   {
-    "id": "bw10-64",
+    "setOrder":57,
+	"id": "bw10-64",
     "name": "Salamence",
     "imageUrl": "https://images.pokemontcg.io/bw10/64.png",
     "subtype": "Stage 2",
@@ -3376,7 +3440,8 @@
     "nationalPokedexNumber": 373
   },
   {
-    "id": "bw10-65",
+    "setOrder":57,
+	"id": "bw10-65",
     "name": "Dialga-EX",
     "imageUrl": "https://images.pokemontcg.io/bw10/65.png",
     "subtype": "EX",
@@ -3434,7 +3499,8 @@
     "nationalPokedexNumber": 483
   },
   {
-    "id": "bw10-66",
+    "setOrder":57,
+	"id": "bw10-66",
     "name": "Palkia-EX",
     "imageUrl": "https://images.pokemontcg.io/bw10/66.png",
     "subtype": "EX",
@@ -3492,7 +3558,8 @@
     "nationalPokedexNumber": 484
   },
   {
-    "id": "bw10-67",
+    "setOrder":57,
+	"id": "bw10-67",
     "name": "Axew",
     "imageUrl": "https://images.pokemontcg.io/bw10/67.png",
     "subtype": "Basic",
@@ -3545,7 +3612,8 @@
     ]
   },
   {
-    "id": "bw10-68",
+    "setOrder":57,
+	"id": "bw10-68",
     "name": "Fraxure",
     "imageUrl": "https://images.pokemontcg.io/bw10/68.png",
     "subtype": "Stage 1",
@@ -3600,7 +3668,8 @@
     ]
   },
   {
-    "id": "bw10-69",
+    "setOrder":57,
+	"id": "bw10-69",
     "name": "Haxorus",
     "imageUrl": "https://images.pokemontcg.io/bw10/69.png",
     "subtype": "Stage 2",
@@ -3652,7 +3721,8 @@
     "nationalPokedexNumber": 612
   },
   {
-    "id": "bw10-70",
+    "setOrder":57,
+	"id": "bw10-70",
     "name": "Druddigon",
     "imageUrl": "https://images.pokemontcg.io/bw10/70.png",
     "subtype": "Basic",
@@ -3703,7 +3773,8 @@
     "nationalPokedexNumber": 621
   },
   {
-    "id": "bw10-71",
+    "setOrder":57,
+	"id": "bw10-71",
     "name": "Kangaskhan",
     "imageUrl": "https://images.pokemontcg.io/bw10/71.png",
     "subtype": "Basic",
@@ -3754,7 +3825,8 @@
     "nationalPokedexNumber": 115
   },
   {
-    "id": "bw10-72",
+    "setOrder":57,
+	"id": "bw10-72",
     "name": "Porygon",
     "imageUrl": "https://images.pokemontcg.io/bw10/72.png",
     "subtype": "Basic",
@@ -3797,7 +3869,8 @@
     ]
   },
   {
-    "id": "bw10-73",
+    "setOrder":57,
+	"id": "bw10-73",
     "name": "Porygon2",
     "imageUrl": "https://images.pokemontcg.io/bw10/73.png",
     "subtype": "Stage 1",
@@ -3842,7 +3915,8 @@
     ]
   },
   {
-    "id": "bw10-74",
+    "setOrder":57,
+	"id": "bw10-74",
     "name": "Porygon-Z",
     "imageUrl": "https://images.pokemontcg.io/bw10/74.png",
     "subtype": "Stage 2",
@@ -3890,7 +3964,8 @@
     "nationalPokedexNumber": 474
   },
   {
-    "id": "bw10-75",
+    "setOrder":57,
+	"id": "bw10-75",
     "name": "Teddiursa",
     "imageUrl": "https://images.pokemontcg.io/bw10/75.png",
     "subtype": "Basic",
@@ -3935,7 +4010,8 @@
     ]
   },
   {
-    "id": "bw10-76",
+    "setOrder":57,
+	"id": "bw10-76",
     "name": "Ursaring",
     "imageUrl": "https://images.pokemontcg.io/bw10/76.png",
     "subtype": "Stage 1",
@@ -3992,7 +4068,8 @@
     "nationalPokedexNumber": 217
   },
   {
-    "id": "bw10-77",
+    "setOrder":57,
+	"id": "bw10-77",
     "name": "Chatot",
     "imageUrl": "https://images.pokemontcg.io/bw10/77.png",
     "subtype": "Basic",
@@ -4048,7 +4125,8 @@
     "nationalPokedexNumber": 441
   },
   {
-    "id": "bw10-78",
+    "setOrder":57,
+	"id": "bw10-78",
     "name": "Caitlin",
     "imageUrl": "https://images.pokemontcg.io/bw10/78.png",
     "subtype": "Supporter",
@@ -4065,7 +4143,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw10/78_hires.png"
   },
   {
-    "id": "bw10-79",
+    "setOrder":57,
+	"id": "bw10-79",
     "name": "Cover Fossil",
     "imageUrl": "https://images.pokemontcg.io/bw10/79.png",
     "subtype": "Item",
@@ -4082,7 +4161,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw10/79_hires.png"
   },
   {
-    "id": "bw10-80",
+    "setOrder":57,
+	"id": "bw10-80",
     "name": "Energy Retrieval",
     "imageUrl": "https://images.pokemontcg.io/bw10/80.png",
     "subtype": "Item",
@@ -4099,7 +4179,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw10/80_hires.png"
   },
   {
-    "id": "bw10-81",
+    "setOrder":57,
+	"id": "bw10-81",
     "name": "Iris",
     "imageUrl": "https://images.pokemontcg.io/bw10/81.png",
     "subtype": "Supporter",
@@ -4116,7 +4197,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw10/81_hires.png"
   },
   {
-    "id": "bw10-82",
+    "setOrder":57,
+	"id": "bw10-82",
     "name": "Plume Fossil",
     "imageUrl": "https://images.pokemontcg.io/bw10/82.png",
     "subtype": "Item",
@@ -4133,7 +4215,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw10/82_hires.png"
   },
   {
-    "id": "bw10-83",
+    "setOrder":57,
+	"id": "bw10-83",
     "name": "Pokémon Catcher",
     "imageUrl": "https://images.pokemontcg.io/bw10/83.png",
     "subtype": "Item",
@@ -4150,7 +4233,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw10/83_hires.png"
   },
   {
-    "id": "bw10-84",
+    "setOrder":57,
+	"id": "bw10-84",
     "name": "Professor Juniper",
     "imageUrl": "https://images.pokemontcg.io/bw10/84.png",
     "subtype": "Supporter",
@@ -4167,7 +4251,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw10/84_hires.png"
   },
   {
-    "id": "bw10-85",
+    "setOrder":57,
+	"id": "bw10-85",
     "name": "Rare Candy",
     "imageUrl": "https://images.pokemontcg.io/bw10/85.png",
     "subtype": "Item",
@@ -4184,7 +4269,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw10/85_hires.png"
   },
   {
-    "id": "bw10-86",
+    "setOrder":57,
+	"id": "bw10-86",
     "name": "Reversal Trigger",
     "imageUrl": "https://images.pokemontcg.io/bw10/86.png",
     "subtype": "Pokémon Tool",
@@ -4201,7 +4287,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw10/86_hires.png"
   },
   {
-    "id": "bw10-87",
+    "setOrder":57,
+	"id": "bw10-87",
     "name": "Root Fossil Lileep",
     "imageUrl": "https://images.pokemontcg.io/bw10/87.png",
     "subtype": "Item",
@@ -4218,7 +4305,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw10/87_hires.png"
   },
   {
-    "id": "bw10-88",
+    "setOrder":57,
+	"id": "bw10-88",
     "name": "Silver Bangle",
     "imageUrl": "https://images.pokemontcg.io/bw10/88.png",
     "subtype": "Pokémon Tool",
@@ -4235,7 +4323,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw10/88_hires.png"
   },
   {
-    "id": "bw10-89",
+    "setOrder":57,
+	"id": "bw10-89",
     "name": "Silver Mirror",
     "imageUrl": "https://images.pokemontcg.io/bw10/89.png",
     "subtype": "Pokémon Tool",
@@ -4252,7 +4341,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw10/89_hires.png"
   },
   {
-    "id": "bw10-90",
+    "setOrder":57,
+	"id": "bw10-90",
     "name": "Ultra Ball",
     "imageUrl": "https://images.pokemontcg.io/bw10/90.png",
     "subtype": "Item",
@@ -4269,7 +4359,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw10/90_hires.png"
   },
   {
-    "id": "bw10-91",
+    "setOrder":57,
+	"id": "bw10-91",
     "name": "Plasma Energy",
     "imageUrl": "https://images.pokemontcg.io/bw10/91.png",
     "subtype": "Special",
@@ -4286,7 +4377,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw10/91_hires.png"
   },
   {
-    "id": "bw10-92",
+    "setOrder":57,
+	"id": "bw10-92",
     "name": "G Booster",
     "imageUrl": "https://images.pokemontcg.io/bw10/92.png",
     "subtype": "Pokémon Tool",
@@ -4303,7 +4395,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw10/92_hires.png"
   },
   {
-    "id": "bw10-93",
+    "setOrder":57,
+	"id": "bw10-93",
     "name": "G Scope",
     "imageUrl": "https://images.pokemontcg.io/bw10/93.png",
     "subtype": "Pokémon Tool",
@@ -4320,7 +4413,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw10/93_hires.png"
   },
   {
-    "id": "bw10-94",
+    "setOrder":57,
+	"id": "bw10-94",
     "name": "Master Ball",
     "imageUrl": "https://images.pokemontcg.io/bw10/94.png",
     "subtype": "Item",
@@ -4337,7 +4431,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw10/94_hires.png"
   },
   {
-    "id": "bw10-95",
+    "setOrder":57,
+	"id": "bw10-95",
     "name": "Scoop Up Cyclone",
     "imageUrl": "https://images.pokemontcg.io/bw10/95.png",
     "subtype": "Item",
@@ -4354,7 +4449,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw10/95_hires.png"
   },
   {
-    "id": "bw10-96",
+    "setOrder":57,
+	"id": "bw10-96",
     "name": "Virizion-EX",
     "imageUrl": "https://images.pokemontcg.io/bw10/96.png",
     "subtype": "EX",
@@ -4409,7 +4505,8 @@
     "nationalPokedexNumber": 640
   },
   {
-    "id": "bw10-97",
+    "setOrder":57,
+	"id": "bw10-97",
     "name": "Genesect-EX",
     "imageUrl": "https://images.pokemontcg.io/bw10/97.png",
     "subtype": "EX",
@@ -4459,7 +4556,8 @@
     "nationalPokedexNumber": 649
   },
   {
-    "id": "bw10-98",
+    "setOrder":57,
+	"id": "bw10-98",
     "name": "Jirachi-EX",
     "imageUrl": "https://images.pokemontcg.io/bw10/98.png",
     "subtype": "EX",
@@ -4515,7 +4613,8 @@
     "nationalPokedexNumber": 385
   },
   {
-    "id": "bw10-99",
+    "setOrder":57,
+	"id": "bw10-99",
     "name": "Dialga-EX",
     "imageUrl": "https://images.pokemontcg.io/bw10/99.png",
     "subtype": "EX",
@@ -4573,7 +4672,8 @@
     "nationalPokedexNumber": 483
   },
   {
-    "id": "bw10-100",
+    "setOrder":57,
+	"id": "bw10-100",
     "name": "Palkia-EX",
     "imageUrl": "https://images.pokemontcg.io/bw10/100.png",
     "subtype": "EX",
@@ -4631,7 +4731,8 @@
     "nationalPokedexNumber": 484
   },
   {
-    "id": "bw10-101",
+    "setOrder":57,
+	"id": "bw10-101",
     "name": "Iris",
     "imageUrl": "https://images.pokemontcg.io/bw10/101.png",
     "subtype": "Supporter",
@@ -4648,7 +4749,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw10/101_hires.png"
   },
   {
-    "id": "bw10-102",
+    "setOrder":57,
+	"id": "bw10-102",
     "name": "Exeggcute",
     "imageUrl": "https://images.pokemontcg.io/bw10/102.png",
     "subtype": "Basic",
@@ -4703,7 +4805,8 @@
     ]
   },
   {
-    "id": "bw10-103",
+    "setOrder":57,
+	"id": "bw10-103",
     "name": "Virizion",
     "imageUrl": "https://images.pokemontcg.io/bw10/103.png",
     "subtype": "Basic",
@@ -4759,7 +4862,8 @@
     "nationalPokedexNumber": 640
   },
   {
-    "id": "bw10-104",
+    "setOrder":57,
+	"id": "bw10-104",
     "name": "Dusknoir",
     "imageUrl": "https://images.pokemontcg.io/bw10/104.png",
     "subtype": "Stage 2",
@@ -4810,7 +4914,8 @@
     "nationalPokedexNumber": 477
   },
   {
-    "id": "bw10-105",
+    "setOrder":57,
+	"id": "bw10-105",
     "name": "Rare Candy",
     "imageUrl": "https://images.pokemontcg.io/bw10/105.png",
     "subtype": "Item",

--- a/json/cards/Plasma Freeze.json
+++ b/json/cards/Plasma Freeze.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "bw9-1",
+    "setOrder":56,
+	"id": "bw9-1",
     "name": "Weedle",
     "imageUrl": "https://images.pokemontcg.io/bw9/1.png",
     "subtype": "Basic",
@@ -43,7 +44,8 @@
     ]
   },
   {
-    "id": "bw9-2",
+    "setOrder":56,
+	"id": "bw9-2",
     "name": "Kakuna",
     "imageUrl": "https://images.pokemontcg.io/bw9/2.png",
     "subtype": "Stage 1",
@@ -88,7 +90,8 @@
     ]
   },
   {
-    "id": "bw9-3",
+    "setOrder":56,
+	"id": "bw9-3",
     "name": "Beedrill",
     "imageUrl": "https://images.pokemontcg.io/bw9/3.png",
     "subtype": "Stage 2",
@@ -137,7 +140,8 @@
     "nationalPokedexNumber": 15
   },
   {
-    "id": "bw9-4",
+    "setOrder":56,
+	"id": "bw9-4",
     "name": "Exeggcute",
     "imageUrl": "https://images.pokemontcg.io/bw9/4.png",
     "subtype": "Basic",
@@ -192,7 +196,8 @@
     ]
   },
   {
-    "id": "bw9-5",
+    "setOrder":56,
+	"id": "bw9-5",
     "name": "Exeggutor",
     "imageUrl": "https://images.pokemontcg.io/bw9/5.png",
     "subtype": "Stage 1",
@@ -251,7 +256,8 @@
     "nationalPokedexNumber": 103
   },
   {
-    "id": "bw9-6",
+    "setOrder":56,
+	"id": "bw9-6",
     "name": "Treecko",
     "imageUrl": "https://images.pokemontcg.io/bw9/6.png",
     "subtype": "Basic",
@@ -310,7 +316,8 @@
     ]
   },
   {
-    "id": "bw9-7",
+    "setOrder":56,
+	"id": "bw9-7",
     "name": "Grovyle",
     "imageUrl": "https://images.pokemontcg.io/bw9/7.png",
     "subtype": "Stage 1",
@@ -370,7 +377,8 @@
     ]
   },
   {
-    "id": "bw9-8",
+    "setOrder":56,
+	"id": "bw9-8",
     "name": "Sceptile",
     "imageUrl": "https://images.pokemontcg.io/bw9/8.png",
     "subtype": "Stage 2",
@@ -430,7 +438,8 @@
     "nationalPokedexNumber": 254
   },
   {
-    "id": "bw9-9",
+    "setOrder":56,
+	"id": "bw9-9",
     "name": "Cacnea",
     "imageUrl": "https://images.pokemontcg.io/bw9/9.png",
     "subtype": "Basic",
@@ -480,7 +489,8 @@
     ]
   },
   {
-    "id": "bw9-10",
+    "setOrder":56,
+	"id": "bw9-10",
     "name": "Cacturne",
     "imageUrl": "https://images.pokemontcg.io/bw9/10.png",
     "subtype": "Stage 1",
@@ -537,7 +547,8 @@
     "nationalPokedexNumber": 332
   },
   {
-    "id": "bw9-11",
+    "setOrder":56,
+	"id": "bw9-11",
     "name": "Leafeon",
     "imageUrl": "https://images.pokemontcg.io/bw9/11.png",
     "subtype": "Stage 1",
@@ -596,7 +607,8 @@
     "nationalPokedexNumber": 470
   },
   {
-    "id": "bw9-12",
+    "setOrder":56,
+	"id": "bw9-12",
     "name": "Flareon",
     "imageUrl": "https://images.pokemontcg.io/bw9/12.png",
     "subtype": "Stage 1",
@@ -650,7 +662,8 @@
     "nationalPokedexNumber": 136
   },
   {
-    "id": "bw9-13",
+    "setOrder":56,
+	"id": "bw9-13",
     "name": "Heatran-EX",
     "imageUrl": "https://images.pokemontcg.io/bw9/13.png",
     "subtype": "EX",
@@ -709,7 +722,8 @@
     "nationalPokedexNumber": 485
   },
   {
-    "id": "bw9-14",
+    "setOrder":56,
+	"id": "bw9-14",
     "name": "Litwick",
     "imageUrl": "https://images.pokemontcg.io/bw9/14.png",
     "subtype": "Basic",
@@ -762,7 +776,8 @@
     ]
   },
   {
-    "id": "bw9-15",
+    "setOrder":56,
+	"id": "bw9-15",
     "name": "Lampent",
     "imageUrl": "https://images.pokemontcg.io/bw9/15.png",
     "subtype": "Stage 1",
@@ -818,7 +833,8 @@
     ]
   },
   {
-    "id": "bw9-16",
+    "setOrder":56,
+	"id": "bw9-16",
     "name": "Chandelure",
     "imageUrl": "https://images.pokemontcg.io/bw9/16.png",
     "subtype": "Stage 2",
@@ -867,7 +883,8 @@
     "nationalPokedexNumber": 609
   },
   {
-    "id": "bw9-17",
+    "setOrder":56,
+	"id": "bw9-17",
     "name": "Reshiram",
     "imageUrl": "https://images.pokemontcg.io/bw9/17.png",
     "subtype": "Basic",
@@ -922,7 +939,8 @@
     "nationalPokedexNumber": 643
   },
   {
-    "id": "bw9-18",
+    "setOrder":56,
+	"id": "bw9-18",
     "name": "Horsea",
     "imageUrl": "https://images.pokemontcg.io/bw9/18.png",
     "subtype": "Basic",
@@ -965,7 +983,8 @@
     ]
   },
   {
-    "id": "bw9-19",
+    "setOrder":56,
+	"id": "bw9-19",
     "name": "Seadra",
     "imageUrl": "https://images.pokemontcg.io/bw9/19.png",
     "subtype": "Stage 1",
@@ -1009,7 +1028,8 @@
     ]
   },
   {
-    "id": "bw9-20",
+    "setOrder":56,
+	"id": "bw9-20",
     "name": "Vaporeon",
     "imageUrl": "https://images.pokemontcg.io/bw9/20.png",
     "subtype": "Stage 1",
@@ -1061,7 +1081,8 @@
     "nationalPokedexNumber": 134
   },
   {
-    "id": "bw9-21",
+    "setOrder":56,
+	"id": "bw9-21",
     "name": "Wooper",
     "imageUrl": "https://images.pokemontcg.io/bw9/21.png",
     "subtype": "Basic",
@@ -1106,7 +1127,8 @@
     ]
   },
   {
-    "id": "bw9-22",
+    "setOrder":56,
+	"id": "bw9-22",
     "name": "Quagsire",
     "imageUrl": "https://images.pokemontcg.io/bw9/22.png",
     "subtype": "Stage 1",
@@ -1156,7 +1178,8 @@
     "nationalPokedexNumber": 195
   },
   {
-    "id": "bw9-23",
+    "setOrder":56,
+	"id": "bw9-23",
     "name": "Glaceon",
     "imageUrl": "https://images.pokemontcg.io/bw9/23.png",
     "subtype": "Stage 1",
@@ -1205,7 +1228,8 @@
     "nationalPokedexNumber": 471
   },
   {
-    "id": "bw9-24",
+    "setOrder":56,
+	"id": "bw9-24",
     "name": "Tympole",
     "imageUrl": "https://images.pokemontcg.io/bw9/24.png",
     "subtype": "Basic",
@@ -1248,7 +1272,8 @@
     ]
   },
   {
-    "id": "bw9-25",
+    "setOrder":56,
+	"id": "bw9-25",
     "name": "Palpitoad",
     "imageUrl": "https://images.pokemontcg.io/bw9/25.png",
     "subtype": "Stage 1",
@@ -1305,7 +1330,8 @@
     ]
   },
   {
-    "id": "bw9-26",
+    "setOrder":56,
+	"id": "bw9-26",
     "name": "Seismitoad",
     "imageUrl": "https://images.pokemontcg.io/bw9/26.png",
     "subtype": "Stage 2",
@@ -1361,7 +1387,8 @@
     "nationalPokedexNumber": 537
   },
   {
-    "id": "bw9-27",
+    "setOrder":56,
+	"id": "bw9-27",
     "name": "Vanillite",
     "imageUrl": "https://images.pokemontcg.io/bw9/27.png",
     "subtype": "Basic",
@@ -1405,7 +1432,8 @@
     ]
   },
   {
-    "id": "bw9-28",
+    "setOrder":56,
+	"id": "bw9-28",
     "name": "Vanillish",
     "imageUrl": "https://images.pokemontcg.io/bw9/28.png",
     "subtype": "Stage 1",
@@ -1450,7 +1478,8 @@
     ]
   },
   {
-    "id": "bw9-29",
+    "setOrder":56,
+	"id": "bw9-29",
     "name": "Vanilluxe",
     "imageUrl": "https://images.pokemontcg.io/bw9/29.png",
     "subtype": "Stage 2",
@@ -1501,7 +1530,8 @@
     "nationalPokedexNumber": 584
   },
   {
-    "id": "bw9-30",
+    "setOrder":56,
+	"id": "bw9-30",
     "name": "Cryogonal",
     "imageUrl": "https://images.pokemontcg.io/bw9/30.png",
     "subtype": "Basic",
@@ -1550,7 +1580,8 @@
     "nationalPokedexNumber": 615
   },
   {
-    "id": "bw9-31",
+    "setOrder":56,
+	"id": "bw9-31",
     "name": "Kyurem",
     "imageUrl": "https://images.pokemontcg.io/bw9/31.png",
     "subtype": "Basic",
@@ -1604,7 +1635,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "bw9-32",
+    "setOrder":56,
+	"id": "bw9-32",
     "name": "Voltorb",
     "imageUrl": "https://images.pokemontcg.io/bw9/32.png",
     "subtype": "Basic",
@@ -1648,7 +1680,8 @@
     ]
   },
   {
-    "id": "bw9-33",
+    "setOrder":56,
+	"id": "bw9-33",
     "name": "Electrode",
     "imageUrl": "https://images.pokemontcg.io/bw9/33.png",
     "subtype": "Stage 1",
@@ -1696,7 +1729,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "bw9-34",
+    "setOrder":56,
+	"id": "bw9-34",
     "name": "Jolteon",
     "imageUrl": "https://images.pokemontcg.io/bw9/34.png",
     "subtype": "Stage 1",
@@ -1747,7 +1781,8 @@
     "nationalPokedexNumber": 135
   },
   {
-    "id": "bw9-35",
+    "setOrder":56,
+	"id": "bw9-35",
     "name": "Chinchou",
     "imageUrl": "https://images.pokemontcg.io/bw9/35.png",
     "subtype": "Basic",
@@ -1792,7 +1827,8 @@
     ]
   },
   {
-    "id": "bw9-36",
+    "setOrder":56,
+	"id": "bw9-36",
     "name": "Lanturn",
     "imageUrl": "https://images.pokemontcg.io/bw9/36.png",
     "subtype": "Stage 1",
@@ -1845,7 +1881,8 @@
     "nationalPokedexNumber": 171
   },
   {
-    "id": "bw9-37",
+    "setOrder":56,
+	"id": "bw9-37",
     "name": "Pachirisu",
     "imageUrl": "https://images.pokemontcg.io/bw9/37.png",
     "subtype": "Basic",
@@ -1894,7 +1931,8 @@
     "nationalPokedexNumber": 417
   },
   {
-    "id": "bw9-38",
+    "setOrder":56,
+	"id": "bw9-38",
     "name": "Thundurus-EX",
     "imageUrl": "https://images.pokemontcg.io/bw9/38.png",
     "subtype": "EX",
@@ -1949,7 +1987,8 @@
     "nationalPokedexNumber": 642
   },
   {
-    "id": "bw9-39",
+    "setOrder":56,
+	"id": "bw9-39",
     "name": "Zekrom",
     "imageUrl": "https://images.pokemontcg.io/bw9/39.png",
     "subtype": "Basic",
@@ -2004,7 +2043,8 @@
     "nationalPokedexNumber": 644
   },
   {
-    "id": "bw9-40",
+    "setOrder":56,
+	"id": "bw9-40",
     "name": "Nidoran♀",
     "imageUrl": "https://images.pokemontcg.io/bw9/40.png",
     "subtype": "Basic",
@@ -2048,7 +2088,8 @@
     ]
   },
   {
-    "id": "bw9-41",
+    "setOrder":56,
+	"id": "bw9-41",
     "name": "Nidorina",
     "imageUrl": "https://images.pokemontcg.io/bw9/41.png",
     "subtype": "Stage 1",
@@ -2106,7 +2147,8 @@
     ]
   },
   {
-    "id": "bw9-42",
+    "setOrder":56,
+	"id": "bw9-42",
     "name": "Nidoqueen",
     "imageUrl": "https://images.pokemontcg.io/bw9/42.png",
     "subtype": "Stage 2",
@@ -2161,7 +2203,8 @@
     "nationalPokedexNumber": 31
   },
   {
-    "id": "bw9-43",
+    "setOrder":56,
+	"id": "bw9-43",
     "name": "Nidoran♂",
     "imageUrl": "https://images.pokemontcg.io/bw9/43.png",
     "subtype": "Basic",
@@ -2204,7 +2247,8 @@
     ]
   },
   {
-    "id": "bw9-44",
+    "setOrder":56,
+	"id": "bw9-44",
     "name": "Nidorino",
     "imageUrl": "https://images.pokemontcg.io/bw9/44.png",
     "subtype": "Stage 1",
@@ -2262,7 +2306,8 @@
     ]
   },
   {
-    "id": "bw9-45",
+    "setOrder":56,
+	"id": "bw9-45",
     "name": "Grimer",
     "imageUrl": "https://images.pokemontcg.io/bw9/45.png",
     "subtype": "Basic",
@@ -2317,7 +2362,8 @@
     ]
   },
   {
-    "id": "bw9-46",
+    "setOrder":56,
+	"id": "bw9-46",
     "name": "Muk",
     "imageUrl": "https://images.pokemontcg.io/bw9/46.png",
     "subtype": "Stage 1",
@@ -2374,7 +2420,8 @@
     "nationalPokedexNumber": 89
   },
   {
-    "id": "bw9-47",
+    "setOrder":56,
+	"id": "bw9-47",
     "name": "Mr. Mime",
     "imageUrl": "https://images.pokemontcg.io/bw9/47.png",
     "subtype": "Basic",
@@ -2420,7 +2467,8 @@
     "nationalPokedexNumber": 122
   },
   {
-    "id": "bw9-48",
+    "setOrder":56,
+	"id": "bw9-48",
     "name": "Espeon",
     "imageUrl": "https://images.pokemontcg.io/bw9/48.png",
     "subtype": "Stage 1",
@@ -2470,7 +2518,8 @@
     "nationalPokedexNumber": 196
   },
   {
-    "id": "bw9-49",
+    "setOrder":56,
+	"id": "bw9-49",
     "name": "Sableye",
     "imageUrl": "https://images.pokemontcg.io/bw9/49.png",
     "subtype": "Basic",
@@ -2514,7 +2563,8 @@
     "nationalPokedexNumber": 302
   },
   {
-    "id": "bw9-50",
+    "setOrder":56,
+	"id": "bw9-50",
     "name": "Beldum",
     "imageUrl": "https://images.pokemontcg.io/bw9/50.png",
     "subtype": "Basic",
@@ -2567,7 +2617,8 @@
     ]
   },
   {
-    "id": "bw9-51",
+    "setOrder":56,
+	"id": "bw9-51",
     "name": "Metang",
     "imageUrl": "https://images.pokemontcg.io/bw9/51.png",
     "subtype": "Stage 1",
@@ -2623,7 +2674,8 @@
     ]
   },
   {
-    "id": "bw9-52",
+    "setOrder":56,
+	"id": "bw9-52",
     "name": "Metagross",
     "imageUrl": "https://images.pokemontcg.io/bw9/52.png",
     "subtype": "Stage 2",
@@ -2673,7 +2725,8 @@
     "nationalPokedexNumber": 376
   },
   {
-    "id": "bw9-53",
+    "setOrder":56,
+	"id": "bw9-53",
     "name": "Deoxys-EX",
     "imageUrl": "https://images.pokemontcg.io/bw9/53.png",
     "subtype": "EX",
@@ -2723,7 +2776,8 @@
     "nationalPokedexNumber": 386
   },
   {
-    "id": "bw9-54",
+    "setOrder":56,
+	"id": "bw9-54",
     "name": "Yamask",
     "imageUrl": "https://images.pokemontcg.io/bw9/54.png",
     "subtype": "Basic",
@@ -2767,7 +2821,8 @@
     ]
   },
   {
-    "id": "bw9-55",
+    "setOrder":56,
+	"id": "bw9-55",
     "name": "Yamask",
     "imageUrl": "https://images.pokemontcg.io/bw9/55.png",
     "subtype": "Basic",
@@ -2821,7 +2876,8 @@
     ]
   },
   {
-    "id": "bw9-56",
+    "setOrder":56,
+	"id": "bw9-56",
     "name": "Cofagrigus",
     "imageUrl": "https://images.pokemontcg.io/bw9/56.png",
     "subtype": "Stage 1",
@@ -2870,7 +2926,8 @@
     "nationalPokedexNumber": 563
   },
   {
-    "id": "bw9-57",
+    "setOrder":56,
+	"id": "bw9-57",
     "name": "Cofagrigus",
     "imageUrl": "https://images.pokemontcg.io/bw9/57.png",
     "subtype": "Stage 1",
@@ -2923,7 +2980,8 @@
     "nationalPokedexNumber": 563
   },
   {
-    "id": "bw9-58",
+    "setOrder":56,
+	"id": "bw9-58",
     "name": "Nidoking",
     "imageUrl": "https://images.pokemontcg.io/bw9/58.png",
     "subtype": "Stage 2",
@@ -2985,7 +3043,8 @@
     "nationalPokedexNumber": 34
   },
   {
-    "id": "bw9-59",
+    "setOrder":56,
+	"id": "bw9-59",
     "name": "Mankey",
     "imageUrl": "https://images.pokemontcg.io/bw9/59.png",
     "subtype": "Basic",
@@ -3028,7 +3087,8 @@
     ]
   },
   {
-    "id": "bw9-60",
+    "setOrder":56,
+	"id": "bw9-60",
     "name": "Primeape",
     "imageUrl": "https://images.pokemontcg.io/bw9/60.png",
     "subtype": "Stage 1",
@@ -3080,7 +3140,8 @@
     "nationalPokedexNumber": 57
   },
   {
-    "id": "bw9-61",
+    "setOrder":56,
+	"id": "bw9-61",
     "name": "Onix",
     "imageUrl": "https://images.pokemontcg.io/bw9/61.png",
     "subtype": "Basic",
@@ -3139,7 +3200,8 @@
     ]
   },
   {
-    "id": "bw9-62",
+    "setOrder":56,
+	"id": "bw9-62",
     "name": "Makuhita",
     "imageUrl": "https://images.pokemontcg.io/bw9/62.png",
     "subtype": "Basic",
@@ -3196,7 +3258,8 @@
     ]
   },
   {
-    "id": "bw9-63",
+    "setOrder":56,
+	"id": "bw9-63",
     "name": "Hariyama",
     "imageUrl": "https://images.pokemontcg.io/bw9/63.png",
     "subtype": "Stage 1",
@@ -3251,7 +3314,8 @@
     "nationalPokedexNumber": 297
   },
   {
-    "id": "bw9-64",
+    "setOrder":56,
+	"id": "bw9-64",
     "name": "Umbreon",
     "imageUrl": "https://images.pokemontcg.io/bw9/64.png",
     "subtype": "Stage 1",
@@ -3305,7 +3369,8 @@
     "nationalPokedexNumber": 197
   },
   {
-    "id": "bw9-65",
+    "setOrder":56,
+	"id": "bw9-65",
     "name": "Sneasel",
     "imageUrl": "https://images.pokemontcg.io/bw9/65.png",
     "subtype": "Basic",
@@ -3355,7 +3420,8 @@
     ]
   },
   {
-    "id": "bw9-66",
+    "setOrder":56,
+	"id": "bw9-66",
     "name": "Weavile",
     "imageUrl": "https://images.pokemontcg.io/bw9/66.png",
     "subtype": "Stage 1",
@@ -3412,7 +3478,8 @@
     "nationalPokedexNumber": 461
   },
   {
-    "id": "bw9-67",
+    "setOrder":56,
+	"id": "bw9-67",
     "name": "Absol",
     "imageUrl": "https://images.pokemontcg.io/bw9/67.png",
     "subtype": "Basic",
@@ -3470,7 +3537,8 @@
     "nationalPokedexNumber": 359
   },
   {
-    "id": "bw9-68",
+    "setOrder":56,
+	"id": "bw9-68",
     "name": "Sandile",
     "imageUrl": "https://images.pokemontcg.io/bw9/68.png",
     "subtype": "Basic",
@@ -3521,7 +3589,8 @@
     ]
   },
   {
-    "id": "bw9-69",
+    "setOrder":56,
+	"id": "bw9-69",
     "name": "Krokorok",
     "imageUrl": "https://images.pokemontcg.io/bw9/69.png",
     "subtype": "Stage 1",
@@ -3583,7 +3652,8 @@
     ]
   },
   {
-    "id": "bw9-70",
+    "setOrder":56,
+	"id": "bw9-70",
     "name": "Krookodile",
     "imageUrl": "https://images.pokemontcg.io/bw9/70.png",
     "subtype": "Stage 2",
@@ -3643,7 +3713,8 @@
     "nationalPokedexNumber": 553
   },
   {
-    "id": "bw9-71",
+    "setOrder":56,
+	"id": "bw9-71",
     "name": "Pawniard",
     "imageUrl": "https://images.pokemontcg.io/bw9/71.png",
     "subtype": "Basic",
@@ -3692,7 +3763,8 @@
     ]
   },
   {
-    "id": "bw9-72",
+    "setOrder":56,
+	"id": "bw9-72",
     "name": "Pawniard",
     "imageUrl": "https://images.pokemontcg.io/bw9/72.png",
     "subtype": "Basic",
@@ -3742,7 +3814,8 @@
     ]
   },
   {
-    "id": "bw9-73",
+    "setOrder":56,
+	"id": "bw9-73",
     "name": "Bisharp",
     "imageUrl": "https://images.pokemontcg.io/bw9/73.png",
     "subtype": "Stage 1",
@@ -3800,7 +3873,8 @@
     "nationalPokedexNumber": 625
   },
   {
-    "id": "bw9-74",
+    "setOrder":56,
+	"id": "bw9-74",
     "name": "Bisharp",
     "imageUrl": "https://images.pokemontcg.io/bw9/74.png",
     "subtype": "Stage 1",
@@ -3859,7 +3933,8 @@
     "nationalPokedexNumber": 625
   },
   {
-    "id": "bw9-75",
+    "setOrder":56,
+	"id": "bw9-75",
     "name": "Deino",
     "imageUrl": "https://images.pokemontcg.io/bw9/75.png",
     "subtype": "Basic",
@@ -3921,7 +3996,8 @@
     ]
   },
   {
-    "id": "bw9-76",
+    "setOrder":56,
+	"id": "bw9-76",
     "name": "Deino",
     "imageUrl": "https://images.pokemontcg.io/bw9/76.png",
     "subtype": "Basic",
@@ -3972,7 +4048,8 @@
     ]
   },
   {
-    "id": "bw9-77",
+    "setOrder":56,
+	"id": "bw9-77",
     "name": "Zweilous",
     "imageUrl": "https://images.pokemontcg.io/bw9/77.png",
     "subtype": "Stage 1",
@@ -4035,7 +4112,8 @@
     ]
   },
   {
-    "id": "bw9-78",
+    "setOrder":56,
+	"id": "bw9-78",
     "name": "Hydreigon",
     "imageUrl": "https://images.pokemontcg.io/bw9/78.png",
     "subtype": "Stage 2",
@@ -4098,7 +4176,8 @@
     "nationalPokedexNumber": 635
   },
   {
-    "id": "bw9-79",
+    "setOrder":56,
+	"id": "bw9-79",
     "name": "Steelix",
     "imageUrl": "https://images.pokemontcg.io/bw9/79.png",
     "subtype": "Stage 1",
@@ -4163,7 +4242,8 @@
     "nationalPokedexNumber": 208
   },
   {
-    "id": "bw9-80",
+    "setOrder":56,
+	"id": "bw9-80",
     "name": "Mawile",
     "imageUrl": "https://images.pokemontcg.io/bw9/80.png",
     "subtype": "Basic",
@@ -4220,7 +4300,8 @@
     "nationalPokedexNumber": 303
   },
   {
-    "id": "bw9-81",
+    "setOrder":56,
+	"id": "bw9-81",
     "name": "Dratini",
     "imageUrl": "https://images.pokemontcg.io/bw9/81.png",
     "subtype": "Basic",
@@ -4273,7 +4354,8 @@
     ]
   },
   {
-    "id": "bw9-82",
+    "setOrder":56,
+	"id": "bw9-82",
     "name": "Dragonair",
     "imageUrl": "https://images.pokemontcg.io/bw9/82.png",
     "subtype": "Stage 1",
@@ -4328,7 +4410,8 @@
     ]
   },
   {
-    "id": "bw9-83",
+    "setOrder":56,
+	"id": "bw9-83",
     "name": "Dragonite",
     "imageUrl": "https://images.pokemontcg.io/bw9/83.png",
     "subtype": "Stage 2",
@@ -4385,7 +4468,8 @@
     "nationalPokedexNumber": 149
   },
   {
-    "id": "bw9-84",
+    "setOrder":56,
+	"id": "bw9-84",
     "name": "Kingdra",
     "imageUrl": "https://images.pokemontcg.io/bw9/84.png",
     "subtype": "Stage 2",
@@ -4435,7 +4519,8 @@
     "nationalPokedexNumber": 230
   },
   {
-    "id": "bw9-85",
+    "setOrder":56,
+	"id": "bw9-85",
     "name": "Latias-EX",
     "imageUrl": "https://images.pokemontcg.io/bw9/85.png",
     "subtype": "EX",
@@ -4485,7 +4570,8 @@
     "nationalPokedexNumber": 380
   },
   {
-    "id": "bw9-86",
+    "setOrder":56,
+	"id": "bw9-86",
     "name": "Latios-EX",
     "imageUrl": "https://images.pokemontcg.io/bw9/86.png",
     "subtype": "EX",
@@ -4542,7 +4628,8 @@
     "evolvesTo": "M Latios-EX"
   },
   {
-    "id": "bw9-87",
+    "setOrder":56,
+	"id": "bw9-87",
     "name": "Rattata",
     "imageUrl": "https://images.pokemontcg.io/bw9/87.png",
     "subtype": "Basic",
@@ -4586,7 +4673,8 @@
     ]
   },
   {
-    "id": "bw9-88",
+    "setOrder":56,
+	"id": "bw9-88",
     "name": "Raticate",
     "imageUrl": "https://images.pokemontcg.io/bw9/88.png",
     "subtype": "Stage 1",
@@ -4634,7 +4722,8 @@
     "nationalPokedexNumber": 20
   },
   {
-    "id": "bw9-89",
+    "setOrder":56,
+	"id": "bw9-89",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/bw9/89.png",
     "subtype": "Basic",
@@ -4694,7 +4783,8 @@
     ]
   },
   {
-    "id": "bw9-90",
+    "setOrder":56,
+	"id": "bw9-90",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/bw9/90.png",
     "subtype": "Basic",
@@ -4755,7 +4845,8 @@
     ]
   },
   {
-    "id": "bw9-91",
+    "setOrder":56,
+	"id": "bw9-91",
     "name": "Hoothoot",
     "imageUrl": "https://images.pokemontcg.io/bw9/91.png",
     "subtype": "Basic",
@@ -4804,7 +4895,8 @@
     ]
   },
   {
-    "id": "bw9-92",
+    "setOrder":56,
+	"id": "bw9-92",
     "name": "Noctowl",
     "imageUrl": "https://images.pokemontcg.io/bw9/92.png",
     "subtype": "Stage 1",
@@ -4863,7 +4955,8 @@
     "nationalPokedexNumber": 164
   },
   {
-    "id": "bw9-93",
+    "setOrder":56,
+	"id": "bw9-93",
     "name": "Miltank",
     "imageUrl": "https://images.pokemontcg.io/bw9/93.png",
     "subtype": "Basic",
@@ -4916,7 +5009,8 @@
     "nationalPokedexNumber": 241
   },
   {
-    "id": "bw9-94",
+    "setOrder":56,
+	"id": "bw9-94",
     "name": "Kecleon",
     "imageUrl": "https://images.pokemontcg.io/bw9/94.png",
     "subtype": "Basic",
@@ -4961,7 +5055,8 @@
     "nationalPokedexNumber": 352
   },
   {
-    "id": "bw9-95",
+    "setOrder":56,
+	"id": "bw9-95",
     "name": "Starly",
     "imageUrl": "https://images.pokemontcg.io/bw9/95.png",
     "subtype": "Basic",
@@ -5010,7 +5105,8 @@
     ]
   },
   {
-    "id": "bw9-96",
+    "setOrder":56,
+	"id": "bw9-96",
     "name": "Staravia",
     "imageUrl": "https://images.pokemontcg.io/bw9/96.png",
     "subtype": "Stage 1",
@@ -5061,7 +5157,8 @@
     ]
   },
   {
-    "id": "bw9-97",
+    "setOrder":56,
+	"id": "bw9-97",
     "name": "Staraptor",
     "imageUrl": "https://images.pokemontcg.io/bw9/97.png",
     "subtype": "Stage 2",
@@ -5122,7 +5219,8 @@
     "nationalPokedexNumber": 398
   },
   {
-    "id": "bw9-98",
+    "setOrder":56,
+	"id": "bw9-98",
     "name": "Tornadus-EX",
     "imageUrl": "https://images.pokemontcg.io/bw9/98.png",
     "subtype": "EX",
@@ -5184,7 +5282,8 @@
     "nationalPokedexNumber": 641
   },
   {
-    "id": "bw9-99",
+    "setOrder":56,
+	"id": "bw9-99",
     "name": "Float Stone",
     "imageUrl": "https://images.pokemontcg.io/bw9/99.png",
     "subtype": "Pokémon Tool",
@@ -5201,7 +5300,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw9/99_hires.png"
   },
   {
-    "id": "bw9-100",
+    "setOrder":56,
+	"id": "bw9-100",
     "name": "Frozen City",
     "imageUrl": "https://images.pokemontcg.io/bw9/100.png",
     "subtype": "Stadium",
@@ -5218,7 +5318,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw9/100_hires.png"
   },
   {
-    "id": "bw9-101",
+    "setOrder":56,
+	"id": "bw9-101",
     "name": "Ghetsis",
     "imageUrl": "https://images.pokemontcg.io/bw9/101.png",
     "subtype": "Supporter",
@@ -5235,7 +5336,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw9/101_hires.png"
   },
   {
-    "id": "bw9-102",
+    "setOrder":56,
+	"id": "bw9-102",
     "name": "Shadow Triad",
     "imageUrl": "https://images.pokemontcg.io/bw9/102.png",
     "subtype": "Supporter",
@@ -5252,7 +5354,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw9/102_hires.png"
   },
   {
-    "id": "bw9-103",
+    "setOrder":56,
+	"id": "bw9-103",
     "name": "Superior Energy Retrieval",
     "imageUrl": "https://images.pokemontcg.io/bw9/103.png",
     "subtype": "Item",
@@ -5269,7 +5372,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw9/103_hires.png"
   },
   {
-    "id": "bw9-104",
+    "setOrder":56,
+	"id": "bw9-104",
     "name": "Team Plasma Badge",
     "imageUrl": "https://images.pokemontcg.io/bw9/104.png",
     "subtype": "Pokémon Tool",
@@ -5286,7 +5390,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw9/104_hires.png"
   },
   {
-    "id": "bw9-105",
+    "setOrder":56,
+	"id": "bw9-105",
     "name": "Team Plasma Ball",
     "imageUrl": "https://images.pokemontcg.io/bw9/105.png",
     "subtype": "Item",
@@ -5303,7 +5408,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw9/105_hires.png"
   },
   {
-    "id": "bw9-106",
+    "setOrder":56,
+	"id": "bw9-106",
     "name": "Plasma Energy",
     "imageUrl": "https://images.pokemontcg.io/bw9/106.png",
     "subtype": "Special",
@@ -5320,7 +5426,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw9/106_hires.png"
   },
   {
-    "id": "bw9-107",
+    "setOrder":56,
+	"id": "bw9-107",
     "name": "Life Dew",
     "imageUrl": "https://images.pokemontcg.io/bw9/107.png",
     "subtype": "Pokémon Tool",
@@ -5337,7 +5444,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw9/107_hires.png"
   },
   {
-    "id": "bw9-108",
+    "setOrder":56,
+	"id": "bw9-108",
     "name": "Rock Guard",
     "imageUrl": "https://images.pokemontcg.io/bw9/108.png",
     "subtype": "Pokémon Tool",
@@ -5354,7 +5462,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw9/108_hires.png"
   },
   {
-    "id": "bw9-109",
+    "setOrder":56,
+	"id": "bw9-109",
     "name": "Heatran-EX",
     "imageUrl": "https://images.pokemontcg.io/bw9/109.png",
     "subtype": "EX",
@@ -5413,7 +5522,8 @@
     "nationalPokedexNumber": 485
   },
   {
-    "id": "bw9-110",
+    "setOrder":56,
+	"id": "bw9-110",
     "name": "Thundurus-EX",
     "imageUrl": "https://images.pokemontcg.io/bw9/110.png",
     "subtype": "EX",
@@ -5468,7 +5578,8 @@
     "nationalPokedexNumber": 642
   },
   {
-    "id": "bw9-111",
+    "setOrder":56,
+	"id": "bw9-111",
     "name": "Deoxys-EX",
     "imageUrl": "https://images.pokemontcg.io/bw9/111.png",
     "subtype": "EX",
@@ -5518,7 +5629,8 @@
     "nationalPokedexNumber": 386
   },
   {
-    "id": "bw9-112",
+    "setOrder":56,
+	"id": "bw9-112",
     "name": "Latias-EX",
     "imageUrl": "https://images.pokemontcg.io/bw9/112.png",
     "subtype": "EX",
@@ -5568,7 +5680,8 @@
     "nationalPokedexNumber": 380
   },
   {
-    "id": "bw9-113",
+    "setOrder":56,
+	"id": "bw9-113",
     "name": "Latios-EX",
     "imageUrl": "https://images.pokemontcg.io/bw9/113.png",
     "subtype": "EX",
@@ -5625,7 +5738,8 @@
     "evolvesTo": "M Latios-EX"
   },
   {
-    "id": "bw9-114",
+    "setOrder":56,
+	"id": "bw9-114",
     "name": "Tornadus-EX",
     "imageUrl": "https://images.pokemontcg.io/bw9/114.png",
     "subtype": "EX",
@@ -5687,7 +5801,8 @@
     "nationalPokedexNumber": 641
   },
   {
-    "id": "bw9-115",
+    "setOrder":56,
+	"id": "bw9-115",
     "name": "Ghetsis",
     "imageUrl": "https://images.pokemontcg.io/bw9/115.png",
     "subtype": "Supporter",
@@ -5704,7 +5819,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw9/115_hires.png"
   },
   {
-    "id": "bw9-116",
+    "setOrder":56,
+	"id": "bw9-116",
     "name": "Professor Juniper",
     "imageUrl": "https://images.pokemontcg.io/bw9/116.png",
     "subtype": "Supporter",
@@ -5721,7 +5837,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw9/116_hires.png"
   },
   {
-    "id": "bw9-117",
+    "setOrder":56,
+	"id": "bw9-117",
     "name": "Empoleon",
     "imageUrl": "https://images.pokemontcg.io/bw9/117.png",
     "subtype": "Stage 2",
@@ -5768,7 +5885,8 @@
     "nationalPokedexNumber": 395
   },
   {
-    "id": "bw9-118",
+    "setOrder":56,
+	"id": "bw9-118",
     "name": "Sigilyph",
     "imageUrl": "https://images.pokemontcg.io/bw9/118.png",
     "subtype": "Basic",
@@ -5815,7 +5933,8 @@
     "nationalPokedexNumber": 561
   },
   {
-    "id": "bw9-119",
+    "setOrder":56,
+	"id": "bw9-119",
     "name": "Garbodor",
     "imageUrl": "https://images.pokemontcg.io/bw9/119.png",
     "subtype": "Stage 1",
@@ -5865,7 +5984,8 @@
     "nationalPokedexNumber": 569
   },
   {
-    "id": "bw9-120",
+    "setOrder":56,
+	"id": "bw9-120",
     "name": "Garchomp",
     "imageUrl": "https://images.pokemontcg.io/bw9/120.png",
     "subtype": "Stage 2",
@@ -5916,7 +6036,8 @@
     "nationalPokedexNumber": 445
   },
   {
-    "id": "bw9-121",
+    "setOrder":56,
+	"id": "bw9-121",
     "name": "Max Potion",
     "imageUrl": "https://images.pokemontcg.io/bw9/121.png",
     "subtype": "Item",
@@ -5933,7 +6054,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw9/121_hires.png"
   },
   {
-    "id": "bw9-122",
+    "setOrder":56,
+	"id": "bw9-122",
     "name": "Ultra Ball",
     "imageUrl": "https://images.pokemontcg.io/bw9/122.png",
     "subtype": "Item",

--- a/json/cards/Plasma Storm.json
+++ b/json/cards/Plasma Storm.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "bw8-1",
+    "setOrder":55,
+	"id": "bw8-1",
     "name": "Turtwig",
     "imageUrl": "https://images.pokemontcg.io/bw8/1.png",
     "subtype": "Basic",
@@ -61,7 +62,8 @@
     ]
   },
   {
-    "id": "bw8-2",
+    "setOrder":55,
+	"id": "bw8-2",
     "name": "Grotle",
     "imageUrl": "https://images.pokemontcg.io/bw8/2.png",
     "subtype": "Stage 1",
@@ -115,7 +117,8 @@
     ]
   },
   {
-    "id": "bw8-3",
+    "setOrder":55,
+	"id": "bw8-3",
     "name": "Torterra",
     "imageUrl": "https://images.pokemontcg.io/bw8/3.png",
     "subtype": "Stage 2",
@@ -179,7 +182,8 @@
     "nationalPokedexNumber": 389
   },
   {
-    "id": "bw8-4",
+    "setOrder":55,
+	"id": "bw8-4",
     "name": "Combee",
     "imageUrl": "https://images.pokemontcg.io/bw8/4.png",
     "subtype": "Basic",
@@ -222,7 +226,8 @@
     ]
   },
   {
-    "id": "bw8-5",
+    "setOrder":55,
+	"id": "bw8-5",
     "name": "Vespiquen",
     "imageUrl": "https://images.pokemontcg.io/bw8/5.png",
     "subtype": "Stage 1",
@@ -273,7 +278,8 @@
     "nationalPokedexNumber": 416
   },
   {
-    "id": "bw8-6",
+    "setOrder":55,
+	"id": "bw8-6",
     "name": "Cherubi",
     "imageUrl": "https://images.pokemontcg.io/bw8/6.png",
     "subtype": "Basic",
@@ -322,7 +328,8 @@
     ]
   },
   {
-    "id": "bw8-7",
+    "setOrder":55,
+	"id": "bw8-7",
     "name": "Cherrim",
     "imageUrl": "https://images.pokemontcg.io/bw8/7.png",
     "subtype": "Stage 1",
@@ -375,7 +382,8 @@
     "nationalPokedexNumber": 421
   },
   {
-    "id": "bw8-8",
+    "setOrder":55,
+	"id": "bw8-8",
     "name": "Sewaddle",
     "imageUrl": "https://images.pokemontcg.io/bw8/8.png",
     "subtype": "Basic",
@@ -418,7 +426,8 @@
     ]
   },
   {
-    "id": "bw8-9",
+    "setOrder":55,
+	"id": "bw8-9",
     "name": "Swadloon",
     "imageUrl": "https://images.pokemontcg.io/bw8/9.png",
     "subtype": "Stage 1",
@@ -473,7 +482,8 @@
     ]
   },
   {
-    "id": "bw8-10",
+    "setOrder":55,
+	"id": "bw8-10",
     "name": "Leavanny",
     "imageUrl": "https://images.pokemontcg.io/bw8/10.png",
     "subtype": "Stage 2",
@@ -527,7 +537,8 @@
     "nationalPokedexNumber": 542
   },
   {
-    "id": "bw8-11",
+    "setOrder":55,
+	"id": "bw8-11",
     "name": "Maractus",
     "imageUrl": "https://images.pokemontcg.io/bw8/11.png",
     "subtype": "Basic",
@@ -583,7 +594,8 @@
     "nationalPokedexNumber": 556
   },
   {
-    "id": "bw8-12",
+    "setOrder":55,
+	"id": "bw8-12",
     "name": "Foongus",
     "imageUrl": "https://images.pokemontcg.io/bw8/12.png",
     "subtype": "Basic",
@@ -632,7 +644,8 @@
     ]
   },
   {
-    "id": "bw8-13",
+    "setOrder":55,
+	"id": "bw8-13",
     "name": "Amoonguss",
     "imageUrl": "https://images.pokemontcg.io/bw8/13.png",
     "subtype": "Stage 1",
@@ -690,7 +703,8 @@
     "nationalPokedexNumber": 591
   },
   {
-    "id": "bw8-14",
+    "setOrder":55,
+	"id": "bw8-14",
     "name": "Moltres-EX",
     "imageUrl": "https://images.pokemontcg.io/bw8/14.png",
     "subtype": "EX",
@@ -752,7 +766,8 @@
     "nationalPokedexNumber": 146
   },
   {
-    "id": "bw8-15",
+    "setOrder":55,
+	"id": "bw8-15",
     "name": "Chimchar",
     "imageUrl": "https://images.pokemontcg.io/bw8/15.png",
     "subtype": "Basic",
@@ -795,7 +810,8 @@
     ]
   },
   {
-    "id": "bw8-16",
+    "setOrder":55,
+	"id": "bw8-16",
     "name": "Monferno",
     "imageUrl": "https://images.pokemontcg.io/bw8/16.png",
     "subtype": "Stage 1",
@@ -849,7 +865,8 @@
     ]
   },
   {
-    "id": "bw8-17",
+    "setOrder":55,
+	"id": "bw8-17",
     "name": "Infernape",
     "imageUrl": "https://images.pokemontcg.io/bw8/17.png",
     "subtype": "Stage 2",
@@ -897,7 +914,8 @@
     "nationalPokedexNumber": 392
   },
   {
-    "id": "bw8-18",
+    "setOrder":55,
+	"id": "bw8-18",
     "name": "Victini-EX",
     "imageUrl": "https://images.pokemontcg.io/bw8/18.png",
     "subtype": "EX",
@@ -951,7 +969,8 @@
     "nationalPokedexNumber": 494
   },
   {
-    "id": "bw8-19",
+    "setOrder":55,
+	"id": "bw8-19",
     "name": "Pansear",
     "imageUrl": "https://images.pokemontcg.io/bw8/19.png",
     "subtype": "Basic",
@@ -1006,7 +1025,8 @@
     ]
   },
   {
-    "id": "bw8-20",
+    "setOrder":55,
+	"id": "bw8-20",
     "name": "Simisear",
     "imageUrl": "https://images.pokemontcg.io/bw8/20.png",
     "subtype": "Stage 1",
@@ -1059,7 +1079,8 @@
     "nationalPokedexNumber": 514
   },
   {
-    "id": "bw8-21",
+    "setOrder":55,
+	"id": "bw8-21",
     "name": "Litwick",
     "imageUrl": "https://images.pokemontcg.io/bw8/21.png",
     "subtype": "Basic",
@@ -1102,7 +1123,8 @@
     ]
   },
   {
-    "id": "bw8-22",
+    "setOrder":55,
+	"id": "bw8-22",
     "name": "Lampent",
     "imageUrl": "https://images.pokemontcg.io/bw8/22.png",
     "subtype": "Stage 1",
@@ -1152,7 +1174,8 @@
     ]
   },
   {
-    "id": "bw8-23",
+    "setOrder":55,
+	"id": "bw8-23",
     "name": "Heatmor",
     "imageUrl": "https://images.pokemontcg.io/bw8/23.png",
     "subtype": "Basic",
@@ -1204,7 +1227,8 @@
     "nationalPokedexNumber": 631
   },
   {
-    "id": "bw8-24",
+    "setOrder":55,
+	"id": "bw8-24",
     "name": "Squirtle",
     "imageUrl": "https://images.pokemontcg.io/bw8/24.png",
     "subtype": "Basic",
@@ -1247,7 +1271,8 @@
     ]
   },
   {
-    "id": "bw8-25",
+    "setOrder":55,
+	"id": "bw8-25",
     "name": "Articuno-EX",
     "imageUrl": "https://images.pokemontcg.io/bw8/25.png",
     "subtype": "EX",
@@ -1310,7 +1335,8 @@
     "nationalPokedexNumber": 144
   },
   {
-    "id": "bw8-26",
+    "setOrder":55,
+	"id": "bw8-26",
     "name": "Swinub",
     "imageUrl": "https://images.pokemontcg.io/bw8/26.png",
     "subtype": "Basic",
@@ -1355,7 +1381,8 @@
     ]
   },
   {
-    "id": "bw8-27",
+    "setOrder":55,
+	"id": "bw8-27",
     "name": "Piloswine",
     "imageUrl": "https://images.pokemontcg.io/bw8/27.png",
     "subtype": "Stage 1",
@@ -1414,7 +1441,8 @@
     ]
   },
   {
-    "id": "bw8-28",
+    "setOrder":55,
+	"id": "bw8-28",
     "name": "Mamoswine",
     "imageUrl": "https://images.pokemontcg.io/bw8/28.png",
     "subtype": "Stage 2",
@@ -1472,7 +1500,8 @@
     "nationalPokedexNumber": 473
   },
   {
-    "id": "bw8-29",
+    "setOrder":55,
+	"id": "bw8-29",
     "name": "Lotad",
     "imageUrl": "https://images.pokemontcg.io/bw8/29.png",
     "subtype": "Basic",
@@ -1516,7 +1545,8 @@
     ]
   },
   {
-    "id": "bw8-30",
+    "setOrder":55,
+	"id": "bw8-30",
     "name": "Lombre",
     "imageUrl": "https://images.pokemontcg.io/bw8/30.png",
     "subtype": "Stage 1",
@@ -1573,7 +1603,8 @@
     ]
   },
   {
-    "id": "bw8-31",
+    "setOrder":55,
+	"id": "bw8-31",
     "name": "Ludicolo",
     "imageUrl": "https://images.pokemontcg.io/bw8/31.png",
     "subtype": "Stage 2",
@@ -1623,7 +1654,8 @@
     "nationalPokedexNumber": 272
   },
   {
-    "id": "bw8-32",
+    "setOrder":55,
+	"id": "bw8-32",
     "name": "Carvanha",
     "imageUrl": "https://images.pokemontcg.io/bw8/32.png",
     "subtype": "Basic",
@@ -1667,7 +1699,8 @@
     ]
   },
   {
-    "id": "bw8-33",
+    "setOrder":55,
+	"id": "bw8-33",
     "name": "Sharpedo",
     "imageUrl": "https://images.pokemontcg.io/bw8/33.png",
     "subtype": "Stage 1",
@@ -1711,7 +1744,8 @@
     "nationalPokedexNumber": 319
   },
   {
-    "id": "bw8-34",
+    "setOrder":55,
+	"id": "bw8-34",
     "name": "Manaphy",
     "imageUrl": "https://images.pokemontcg.io/bw8/34.png",
     "subtype": "Basic",
@@ -1756,7 +1790,8 @@
     "nationalPokedexNumber": 490
   },
   {
-    "id": "bw8-35",
+    "setOrder":55,
+	"id": "bw8-35",
     "name": "Vanillite",
     "imageUrl": "https://images.pokemontcg.io/bw8/35.png",
     "subtype": "Basic",
@@ -1799,7 +1834,8 @@
     ]
   },
   {
-    "id": "bw8-36",
+    "setOrder":55,
+	"id": "bw8-36",
     "name": "Vanillish",
     "imageUrl": "https://images.pokemontcg.io/bw8/36.png",
     "subtype": "Stage 1",
@@ -1844,7 +1880,8 @@
     ]
   },
   {
-    "id": "bw8-37",
+    "setOrder":55,
+	"id": "bw8-37",
     "name": "Vanilluxe",
     "imageUrl": "https://images.pokemontcg.io/bw8/37.png",
     "subtype": "Stage 2",
@@ -1896,7 +1933,8 @@
     "nationalPokedexNumber": 584
   },
   {
-    "id": "bw8-38",
+    "setOrder":55,
+	"id": "bw8-38",
     "name": "Frillish",
     "imageUrl": "https://images.pokemontcg.io/bw8/38.png",
     "subtype": "Basic",
@@ -1941,7 +1979,8 @@
     ]
   },
   {
-    "id": "bw8-39",
+    "setOrder":55,
+	"id": "bw8-39",
     "name": "Jellicent",
     "imageUrl": "https://images.pokemontcg.io/bw8/39.png",
     "subtype": "Stage 1",
@@ -1989,7 +2028,8 @@
     "nationalPokedexNumber": 593
   },
   {
-    "id": "bw8-40",
+    "setOrder":55,
+	"id": "bw8-40",
     "name": "Cubchoo",
     "imageUrl": "https://images.pokemontcg.io/bw8/40.png",
     "subtype": "Basic",
@@ -2044,7 +2084,8 @@
     ]
   },
   {
-    "id": "bw8-41",
+    "setOrder":55,
+	"id": "bw8-41",
     "name": "Beartic",
     "imageUrl": "https://images.pokemontcg.io/bw8/41.png",
     "subtype": "Stage 1",
@@ -2100,7 +2141,8 @@
     "nationalPokedexNumber": 614
   },
   {
-    "id": "bw8-42",
+    "setOrder":55,
+	"id": "bw8-42",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/bw8/42.png",
     "subtype": "Basic",
@@ -2153,7 +2195,8 @@
     ]
   },
   {
-    "id": "bw8-43",
+    "setOrder":55,
+	"id": "bw8-43",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/bw8/43.png",
     "subtype": "Basic",
@@ -2196,7 +2239,8 @@
     ]
   },
   {
-    "id": "bw8-44",
+    "setOrder":55,
+	"id": "bw8-44",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/bw8/44.png",
     "subtype": "Stage 1",
@@ -2251,7 +2295,8 @@
     ]
   },
   {
-    "id": "bw8-45",
+    "setOrder":55,
+	"id": "bw8-45",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/bw8/45.png",
     "subtype": "Stage 1",
@@ -2297,7 +2342,8 @@
     ]
   },
   {
-    "id": "bw8-46",
+    "setOrder":55,
+	"id": "bw8-46",
     "name": "Magnezone",
     "imageUrl": "https://images.pokemontcg.io/bw8/46.png",
     "subtype": "Stage 2",
@@ -2347,7 +2393,8 @@
     "nationalPokedexNumber": 462
   },
   {
-    "id": "bw8-47",
+    "setOrder":55,
+	"id": "bw8-47",
     "name": "Magnezone",
     "imageUrl": "https://images.pokemontcg.io/bw8/47.png",
     "subtype": "Stage 2",
@@ -2400,7 +2447,8 @@
     "nationalPokedexNumber": 462
   },
   {
-    "id": "bw8-48",
+    "setOrder":55,
+	"id": "bw8-48",
     "name": "Zapdos-EX",
     "imageUrl": "https://images.pokemontcg.io/bw8/48.png",
     "subtype": "EX",
@@ -2462,7 +2510,8 @@
     "nationalPokedexNumber": 145
   },
   {
-    "id": "bw8-49",
+    "setOrder":55,
+	"id": "bw8-49",
     "name": "Rotom",
     "imageUrl": "https://images.pokemontcg.io/bw8/49.png",
     "subtype": "Basic",
@@ -2512,7 +2561,8 @@
     "nationalPokedexNumber": 479
   },
   {
-    "id": "bw8-50",
+    "setOrder":55,
+	"id": "bw8-50",
     "name": "Joltik",
     "imageUrl": "https://images.pokemontcg.io/bw8/50.png",
     "subtype": "Basic",
@@ -2555,7 +2605,8 @@
     ]
   },
   {
-    "id": "bw8-51",
+    "setOrder":55,
+	"id": "bw8-51",
     "name": "Galvantula",
     "imageUrl": "https://images.pokemontcg.io/bw8/51.png",
     "subtype": "Stage 1",
@@ -2603,7 +2654,8 @@
     "nationalPokedexNumber": 596
   },
   {
-    "id": "bw8-52",
+    "setOrder":55,
+	"id": "bw8-52",
     "name": "Zubat",
     "imageUrl": "https://images.pokemontcg.io/bw8/52.png",
     "subtype": "Basic",
@@ -2652,7 +2704,8 @@
     ]
   },
   {
-    "id": "bw8-53",
+    "setOrder":55,
+	"id": "bw8-53",
     "name": "Zubat",
     "imageUrl": "https://images.pokemontcg.io/bw8/53.png",
     "subtype": "Basic",
@@ -2707,7 +2760,8 @@
     ]
   },
   {
-    "id": "bw8-54",
+    "setOrder":55,
+	"id": "bw8-54",
     "name": "Golbat",
     "imageUrl": "https://images.pokemontcg.io/bw8/54.png",
     "subtype": "Stage 1",
@@ -2758,7 +2812,8 @@
     ]
   },
   {
-    "id": "bw8-55",
+    "setOrder":55,
+	"id": "bw8-55",
     "name": "Crobat",
     "imageUrl": "https://images.pokemontcg.io/bw8/55.png",
     "subtype": "Stage 2",
@@ -2809,7 +2864,8 @@
     "nationalPokedexNumber": 169
   },
   {
-    "id": "bw8-56",
+    "setOrder":55,
+	"id": "bw8-56",
     "name": "Koffing",
     "imageUrl": "https://images.pokemontcg.io/bw8/56.png",
     "subtype": "Basic",
@@ -2863,7 +2919,8 @@
     ]
   },
   {
-    "id": "bw8-57",
+    "setOrder":55,
+	"id": "bw8-57",
     "name": "Koffing",
     "imageUrl": "https://images.pokemontcg.io/bw8/57.png",
     "subtype": "Basic",
@@ -2907,7 +2964,8 @@
     ]
   },
   {
-    "id": "bw8-58",
+    "setOrder":55,
+	"id": "bw8-58",
     "name": "Weezing",
     "imageUrl": "https://images.pokemontcg.io/bw8/58.png",
     "subtype": "Stage 1",
@@ -2955,7 +3013,8 @@
     "nationalPokedexNumber": 110
   },
   {
-    "id": "bw8-59",
+    "setOrder":55,
+	"id": "bw8-59",
     "name": "Ralts",
     "imageUrl": "https://images.pokemontcg.io/bw8/59.png",
     "subtype": "Basic",
@@ -2998,7 +3057,8 @@
     ]
   },
   {
-    "id": "bw8-60",
+    "setOrder":55,
+	"id": "bw8-60",
     "name": "Kirlia",
     "imageUrl": "https://images.pokemontcg.io/bw8/60.png",
     "subtype": "Stage 1",
@@ -3043,7 +3103,8 @@
     ]
   },
   {
-    "id": "bw8-61",
+    "setOrder":55,
+	"id": "bw8-61",
     "name": "Gallade",
     "imageUrl": "https://images.pokemontcg.io/bw8/61.png",
     "subtype": "Stage 2",
@@ -3097,7 +3158,8 @@
     "nationalPokedexNumber": 475
   },
   {
-    "id": "bw8-62",
+    "setOrder":55,
+	"id": "bw8-62",
     "name": "Giratina",
     "imageUrl": "https://images.pokemontcg.io/bw8/62.png",
     "subtype": "Basic",
@@ -3153,7 +3215,8 @@
     "nationalPokedexNumber": 487
   },
   {
-    "id": "bw8-63",
+    "setOrder":55,
+	"id": "bw8-63",
     "name": "Trubbish",
     "imageUrl": "https://images.pokemontcg.io/bw8/63.png",
     "subtype": "Basic",
@@ -3206,7 +3269,8 @@
     ]
   },
   {
-    "id": "bw8-64",
+    "setOrder":55,
+	"id": "bw8-64",
     "name": "Trubbish",
     "imageUrl": "https://images.pokemontcg.io/bw8/64.png",
     "subtype": "Basic",
@@ -3260,7 +3324,8 @@
     ]
   },
   {
-    "id": "bw8-65",
+    "setOrder":55,
+	"id": "bw8-65",
     "name": "Trubbish",
     "imageUrl": "https://images.pokemontcg.io/bw8/65.png",
     "subtype": "Basic",
@@ -3305,7 +3370,8 @@
     ]
   },
   {
-    "id": "bw8-66",
+    "setOrder":55,
+	"id": "bw8-66",
     "name": "Garbodor",
     "imageUrl": "https://images.pokemontcg.io/bw8/66.png",
     "subtype": "Stage 1",
@@ -3359,7 +3425,8 @@
     "nationalPokedexNumber": 569
   },
   {
-    "id": "bw8-67",
+    "setOrder":55,
+	"id": "bw8-67",
     "name": "Garbodor",
     "imageUrl": "https://images.pokemontcg.io/bw8/67.png",
     "subtype": "Stage 1",
@@ -3415,7 +3482,8 @@
     "nationalPokedexNumber": 569
   },
   {
-    "id": "bw8-68",
+    "setOrder":55,
+	"id": "bw8-68",
     "name": "Elgyem",
     "imageUrl": "https://images.pokemontcg.io/bw8/68.png",
     "subtype": "Basic",
@@ -3459,7 +3527,8 @@
     ]
   },
   {
-    "id": "bw8-69",
+    "setOrder":55,
+	"id": "bw8-69",
     "name": "Elgyem",
     "imageUrl": "https://images.pokemontcg.io/bw8/69.png",
     "subtype": "Basic",
@@ -3512,7 +3581,8 @@
     ]
   },
   {
-    "id": "bw8-70",
+    "setOrder":55,
+	"id": "bw8-70",
     "name": "Beheeyem",
     "imageUrl": "https://images.pokemontcg.io/bw8/70.png",
     "subtype": "Stage 1",
@@ -3564,7 +3634,8 @@
     "nationalPokedexNumber": 606
   },
   {
-    "id": "bw8-71",
+    "setOrder":55,
+	"id": "bw8-71",
     "name": "Phanpy",
     "imageUrl": "https://images.pokemontcg.io/bw8/71.png",
     "subtype": "Basic",
@@ -3625,7 +3696,8 @@
     ]
   },
   {
-    "id": "bw8-72",
+    "setOrder":55,
+	"id": "bw8-72",
     "name": "Donphan",
     "imageUrl": "https://images.pokemontcg.io/bw8/72.png",
     "subtype": "Stage 1",
@@ -3687,7 +3759,8 @@
     "nationalPokedexNumber": 232
   },
   {
-    "id": "bw8-73",
+    "setOrder":55,
+	"id": "bw8-73",
     "name": "Lunatone",
     "imageUrl": "https://images.pokemontcg.io/bw8/73.png",
     "subtype": "Basic",
@@ -3735,7 +3808,8 @@
     "nationalPokedexNumber": 337
   },
   {
-    "id": "bw8-74",
+    "setOrder":55,
+	"id": "bw8-74",
     "name": "Solrock",
     "imageUrl": "https://images.pokemontcg.io/bw8/74.png",
     "subtype": "Basic",
@@ -3789,7 +3863,8 @@
     "nationalPokedexNumber": 338
   },
   {
-    "id": "bw8-75",
+    "setOrder":55,
+	"id": "bw8-75",
     "name": "Riolu",
     "imageUrl": "https://images.pokemontcg.io/bw8/75.png",
     "subtype": "Basic",
@@ -3842,7 +3917,8 @@
     ]
   },
   {
-    "id": "bw8-76",
+    "setOrder":55,
+	"id": "bw8-76",
     "name": "Riolu",
     "imageUrl": "https://images.pokemontcg.io/bw8/76.png",
     "subtype": "Basic",
@@ -3897,7 +3973,8 @@
     ]
   },
   {
-    "id": "bw8-77",
+    "setOrder":55,
+	"id": "bw8-77",
     "name": "Lucario",
     "imageUrl": "https://images.pokemontcg.io/bw8/77.png",
     "subtype": "Stage 1",
@@ -3950,7 +4027,8 @@
     "nationalPokedexNumber": 448
   },
   {
-    "id": "bw8-78",
+    "setOrder":55,
+	"id": "bw8-78",
     "name": "Lucario",
     "imageUrl": "https://images.pokemontcg.io/bw8/78.png",
     "subtype": "Stage 1",
@@ -3999,7 +4077,8 @@
     "nationalPokedexNumber": 448
   },
   {
-    "id": "bw8-79",
+    "setOrder":55,
+	"id": "bw8-79",
     "name": "Timburr",
     "imageUrl": "https://images.pokemontcg.io/bw8/79.png",
     "subtype": "Basic",
@@ -4055,7 +4134,8 @@
     ]
   },
   {
-    "id": "bw8-80",
+    "setOrder":55,
+	"id": "bw8-80",
     "name": "Gurdurr",
     "imageUrl": "https://images.pokemontcg.io/bw8/80.png",
     "subtype": "Stage 1",
@@ -4115,7 +4195,8 @@
     ]
   },
   {
-    "id": "bw8-81",
+    "setOrder":55,
+	"id": "bw8-81",
     "name": "Conkeldurr",
     "imageUrl": "https://images.pokemontcg.io/bw8/81.png",
     "subtype": "Stage 2",
@@ -4172,7 +4253,8 @@
     "nationalPokedexNumber": 534
   },
   {
-    "id": "bw8-82",
+    "setOrder":55,
+	"id": "bw8-82",
     "name": "Purrloin",
     "imageUrl": "https://images.pokemontcg.io/bw8/82.png",
     "subtype": "Basic",
@@ -4231,7 +4313,8 @@
     ]
   },
   {
-    "id": "bw8-83",
+    "setOrder":55,
+	"id": "bw8-83",
     "name": "Purrloin",
     "imageUrl": "https://images.pokemontcg.io/bw8/83.png",
     "subtype": "Basic",
@@ -4290,7 +4373,8 @@
     ]
   },
   {
-    "id": "bw8-84",
+    "setOrder":55,
+	"id": "bw8-84",
     "name": "Liepard",
     "imageUrl": "https://images.pokemontcg.io/bw8/84.png",
     "subtype": "Stage 1",
@@ -4347,7 +4431,8 @@
     "nationalPokedexNumber": 510
   },
   {
-    "id": "bw8-85",
+    "setOrder":55,
+	"id": "bw8-85",
     "name": "Scraggy",
     "imageUrl": "https://images.pokemontcg.io/bw8/85.png",
     "subtype": "Basic",
@@ -4407,7 +4492,8 @@
     ]
   },
   {
-    "id": "bw8-86",
+    "setOrder":55,
+	"id": "bw8-86",
     "name": "Scrafty",
     "imageUrl": "https://images.pokemontcg.io/bw8/86.png",
     "subtype": "Stage 1",
@@ -4466,7 +4552,8 @@
     "nationalPokedexNumber": 560
   },
   {
-    "id": "bw8-87",
+    "setOrder":55,
+	"id": "bw8-87",
     "name": "Skarmory",
     "imageUrl": "https://images.pokemontcg.io/bw8/87.png",
     "subtype": "Basic",
@@ -4523,7 +4610,8 @@
     "nationalPokedexNumber": 227
   },
   {
-    "id": "bw8-88",
+    "setOrder":55,
+	"id": "bw8-88",
     "name": "Klink",
     "imageUrl": "https://images.pokemontcg.io/bw8/88.png",
     "subtype": "Basic",
@@ -4583,7 +4671,8 @@
     ]
   },
   {
-    "id": "bw8-89",
+    "setOrder":55,
+	"id": "bw8-89",
     "name": "Klang",
     "imageUrl": "https://images.pokemontcg.io/bw8/89.png",
     "subtype": "Stage 1",
@@ -4645,7 +4734,8 @@
     ]
   },
   {
-    "id": "bw8-90",
+    "setOrder":55,
+	"id": "bw8-90",
     "name": "Klinklang",
     "imageUrl": "https://images.pokemontcg.io/bw8/90.png",
     "subtype": "Stage 2",
@@ -4701,7 +4791,8 @@
     "nationalPokedexNumber": 601
   },
   {
-    "id": "bw8-91",
+    "setOrder":55,
+	"id": "bw8-91",
     "name": "Durant",
     "imageUrl": "https://images.pokemontcg.io/bw8/91.png",
     "subtype": "Basic",
@@ -4759,7 +4850,8 @@
     "nationalPokedexNumber": 632
   },
   {
-    "id": "bw8-92",
+    "setOrder":55,
+	"id": "bw8-92",
     "name": "Durant",
     "imageUrl": "https://images.pokemontcg.io/bw8/92.png",
     "subtype": "Basic",
@@ -4815,7 +4907,8 @@
     "nationalPokedexNumber": 632
   },
   {
-    "id": "bw8-93",
+    "setOrder":55,
+	"id": "bw8-93",
     "name": "Cobalion-EX",
     "imageUrl": "https://images.pokemontcg.io/bw8/93.png",
     "subtype": "EX",
@@ -4876,7 +4969,8 @@
     "nationalPokedexNumber": 638
   },
   {
-    "id": "bw8-94",
+    "setOrder":55,
+	"id": "bw8-94",
     "name": "Druddigon",
     "imageUrl": "https://images.pokemontcg.io/bw8/94.png",
     "subtype": "Basic",
@@ -4929,7 +5023,8 @@
     "nationalPokedexNumber": 621
   },
   {
-    "id": "bw8-95",
+    "setOrder":55,
+	"id": "bw8-95",
     "name": "Black Kyurem-EX",
     "imageUrl": "https://images.pokemontcg.io/bw8/95.png",
     "subtype": "EX",
@@ -4988,7 +5083,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "bw8-96",
+    "setOrder":55,
+	"id": "bw8-96",
     "name": "White Kyurem-EX",
     "imageUrl": "https://images.pokemontcg.io/bw8/96.png",
     "subtype": "EX",
@@ -5047,7 +5143,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "bw8-97",
+    "setOrder":55,
+	"id": "bw8-97",
     "name": "Clefairy",
     "imageUrl": "https://images.pokemontcg.io/bw8/97.png",
     "subtype": "Basic",
@@ -5100,7 +5197,8 @@
     ]
   },
   {
-    "id": "bw8-98",
+    "setOrder":55,
+	"id": "bw8-98",
     "name": "Clefable",
     "imageUrl": "https://images.pokemontcg.io/bw8/98.png",
     "subtype": "Stage 1",
@@ -5148,7 +5246,8 @@
     "nationalPokedexNumber": 36
   },
   {
-    "id": "bw8-99",
+    "setOrder":55,
+	"id": "bw8-99",
     "name": "Doduo",
     "imageUrl": "https://images.pokemontcg.io/bw8/99.png",
     "subtype": "Basic",
@@ -5198,7 +5297,8 @@
     ]
   },
   {
-    "id": "bw8-100",
+    "setOrder":55,
+	"id": "bw8-100",
     "name": "Dodrio",
     "imageUrl": "https://images.pokemontcg.io/bw8/100.png",
     "subtype": "Stage 1",
@@ -5256,7 +5356,8 @@
     "nationalPokedexNumber": 85
   },
   {
-    "id": "bw8-101",
+    "setOrder":55,
+	"id": "bw8-101",
     "name": "Snorlax",
     "imageUrl": "https://images.pokemontcg.io/bw8/101.png",
     "subtype": "Basic",
@@ -5308,7 +5409,8 @@
     "nationalPokedexNumber": 143
   },
   {
-    "id": "bw8-102",
+    "setOrder":55,
+	"id": "bw8-102",
     "name": "Togepi",
     "imageUrl": "https://images.pokemontcg.io/bw8/102.png",
     "subtype": "Basic",
@@ -5351,7 +5453,8 @@
     ]
   },
   {
-    "id": "bw8-103",
+    "setOrder":55,
+	"id": "bw8-103",
     "name": "Togetic",
     "imageUrl": "https://images.pokemontcg.io/bw8/103.png",
     "subtype": "Stage 1",
@@ -5401,7 +5504,8 @@
     ]
   },
   {
-    "id": "bw8-104",
+    "setOrder":55,
+	"id": "bw8-104",
     "name": "Togekiss",
     "imageUrl": "https://images.pokemontcg.io/bw8/104.png",
     "subtype": "Stage 2",
@@ -5453,7 +5557,8 @@
     "nationalPokedexNumber": 468
   },
   {
-    "id": "bw8-105",
+    "setOrder":55,
+	"id": "bw8-105",
     "name": "Whismur",
     "imageUrl": "https://images.pokemontcg.io/bw8/105.png",
     "subtype": "Basic",
@@ -5508,7 +5613,8 @@
     ]
   },
   {
-    "id": "bw8-106",
+    "setOrder":55,
+	"id": "bw8-106",
     "name": "Loudred",
     "imageUrl": "https://images.pokemontcg.io/bw8/106.png",
     "subtype": "Stage 1",
@@ -5565,7 +5671,8 @@
     ]
   },
   {
-    "id": "bw8-107",
+    "setOrder":55,
+	"id": "bw8-107",
     "name": "Exploud",
     "imageUrl": "https://images.pokemontcg.io/bw8/107.png",
     "subtype": "Stage 2",
@@ -5623,7 +5730,8 @@
     "nationalPokedexNumber": 295
   },
   {
-    "id": "bw8-108",
+    "setOrder":55,
+	"id": "bw8-108",
     "name": "Lugia-EX",
     "imageUrl": "https://images.pokemontcg.io/bw8/108.png",
     "subtype": "EX",
@@ -5681,7 +5789,8 @@
     "nationalPokedexNumber": 249
   },
   {
-    "id": "bw8-109",
+    "setOrder":55,
+	"id": "bw8-109",
     "name": "Skitty",
     "imageUrl": "https://images.pokemontcg.io/bw8/109.png",
     "subtype": "Basic",
@@ -5725,7 +5834,8 @@
     ]
   },
   {
-    "id": "bw8-110",
+    "setOrder":55,
+	"id": "bw8-110",
     "name": "Patrat",
     "imageUrl": "https://images.pokemontcg.io/bw8/110.png",
     "subtype": "Basic",
@@ -5768,7 +5878,8 @@
     ]
   },
   {
-    "id": "bw8-111",
+    "setOrder":55,
+	"id": "bw8-111",
     "name": "Patrat",
     "imageUrl": "https://images.pokemontcg.io/bw8/111.png",
     "subtype": "Basic",
@@ -5821,7 +5932,8 @@
     ]
   },
   {
-    "id": "bw8-112",
+    "setOrder":55,
+	"id": "bw8-112",
     "name": "Watchog",
     "imageUrl": "https://images.pokemontcg.io/bw8/112.png",
     "subtype": "Stage 1",
@@ -5872,7 +5984,8 @@
     "nationalPokedexNumber": 505
   },
   {
-    "id": "bw8-113",
+    "setOrder":55,
+	"id": "bw8-113",
     "name": "Watchog",
     "imageUrl": "https://images.pokemontcg.io/bw8/113.png",
     "subtype": "Stage 1",
@@ -5925,7 +6038,8 @@
     "nationalPokedexNumber": 505
   },
   {
-    "id": "bw8-114",
+    "setOrder":55,
+	"id": "bw8-114",
     "name": "Bouffalant",
     "imageUrl": "https://images.pokemontcg.io/bw8/114.png",
     "subtype": "Basic",
@@ -5978,7 +6092,8 @@
     "nationalPokedexNumber": 626
   },
   {
-    "id": "bw8-115",
+    "setOrder":55,
+	"id": "bw8-115",
     "name": "Rufflet",
     "imageUrl": "https://images.pokemontcg.io/bw8/115.png",
     "subtype": "Basic",
@@ -6028,7 +6143,8 @@
     ]
   },
   {
-    "id": "bw8-116",
+    "setOrder":55,
+	"id": "bw8-116",
     "name": "Braviary",
     "imageUrl": "https://images.pokemontcg.io/bw8/116.png",
     "subtype": "Stage 1",
@@ -6083,7 +6199,8 @@
     "nationalPokedexNumber": 628
   },
   {
-    "id": "bw8-117",
+    "setOrder":55,
+	"id": "bw8-117",
     "name": "Bicycle",
     "imageUrl": "https://images.pokemontcg.io/bw8/117.png",
     "subtype": "Item",
@@ -6100,7 +6217,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw8/117_hires.png"
   },
   {
-    "id": "bw8-118",
+    "setOrder":55,
+	"id": "bw8-118",
     "name": "Colress",
     "imageUrl": "https://images.pokemontcg.io/bw8/118.png",
     "subtype": "Supporter",
@@ -6117,7 +6235,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw8/118_hires.png"
   },
   {
-    "id": "bw8-119",
+    "setOrder":55,
+	"id": "bw8-119",
     "name": "Colress Machine",
     "imageUrl": "https://images.pokemontcg.io/bw8/119.png",
     "subtype": "Item",
@@ -6134,7 +6253,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw8/119_hires.png"
   },
   {
-    "id": "bw8-120",
+    "setOrder":55,
+	"id": "bw8-120",
     "name": "Escape Rope",
     "imageUrl": "https://images.pokemontcg.io/bw8/120.png",
     "subtype": "Item",
@@ -6151,7 +6271,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw8/120_hires.png"
   },
   {
-    "id": "bw8-121",
+    "setOrder":55,
+	"id": "bw8-121",
     "name": "Ether",
     "imageUrl": "https://images.pokemontcg.io/bw8/121.png",
     "subtype": "Item",
@@ -6168,7 +6289,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw8/121_hires.png"
   },
   {
-    "id": "bw8-122",
+    "setOrder":55,
+	"id": "bw8-122",
     "name": "Eviolite",
     "imageUrl": "https://images.pokemontcg.io/bw8/122.png",
     "subtype": "Pokémon Tool",
@@ -6185,7 +6307,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw8/122_hires.png"
   },
   {
-    "id": "bw8-123",
+    "setOrder":55,
+	"id": "bw8-123",
     "name": "Hypnotoxic Laser",
     "imageUrl": "https://images.pokemontcg.io/bw8/123.png",
     "subtype": "Item",
@@ -6202,7 +6325,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw8/123_hires.png"
   },
   {
-    "id": "bw8-124",
+    "setOrder":55,
+	"id": "bw8-124",
     "name": "Plasma Frigate",
     "imageUrl": "https://images.pokemontcg.io/bw8/124.png",
     "subtype": "Stadium",
@@ -6219,7 +6343,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw8/124_hires.png"
   },
   {
-    "id": "bw8-125",
+    "setOrder":55,
+	"id": "bw8-125",
     "name": "Team Plasma Grunt",
     "imageUrl": "https://images.pokemontcg.io/bw8/125.png",
     "subtype": "Supporter",
@@ -6236,7 +6361,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw8/125_hires.png"
   },
   {
-    "id": "bw8-126",
+    "setOrder":55,
+	"id": "bw8-126",
     "name": "Virbank City Gym",
     "imageUrl": "https://images.pokemontcg.io/bw8/126.png",
     "subtype": "Stadium",
@@ -6253,7 +6379,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw8/126_hires.png"
   },
   {
-    "id": "bw8-127",
+    "setOrder":55,
+	"id": "bw8-127",
     "name": "Plasma Energy",
     "imageUrl": "https://images.pokemontcg.io/bw8/127.png",
     "subtype": "Special",
@@ -6270,7 +6397,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw8/127_hires.png"
   },
   {
-    "id": "bw8-128",
+    "setOrder":55,
+	"id": "bw8-128",
     "name": "Dowsing Machine",
     "imageUrl": "https://images.pokemontcg.io/bw8/128.png",
     "subtype": "Item",
@@ -6287,7 +6415,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw8/128_hires.png"
   },
   {
-    "id": "bw8-129",
+    "setOrder":55,
+	"id": "bw8-129",
     "name": "Scramble Switch",
     "imageUrl": "https://images.pokemontcg.io/bw8/129.png",
     "subtype": "Item",
@@ -6304,7 +6433,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw8/129_hires.png"
   },
   {
-    "id": "bw8-130",
+    "setOrder":55,
+	"id": "bw8-130",
     "name": "Victory Piece",
     "imageUrl": "https://images.pokemontcg.io/bw8/130.png",
     "subtype": "Pokémon Tool",
@@ -6321,7 +6451,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw8/130_hires.png"
   },
   {
-    "id": "bw8-131",
+    "setOrder":55,
+	"id": "bw8-131",
     "name": "Victini-EX",
     "imageUrl": "https://images.pokemontcg.io/bw8/131.png",
     "subtype": "EX",
@@ -6375,7 +6506,8 @@
     "nationalPokedexNumber": 494
   },
   {
-    "id": "bw8-132",
+    "setOrder":55,
+	"id": "bw8-132",
     "name": "Articuno-EX",
     "imageUrl": "https://images.pokemontcg.io/bw8/132.png",
     "subtype": "EX",
@@ -6438,7 +6570,8 @@
     "nationalPokedexNumber": 144
   },
   {
-    "id": "bw8-133",
+    "setOrder":55,
+	"id": "bw8-133",
     "name": "Cobalion-EX",
     "imageUrl": "https://images.pokemontcg.io/bw8/133.png",
     "subtype": "EX",
@@ -6499,7 +6632,8 @@
     "nationalPokedexNumber": 638
   },
   {
-    "id": "bw8-134",
+    "setOrder":55,
+	"id": "bw8-134",
     "name": "Lugia-EX",
     "imageUrl": "https://images.pokemontcg.io/bw8/134.png",
     "subtype": "EX",
@@ -6557,7 +6691,8 @@
     "nationalPokedexNumber": 249
   },
   {
-    "id": "bw8-135",
+    "setOrder":55,
+	"id": "bw8-135",
     "name": "Colress",
     "imageUrl": "https://images.pokemontcg.io/bw8/135.png",
     "subtype": "Supporter",
@@ -6574,7 +6709,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/bw8/135_hires.png"
   },
   {
-    "id": "bw8-136",
+    "setOrder":55,
+	"id": "bw8-136",
     "name": "Charizard",
     "imageUrl": "https://images.pokemontcg.io/bw8/136.png",
     "subtype": "Stage 2",
@@ -6632,7 +6768,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "bw8-137",
+    "setOrder":55,
+	"id": "bw8-137",
     "name": "Blastoise",
     "imageUrl": "https://images.pokemontcg.io/bw8/137.png",
     "subtype": "Stage 2",
@@ -6684,7 +6821,8 @@
     "nationalPokedexNumber": 9
   },
   {
-    "id": "bw8-138",
+    "setOrder":55,
+	"id": "bw8-138",
     "name": "Random Receiver",
     "imageUrl": "https://images.pokemontcg.io/bw8/138.png",
     "subtype": "Item",

--- a/json/cards/Platinum.json
+++ b/json/cards/Platinum.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "pl1-1",
+    "setOrder":39,
+	"id": "pl1-1",
     "name": "Ampharos",
     "imageUrl": "https://images.pokemontcg.io/pl1/1.png",
     "subtype": "Stage 2",
@@ -66,7 +67,8 @@
     "nationalPokedexNumber": 181
   },
   {
-    "id": "pl1-2",
+    "setOrder":39,
+	"id": "pl1-2",
     "name": "Blastoise",
     "imageUrl": "https://images.pokemontcg.io/pl1/2.png",
     "subtype": "Stage 2",
@@ -127,7 +129,8 @@
     "nationalPokedexNumber": 9
   },
   {
-    "id": "pl1-3",
+    "setOrder":39,
+	"id": "pl1-3",
     "name": "Blaziken",
     "imageUrl": "https://images.pokemontcg.io/pl1/3.png",
     "subtype": "Stage 2",
@@ -186,7 +189,8 @@
     "nationalPokedexNumber": 257
   },
   {
-    "id": "pl1-4",
+    "setOrder":39,
+	"id": "pl1-4",
     "name": "Delcatty",
     "imageUrl": "https://images.pokemontcg.io/pl1/4.png",
     "subtype": "Stage 1",
@@ -244,7 +248,8 @@
     "nationalPokedexNumber": 301
   },
   {
-    "id": "pl1-5",
+    "setOrder":39,
+	"id": "pl1-5",
     "name": "Dialga",
     "imageUrl": "https://images.pokemontcg.io/pl1/5.png",
     "subtype": "Basic",
@@ -300,7 +305,8 @@
     "nationalPokedexNumber": 483
   },
   {
-    "id": "pl1-6",
+    "setOrder":39,
+	"id": "pl1-6",
     "name": "Dialga",
     "imageUrl": "https://images.pokemontcg.io/pl1/6.png",
     "subtype": "Basic",
@@ -356,7 +362,8 @@
     "nationalPokedexNumber": 483
   },
   {
-    "id": "pl1-7",
+    "setOrder":39,
+	"id": "pl1-7",
     "name": "Dialga G",
     "imageUrl": "https://images.pokemontcg.io/pl1/7.png",
     "subtype": "Basic",
@@ -416,7 +423,8 @@
     "nationalPokedexNumber": 483
   },
   {
-    "id": "pl1-8",
+    "setOrder":39,
+	"id": "pl1-8",
     "name": "Gardevoir",
     "imageUrl": "https://images.pokemontcg.io/pl1/8.png",
     "subtype": "Stage 2",
@@ -474,7 +482,8 @@
     "nationalPokedexNumber": 282
   },
   {
-    "id": "pl1-9",
+    "setOrder":39,
+	"id": "pl1-9",
     "name": "Giratina",
     "imageUrl": "https://images.pokemontcg.io/pl1/9.png",
     "subtype": "Basic",
@@ -530,7 +539,8 @@
     "nationalPokedexNumber": 487
   },
   {
-    "id": "pl1-10",
+    "setOrder":39,
+	"id": "pl1-10",
     "name": "Giratina",
     "imageUrl": "https://images.pokemontcg.io/pl1/10.png",
     "subtype": "Basic",
@@ -601,7 +611,8 @@
     "nationalPokedexNumber": 487
   },
   {
-    "id": "pl1-11",
+    "setOrder":39,
+	"id": "pl1-11",
     "name": "Manectric",
     "imageUrl": "https://images.pokemontcg.io/pl1/11.png",
     "subtype": "Stage 1",
@@ -661,7 +672,8 @@
     "nationalPokedexNumber": 310
   },
   {
-    "id": "pl1-12",
+    "setOrder":39,
+	"id": "pl1-12",
     "name": "Palkia G",
     "imageUrl": "https://images.pokemontcg.io/pl1/12.png",
     "subtype": "Basic",
@@ -715,7 +727,8 @@
     "nationalPokedexNumber": 484
   },
   {
-    "id": "pl1-13",
+    "setOrder":39,
+	"id": "pl1-13",
     "name": "Rampardos",
     "imageUrl": "https://images.pokemontcg.io/pl1/13.png",
     "subtype": "Stage 2",
@@ -772,7 +785,8 @@
     "nationalPokedexNumber": 409
   },
   {
-    "id": "pl1-14",
+    "setOrder":39,
+	"id": "pl1-14",
     "name": "Shaymin",
     "imageUrl": "https://images.pokemontcg.io/pl1/14.png",
     "subtype": "Basic",
@@ -829,7 +843,8 @@
     "nationalPokedexNumber": 492
   },
   {
-    "id": "pl1-15",
+    "setOrder":39,
+	"id": "pl1-15",
     "name": "Shaymin",
     "imageUrl": "https://images.pokemontcg.io/pl1/15.png",
     "subtype": "Basic",
@@ -886,7 +901,8 @@
     "nationalPokedexNumber": 492
   },
   {
-    "id": "pl1-16",
+    "setOrder":39,
+	"id": "pl1-16",
     "name": "Slaking",
     "imageUrl": "https://images.pokemontcg.io/pl1/16.png",
     "subtype": "Stage 2",
@@ -939,7 +955,8 @@
     "nationalPokedexNumber": 289
   },
   {
-    "id": "pl1-17",
+    "setOrder":39,
+	"id": "pl1-17",
     "name": "Weavile G",
     "imageUrl": "https://images.pokemontcg.io/pl1/17.png",
     "subtype": "Basic",
@@ -994,7 +1011,8 @@
     "nationalPokedexNumber": 461
   },
   {
-    "id": "pl1-18",
+    "setOrder":39,
+	"id": "pl1-18",
     "name": "Altaria",
     "imageUrl": "https://images.pokemontcg.io/pl1/18.png",
     "subtype": "Stage 1",
@@ -1062,7 +1080,8 @@
     "nationalPokedexNumber": 334
   },
   {
-    "id": "pl1-19",
+    "setOrder":39,
+	"id": "pl1-19",
     "name": "Banette",
     "imageUrl": "https://images.pokemontcg.io/pl1/19.png",
     "subtype": "Stage 1",
@@ -1125,7 +1144,8 @@
     "nationalPokedexNumber": 354
   },
   {
-    "id": "pl1-20",
+    "setOrder":39,
+	"id": "pl1-20",
     "name": "Bastiodon",
     "imageUrl": "https://images.pokemontcg.io/pl1/20.png",
     "subtype": "Stage 2",
@@ -1195,7 +1215,8 @@
     "nationalPokedexNumber": 411
   },
   {
-    "id": "pl1-21",
+    "setOrder":39,
+	"id": "pl1-21",
     "name": "Beautifly",
     "imageUrl": "https://images.pokemontcg.io/pl1/21.png",
     "subtype": "Stage 2",
@@ -1249,7 +1270,8 @@
     "nationalPokedexNumber": 267
   },
   {
-    "id": "pl1-22",
+    "setOrder":39,
+	"id": "pl1-22",
     "name": "Blissey",
     "imageUrl": "https://images.pokemontcg.io/pl1/22.png",
     "subtype": "Stage 1",
@@ -1309,7 +1331,8 @@
     "nationalPokedexNumber": 242
   },
   {
-    "id": "pl1-23",
+    "setOrder":39,
+	"id": "pl1-23",
     "name": "Dialga",
     "imageUrl": "https://images.pokemontcg.io/pl1/23.png",
     "subtype": "Basic",
@@ -1371,7 +1394,8 @@
     "nationalPokedexNumber": 483
   },
   {
-    "id": "pl1-24",
+    "setOrder":39,
+	"id": "pl1-24",
     "name": "Dugtrio",
     "imageUrl": "https://images.pokemontcg.io/pl1/24.png",
     "subtype": "Stage 1",
@@ -1433,7 +1457,8 @@
     "nationalPokedexNumber": 51
   },
   {
-    "id": "pl1-25",
+    "setOrder":39,
+	"id": "pl1-25",
     "name": "Dustox",
     "imageUrl": "https://images.pokemontcg.io/pl1/25.png",
     "subtype": "Stage 2",
@@ -1489,7 +1514,8 @@
     "nationalPokedexNumber": 269
   },
   {
-    "id": "pl1-26",
+    "setOrder":39,
+	"id": "pl1-26",
     "name": "Empoleon",
     "imageUrl": "https://images.pokemontcg.io/pl1/26.png",
     "subtype": "Stage 2",
@@ -1544,7 +1570,8 @@
     "nationalPokedexNumber": 395
   },
   {
-    "id": "pl1-27",
+    "setOrder":39,
+	"id": "pl1-27",
     "name": "Giratina",
     "imageUrl": "https://images.pokemontcg.io/pl1/27.png",
     "subtype": "Basic",
@@ -1605,7 +1632,8 @@
     "nationalPokedexNumber": 487
   },
   {
-    "id": "pl1-28",
+    "setOrder":39,
+	"id": "pl1-28",
     "name": "Giratina",
     "imageUrl": "https://images.pokemontcg.io/pl1/28.png",
     "subtype": "Basic",
@@ -1665,7 +1693,8 @@
     "nationalPokedexNumber": 487
   },
   {
-    "id": "pl1-29",
+    "setOrder":39,
+	"id": "pl1-29",
     "name": "Golduck",
     "imageUrl": "https://images.pokemontcg.io/pl1/29.png",
     "subtype": "Stage 1",
@@ -1714,7 +1743,8 @@
     "nationalPokedexNumber": 55
   },
   {
-    "id": "pl1-30",
+    "setOrder":39,
+	"id": "pl1-30",
     "name": "Gyarados G",
     "imageUrl": "https://images.pokemontcg.io/pl1/30.png",
     "subtype": "Basic",
@@ -1771,7 +1801,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "pl1-31",
+    "setOrder":39,
+	"id": "pl1-31",
     "name": "Infernape",
     "imageUrl": "https://images.pokemontcg.io/pl1/31.png",
     "subtype": "Stage 2",
@@ -1820,7 +1851,8 @@
     "nationalPokedexNumber": 392
   },
   {
-    "id": "pl1-32",
+    "setOrder":39,
+	"id": "pl1-32",
     "name": "Kricketune",
     "imageUrl": "https://images.pokemontcg.io/pl1/32.png",
     "subtype": "Stage 1",
@@ -1873,7 +1905,8 @@
     "nationalPokedexNumber": 402
   },
   {
-    "id": "pl1-33",
+    "setOrder":39,
+	"id": "pl1-33",
     "name": "Lickilicky",
     "imageUrl": "https://images.pokemontcg.io/pl1/33.png",
     "subtype": "Stage 1",
@@ -1932,7 +1965,8 @@
     "nationalPokedexNumber": 463
   },
   {
-    "id": "pl1-34",
+    "setOrder":39,
+	"id": "pl1-34",
     "name": "Ludicolo",
     "imageUrl": "https://images.pokemontcg.io/pl1/34.png",
     "subtype": "Stage 2",
@@ -1992,7 +2026,8 @@
     "nationalPokedexNumber": 272
   },
   {
-    "id": "pl1-35",
+    "setOrder":39,
+	"id": "pl1-35",
     "name": "Luvdisc",
     "imageUrl": "https://images.pokemontcg.io/pl1/35.png",
     "subtype": "Basic",
@@ -2042,7 +2077,8 @@
     "nationalPokedexNumber": 370
   },
   {
-    "id": "pl1-36",
+    "setOrder":39,
+	"id": "pl1-36",
     "name": "Ninetales",
     "imageUrl": "https://images.pokemontcg.io/pl1/36.png",
     "subtype": "Stage 1",
@@ -2091,7 +2127,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "pl1-37",
+    "setOrder":39,
+	"id": "pl1-37",
     "name": "Palkia",
     "imageUrl": "https://images.pokemontcg.io/pl1/37.png",
     "subtype": "Basic",
@@ -2145,7 +2182,8 @@
     "nationalPokedexNumber": 484
   },
   {
-    "id": "pl1-38",
+    "setOrder":39,
+	"id": "pl1-38",
     "name": "Shaymin",
     "imageUrl": "https://images.pokemontcg.io/pl1/38.png",
     "subtype": "Basic",
@@ -2203,7 +2241,8 @@
     "nationalPokedexNumber": 492
   },
   {
-    "id": "pl1-39",
+    "setOrder":39,
+	"id": "pl1-39",
     "name": "Torterra",
     "imageUrl": "https://images.pokemontcg.io/pl1/39.png",
     "subtype": "Stage 2",
@@ -2262,7 +2301,8 @@
     "nationalPokedexNumber": 389
   },
   {
-    "id": "pl1-40",
+    "setOrder":39,
+	"id": "pl1-40",
     "name": "Toxicroak G",
     "imageUrl": "https://images.pokemontcg.io/pl1/40.png",
     "subtype": "Basic",
@@ -2310,7 +2350,8 @@
     "nationalPokedexNumber": 454
   },
   {
-    "id": "pl1-41",
+    "setOrder":39,
+	"id": "pl1-41",
     "name": "Bronzong G",
     "imageUrl": "https://images.pokemontcg.io/pl1/41.png",
     "subtype": "Basic",
@@ -2366,7 +2407,8 @@
     "nationalPokedexNumber": 437
   },
   {
-    "id": "pl1-42",
+    "setOrder":39,
+	"id": "pl1-42",
     "name": "Cacturne",
     "imageUrl": "https://images.pokemontcg.io/pl1/42.png",
     "subtype": "Stage 1",
@@ -2420,7 +2462,8 @@
     "nationalPokedexNumber": 332
   },
   {
-    "id": "pl1-43",
+    "setOrder":39,
+	"id": "pl1-43",
     "name": "Carnivine",
     "imageUrl": "https://images.pokemontcg.io/pl1/43.png",
     "subtype": "Basic",
@@ -2488,7 +2531,8 @@
     "nationalPokedexNumber": 455
   },
   {
-    "id": "pl1-44",
+    "setOrder":39,
+	"id": "pl1-44",
     "name": "Cascoon",
     "imageUrl": "https://images.pokemontcg.io/pl1/44.png",
     "subtype": "Stage 1",
@@ -2544,7 +2588,8 @@
     ]
   },
   {
-    "id": "pl1-45",
+    "setOrder":39,
+	"id": "pl1-45",
     "name": "Combusken",
     "imageUrl": "https://images.pokemontcg.io/pl1/45.png",
     "subtype": "Stage 1",
@@ -2601,7 +2646,8 @@
     ]
   },
   {
-    "id": "pl1-46",
+    "setOrder":39,
+	"id": "pl1-46",
     "name": "Cranidos",
     "imageUrl": "https://images.pokemontcg.io/pl1/46.png",
     "subtype": "Stage 1",
@@ -2656,7 +2702,8 @@
     ]
   },
   {
-    "id": "pl1-47",
+    "setOrder":39,
+	"id": "pl1-47",
     "name": "Crobat G",
     "imageUrl": "https://images.pokemontcg.io/pl1/47.png",
     "subtype": "Basic",
@@ -2706,7 +2753,8 @@
     "nationalPokedexNumber": 169
   },
   {
-    "id": "pl1-48",
+    "setOrder":39,
+	"id": "pl1-48",
     "name": "Flaaffy",
     "imageUrl": "https://images.pokemontcg.io/pl1/48.png",
     "subtype": "Stage 1",
@@ -2767,7 +2815,8 @@
     ]
   },
   {
-    "id": "pl1-49",
+    "setOrder":39,
+	"id": "pl1-49",
     "name": "Grotle",
     "imageUrl": "https://images.pokemontcg.io/pl1/49.png",
     "subtype": "Stage 1",
@@ -2832,7 +2881,8 @@
     ]
   },
   {
-    "id": "pl1-50",
+    "setOrder":39,
+	"id": "pl1-50",
     "name": "Houndoom G",
     "imageUrl": "https://images.pokemontcg.io/pl1/50.png",
     "subtype": "Basic",
@@ -2891,7 +2941,8 @@
     "nationalPokedexNumber": 229
   },
   {
-    "id": "pl1-51",
+    "setOrder":39,
+	"id": "pl1-51",
     "name": "Kirlia",
     "imageUrl": "https://images.pokemontcg.io/pl1/51.png",
     "subtype": "Stage 1",
@@ -2949,7 +3000,8 @@
     ]
   },
   {
-    "id": "pl1-52",
+    "setOrder":39,
+	"id": "pl1-52",
     "name": "Lombre",
     "imageUrl": "https://images.pokemontcg.io/pl1/52.png",
     "subtype": "Stage 1",
@@ -3006,7 +3058,8 @@
     ]
   },
   {
-    "id": "pl1-53",
+    "setOrder":39,
+	"id": "pl1-53",
     "name": "Lucario",
     "imageUrl": "https://images.pokemontcg.io/pl1/53.png",
     "subtype": "Stage 1",
@@ -3055,7 +3108,8 @@
     "nationalPokedexNumber": 448
   },
   {
-    "id": "pl1-54",
+    "setOrder":39,
+	"id": "pl1-54",
     "name": "Mightyena",
     "imageUrl": "https://images.pokemontcg.io/pl1/54.png",
     "subtype": "Stage 1",
@@ -3117,7 +3171,8 @@
     "nationalPokedexNumber": 262
   },
   {
-    "id": "pl1-55",
+    "setOrder":39,
+	"id": "pl1-55",
     "name": "Mismagius",
     "imageUrl": "https://images.pokemontcg.io/pl1/55.png",
     "subtype": "Stage 1",
@@ -3176,7 +3231,8 @@
     "nationalPokedexNumber": 429
   },
   {
-    "id": "pl1-56",
+    "setOrder":39,
+	"id": "pl1-56",
     "name": "Monferno",
     "imageUrl": "https://images.pokemontcg.io/pl1/56.png",
     "subtype": "Stage 1",
@@ -3228,7 +3284,8 @@
     ]
   },
   {
-    "id": "pl1-57",
+    "setOrder":39,
+	"id": "pl1-57",
     "name": "Muk",
     "imageUrl": "https://images.pokemontcg.io/pl1/57.png",
     "subtype": "Stage 1",
@@ -3289,7 +3346,8 @@
     "nationalPokedexNumber": 89
   },
   {
-    "id": "pl1-58",
+    "setOrder":39,
+	"id": "pl1-58",
     "name": "Octillery",
     "imageUrl": "https://images.pokemontcg.io/pl1/58.png",
     "subtype": "Stage 1",
@@ -3342,7 +3400,8 @@
     "nationalPokedexNumber": 224
   },
   {
-    "id": "pl1-59",
+    "setOrder":39,
+	"id": "pl1-59",
     "name": "Prinplup",
     "imageUrl": "https://images.pokemontcg.io/pl1/59.png",
     "subtype": "Stage 1",
@@ -3398,7 +3457,8 @@
     ]
   },
   {
-    "id": "pl1-60",
+    "setOrder":39,
+	"id": "pl1-60",
     "name": "Probopass",
     "imageUrl": "https://images.pokemontcg.io/pl1/60.png",
     "subtype": "Stage 1",
@@ -3454,7 +3514,8 @@
     "nationalPokedexNumber": 476
   },
   {
-    "id": "pl1-61",
+    "setOrder":39,
+	"id": "pl1-61",
     "name": "Seviper",
     "imageUrl": "https://images.pokemontcg.io/pl1/61.png",
     "subtype": "Basic",
@@ -3515,7 +3576,8 @@
     "nationalPokedexNumber": 336
   },
   {
-    "id": "pl1-62",
+    "setOrder":39,
+	"id": "pl1-62",
     "name": "Shieldon",
     "imageUrl": "https://images.pokemontcg.io/pl1/62.png",
     "subtype": "Stage 1",
@@ -3576,7 +3638,8 @@
     ]
   },
   {
-    "id": "pl1-63",
+    "setOrder":39,
+	"id": "pl1-63",
     "name": "Silcoon",
     "imageUrl": "https://images.pokemontcg.io/pl1/63.png",
     "subtype": "Stage 1",
@@ -3632,7 +3695,8 @@
     ]
   },
   {
-    "id": "pl1-64",
+    "setOrder":39,
+	"id": "pl1-64",
     "name": "Vigoroth",
     "imageUrl": "https://images.pokemontcg.io/pl1/64.png",
     "subtype": "Stage 1",
@@ -3688,7 +3752,8 @@
     ]
   },
   {
-    "id": "pl1-65",
+    "setOrder":39,
+	"id": "pl1-65",
     "name": "Wartortle",
     "imageUrl": "https://images.pokemontcg.io/pl1/65.png",
     "subtype": "Stage 1",
@@ -3743,7 +3808,8 @@
     ]
   },
   {
-    "id": "pl1-66",
+    "setOrder":39,
+	"id": "pl1-66",
     "name": "Zangoose",
     "imageUrl": "https://images.pokemontcg.io/pl1/66.png",
     "subtype": "Basic",
@@ -3800,7 +3866,8 @@
     "nationalPokedexNumber": 335
   },
   {
-    "id": "pl1-67",
+    "setOrder":39,
+	"id": "pl1-67",
     "name": "Cacnea",
     "imageUrl": "https://images.pokemontcg.io/pl1/67.png",
     "subtype": "Basic",
@@ -3859,7 +3926,8 @@
     ]
   },
   {
-    "id": "pl1-68",
+    "setOrder":39,
+	"id": "pl1-68",
     "name": "Carnivine",
     "imageUrl": "https://images.pokemontcg.io/pl1/68.png",
     "subtype": "Basic",
@@ -3917,7 +3985,8 @@
     "nationalPokedexNumber": 455
   },
   {
-    "id": "pl1-69",
+    "setOrder":39,
+	"id": "pl1-69",
     "name": "Chansey",
     "imageUrl": "https://images.pokemontcg.io/pl1/69.png",
     "subtype": "Basic",
@@ -3972,7 +4041,8 @@
     ]
   },
   {
-    "id": "pl1-70",
+    "setOrder":39,
+	"id": "pl1-70",
     "name": "Chimchar",
     "imageUrl": "https://images.pokemontcg.io/pl1/70.png",
     "subtype": "Basic",
@@ -4026,7 +4096,8 @@
     ]
   },
   {
-    "id": "pl1-71",
+    "setOrder":39,
+	"id": "pl1-71",
     "name": "Combee",
     "imageUrl": "https://images.pokemontcg.io/pl1/71.png",
     "subtype": "Basic",
@@ -4086,7 +4157,8 @@
     ]
   },
   {
-    "id": "pl1-72",
+    "setOrder":39,
+	"id": "pl1-72",
     "name": "Diglett",
     "imageUrl": "https://images.pokemontcg.io/pl1/72.png",
     "subtype": "Basic",
@@ -4146,7 +4218,8 @@
     ]
   },
   {
-    "id": "pl1-73",
+    "setOrder":39,
+	"id": "pl1-73",
     "name": "Dunsparce",
     "imageUrl": "https://images.pokemontcg.io/pl1/73.png",
     "subtype": "Basic",
@@ -4196,7 +4269,8 @@
     "nationalPokedexNumber": 206
   },
   {
-    "id": "pl1-74",
+    "setOrder":39,
+	"id": "pl1-74",
     "name": "Electrike",
     "imageUrl": "https://images.pokemontcg.io/pl1/74.png",
     "subtype": "Basic",
@@ -4253,7 +4327,8 @@
     ]
   },
   {
-    "id": "pl1-75",
+    "setOrder":39,
+	"id": "pl1-75",
     "name": "Grimer",
     "imageUrl": "https://images.pokemontcg.io/pl1/75.png",
     "subtype": "Basic",
@@ -4307,7 +4382,8 @@
     ]
   },
   {
-    "id": "pl1-76",
+    "setOrder":39,
+	"id": "pl1-76",
     "name": "Happiny",
     "imageUrl": "https://images.pokemontcg.io/pl1/76.png",
     "subtype": "Basic",
@@ -4356,7 +4432,8 @@
     ]
   },
   {
-    "id": "pl1-77",
+    "setOrder":39,
+	"id": "pl1-77",
     "name": "Honchkrow G",
     "imageUrl": "https://images.pokemontcg.io/pl1/77.png",
     "subtype": "Basic",
@@ -4413,7 +4490,8 @@
     "nationalPokedexNumber": 430
   },
   {
-    "id": "pl1-78",
+    "setOrder":39,
+	"id": "pl1-78",
     "name": "Kricketot",
     "imageUrl": "https://images.pokemontcg.io/pl1/78.png",
     "subtype": "Basic",
@@ -4467,7 +4545,8 @@
     ]
   },
   {
-    "id": "pl1-79",
+    "setOrder":39,
+	"id": "pl1-79",
     "name": "Lapras",
     "imageUrl": "https://images.pokemontcg.io/pl1/79.png",
     "subtype": "Basic",
@@ -4520,7 +4599,8 @@
     "nationalPokedexNumber": 131
   },
   {
-    "id": "pl1-80",
+    "setOrder":39,
+	"id": "pl1-80",
     "name": "Lickitung",
     "imageUrl": "https://images.pokemontcg.io/pl1/80.png",
     "subtype": "Basic",
@@ -4577,7 +4657,8 @@
     ]
   },
   {
-    "id": "pl1-81",
+    "setOrder":39,
+	"id": "pl1-81",
     "name": "Lotad",
     "imageUrl": "https://images.pokemontcg.io/pl1/81.png",
     "subtype": "Basic",
@@ -4630,7 +4711,8 @@
     ]
   },
   {
-    "id": "pl1-82",
+    "setOrder":39,
+	"id": "pl1-82",
     "name": "Mareep",
     "imageUrl": "https://images.pokemontcg.io/pl1/82.png",
     "subtype": "Basic",
@@ -4689,7 +4771,8 @@
     ]
   },
   {
-    "id": "pl1-83",
+    "setOrder":39,
+	"id": "pl1-83",
     "name": "Misdreavus",
     "imageUrl": "https://images.pokemontcg.io/pl1/83.png",
     "subtype": "Basic",
@@ -4748,7 +4831,8 @@
     ]
   },
   {
-    "id": "pl1-84",
+    "setOrder":39,
+	"id": "pl1-84",
     "name": "Nosepass",
     "imageUrl": "https://images.pokemontcg.io/pl1/84.png",
     "subtype": "Basic",
@@ -4802,7 +4886,8 @@
     ]
   },
   {
-    "id": "pl1-85",
+    "setOrder":39,
+	"id": "pl1-85",
     "name": "Piplup",
     "imageUrl": "https://images.pokemontcg.io/pl1/85.png",
     "subtype": "Basic",
@@ -4856,7 +4941,8 @@
     ]
   },
   {
-    "id": "pl1-86",
+    "setOrder":39,
+	"id": "pl1-86",
     "name": "Poochyena",
     "imageUrl": "https://images.pokemontcg.io/pl1/86.png",
     "subtype": "Basic",
@@ -4915,7 +5001,8 @@
     ]
   },
   {
-    "id": "pl1-87",
+    "setOrder":39,
+	"id": "pl1-87",
     "name": "Psyduck",
     "imageUrl": "https://images.pokemontcg.io/pl1/87.png",
     "subtype": "Basic",
@@ -4969,7 +5056,8 @@
     ]
   },
   {
-    "id": "pl1-88",
+    "setOrder":39,
+	"id": "pl1-88",
     "name": "Purugly G",
     "imageUrl": "https://images.pokemontcg.io/pl1/88.png",
     "subtype": "Basic",
@@ -5024,7 +5112,8 @@
     "nationalPokedexNumber": 432
   },
   {
-    "id": "pl1-89",
+    "setOrder":39,
+	"id": "pl1-89",
     "name": "Ralts",
     "imageUrl": "https://images.pokemontcg.io/pl1/89.png",
     "subtype": "Basic",
@@ -5077,7 +5166,8 @@
     ]
   },
   {
-    "id": "pl1-90",
+    "setOrder":39,
+	"id": "pl1-90",
     "name": "Remoraid",
     "imageUrl": "https://images.pokemontcg.io/pl1/90.png",
     "subtype": "Basic",
@@ -5131,7 +5221,8 @@
     ]
   },
   {
-    "id": "pl1-91",
+    "setOrder":39,
+	"id": "pl1-91",
     "name": "Riolu",
     "imageUrl": "https://images.pokemontcg.io/pl1/91.png",
     "subtype": "Basic",
@@ -5185,7 +5276,8 @@
     ]
   },
   {
-    "id": "pl1-92",
+    "setOrder":39,
+	"id": "pl1-92",
     "name": "Shuppet",
     "imageUrl": "https://images.pokemontcg.io/pl1/92.png",
     "subtype": "Basic",
@@ -5244,7 +5336,8 @@
     ]
   },
   {
-    "id": "pl1-93",
+    "setOrder":39,
+	"id": "pl1-93",
     "name": "Skitty",
     "imageUrl": "https://images.pokemontcg.io/pl1/93.png",
     "subtype": "Basic",
@@ -5297,7 +5390,8 @@
     ]
   },
   {
-    "id": "pl1-94",
+    "setOrder":39,
+	"id": "pl1-94",
     "name": "Skuntank G",
     "imageUrl": "https://images.pokemontcg.io/pl1/94.png",
     "subtype": "Basic",
@@ -5345,7 +5439,8 @@
     "nationalPokedexNumber": 435
   },
   {
-    "id": "pl1-95",
+    "setOrder":39,
+	"id": "pl1-95",
     "name": "Slakoth",
     "imageUrl": "https://images.pokemontcg.io/pl1/95.png",
     "subtype": "Basic",
@@ -5399,7 +5494,8 @@
     ]
   },
   {
-    "id": "pl1-96",
+    "setOrder":39,
+	"id": "pl1-96",
     "name": "Squirtle",
     "imageUrl": "https://images.pokemontcg.io/pl1/96.png",
     "subtype": "Basic",
@@ -5453,7 +5549,8 @@
     ]
   },
   {
-    "id": "pl1-97",
+    "setOrder":39,
+	"id": "pl1-97",
     "name": "Swablu",
     "imageUrl": "https://images.pokemontcg.io/pl1/97.png",
     "subtype": "Basic",
@@ -5509,7 +5606,8 @@
     ]
   },
   {
-    "id": "pl1-98",
+    "setOrder":39,
+	"id": "pl1-98",
     "name": "Tauros",
     "imageUrl": "https://images.pokemontcg.io/pl1/98.png",
     "subtype": "Basic",
@@ -5559,7 +5657,8 @@
     "nationalPokedexNumber": 128
   },
   {
-    "id": "pl1-99",
+    "setOrder":39,
+	"id": "pl1-99",
     "name": "Torchic",
     "imageUrl": "https://images.pokemontcg.io/pl1/99.png",
     "subtype": "Basic",
@@ -5612,7 +5711,8 @@
     ]
   },
   {
-    "id": "pl1-100",
+    "setOrder":39,
+	"id": "pl1-100",
     "name": "Torkoal",
     "imageUrl": "https://images.pokemontcg.io/pl1/100.png",
     "subtype": "Basic",
@@ -5665,7 +5765,8 @@
     "nationalPokedexNumber": 324
   },
   {
-    "id": "pl1-101",
+    "setOrder":39,
+	"id": "pl1-101",
     "name": "Turtwig",
     "imageUrl": "https://images.pokemontcg.io/pl1/101.png",
     "subtype": "Basic",
@@ -5726,7 +5827,8 @@
     ]
   },
   {
-    "id": "pl1-102",
+    "setOrder":39,
+	"id": "pl1-102",
     "name": "Vulpix",
     "imageUrl": "https://images.pokemontcg.io/pl1/102.png",
     "subtype": "Basic",
@@ -5780,7 +5882,8 @@
     ]
   },
   {
-    "id": "pl1-103",
+    "setOrder":39,
+	"id": "pl1-103",
     "name": "Wurmple",
     "imageUrl": "https://images.pokemontcg.io/pl1/103.png",
     "subtype": "Basic",
@@ -5835,7 +5938,8 @@
     ]
   },
   {
-    "id": "pl1-104",
+    "setOrder":39,
+	"id": "pl1-104",
     "name": "Broken Time-Space",
     "imageUrl": "https://images.pokemontcg.io/pl1/104.png",
     "subtype": "Stadium",
@@ -5853,7 +5957,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/104_hires.png"
   },
   {
-    "id": "pl1-105",
+    "setOrder":39,
+	"id": "pl1-105",
     "name": "Cyrus's Conspiracy",
     "imageUrl": "https://images.pokemontcg.io/pl1/105.png",
     "subtype": "Supporter",
@@ -5872,7 +5977,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/105_hires.png"
   },
   {
-    "id": "pl1-106",
+    "setOrder":39,
+	"id": "pl1-106",
     "name": "Galactic HQ",
     "imageUrl": "https://images.pokemontcg.io/pl1/106.png",
     "subtype": "Stadium",
@@ -5890,7 +5996,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/106_hires.png"
   },
   {
-    "id": "pl1-107",
+    "setOrder":39,
+	"id": "pl1-107",
     "name": "Level Max",
     "imageUrl": "https://images.pokemontcg.io/pl1/107.png",
     "subtype": "Item",
@@ -5908,7 +6015,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/107_hires.png"
   },
   {
-    "id": "pl1-108",
+    "setOrder":39,
+	"id": "pl1-108",
     "name": "Life Herb",
     "imageUrl": "https://images.pokemontcg.io/pl1/108.png",
     "subtype": "Item",
@@ -5926,7 +6034,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/108_hires.png"
   },
   {
-    "id": "pl1-109",
+    "setOrder":39,
+	"id": "pl1-109",
     "name": "Looker's Investigation",
     "imageUrl": "https://images.pokemontcg.io/pl1/109.png",
     "subtype": "Supporter",
@@ -5945,7 +6054,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/109_hires.png"
   },
   {
-    "id": "pl1-110",
+    "setOrder":39,
+	"id": "pl1-110",
     "name": "Memory Berry",
     "imageUrl": "https://images.pokemontcg.io/pl1/110.png",
     "subtype": "Pokémon Tool",
@@ -5964,7 +6074,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/110_hires.png"
   },
   {
-    "id": "pl1-111",
+    "setOrder":39,
+	"id": "pl1-111",
     "name": "Miasma Valley",
     "imageUrl": "https://images.pokemontcg.io/pl1/111.png",
     "subtype": "Stadium",
@@ -5982,7 +6093,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/111_hires.png"
   },
   {
-    "id": "pl1-112",
+    "setOrder":39,
+	"id": "pl1-112",
     "name": "PlusPower",
     "imageUrl": "https://images.pokemontcg.io/pl1/112.png",
     "subtype": "Item",
@@ -6000,7 +6112,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/112_hires.png"
   },
   {
-    "id": "pl1-113",
+    "setOrder":39,
+	"id": "pl1-113",
     "name": "Poké Ball",
     "imageUrl": "https://images.pokemontcg.io/pl1/113.png",
     "subtype": "Item",
@@ -6018,7 +6131,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/113_hires.png"
   },
   {
-    "id": "pl1-114",
+    "setOrder":39,
+	"id": "pl1-114",
     "name": "Pokédex HANDY910is",
     "imageUrl": "https://images.pokemontcg.io/pl1/114.png",
     "subtype": "Item",
@@ -6036,7 +6150,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/114_hires.png"
   },
   {
-    "id": "pl1-115",
+    "setOrder":39,
+	"id": "pl1-115",
     "name": "Pokémon Rescue",
     "imageUrl": "https://images.pokemontcg.io/pl1/115.png",
     "subtype": "Item",
@@ -6054,7 +6169,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/115_hires.png"
   },
   {
-    "id": "pl1-116",
+    "setOrder":39,
+	"id": "pl1-116",
     "name": "Team Galactic's Invention G-101 Energy Gain",
     "imageUrl": "https://images.pokemontcg.io/pl1/116.png",
     "subtype": "Pokémon Tool",
@@ -6073,7 +6189,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/116_hires.png"
   },
   {
-    "id": "pl1-117",
+    "setOrder":39,
+	"id": "pl1-117",
     "name": "Team Galactic's Invention G-103 Power Spray",
     "imageUrl": "https://images.pokemontcg.io/pl1/117.png",
     "subtype": "Item",
@@ -6091,7 +6208,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/117_hires.png"
   },
   {
-    "id": "pl1-118",
+    "setOrder":39,
+	"id": "pl1-118",
     "name": "Team Galactic's Invention G-105 Poké Turn",
     "imageUrl": "https://images.pokemontcg.io/pl1/118.png",
     "subtype": "Item",
@@ -6109,7 +6227,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/118_hires.png"
   },
   {
-    "id": "pl1-119",
+    "setOrder":39,
+	"id": "pl1-119",
     "name": "Armor Fossil",
     "imageUrl": "https://images.pokemontcg.io/pl1/119.png",
     "subtype": "Item",
@@ -6128,7 +6247,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/119_hires.png"
   },
   {
-    "id": "pl1-120",
+    "setOrder":39,
+	"id": "pl1-120",
     "name": "Skull Fossil",
     "imageUrl": "https://images.pokemontcg.io/pl1/120.png",
     "subtype": "Item",
@@ -6147,7 +6267,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/120_hires.png"
   },
   {
-    "id": "pl1-121",
+    "setOrder":39,
+	"id": "pl1-121",
     "name": "Rainbow Energy",
     "imageUrl": "https://images.pokemontcg.io/pl1/121.png",
     "subtype": "Special",
@@ -6164,7 +6285,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl1/121_hires.png"
   },
   {
-    "id": "pl1-122",
+    "setOrder":39,
+	"id": "pl1-122",
     "name": "Dialga G",
     "imageUrl": "https://images.pokemontcg.io/pl1/122.png",
     "subtype": "Level Up",
@@ -6223,7 +6345,8 @@
     "nationalPokedexNumber": 483
   },
   {
-    "id": "pl1-123",
+    "setOrder":39,
+	"id": "pl1-123",
     "name": "Drapion",
     "imageUrl": "https://images.pokemontcg.io/pl1/123.png",
     "subtype": "Level Up",
@@ -6277,7 +6400,8 @@
     "nationalPokedexNumber": 452
   },
   {
-    "id": "pl1-124",
+    "setOrder":39,
+	"id": "pl1-124",
     "name": "Giratina",
     "imageUrl": "https://images.pokemontcg.io/pl1/124.png",
     "subtype": "Level Up",
@@ -6337,7 +6461,8 @@
     "nationalPokedexNumber": 487
   },
   {
-    "id": "pl1-125",
+    "setOrder":39,
+	"id": "pl1-125",
     "name": "Palkia G",
     "imageUrl": "https://images.pokemontcg.io/pl1/125.png",
     "subtype": "Level Up",
@@ -6390,7 +6515,8 @@
     "nationalPokedexNumber": 484
   },
   {
-    "id": "pl1-126",
+    "setOrder":39,
+	"id": "pl1-126",
     "name": "Shaymin",
     "imageUrl": "https://images.pokemontcg.io/pl1/126.png",
     "subtype": "Level Up",
@@ -6447,7 +6573,8 @@
     "nationalPokedexNumber": 492
   },
   {
-    "id": "pl1-127",
+    "setOrder":39,
+	"id": "pl1-127",
     "name": "Shaymin",
     "imageUrl": "https://images.pokemontcg.io/pl1/127.png",
     "subtype": "Level Up",
@@ -6500,7 +6627,8 @@
     "nationalPokedexNumber": 492
   },
   {
-    "id": "pl1-128",
+    "setOrder":39,
+	"id": "pl1-128",
     "name": "Electabuzz",
     "imageUrl": "https://images.pokemontcg.io/pl1/128.png",
     "subtype": "Basic",
@@ -6555,7 +6683,8 @@
     ]
   },
   {
-    "id": "pl1-129",
+    "setOrder":39,
+	"id": "pl1-129",
     "name": "Hitmonchan",
     "imageUrl": "https://images.pokemontcg.io/pl1/129.png",
     "subtype": "Basic",
@@ -6608,7 +6737,8 @@
     "nationalPokedexNumber": 107
   },
   {
-    "id": "pl1-130",
+    "setOrder":39,
+	"id": "pl1-130",
     "name": "Scyther",
     "imageUrl": "https://images.pokemontcg.io/pl1/130.png",
     "subtype": "Basic",
@@ -6666,7 +6796,8 @@
     ]
   },
   {
-    "id": "pl1-SH4",
+    "setOrder":39,
+	"id": "pl1-SH4",
     "name": "Lotad",
     "imageUrl": "https://images.pokemontcg.io/pl1/SH4.png",
     "subtype": "Basic",
@@ -6725,7 +6856,8 @@
     ]
   },
   {
-    "id": "pl1-SH5",
+    "setOrder":39,
+	"id": "pl1-SH5",
     "name": "Swablu",
     "imageUrl": "https://images.pokemontcg.io/pl1/SH5.png",
     "subtype": "Basic",
@@ -6793,7 +6925,8 @@
     ]
   },
   {
-    "id": "pl1-SH6",
+    "setOrder":39,
+	"id": "pl1-SH6",
     "name": "Vulpix",
     "imageUrl": "https://images.pokemontcg.io/pl1/SH6.png",
     "subtype": "Basic",

--- a/json/cards/Power Keepers.json
+++ b/json/cards/Power Keepers.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "ex16-1",
+    "setOrder":31,
+	"id": "ex16-1",
     "name": "Aggron",
     "imageUrl": "https://images.pokemontcg.io/ex16/1.png",
     "subtype": "Stage 2",
@@ -69,7 +70,8 @@
     "nationalPokedexNumber": 306
   },
   {
-    "id": "ex16-2",
+    "setOrder":31,
+	"id": "ex16-2",
     "name": "Altaria",
     "imageUrl": "https://images.pokemontcg.io/ex16/2.png",
     "subtype": "Stage 1",
@@ -137,7 +139,8 @@
     "nationalPokedexNumber": 334
   },
   {
-    "id": "ex16-3",
+    "setOrder":31,
+	"id": "ex16-3",
     "name": "Armaldo",
     "imageUrl": "https://images.pokemontcg.io/ex16/3.png",
     "subtype": "Stage 2",
@@ -191,7 +194,8 @@
     "nationalPokedexNumber": 348
   },
   {
-    "id": "ex16-4",
+    "setOrder":31,
+	"id": "ex16-4",
     "name": "Banette",
     "imageUrl": "https://images.pokemontcg.io/ex16/4.png",
     "subtype": "Stage 1",
@@ -250,7 +254,8 @@
     "nationalPokedexNumber": 354
   },
   {
-    "id": "ex16-5",
+    "setOrder":31,
+	"id": "ex16-5",
     "name": "Blaziken",
     "imageUrl": "https://images.pokemontcg.io/ex16/5.png",
     "subtype": "Stage 2",
@@ -299,7 +304,8 @@
     "nationalPokedexNumber": 257
   },
   {
-    "id": "ex16-6",
+    "setOrder":31,
+	"id": "ex16-6",
     "name": "Charizard",
     "imageUrl": "https://images.pokemontcg.io/ex16/6.png",
     "subtype": "Stage 2",
@@ -353,7 +359,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "ex16-7",
+    "setOrder":31,
+	"id": "ex16-7",
     "name": "Cradily",
     "imageUrl": "https://images.pokemontcg.io/ex16/7.png",
     "subtype": "Stage 2",
@@ -402,7 +409,8 @@
     "nationalPokedexNumber": 346
   },
   {
-    "id": "ex16-8",
+    "setOrder":31,
+	"id": "ex16-8",
     "name": "Delcatty",
     "imageUrl": "https://images.pokemontcg.io/ex16/8.png",
     "subtype": "Stage 1",
@@ -448,7 +456,8 @@
     "nationalPokedexNumber": 301
   },
   {
-    "id": "ex16-9",
+    "setOrder":31,
+	"id": "ex16-9",
     "name": "Gardevoir",
     "imageUrl": "https://images.pokemontcg.io/ex16/9.png",
     "subtype": "Stage 2",
@@ -495,7 +504,8 @@
     "nationalPokedexNumber": 282
   },
   {
-    "id": "ex16-10",
+    "setOrder":31,
+	"id": "ex16-10",
     "name": "Kabutops",
     "imageUrl": "https://images.pokemontcg.io/ex16/10.png",
     "subtype": "Stage 2",
@@ -554,7 +564,8 @@
     "nationalPokedexNumber": 141
   },
   {
-    "id": "ex16-11",
+    "setOrder":31,
+	"id": "ex16-11",
     "name": "Machamp",
     "imageUrl": "https://images.pokemontcg.io/ex16/11.png",
     "subtype": "Stage 2",
@@ -614,7 +625,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "ex16-12",
+    "setOrder":31,
+	"id": "ex16-12",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/ex16/12.png",
     "subtype": "Stage 1",
@@ -666,7 +678,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "ex16-13",
+    "setOrder":31,
+	"id": "ex16-13",
     "name": "Slaking",
     "imageUrl": "https://images.pokemontcg.io/ex16/13.png",
     "subtype": "Stage 2",
@@ -717,7 +730,8 @@
     "nationalPokedexNumber": 289
   },
   {
-    "id": "ex16-14",
+    "setOrder":31,
+	"id": "ex16-14",
     "name": "Dusclops",
     "imageUrl": "https://images.pokemontcg.io/ex16/14.png",
     "subtype": "Stage 1",
@@ -780,7 +794,8 @@
     ]
   },
   {
-    "id": "ex16-15",
+    "setOrder":31,
+	"id": "ex16-15",
     "name": "Lanturn",
     "imageUrl": "https://images.pokemontcg.io/ex16/15.png",
     "subtype": "Stage 1",
@@ -829,7 +844,8 @@
     "nationalPokedexNumber": 171
   },
   {
-    "id": "ex16-16",
+    "setOrder":31,
+	"id": "ex16-16",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/ex16/16.png",
     "subtype": "Stage 1",
@@ -885,7 +901,8 @@
     ]
   },
   {
-    "id": "ex16-17",
+    "setOrder":31,
+	"id": "ex16-17",
     "name": "Mawile",
     "imageUrl": "https://images.pokemontcg.io/ex16/17.png",
     "subtype": "Basic",
@@ -941,7 +958,8 @@
     "nationalPokedexNumber": 303
   },
   {
-    "id": "ex16-18",
+    "setOrder":31,
+	"id": "ex16-18",
     "name": "Mightyena",
     "imageUrl": "https://images.pokemontcg.io/ex16/18.png",
     "subtype": "Stage 1",
@@ -997,7 +1015,8 @@
     "nationalPokedexNumber": 262
   },
   {
-    "id": "ex16-19",
+    "setOrder":31,
+	"id": "ex16-19",
     "name": "Ninetales",
     "imageUrl": "https://images.pokemontcg.io/ex16/19.png",
     "subtype": "Stage 1",
@@ -1055,7 +1074,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "ex16-20",
+    "setOrder":31,
+	"id": "ex16-20",
     "name": "Omastar",
     "imageUrl": "https://images.pokemontcg.io/ex16/20.png",
     "subtype": "Stage 2",
@@ -1107,7 +1127,8 @@
     "nationalPokedexNumber": 139
   },
   {
-    "id": "ex16-21",
+    "setOrder":31,
+	"id": "ex16-21",
     "name": "Pichu",
     "imageUrl": "https://images.pokemontcg.io/ex16/21.png",
     "subtype": "Basic",
@@ -1155,7 +1176,8 @@
     ]
   },
   {
-    "id": "ex16-22",
+    "setOrder":31,
+	"id": "ex16-22",
     "name": "Sableye",
     "imageUrl": "https://images.pokemontcg.io/ex16/22.png",
     "subtype": "Basic",
@@ -1210,7 +1232,8 @@
     "nationalPokedexNumber": 302
   },
   {
-    "id": "ex16-23",
+    "setOrder":31,
+	"id": "ex16-23",
     "name": "Seviper",
     "imageUrl": "https://images.pokemontcg.io/ex16/23.png",
     "subtype": "Basic",
@@ -1261,7 +1284,8 @@
     "nationalPokedexNumber": 336
   },
   {
-    "id": "ex16-24",
+    "setOrder":31,
+	"id": "ex16-24",
     "name": "Wobbuffet",
     "imageUrl": "https://images.pokemontcg.io/ex16/24.png",
     "subtype": "Basic",
@@ -1309,7 +1333,8 @@
     "nationalPokedexNumber": 202
   },
   {
-    "id": "ex16-25",
+    "setOrder":31,
+	"id": "ex16-25",
     "name": "Zangoose",
     "imageUrl": "https://images.pokemontcg.io/ex16/25.png",
     "subtype": "Basic",
@@ -1364,7 +1389,8 @@
     "nationalPokedexNumber": 335
   },
   {
-    "id": "ex16-26",
+    "setOrder":31,
+	"id": "ex16-26",
     "name": "Anorith",
     "imageUrl": "https://images.pokemontcg.io/ex16/26.png",
     "subtype": "Stage 1",
@@ -1414,7 +1440,8 @@
     ]
   },
   {
-    "id": "ex16-27",
+    "setOrder":31,
+	"id": "ex16-27",
     "name": "Cacturne",
     "imageUrl": "https://images.pokemontcg.io/ex16/27.png",
     "subtype": "Stage 1",
@@ -1468,7 +1495,8 @@
     "nationalPokedexNumber": 332
   },
   {
-    "id": "ex16-28",
+    "setOrder":31,
+	"id": "ex16-28",
     "name": "Charmeleon",
     "imageUrl": "https://images.pokemontcg.io/ex16/28.png",
     "subtype": "Stage 1",
@@ -1523,7 +1551,8 @@
     ]
   },
   {
-    "id": "ex16-29",
+    "setOrder":31,
+	"id": "ex16-29",
     "name": "Combusken",
     "imageUrl": "https://images.pokemontcg.io/ex16/29.png",
     "subtype": "Stage 1",
@@ -1573,7 +1602,8 @@
     ]
   },
   {
-    "id": "ex16-30",
+    "setOrder":31,
+	"id": "ex16-30",
     "name": "Glalie",
     "imageUrl": "https://images.pokemontcg.io/ex16/30.png",
     "subtype": "Stage 1",
@@ -1631,7 +1661,8 @@
     "nationalPokedexNumber": 362
   },
   {
-    "id": "ex16-31",
+    "setOrder":31,
+	"id": "ex16-31",
     "name": "Kirlia",
     "imageUrl": "https://images.pokemontcg.io/ex16/31.png",
     "subtype": "Stage 1",
@@ -1686,7 +1717,8 @@
     ]
   },
   {
-    "id": "ex16-32",
+    "setOrder":31,
+	"id": "ex16-32",
     "name": "Lairon",
     "imageUrl": "https://images.pokemontcg.io/ex16/32.png",
     "subtype": "Stage 1",
@@ -1749,7 +1781,8 @@
     ]
   },
   {
-    "id": "ex16-33",
+    "setOrder":31,
+	"id": "ex16-33",
     "name": "Machoke",
     "imageUrl": "https://images.pokemontcg.io/ex16/33.png",
     "subtype": "Stage 1",
@@ -1804,7 +1837,8 @@
     ]
   },
   {
-    "id": "ex16-34",
+    "setOrder":31,
+	"id": "ex16-34",
     "name": "Medicham",
     "imageUrl": "https://images.pokemontcg.io/ex16/34.png",
     "subtype": "Stage 1",
@@ -1862,7 +1896,8 @@
     "nationalPokedexNumber": 308
   },
   {
-    "id": "ex16-35",
+    "setOrder":31,
+	"id": "ex16-35",
     "name": "Metang",
     "imageUrl": "https://images.pokemontcg.io/ex16/35.png",
     "subtype": "Stage 1",
@@ -1919,7 +1954,8 @@
     ]
   },
   {
-    "id": "ex16-36",
+    "setOrder":31,
+	"id": "ex16-36",
     "name": "Nuzleaf",
     "imageUrl": "https://images.pokemontcg.io/ex16/36.png",
     "subtype": "Stage 1",
@@ -1980,7 +2016,8 @@
     ]
   },
   {
-    "id": "ex16-37",
+    "setOrder":31,
+	"id": "ex16-37",
     "name": "Sealeo",
     "imageUrl": "https://images.pokemontcg.io/ex16/37.png",
     "subtype": "Stage 1",
@@ -2025,7 +2062,8 @@
     ]
   },
   {
-    "id": "ex16-38",
+    "setOrder":31,
+	"id": "ex16-38",
     "name": "Sharpedo",
     "imageUrl": "https://images.pokemontcg.io/ex16/38.png",
     "subtype": "Stage 1",
@@ -2081,7 +2119,8 @@
     "nationalPokedexNumber": 319
   },
   {
-    "id": "ex16-39",
+    "setOrder":31,
+	"id": "ex16-39",
     "name": "Shelgon",
     "imageUrl": "https://images.pokemontcg.io/ex16/39.png",
     "subtype": "Stage 1",
@@ -2148,7 +2187,8 @@
     ]
   },
   {
-    "id": "ex16-40",
+    "setOrder":31,
+	"id": "ex16-40",
     "name": "Vibrava",
     "imageUrl": "https://images.pokemontcg.io/ex16/40.png",
     "subtype": "Stage 1",
@@ -2214,7 +2254,8 @@
     ]
   },
   {
-    "id": "ex16-41",
+    "setOrder":31,
+	"id": "ex16-41",
     "name": "Vigoroth",
     "imageUrl": "https://images.pokemontcg.io/ex16/41.png",
     "subtype": "Stage 1",
@@ -2264,7 +2305,8 @@
     ]
   },
   {
-    "id": "ex16-42",
+    "setOrder":31,
+	"id": "ex16-42",
     "name": "Aron",
     "imageUrl": "https://images.pokemontcg.io/ex16/42.png",
     "subtype": "Basic",
@@ -2324,7 +2366,8 @@
     ]
   },
   {
-    "id": "ex16-43",
+    "setOrder":31,
+	"id": "ex16-43",
     "name": "Bagon",
     "imageUrl": "https://images.pokemontcg.io/ex16/43.png",
     "subtype": "Basic",
@@ -2377,7 +2420,8 @@
     ]
   },
   {
-    "id": "ex16-44",
+    "setOrder":31,
+	"id": "ex16-44",
     "name": "Baltoy",
     "imageUrl": "https://images.pokemontcg.io/ex16/44.png",
     "subtype": "Basic",
@@ -2430,7 +2474,8 @@
     ]
   },
   {
-    "id": "ex16-45",
+    "setOrder":31,
+	"id": "ex16-45",
     "name": "Beldum",
     "imageUrl": "https://images.pokemontcg.io/ex16/45.png",
     "subtype": "Basic",
@@ -2480,7 +2525,8 @@
     ]
   },
   {
-    "id": "ex16-46",
+    "setOrder":31,
+	"id": "ex16-46",
     "name": "Cacnea",
     "imageUrl": "https://images.pokemontcg.io/ex16/46.png",
     "subtype": "Basic",
@@ -2523,7 +2569,8 @@
     ]
   },
   {
-    "id": "ex16-47",
+    "setOrder":31,
+	"id": "ex16-47",
     "name": "Carvanha",
     "imageUrl": "https://images.pokemontcg.io/ex16/47.png",
     "subtype": "Basic",
@@ -2578,7 +2625,8 @@
     ]
   },
   {
-    "id": "ex16-48",
+    "setOrder":31,
+	"id": "ex16-48",
     "name": "Charmander",
     "imageUrl": "https://images.pokemontcg.io/ex16/48.png",
     "subtype": "Basic",
@@ -2621,7 +2669,8 @@
     ]
   },
   {
-    "id": "ex16-49",
+    "setOrder":31,
+	"id": "ex16-49",
     "name": "Chinchou",
     "imageUrl": "https://images.pokemontcg.io/ex16/49.png",
     "subtype": "Basic",
@@ -2674,7 +2723,8 @@
     ]
   },
   {
-    "id": "ex16-50",
+    "setOrder":31,
+	"id": "ex16-50",
     "name": "Duskull",
     "imageUrl": "https://images.pokemontcg.io/ex16/50.png",
     "subtype": "Basic",
@@ -2724,7 +2774,8 @@
     ]
   },
   {
-    "id": "ex16-51",
+    "setOrder":31,
+	"id": "ex16-51",
     "name": "Kabuto",
     "imageUrl": "https://images.pokemontcg.io/ex16/51.png",
     "subtype": "Stage 1",
@@ -2779,7 +2830,8 @@
     ]
   },
   {
-    "id": "ex16-52",
+    "setOrder":31,
+	"id": "ex16-52",
     "name": "Lileep",
     "imageUrl": "https://images.pokemontcg.io/ex16/52.png",
     "subtype": "Stage 1",
@@ -2836,7 +2888,8 @@
     ]
   },
   {
-    "id": "ex16-53",
+    "setOrder":31,
+	"id": "ex16-53",
     "name": "Machop",
     "imageUrl": "https://images.pokemontcg.io/ex16/53.png",
     "subtype": "Basic",
@@ -2889,7 +2942,8 @@
     ]
   },
   {
-    "id": "ex16-54",
+    "setOrder":31,
+	"id": "ex16-54",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/ex16/54.png",
     "subtype": "Basic",
@@ -2948,7 +3002,8 @@
     ]
   },
   {
-    "id": "ex16-55",
+    "setOrder":31,
+	"id": "ex16-55",
     "name": "Meditite",
     "imageUrl": "https://images.pokemontcg.io/ex16/55.png",
     "subtype": "Basic",
@@ -3000,7 +3055,8 @@
     ]
   },
   {
-    "id": "ex16-56",
+    "setOrder":31,
+	"id": "ex16-56",
     "name": "Omanyte",
     "imageUrl": "https://images.pokemontcg.io/ex16/56.png",
     "subtype": "Stage 1",
@@ -3054,7 +3110,8 @@
     ]
   },
   {
-    "id": "ex16-57",
+    "setOrder":31,
+	"id": "ex16-57",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/ex16/57.png",
     "subtype": "Basic",
@@ -3107,7 +3164,8 @@
     ]
   },
   {
-    "id": "ex16-58",
+    "setOrder":31,
+	"id": "ex16-58",
     "name": "Poochyena",
     "imageUrl": "https://images.pokemontcg.io/ex16/58.png",
     "subtype": "Basic",
@@ -3156,7 +3214,8 @@
     ]
   },
   {
-    "id": "ex16-59",
+    "setOrder":31,
+	"id": "ex16-59",
     "name": "Ralts",
     "imageUrl": "https://images.pokemontcg.io/ex16/59.png",
     "subtype": "Basic",
@@ -3209,7 +3268,8 @@
     ]
   },
   {
-    "id": "ex16-60",
+    "setOrder":31,
+	"id": "ex16-60",
     "name": "Seedot",
     "imageUrl": "https://images.pokemontcg.io/ex16/60.png",
     "subtype": "Basic",
@@ -3262,7 +3322,8 @@
     ]
   },
   {
-    "id": "ex16-61",
+    "setOrder":31,
+	"id": "ex16-61",
     "name": "Shuppet",
     "imageUrl": "https://images.pokemontcg.io/ex16/61.png",
     "subtype": "Basic",
@@ -3311,7 +3372,8 @@
     ]
   },
   {
-    "id": "ex16-62",
+    "setOrder":31,
+	"id": "ex16-62",
     "name": "Skitty",
     "imageUrl": "https://images.pokemontcg.io/ex16/62.png",
     "subtype": "Basic",
@@ -3364,7 +3426,8 @@
     ]
   },
   {
-    "id": "ex16-63",
+    "setOrder":31,
+	"id": "ex16-63",
     "name": "Slakoth",
     "imageUrl": "https://images.pokemontcg.io/ex16/63.png",
     "subtype": "Basic",
@@ -3416,7 +3479,8 @@
     ]
   },
   {
-    "id": "ex16-64",
+    "setOrder":31,
+	"id": "ex16-64",
     "name": "Snorunt",
     "imageUrl": "https://images.pokemontcg.io/ex16/64.png",
     "subtype": "Basic",
@@ -3470,7 +3534,8 @@
     ]
   },
   {
-    "id": "ex16-65",
+    "setOrder":31,
+	"id": "ex16-65",
     "name": "Spheal",
     "imageUrl": "https://images.pokemontcg.io/ex16/65.png",
     "subtype": "Basic",
@@ -3523,7 +3588,8 @@
     ]
   },
   {
-    "id": "ex16-66",
+    "setOrder":31,
+	"id": "ex16-66",
     "name": "Swablu",
     "imageUrl": "https://images.pokemontcg.io/ex16/66.png",
     "subtype": "Basic",
@@ -3572,7 +3638,8 @@
     ]
   },
   {
-    "id": "ex16-67",
+    "setOrder":31,
+	"id": "ex16-67",
     "name": "Torchic",
     "imageUrl": "https://images.pokemontcg.io/ex16/67.png",
     "subtype": "Basic",
@@ -3615,7 +3682,8 @@
     ]
   },
   {
-    "id": "ex16-68",
+    "setOrder":31,
+	"id": "ex16-68",
     "name": "Trapinch",
     "imageUrl": "https://images.pokemontcg.io/ex16/68.png",
     "subtype": "Basic",
@@ -3658,7 +3726,8 @@
     ]
   },
   {
-    "id": "ex16-69",
+    "setOrder":31,
+	"id": "ex16-69",
     "name": "Vulpix",
     "imageUrl": "https://images.pokemontcg.io/ex16/69.png",
     "subtype": "Basic",
@@ -3711,7 +3780,8 @@
     ]
   },
   {
-    "id": "ex16-70",
+    "setOrder":31,
+	"id": "ex16-70",
     "name": "Wynaut",
     "imageUrl": "https://images.pokemontcg.io/ex16/70.png",
     "subtype": "Basic",
@@ -3759,7 +3829,8 @@
     ]
   },
   {
-    "id": "ex16-71",
+    "setOrder":31,
+	"id": "ex16-71",
     "name": "Battle Frontier",
     "imageUrl": "https://images.pokemontcg.io/ex16/71.png",
     "subtype": "Stadium",
@@ -3778,7 +3849,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/71_hires.png"
   },
   {
-    "id": "ex16-72",
+    "setOrder":31,
+	"id": "ex16-72",
     "name": "Drake's Stadium",
     "imageUrl": "https://images.pokemontcg.io/ex16/72.png",
     "subtype": "Stadium",
@@ -3797,7 +3869,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/72_hires.png"
   },
   {
-    "id": "ex16-73",
+    "setOrder":31,
+	"id": "ex16-73",
     "name": "Energy Recycle System",
     "imageUrl": "https://images.pokemontcg.io/ex16/73.png",
     "subtype": "Item",
@@ -3815,7 +3888,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/73_hires.png"
   },
   {
-    "id": "ex16-74",
+    "setOrder":31,
+	"id": "ex16-74",
     "name": "Energy Removal 2",
     "imageUrl": "https://images.pokemontcg.io/ex16/74.png",
     "subtype": "Item",
@@ -3833,7 +3907,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/74_hires.png"
   },
   {
-    "id": "ex16-75",
+    "setOrder":31,
+	"id": "ex16-75",
     "name": "Energy Switch",
     "imageUrl": "https://images.pokemontcg.io/ex16/75.png",
     "subtype": "Item",
@@ -3851,7 +3926,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/75_hires.png"
   },
   {
-    "id": "ex16-76",
+    "setOrder":31,
+	"id": "ex16-76",
     "name": "Glacia's Stadium",
     "imageUrl": "https://images.pokemontcg.io/ex16/76.png",
     "subtype": "Stadium",
@@ -3870,7 +3946,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/76_hires.png"
   },
   {
-    "id": "ex16-77",
+    "setOrder":31,
+	"id": "ex16-77",
     "name": "Great Ball",
     "imageUrl": "https://images.pokemontcg.io/ex16/77.png",
     "subtype": "Item",
@@ -3888,7 +3965,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/77_hires.png"
   },
   {
-    "id": "ex16-78",
+    "setOrder":31,
+	"id": "ex16-78",
     "name": "Master Ball",
     "imageUrl": "https://images.pokemontcg.io/ex16/78.png",
     "subtype": "Item",
@@ -3906,7 +3984,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/78_hires.png"
   },
   {
-    "id": "ex16-79",
+    "setOrder":31,
+	"id": "ex16-79",
     "name": "Phoebe's Stadium",
     "imageUrl": "https://images.pokemontcg.io/ex16/79.png",
     "subtype": "Stadium",
@@ -3925,7 +4004,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/79_hires.png"
   },
   {
-    "id": "ex16-80",
+    "setOrder":31,
+	"id": "ex16-80",
     "name": "Professor Birch",
     "imageUrl": "https://images.pokemontcg.io/ex16/80.png",
     "subtype": "Supporter",
@@ -3944,7 +4024,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/80_hires.png"
   },
   {
-    "id": "ex16-81",
+    "setOrder":31,
+	"id": "ex16-81",
     "name": "Scott",
     "imageUrl": "https://images.pokemontcg.io/ex16/81.png",
     "subtype": "Supporter",
@@ -3963,7 +4044,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/81_hires.png"
   },
   {
-    "id": "ex16-82",
+    "setOrder":31,
+	"id": "ex16-82",
     "name": "Sidney's Stadium",
     "imageUrl": "https://images.pokemontcg.io/ex16/82.png",
     "subtype": "Stadium",
@@ -3982,7 +4064,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/82_hires.png"
   },
   {
-    "id": "ex16-83",
+    "setOrder":31,
+	"id": "ex16-83",
     "name": "Steven's Advice",
     "imageUrl": "https://images.pokemontcg.io/ex16/83.png",
     "subtype": "Supporter",
@@ -4001,7 +4084,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/83_hires.png"
   },
   {
-    "id": "ex16-84",
+    "setOrder":31,
+	"id": "ex16-84",
     "name": "Claw Fossil",
     "imageUrl": "https://images.pokemontcg.io/ex16/84.png",
     "subtype": "Item",
@@ -4020,7 +4104,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/84_hires.png"
   },
   {
-    "id": "ex16-85",
+    "setOrder":31,
+	"id": "ex16-85",
     "name": "Mysterious Fossil",
     "imageUrl": "https://images.pokemontcg.io/ex16/85.png",
     "subtype": "Item",
@@ -4038,7 +4123,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/85_hires.png"
   },
   {
-    "id": "ex16-86",
+    "setOrder":31,
+	"id": "ex16-86",
     "name": "Root Fossil",
     "imageUrl": "https://images.pokemontcg.io/ex16/86.png",
     "subtype": "Item",
@@ -4057,7 +4143,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/86_hires.png"
   },
   {
-    "id": "ex16-87",
+    "setOrder":31,
+	"id": "ex16-87",
     "name": "Darkness Energy",
     "imageUrl": "https://images.pokemontcg.io/ex16/87.png",
     "subtype": "Special",
@@ -4074,7 +4161,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/87_hires.png"
   },
   {
-    "id": "ex16-88",
+    "setOrder":31,
+	"id": "ex16-88",
     "name": "Metal Energy",
     "imageUrl": "https://images.pokemontcg.io/ex16/88.png",
     "subtype": "Special",
@@ -4091,7 +4179,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/88_hires.png"
   },
   {
-    "id": "ex16-89",
+    "setOrder":31,
+	"id": "ex16-89",
     "name": "Multi Energy",
     "imageUrl": "https://images.pokemontcg.io/ex16/89.png",
     "subtype": "Special",
@@ -4108,7 +4197,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/89_hires.png"
   },
   {
-    "id": "ex16-90",
+    "setOrder":31,
+	"id": "ex16-90",
     "name": "Cyclone Energy",
     "imageUrl": "https://images.pokemontcg.io/ex16/90.png",
     "subtype": "Special",
@@ -4125,7 +4215,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/90_hires.png"
   },
   {
-    "id": "ex16-91",
+    "setOrder":31,
+	"id": "ex16-91",
     "name": "Warp Energy",
     "imageUrl": "https://images.pokemontcg.io/ex16/91.png",
     "subtype": "Special",
@@ -4142,7 +4233,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/91_hires.png"
   },
   {
-    "id": "ex16-92",
+    "setOrder":31,
+	"id": "ex16-92",
     "name": "Absol ex",
     "imageUrl": "https://images.pokemontcg.io/ex16/92.png",
     "subtype": "EX",
@@ -4198,7 +4290,8 @@
     "nationalPokedexNumber": 359
   },
   {
-    "id": "ex16-93",
+    "setOrder":31,
+	"id": "ex16-93",
     "name": "Claydol ex",
     "imageUrl": "https://images.pokemontcg.io/ex16/93.png",
     "subtype": "EX",
@@ -4261,7 +4354,8 @@
     "nationalPokedexNumber": 344
   },
   {
-    "id": "ex16-94",
+    "setOrder":31,
+	"id": "ex16-94",
     "name": "Flygon ex",
     "imageUrl": "https://images.pokemontcg.io/ex16/94.png",
     "subtype": "EX",
@@ -4320,7 +4414,8 @@
     "nationalPokedexNumber": 330
   },
   {
-    "id": "ex16-95",
+    "setOrder":31,
+	"id": "ex16-95",
     "name": "Metagross ex",
     "imageUrl": "https://images.pokemontcg.io/ex16/95.png",
     "subtype": "EX",
@@ -4381,7 +4476,8 @@
     "nationalPokedexNumber": 376
   },
   {
-    "id": "ex16-96",
+    "setOrder":31,
+	"id": "ex16-96",
     "name": "Salamence ex",
     "imageUrl": "https://images.pokemontcg.io/ex16/96.png",
     "subtype": "EX",
@@ -4452,7 +4548,8 @@
     "nationalPokedexNumber": 373
   },
   {
-    "id": "ex16-97",
+    "setOrder":31,
+	"id": "ex16-97",
     "name": "Shiftry ex",
     "imageUrl": "https://images.pokemontcg.io/ex16/97.png",
     "subtype": "EX",
@@ -4514,7 +4611,8 @@
     "nationalPokedexNumber": 275
   },
   {
-    "id": "ex16-98",
+    "setOrder":31,
+	"id": "ex16-98",
     "name": "Skarmory ex",
     "imageUrl": "https://images.pokemontcg.io/ex16/98.png",
     "subtype": "EX",
@@ -4581,7 +4679,8 @@
     "nationalPokedexNumber": 227
   },
   {
-    "id": "ex16-99",
+    "setOrder":31,
+	"id": "ex16-99",
     "name": "Walrein ex",
     "imageUrl": "https://images.pokemontcg.io/ex16/99.png",
     "subtype": "EX",
@@ -4635,7 +4734,8 @@
     "nationalPokedexNumber": 365
   },
   {
-    "id": "ex16-100",
+    "setOrder":31,
+	"id": "ex16-100",
     "name": "Flareon Star",
     "imageUrl": "https://images.pokemontcg.io/ex16/100.png",
     "subtype": "Basic",
@@ -4685,7 +4785,8 @@
     "nationalPokedexNumber": 136
   },
   {
-    "id": "ex16-101",
+    "setOrder":31,
+	"id": "ex16-101",
     "name": "Jolteon Star",
     "imageUrl": "https://images.pokemontcg.io/ex16/101.png",
     "subtype": "Basic",
@@ -4741,7 +4842,8 @@
     "nationalPokedexNumber": 135
   },
   {
-    "id": "ex16-102",
+    "setOrder":31,
+	"id": "ex16-102",
     "name": "Vaporeon Star",
     "imageUrl": "https://images.pokemontcg.io/ex16/102.png",
     "subtype": "Basic",
@@ -4791,7 +4893,8 @@
     "nationalPokedexNumber": 134
   },
   {
-    "id": "ex16-103",
+    "setOrder":31,
+	"id": "ex16-103",
     "name": "Grass Energy",
     "imageUrl": "https://images.pokemontcg.io/ex16/103.png",
     "subtype": "Basic",
@@ -4805,7 +4908,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/103_hires.png"
   },
   {
-    "id": "ex16-104",
+    "setOrder":31,
+	"id": "ex16-104",
     "name": "Fire Energy",
     "imageUrl": "https://images.pokemontcg.io/ex16/104.png",
     "subtype": "Basic",
@@ -4819,7 +4923,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/104_hires.png"
   },
   {
-    "id": "ex16-105",
+    "setOrder":31,
+	"id": "ex16-105",
     "name": "Water Energy",
     "imageUrl": "https://images.pokemontcg.io/ex16/105.png",
     "subtype": "Basic",
@@ -4833,7 +4938,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/105_hires.png"
   },
   {
-    "id": "ex16-106",
+    "setOrder":31,
+	"id": "ex16-106",
     "name": "Lightning Energy",
     "imageUrl": "https://images.pokemontcg.io/ex16/106.png",
     "subtype": "Basic",
@@ -4847,7 +4953,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/106_hires.png"
   },
   {
-    "id": "ex16-107",
+    "setOrder":31,
+	"id": "ex16-107",
     "name": "Psychic Energy",
     "imageUrl": "https://images.pokemontcg.io/ex16/107.png",
     "subtype": "Basic",
@@ -4861,7 +4968,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex16/107_hires.png"
   },
   {
-    "id": "ex16-108",
+    "setOrder":31,
+	"id": "ex16-108",
     "name": "Fighting Energy",
     "imageUrl": "https://images.pokemontcg.io/ex16/108.png",
     "subtype": "Basic",

--- a/json/cards/Primal Clash.json
+++ b/json/cards/Primal Clash.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "xy5-1",
+    "setOrder":63,
+	"id": "xy5-1",
     "name": "Weedle",
     "imageUrl": "https://images.pokemontcg.io/xy5/1.png",
     "subtype": "Basic",
@@ -43,7 +44,8 @@
     ]
   },
   {
-    "id": "xy5-2",
+    "setOrder":63,
+	"id": "xy5-2",
     "name": "Kakuna",
     "imageUrl": "https://images.pokemontcg.io/xy5/2.png",
     "subtype": "Stage 1",
@@ -89,7 +91,8 @@
     ]
   },
   {
-    "id": "xy5-3",
+    "setOrder":63,
+	"id": "xy5-3",
     "name": "Beedrill",
     "imageUrl": "https://images.pokemontcg.io/xy5/3.png",
     "subtype": "Stage 2",
@@ -137,7 +140,8 @@
     "nationalPokedexNumber": 15
   },
   {
-    "id": "xy5-4",
+    "setOrder":63,
+	"id": "xy5-4",
     "name": "Tangela",
     "imageUrl": "https://images.pokemontcg.io/xy5/4.png",
     "subtype": "Basic",
@@ -193,7 +197,8 @@
     ]
   },
   {
-    "id": "xy5-5",
+    "setOrder":63,
+	"id": "xy5-5",
     "name": "Tangrowth",
     "imageUrl": "https://images.pokemontcg.io/xy5/5.png",
     "subtype": "Stage 1",
@@ -251,7 +256,8 @@
     "nationalPokedexNumber": 465
   },
   {
-    "id": "xy5-6",
+    "setOrder":63,
+	"id": "xy5-6",
     "name": "Treecko",
     "imageUrl": "https://images.pokemontcg.io/xy5/6.png",
     "subtype": "Basic",
@@ -294,7 +300,8 @@
     ]
   },
   {
-    "id": "xy5-7",
+    "setOrder":63,
+	"id": "xy5-7",
     "name": "Grovyle",
     "imageUrl": "https://images.pokemontcg.io/xy5/7.png",
     "subtype": "Stage 1",
@@ -349,7 +356,8 @@
     ]
   },
   {
-    "id": "xy5-8",
+    "setOrder":63,
+	"id": "xy5-8",
     "name": "Sceptile",
     "imageUrl": "https://images.pokemontcg.io/xy5/8.png",
     "subtype": "Stage 2",
@@ -398,7 +406,8 @@
     "nationalPokedexNumber": 254
   },
   {
-    "id": "xy5-9",
+    "setOrder":63,
+	"id": "xy5-9",
     "name": "Sceptile",
     "imageUrl": "https://images.pokemontcg.io/xy5/9.png",
     "subtype": "Stage 2",
@@ -455,7 +464,8 @@
     "nationalPokedexNumber": 254
   },
   {
-    "id": "xy5-10",
+    "setOrder":63,
+	"id": "xy5-10",
     "name": "Lotad",
     "imageUrl": "https://images.pokemontcg.io/xy5/10.png",
     "subtype": "Basic",
@@ -499,7 +509,8 @@
     ]
   },
   {
-    "id": "xy5-11",
+    "setOrder":63,
+	"id": "xy5-11",
     "name": "Lombre",
     "imageUrl": "https://images.pokemontcg.io/xy5/11.png",
     "subtype": "Stage 1",
@@ -554,7 +565,8 @@
     ]
   },
   {
-    "id": "xy5-12",
+    "setOrder":63,
+	"id": "xy5-12",
     "name": "Ludicolo",
     "imageUrl": "https://images.pokemontcg.io/xy5/12.png",
     "subtype": "Stage 2",
@@ -603,7 +615,8 @@
     "nationalPokedexNumber": 272
   },
   {
-    "id": "xy5-13",
+    "setOrder":63,
+	"id": "xy5-13",
     "name": "Surskit",
     "imageUrl": "https://images.pokemontcg.io/xy5/13.png",
     "subtype": "Basic",
@@ -646,7 +659,8 @@
     ]
   },
   {
-    "id": "xy5-14",
+    "setOrder":63,
+	"id": "xy5-14",
     "name": "Masquerain",
     "imageUrl": "https://images.pokemontcg.io/xy5/14.png",
     "subtype": "Stage 1",
@@ -697,7 +711,8 @@
     "nationalPokedexNumber": 284
   },
   {
-    "id": "xy5-15",
+    "setOrder":63,
+	"id": "xy5-15",
     "name": "Shroomish",
     "imageUrl": "https://images.pokemontcg.io/xy5/15.png",
     "subtype": "Basic",
@@ -740,7 +755,8 @@
     ]
   },
   {
-    "id": "xy5-16",
+    "setOrder":63,
+	"id": "xy5-16",
     "name": "Breloom",
     "imageUrl": "https://images.pokemontcg.io/xy5/16.png",
     "subtype": "Stage 1",
@@ -794,7 +810,8 @@
     "nationalPokedexNumber": 286
   },
   {
-    "id": "xy5-17",
+    "setOrder":63,
+	"id": "xy5-17",
     "name": "Volbeat",
     "imageUrl": "https://images.pokemontcg.io/xy5/17.png",
     "subtype": "Basic",
@@ -844,7 +861,8 @@
     "nationalPokedexNumber": 313
   },
   {
-    "id": "xy5-18",
+    "setOrder":63,
+	"id": "xy5-18",
     "name": "Illumise",
     "imageUrl": "https://images.pokemontcg.io/xy5/18.png",
     "subtype": "Basic",
@@ -893,7 +911,8 @@
     "nationalPokedexNumber": 314
   },
   {
-    "id": "xy5-19",
+    "setOrder":63,
+	"id": "xy5-19",
     "name": "Trevenant-EX",
     "imageUrl": "https://images.pokemontcg.io/xy5/19.png",
     "subtype": "EX",
@@ -949,7 +968,8 @@
     "nationalPokedexNumber": 709
   },
   {
-    "id": "xy5-20",
+    "setOrder":63,
+	"id": "xy5-20",
     "name": "Vulpix",
     "imageUrl": "https://images.pokemontcg.io/xy5/20.png",
     "subtype": "Basic",
@@ -1001,7 +1021,8 @@
     ]
   },
   {
-    "id": "xy5-21",
+    "setOrder":63,
+	"id": "xy5-21",
     "name": "Ninetales",
     "imageUrl": "https://images.pokemontcg.io/xy5/21.png",
     "subtype": "Stage 1",
@@ -1049,7 +1070,8 @@
     "nationalPokedexNumber": 38
   },
   {
-    "id": "xy5-22",
+    "setOrder":63,
+	"id": "xy5-22",
     "name": "Slugma",
     "imageUrl": "https://images.pokemontcg.io/xy5/22.png",
     "subtype": "Basic",
@@ -1105,7 +1127,8 @@
     ]
   },
   {
-    "id": "xy5-23",
+    "setOrder":63,
+	"id": "xy5-23",
     "name": "Magcargo",
     "imageUrl": "https://images.pokemontcg.io/xy5/23.png",
     "subtype": "Stage 1",
@@ -1160,7 +1183,8 @@
     "nationalPokedexNumber": 219
   },
   {
-    "id": "xy5-24",
+    "setOrder":63,
+	"id": "xy5-24",
     "name": "Magcargo",
     "imageUrl": "https://images.pokemontcg.io/xy5/24.png",
     "subtype": "Stage 1",
@@ -1219,7 +1243,8 @@
     "nationalPokedexNumber": 219
   },
   {
-    "id": "xy5-25",
+    "setOrder":63,
+	"id": "xy5-25",
     "name": "Torchic",
     "imageUrl": "https://images.pokemontcg.io/xy5/25.png",
     "subtype": "Basic",
@@ -1262,7 +1287,8 @@
     ]
   },
   {
-    "id": "xy5-26",
+    "setOrder":63,
+	"id": "xy5-26",
     "name": "Torchic",
     "imageUrl": "https://images.pokemontcg.io/xy5/26.png",
     "subtype": "Basic",
@@ -1318,7 +1344,8 @@
     ]
   },
   {
-    "id": "xy5-27",
+    "setOrder":63,
+	"id": "xy5-27",
     "name": "Combusken",
     "imageUrl": "https://images.pokemontcg.io/xy5/27.png",
     "subtype": "Stage 1",
@@ -1372,7 +1399,8 @@
     ]
   },
   {
-    "id": "xy5-28",
+    "setOrder":63,
+	"id": "xy5-28",
     "name": "Blaziken",
     "imageUrl": "https://images.pokemontcg.io/xy5/28.png",
     "subtype": "Stage 2",
@@ -1423,7 +1451,8 @@
     "nationalPokedexNumber": 257
   },
   {
-    "id": "xy5-29",
+    "setOrder":63,
+	"id": "xy5-29",
     "name": "Camerupt-EX",
     "imageUrl": "https://images.pokemontcg.io/xy5/29.png",
     "subtype": "EX",
@@ -1482,7 +1511,8 @@
     "nationalPokedexNumber": 323
   },
   {
-    "id": "xy5-30",
+    "setOrder":63,
+	"id": "xy5-30",
     "name": "Horsea",
     "imageUrl": "https://images.pokemontcg.io/xy5/30.png",
     "subtype": "Basic",
@@ -1525,7 +1555,8 @@
     ]
   },
   {
-    "id": "xy5-31",
+    "setOrder":63,
+	"id": "xy5-31",
     "name": "Seadra",
     "imageUrl": "https://images.pokemontcg.io/xy5/31.png",
     "subtype": "Stage 1",
@@ -1579,7 +1610,8 @@
     ]
   },
   {
-    "id": "xy5-32",
+    "setOrder":63,
+	"id": "xy5-32",
     "name": "Staryu",
     "imageUrl": "https://images.pokemontcg.io/xy5/32.png",
     "subtype": "Basic",
@@ -1622,7 +1654,8 @@
     ]
   },
   {
-    "id": "xy5-33",
+    "setOrder":63,
+	"id": "xy5-33",
     "name": "Mudkip",
     "imageUrl": "https://images.pokemontcg.io/xy5/33.png",
     "subtype": "Basic",
@@ -1675,7 +1708,8 @@
     ]
   },
   {
-    "id": "xy5-34",
+    "setOrder":63,
+	"id": "xy5-34",
     "name": "Marshtomp",
     "imageUrl": "https://images.pokemontcg.io/xy5/34.png",
     "subtype": "Stage 1",
@@ -1733,7 +1767,8 @@
     ]
   },
   {
-    "id": "xy5-35",
+    "setOrder":63,
+	"id": "xy5-35",
     "name": "Swampert",
     "imageUrl": "https://images.pokemontcg.io/xy5/35.png",
     "subtype": "Stage 2",
@@ -1790,7 +1825,8 @@
     "nationalPokedexNumber": 260
   },
   {
-    "id": "xy5-36",
+    "setOrder":63,
+	"id": "xy5-36",
     "name": "Swampert",
     "imageUrl": "https://images.pokemontcg.io/xy5/36.png",
     "subtype": "Stage 2",
@@ -1844,7 +1880,8 @@
     "nationalPokedexNumber": 260
   },
   {
-    "id": "xy5-37",
+    "setOrder":63,
+	"id": "xy5-37",
     "name": "Ludicolo",
     "imageUrl": "https://images.pokemontcg.io/xy5/37.png",
     "subtype": "Stage 2",
@@ -1901,7 +1938,8 @@
     "nationalPokedexNumber": 272
   },
   {
-    "id": "xy5-38",
+    "setOrder":63,
+	"id": "xy5-38",
     "name": "Wailord-EX",
     "imageUrl": "https://images.pokemontcg.io/xy5/38.png",
     "subtype": "EX",
@@ -1956,7 +1994,8 @@
     "nationalPokedexNumber": 321
   },
   {
-    "id": "xy5-39",
+    "setOrder":63,
+	"id": "xy5-39",
     "name": "Barboach",
     "imageUrl": "https://images.pokemontcg.io/xy5/39.png",
     "subtype": "Basic",
@@ -2001,7 +2040,8 @@
     ]
   },
   {
-    "id": "xy5-40",
+    "setOrder":63,
+	"id": "xy5-40",
     "name": "Whiscash",
     "imageUrl": "https://images.pokemontcg.io/xy5/40.png",
     "subtype": "Stage 1",
@@ -2055,7 +2095,8 @@
     "nationalPokedexNumber": 340
   },
   {
-    "id": "xy5-41",
+    "setOrder":63,
+	"id": "xy5-41",
     "name": "Whiscash",
     "imageUrl": "https://images.pokemontcg.io/xy5/41.png",
     "subtype": "Stage 1",
@@ -2117,7 +2158,8 @@
     "nationalPokedexNumber": 340
   },
   {
-    "id": "xy5-42",
+    "setOrder":63,
+	"id": "xy5-42",
     "name": "Corphish",
     "imageUrl": "https://images.pokemontcg.io/xy5/42.png",
     "subtype": "Basic",
@@ -2170,7 +2212,8 @@
     ]
   },
   {
-    "id": "xy5-43",
+    "setOrder":63,
+	"id": "xy5-43",
     "name": "Feebas",
     "imageUrl": "https://images.pokemontcg.io/xy5/43.png",
     "subtype": "Basic",
@@ -2213,7 +2256,8 @@
     ]
   },
   {
-    "id": "xy5-44",
+    "setOrder":63,
+	"id": "xy5-44",
     "name": "Milotic",
     "imageUrl": "https://images.pokemontcg.io/xy5/44.png",
     "subtype": "Stage 1",
@@ -2262,7 +2306,8 @@
     "nationalPokedexNumber": 350
   },
   {
-    "id": "xy5-45",
+    "setOrder":63,
+	"id": "xy5-45",
     "name": "Spheal",
     "imageUrl": "https://images.pokemontcg.io/xy5/45.png",
     "subtype": "Basic",
@@ -2307,7 +2352,8 @@
     ]
   },
   {
-    "id": "xy5-46",
+    "setOrder":63,
+	"id": "xy5-46",
     "name": "Spheal",
     "imageUrl": "https://images.pokemontcg.io/xy5/46.png",
     "subtype": "Basic",
@@ -2352,7 +2398,8 @@
     ]
   },
   {
-    "id": "xy5-47",
+    "setOrder":63,
+	"id": "xy5-47",
     "name": "Sealeo",
     "imageUrl": "https://images.pokemontcg.io/xy5/47.png",
     "subtype": "Stage 1",
@@ -2410,7 +2457,8 @@
     ]
   },
   {
-    "id": "xy5-48",
+    "setOrder":63,
+	"id": "xy5-48",
     "name": "Walrein",
     "imageUrl": "https://images.pokemontcg.io/xy5/48.png",
     "subtype": "Stage 2",
@@ -2467,7 +2515,8 @@
     "nationalPokedexNumber": 365
   },
   {
-    "id": "xy5-49",
+    "setOrder":63,
+	"id": "xy5-49",
     "name": "Clamperl",
     "imageUrl": "https://images.pokemontcg.io/xy5/49.png",
     "subtype": "Basic",
@@ -2512,7 +2561,8 @@
     ]
   },
   {
-    "id": "xy5-50",
+    "setOrder":63,
+	"id": "xy5-50",
     "name": "Huntail",
     "imageUrl": "https://images.pokemontcg.io/xy5/50.png",
     "subtype": "Stage 1",
@@ -2564,7 +2614,8 @@
     "nationalPokedexNumber": 367
   },
   {
-    "id": "xy5-51",
+    "setOrder":63,
+	"id": "xy5-51",
     "name": "Gorebyss",
     "imageUrl": "https://images.pokemontcg.io/xy5/51.png",
     "subtype": "Stage 1",
@@ -2612,7 +2663,8 @@
     "nationalPokedexNumber": 368
   },
   {
-    "id": "xy5-52",
+    "setOrder":63,
+	"id": "xy5-52",
     "name": "Gorebyss",
     "imageUrl": "https://images.pokemontcg.io/xy5/52.png",
     "subtype": "Stage 1",
@@ -2658,7 +2710,8 @@
     "nationalPokedexNumber": 368
   },
   {
-    "id": "xy5-53",
+    "setOrder":63,
+	"id": "xy5-53",
     "name": "Kyogre",
     "imageUrl": "https://images.pokemontcg.io/xy5/53.png",
     "subtype": "Basic",
@@ -2714,7 +2767,8 @@
     "nationalPokedexNumber": 382
   },
   {
-    "id": "xy5-54",
+    "setOrder":63,
+	"id": "xy5-54",
     "name": "Kyogre-EX",
     "imageUrl": "https://images.pokemontcg.io/xy5/54.png",
     "subtype": "EX",
@@ -2773,7 +2827,8 @@
     "nationalPokedexNumber": 382
   },
   {
-    "id": "xy5-55",
+    "setOrder":63,
+	"id": "xy5-55",
     "name": "Primal Kyogre-EX",
     "imageUrl": "https://images.pokemontcg.io/xy5/55.png",
     "subtype": "MEGA",
@@ -2828,7 +2883,8 @@
     "nationalPokedexNumber": 382
   },
   {
-    "id": "xy5-56",
+    "setOrder":63,
+	"id": "xy5-56",
     "name": "Manaphy",
     "imageUrl": "https://images.pokemontcg.io/xy5/56.png",
     "subtype": "Basic",
@@ -2877,7 +2933,8 @@
     "nationalPokedexNumber": 490
   },
   {
-    "id": "xy5-57",
+    "setOrder":63,
+	"id": "xy5-57",
     "name": "Chinchou",
     "imageUrl": "https://images.pokemontcg.io/xy5/57.png",
     "subtype": "Basic",
@@ -2928,7 +2985,8 @@
     ]
   },
   {
-    "id": "xy5-58",
+    "setOrder":63,
+	"id": "xy5-58",
     "name": "Lanturn",
     "imageUrl": "https://images.pokemontcg.io/xy5/58.png",
     "subtype": "Stage 1",
@@ -2988,7 +3046,8 @@
     "nationalPokedexNumber": 171
   },
   {
-    "id": "xy5-59",
+    "setOrder":63,
+	"id": "xy5-59",
     "name": "Electrike",
     "imageUrl": "https://images.pokemontcg.io/xy5/59.png",
     "subtype": "Basic",
@@ -3047,7 +3106,8 @@
     ]
   },
   {
-    "id": "xy5-60",
+    "setOrder":63,
+	"id": "xy5-60",
     "name": "Electrike",
     "imageUrl": "https://images.pokemontcg.io/xy5/60.png",
     "subtype": "Basic",
@@ -3100,7 +3160,8 @@
     ]
   },
   {
-    "id": "xy5-61",
+    "setOrder":63,
+	"id": "xy5-61",
     "name": "Manectric",
     "imageUrl": "https://images.pokemontcg.io/xy5/61.png",
     "subtype": "Stage 1",
@@ -3159,7 +3220,8 @@
     "nationalPokedexNumber": 310
   },
   {
-    "id": "xy5-62",
+    "setOrder":63,
+	"id": "xy5-62",
     "name": "Tynamo",
     "imageUrl": "https://images.pokemontcg.io/xy5/62.png",
     "subtype": "Basic",
@@ -3208,7 +3270,8 @@
     ]
   },
   {
-    "id": "xy5-63",
+    "setOrder":63,
+	"id": "xy5-63",
     "name": "Eelektrik",
     "imageUrl": "https://images.pokemontcg.io/xy5/63.png",
     "subtype": "Stage 1",
@@ -3271,7 +3334,8 @@
     ]
   },
   {
-    "id": "xy5-64",
+    "setOrder":63,
+	"id": "xy5-64",
     "name": "Eelektrik",
     "imageUrl": "https://images.pokemontcg.io/xy5/64.png",
     "subtype": "Stage 1",
@@ -3328,7 +3392,8 @@
     ]
   },
   {
-    "id": "xy5-65",
+    "setOrder":63,
+	"id": "xy5-65",
     "name": "Eelektross",
     "imageUrl": "https://images.pokemontcg.io/xy5/65.png",
     "subtype": "Stage 2",
@@ -3385,7 +3450,8 @@
     "nationalPokedexNumber": 604
   },
   {
-    "id": "xy5-66",
+    "setOrder":63,
+	"id": "xy5-66",
     "name": "Nidoran♀",
     "imageUrl": "https://images.pokemontcg.io/xy5/66.png",
     "subtype": "Basic",
@@ -3438,7 +3504,8 @@
     ]
   },
   {
-    "id": "xy5-67",
+    "setOrder":63,
+	"id": "xy5-67",
     "name": "Nidorina",
     "imageUrl": "https://images.pokemontcg.io/xy5/67.png",
     "subtype": "Stage 1",
@@ -3494,7 +3561,8 @@
     ]
   },
   {
-    "id": "xy5-68",
+    "setOrder":63,
+	"id": "xy5-68",
     "name": "Nidoqueen",
     "imageUrl": "https://images.pokemontcg.io/xy5/68.png",
     "subtype": "Stage 2",
@@ -3549,7 +3617,8 @@
     "nationalPokedexNumber": 31
   },
   {
-    "id": "xy5-69",
+    "setOrder":63,
+	"id": "xy5-69",
     "name": "Nidoqueen",
     "imageUrl": "https://images.pokemontcg.io/xy5/69.png",
     "subtype": "Stage 2",
@@ -3606,7 +3675,8 @@
     "nationalPokedexNumber": 31
   },
   {
-    "id": "xy5-70",
+    "setOrder":63,
+	"id": "xy5-70",
     "name": "Tentacool",
     "imageUrl": "https://images.pokemontcg.io/xy5/70.png",
     "subtype": "Basic",
@@ -3649,7 +3719,8 @@
     ]
   },
   {
-    "id": "xy5-71",
+    "setOrder":63,
+	"id": "xy5-71",
     "name": "Tentacool",
     "imageUrl": "https://images.pokemontcg.io/xy5/71.png",
     "subtype": "Basic",
@@ -3697,7 +3768,8 @@
     ]
   },
   {
-    "id": "xy5-72",
+    "setOrder":63,
+	"id": "xy5-72",
     "name": "Tentacruel",
     "imageUrl": "https://images.pokemontcg.io/xy5/72.png",
     "subtype": "Stage 1",
@@ -3750,7 +3822,8 @@
     "nationalPokedexNumber": 73
   },
   {
-    "id": "xy5-73",
+    "setOrder":63,
+	"id": "xy5-73",
     "name": "Starmie",
     "imageUrl": "https://images.pokemontcg.io/xy5/73.png",
     "subtype": "Stage 1",
@@ -3788,7 +3861,8 @@
     "nationalPokedexNumber": 121
   },
   {
-    "id": "xy5-74",
+    "setOrder":63,
+	"id": "xy5-74",
     "name": "Rhyhorn",
     "imageUrl": "https://images.pokemontcg.io/xy5/74.png",
     "subtype": "Basic",
@@ -3834,7 +3908,8 @@
     ]
   },
   {
-    "id": "xy5-75",
+    "setOrder":63,
+	"id": "xy5-75",
     "name": "Rhydon",
     "imageUrl": "https://images.pokemontcg.io/xy5/75.png",
     "subtype": "Stage 1",
@@ -3895,7 +3970,8 @@
     ]
   },
   {
-    "id": "xy5-76",
+    "setOrder":63,
+	"id": "xy5-76",
     "name": "Rhyperior",
     "imageUrl": "https://images.pokemontcg.io/xy5/76.png",
     "subtype": "Stage 2",
@@ -3953,7 +4029,8 @@
     "nationalPokedexNumber": 464
   },
   {
-    "id": "xy5-77",
+    "setOrder":63,
+	"id": "xy5-77",
     "name": "Rhyperior",
     "imageUrl": "https://images.pokemontcg.io/xy5/77.png",
     "subtype": "Stage 2",
@@ -4009,7 +4086,8 @@
     "nationalPokedexNumber": 464
   },
   {
-    "id": "xy5-78",
+    "setOrder":63,
+	"id": "xy5-78",
     "name": "Nosepass",
     "imageUrl": "https://images.pokemontcg.io/xy5/78.png",
     "subtype": "Basic",
@@ -4066,7 +4144,8 @@
     ]
   },
   {
-    "id": "xy5-79",
+    "setOrder":63,
+	"id": "xy5-79",
     "name": "Meditite",
     "imageUrl": "https://images.pokemontcg.io/xy5/79.png",
     "subtype": "Basic",
@@ -4109,7 +4188,8 @@
     ]
   },
   {
-    "id": "xy5-80",
+    "setOrder":63,
+	"id": "xy5-80",
     "name": "Medicham",
     "imageUrl": "https://images.pokemontcg.io/xy5/80.png",
     "subtype": "Stage 1",
@@ -4161,7 +4241,8 @@
     "nationalPokedexNumber": 308
   },
   {
-    "id": "xy5-81",
+    "setOrder":63,
+	"id": "xy5-81",
     "name": "Medicham",
     "imageUrl": "https://images.pokemontcg.io/xy5/81.png",
     "subtype": "Stage 1",
@@ -4216,7 +4297,8 @@
     "nationalPokedexNumber": 308
   },
   {
-    "id": "xy5-82",
+    "setOrder":63,
+	"id": "xy5-82",
     "name": "Trapinch",
     "imageUrl": "https://images.pokemontcg.io/xy5/82.png",
     "subtype": "Basic",
@@ -4269,7 +4351,8 @@
     ]
   },
   {
-    "id": "xy5-83",
+    "setOrder":63,
+	"id": "xy5-83",
     "name": "Solrock",
     "imageUrl": "https://images.pokemontcg.io/xy5/83.png",
     "subtype": "Basic",
@@ -4319,7 +4402,8 @@
     "nationalPokedexNumber": 338
   },
   {
-    "id": "xy5-84",
+    "setOrder":63,
+	"id": "xy5-84",
     "name": "Groudon",
     "imageUrl": "https://images.pokemontcg.io/xy5/84.png",
     "subtype": "Basic",
@@ -4375,7 +4459,8 @@
     "nationalPokedexNumber": 383
   },
   {
-    "id": "xy5-85",
+    "setOrder":63,
+	"id": "xy5-85",
     "name": "Groudon-EX",
     "imageUrl": "https://images.pokemontcg.io/xy5/85.png",
     "subtype": "EX",
@@ -4434,7 +4519,8 @@
     "nationalPokedexNumber": 383
   },
   {
-    "id": "xy5-86",
+    "setOrder":63,
+	"id": "xy5-86",
     "name": "Primal Groudon-EX",
     "imageUrl": "https://images.pokemontcg.io/xy5/86.png",
     "subtype": "MEGA",
@@ -4489,7 +4575,8 @@
     "nationalPokedexNumber": 383
   },
   {
-    "id": "xy5-87",
+    "setOrder":63,
+	"id": "xy5-87",
     "name": "Hippopotas",
     "imageUrl": "https://images.pokemontcg.io/xy5/87.png",
     "subtype": "Basic",
@@ -4546,7 +4633,8 @@
     ]
   },
   {
-    "id": "xy5-88",
+    "setOrder":63,
+	"id": "xy5-88",
     "name": "Hippowdon",
     "imageUrl": "https://images.pokemontcg.io/xy5/88.png",
     "subtype": "Stage 1",
@@ -4604,7 +4692,8 @@
     "nationalPokedexNumber": 450
   },
   {
-    "id": "xy5-89",
+    "setOrder":63,
+	"id": "xy5-89",
     "name": "Drilbur",
     "imageUrl": "https://images.pokemontcg.io/xy5/89.png",
     "subtype": "Basic",
@@ -4648,7 +4737,8 @@
     ]
   },
   {
-    "id": "xy5-90",
+    "setOrder":63,
+	"id": "xy5-90",
     "name": "Diggersby",
     "imageUrl": "https://images.pokemontcg.io/xy5/90.png",
     "subtype": "Stage 1",
@@ -4702,7 +4792,8 @@
     "nationalPokedexNumber": 660
   },
   {
-    "id": "xy5-91",
+    "setOrder":63,
+	"id": "xy5-91",
     "name": "Sharpedo-EX",
     "imageUrl": "https://images.pokemontcg.io/xy5/91.png",
     "subtype": "EX",
@@ -4757,7 +4848,8 @@
     "nationalPokedexNumber": 319
   },
   {
-    "id": "xy5-92",
+    "setOrder":63,
+	"id": "xy5-92",
     "name": "Crawdaunt",
     "imageUrl": "https://images.pokemontcg.io/xy5/92.png",
     "subtype": "Stage 1",
@@ -4812,7 +4904,8 @@
     "nationalPokedexNumber": 342
   },
   {
-    "id": "xy5-93",
+    "setOrder":63,
+	"id": "xy5-93",
     "name": "Aggron-EX",
     "imageUrl": "https://images.pokemontcg.io/xy5/93.png",
     "subtype": "EX",
@@ -4879,7 +4972,8 @@
     "evolvesTo": "M Aggron-EX"
   },
   {
-    "id": "xy5-94",
+    "setOrder":63,
+	"id": "xy5-94",
     "name": "M Aggron-EX",
     "imageUrl": "https://images.pokemontcg.io/xy5/94.png",
     "subtype": "MEGA",
@@ -4936,7 +5030,8 @@
     "nationalPokedexNumber": 306
   },
   {
-    "id": "xy5-95",
+    "setOrder":63,
+	"id": "xy5-95",
     "name": "Probopass",
     "imageUrl": "https://images.pokemontcg.io/xy5/95.png",
     "subtype": "Stage 1",
@@ -4996,7 +5091,8 @@
     "nationalPokedexNumber": 476
   },
   {
-    "id": "xy5-96",
+    "setOrder":63,
+	"id": "xy5-96",
     "name": "Excadrill",
     "imageUrl": "https://images.pokemontcg.io/xy5/96.png",
     "subtype": "Stage 1",
@@ -5055,7 +5151,8 @@
     "nationalPokedexNumber": 530
   },
   {
-    "id": "xy5-97",
+    "setOrder":63,
+	"id": "xy5-97",
     "name": "Excadrill",
     "imageUrl": "https://images.pokemontcg.io/xy5/97.png",
     "subtype": "Stage 1",
@@ -5119,7 +5216,8 @@
     "nationalPokedexNumber": 530
   },
   {
-    "id": "xy5-98",
+    "setOrder":63,
+	"id": "xy5-98",
     "name": "Honedge",
     "imageUrl": "https://images.pokemontcg.io/xy5/98.png",
     "subtype": "Basic",
@@ -5169,7 +5267,8 @@
     ]
   },
   {
-    "id": "xy5-99",
+    "setOrder":63,
+	"id": "xy5-99",
     "name": "Doublade",
     "imageUrl": "https://images.pokemontcg.io/xy5/99.png",
     "subtype": "Stage 1",
@@ -5232,7 +5331,8 @@
     ]
   },
   {
-    "id": "xy5-100",
+    "setOrder":63,
+	"id": "xy5-100",
     "name": "Aegislash",
     "imageUrl": "https://images.pokemontcg.io/xy5/100.png",
     "subtype": "Stage 2",
@@ -5288,7 +5388,8 @@
     "nationalPokedexNumber": 681
   },
   {
-    "id": "xy5-101",
+    "setOrder":63,
+	"id": "xy5-101",
     "name": "Mr. Mime",
     "imageUrl": "https://images.pokemontcg.io/xy5/101.png",
     "subtype": "Basic",
@@ -5345,7 +5446,8 @@
     "nationalPokedexNumber": 122
   },
   {
-    "id": "xy5-102",
+    "setOrder":63,
+	"id": "xy5-102",
     "name": "Marill",
     "imageUrl": "https://images.pokemontcg.io/xy5/102.png",
     "subtype": "Basic",
@@ -5405,7 +5507,8 @@
     ]
   },
   {
-    "id": "xy5-103",
+    "setOrder":63,
+	"id": "xy5-103",
     "name": "Azumarill",
     "imageUrl": "https://images.pokemontcg.io/xy5/103.png",
     "subtype": "Stage 1",
@@ -5465,7 +5568,8 @@
     "nationalPokedexNumber": 184
   },
   {
-    "id": "xy5-104",
+    "setOrder":63,
+	"id": "xy5-104",
     "name": "Azumarill",
     "imageUrl": "https://images.pokemontcg.io/xy5/104.png",
     "subtype": "Stage 1",
@@ -5529,7 +5633,8 @@
     "nationalPokedexNumber": 184
   },
   {
-    "id": "xy5-105",
+    "setOrder":63,
+	"id": "xy5-105",
     "name": "Gardevoir-EX",
     "imageUrl": "https://images.pokemontcg.io/xy5/105.png",
     "subtype": "EX",
@@ -5591,7 +5696,8 @@
     "evolvesTo": "M Gardevoir-EX"
   },
   {
-    "id": "xy5-106",
+    "setOrder":63,
+	"id": "xy5-106",
     "name": "M Gardevoir-EX",
     "imageUrl": "https://images.pokemontcg.io/xy5/106.png",
     "subtype": "MEGA",
@@ -5645,7 +5751,8 @@
     "nationalPokedexNumber": 282
   },
   {
-    "id": "xy5-107",
+    "setOrder":63,
+	"id": "xy5-107",
     "name": "Kingdra",
     "imageUrl": "https://images.pokemontcg.io/xy5/107.png",
     "subtype": "Stage 2",
@@ -5696,7 +5803,8 @@
     "nationalPokedexNumber": 230
   },
   {
-    "id": "xy5-108",
+    "setOrder":63,
+	"id": "xy5-108",
     "name": "Kingdra",
     "imageUrl": "https://images.pokemontcg.io/xy5/108.png",
     "subtype": "Stage 2",
@@ -5752,7 +5860,8 @@
     "nationalPokedexNumber": 230
   },
   {
-    "id": "xy5-109",
+    "setOrder":63,
+	"id": "xy5-109",
     "name": "Vibrava",
     "imageUrl": "https://images.pokemontcg.io/xy5/109.png",
     "subtype": "Stage 1",
@@ -5807,7 +5916,8 @@
     ]
   },
   {
-    "id": "xy5-110",
+    "setOrder":63,
+	"id": "xy5-110",
     "name": "Flygon",
     "imageUrl": "https://images.pokemontcg.io/xy5/110.png",
     "subtype": "Stage 2",
@@ -5855,7 +5965,8 @@
     "nationalPokedexNumber": 330
   },
   {
-    "id": "xy5-111",
+    "setOrder":63,
+	"id": "xy5-111",
     "name": "Zigzagoon",
     "imageUrl": "https://images.pokemontcg.io/xy5/111.png",
     "subtype": "Basic",
@@ -5908,7 +6019,8 @@
     ]
   },
   {
-    "id": "xy5-112",
+    "setOrder":63,
+	"id": "xy5-112",
     "name": "Linoone",
     "imageUrl": "https://images.pokemontcg.io/xy5/112.png",
     "subtype": "Stage 1",
@@ -5960,7 +6072,8 @@
     "nationalPokedexNumber": 264
   },
   {
-    "id": "xy5-113",
+    "setOrder":63,
+	"id": "xy5-113",
     "name": "Skitty",
     "imageUrl": "https://images.pokemontcg.io/xy5/113.png",
     "subtype": "Basic",
@@ -6013,7 +6126,8 @@
     ]
   },
   {
-    "id": "xy5-114",
+    "setOrder":63,
+	"id": "xy5-114",
     "name": "Delcatty",
     "imageUrl": "https://images.pokemontcg.io/xy5/114.png",
     "subtype": "Stage 1",
@@ -6064,7 +6178,8 @@
     "nationalPokedexNumber": 301
   },
   {
-    "id": "xy5-115",
+    "setOrder":63,
+	"id": "xy5-115",
     "name": "Spinda",
     "imageUrl": "https://images.pokemontcg.io/xy5/115.png",
     "subtype": "Basic",
@@ -6113,7 +6228,8 @@
     "nationalPokedexNumber": 327
   },
   {
-    "id": "xy5-116",
+    "setOrder":63,
+	"id": "xy5-116",
     "name": "Bidoof",
     "imageUrl": "https://images.pokemontcg.io/xy5/116.png",
     "subtype": "Basic",
@@ -6167,7 +6283,8 @@
     ]
   },
   {
-    "id": "xy5-117",
+    "setOrder":63,
+	"id": "xy5-117",
     "name": "Bidoof",
     "imageUrl": "https://images.pokemontcg.io/xy5/117.png",
     "subtype": "Basic",
@@ -6216,7 +6333,8 @@
     ]
   },
   {
-    "id": "xy5-118",
+    "setOrder":63,
+	"id": "xy5-118",
     "name": "Bibarel",
     "imageUrl": "https://images.pokemontcg.io/xy5/118.png",
     "subtype": "Stage 1",
@@ -6270,7 +6388,8 @@
     "nationalPokedexNumber": 400
   },
   {
-    "id": "xy5-119",
+    "setOrder":63,
+	"id": "xy5-119",
     "name": "Bouffalant",
     "imageUrl": "https://images.pokemontcg.io/xy5/119.png",
     "subtype": "Basic",
@@ -6318,7 +6437,8 @@
     "nationalPokedexNumber": 626
   },
   {
-    "id": "xy5-120",
+    "setOrder":63,
+	"id": "xy5-120",
     "name": "Bunnelby",
     "imageUrl": "https://images.pokemontcg.io/xy5/120.png",
     "subtype": "Basic",
@@ -6363,7 +6483,8 @@
     ]
   },
   {
-    "id": "xy5-121",
+    "setOrder":63,
+	"id": "xy5-121",
     "name": "Bunnelby",
     "imageUrl": "https://images.pokemontcg.io/xy5/121.png",
     "subtype": "Basic",
@@ -6420,7 +6541,8 @@
     ]
   },
   {
-    "id": "xy5-122",
+    "setOrder":63,
+	"id": "xy5-122",
     "name": "Acro Bike",
     "imageUrl": "https://images.pokemontcg.io/xy5/122.png",
     "subtype": "Item",
@@ -6437,7 +6559,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/122_hires.png"
   },
   {
-    "id": "xy5-123",
+    "setOrder":63,
+	"id": "xy5-123",
     "name": "Aggron Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xy5/123.png",
     "subtype": "Pokémon Tool",
@@ -6454,7 +6577,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/123_hires.png"
   },
   {
-    "id": "xy5-124",
+    "setOrder":63,
+	"id": "xy5-124",
     "name": "Archie's Ace in the Hole",
     "imageUrl": "https://images.pokemontcg.io/xy5/124.png",
     "subtype": "Supporter",
@@ -6471,7 +6595,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/124_hires.png"
   },
   {
-    "id": "xy5-125",
+    "setOrder":63,
+	"id": "xy5-125",
     "name": "Dive Ball",
     "imageUrl": "https://images.pokemontcg.io/xy5/125.png",
     "subtype": "Item",
@@ -6488,7 +6613,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/125_hires.png"
   },
   {
-    "id": "xy5-126",
+    "setOrder":63,
+	"id": "xy5-126",
     "name": "Energy Retrieval",
     "imageUrl": "https://images.pokemontcg.io/xy5/126.png",
     "subtype": "Item",
@@ -6505,7 +6631,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/126_hires.png"
   },
   {
-    "id": "xy5-127",
+    "setOrder":63,
+	"id": "xy5-127",
     "name": "Escape Rope",
     "imageUrl": "https://images.pokemontcg.io/xy5/127.png",
     "subtype": "Item",
@@ -6522,7 +6649,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/127_hires.png"
   },
   {
-    "id": "xy5-128",
+    "setOrder":63,
+	"id": "xy5-128",
     "name": "Exp. Share",
     "imageUrl": "https://images.pokemontcg.io/xy5/128.png",
     "subtype": "Pokémon Tool",
@@ -6539,7 +6667,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/128_hires.png"
   },
   {
-    "id": "xy5-129",
+    "setOrder":63,
+	"id": "xy5-129",
     "name": "Fresh Water Set",
     "imageUrl": "https://images.pokemontcg.io/xy5/129.png",
     "subtype": "Item",
@@ -6556,7 +6685,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/129_hires.png"
   },
   {
-    "id": "xy5-130",
+    "setOrder":63,
+	"id": "xy5-130",
     "name": "Gardevoir Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xy5/130.png",
     "subtype": "Pokémon Tool",
@@ -6573,7 +6703,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/130_hires.png"
   },
   {
-    "id": "xy5-131",
+    "setOrder":63,
+	"id": "xy5-131",
     "name": "Groudon Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xy5/131.png",
     "subtype": "Pokémon Tool",
@@ -6590,7 +6721,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/131_hires.png"
   },
   {
-    "id": "xy5-132",
+    "setOrder":63,
+	"id": "xy5-132",
     "name": "Kyogre Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xy5/132.png",
     "subtype": "Pokémon Tool",
@@ -6607,7 +6739,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/132_hires.png"
   },
   {
-    "id": "xy5-133",
+    "setOrder":63,
+	"id": "xy5-133",
     "name": "Maxie's Hidden Ball Trick",
     "imageUrl": "https://images.pokemontcg.io/xy5/133.png",
     "subtype": "Supporter",
@@ -6624,7 +6757,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/133_hires.png"
   },
   {
-    "id": "xy5-134",
+    "setOrder":63,
+	"id": "xy5-134",
     "name": "Professor Birch's Observations",
     "imageUrl": "https://images.pokemontcg.io/xy5/134.png",
     "subtype": "Supporter",
@@ -6641,7 +6775,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/134_hires.png"
   },
   {
-    "id": "xy5-135",
+    "setOrder":63,
+	"id": "xy5-135",
     "name": "Rare Candy",
     "imageUrl": "https://images.pokemontcg.io/xy5/135.png",
     "subtype": "Item",
@@ -6658,7 +6793,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/135_hires.png"
   },
   {
-    "id": "xy5-136",
+    "setOrder":63,
+	"id": "xy5-136",
     "name": "Repeat Ball",
     "imageUrl": "https://images.pokemontcg.io/xy5/136.png",
     "subtype": "Item",
@@ -6675,7 +6811,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/136_hires.png"
   },
   {
-    "id": "xy5-137",
+    "setOrder":63,
+	"id": "xy5-137",
     "name": "Rough Seas",
     "imageUrl": "https://images.pokemontcg.io/xy5/137.png",
     "subtype": "Stadium",
@@ -6692,7 +6829,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/137_hires.png"
   },
   {
-    "id": "xy5-138",
+    "setOrder":63,
+	"id": "xy5-138",
     "name": "Scorched Earth",
     "imageUrl": "https://images.pokemontcg.io/xy5/138.png",
     "subtype": "Stadium",
@@ -6709,7 +6847,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/138_hires.png"
   },
   {
-    "id": "xy5-139",
+    "setOrder":63,
+	"id": "xy5-139",
     "name": "Shrine of Memories",
     "imageUrl": "https://images.pokemontcg.io/xy5/139.png",
     "subtype": "Stadium",
@@ -6726,7 +6865,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/139_hires.png"
   },
   {
-    "id": "xy5-140",
+    "setOrder":63,
+	"id": "xy5-140",
     "name": "Silent Lab",
     "imageUrl": "https://images.pokemontcg.io/xy5/140.png",
     "subtype": "Stadium",
@@ -6743,7 +6883,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/140_hires.png"
   },
   {
-    "id": "xy5-141",
+    "setOrder":63,
+	"id": "xy5-141",
     "name": "Teammates",
     "imageUrl": "https://images.pokemontcg.io/xy5/141.png",
     "subtype": "Supporter",
@@ -6760,7 +6901,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/141_hires.png"
   },
   {
-    "id": "xy5-142",
+    "setOrder":63,
+	"id": "xy5-142",
     "name": "Weakness Policy",
     "imageUrl": "https://images.pokemontcg.io/xy5/142.png",
     "subtype": "Pokémon Tool",
@@ -6777,7 +6919,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/142_hires.png"
   },
   {
-    "id": "xy5-143",
+    "setOrder":63,
+	"id": "xy5-143",
     "name": "Shield Energy",
     "imageUrl": "https://images.pokemontcg.io/xy5/143.png",
     "subtype": "Special",
@@ -6794,7 +6937,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/143_hires.png"
   },
   {
-    "id": "xy5-144",
+    "setOrder":63,
+	"id": "xy5-144",
     "name": "Wonder Energy",
     "imageUrl": "https://images.pokemontcg.io/xy5/144.png",
     "subtype": "Special",
@@ -6811,7 +6955,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/144_hires.png"
   },
   {
-    "id": "xy5-145",
+    "setOrder":63,
+	"id": "xy5-145",
     "name": "Trevenant-EX",
     "imageUrl": "https://images.pokemontcg.io/xy5/145.png",
     "subtype": "EX",
@@ -6867,7 +7012,8 @@
     "nationalPokedexNumber": 709
   },
   {
-    "id": "xy5-146",
+    "setOrder":63,
+	"id": "xy5-146",
     "name": "Camerupt-EX",
     "imageUrl": "https://images.pokemontcg.io/xy5/146.png",
     "subtype": "EX",
@@ -6926,7 +7072,8 @@
     "nationalPokedexNumber": 323
   },
   {
-    "id": "xy5-147",
+    "setOrder":63,
+	"id": "xy5-147",
     "name": "Wailord-EX",
     "imageUrl": "https://images.pokemontcg.io/xy5/147.png",
     "subtype": "EX",
@@ -6981,7 +7128,8 @@
     "nationalPokedexNumber": 321
   },
   {
-    "id": "xy5-148",
+    "setOrder":63,
+	"id": "xy5-148",
     "name": "Kyogre-EX",
     "imageUrl": "https://images.pokemontcg.io/xy5/148.png",
     "subtype": "EX",
@@ -7040,7 +7188,8 @@
     "nationalPokedexNumber": 382
   },
   {
-    "id": "xy5-149",
+    "setOrder":63,
+	"id": "xy5-149",
     "name": "Primal Kyogre-EX",
     "imageUrl": "https://images.pokemontcg.io/xy5/149.png",
     "subtype": "MEGA",
@@ -7095,7 +7244,8 @@
     "nationalPokedexNumber": 382
   },
   {
-    "id": "xy5-150",
+    "setOrder":63,
+	"id": "xy5-150",
     "name": "Groudon-EX",
     "imageUrl": "https://images.pokemontcg.io/xy5/150.png",
     "subtype": "EX",
@@ -7154,7 +7304,8 @@
     "nationalPokedexNumber": 383
   },
   {
-    "id": "xy5-151",
+    "setOrder":63,
+	"id": "xy5-151",
     "name": "Primal Groudon-EX",
     "imageUrl": "https://images.pokemontcg.io/xy5/151.png",
     "subtype": "MEGA",
@@ -7209,7 +7360,8 @@
     "nationalPokedexNumber": 383
   },
   {
-    "id": "xy5-152",
+    "setOrder":63,
+	"id": "xy5-152",
     "name": "Sharpedo-EX",
     "imageUrl": "https://images.pokemontcg.io/xy5/152.png",
     "subtype": "EX",
@@ -7264,7 +7416,8 @@
     "nationalPokedexNumber": 319
   },
   {
-    "id": "xy5-153",
+    "setOrder":63,
+	"id": "xy5-153",
     "name": "Aggron-EX",
     "imageUrl": "https://images.pokemontcg.io/xy5/153.png",
     "subtype": "EX",
@@ -7331,7 +7484,8 @@
     "evolvesTo": "M Aggron-EX"
   },
   {
-    "id": "xy5-154",
+    "setOrder":63,
+	"id": "xy5-154",
     "name": "M Aggron-EX",
     "imageUrl": "https://images.pokemontcg.io/xy5/154.png",
     "subtype": "MEGA",
@@ -7388,7 +7542,8 @@
     "nationalPokedexNumber": 306
   },
   {
-    "id": "xy5-155",
+    "setOrder":63,
+	"id": "xy5-155",
     "name": "Gardevoir-EX",
     "imageUrl": "https://images.pokemontcg.io/xy5/155.png",
     "subtype": "EX",
@@ -7450,7 +7605,8 @@
     "evolvesTo": "M Gardevoir-EX"
   },
   {
-    "id": "xy5-156",
+    "setOrder":63,
+	"id": "xy5-156",
     "name": "M Gardevoir-EX",
     "imageUrl": "https://images.pokemontcg.io/xy5/156.png",
     "subtype": "MEGA",
@@ -7504,7 +7660,8 @@
     "nationalPokedexNumber": 282
   },
   {
-    "id": "xy5-157",
+    "setOrder":63,
+	"id": "xy5-157",
     "name": "Archie's Ace in the Hole",
     "imageUrl": "https://images.pokemontcg.io/xy5/157.png",
     "subtype": "Supporter",
@@ -7521,7 +7678,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/157_hires.png"
   },
   {
-    "id": "xy5-158",
+    "setOrder":63,
+	"id": "xy5-158",
     "name": "Maxie's Hidden Ball Trick",
     "imageUrl": "https://images.pokemontcg.io/xy5/158.png",
     "subtype": "Supporter",
@@ -7538,7 +7696,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/158_hires.png"
   },
   {
-    "id": "xy5-159",
+    "setOrder":63,
+	"id": "xy5-159",
     "name": "Professor Birch's Observations",
     "imageUrl": "https://images.pokemontcg.io/xy5/159.png",
     "subtype": "Supporter",
@@ -7555,7 +7714,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy5/159_hires.png"
   },
   {
-    "id": "xy5-160",
+    "setOrder":63,
+	"id": "xy5-160",
     "name": "Teammates",
     "imageUrl": "https://images.pokemontcg.io/xy5/160.png",
     "subtype": "Supporter",

--- a/json/cards/Rising Rivals.json
+++ b/json/cards/Rising Rivals.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "pl2-1",
+    "setOrder":40,
+	"id": "pl2-1",
     "name": "Arcanine",
     "imageUrl": "https://images.pokemontcg.io/pl2/1.png",
     "subtype": "Stage 1",
@@ -60,7 +61,8 @@
     "nationalPokedexNumber": 59
   },
   {
-    "id": "pl2-2",
+    "setOrder":40,
+	"id": "pl2-2",
     "name": "Bastiodon GL",
     "imageUrl": "https://images.pokemontcg.io/pl2/2.png",
     "subtype": "Basic",
@@ -123,7 +125,8 @@
     "nationalPokedexNumber": 411
   },
   {
-    "id": "pl2-3",
+    "setOrder":40,
+	"id": "pl2-3",
     "name": "Darkrai G",
     "imageUrl": "https://images.pokemontcg.io/pl2/3.png",
     "subtype": "Basic",
@@ -178,7 +181,8 @@
     "nationalPokedexNumber": 491
   },
   {
-    "id": "pl2-4",
+    "setOrder":40,
+	"id": "pl2-4",
     "name": "Floatzel GL",
     "imageUrl": "https://images.pokemontcg.io/pl2/4.png",
     "subtype": "Basic",
@@ -229,7 +233,8 @@
     "nationalPokedexNumber": 419
   },
   {
-    "id": "pl2-5",
+    "setOrder":40,
+	"id": "pl2-5",
     "name": "Flygon",
     "imageUrl": "https://images.pokemontcg.io/pl2/5.png",
     "subtype": "Stage 2",
@@ -291,7 +296,8 @@
     "nationalPokedexNumber": 330
   },
   {
-    "id": "pl2-6",
+    "setOrder":40,
+	"id": "pl2-6",
     "name": "Froslass GL",
     "imageUrl": "https://images.pokemontcg.io/pl2/6.png",
     "subtype": "Basic",
@@ -342,7 +348,8 @@
     "nationalPokedexNumber": 478
   },
   {
-    "id": "pl2-7",
+    "setOrder":40,
+	"id": "pl2-7",
     "name": "Jirachi",
     "imageUrl": "https://images.pokemontcg.io/pl2/7.png",
     "subtype": "Basic",
@@ -400,7 +407,8 @@
     "nationalPokedexNumber": 385
   },
   {
-    "id": "pl2-8",
+    "setOrder":40,
+	"id": "pl2-8",
     "name": "Lucario GL",
     "imageUrl": "https://images.pokemontcg.io/pl2/8.png",
     "subtype": "Basic",
@@ -448,7 +456,8 @@
     "nationalPokedexNumber": 448
   },
   {
-    "id": "pl2-9",
+    "setOrder":40,
+	"id": "pl2-9",
     "name": "Luxray GL",
     "imageUrl": "https://images.pokemontcg.io/pl2/9.png",
     "subtype": "Basic",
@@ -507,7 +516,8 @@
     "nationalPokedexNumber": 405
   },
   {
-    "id": "pl2-10",
+    "setOrder":40,
+	"id": "pl2-10",
     "name": "Mismagius GL",
     "imageUrl": "https://images.pokemontcg.io/pl2/10.png",
     "subtype": "Basic",
@@ -564,7 +574,8 @@
     "nationalPokedexNumber": 429
   },
   {
-    "id": "pl2-11",
+    "setOrder":40,
+	"id": "pl2-11",
     "name": "Rampardos GL",
     "imageUrl": "https://images.pokemontcg.io/pl2/11.png",
     "subtype": "Basic",
@@ -617,7 +628,8 @@
     "nationalPokedexNumber": 409
   },
   {
-    "id": "pl2-12",
+    "setOrder":40,
+	"id": "pl2-12",
     "name": "Roserade GL",
     "imageUrl": "https://images.pokemontcg.io/pl2/12.png",
     "subtype": "Basic",
@@ -668,7 +680,8 @@
     "nationalPokedexNumber": 407
   },
   {
-    "id": "pl2-13",
+    "setOrder":40,
+	"id": "pl2-13",
     "name": "Shiftry",
     "imageUrl": "https://images.pokemontcg.io/pl2/13.png",
     "subtype": "Stage 2",
@@ -733,7 +746,8 @@
     "nationalPokedexNumber": 275
   },
   {
-    "id": "pl2-14",
+    "setOrder":40,
+	"id": "pl2-14",
     "name": "Aggron",
     "imageUrl": "https://images.pokemontcg.io/pl2/14.png",
     "subtype": "Stage 2",
@@ -807,7 +821,8 @@
     "nationalPokedexNumber": 306
   },
   {
-    "id": "pl2-15",
+    "setOrder":40,
+	"id": "pl2-15",
     "name": "Beedrill",
     "imageUrl": "https://images.pokemontcg.io/pl2/15.png",
     "subtype": "Stage 2",
@@ -856,7 +871,8 @@
     "nationalPokedexNumber": 15
   },
   {
-    "id": "pl2-16",
+    "setOrder":40,
+	"id": "pl2-16",
     "name": "Bronzong 4",
     "imageUrl": "https://images.pokemontcg.io/pl2/16.png",
     "subtype": "Basic",
@@ -915,7 +931,8 @@
     "nationalPokedexNumber": 437
   },
   {
-    "id": "pl2-17",
+    "setOrder":40,
+	"id": "pl2-17",
     "name": "Drapion 4",
     "imageUrl": "https://images.pokemontcg.io/pl2/17.png",
     "subtype": "Basic",
@@ -977,7 +994,8 @@
     "nationalPokedexNumber": 452
   },
   {
-    "id": "pl2-18",
+    "setOrder":40,
+	"id": "pl2-18",
     "name": "Espeon 4",
     "imageUrl": "https://images.pokemontcg.io/pl2/18.png",
     "subtype": "Basic",
@@ -1028,7 +1046,8 @@
     "nationalPokedexNumber": 196
   },
   {
-    "id": "pl2-19",
+    "setOrder":40,
+	"id": "pl2-19",
     "name": "Flareon",
     "imageUrl": "https://images.pokemontcg.io/pl2/19.png",
     "subtype": "Stage 1",
@@ -1085,7 +1104,8 @@
     "nationalPokedexNumber": 136
   },
   {
-    "id": "pl2-20",
+    "setOrder":40,
+	"id": "pl2-20",
     "name": "Gallade 4",
     "imageUrl": "https://images.pokemontcg.io/pl2/20.png",
     "subtype": "Basic",
@@ -1138,7 +1158,8 @@
     "nationalPokedexNumber": 475
   },
   {
-    "id": "pl2-21",
+    "setOrder":40,
+	"id": "pl2-21",
     "name": "Gastrodon East Sea",
     "imageUrl": "https://images.pokemontcg.io/pl2/21.png",
     "subtype": "Stage 1",
@@ -1201,7 +1222,8 @@
     "nationalPokedexNumber": 423
   },
   {
-    "id": "pl2-22",
+    "setOrder":40,
+	"id": "pl2-22",
     "name": "Gastrodon West Sea",
     "imageUrl": "https://images.pokemontcg.io/pl2/22.png",
     "subtype": "Stage 1",
@@ -1276,7 +1298,8 @@
     "nationalPokedexNumber": 423
   },
   {
-    "id": "pl2-23",
+    "setOrder":40,
+	"id": "pl2-23",
     "name": "Golem 4",
     "imageUrl": "https://images.pokemontcg.io/pl2/23.png",
     "subtype": "Basic",
@@ -1340,7 +1363,8 @@
     "nationalPokedexNumber": 76
   },
   {
-    "id": "pl2-24",
+    "setOrder":40,
+	"id": "pl2-24",
     "name": "Heracross 4",
     "imageUrl": "https://images.pokemontcg.io/pl2/24.png",
     "subtype": "Basic",
@@ -1392,7 +1416,8 @@
     "nationalPokedexNumber": 214
   },
   {
-    "id": "pl2-25",
+    "setOrder":40,
+	"id": "pl2-25",
     "name": "Hippowdon",
     "imageUrl": "https://images.pokemontcg.io/pl2/25.png",
     "subtype": "Stage 1",
@@ -1460,7 +1485,8 @@
     "nationalPokedexNumber": 450
   },
   {
-    "id": "pl2-26",
+    "setOrder":40,
+	"id": "pl2-26",
     "name": "Jolteon",
     "imageUrl": "https://images.pokemontcg.io/pl2/26.png",
     "subtype": "Stage 1",
@@ -1520,7 +1546,8 @@
     "nationalPokedexNumber": 135
   },
   {
-    "id": "pl2-27",
+    "setOrder":40,
+	"id": "pl2-27",
     "name": "Mamoswine GL",
     "imageUrl": "https://images.pokemontcg.io/pl2/27.png",
     "subtype": "Basic",
@@ -1578,7 +1605,8 @@
     "nationalPokedexNumber": 473
   },
   {
-    "id": "pl2-28",
+    "setOrder":40,
+	"id": "pl2-28",
     "name": "Mr. Mime 4",
     "imageUrl": "https://images.pokemontcg.io/pl2/28.png",
     "subtype": "Basic",
@@ -1629,7 +1657,8 @@
     "nationalPokedexNumber": 122
   },
   {
-    "id": "pl2-29",
+    "setOrder":40,
+	"id": "pl2-29",
     "name": "Nidoking",
     "imageUrl": "https://images.pokemontcg.io/pl2/29.png",
     "subtype": "Stage 2",
@@ -1697,7 +1726,8 @@
     "nationalPokedexNumber": 34
   },
   {
-    "id": "pl2-30",
+    "setOrder":40,
+	"id": "pl2-30",
     "name": "Nidoqueen",
     "imageUrl": "https://images.pokemontcg.io/pl2/30.png",
     "subtype": "Stage 2",
@@ -1763,7 +1793,8 @@
     "nationalPokedexNumber": 31
   },
   {
-    "id": "pl2-31",
+    "setOrder":40,
+	"id": "pl2-31",
     "name": "Raichu GL",
     "imageUrl": "https://images.pokemontcg.io/pl2/31.png",
     "subtype": "Basic",
@@ -1817,7 +1848,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "pl2-32",
+    "setOrder":40,
+	"id": "pl2-32",
     "name": "Rhyperior 4",
     "imageUrl": "https://images.pokemontcg.io/pl2/32.png",
     "subtype": "Basic",
@@ -1879,7 +1911,8 @@
     "nationalPokedexNumber": 464
   },
   {
-    "id": "pl2-33",
+    "setOrder":40,
+	"id": "pl2-33",
     "name": "Snorlax",
     "imageUrl": "https://images.pokemontcg.io/pl2/33.png",
     "subtype": "Basic",
@@ -1935,7 +1968,8 @@
     "nationalPokedexNumber": 143
   },
   {
-    "id": "pl2-34",
+    "setOrder":40,
+	"id": "pl2-34",
     "name": "Vaporeon",
     "imageUrl": "https://images.pokemontcg.io/pl2/34.png",
     "subtype": "Stage 1",
@@ -1993,7 +2027,8 @@
     "nationalPokedexNumber": 134
   },
   {
-    "id": "pl2-35",
+    "setOrder":40,
+	"id": "pl2-35",
     "name": "Vespiquen 4",
     "imageUrl": "https://images.pokemontcg.io/pl2/35.png",
     "subtype": "Basic",
@@ -2047,7 +2082,8 @@
     "nationalPokedexNumber": 416
   },
   {
-    "id": "pl2-36",
+    "setOrder":40,
+	"id": "pl2-36",
     "name": "Walrein",
     "imageUrl": "https://images.pokemontcg.io/pl2/36.png",
     "subtype": "Stage 2",
@@ -2100,7 +2136,8 @@
     "nationalPokedexNumber": 365
   },
   {
-    "id": "pl2-37",
+    "setOrder":40,
+	"id": "pl2-37",
     "name": "Yanmega 4",
     "imageUrl": "https://images.pokemontcg.io/pl2/37.png",
     "subtype": "Basic",
@@ -2158,7 +2195,8 @@
     "nationalPokedexNumber": 469
   },
   {
-    "id": "pl2-38",
+    "setOrder":40,
+	"id": "pl2-38",
     "name": "Alakazam 4",
     "imageUrl": "https://images.pokemontcg.io/pl2/38.png",
     "subtype": "Basic",
@@ -2210,7 +2248,8 @@
     "nationalPokedexNumber": 65
   },
   {
-    "id": "pl2-39",
+    "setOrder":40,
+	"id": "pl2-39",
     "name": "Electrode G",
     "imageUrl": "https://images.pokemontcg.io/pl2/39.png",
     "subtype": "Basic",
@@ -2267,7 +2306,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "pl2-40",
+    "setOrder":40,
+	"id": "pl2-40",
     "name": "Gengar GL",
     "imageUrl": "https://images.pokemontcg.io/pl2/40.png",
     "subtype": "Basic",
@@ -2325,7 +2365,8 @@
     "nationalPokedexNumber": 94
   },
   {
-    "id": "pl2-41",
+    "setOrder":40,
+	"id": "pl2-41",
     "name": "Glaceon",
     "imageUrl": "https://images.pokemontcg.io/pl2/41.png",
     "subtype": "Stage 1",
@@ -2384,7 +2425,8 @@
     "nationalPokedexNumber": 471
   },
   {
-    "id": "pl2-42",
+    "setOrder":40,
+	"id": "pl2-42",
     "name": "Hippowdon 4",
     "imageUrl": "https://images.pokemontcg.io/pl2/42.png",
     "subtype": "Basic",
@@ -2439,7 +2481,8 @@
     "nationalPokedexNumber": 450
   },
   {
-    "id": "pl2-43",
+    "setOrder":40,
+	"id": "pl2-43",
     "name": "Infernape 4",
     "imageUrl": "https://images.pokemontcg.io/pl2/43.png",
     "subtype": "Basic",
@@ -2492,7 +2535,8 @@
     "nationalPokedexNumber": 392
   },
   {
-    "id": "pl2-44",
+    "setOrder":40,
+	"id": "pl2-44",
     "name": "Lairon",
     "imageUrl": "https://images.pokemontcg.io/pl2/44.png",
     "subtype": "Stage 1",
@@ -2556,7 +2600,8 @@
     ]
   },
   {
-    "id": "pl2-45",
+    "setOrder":40,
+	"id": "pl2-45",
     "name": "Leafeon",
     "imageUrl": "https://images.pokemontcg.io/pl2/45.png",
     "subtype": "Stage 1",
@@ -2622,7 +2667,8 @@
     "nationalPokedexNumber": 470
   },
   {
-    "id": "pl2-46",
+    "setOrder":40,
+	"id": "pl2-46",
     "name": "Machamp GL",
     "imageUrl": "https://images.pokemontcg.io/pl2/46.png",
     "subtype": "Basic",
@@ -2679,7 +2725,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "pl2-47",
+    "setOrder":40,
+	"id": "pl2-47",
     "name": "Rapidash 4",
     "imageUrl": "https://images.pokemontcg.io/pl2/47.png",
     "subtype": "Basic",
@@ -2726,7 +2773,8 @@
     "nationalPokedexNumber": 78
   },
   {
-    "id": "pl2-48",
+    "setOrder":40,
+	"id": "pl2-48",
     "name": "Scizor 4",
     "imageUrl": "https://images.pokemontcg.io/pl2/48.png",
     "subtype": "Basic",
@@ -2778,7 +2826,8 @@
     "nationalPokedexNumber": 212
   },
   {
-    "id": "pl2-49",
+    "setOrder":40,
+	"id": "pl2-49",
     "name": "Sharpedo",
     "imageUrl": "https://images.pokemontcg.io/pl2/49.png",
     "subtype": "Stage 1",
@@ -2840,7 +2889,8 @@
     "nationalPokedexNumber": 319
   },
   {
-    "id": "pl2-50",
+    "setOrder":40,
+	"id": "pl2-50",
     "name": "Starmie",
     "imageUrl": "https://images.pokemontcg.io/pl2/50.png",
     "subtype": "Stage 1",
@@ -2893,7 +2943,8 @@
     "nationalPokedexNumber": 121
   },
   {
-    "id": "pl2-51",
+    "setOrder":40,
+	"id": "pl2-51",
     "name": "Steelix GL",
     "imageUrl": "https://images.pokemontcg.io/pl2/51.png",
     "subtype": "Basic",
@@ -2956,7 +3007,8 @@
     "nationalPokedexNumber": 208
   },
   {
-    "id": "pl2-52",
+    "setOrder":40,
+	"id": "pl2-52",
     "name": "Tropius",
     "imageUrl": "https://images.pokemontcg.io/pl2/52.png",
     "subtype": "Basic",
@@ -3026,7 +3078,8 @@
     "nationalPokedexNumber": 357
   },
   {
-    "id": "pl2-53",
+    "setOrder":40,
+	"id": "pl2-53",
     "name": "Vibrava",
     "imageUrl": "https://images.pokemontcg.io/pl2/53.png",
     "subtype": "Stage 1",
@@ -3087,7 +3140,8 @@
     ]
   },
   {
-    "id": "pl2-54",
+    "setOrder":40,
+	"id": "pl2-54",
     "name": "Whiscash 4",
     "imageUrl": "https://images.pokemontcg.io/pl2/54.png",
     "subtype": "Basic",
@@ -3145,7 +3199,8 @@
     "nationalPokedexNumber": 340
   },
   {
-    "id": "pl2-55",
+    "setOrder":40,
+	"id": "pl2-55",
     "name": "Aerodactyl GL",
     "imageUrl": "https://images.pokemontcg.io/pl2/55.png",
     "subtype": "Basic",
@@ -3199,7 +3254,8 @@
     "nationalPokedexNumber": 142
   },
   {
-    "id": "pl2-56",
+    "setOrder":40,
+	"id": "pl2-56",
     "name": "Ambipom G",
     "imageUrl": "https://images.pokemontcg.io/pl2/56.png",
     "subtype": "Basic",
@@ -3250,7 +3306,8 @@
     "nationalPokedexNumber": 424
   },
   {
-    "id": "pl2-57",
+    "setOrder":40,
+	"id": "pl2-57",
     "name": "Aron",
     "imageUrl": "https://images.pokemontcg.io/pl2/57.png",
     "subtype": "Basic",
@@ -3310,7 +3367,8 @@
     ]
   },
   {
-    "id": "pl2-58",
+    "setOrder":40,
+	"id": "pl2-58",
     "name": "Carvanha",
     "imageUrl": "https://images.pokemontcg.io/pl2/58.png",
     "subtype": "Basic",
@@ -3369,7 +3427,8 @@
     ]
   },
   {
-    "id": "pl2-59",
+    "setOrder":40,
+	"id": "pl2-59",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/pl2/59.png",
     "subtype": "Basic",
@@ -3429,7 +3488,8 @@
     ]
   },
   {
-    "id": "pl2-60",
+    "setOrder":40,
+	"id": "pl2-60",
     "name": "Flareon 4",
     "imageUrl": "https://images.pokemontcg.io/pl2/60.png",
     "subtype": "Basic",
@@ -3480,7 +3540,8 @@
     "nationalPokedexNumber": 136
   },
   {
-    "id": "pl2-61",
+    "setOrder":40,
+	"id": "pl2-61",
     "name": "Forretress G",
     "imageUrl": "https://images.pokemontcg.io/pl2/61.png",
     "subtype": "Basic",
@@ -3539,7 +3600,8 @@
     "nationalPokedexNumber": 205
   },
   {
-    "id": "pl2-62",
+    "setOrder":40,
+	"id": "pl2-62",
     "name": "Gliscor 4",
     "imageUrl": "https://images.pokemontcg.io/pl2/62.png",
     "subtype": "Basic",
@@ -3596,7 +3658,8 @@
     "nationalPokedexNumber": 472
   },
   {
-    "id": "pl2-63",
+    "setOrder":40,
+	"id": "pl2-63",
     "name": "Growlithe",
     "imageUrl": "https://images.pokemontcg.io/pl2/63.png",
     "subtype": "Basic",
@@ -3652,7 +3715,8 @@
     ]
   },
   {
-    "id": "pl2-64",
+    "setOrder":40,
+	"id": "pl2-64",
     "name": "Hippopotas",
     "imageUrl": "https://images.pokemontcg.io/pl2/64.png",
     "subtype": "Basic",
@@ -3714,7 +3778,8 @@
     ]
   },
   {
-    "id": "pl2-65",
+    "setOrder":40,
+	"id": "pl2-65",
     "name": "Houndoom 4",
     "imageUrl": "https://images.pokemontcg.io/pl2/65.png",
     "subtype": "Basic",
@@ -3773,7 +3838,8 @@
     "nationalPokedexNumber": 229
   },
   {
-    "id": "pl2-66",
+    "setOrder":40,
+	"id": "pl2-66",
     "name": "Kakuna",
     "imageUrl": "https://images.pokemontcg.io/pl2/66.png",
     "subtype": "Stage 1",
@@ -3824,7 +3890,8 @@
     ]
   },
   {
-    "id": "pl2-67",
+    "setOrder":40,
+	"id": "pl2-67",
     "name": "Kecleon",
     "imageUrl": "https://images.pokemontcg.io/pl2/67.png",
     "subtype": "Basic",
@@ -3872,7 +3939,8 @@
     "nationalPokedexNumber": 352
   },
   {
-    "id": "pl2-68",
+    "setOrder":40,
+	"id": "pl2-68",
     "name": "Koffing",
     "imageUrl": "https://images.pokemontcg.io/pl2/68.png",
     "subtype": "Basic",
@@ -3926,7 +3994,8 @@
     ]
   },
   {
-    "id": "pl2-69",
+    "setOrder":40,
+	"id": "pl2-69",
     "name": "Munchlax",
     "imageUrl": "https://images.pokemontcg.io/pl2/69.png",
     "subtype": "Basic",
@@ -3977,7 +4046,8 @@
     ]
   },
   {
-    "id": "pl2-70",
+    "setOrder":40,
+	"id": "pl2-70",
     "name": "Munchlax",
     "imageUrl": "https://images.pokemontcg.io/pl2/70.png",
     "subtype": "Basic",
@@ -4028,7 +4098,8 @@
     ]
   },
   {
-    "id": "pl2-71",
+    "setOrder":40,
+	"id": "pl2-71",
     "name": "Nidoran♀",
     "imageUrl": "https://images.pokemontcg.io/pl2/71.png",
     "subtype": "Basic",
@@ -4082,7 +4153,8 @@
     ]
   },
   {
-    "id": "pl2-72",
+    "setOrder":40,
+	"id": "pl2-72",
     "name": "Nidoran♂",
     "imageUrl": "https://images.pokemontcg.io/pl2/72.png",
     "subtype": "Basic",
@@ -4136,7 +4208,8 @@
     ]
   },
   {
-    "id": "pl2-73",
+    "setOrder":40,
+	"id": "pl2-73",
     "name": "Nidorina",
     "imageUrl": "https://images.pokemontcg.io/pl2/73.png",
     "subtype": "Stage 1",
@@ -4193,7 +4266,8 @@
     ]
   },
   {
-    "id": "pl2-74",
+    "setOrder":40,
+	"id": "pl2-74",
     "name": "Nidorino",
     "imageUrl": "https://images.pokemontcg.io/pl2/74.png",
     "subtype": "Stage 1",
@@ -4250,7 +4324,8 @@
     ]
   },
   {
-    "id": "pl2-75",
+    "setOrder":40,
+	"id": "pl2-75",
     "name": "Nuzleaf",
     "imageUrl": "https://images.pokemontcg.io/pl2/75.png",
     "subtype": "Stage 1",
@@ -4311,7 +4386,8 @@
     ]
   },
   {
-    "id": "pl2-76",
+    "setOrder":40,
+	"id": "pl2-76",
     "name": "Quagsire GL",
     "imageUrl": "https://images.pokemontcg.io/pl2/76.png",
     "subtype": "Basic",
@@ -4366,7 +4442,8 @@
     "nationalPokedexNumber": 195
   },
   {
-    "id": "pl2-77",
+    "setOrder":40,
+	"id": "pl2-77",
     "name": "Sealeo",
     "imageUrl": "https://images.pokemontcg.io/pl2/77.png",
     "subtype": "Stage 1",
@@ -4422,7 +4499,8 @@
     ]
   },
   {
-    "id": "pl2-78",
+    "setOrder":40,
+	"id": "pl2-78",
     "name": "Seedot",
     "imageUrl": "https://images.pokemontcg.io/pl2/78.png",
     "subtype": "Basic",
@@ -4481,7 +4559,8 @@
     ]
   },
   {
-    "id": "pl2-79",
+    "setOrder":40,
+	"id": "pl2-79",
     "name": "Shellos East Sea",
     "imageUrl": "https://images.pokemontcg.io/pl2/79.png",
     "subtype": "Basic",
@@ -4534,7 +4613,8 @@
     ]
   },
   {
-    "id": "pl2-80",
+    "setOrder":40,
+	"id": "pl2-80",
     "name": "Shellos West Sea",
     "imageUrl": "https://images.pokemontcg.io/pl2/80.png",
     "subtype": "Basic",
@@ -4589,7 +4669,8 @@
     ]
   },
   {
-    "id": "pl2-81",
+    "setOrder":40,
+	"id": "pl2-81",
     "name": "Snorlax",
     "imageUrl": "https://images.pokemontcg.io/pl2/81.png",
     "subtype": "Basic",
@@ -4651,7 +4732,8 @@
     "nationalPokedexNumber": 143
   },
   {
-    "id": "pl2-82",
+    "setOrder":40,
+	"id": "pl2-82",
     "name": "Spheal",
     "imageUrl": "https://images.pokemontcg.io/pl2/82.png",
     "subtype": "Basic",
@@ -4706,7 +4788,8 @@
     ]
   },
   {
-    "id": "pl2-83",
+    "setOrder":40,
+	"id": "pl2-83",
     "name": "Staryu",
     "imageUrl": "https://images.pokemontcg.io/pl2/83.png",
     "subtype": "Basic",
@@ -4759,7 +4842,8 @@
     ]
   },
   {
-    "id": "pl2-84",
+    "setOrder":40,
+	"id": "pl2-84",
     "name": "Trapinch",
     "imageUrl": "https://images.pokemontcg.io/pl2/84.png",
     "subtype": "Basic",
@@ -4814,7 +4898,8 @@
     ]
   },
   {
-    "id": "pl2-85",
+    "setOrder":40,
+	"id": "pl2-85",
     "name": "Turtwig GL",
     "imageUrl": "https://images.pokemontcg.io/pl2/85.png",
     "subtype": "Basic",
@@ -4873,7 +4958,8 @@
     ]
   },
   {
-    "id": "pl2-86",
+    "setOrder":40,
+	"id": "pl2-86",
     "name": "Weedle",
     "imageUrl": "https://images.pokemontcg.io/pl2/86.png",
     "subtype": "Basic",
@@ -4926,7 +5012,8 @@
     ]
   },
   {
-    "id": "pl2-87",
+    "setOrder":40,
+	"id": "pl2-87",
     "name": "Weezing",
     "imageUrl": "https://images.pokemontcg.io/pl2/87.png",
     "subtype": "Stage 1",
@@ -4983,7 +5070,8 @@
     "nationalPokedexNumber": 110
   },
   {
-    "id": "pl2-88",
+    "setOrder":40,
+	"id": "pl2-88",
     "name": "Aaron's Collection",
     "imageUrl": "https://images.pokemontcg.io/pl2/88.png",
     "subtype": "Supporter",
@@ -5002,7 +5090,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl2/88_hires.png"
   },
   {
-    "id": "pl2-89",
+    "setOrder":40,
+	"id": "pl2-89",
     "name": "Bebe's Search",
     "imageUrl": "https://images.pokemontcg.io/pl2/89.png",
     "subtype": "Supporter",
@@ -5021,7 +5110,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl2/89_hires.png"
   },
   {
-    "id": "pl2-90",
+    "setOrder":40,
+	"id": "pl2-90",
     "name": "Bertha's Warmth",
     "imageUrl": "https://images.pokemontcg.io/pl2/90.png",
     "subtype": "Supporter",
@@ -5040,7 +5130,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl2/90_hires.png"
   },
   {
-    "id": "pl2-91",
+    "setOrder":40,
+	"id": "pl2-91",
     "name": "Flint's Willpower",
     "imageUrl": "https://images.pokemontcg.io/pl2/91.png",
     "subtype": "Supporter",
@@ -5059,7 +5150,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl2/91_hires.png"
   },
   {
-    "id": "pl2-92",
+    "setOrder":40,
+	"id": "pl2-92",
     "name": "Lucian's Assignment",
     "imageUrl": "https://images.pokemontcg.io/pl2/92.png",
     "subtype": "Supporter",
@@ -5078,7 +5170,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl2/92_hires.png"
   },
   {
-    "id": "pl2-93",
+    "setOrder":40,
+	"id": "pl2-93",
     "name": "Pokémon Contest Hall",
     "imageUrl": "https://images.pokemontcg.io/pl2/93.png",
     "subtype": "Stadium",
@@ -5096,7 +5189,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl2/93_hires.png"
   },
   {
-    "id": "pl2-94",
+    "setOrder":40,
+	"id": "pl2-94",
     "name": "Sunyshore City Gym",
     "imageUrl": "https://images.pokemontcg.io/pl2/94.png",
     "subtype": "Stadium",
@@ -5114,7 +5208,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl2/94_hires.png"
   },
   {
-    "id": "pl2-95",
+    "setOrder":40,
+	"id": "pl2-95",
     "name": "Team Galactic's Invention G-107 Technical Machine",
     "imageUrl": "https://images.pokemontcg.io/pl2/95.png",
     "subtype": "Technical Machine",
@@ -5131,7 +5226,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl2/95_hires.png"
   },
   {
-    "id": "pl2-96",
+    "setOrder":40,
+	"id": "pl2-96",
     "name": "Team Galactic's Invention G-109 SP Radar",
     "imageUrl": "https://images.pokemontcg.io/pl2/96.png",
     "subtype": "Item",
@@ -5149,7 +5245,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl2/96_hires.png"
   },
   {
-    "id": "pl2-97",
+    "setOrder":40,
+	"id": "pl2-97",
     "name": "Underground Expedition",
     "imageUrl": "https://images.pokemontcg.io/pl2/97.png",
     "subtype": "Supporter",
@@ -5168,7 +5265,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl2/97_hires.png"
   },
   {
-    "id": "pl2-98",
+    "setOrder":40,
+	"id": "pl2-98",
     "name": "Volkner's Philosophy",
     "imageUrl": "https://images.pokemontcg.io/pl2/98.png",
     "subtype": "Supporter",
@@ -5187,7 +5285,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl2/98_hires.png"
   },
   {
-    "id": "pl2-99",
+    "setOrder":40,
+	"id": "pl2-99",
     "name": "Darkness Energy",
     "imageUrl": "https://images.pokemontcg.io/pl2/99.png",
     "subtype": "Special",
@@ -5204,7 +5303,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl2/99_hires.png"
   },
   {
-    "id": "pl2-100",
+    "setOrder":40,
+	"id": "pl2-100",
     "name": "Metal Energy",
     "imageUrl": "https://images.pokemontcg.io/pl2/100.png",
     "subtype": "Special",
@@ -5221,7 +5321,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl2/100_hires.png"
   },
   {
-    "id": "pl2-101",
+    "setOrder":40,
+	"id": "pl2-101",
     "name": "SP Energy",
     "imageUrl": "https://images.pokemontcg.io/pl2/101.png",
     "subtype": "Special",
@@ -5238,7 +5339,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl2/101_hires.png"
   },
   {
-    "id": "pl2-102",
+    "setOrder":40,
+	"id": "pl2-102",
     "name": "Upper Energy",
     "imageUrl": "https://images.pokemontcg.io/pl2/102.png",
     "subtype": "Special",
@@ -5255,7 +5357,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl2/102_hires.png"
   },
   {
-    "id": "pl2-103",
+    "setOrder":40,
+	"id": "pl2-103",
     "name": "Alakazam 4",
     "imageUrl": "https://images.pokemontcg.io/pl2/103.png",
     "subtype": "Level Up",
@@ -5307,7 +5410,8 @@
     "nationalPokedexNumber": 65
   },
   {
-    "id": "pl2-104",
+    "setOrder":40,
+	"id": "pl2-104",
     "name": "Floatzel GL",
     "imageUrl": "https://images.pokemontcg.io/pl2/104.png",
     "subtype": "Level Up",
@@ -5354,7 +5458,8 @@
     "nationalPokedexNumber": 419
   },
   {
-    "id": "pl2-105",
+    "setOrder":40,
+	"id": "pl2-105",
     "name": "Flygon",
     "imageUrl": "https://images.pokemontcg.io/pl2/105.png",
     "subtype": "Level Up",
@@ -5408,7 +5513,8 @@
     "nationalPokedexNumber": 330
   },
   {
-    "id": "pl2-106",
+    "setOrder":40,
+	"id": "pl2-106",
     "name": "Gallade 4",
     "imageUrl": "https://images.pokemontcg.io/pl2/106.png",
     "subtype": "Level Up",
@@ -5459,7 +5565,8 @@
     "nationalPokedexNumber": 475
   },
   {
-    "id": "pl2-107",
+    "setOrder":40,
+	"id": "pl2-107",
     "name": "Hippowdon",
     "imageUrl": "https://images.pokemontcg.io/pl2/107.png",
     "subtype": "Level Up",
@@ -5520,7 +5627,8 @@
     "nationalPokedexNumber": 450
   },
   {
-    "id": "pl2-108",
+    "setOrder":40,
+	"id": "pl2-108",
     "name": "Infernape 4",
     "imageUrl": "https://images.pokemontcg.io/pl2/108.png",
     "subtype": "Level Up",
@@ -5568,7 +5676,8 @@
     "nationalPokedexNumber": 392
   },
   {
-    "id": "pl2-109",
+    "setOrder":40,
+	"id": "pl2-109",
     "name": "Luxray GL",
     "imageUrl": "https://images.pokemontcg.io/pl2/109.png",
     "subtype": "Level Up",
@@ -5621,7 +5730,8 @@
     "nationalPokedexNumber": 405
   },
   {
-    "id": "pl2-110",
+    "setOrder":40,
+	"id": "pl2-110",
     "name": "Mismagius GL",
     "imageUrl": "https://images.pokemontcg.io/pl2/110.png",
     "subtype": "Level Up",
@@ -5678,7 +5788,8 @@
     "nationalPokedexNumber": 429
   },
   {
-    "id": "pl2-111",
+    "setOrder":40,
+	"id": "pl2-111",
     "name": "Snorlax",
     "imageUrl": "https://images.pokemontcg.io/pl2/111.png",
     "subtype": "Level Up",
@@ -5733,7 +5844,8 @@
     "nationalPokedexNumber": 143
   },
   {
-    "id": "pl2-112",
+    "setOrder":40,
+	"id": "pl2-112",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/pl2/112.png",
     "subtype": "Basic",
@@ -5787,7 +5899,8 @@
     ]
   },
   {
-    "id": "pl2-113",
+    "setOrder":40,
+	"id": "pl2-113",
     "name": "Flying Pikachu",
     "imageUrl": "https://images.pokemontcg.io/pl2/113.png",
     "subtype": "Basic",
@@ -5842,7 +5955,8 @@
     ]
   },
   {
-    "id": "pl2-114",
+    "setOrder":40,
+	"id": "pl2-114",
     "name": "Surfing Pikachu",
     "imageUrl": "https://images.pokemontcg.io/pl2/114.png",
     "subtype": "Basic",
@@ -5887,7 +6001,8 @@
     ]
   },
   {
-    "id": "pl2-RT1",
+    "setOrder":40,
+	"id": "pl2-RT1",
     "name": "Fan Rotom",
     "imageUrl": "https://images.pokemontcg.io/pl2/RT1.png",
     "subtype": "Basic",
@@ -5948,7 +6063,8 @@
     "nationalPokedexNumber": 479
   },
   {
-    "id": "pl2-RT2",
+    "setOrder":40,
+	"id": "pl2-RT2",
     "name": "Frost Rotom",
     "imageUrl": "https://images.pokemontcg.io/pl2/RT2.png",
     "subtype": "Basic",
@@ -6014,7 +6130,8 @@
     "nationalPokedexNumber": 479
   },
   {
-    "id": "pl2-RT3",
+    "setOrder":40,
+	"id": "pl2-RT3",
     "name": "Heat Rotom",
     "imageUrl": "https://images.pokemontcg.io/pl2/RT3.png",
     "subtype": "Basic",
@@ -6077,7 +6194,8 @@
     "nationalPokedexNumber": 479
   },
   {
-    "id": "pl2-RT4",
+    "setOrder":40,
+	"id": "pl2-RT4",
     "name": "Mow Rotom",
     "imageUrl": "https://images.pokemontcg.io/pl2/RT4.png",
     "subtype": "Basic",
@@ -6142,7 +6260,8 @@
     "nationalPokedexNumber": 479
   },
   {
-    "id": "pl2-RT5",
+    "setOrder":40,
+	"id": "pl2-RT5",
     "name": "Wash Rotom",
     "imageUrl": "https://images.pokemontcg.io/pl2/RT5.png",
     "subtype": "Basic",
@@ -6205,7 +6324,8 @@
     "nationalPokedexNumber": 479
   },
   {
-    "id": "pl2-RT6",
+    "setOrder":40,
+	"id": "pl2-RT6",
     "name": "Charon's Choice",
     "imageUrl": "https://images.pokemontcg.io/pl2/RT6.png",
     "subtype": "Supporter",

--- a/json/cards/Roaring Skies.json
+++ b/json/cards/Roaring Skies.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "xy6-1",
+    "setOrder":64,
+	"id": "xy6-1",
     "name": "Exeggcute",
     "imageUrl": "https://images.pokemontcg.io/xy6/1.png",
     "subtype": "Basic",
@@ -52,7 +53,8 @@
     ]
   },
   {
-    "id": "xy6-2",
+    "setOrder":64,
+	"id": "xy6-2",
     "name": "Exeggutor",
     "imageUrl": "https://images.pokemontcg.io/xy6/2.png",
     "subtype": "Stage 1",
@@ -106,7 +108,8 @@
     "nationalPokedexNumber": 103
   },
   {
-    "id": "xy6-3",
+    "setOrder":64,
+	"id": "xy6-3",
     "name": "Wurmple",
     "imageUrl": "https://images.pokemontcg.io/xy6/3.png",
     "subtype": "Basic",
@@ -160,7 +163,8 @@
     ]
   },
   {
-    "id": "xy6-4",
+    "setOrder":64,
+	"id": "xy6-4",
     "name": "Silcoon",
     "imageUrl": "https://images.pokemontcg.io/xy6/4.png",
     "subtype": "Stage 1",
@@ -206,7 +210,8 @@
     ]
   },
   {
-    "id": "xy6-5",
+    "setOrder":64,
+	"id": "xy6-5",
     "name": "Beautifly",
     "imageUrl": "https://images.pokemontcg.io/xy6/5.png",
     "subtype": "Stage 2",
@@ -251,7 +256,8 @@
     "nationalPokedexNumber": 267
   },
   {
-    "id": "xy6-6",
+    "setOrder":64,
+	"id": "xy6-6",
     "name": "Cascoon",
     "imageUrl": "https://images.pokemontcg.io/xy6/6.png",
     "subtype": "Stage 1",
@@ -307,7 +313,8 @@
     ]
   },
   {
-    "id": "xy6-7",
+    "setOrder":64,
+	"id": "xy6-7",
     "name": "Dustox",
     "imageUrl": "https://images.pokemontcg.io/xy6/7.png",
     "subtype": "Stage 2",
@@ -362,7 +369,8 @@
     "nationalPokedexNumber": 269
   },
   {
-    "id": "xy6-8",
+    "setOrder":64,
+	"id": "xy6-8",
     "name": "Dustox",
     "imageUrl": "https://images.pokemontcg.io/xy6/8.png",
     "subtype": "Stage 2",
@@ -418,7 +426,8 @@
     "nationalPokedexNumber": 269
   },
   {
-    "id": "xy6-9",
+    "setOrder":64,
+	"id": "xy6-9",
     "name": "Nincada",
     "imageUrl": "https://images.pokemontcg.io/xy6/9.png",
     "subtype": "Basic",
@@ -461,7 +470,8 @@
     ]
   },
   {
-    "id": "xy6-10",
+    "setOrder":64,
+	"id": "xy6-10",
     "name": "Ninjask",
     "imageUrl": "https://images.pokemontcg.io/xy6/10.png",
     "subtype": "Stage 1",
@@ -508,7 +518,8 @@
     ]
   },
   {
-    "id": "xy6-11",
+    "setOrder":64,
+	"id": "xy6-11",
     "name": "Shedinja",
     "imageUrl": "https://images.pokemontcg.io/xy6/11.png",
     "subtype": "Stage 1",
@@ -552,7 +563,8 @@
     "nationalPokedexNumber": 292
   },
   {
-    "id": "xy6-12",
+    "setOrder":64,
+	"id": "xy6-12",
     "name": "Tropius",
     "imageUrl": "https://images.pokemontcg.io/xy6/12.png",
     "subtype": "Basic",
@@ -607,7 +619,8 @@
     "nationalPokedexNumber": 357
   },
   {
-    "id": "xy6-13",
+    "setOrder":64,
+	"id": "xy6-13",
     "name": "Victini",
     "imageUrl": "https://images.pokemontcg.io/xy6/13.png",
     "subtype": "Basic",
@@ -657,7 +670,8 @@
     "nationalPokedexNumber": 494
   },
   {
-    "id": "xy6-14",
+    "setOrder":64,
+	"id": "xy6-14",
     "name": "Fletchinder",
     "imageUrl": "https://images.pokemontcg.io/xy6/14.png",
     "subtype": "Stage 1",
@@ -698,7 +712,8 @@
     ]
   },
   {
-    "id": "xy6-15",
+    "setOrder":64,
+	"id": "xy6-15",
     "name": "Talonflame",
     "imageUrl": "https://images.pokemontcg.io/xy6/15.png",
     "subtype": "Stage 2",
@@ -746,7 +761,8 @@
     "nationalPokedexNumber": 663
   },
   {
-    "id": "xy6-16",
+    "setOrder":64,
+	"id": "xy6-16",
     "name": "Articuno",
     "imageUrl": "https://images.pokemontcg.io/xy6/16.png",
     "subtype": "Basic",
@@ -804,7 +820,8 @@
     "nationalPokedexNumber": 144
   },
   {
-    "id": "xy6-17",
+    "setOrder":64,
+	"id": "xy6-17",
     "name": "Articuno",
     "imageUrl": "https://images.pokemontcg.io/xy6/17.png",
     "subtype": "Basic",
@@ -866,7 +883,8 @@
     "nationalPokedexNumber": 144
   },
   {
-    "id": "xy6-18",
+    "setOrder":64,
+	"id": "xy6-18",
     "name": "Wingull",
     "imageUrl": "https://images.pokemontcg.io/xy6/18.png",
     "subtype": "Basic",
@@ -915,7 +933,8 @@
     ]
   },
   {
-    "id": "xy6-19",
+    "setOrder":64,
+	"id": "xy6-19",
     "name": "Pelipper",
     "imageUrl": "https://images.pokemontcg.io/xy6/19.png",
     "subtype": "Stage 1",
@@ -976,7 +995,8 @@
     "nationalPokedexNumber": 279
   },
   {
-    "id": "xy6-20",
+    "setOrder":64,
+	"id": "xy6-20",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/xy6/20.png",
     "subtype": "Basic",
@@ -1035,7 +1055,8 @@
     ]
   },
   {
-    "id": "xy6-21",
+    "setOrder":64,
+	"id": "xy6-21",
     "name": "Voltorb",
     "imageUrl": "https://images.pokemontcg.io/xy6/21.png",
     "subtype": "Basic",
@@ -1094,7 +1115,8 @@
     ]
   },
   {
-    "id": "xy6-22",
+    "setOrder":64,
+	"id": "xy6-22",
     "name": "Electrode",
     "imageUrl": "https://images.pokemontcg.io/xy6/22.png",
     "subtype": "Stage 1",
@@ -1152,7 +1174,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "xy6-23",
+    "setOrder":64,
+	"id": "xy6-23",
     "name": "Zapdos",
     "imageUrl": "https://images.pokemontcg.io/xy6/23.png",
     "subtype": "Basic",
@@ -1210,7 +1233,8 @@
     "nationalPokedexNumber": 145
   },
   {
-    "id": "xy6-24",
+    "setOrder":64,
+	"id": "xy6-24",
     "name": "Electrike",
     "imageUrl": "https://images.pokemontcg.io/xy6/24.png",
     "subtype": "Basic",
@@ -1259,7 +1283,8 @@
     ]
   },
   {
-    "id": "xy6-25",
+    "setOrder":64,
+	"id": "xy6-25",
     "name": "Manectric",
     "imageUrl": "https://images.pokemontcg.io/xy6/25.png",
     "subtype": "Stage 1",
@@ -1316,7 +1341,8 @@
     "nationalPokedexNumber": 310
   },
   {
-    "id": "xy6-26",
+    "setOrder":64,
+	"id": "xy6-26",
     "name": "Thundurus-EX",
     "imageUrl": "https://images.pokemontcg.io/xy6/26.png",
     "subtype": "EX",
@@ -1378,7 +1404,8 @@
     "nationalPokedexNumber": 642
   },
   {
-    "id": "xy6-27",
+    "setOrder":64,
+	"id": "xy6-27",
     "name": "Natu",
     "imageUrl": "https://images.pokemontcg.io/xy6/27.png",
     "subtype": "Basic",
@@ -1421,7 +1448,8 @@
     ]
   },
   {
-    "id": "xy6-28",
+    "setOrder":64,
+	"id": "xy6-28",
     "name": "Natu",
     "imageUrl": "https://images.pokemontcg.io/xy6/28.png",
     "subtype": "Basic",
@@ -1469,7 +1497,8 @@
     ]
   },
   {
-    "id": "xy6-29",
+    "setOrder":64,
+	"id": "xy6-29",
     "name": "Xatu",
     "imageUrl": "https://images.pokemontcg.io/xy6/29.png",
     "subtype": "Stage 1",
@@ -1520,7 +1549,8 @@
     "nationalPokedexNumber": 178
   },
   {
-    "id": "xy6-30",
+    "setOrder":64,
+	"id": "xy6-30",
     "name": "Shuppet",
     "imageUrl": "https://images.pokemontcg.io/xy6/30.png",
     "subtype": "Basic",
@@ -1569,7 +1599,8 @@
     ]
   },
   {
-    "id": "xy6-31",
+    "setOrder":64,
+	"id": "xy6-31",
     "name": "Banette",
     "imageUrl": "https://images.pokemontcg.io/xy6/31.png",
     "subtype": "Stage 1",
@@ -1623,7 +1654,8 @@
     "nationalPokedexNumber": 354
   },
   {
-    "id": "xy6-32",
+    "setOrder":64,
+	"id": "xy6-32",
     "name": "Banette",
     "imageUrl": "https://images.pokemontcg.io/xy6/32.png",
     "subtype": "Stage 1",
@@ -1684,7 +1716,8 @@
     "nationalPokedexNumber": 354
   },
   {
-    "id": "xy6-33",
+    "setOrder":64,
+	"id": "xy6-33",
     "name": "Deoxys",
     "imageUrl": "https://images.pokemontcg.io/xy6/33.png",
     "subtype": "Basic",
@@ -1734,7 +1767,8 @@
     "nationalPokedexNumber": 386
   },
   {
-    "id": "xy6-34",
+    "setOrder":64,
+	"id": "xy6-34",
     "name": "Gallade-EX",
     "imageUrl": "https://images.pokemontcg.io/xy6/34.png",
     "subtype": "EX",
@@ -1791,7 +1825,8 @@
     "evolvesTo": "M Gallade-EX"
   },
   {
-    "id": "xy6-35",
+    "setOrder":64,
+	"id": "xy6-35",
     "name": "M Gallade-EX",
     "imageUrl": "https://images.pokemontcg.io/xy6/35.png",
     "subtype": "MEGA",
@@ -1839,7 +1874,8 @@
     "nationalPokedexNumber": 475
   },
   {
-    "id": "xy6-36",
+    "setOrder":64,
+	"id": "xy6-36",
     "name": "Gligar",
     "imageUrl": "https://images.pokemontcg.io/xy6/36.png",
     "subtype": "Basic",
@@ -1882,7 +1918,8 @@
     ]
   },
   {
-    "id": "xy6-37",
+    "setOrder":64,
+	"id": "xy6-37",
     "name": "Gliscor",
     "imageUrl": "https://images.pokemontcg.io/xy6/37.png",
     "subtype": "Stage 1",
@@ -1933,7 +1970,8 @@
     "nationalPokedexNumber": 472
   },
   {
-    "id": "xy6-38",
+    "setOrder":64,
+	"id": "xy6-38",
     "name": "Binacle",
     "imageUrl": "https://images.pokemontcg.io/xy6/38.png",
     "subtype": "Basic",
@@ -1988,7 +2026,8 @@
     ]
   },
   {
-    "id": "xy6-39",
+    "setOrder":64,
+	"id": "xy6-39",
     "name": "Hawlucha",
     "imageUrl": "https://images.pokemontcg.io/xy6/39.png",
     "subtype": "Basic",
@@ -2045,7 +2084,8 @@
     "nationalPokedexNumber": 701
   },
   {
-    "id": "xy6-40",
+    "setOrder":64,
+	"id": "xy6-40",
     "name": "Absol",
     "imageUrl": "https://images.pokemontcg.io/xy6/40.png",
     "subtype": "Basic",
@@ -2097,7 +2137,8 @@
     "nationalPokedexNumber": 359
   },
   {
-    "id": "xy6-41",
+    "setOrder":64,
+	"id": "xy6-41",
     "name": "Inkay",
     "imageUrl": "https://images.pokemontcg.io/xy6/41.png",
     "subtype": "Basic",
@@ -2156,7 +2197,8 @@
     ]
   },
   {
-    "id": "xy6-42",
+    "setOrder":64,
+	"id": "xy6-42",
     "name": "Jirachi",
     "imageUrl": "https://images.pokemontcg.io/xy6/42.png",
     "subtype": "Basic",
@@ -2212,7 +2254,8 @@
     "nationalPokedexNumber": 385
   },
   {
-    "id": "xy6-43",
+    "setOrder":64,
+	"id": "xy6-43",
     "name": "Togepi",
     "imageUrl": "https://images.pokemontcg.io/xy6/43.png",
     "subtype": "Basic",
@@ -2261,7 +2304,8 @@
     ]
   },
   {
-    "id": "xy6-44",
+    "setOrder":64,
+	"id": "xy6-44",
     "name": "Togetic",
     "imageUrl": "https://images.pokemontcg.io/xy6/44.png",
     "subtype": "Stage 1",
@@ -2322,7 +2366,8 @@
     ]
   },
   {
-    "id": "xy6-45",
+    "setOrder":64,
+	"id": "xy6-45",
     "name": "Togekiss",
     "imageUrl": "https://images.pokemontcg.io/xy6/45.png",
     "subtype": "Stage 2",
@@ -2381,7 +2426,8 @@
     "nationalPokedexNumber": 468
   },
   {
-    "id": "xy6-46",
+    "setOrder":64,
+	"id": "xy6-46",
     "name": "Togekiss",
     "imageUrl": "https://images.pokemontcg.io/xy6/46.png",
     "subtype": "Stage 2",
@@ -2439,7 +2485,8 @@
     "nationalPokedexNumber": 468
   },
   {
-    "id": "xy6-47",
+    "setOrder":64,
+	"id": "xy6-47",
     "name": "Carbink",
     "imageUrl": "https://images.pokemontcg.io/xy6/47.png",
     "subtype": "Basic",
@@ -2493,7 +2540,8 @@
     "nationalPokedexNumber": 703
   },
   {
-    "id": "xy6-48",
+    "setOrder":64,
+	"id": "xy6-48",
     "name": "Klefki",
     "imageUrl": "https://images.pokemontcg.io/xy6/48.png",
     "subtype": "Basic",
@@ -2549,7 +2597,8 @@
     "nationalPokedexNumber": 707
   },
   {
-    "id": "xy6-49",
+    "setOrder":64,
+	"id": "xy6-49",
     "name": "Dratini",
     "imageUrl": "https://images.pokemontcg.io/xy6/49.png",
     "subtype": "Basic",
@@ -2602,7 +2651,8 @@
     ]
   },
   {
-    "id": "xy6-50",
+    "setOrder":64,
+	"id": "xy6-50",
     "name": "Dragonair",
     "imageUrl": "https://images.pokemontcg.io/xy6/50.png",
     "subtype": "Stage 1",
@@ -2658,7 +2708,8 @@
     ]
   },
   {
-    "id": "xy6-51",
+    "setOrder":64,
+	"id": "xy6-51",
     "name": "Dragonite",
     "imageUrl": "https://images.pokemontcg.io/xy6/51.png",
     "subtype": "Stage 2",
@@ -2708,7 +2759,8 @@
     "nationalPokedexNumber": 149
   },
   {
-    "id": "xy6-52",
+    "setOrder":64,
+	"id": "xy6-52",
     "name": "Dragonite",
     "imageUrl": "https://images.pokemontcg.io/xy6/52.png",
     "subtype": "Stage 2",
@@ -2769,7 +2821,8 @@
     "nationalPokedexNumber": 149
   },
   {
-    "id": "xy6-53",
+    "setOrder":64,
+	"id": "xy6-53",
     "name": "Altaria",
     "imageUrl": "https://images.pokemontcg.io/xy6/53.png",
     "subtype": "Stage 1",
@@ -2820,7 +2873,8 @@
     "nationalPokedexNumber": 334
   },
   {
-    "id": "xy6-54",
+    "setOrder":64,
+	"id": "xy6-54",
     "name": "Bagon",
     "imageUrl": "https://images.pokemontcg.io/xy6/54.png",
     "subtype": "Basic",
@@ -2864,7 +2918,8 @@
     ]
   },
   {
-    "id": "xy6-55",
+    "setOrder":64,
+	"id": "xy6-55",
     "name": "Bagon",
     "imageUrl": "https://images.pokemontcg.io/xy6/55.png",
     "subtype": "Basic",
@@ -2917,7 +2972,8 @@
     ]
   },
   {
-    "id": "xy6-56",
+    "setOrder":64,
+	"id": "xy6-56",
     "name": "Shelgon",
     "imageUrl": "https://images.pokemontcg.io/xy6/56.png",
     "subtype": "Stage 1",
@@ -2970,7 +3026,8 @@
     ]
   },
   {
-    "id": "xy6-57",
+    "setOrder":64,
+	"id": "xy6-57",
     "name": "Salamence",
     "imageUrl": "https://images.pokemontcg.io/xy6/57.png",
     "subtype": "Stage 2",
@@ -3037,7 +3094,8 @@
     "nationalPokedexNumber": 373
   },
   {
-    "id": "xy6-58",
+    "setOrder":64,
+	"id": "xy6-58",
     "name": "Latios-EX",
     "imageUrl": "https://images.pokemontcg.io/xy6/58.png",
     "subtype": "EX",
@@ -3094,7 +3152,8 @@
     "evolvesTo": "M Latios-EX"
   },
   {
-    "id": "xy6-59",
+    "setOrder":64,
+	"id": "xy6-59",
     "name": "M Latios-EX",
     "imageUrl": "https://images.pokemontcg.io/xy6/59.png",
     "subtype": "MEGA",
@@ -3138,7 +3197,8 @@
     "nationalPokedexNumber": 381
   },
   {
-    "id": "xy6-60",
+    "setOrder":64,
+	"id": "xy6-60",
     "name": "Rayquaza-EX",
     "imageUrl": "https://images.pokemontcg.io/xy6/60.png",
     "subtype": "EX",
@@ -3196,7 +3256,8 @@
     "evolvesTo": "M Rayquaza-EX"
   },
   {
-    "id": "xy6-61",
+    "setOrder":64,
+	"id": "xy6-61",
     "name": "M Rayquaza-EX",
     "imageUrl": "https://images.pokemontcg.io/xy6/61.png",
     "subtype": "MEGA",
@@ -3250,7 +3311,8 @@
     "nationalPokedexNumber": 384
   },
   {
-    "id": "xy6-62",
+    "setOrder":64,
+	"id": "xy6-62",
     "name": "Hydreigon-EX",
     "imageUrl": "https://images.pokemontcg.io/xy6/62.png",
     "subtype": "EX",
@@ -3302,7 +3364,8 @@
     "nationalPokedexNumber": 635
   },
   {
-    "id": "xy6-63",
+    "setOrder":64,
+	"id": "xy6-63",
     "name": "Reshiram",
     "imageUrl": "https://images.pokemontcg.io/xy6/63.png",
     "subtype": "Basic",
@@ -3351,7 +3414,8 @@
     "nationalPokedexNumber": 643
   },
   {
-    "id": "xy6-64",
+    "setOrder":64,
+	"id": "xy6-64",
     "name": "Zekrom",
     "imageUrl": "https://images.pokemontcg.io/xy6/64.png",
     "subtype": "Basic",
@@ -3404,7 +3468,8 @@
     "nationalPokedexNumber": 644
   },
   {
-    "id": "xy6-65",
+    "setOrder":64,
+	"id": "xy6-65",
     "name": "Spearow",
     "imageUrl": "https://images.pokemontcg.io/xy6/65.png",
     "subtype": "Basic",
@@ -3454,7 +3519,8 @@
     ]
   },
   {
-    "id": "xy6-66",
+    "setOrder":64,
+	"id": "xy6-66",
     "name": "Fearow",
     "imageUrl": "https://images.pokemontcg.io/xy6/66.png",
     "subtype": "Stage 1",
@@ -3513,7 +3579,8 @@
     "nationalPokedexNumber": 22
   },
   {
-    "id": "xy6-67",
+    "setOrder":64,
+	"id": "xy6-67",
     "name": "Meowth",
     "imageUrl": "https://images.pokemontcg.io/xy6/67.png",
     "subtype": "Basic",
@@ -3567,7 +3634,8 @@
     ]
   },
   {
-    "id": "xy6-68",
+    "setOrder":64,
+	"id": "xy6-68",
     "name": "Dunsparce",
     "imageUrl": "https://images.pokemontcg.io/xy6/68.png",
     "subtype": "Basic",
@@ -3613,7 +3681,8 @@
     "nationalPokedexNumber": 206
   },
   {
-    "id": "xy6-69",
+    "setOrder":64,
+	"id": "xy6-69",
     "name": "Skarmory",
     "imageUrl": "https://images.pokemontcg.io/xy6/69.png",
     "subtype": "Basic",
@@ -3669,7 +3738,8 @@
     "nationalPokedexNumber": 227
   },
   {
-    "id": "xy6-70",
+    "setOrder":64,
+	"id": "xy6-70",
     "name": "Taillow",
     "imageUrl": "https://images.pokemontcg.io/xy6/70.png",
     "subtype": "Basic",
@@ -3718,7 +3788,8 @@
     ]
   },
   {
-    "id": "xy6-71",
+    "setOrder":64,
+	"id": "xy6-71",
     "name": "Swellow",
     "imageUrl": "https://images.pokemontcg.io/xy6/71.png",
     "subtype": "Stage 1",
@@ -3776,7 +3847,8 @@
     "nationalPokedexNumber": 277
   },
   {
-    "id": "xy6-72",
+    "setOrder":64,
+	"id": "xy6-72",
     "name": "Swellow",
     "imageUrl": "https://images.pokemontcg.io/xy6/72.png",
     "subtype": "Stage 1",
@@ -3839,7 +3911,8 @@
     "nationalPokedexNumber": 277
   },
   {
-    "id": "xy6-73",
+    "setOrder":64,
+	"id": "xy6-73",
     "name": "Swablu",
     "imageUrl": "https://images.pokemontcg.io/xy6/73.png",
     "subtype": "Basic",
@@ -3888,7 +3961,8 @@
     ]
   },
   {
-    "id": "xy6-74",
+    "setOrder":64,
+	"id": "xy6-74",
     "name": "Altaria",
     "imageUrl": "https://images.pokemontcg.io/xy6/74.png",
     "subtype": "Stage 1",
@@ -3945,7 +4019,8 @@
     "nationalPokedexNumber": 334
   },
   {
-    "id": "xy6-75",
+    "setOrder":64,
+	"id": "xy6-75",
     "name": "Rayquaza-EX",
     "imageUrl": "https://images.pokemontcg.io/xy6/75.png",
     "subtype": "EX",
@@ -4007,7 +4082,8 @@
     "evolvesTo": "M Rayquaza-EX"
   },
   {
-    "id": "xy6-76",
+    "setOrder":64,
+	"id": "xy6-76",
     "name": "M Rayquaza-EX",
     "imageUrl": "https://images.pokemontcg.io/xy6/76.png",
     "subtype": "MEGA",
@@ -4064,7 +4140,8 @@
     "nationalPokedexNumber": 384
   },
   {
-    "id": "xy6-77",
+    "setOrder":64,
+	"id": "xy6-77",
     "name": "Shaymin-EX",
     "imageUrl": "https://images.pokemontcg.io/xy6/77.png",
     "subtype": "EX",
@@ -4119,7 +4196,8 @@
     "nationalPokedexNumber": 492
   },
   {
-    "id": "xy6-77a",
+    "setOrder":64,
+	"id": "xy6-77a",
     "name": "Shaymin-EX",
     "imageUrl": "https://images.pokemontcg.io/xy6/77a.png",
     "subtype": "EX",
@@ -4174,7 +4252,8 @@
     "nationalPokedexNumber": 492
   },
   {
-    "id": "xy6-78",
+    "setOrder":64,
+	"id": "xy6-78",
     "name": "Pidove",
     "imageUrl": "https://images.pokemontcg.io/xy6/78.png",
     "subtype": "Basic",
@@ -4233,7 +4312,8 @@
     ]
   },
   {
-    "id": "xy6-79",
+    "setOrder":64,
+	"id": "xy6-79",
     "name": "Tranquill",
     "imageUrl": "https://images.pokemontcg.io/xy6/79.png",
     "subtype": "Stage 1",
@@ -4284,7 +4364,8 @@
     ]
   },
   {
-    "id": "xy6-80",
+    "setOrder":64,
+	"id": "xy6-80",
     "name": "Unfezant",
     "imageUrl": "https://images.pokemontcg.io/xy6/80.png",
     "subtype": "Stage 2",
@@ -4342,7 +4423,8 @@
     "nationalPokedexNumber": 521
   },
   {
-    "id": "xy6-81",
+    "setOrder":64,
+	"id": "xy6-81",
     "name": "Unfezant",
     "imageUrl": "https://images.pokemontcg.io/xy6/81.png",
     "subtype": "Stage 2",
@@ -4402,7 +4484,8 @@
     "nationalPokedexNumber": 521
   },
   {
-    "id": "xy6-82",
+    "setOrder":64,
+	"id": "xy6-82",
     "name": "Fletchling",
     "imageUrl": "https://images.pokemontcg.io/xy6/82.png",
     "subtype": "Basic",
@@ -4451,7 +4534,8 @@
     ]
   },
   {
-    "id": "xy6-83",
+    "setOrder":64,
+	"id": "xy6-83",
     "name": "Gallade Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xy6/83.png",
     "subtype": "Pokémon Tool",
@@ -4468,7 +4552,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy6/83_hires.png"
   },
   {
-    "id": "xy6-84",
+    "setOrder":64,
+	"id": "xy6-84",
     "name": "Healing Scarf",
     "imageUrl": "https://images.pokemontcg.io/xy6/84.png",
     "subtype": "Pokémon Tool",
@@ -4485,7 +4570,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy6/84_hires.png"
   },
   {
-    "id": "xy6-85",
+    "setOrder":64,
+	"id": "xy6-85",
     "name": "Latios Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xy6/85.png",
     "subtype": "Pokémon Tool",
@@ -4502,7 +4588,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy6/85_hires.png"
   },
   {
-    "id": "xy6-86",
+    "setOrder":64,
+	"id": "xy6-86",
     "name": "Mega Turbo",
     "imageUrl": "https://images.pokemontcg.io/xy6/86.png",
     "subtype": "Item",
@@ -4519,7 +4606,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy6/86_hires.png"
   },
   {
-    "id": "xy6-87",
+    "setOrder":64,
+	"id": "xy6-87",
     "name": "Rayquaza Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xy6/87.png",
     "subtype": "Pokémon Tool",
@@ -4536,7 +4624,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy6/87_hires.png"
   },
   {
-    "id": "xy6-88",
+    "setOrder":64,
+	"id": "xy6-88",
     "name": "Revive",
     "imageUrl": "https://images.pokemontcg.io/xy6/88.png",
     "subtype": "Item",
@@ -4553,7 +4642,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy6/88_hires.png"
   },
   {
-    "id": "xy6-89",
+    "setOrder":64,
+	"id": "xy6-89",
     "name": "Sky Field",
     "imageUrl": "https://images.pokemontcg.io/xy6/89.png",
     "subtype": "Stadium",
@@ -4570,7 +4660,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy6/89_hires.png"
   },
   {
-    "id": "xy6-90",
+    "setOrder":64,
+	"id": "xy6-90",
     "name": "Steven",
     "imageUrl": "https://images.pokemontcg.io/xy6/90.png",
     "subtype": "Supporter",
@@ -4587,7 +4678,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy6/90_hires.png"
   },
   {
-    "id": "xy6-91",
+    "setOrder":64,
+	"id": "xy6-91",
     "name": "Switch",
     "imageUrl": "https://images.pokemontcg.io/xy6/91.png",
     "subtype": "Item",
@@ -4604,7 +4696,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy6/91_hires.png"
   },
   {
-    "id": "xy6-92",
+    "setOrder":64,
+	"id": "xy6-92",
     "name": "Trainers' Mail",
     "imageUrl": "https://images.pokemontcg.io/xy6/92.png",
     "subtype": "Item",
@@ -4621,7 +4714,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy6/92_hires.png"
   },
   {
-    "id": "xy6-92a",
+    "setOrder":64,
+	"id": "xy6-92a",
     "name": "Trainers' Mail",
     "imageUrl": "https://images.pokemontcg.io/xy6/92a.png",
     "subtype": "Item",
@@ -4638,7 +4732,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy6/92a_hires.png"
   },
   {
-    "id": "xy6-93",
+    "setOrder":64,
+	"id": "xy6-93",
     "name": "Ultra Ball",
     "imageUrl": "https://images.pokemontcg.io/xy6/93.png",
     "subtype": "Item",
@@ -4655,7 +4750,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy6/93_hires.png"
   },
   {
-    "id": "xy6-94",
+    "setOrder":64,
+	"id": "xy6-94",
     "name": "Wally",
     "imageUrl": "https://images.pokemontcg.io/xy6/94.png",
     "subtype": "Supporter",
@@ -4672,7 +4768,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy6/94_hires.png"
   },
   {
-    "id": "xy6-95",
+    "setOrder":64,
+	"id": "xy6-95",
     "name": "Wide Lens",
     "imageUrl": "https://images.pokemontcg.io/xy6/95.png",
     "subtype": "Pokémon Tool",
@@ -4689,7 +4786,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy6/95_hires.png"
   },
   {
-    "id": "xy6-96",
+    "setOrder":64,
+	"id": "xy6-96",
     "name": "Winona",
     "imageUrl": "https://images.pokemontcg.io/xy6/96.png",
     "subtype": "Supporter",
@@ -4706,7 +4804,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy6/96_hires.png"
   },
   {
-    "id": "xy6-97",
+    "setOrder":64,
+	"id": "xy6-97",
     "name": "Double Dragon Energy",
     "imageUrl": "https://images.pokemontcg.io/xy6/97.png",
     "subtype": "Special",
@@ -4723,7 +4822,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy6/97_hires.png"
   },
   {
-    "id": "xy6-98",
+    "setOrder":64,
+	"id": "xy6-98",
     "name": "Thundurus-EX",
     "imageUrl": "https://images.pokemontcg.io/xy6/98.png",
     "subtype": "EX",
@@ -4785,7 +4885,8 @@
     "nationalPokedexNumber": 642
   },
   {
-    "id": "xy6-99",
+    "setOrder":64,
+	"id": "xy6-99",
     "name": "Gallade-EX",
     "imageUrl": "https://images.pokemontcg.io/xy6/99.png",
     "subtype": "EX",
@@ -4842,7 +4943,8 @@
     "evolvesTo": "M Gallade-EX"
   },
   {
-    "id": "xy6-100",
+    "setOrder":64,
+	"id": "xy6-100",
     "name": "M Gallade-EX",
     "imageUrl": "https://images.pokemontcg.io/xy6/100.png",
     "subtype": "MEGA",
@@ -4890,7 +4992,8 @@
     "nationalPokedexNumber": 475
   },
   {
-    "id": "xy6-101",
+    "setOrder":64,
+	"id": "xy6-101",
     "name": "Latios-EX",
     "imageUrl": "https://images.pokemontcg.io/xy6/101.png",
     "subtype": "EX",
@@ -4947,7 +5050,8 @@
     "evolvesTo": "M Latios-EX"
   },
   {
-    "id": "xy6-102",
+    "setOrder":64,
+	"id": "xy6-102",
     "name": "M Latios-EX",
     "imageUrl": "https://images.pokemontcg.io/xy6/102.png",
     "subtype": "MEGA",
@@ -4991,7 +5095,8 @@
     "nationalPokedexNumber": 381
   },
   {
-    "id": "xy6-103",
+    "setOrder":64,
+	"id": "xy6-103",
     "name": "Hydreigon-EX",
     "imageUrl": "https://images.pokemontcg.io/xy6/103.png",
     "subtype": "EX",
@@ -5043,7 +5148,8 @@
     "nationalPokedexNumber": 635
   },
   {
-    "id": "xy6-104",
+    "setOrder":64,
+	"id": "xy6-104",
     "name": "Rayquaza-EX",
     "imageUrl": "https://images.pokemontcg.io/xy6/104.png",
     "subtype": "EX",
@@ -5105,7 +5211,8 @@
     "evolvesTo": "M Rayquaza-EX"
   },
   {
-    "id": "xy6-105",
+    "setOrder":64,
+	"id": "xy6-105",
     "name": "M Rayquaza-EX",
     "imageUrl": "https://images.pokemontcg.io/xy6/105.png",
     "subtype": "MEGA",
@@ -5162,7 +5269,8 @@
     "nationalPokedexNumber": 384
   },
   {
-    "id": "xy6-106",
+    "setOrder":64,
+	"id": "xy6-106",
     "name": "Shaymin-EX",
     "imageUrl": "https://images.pokemontcg.io/xy6/106.png",
     "subtype": "EX",
@@ -5217,7 +5325,8 @@
     "nationalPokedexNumber": 492
   },
   {
-    "id": "xy6-107",
+    "setOrder":64,
+	"id": "xy6-107",
     "name": "Wally",
     "imageUrl": "https://images.pokemontcg.io/xy6/107.png",
     "subtype": "Supporter",
@@ -5234,7 +5343,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy6/107_hires.png"
   },
   {
-    "id": "xy6-108",
+    "setOrder":64,
+	"id": "xy6-108",
     "name": "Winona",
     "imageUrl": "https://images.pokemontcg.io/xy6/108.png",
     "subtype": "Supporter",
@@ -5251,7 +5361,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy6/108_hires.png"
   },
   {
-    "id": "xy6-109",
+    "setOrder":64,
+	"id": "xy6-109",
     "name": "Energy Switch",
     "imageUrl": "https://images.pokemontcg.io/xy6/109.png",
     "subtype": "Item",
@@ -5268,7 +5379,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy6/109_hires.png"
   },
   {
-    "id": "xy6-110",
+    "setOrder":64,
+	"id": "xy6-110",
     "name": "VS Seeker",
     "imageUrl": "https://images.pokemontcg.io/xy6/110.png",
     "subtype": "Item",

--- a/json/cards/Ruby & Sapphire.json
+++ b/json/cards/Ruby & Sapphire.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "ex1-1",
+    "setOrder":16,
+	"id": "ex1-1",
     "name": "Aggron",
     "imageUrl": "https://images.pokemontcg.io/ex1/1.png",
     "subtype": "Stage 2",
@@ -74,7 +75,8 @@
     "nationalPokedexNumber": 306
   },
   {
-    "id": "ex1-2",
+    "setOrder":16,
+	"id": "ex1-2",
     "name": "Beautifly",
     "imageUrl": "https://images.pokemontcg.io/ex1/2.png",
     "subtype": "Stage 2",
@@ -128,7 +130,8 @@
     "nationalPokedexNumber": 267
   },
   {
-    "id": "ex1-3",
+    "setOrder":16,
+	"id": "ex1-3",
     "name": "Blaziken",
     "imageUrl": "https://images.pokemontcg.io/ex1/3.png",
     "subtype": "Stage 2",
@@ -177,7 +180,8 @@
     "nationalPokedexNumber": 257
   },
   {
-    "id": "ex1-4",
+    "setOrder":16,
+	"id": "ex1-4",
     "name": "Camerupt",
     "imageUrl": "https://images.pokemontcg.io/ex1/4.png",
     "subtype": "Stage 1",
@@ -233,7 +237,8 @@
     "nationalPokedexNumber": 323
   },
   {
-    "id": "ex1-5",
+    "setOrder":16,
+	"id": "ex1-5",
     "name": "Delcatty",
     "imageUrl": "https://images.pokemontcg.io/ex1/5.png",
     "subtype": "Stage 1",
@@ -279,7 +284,8 @@
     "nationalPokedexNumber": 301
   },
   {
-    "id": "ex1-6",
+    "setOrder":16,
+	"id": "ex1-6",
     "name": "Dustox",
     "imageUrl": "https://images.pokemontcg.io/ex1/6.png",
     "subtype": "Stage 2",
@@ -334,7 +340,8 @@
     "nationalPokedexNumber": 269
   },
   {
-    "id": "ex1-7",
+    "setOrder":16,
+	"id": "ex1-7",
     "name": "Gardevoir",
     "imageUrl": "https://images.pokemontcg.io/ex1/7.png",
     "subtype": "Stage 2",
@@ -381,7 +388,8 @@
     "nationalPokedexNumber": 282
   },
   {
-    "id": "ex1-8",
+    "setOrder":16,
+	"id": "ex1-8",
     "name": "Hariyama",
     "imageUrl": "https://images.pokemontcg.io/ex1/8.png",
     "subtype": "Stage 1",
@@ -434,7 +442,8 @@
     "nationalPokedexNumber": 297
   },
   {
-    "id": "ex1-9",
+    "setOrder":16,
+	"id": "ex1-9",
     "name": "Manectric",
     "imageUrl": "https://images.pokemontcg.io/ex1/9.png",
     "subtype": "Stage 1",
@@ -492,7 +501,8 @@
     "nationalPokedexNumber": 310
   },
   {
-    "id": "ex1-10",
+    "setOrder":16,
+	"id": "ex1-10",
     "name": "Mightyena",
     "imageUrl": "https://images.pokemontcg.io/ex1/10.png",
     "subtype": "Stage 1",
@@ -546,7 +556,8 @@
     "nationalPokedexNumber": 262
   },
   {
-    "id": "ex1-11",
+    "setOrder":16,
+	"id": "ex1-11",
     "name": "Sceptile",
     "imageUrl": "https://images.pokemontcg.io/ex1/11.png",
     "subtype": "Stage 2",
@@ -608,7 +619,8 @@
     "nationalPokedexNumber": 254
   },
   {
-    "id": "ex1-12",
+    "setOrder":16,
+	"id": "ex1-12",
     "name": "Slaking",
     "imageUrl": "https://images.pokemontcg.io/ex1/12.png",
     "subtype": "Stage 2",
@@ -659,7 +671,8 @@
     "nationalPokedexNumber": 289
   },
   {
-    "id": "ex1-13",
+    "setOrder":16,
+	"id": "ex1-13",
     "name": "Swampert",
     "imageUrl": "https://images.pokemontcg.io/ex1/13.png",
     "subtype": "Stage 2",
@@ -710,7 +723,8 @@
     "nationalPokedexNumber": 260
   },
   {
-    "id": "ex1-14",
+    "setOrder":16,
+	"id": "ex1-14",
     "name": "Wailord",
     "imageUrl": "https://images.pokemontcg.io/ex1/14.png",
     "subtype": "Stage 1",
@@ -769,7 +783,8 @@
     "nationalPokedexNumber": 321
   },
   {
-    "id": "ex1-15",
+    "setOrder":16,
+	"id": "ex1-15",
     "name": "Blaziken",
     "imageUrl": "https://images.pokemontcg.io/ex1/15.png",
     "subtype": "Stage 2",
@@ -824,7 +839,8 @@
     "nationalPokedexNumber": 257
   },
   {
-    "id": "ex1-16",
+    "setOrder":16,
+	"id": "ex1-16",
     "name": "Breloom",
     "imageUrl": "https://images.pokemontcg.io/ex1/16.png",
     "subtype": "Stage 1",
@@ -877,7 +893,8 @@
     "nationalPokedexNumber": 286
   },
   {
-    "id": "ex1-17",
+    "setOrder":16,
+	"id": "ex1-17",
     "name": "Donphan",
     "imageUrl": "https://images.pokemontcg.io/ex1/17.png",
     "subtype": "Stage 1",
@@ -931,7 +948,8 @@
     "nationalPokedexNumber": 232
   },
   {
-    "id": "ex1-18",
+    "setOrder":16,
+	"id": "ex1-18",
     "name": "Nosepass",
     "imageUrl": "https://images.pokemontcg.io/ex1/18.png",
     "subtype": "Basic",
@@ -984,7 +1002,8 @@
     ]
   },
   {
-    "id": "ex1-19",
+    "setOrder":16,
+	"id": "ex1-19",
     "name": "Pelipper",
     "imageUrl": "https://images.pokemontcg.io/ex1/19.png",
     "subtype": "Stage 1",
@@ -1052,7 +1071,8 @@
     "nationalPokedexNumber": 279
   },
   {
-    "id": "ex1-20",
+    "setOrder":16,
+	"id": "ex1-20",
     "name": "Sceptile",
     "imageUrl": "https://images.pokemontcg.io/ex1/20.png",
     "subtype": "Stage 2",
@@ -1108,7 +1128,8 @@
     "nationalPokedexNumber": 254
   },
   {
-    "id": "ex1-21",
+    "setOrder":16,
+	"id": "ex1-21",
     "name": "Seaking",
     "imageUrl": "https://images.pokemontcg.io/ex1/21.png",
     "subtype": "Stage 1",
@@ -1156,7 +1177,8 @@
     "nationalPokedexNumber": 119
   },
   {
-    "id": "ex1-22",
+    "setOrder":16,
+	"id": "ex1-22",
     "name": "Sharpedo",
     "imageUrl": "https://images.pokemontcg.io/ex1/22.png",
     "subtype": "Stage 1",
@@ -1204,7 +1226,8 @@
     "nationalPokedexNumber": 319
   },
   {
-    "id": "ex1-23",
+    "setOrder":16,
+	"id": "ex1-23",
     "name": "Swampert",
     "imageUrl": "https://images.pokemontcg.io/ex1/23.png",
     "subtype": "Stage 2",
@@ -1262,7 +1285,8 @@
     "nationalPokedexNumber": 260
   },
   {
-    "id": "ex1-24",
+    "setOrder":16,
+	"id": "ex1-24",
     "name": "Weezing",
     "imageUrl": "https://images.pokemontcg.io/ex1/24.png",
     "subtype": "Stage 1",
@@ -1314,7 +1338,8 @@
     "nationalPokedexNumber": 110
   },
   {
-    "id": "ex1-25",
+    "setOrder":16,
+	"id": "ex1-25",
     "name": "Aron",
     "imageUrl": "https://images.pokemontcg.io/ex1/25.png",
     "subtype": "Basic",
@@ -1373,7 +1398,8 @@
     ]
   },
   {
-    "id": "ex1-26",
+    "setOrder":16,
+	"id": "ex1-26",
     "name": "Cascoon",
     "imageUrl": "https://images.pokemontcg.io/ex1/26.png",
     "subtype": "Stage 1",
@@ -1423,7 +1449,8 @@
     ]
   },
   {
-    "id": "ex1-27",
+    "setOrder":16,
+	"id": "ex1-27",
     "name": "Combusken",
     "imageUrl": "https://images.pokemontcg.io/ex1/27.png",
     "subtype": "Stage 1",
@@ -1478,7 +1505,8 @@
     ]
   },
   {
-    "id": "ex1-28",
+    "setOrder":16,
+	"id": "ex1-28",
     "name": "Combusken",
     "imageUrl": "https://images.pokemontcg.io/ex1/28.png",
     "subtype": "Stage 1",
@@ -1528,7 +1556,8 @@
     ]
   },
   {
-    "id": "ex1-29",
+    "setOrder":16,
+	"id": "ex1-29",
     "name": "Delcatty",
     "imageUrl": "https://images.pokemontcg.io/ex1/29.png",
     "subtype": "Stage 1",
@@ -1579,7 +1608,8 @@
     "nationalPokedexNumber": 301
   },
   {
-    "id": "ex1-30",
+    "setOrder":16,
+	"id": "ex1-30",
     "name": "Electrike",
     "imageUrl": "https://images.pokemontcg.io/ex1/30.png",
     "subtype": "Basic",
@@ -1638,7 +1668,8 @@
     ]
   },
   {
-    "id": "ex1-31",
+    "setOrder":16,
+	"id": "ex1-31",
     "name": "Grovyle",
     "imageUrl": "https://images.pokemontcg.io/ex1/31.png",
     "subtype": "Stage 1",
@@ -1700,7 +1731,8 @@
     ]
   },
   {
-    "id": "ex1-32",
+    "setOrder":16,
+	"id": "ex1-32",
     "name": "Grovyle",
     "imageUrl": "https://images.pokemontcg.io/ex1/32.png",
     "subtype": "Stage 1",
@@ -1756,7 +1788,8 @@
     ]
   },
   {
-    "id": "ex1-33",
+    "setOrder":16,
+	"id": "ex1-33",
     "name": "Hariyama",
     "imageUrl": "https://images.pokemontcg.io/ex1/33.png",
     "subtype": "Stage 1",
@@ -1809,7 +1842,8 @@
     "nationalPokedexNumber": 297
   },
   {
-    "id": "ex1-34",
+    "setOrder":16,
+	"id": "ex1-34",
     "name": "Kirlia",
     "imageUrl": "https://images.pokemontcg.io/ex1/34.png",
     "subtype": "Stage 1",
@@ -1865,7 +1899,8 @@
     ]
   },
   {
-    "id": "ex1-35",
+    "setOrder":16,
+	"id": "ex1-35",
     "name": "Kirlia",
     "imageUrl": "https://images.pokemontcg.io/ex1/35.png",
     "subtype": "Stage 1",
@@ -1919,7 +1954,8 @@
     ]
   },
   {
-    "id": "ex1-36",
+    "setOrder":16,
+	"id": "ex1-36",
     "name": "Lairon",
     "imageUrl": "https://images.pokemontcg.io/ex1/36.png",
     "subtype": "Stage 1",
@@ -1982,7 +2018,8 @@
     ]
   },
   {
-    "id": "ex1-37",
+    "setOrder":16,
+	"id": "ex1-37",
     "name": "Lairon",
     "imageUrl": "https://images.pokemontcg.io/ex1/37.png",
     "subtype": "Stage 1",
@@ -2045,7 +2082,8 @@
     ]
   },
   {
-    "id": "ex1-38",
+    "setOrder":16,
+	"id": "ex1-38",
     "name": "Linoone",
     "imageUrl": "https://images.pokemontcg.io/ex1/38.png",
     "subtype": "Stage 1",
@@ -2096,7 +2134,8 @@
     "nationalPokedexNumber": 264
   },
   {
-    "id": "ex1-39",
+    "setOrder":16,
+	"id": "ex1-39",
     "name": "Manectric",
     "imageUrl": "https://images.pokemontcg.io/ex1/39.png",
     "subtype": "Stage 1",
@@ -2155,7 +2194,8 @@
     "nationalPokedexNumber": 310
   },
   {
-    "id": "ex1-40",
+    "setOrder":16,
+	"id": "ex1-40",
     "name": "Marshtomp",
     "imageUrl": "https://images.pokemontcg.io/ex1/40.png",
     "subtype": "Stage 1",
@@ -2210,7 +2250,8 @@
     ]
   },
   {
-    "id": "ex1-41",
+    "setOrder":16,
+	"id": "ex1-41",
     "name": "Marshtomp",
     "imageUrl": "https://images.pokemontcg.io/ex1/41.png",
     "subtype": "Stage 1",
@@ -2260,7 +2301,8 @@
     ]
   },
   {
-    "id": "ex1-42",
+    "setOrder":16,
+	"id": "ex1-42",
     "name": "Mightyena",
     "imageUrl": "https://images.pokemontcg.io/ex1/42.png",
     "subtype": "Stage 1",
@@ -2319,7 +2361,8 @@
     "nationalPokedexNumber": 262
   },
   {
-    "id": "ex1-43",
+    "setOrder":16,
+	"id": "ex1-43",
     "name": "Silcoon",
     "imageUrl": "https://images.pokemontcg.io/ex1/43.png",
     "subtype": "Stage 1",
@@ -2369,7 +2412,8 @@
     ]
   },
   {
-    "id": "ex1-44",
+    "setOrder":16,
+	"id": "ex1-44",
     "name": "Skitty",
     "imageUrl": "https://images.pokemontcg.io/ex1/44.png",
     "subtype": "Basic",
@@ -2421,7 +2465,8 @@
     ]
   },
   {
-    "id": "ex1-45",
+    "setOrder":16,
+	"id": "ex1-45",
     "name": "Slakoth",
     "imageUrl": "https://images.pokemontcg.io/ex1/45.png",
     "subtype": "Basic",
@@ -2474,7 +2519,8 @@
     ]
   },
   {
-    "id": "ex1-46",
+    "setOrder":16,
+	"id": "ex1-46",
     "name": "Swellow",
     "imageUrl": "https://images.pokemontcg.io/ex1/46.png",
     "subtype": "Stage 1",
@@ -2524,7 +2570,8 @@
     "nationalPokedexNumber": 277
   },
   {
-    "id": "ex1-47",
+    "setOrder":16,
+	"id": "ex1-47",
     "name": "Vigoroth",
     "imageUrl": "https://images.pokemontcg.io/ex1/47.png",
     "subtype": "Stage 1",
@@ -2580,7 +2627,8 @@
     ]
   },
   {
-    "id": "ex1-48",
+    "setOrder":16,
+	"id": "ex1-48",
     "name": "Wailmer",
     "imageUrl": "https://images.pokemontcg.io/ex1/48.png",
     "subtype": "Basic",
@@ -2636,7 +2684,8 @@
     ]
   },
   {
-    "id": "ex1-49",
+    "setOrder":16,
+	"id": "ex1-49",
     "name": "Aron",
     "imageUrl": "https://images.pokemontcg.io/ex1/49.png",
     "subtype": "Basic",
@@ -2695,7 +2744,8 @@
     ]
   },
   {
-    "id": "ex1-50",
+    "setOrder":16,
+	"id": "ex1-50",
     "name": "Aron",
     "imageUrl": "https://images.pokemontcg.io/ex1/50.png",
     "subtype": "Basic",
@@ -2745,7 +2795,8 @@
     ]
   },
   {
-    "id": "ex1-51",
+    "setOrder":16,
+	"id": "ex1-51",
     "name": "Carvanha",
     "imageUrl": "https://images.pokemontcg.io/ex1/51.png",
     "subtype": "Basic",
@@ -2793,7 +2844,8 @@
     ]
   },
   {
-    "id": "ex1-52",
+    "setOrder":16,
+	"id": "ex1-52",
     "name": "Electrike",
     "imageUrl": "https://images.pokemontcg.io/ex1/52.png",
     "subtype": "Basic",
@@ -2842,7 +2894,8 @@
     ]
   },
   {
-    "id": "ex1-53",
+    "setOrder":16,
+	"id": "ex1-53",
     "name": "Electrike",
     "imageUrl": "https://images.pokemontcg.io/ex1/53.png",
     "subtype": "Basic",
@@ -2901,7 +2954,8 @@
     ]
   },
   {
-    "id": "ex1-54",
+    "setOrder":16,
+	"id": "ex1-54",
     "name": "Koffing",
     "imageUrl": "https://images.pokemontcg.io/ex1/54.png",
     "subtype": "Basic",
@@ -2954,7 +3008,8 @@
     ]
   },
   {
-    "id": "ex1-55",
+    "setOrder":16,
+	"id": "ex1-55",
     "name": "Goldeen",
     "imageUrl": "https://images.pokemontcg.io/ex1/55.png",
     "subtype": "Basic",
@@ -2997,7 +3052,8 @@
     ]
   },
   {
-    "id": "ex1-56",
+    "setOrder":16,
+	"id": "ex1-56",
     "name": "Makuhita",
     "imageUrl": "https://images.pokemontcg.io/ex1/56.png",
     "subtype": "Basic",
@@ -3050,7 +3106,8 @@
     ]
   },
   {
-    "id": "ex1-57",
+    "setOrder":16,
+	"id": "ex1-57",
     "name": "Makuhita",
     "imageUrl": "https://images.pokemontcg.io/ex1/57.png",
     "subtype": "Basic",
@@ -3103,7 +3160,8 @@
     ]
   },
   {
-    "id": "ex1-58",
+    "setOrder":16,
+	"id": "ex1-58",
     "name": "Makuhita",
     "imageUrl": "https://images.pokemontcg.io/ex1/58.png",
     "subtype": "Basic",
@@ -3146,7 +3204,8 @@
     ]
   },
   {
-    "id": "ex1-59",
+    "setOrder":16,
+	"id": "ex1-59",
     "name": "Mudkip",
     "imageUrl": "https://images.pokemontcg.io/ex1/59.png",
     "subtype": "Basic",
@@ -3189,7 +3248,8 @@
     ]
   },
   {
-    "id": "ex1-60",
+    "setOrder":16,
+	"id": "ex1-60",
     "name": "Mudkip",
     "imageUrl": "https://images.pokemontcg.io/ex1/60.png",
     "subtype": "Basic",
@@ -3242,7 +3302,8 @@
     ]
   },
   {
-    "id": "ex1-61",
+    "setOrder":16,
+	"id": "ex1-61",
     "name": "Numel",
     "imageUrl": "https://images.pokemontcg.io/ex1/61.png",
     "subtype": "Basic",
@@ -3295,7 +3356,8 @@
     ]
   },
   {
-    "id": "ex1-62",
+    "setOrder":16,
+	"id": "ex1-62",
     "name": "Phanpy",
     "imageUrl": "https://images.pokemontcg.io/ex1/62.png",
     "subtype": "Basic",
@@ -3348,7 +3410,8 @@
     ]
   },
   {
-    "id": "ex1-63",
+    "setOrder":16,
+	"id": "ex1-63",
     "name": "Poochyena",
     "imageUrl": "https://images.pokemontcg.io/ex1/63.png",
     "subtype": "Basic",
@@ -3397,7 +3460,8 @@
     ]
   },
   {
-    "id": "ex1-64",
+    "setOrder":16,
+	"id": "ex1-64",
     "name": "Poochyena",
     "imageUrl": "https://images.pokemontcg.io/ex1/64.png",
     "subtype": "Basic",
@@ -3456,7 +3520,8 @@
     ]
   },
   {
-    "id": "ex1-65",
+    "setOrder":16,
+	"id": "ex1-65",
     "name": "Poochyena",
     "imageUrl": "https://images.pokemontcg.io/ex1/65.png",
     "subtype": "Basic",
@@ -3505,7 +3570,8 @@
     ]
   },
   {
-    "id": "ex1-66",
+    "setOrder":16,
+	"id": "ex1-66",
     "name": "Ralts",
     "imageUrl": "https://images.pokemontcg.io/ex1/66.png",
     "subtype": "Basic",
@@ -3548,7 +3614,8 @@
     ]
   },
   {
-    "id": "ex1-67",
+    "setOrder":16,
+	"id": "ex1-67",
     "name": "Ralts",
     "imageUrl": "https://images.pokemontcg.io/ex1/67.png",
     "subtype": "Basic",
@@ -3601,7 +3668,8 @@
     ]
   },
   {
-    "id": "ex1-68",
+    "setOrder":16,
+	"id": "ex1-68",
     "name": "Ralts",
     "imageUrl": "https://images.pokemontcg.io/ex1/68.png",
     "subtype": "Basic",
@@ -3654,7 +3722,8 @@
     ]
   },
   {
-    "id": "ex1-69",
+    "setOrder":16,
+	"id": "ex1-69",
     "name": "Shroomish",
     "imageUrl": "https://images.pokemontcg.io/ex1/69.png",
     "subtype": "Basic",
@@ -3703,7 +3772,8 @@
     ]
   },
   {
-    "id": "ex1-70",
+    "setOrder":16,
+	"id": "ex1-70",
     "name": "Skitty",
     "imageUrl": "https://images.pokemontcg.io/ex1/70.png",
     "subtype": "Basic",
@@ -3755,7 +3825,8 @@
     ]
   },
   {
-    "id": "ex1-71",
+    "setOrder":16,
+	"id": "ex1-71",
     "name": "Skitty",
     "imageUrl": "https://images.pokemontcg.io/ex1/71.png",
     "subtype": "Basic",
@@ -3808,7 +3879,8 @@
     ]
   },
   {
-    "id": "ex1-72",
+    "setOrder":16,
+	"id": "ex1-72",
     "name": "Taillow",
     "imageUrl": "https://images.pokemontcg.io/ex1/72.png",
     "subtype": "Basic",
@@ -3867,7 +3939,8 @@
     ]
   },
   {
-    "id": "ex1-73",
+    "setOrder":16,
+	"id": "ex1-73",
     "name": "Torchic",
     "imageUrl": "https://images.pokemontcg.io/ex1/73.png",
     "subtype": "Basic",
@@ -3920,7 +3993,8 @@
     ]
   },
   {
-    "id": "ex1-74",
+    "setOrder":16,
+	"id": "ex1-74",
     "name": "Torchic",
     "imageUrl": "https://images.pokemontcg.io/ex1/74.png",
     "subtype": "Basic",
@@ -3963,7 +4037,8 @@
     ]
   },
   {
-    "id": "ex1-75",
+    "setOrder":16,
+	"id": "ex1-75",
     "name": "Treecko",
     "imageUrl": "https://images.pokemontcg.io/ex1/75.png",
     "subtype": "Basic",
@@ -4012,7 +4087,8 @@
     ]
   },
   {
-    "id": "ex1-76",
+    "setOrder":16,
+	"id": "ex1-76",
     "name": "Treecko",
     "imageUrl": "https://images.pokemontcg.io/ex1/76.png",
     "subtype": "Basic",
@@ -4071,7 +4147,8 @@
     ]
   },
   {
-    "id": "ex1-77",
+    "setOrder":16,
+	"id": "ex1-77",
     "name": "Wingull",
     "imageUrl": "https://images.pokemontcg.io/ex1/77.png",
     "subtype": "Basic",
@@ -4120,7 +4197,8 @@
     ]
   },
   {
-    "id": "ex1-78",
+    "setOrder":16,
+	"id": "ex1-78",
     "name": "Wurmple",
     "imageUrl": "https://images.pokemontcg.io/ex1/78.png",
     "subtype": "Basic",
@@ -4173,7 +4251,8 @@
     ]
   },
   {
-    "id": "ex1-79",
+    "setOrder":16,
+	"id": "ex1-79",
     "name": "Zigzagoon",
     "imageUrl": "https://images.pokemontcg.io/ex1/79.png",
     "subtype": "Basic",
@@ -4216,7 +4295,8 @@
     ]
   },
   {
-    "id": "ex1-80",
+    "setOrder":16,
+	"id": "ex1-80",
     "name": "Energy Removal 2",
     "imageUrl": "https://images.pokemontcg.io/ex1/80.png",
     "subtype": "Item",
@@ -4234,7 +4314,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/80_hires.png"
   },
   {
-    "id": "ex1-81",
+    "setOrder":16,
+	"id": "ex1-81",
     "name": "Energy Restore",
     "imageUrl": "https://images.pokemontcg.io/ex1/81.png",
     "subtype": "Item",
@@ -4252,7 +4333,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/81_hires.png"
   },
   {
-    "id": "ex1-82",
+    "setOrder":16,
+	"id": "ex1-82",
     "name": "Energy Switch",
     "imageUrl": "https://images.pokemontcg.io/ex1/82.png",
     "subtype": "Item",
@@ -4270,7 +4352,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/82_hires.png"
   },
   {
-    "id": "ex1-83",
+    "setOrder":16,
+	"id": "ex1-83",
     "name": "Lady Outing",
     "imageUrl": "https://images.pokemontcg.io/ex1/83.png",
     "subtype": "Supporter",
@@ -4289,7 +4372,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/83_hires.png"
   },
   {
-    "id": "ex1-84",
+    "setOrder":16,
+	"id": "ex1-84",
     "name": "Lum Berry",
     "imageUrl": "https://images.pokemontcg.io/ex1/84.png",
     "subtype": "Pokémon Tool",
@@ -4308,7 +4392,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/84_hires.png"
   },
   {
-    "id": "ex1-85",
+    "setOrder":16,
+	"id": "ex1-85",
     "name": "Oran Berry",
     "imageUrl": "https://images.pokemontcg.io/ex1/85.png",
     "subtype": "Pokémon Tool",
@@ -4327,7 +4412,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/85_hires.png"
   },
   {
-    "id": "ex1-86",
+    "setOrder":16,
+	"id": "ex1-86",
     "name": "Poké Ball",
     "imageUrl": "https://images.pokemontcg.io/ex1/86.png",
     "subtype": "Item",
@@ -4345,7 +4431,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/86_hires.png"
   },
   {
-    "id": "ex1-87",
+    "setOrder":16,
+	"id": "ex1-87",
     "name": "Pokémon Reversal",
     "imageUrl": "https://images.pokemontcg.io/ex1/87.png",
     "subtype": "Item",
@@ -4363,7 +4450,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/87_hires.png"
   },
   {
-    "id": "ex1-88",
+    "setOrder":16,
+	"id": "ex1-88",
     "name": "PokéNav",
     "imageUrl": "https://images.pokemontcg.io/ex1/88.png",
     "subtype": "Item",
@@ -4381,7 +4469,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/88_hires.png"
   },
   {
-    "id": "ex1-89",
+    "setOrder":16,
+	"id": "ex1-89",
     "name": "Professor Birch",
     "imageUrl": "https://images.pokemontcg.io/ex1/89.png",
     "subtype": "Supporter",
@@ -4400,7 +4489,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/89_hires.png"
   },
   {
-    "id": "ex1-90",
+    "setOrder":16,
+	"id": "ex1-90",
     "name": "Energy Search",
     "imageUrl": "https://images.pokemontcg.io/ex1/90.png",
     "subtype": "Item",
@@ -4418,7 +4508,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/90_hires.png"
   },
   {
-    "id": "ex1-91",
+    "setOrder":16,
+	"id": "ex1-91",
     "name": "Potion",
     "imageUrl": "https://images.pokemontcg.io/ex1/91.png",
     "subtype": "Item",
@@ -4436,7 +4527,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/91_hires.png"
   },
   {
-    "id": "ex1-92",
+    "setOrder":16,
+	"id": "ex1-92",
     "name": "Switch",
     "imageUrl": "https://images.pokemontcg.io/ex1/92.png",
     "subtype": "Item",
@@ -4454,7 +4546,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/92_hires.png"
   },
   {
-    "id": "ex1-93",
+    "setOrder":16,
+	"id": "ex1-93",
     "name": "Darkness Energy",
     "imageUrl": "https://images.pokemontcg.io/ex1/93.png",
     "subtype": "Special",
@@ -4471,7 +4564,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/93_hires.png"
   },
   {
-    "id": "ex1-94",
+    "setOrder":16,
+	"id": "ex1-94",
     "name": "Metal Energy",
     "imageUrl": "https://images.pokemontcg.io/ex1/94.png",
     "subtype": "Special",
@@ -4488,7 +4582,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/94_hires.png"
   },
   {
-    "id": "ex1-95",
+    "setOrder":16,
+	"id": "ex1-95",
     "name": "Rainbow Energy",
     "imageUrl": "https://images.pokemontcg.io/ex1/95.png",
     "subtype": "Special",
@@ -4505,7 +4600,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/95_hires.png"
   },
   {
-    "id": "ex1-96",
+    "setOrder":16,
+	"id": "ex1-96",
     "name": "Chansey ex",
     "imageUrl": "https://images.pokemontcg.io/ex1/96.png",
     "subtype": "EX",
@@ -4566,7 +4662,8 @@
     ]
   },
   {
-    "id": "ex1-97",
+    "setOrder":16,
+	"id": "ex1-97",
     "name": "Electabuzz ex",
     "imageUrl": "https://images.pokemontcg.io/ex1/97.png",
     "subtype": "EX",
@@ -4631,7 +4728,8 @@
     ]
   },
   {
-    "id": "ex1-98",
+    "setOrder":16,
+	"id": "ex1-98",
     "name": "Hitmonchan ex",
     "imageUrl": "https://images.pokemontcg.io/ex1/98.png",
     "subtype": "EX",
@@ -4687,7 +4785,8 @@
     "nationalPokedexNumber": 107
   },
   {
-    "id": "ex1-99",
+    "setOrder":16,
+	"id": "ex1-99",
     "name": "Lapras ex",
     "imageUrl": "https://images.pokemontcg.io/ex1/99.png",
     "subtype": "EX",
@@ -4744,7 +4843,8 @@
     "nationalPokedexNumber": 131
   },
   {
-    "id": "ex1-100",
+    "setOrder":16,
+	"id": "ex1-100",
     "name": "Magmar ex",
     "imageUrl": "https://images.pokemontcg.io/ex1/100.png",
     "subtype": "EX",
@@ -4803,7 +4903,8 @@
     ]
   },
   {
-    "id": "ex1-101",
+    "setOrder":16,
+	"id": "ex1-101",
     "name": "Mewtwo ex",
     "imageUrl": "https://images.pokemontcg.io/ex1/101.png",
     "subtype": "EX",
@@ -4860,7 +4961,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "ex1-102",
+    "setOrder":16,
+	"id": "ex1-102",
     "name": "Scyther ex",
     "imageUrl": "https://images.pokemontcg.io/ex1/102.png",
     "subtype": "EX",
@@ -4924,7 +5026,8 @@
     ]
   },
   {
-    "id": "ex1-103",
+    "setOrder":16,
+	"id": "ex1-103",
     "name": "Sneasel ex",
     "imageUrl": "https://images.pokemontcg.io/ex1/103.png",
     "subtype": "EX",
@@ -4988,7 +5091,8 @@
     ]
   },
   {
-    "id": "ex1-104",
+    "setOrder":16,
+	"id": "ex1-104",
     "name": "Grass Energy",
     "imageUrl": "https://images.pokemontcg.io/ex1/104.png",
     "subtype": "Basic",
@@ -5002,7 +5106,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/104_hires.png"
   },
   {
-    "id": "ex1-105",
+    "setOrder":16,
+	"id": "ex1-105",
     "name": "Fighting Energy",
     "imageUrl": "https://images.pokemontcg.io/ex1/105.png",
     "subtype": "Basic",
@@ -5016,7 +5121,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/105_hires.png"
   },
   {
-    "id": "ex1-106",
+    "setOrder":16,
+	"id": "ex1-106",
     "name": "Water Energy",
     "imageUrl": "https://images.pokemontcg.io/ex1/106.png",
     "subtype": "Basic",
@@ -5030,7 +5136,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/106_hires.png"
   },
   {
-    "id": "ex1-107",
+    "setOrder":16,
+	"id": "ex1-107",
     "name": "Psychic Energy",
     "imageUrl": "https://images.pokemontcg.io/ex1/107.png",
     "subtype": "Basic",
@@ -5044,7 +5151,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/107_hires.png"
   },
   {
-    "id": "ex1-108",
+    "setOrder":16,
+	"id": "ex1-108",
     "name": "Fire Energy",
     "imageUrl": "https://images.pokemontcg.io/ex1/108.png",
     "subtype": "Basic",
@@ -5058,7 +5166,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex1/108_hires.png"
   },
   {
-    "id": "ex1-109",
+    "setOrder":16,
+	"id": "ex1-109",
     "name": "Lightning Energy",
     "imageUrl": "https://images.pokemontcg.io/ex1/109.png",
     "subtype": "Basic",

--- a/json/cards/Sandstorm.json
+++ b/json/cards/Sandstorm.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "ex2-1",
+    "setOrder":17,
+	"id": "ex2-1",
     "name": "Armaldo",
     "imageUrl": "https://images.pokemontcg.io/ex2/1.png",
     "subtype": "Stage 2",
@@ -50,7 +51,8 @@
     "nationalPokedexNumber": 348
   },
   {
-    "id": "ex2-2",
+    "setOrder":17,
+	"id": "ex2-2",
     "name": "Cacturne",
     "imageUrl": "https://images.pokemontcg.io/ex2/2.png",
     "subtype": "Stage 1",
@@ -98,7 +100,8 @@
     "nationalPokedexNumber": 332
   },
   {
-    "id": "ex2-3",
+    "setOrder":17,
+	"id": "ex2-3",
     "name": "Cradily",
     "imageUrl": "https://images.pokemontcg.io/ex2/3.png",
     "subtype": "Stage 2",
@@ -156,7 +159,8 @@
     "nationalPokedexNumber": 346
   },
   {
-    "id": "ex2-4",
+    "setOrder":17,
+	"id": "ex2-4",
     "name": "Dusclops",
     "imageUrl": "https://images.pokemontcg.io/ex2/4.png",
     "subtype": "Stage 1",
@@ -218,7 +222,8 @@
     ]
   },
   {
-    "id": "ex2-5",
+    "setOrder":17,
+	"id": "ex2-5",
     "name": "Flareon",
     "imageUrl": "https://images.pokemontcg.io/ex2/5.png",
     "subtype": "Stage 1",
@@ -273,7 +278,8 @@
     "nationalPokedexNumber": 136
   },
   {
-    "id": "ex2-6",
+    "setOrder":17,
+	"id": "ex2-6",
     "name": "Jolteon",
     "imageUrl": "https://images.pokemontcg.io/ex2/6.png",
     "subtype": "Stage 1",
@@ -332,7 +338,8 @@
     "nationalPokedexNumber": 135
   },
   {
-    "id": "ex2-7",
+    "setOrder":17,
+	"id": "ex2-7",
     "name": "Ludicolo",
     "imageUrl": "https://images.pokemontcg.io/ex2/7.png",
     "subtype": "Stage 2",
@@ -381,7 +388,8 @@
     "nationalPokedexNumber": 272
   },
   {
-    "id": "ex2-8",
+    "setOrder":17,
+	"id": "ex2-8",
     "name": "Lunatone",
     "imageUrl": "https://images.pokemontcg.io/ex2/8.png",
     "subtype": "Basic",
@@ -436,7 +444,8 @@
     "nationalPokedexNumber": 337
   },
   {
-    "id": "ex2-9",
+    "setOrder":17,
+	"id": "ex2-9",
     "name": "Mawile",
     "imageUrl": "https://images.pokemontcg.io/ex2/9.png",
     "subtype": "Basic",
@@ -486,7 +495,8 @@
     "nationalPokedexNumber": 303
   },
   {
-    "id": "ex2-10",
+    "setOrder":17,
+	"id": "ex2-10",
     "name": "Sableye",
     "imageUrl": "https://images.pokemontcg.io/ex2/10.png",
     "subtype": "Basic",
@@ -536,7 +546,8 @@
     "nationalPokedexNumber": 302
   },
   {
-    "id": "ex2-11",
+    "setOrder":17,
+	"id": "ex2-11",
     "name": "Seviper",
     "imageUrl": "https://images.pokemontcg.io/ex2/11.png",
     "subtype": "Basic",
@@ -587,7 +598,8 @@
     "nationalPokedexNumber": 336
   },
   {
-    "id": "ex2-12",
+    "setOrder":17,
+	"id": "ex2-12",
     "name": "Shiftry",
     "imageUrl": "https://images.pokemontcg.io/ex2/12.png",
     "subtype": "Stage 2",
@@ -637,7 +649,8 @@
     "nationalPokedexNumber": 275
   },
   {
-    "id": "ex2-13",
+    "setOrder":17,
+	"id": "ex2-13",
     "name": "Solrock",
     "imageUrl": "https://images.pokemontcg.io/ex2/13.png",
     "subtype": "Basic",
@@ -693,7 +706,8 @@
     "nationalPokedexNumber": 338
   },
   {
-    "id": "ex2-14",
+    "setOrder":17,
+	"id": "ex2-14",
     "name": "Zangoose",
     "imageUrl": "https://images.pokemontcg.io/ex2/14.png",
     "subtype": "Basic",
@@ -749,7 +763,8 @@
     "nationalPokedexNumber": 335
   },
   {
-    "id": "ex2-15",
+    "setOrder":17,
+	"id": "ex2-15",
     "name": "Arcanine",
     "imageUrl": "https://images.pokemontcg.io/ex2/15.png",
     "subtype": "Stage 1",
@@ -797,7 +812,8 @@
     "nationalPokedexNumber": 59
   },
   {
-    "id": "ex2-16",
+    "setOrder":17,
+	"id": "ex2-16",
     "name": "Espeon",
     "imageUrl": "https://images.pokemontcg.io/ex2/16.png",
     "subtype": "Stage 1",
@@ -849,7 +865,8 @@
     "nationalPokedexNumber": 196
   },
   {
-    "id": "ex2-17",
+    "setOrder":17,
+	"id": "ex2-17",
     "name": "Golduck",
     "imageUrl": "https://images.pokemontcg.io/ex2/17.png",
     "subtype": "Stage 1",
@@ -896,7 +913,8 @@
     "nationalPokedexNumber": 55
   },
   {
-    "id": "ex2-18",
+    "setOrder":17,
+	"id": "ex2-18",
     "name": "Kecleon",
     "imageUrl": "https://images.pokemontcg.io/ex2/18.png",
     "subtype": "Basic",
@@ -942,7 +960,8 @@
     "nationalPokedexNumber": 352
   },
   {
-    "id": "ex2-19",
+    "setOrder":17,
+	"id": "ex2-19",
     "name": "Omastar",
     "imageUrl": "https://images.pokemontcg.io/ex2/19.png",
     "subtype": "Stage 2",
@@ -994,7 +1013,8 @@
     "nationalPokedexNumber": 139
   },
   {
-    "id": "ex2-20",
+    "setOrder":17,
+	"id": "ex2-20",
     "name": "Pichu",
     "imageUrl": "https://images.pokemontcg.io/ex2/20.png",
     "subtype": "Basic",
@@ -1042,7 +1062,8 @@
     ]
   },
   {
-    "id": "ex2-21",
+    "setOrder":17,
+	"id": "ex2-21",
     "name": "Sandslash",
     "imageUrl": "https://images.pokemontcg.io/ex2/21.png",
     "subtype": "Stage 1",
@@ -1092,7 +1113,8 @@
     "nationalPokedexNumber": 28
   },
   {
-    "id": "ex2-22",
+    "setOrder":17,
+	"id": "ex2-22",
     "name": "Shiftry",
     "imageUrl": "https://images.pokemontcg.io/ex2/22.png",
     "subtype": "Stage 2",
@@ -1148,7 +1170,8 @@
     "nationalPokedexNumber": 275
   },
   {
-    "id": "ex2-23",
+    "setOrder":17,
+	"id": "ex2-23",
     "name": "Steelix",
     "imageUrl": "https://images.pokemontcg.io/ex2/23.png",
     "subtype": "Stage 1",
@@ -1212,7 +1235,8 @@
     "nationalPokedexNumber": 208
   },
   {
-    "id": "ex2-24",
+    "setOrder":17,
+	"id": "ex2-24",
     "name": "Umbreon",
     "imageUrl": "https://images.pokemontcg.io/ex2/24.png",
     "subtype": "Stage 1",
@@ -1270,7 +1294,8 @@
     "nationalPokedexNumber": 197
   },
   {
-    "id": "ex2-25",
+    "setOrder":17,
+	"id": "ex2-25",
     "name": "Vaporeon",
     "imageUrl": "https://images.pokemontcg.io/ex2/25.png",
     "subtype": "Stage 1",
@@ -1323,7 +1348,8 @@
     "nationalPokedexNumber": 134
   },
   {
-    "id": "ex2-26",
+    "setOrder":17,
+	"id": "ex2-26",
     "name": "Wobbuffet",
     "imageUrl": "https://images.pokemontcg.io/ex2/26.png",
     "subtype": "Basic",
@@ -1371,7 +1397,8 @@
     "nationalPokedexNumber": 202
   },
   {
-    "id": "ex2-27",
+    "setOrder":17,
+	"id": "ex2-27",
     "name": "Anorith",
     "imageUrl": "https://images.pokemontcg.io/ex2/27.png",
     "subtype": "Stage 1",
@@ -1425,7 +1452,8 @@
     ]
   },
   {
-    "id": "ex2-28",
+    "setOrder":17,
+	"id": "ex2-28",
     "name": "Anorith",
     "imageUrl": "https://images.pokemontcg.io/ex2/28.png",
     "subtype": "Stage 1",
@@ -1481,7 +1509,8 @@
     ]
   },
   {
-    "id": "ex2-29",
+    "setOrder":17,
+	"id": "ex2-29",
     "name": "Arbok",
     "imageUrl": "https://images.pokemontcg.io/ex2/29.png",
     "subtype": "Stage 1",
@@ -1529,7 +1558,8 @@
     "nationalPokedexNumber": 24
   },
   {
-    "id": "ex2-30",
+    "setOrder":17,
+	"id": "ex2-30",
     "name": "Azumarill",
     "imageUrl": "https://images.pokemontcg.io/ex2/30.png",
     "subtype": "Stage 1",
@@ -1580,7 +1610,8 @@
     "nationalPokedexNumber": 184
   },
   {
-    "id": "ex2-31",
+    "setOrder":17,
+	"id": "ex2-31",
     "name": "Azurill",
     "imageUrl": "https://images.pokemontcg.io/ex2/31.png",
     "subtype": "Basic",
@@ -1628,7 +1659,8 @@
     ]
   },
   {
-    "id": "ex2-32",
+    "setOrder":17,
+	"id": "ex2-32",
     "name": "Baltoy",
     "imageUrl": "https://images.pokemontcg.io/ex2/32.png",
     "subtype": "Basic",
@@ -1671,7 +1703,8 @@
     ]
   },
   {
-    "id": "ex2-33",
+    "setOrder":17,
+	"id": "ex2-33",
     "name": "Breloom",
     "imageUrl": "https://images.pokemontcg.io/ex2/33.png",
     "subtype": "Stage 1",
@@ -1723,7 +1756,8 @@
     "nationalPokedexNumber": 286
   },
   {
-    "id": "ex2-34",
+    "setOrder":17,
+	"id": "ex2-34",
     "name": "Delcatty",
     "imageUrl": "https://images.pokemontcg.io/ex2/34.png",
     "subtype": "Stage 1",
@@ -1776,7 +1810,8 @@
     "nationalPokedexNumber": 301
   },
   {
-    "id": "ex2-35",
+    "setOrder":17,
+	"id": "ex2-35",
     "name": "Electabuzz",
     "imageUrl": "https://images.pokemontcg.io/ex2/35.png",
     "subtype": "Basic",
@@ -1836,7 +1871,8 @@
     ]
   },
   {
-    "id": "ex2-36",
+    "setOrder":17,
+	"id": "ex2-36",
     "name": "Elekid",
     "imageUrl": "https://images.pokemontcg.io/ex2/36.png",
     "subtype": "Basic",
@@ -1884,7 +1920,8 @@
     ]
   },
   {
-    "id": "ex2-37",
+    "setOrder":17,
+	"id": "ex2-37",
     "name": "Fearow",
     "imageUrl": "https://images.pokemontcg.io/ex2/37.png",
     "subtype": "Stage 1",
@@ -1940,7 +1977,8 @@
     "nationalPokedexNumber": 22
   },
   {
-    "id": "ex2-38",
+    "setOrder":17,
+	"id": "ex2-38",
     "name": "Illumise",
     "imageUrl": "https://images.pokemontcg.io/ex2/38.png",
     "subtype": "Basic",
@@ -1995,7 +2033,8 @@
     "nationalPokedexNumber": 314
   },
   {
-    "id": "ex2-39",
+    "setOrder":17,
+	"id": "ex2-39",
     "name": "Kabuto",
     "imageUrl": "https://images.pokemontcg.io/ex2/39.png",
     "subtype": "Stage 1",
@@ -2055,7 +2094,8 @@
     ]
   },
   {
-    "id": "ex2-40",
+    "setOrder":17,
+	"id": "ex2-40",
     "name": "Kirlia",
     "imageUrl": "https://images.pokemontcg.io/ex2/40.png",
     "subtype": "Stage 1",
@@ -2112,7 +2152,8 @@
     ]
   },
   {
-    "id": "ex2-41",
+    "setOrder":17,
+	"id": "ex2-41",
     "name": "Lairon",
     "imageUrl": "https://images.pokemontcg.io/ex2/41.png",
     "subtype": "Stage 1",
@@ -2174,7 +2215,8 @@
     ]
   },
   {
-    "id": "ex2-42",
+    "setOrder":17,
+	"id": "ex2-42",
     "name": "Lileep",
     "imageUrl": "https://images.pokemontcg.io/ex2/42.png",
     "subtype": "Stage 1",
@@ -2229,7 +2271,8 @@
     ]
   },
   {
-    "id": "ex2-43",
+    "setOrder":17,
+	"id": "ex2-43",
     "name": "Lileep",
     "imageUrl": "https://images.pokemontcg.io/ex2/43.png",
     "subtype": "Stage 1",
@@ -2285,7 +2328,8 @@
     ]
   },
   {
-    "id": "ex2-44",
+    "setOrder":17,
+	"id": "ex2-44",
     "name": "Linoone",
     "imageUrl": "https://images.pokemontcg.io/ex2/44.png",
     "subtype": "Stage 1",
@@ -2333,7 +2377,8 @@
     "nationalPokedexNumber": 264
   },
   {
-    "id": "ex2-45",
+    "setOrder":17,
+	"id": "ex2-45",
     "name": "Lombre",
     "imageUrl": "https://images.pokemontcg.io/ex2/45.png",
     "subtype": "Stage 1",
@@ -2383,7 +2428,8 @@
     ]
   },
   {
-    "id": "ex2-46",
+    "setOrder":17,
+	"id": "ex2-46",
     "name": "Lombre",
     "imageUrl": "https://images.pokemontcg.io/ex2/46.png",
     "subtype": "Stage 1",
@@ -2437,7 +2483,8 @@
     ]
   },
   {
-    "id": "ex2-47",
+    "setOrder":17,
+	"id": "ex2-47",
     "name": "Murkrow",
     "imageUrl": "https://images.pokemontcg.io/ex2/47.png",
     "subtype": "Basic",
@@ -2496,7 +2543,8 @@
     ]
   },
   {
-    "id": "ex2-48",
+    "setOrder":17,
+	"id": "ex2-48",
     "name": "Nuzleaf",
     "imageUrl": "https://images.pokemontcg.io/ex2/48.png",
     "subtype": "Stage 1",
@@ -2552,7 +2600,8 @@
     ]
   },
   {
-    "id": "ex2-49",
+    "setOrder":17,
+	"id": "ex2-49",
     "name": "Nuzleaf",
     "imageUrl": "https://images.pokemontcg.io/ex2/49.png",
     "subtype": "Stage 1",
@@ -2608,7 +2657,8 @@
     ]
   },
   {
-    "id": "ex2-50",
+    "setOrder":17,
+	"id": "ex2-50",
     "name": "Pelipper",
     "imageUrl": "https://images.pokemontcg.io/ex2/50.png",
     "subtype": "Stage 1",
@@ -2653,7 +2703,8 @@
     "nationalPokedexNumber": 279
   },
   {
-    "id": "ex2-51",
+    "setOrder":17,
+	"id": "ex2-51",
     "name": "Quilava",
     "imageUrl": "https://images.pokemontcg.io/ex2/51.png",
     "subtype": "Stage 1",
@@ -2710,7 +2761,8 @@
     ]
   },
   {
-    "id": "ex2-52",
+    "setOrder":17,
+	"id": "ex2-52",
     "name": "Vigoroth",
     "imageUrl": "https://images.pokemontcg.io/ex2/52.png",
     "subtype": "Stage 1",
@@ -2765,7 +2817,8 @@
     ]
   },
   {
-    "id": "ex2-53",
+    "setOrder":17,
+	"id": "ex2-53",
     "name": "Volbeat",
     "imageUrl": "https://images.pokemontcg.io/ex2/53.png",
     "subtype": "Basic",
@@ -2820,7 +2873,8 @@
     "nationalPokedexNumber": 313
   },
   {
-    "id": "ex2-54",
+    "setOrder":17,
+	"id": "ex2-54",
     "name": "Wynaut",
     "imageUrl": "https://images.pokemontcg.io/ex2/54.png",
     "subtype": "Basic",
@@ -2868,7 +2922,8 @@
     ]
   },
   {
-    "id": "ex2-55",
+    "setOrder":17,
+	"id": "ex2-55",
     "name": "Xatu",
     "imageUrl": "https://images.pokemontcg.io/ex2/55.png",
     "subtype": "Stage 1",
@@ -2918,7 +2973,8 @@
     "nationalPokedexNumber": 178
   },
   {
-    "id": "ex2-56",
+    "setOrder":17,
+	"id": "ex2-56",
     "name": "Aron",
     "imageUrl": "https://images.pokemontcg.io/ex2/56.png",
     "subtype": "Basic",
@@ -2968,7 +3024,8 @@
     ]
   },
   {
-    "id": "ex2-57",
+    "setOrder":17,
+	"id": "ex2-57",
     "name": "Cacnea",
     "imageUrl": "https://images.pokemontcg.io/ex2/57.png",
     "subtype": "Basic",
@@ -3016,7 +3073,8 @@
     ]
   },
   {
-    "id": "ex2-58",
+    "setOrder":17,
+	"id": "ex2-58",
     "name": "Cacnea",
     "imageUrl": "https://images.pokemontcg.io/ex2/58.png",
     "subtype": "Basic",
@@ -3059,7 +3117,8 @@
     ]
   },
   {
-    "id": "ex2-59",
+    "setOrder":17,
+	"id": "ex2-59",
     "name": "Cyndaquil",
     "imageUrl": "https://images.pokemontcg.io/ex2/59.png",
     "subtype": "Basic",
@@ -3111,7 +3170,8 @@
     ]
   },
   {
-    "id": "ex2-60",
+    "setOrder":17,
+	"id": "ex2-60",
     "name": "Dunsparce",
     "imageUrl": "https://images.pokemontcg.io/ex2/60.png",
     "subtype": "Basic",
@@ -3160,7 +3220,8 @@
     "nationalPokedexNumber": 206
   },
   {
-    "id": "ex2-61",
+    "setOrder":17,
+	"id": "ex2-61",
     "name": "Duskull",
     "imageUrl": "https://images.pokemontcg.io/ex2/61.png",
     "subtype": "Basic",
@@ -3218,7 +3279,8 @@
     ]
   },
   {
-    "id": "ex2-62",
+    "setOrder":17,
+	"id": "ex2-62",
     "name": "Duskull",
     "imageUrl": "https://images.pokemontcg.io/ex2/62.png",
     "subtype": "Basic",
@@ -3277,7 +3339,8 @@
     ]
   },
   {
-    "id": "ex2-63",
+    "setOrder":17,
+	"id": "ex2-63",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/ex2/63.png",
     "subtype": "Basic",
@@ -3336,7 +3399,8 @@
     ]
   },
   {
-    "id": "ex2-64",
+    "setOrder":17,
+	"id": "ex2-64",
     "name": "Ekans",
     "imageUrl": "https://images.pokemontcg.io/ex2/64.png",
     "subtype": "Basic",
@@ -3379,7 +3443,8 @@
     ]
   },
   {
-    "id": "ex2-65",
+    "setOrder":17,
+	"id": "ex2-65",
     "name": "Growlithe",
     "imageUrl": "https://images.pokemontcg.io/ex2/65.png",
     "subtype": "Basic",
@@ -3428,7 +3493,8 @@
     ]
   },
   {
-    "id": "ex2-66",
+    "setOrder":17,
+	"id": "ex2-66",
     "name": "Lotad",
     "imageUrl": "https://images.pokemontcg.io/ex2/66.png",
     "subtype": "Basic",
@@ -3476,7 +3542,8 @@
     ]
   },
   {
-    "id": "ex2-67",
+    "setOrder":17,
+	"id": "ex2-67",
     "name": "Lotad",
     "imageUrl": "https://images.pokemontcg.io/ex2/67.png",
     "subtype": "Basic",
@@ -3529,7 +3596,8 @@
     ]
   },
   {
-    "id": "ex2-68",
+    "setOrder":17,
+	"id": "ex2-68",
     "name": "Marill",
     "imageUrl": "https://images.pokemontcg.io/ex2/68.png",
     "subtype": "Basic",
@@ -3573,7 +3641,8 @@
     ]
   },
   {
-    "id": "ex2-69",
+    "setOrder":17,
+	"id": "ex2-69",
     "name": "Natu",
     "imageUrl": "https://images.pokemontcg.io/ex2/69.png",
     "subtype": "Basic",
@@ -3625,7 +3694,8 @@
     ]
   },
   {
-    "id": "ex2-70",
+    "setOrder":17,
+	"id": "ex2-70",
     "name": "Omanyte",
     "imageUrl": "https://images.pokemontcg.io/ex2/70.png",
     "subtype": "Stage 1",
@@ -3679,7 +3749,8 @@
     ]
   },
   {
-    "id": "ex2-71",
+    "setOrder":17,
+	"id": "ex2-71",
     "name": "Onix",
     "imageUrl": "https://images.pokemontcg.io/ex2/71.png",
     "subtype": "Basic",
@@ -3736,7 +3807,8 @@
     ]
   },
   {
-    "id": "ex2-72",
+    "setOrder":17,
+	"id": "ex2-72",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/ex2/72.png",
     "subtype": "Basic",
@@ -3790,7 +3862,8 @@
     ]
   },
   {
-    "id": "ex2-73",
+    "setOrder":17,
+	"id": "ex2-73",
     "name": "Psyduck",
     "imageUrl": "https://images.pokemontcg.io/ex2/73.png",
     "subtype": "Basic",
@@ -3833,7 +3906,8 @@
     ]
   },
   {
-    "id": "ex2-74",
+    "setOrder":17,
+	"id": "ex2-74",
     "name": "Ralts",
     "imageUrl": "https://images.pokemontcg.io/ex2/74.png",
     "subtype": "Basic",
@@ -3885,7 +3959,8 @@
     ]
   },
   {
-    "id": "ex2-75",
+    "setOrder":17,
+	"id": "ex2-75",
     "name": "Sandshrew",
     "imageUrl": "https://images.pokemontcg.io/ex2/75.png",
     "subtype": "Basic",
@@ -3928,7 +4003,8 @@
     ]
   },
   {
-    "id": "ex2-76",
+    "setOrder":17,
+	"id": "ex2-76",
     "name": "Seedot",
     "imageUrl": "https://images.pokemontcg.io/ex2/76.png",
     "subtype": "Basic",
@@ -3971,7 +4047,8 @@
     ]
   },
   {
-    "id": "ex2-77",
+    "setOrder":17,
+	"id": "ex2-77",
     "name": "Seedot",
     "imageUrl": "https://images.pokemontcg.io/ex2/77.png",
     "subtype": "Basic",
@@ -4014,7 +4091,8 @@
     ]
   },
   {
-    "id": "ex2-78",
+    "setOrder":17,
+	"id": "ex2-78",
     "name": "Shroomish",
     "imageUrl": "https://images.pokemontcg.io/ex2/78.png",
     "subtype": "Basic",
@@ -4073,7 +4151,8 @@
     ]
   },
   {
-    "id": "ex2-79",
+    "setOrder":17,
+	"id": "ex2-79",
     "name": "Skitty",
     "imageUrl": "https://images.pokemontcg.io/ex2/79.png",
     "subtype": "Basic",
@@ -4126,7 +4205,8 @@
     ]
   },
   {
-    "id": "ex2-80",
+    "setOrder":17,
+	"id": "ex2-80",
     "name": "Slakoth",
     "imageUrl": "https://images.pokemontcg.io/ex2/80.png",
     "subtype": "Basic",
@@ -4169,7 +4249,8 @@
     ]
   },
   {
-    "id": "ex2-81",
+    "setOrder":17,
+	"id": "ex2-81",
     "name": "Spearow",
     "imageUrl": "https://images.pokemontcg.io/ex2/81.png",
     "subtype": "Basic",
@@ -4227,7 +4308,8 @@
     ]
   },
   {
-    "id": "ex2-82",
+    "setOrder":17,
+	"id": "ex2-82",
     "name": "Trapinch",
     "imageUrl": "https://images.pokemontcg.io/ex2/82.png",
     "subtype": "Basic",
@@ -4280,7 +4362,8 @@
     ]
   },
   {
-    "id": "ex2-83",
+    "setOrder":17,
+	"id": "ex2-83",
     "name": "Wailmer",
     "imageUrl": "https://images.pokemontcg.io/ex2/83.png",
     "subtype": "Basic",
@@ -4337,7 +4420,8 @@
     ]
   },
   {
-    "id": "ex2-84",
+    "setOrder":17,
+	"id": "ex2-84",
     "name": "Wingull",
     "imageUrl": "https://images.pokemontcg.io/ex2/84.png",
     "subtype": "Basic",
@@ -4386,7 +4470,8 @@
     ]
   },
   {
-    "id": "ex2-85",
+    "setOrder":17,
+	"id": "ex2-85",
     "name": "Zigzagoon",
     "imageUrl": "https://images.pokemontcg.io/ex2/85.png",
     "subtype": "Basic",
@@ -4439,7 +4524,8 @@
     ]
   },
   {
-    "id": "ex2-86",
+    "setOrder":17,
+	"id": "ex2-86",
     "name": "Double Full Heal",
     "imageUrl": "https://images.pokemontcg.io/ex2/86.png",
     "subtype": "Item",
@@ -4457,7 +4543,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex2/86_hires.png"
   },
   {
-    "id": "ex2-87",
+    "setOrder":17,
+	"id": "ex2-87",
     "name": "Lanette's Net Search",
     "imageUrl": "https://images.pokemontcg.io/ex2/87.png",
     "subtype": "Supporter",
@@ -4476,7 +4563,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex2/87_hires.png"
   },
   {
-    "id": "ex2-88",
+    "setOrder":17,
+	"id": "ex2-88",
     "name": "Rare Candy",
     "imageUrl": "https://images.pokemontcg.io/ex2/88.png",
     "subtype": "Item",
@@ -4494,7 +4582,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex2/88_hires.png"
   },
   {
-    "id": "ex2-89",
+    "setOrder":17,
+	"id": "ex2-89",
     "name": "Wally's Training",
     "imageUrl": "https://images.pokemontcg.io/ex2/89.png",
     "subtype": "Supporter",
@@ -4513,7 +4602,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex2/89_hires.png"
   },
   {
-    "id": "ex2-90",
+    "setOrder":17,
+	"id": "ex2-90",
     "name": "Claw Fossil",
     "imageUrl": "https://images.pokemontcg.io/ex2/90.png",
     "subtype": "Item",
@@ -4532,7 +4622,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex2/90_hires.png"
   },
   {
-    "id": "ex2-91",
+    "setOrder":17,
+	"id": "ex2-91",
     "name": "Mysterious Fossil",
     "imageUrl": "https://images.pokemontcg.io/ex2/91.png",
     "subtype": "Item",
@@ -4550,7 +4641,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex2/91_hires.png"
   },
   {
-    "id": "ex2-92",
+    "setOrder":17,
+	"id": "ex2-92",
     "name": "Root Fossil",
     "imageUrl": "https://images.pokemontcg.io/ex2/92.png",
     "subtype": "Item",
@@ -4569,7 +4661,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex2/92_hires.png"
   },
   {
-    "id": "ex2-93",
+    "setOrder":17,
+	"id": "ex2-93",
     "name": "Multi Energy",
     "imageUrl": "https://images.pokemontcg.io/ex2/93.png",
     "subtype": "Special",
@@ -4586,7 +4679,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex2/93_hires.png"
   },
   {
-    "id": "ex2-94",
+    "setOrder":17,
+	"id": "ex2-94",
     "name": "Aerodactyl ex",
     "imageUrl": "https://images.pokemontcg.io/ex2/94.png",
     "subtype": "EX",
@@ -4653,7 +4747,8 @@
     "nationalPokedexNumber": 142
   },
   {
-    "id": "ex2-95",
+    "setOrder":17,
+	"id": "ex2-95",
     "name": "Aggron ex",
     "imageUrl": "https://images.pokemontcg.io/ex2/95.png",
     "subtype": "EX",
@@ -4726,7 +4821,8 @@
     "nationalPokedexNumber": 306
   },
   {
-    "id": "ex2-96",
+    "setOrder":17,
+	"id": "ex2-96",
     "name": "Gardevoir ex",
     "imageUrl": "https://images.pokemontcg.io/ex2/96.png",
     "subtype": "EX",
@@ -4789,7 +4885,8 @@
     "nationalPokedexNumber": 282
   },
   {
-    "id": "ex2-97",
+    "setOrder":17,
+	"id": "ex2-97",
     "name": "Kabutops ex",
     "imageUrl": "https://images.pokemontcg.io/ex2/97.png",
     "subtype": "EX",
@@ -4851,7 +4948,8 @@
     "nationalPokedexNumber": 141
   },
   {
-    "id": "ex2-98",
+    "setOrder":17,
+	"id": "ex2-98",
     "name": "Raichu ex",
     "imageUrl": "https://images.pokemontcg.io/ex2/98.png",
     "subtype": "EX",
@@ -4907,7 +5005,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "ex2-99",
+    "setOrder":17,
+	"id": "ex2-99",
     "name": "Typhlosion ex",
     "imageUrl": "https://images.pokemontcg.io/ex2/99.png",
     "subtype": "EX",
@@ -4972,7 +5071,8 @@
     "nationalPokedexNumber": 157
   },
   {
-    "id": "ex2-100",
+    "setOrder":17,
+	"id": "ex2-100",
     "name": "Wailord ex",
     "imageUrl": "https://images.pokemontcg.io/ex2/100.png",
     "subtype": "EX",

--- a/json/cards/Secret Wonders.json
+++ b/json/cards/Secret Wonders.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "dp3-1",
+    "setOrder":34,
+	"id": "dp3-1",
     "name": "Ampharos",
     "imageUrl": "https://images.pokemontcg.io/dp3/1.png",
     "subtype": "Stage 2",
@@ -57,7 +58,8 @@
     "nationalPokedexNumber": 181
   },
   {
-    "id": "dp3-2",
+    "setOrder":34,
+	"id": "dp3-2",
     "name": "Blastoise",
     "imageUrl": "https://images.pokemontcg.io/dp3/2.png",
     "subtype": "Stage 2",
@@ -107,7 +109,8 @@
     "nationalPokedexNumber": 9
   },
   {
-    "id": "dp3-3",
+    "setOrder":34,
+	"id": "dp3-3",
     "name": "Charizard",
     "imageUrl": "https://images.pokemontcg.io/dp3/3.png",
     "subtype": "Stage 2",
@@ -165,7 +168,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "dp3-4",
+    "setOrder":34,
+	"id": "dp3-4",
     "name": "Entei",
     "imageUrl": "https://images.pokemontcg.io/dp3/4.png",
     "subtype": "Basic",
@@ -214,7 +218,8 @@
     "nationalPokedexNumber": 244
   },
   {
-    "id": "dp3-5",
+    "setOrder":34,
+	"id": "dp3-5",
     "name": "Flygon",
     "imageUrl": "https://images.pokemontcg.io/dp3/5.png",
     "subtype": "Stage 2",
@@ -269,7 +274,8 @@
     "nationalPokedexNumber": 330
   },
   {
-    "id": "dp3-6",
+    "setOrder":34,
+	"id": "dp3-6",
     "name": "Gallade",
     "imageUrl": "https://images.pokemontcg.io/dp3/6.png",
     "subtype": "Stage 2",
@@ -324,7 +330,8 @@
     "nationalPokedexNumber": 475
   },
   {
-    "id": "dp3-7",
+    "setOrder":34,
+	"id": "dp3-7",
     "name": "Gardevoir",
     "imageUrl": "https://images.pokemontcg.io/dp3/7.png",
     "subtype": "Stage 2",
@@ -374,7 +381,8 @@
     "nationalPokedexNumber": 282
   },
   {
-    "id": "dp3-8",
+    "setOrder":34,
+	"id": "dp3-8",
     "name": "Gastrodon East Sea",
     "imageUrl": "https://images.pokemontcg.io/dp3/8.png",
     "subtype": "Stage 1",
@@ -432,7 +440,8 @@
     "nationalPokedexNumber": 423
   },
   {
-    "id": "dp3-9",
+    "setOrder":34,
+	"id": "dp3-9",
     "name": "Gastrodon West Sea",
     "imageUrl": "https://images.pokemontcg.io/dp3/9.png",
     "subtype": "Stage 1",
@@ -496,7 +505,8 @@
     "nationalPokedexNumber": 423
   },
   {
-    "id": "dp3-10",
+    "setOrder":34,
+	"id": "dp3-10",
     "name": "Ho-Oh",
     "imageUrl": "https://images.pokemontcg.io/dp3/10.png",
     "subtype": "Basic",
@@ -552,7 +562,8 @@
     "nationalPokedexNumber": 250
   },
   {
-    "id": "dp3-11",
+    "setOrder":34,
+	"id": "dp3-11",
     "name": "Jumpluff",
     "imageUrl": "https://images.pokemontcg.io/dp3/11.png",
     "subtype": "Stage 2",
@@ -603,7 +614,8 @@
     "nationalPokedexNumber": 189
   },
   {
-    "id": "dp3-12",
+    "setOrder":34,
+	"id": "dp3-12",
     "name": "Lickilicky",
     "imageUrl": "https://images.pokemontcg.io/dp3/12.png",
     "subtype": "Stage 1",
@@ -661,7 +673,8 @@
     "nationalPokedexNumber": 463
   },
   {
-    "id": "dp3-13",
+    "setOrder":34,
+	"id": "dp3-13",
     "name": "Ludicolo",
     "imageUrl": "https://images.pokemontcg.io/dp3/13.png",
     "subtype": "Stage 2",
@@ -711,7 +724,8 @@
     "nationalPokedexNumber": 272
   },
   {
-    "id": "dp3-14",
+    "setOrder":34,
+	"id": "dp3-14",
     "name": "Lugia",
     "imageUrl": "https://images.pokemontcg.io/dp3/14.png",
     "subtype": "Basic",
@@ -770,7 +784,8 @@
     "nationalPokedexNumber": 249
   },
   {
-    "id": "dp3-15",
+    "setOrder":34,
+	"id": "dp3-15",
     "name": "Mew",
     "imageUrl": "https://images.pokemontcg.io/dp3/15.png",
     "subtype": "Basic",
@@ -822,7 +837,8 @@
     "nationalPokedexNumber": 151
   },
   {
-    "id": "dp3-16",
+    "setOrder":34,
+	"id": "dp3-16",
     "name": "Raikou",
     "imageUrl": "https://images.pokemontcg.io/dp3/16.png",
     "subtype": "Basic",
@@ -877,7 +893,8 @@
     "nationalPokedexNumber": 243
   },
   {
-    "id": "dp3-17",
+    "setOrder":34,
+	"id": "dp3-17",
     "name": "Roserade",
     "imageUrl": "https://images.pokemontcg.io/dp3/17.png",
     "subtype": "Stage 1",
@@ -930,7 +947,8 @@
     "nationalPokedexNumber": 407
   },
   {
-    "id": "dp3-18",
+    "setOrder":34,
+	"id": "dp3-18",
     "name": "Salamence",
     "imageUrl": "https://images.pokemontcg.io/dp3/18.png",
     "subtype": "Stage 2",
@@ -993,7 +1011,8 @@
     "nationalPokedexNumber": 373
   },
   {
-    "id": "dp3-19",
+    "setOrder":34,
+	"id": "dp3-19",
     "name": "Suicune",
     "imageUrl": "https://images.pokemontcg.io/dp3/19.png",
     "subtype": "Basic",
@@ -1041,7 +1060,8 @@
     "nationalPokedexNumber": 245
   },
   {
-    "id": "dp3-20",
+    "setOrder":34,
+	"id": "dp3-20",
     "name": "Venusaur",
     "imageUrl": "https://images.pokemontcg.io/dp3/20.png",
     "subtype": "Stage 2",
@@ -1092,7 +1112,8 @@
     "nationalPokedexNumber": 3
   },
   {
-    "id": "dp3-21",
+    "setOrder":34,
+	"id": "dp3-21",
     "name": "Absol",
     "imageUrl": "https://images.pokemontcg.io/dp3/21.png",
     "subtype": "Basic",
@@ -1148,7 +1169,8 @@
     "nationalPokedexNumber": 359
   },
   {
-    "id": "dp3-22",
+    "setOrder":34,
+	"id": "dp3-22",
     "name": "Arcanine",
     "imageUrl": "https://images.pokemontcg.io/dp3/22.png",
     "subtype": "Stage 1",
@@ -1199,7 +1221,8 @@
     "nationalPokedexNumber": 59
   },
   {
-    "id": "dp3-23",
+    "setOrder":34,
+	"id": "dp3-23",
     "name": "Banette",
     "imageUrl": "https://images.pokemontcg.io/dp3/23.png",
     "subtype": "Stage 1",
@@ -1257,7 +1280,8 @@
     "nationalPokedexNumber": 354
   },
   {
-    "id": "dp3-24",
+    "setOrder":34,
+	"id": "dp3-24",
     "name": "Dugtrio",
     "imageUrl": "https://images.pokemontcg.io/dp3/24.png",
     "subtype": "Stage 1",
@@ -1314,7 +1338,8 @@
     "nationalPokedexNumber": 51
   },
   {
-    "id": "dp3-25",
+    "setOrder":34,
+	"id": "dp3-25",
     "name": "Electivire",
     "imageUrl": "https://images.pokemontcg.io/dp3/25.png",
     "subtype": "Stage 1",
@@ -1371,7 +1396,8 @@
     "nationalPokedexNumber": 466
   },
   {
-    "id": "dp3-26",
+    "setOrder":34,
+	"id": "dp3-26",
     "name": "Electrode",
     "imageUrl": "https://images.pokemontcg.io/dp3/26.png",
     "subtype": "Stage 1",
@@ -1422,7 +1448,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "dp3-27",
+    "setOrder":34,
+	"id": "dp3-27",
     "name": "Furret",
     "imageUrl": "https://images.pokemontcg.io/dp3/27.png",
     "subtype": "Stage 1",
@@ -1474,7 +1501,8 @@
     "nationalPokedexNumber": 162
   },
   {
-    "id": "dp3-28",
+    "setOrder":34,
+	"id": "dp3-28",
     "name": "Golduck",
     "imageUrl": "https://images.pokemontcg.io/dp3/28.png",
     "subtype": "Stage 1",
@@ -1526,7 +1554,8 @@
     "nationalPokedexNumber": 55
   },
   {
-    "id": "dp3-29",
+    "setOrder":34,
+	"id": "dp3-29",
     "name": "Golem",
     "imageUrl": "https://images.pokemontcg.io/dp3/29.png",
     "subtype": "Stage 2",
@@ -1591,7 +1620,8 @@
     "nationalPokedexNumber": 76
   },
   {
-    "id": "dp3-30",
+    "setOrder":34,
+	"id": "dp3-30",
     "name": "Jynx",
     "imageUrl": "https://images.pokemontcg.io/dp3/30.png",
     "subtype": "Basic",
@@ -1644,7 +1674,8 @@
     "nationalPokedexNumber": 124
   },
   {
-    "id": "dp3-31",
+    "setOrder":34,
+	"id": "dp3-31",
     "name": "Magmortar",
     "imageUrl": "https://images.pokemontcg.io/dp3/31.png",
     "subtype": "Stage 1",
@@ -1704,7 +1735,8 @@
     "nationalPokedexNumber": 467
   },
   {
-    "id": "dp3-32",
+    "setOrder":34,
+	"id": "dp3-32",
     "name": "Minun",
     "imageUrl": "https://images.pokemontcg.io/dp3/32.png",
     "subtype": "Basic",
@@ -1756,7 +1788,8 @@
     "nationalPokedexNumber": 312
   },
   {
-    "id": "dp3-33",
+    "setOrder":34,
+	"id": "dp3-33",
     "name": "Mothim",
     "imageUrl": "https://images.pokemontcg.io/dp3/33.png",
     "subtype": "Stage 1",
@@ -1814,7 +1847,8 @@
     ]
   },
   {
-    "id": "dp3-34",
+    "setOrder":34,
+	"id": "dp3-34",
     "name": "Nidoking",
     "imageUrl": "https://images.pokemontcg.io/dp3/34.png",
     "subtype": "Stage 2",
@@ -1870,7 +1904,8 @@
     "nationalPokedexNumber": 34
   },
   {
-    "id": "dp3-35",
+    "setOrder":34,
+	"id": "dp3-35",
     "name": "Pidgeot",
     "imageUrl": "https://images.pokemontcg.io/dp3/35.png",
     "subtype": "Stage 2",
@@ -1926,7 +1961,8 @@
     "nationalPokedexNumber": 18
   },
   {
-    "id": "dp3-36",
+    "setOrder":34,
+	"id": "dp3-36",
     "name": "Plusle",
     "imageUrl": "https://images.pokemontcg.io/dp3/36.png",
     "subtype": "Basic",
@@ -1978,7 +2014,8 @@
     "nationalPokedexNumber": 311
   },
   {
-    "id": "dp3-37",
+    "setOrder":34,
+	"id": "dp3-37",
     "name": "Sharpedo",
     "imageUrl": "https://images.pokemontcg.io/dp3/37.png",
     "subtype": "Stage 1",
@@ -2030,7 +2067,8 @@
     "nationalPokedexNumber": 319
   },
   {
-    "id": "dp3-38",
+    "setOrder":34,
+	"id": "dp3-38",
     "name": "Sunflora",
     "imageUrl": "https://images.pokemontcg.io/dp3/38.png",
     "subtype": "Stage 1",
@@ -2085,7 +2123,8 @@
     "nationalPokedexNumber": 192
   },
   {
-    "id": "dp3-39",
+    "setOrder":34,
+	"id": "dp3-39",
     "name": "Unown S",
     "imageUrl": "https://images.pokemontcg.io/dp3/39.png",
     "subtype": "Basic",
@@ -2131,7 +2170,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp3-40",
+    "setOrder":34,
+	"id": "dp3-40",
     "name": "Weavile",
     "imageUrl": "https://images.pokemontcg.io/dp3/40.png",
     "subtype": "Stage 1",
@@ -2185,7 +2225,8 @@
     "nationalPokedexNumber": 461
   },
   {
-    "id": "dp3-41",
+    "setOrder":34,
+	"id": "dp3-41",
     "name": "Wormadam Plant Cloak",
     "imageUrl": "https://images.pokemontcg.io/dp3/41.png",
     "subtype": "Stage 1",
@@ -2237,7 +2278,8 @@
     ]
   },
   {
-    "id": "dp3-42",
+    "setOrder":34,
+	"id": "dp3-42",
     "name": "Wormadam Sandy Cloak",
     "imageUrl": "https://images.pokemontcg.io/dp3/42.png",
     "subtype": "Stage 1",
@@ -2295,7 +2337,8 @@
     ]
   },
   {
-    "id": "dp3-43",
+    "setOrder":34,
+	"id": "dp3-43",
     "name": "Wormadam Trash Cloak",
     "imageUrl": "https://images.pokemontcg.io/dp3/43.png",
     "subtype": "Stage 1",
@@ -2353,7 +2396,8 @@
     ]
   },
   {
-    "id": "dp3-44",
+    "setOrder":34,
+	"id": "dp3-44",
     "name": "Xatu",
     "imageUrl": "https://images.pokemontcg.io/dp3/44.png",
     "subtype": "Stage 1",
@@ -2407,7 +2451,8 @@
     "nationalPokedexNumber": 178
   },
   {
-    "id": "dp3-45",
+    "setOrder":34,
+	"id": "dp3-45",
     "name": "Breloom",
     "imageUrl": "https://images.pokemontcg.io/dp3/45.png",
     "subtype": "Stage 1",
@@ -2462,7 +2507,8 @@
     "nationalPokedexNumber": 286
   },
   {
-    "id": "dp3-46",
+    "setOrder":34,
+	"id": "dp3-46",
     "name": "Charmeleon",
     "imageUrl": "https://images.pokemontcg.io/dp3/46.png",
     "subtype": "Stage 1",
@@ -2518,7 +2564,8 @@
     ]
   },
   {
-    "id": "dp3-47",
+    "setOrder":34,
+	"id": "dp3-47",
     "name": "Cloyster",
     "imageUrl": "https://images.pokemontcg.io/dp3/47.png",
     "subtype": "Stage 1",
@@ -2571,7 +2618,8 @@
     "nationalPokedexNumber": 91
   },
   {
-    "id": "dp3-48",
+    "setOrder":34,
+	"id": "dp3-48",
     "name": "Donphan",
     "imageUrl": "https://images.pokemontcg.io/dp3/48.png",
     "subtype": "Stage 1",
@@ -2634,7 +2682,8 @@
     "nationalPokedexNumber": 232
   },
   {
-    "id": "dp3-49",
+    "setOrder":34,
+	"id": "dp3-49",
     "name": "Farfetch'd",
     "imageUrl": "https://images.pokemontcg.io/dp3/49.png",
     "subtype": "Basic",
@@ -2690,7 +2739,8 @@
     "nationalPokedexNumber": 83
   },
   {
-    "id": "dp3-50",
+    "setOrder":34,
+	"id": "dp3-50",
     "name": "Flaaffy",
     "imageUrl": "https://images.pokemontcg.io/dp3/50.png",
     "subtype": "Stage 1",
@@ -2752,7 +2802,8 @@
     ]
   },
   {
-    "id": "dp3-51",
+    "setOrder":34,
+	"id": "dp3-51",
     "name": "Ivysaur",
     "imageUrl": "https://images.pokemontcg.io/dp3/51.png",
     "subtype": "Stage 1",
@@ -2810,7 +2861,8 @@
     ]
   },
   {
-    "id": "dp3-52",
+    "setOrder":34,
+	"id": "dp3-52",
     "name": "Kecleon",
     "imageUrl": "https://images.pokemontcg.io/dp3/52.png",
     "subtype": "Basic",
@@ -2857,7 +2909,8 @@
     "nationalPokedexNumber": 352
   },
   {
-    "id": "dp3-53",
+    "setOrder":34,
+	"id": "dp3-53",
     "name": "Kirlia",
     "imageUrl": "https://images.pokemontcg.io/dp3/53.png",
     "subtype": "Stage 1",
@@ -2914,7 +2967,8 @@
     ]
   },
   {
-    "id": "dp3-54",
+    "setOrder":34,
+	"id": "dp3-54",
     "name": "Lombre",
     "imageUrl": "https://images.pokemontcg.io/dp3/54.png",
     "subtype": "Stage 1",
@@ -2970,7 +3024,8 @@
     ]
   },
   {
-    "id": "dp3-55",
+    "setOrder":34,
+	"id": "dp3-55",
     "name": "Miltank",
     "imageUrl": "https://images.pokemontcg.io/dp3/55.png",
     "subtype": "Basic",
@@ -3022,7 +3077,8 @@
     "nationalPokedexNumber": 241
   },
   {
-    "id": "dp3-56",
+    "setOrder":34,
+	"id": "dp3-56",
     "name": "Muk",
     "imageUrl": "https://images.pokemontcg.io/dp3/56.png",
     "subtype": "Stage 1",
@@ -3072,7 +3128,8 @@
     "nationalPokedexNumber": 89
   },
   {
-    "id": "dp3-57",
+    "setOrder":34,
+	"id": "dp3-57",
     "name": "Nidorino",
     "imageUrl": "https://images.pokemontcg.io/dp3/57.png",
     "subtype": "Stage 1",
@@ -3129,7 +3186,8 @@
     ]
   },
   {
-    "id": "dp3-58",
+    "setOrder":34,
+	"id": "dp3-58",
     "name": "Pidgeotto",
     "imageUrl": "https://images.pokemontcg.io/dp3/58.png",
     "subtype": "Stage 1",
@@ -3187,7 +3245,8 @@
     ]
   },
   {
-    "id": "dp3-59",
+    "setOrder":34,
+	"id": "dp3-59",
     "name": "Pinsir",
     "imageUrl": "https://images.pokemontcg.io/dp3/59.png",
     "subtype": "Basic",
@@ -3239,7 +3298,8 @@
     "nationalPokedexNumber": 127
   },
   {
-    "id": "dp3-60",
+    "setOrder":34,
+	"id": "dp3-60",
     "name": "Quagsire",
     "imageUrl": "https://images.pokemontcg.io/dp3/60.png",
     "subtype": "Stage 1",
@@ -3296,7 +3356,8 @@
     "nationalPokedexNumber": 195
   },
   {
-    "id": "dp3-61",
+    "setOrder":34,
+	"id": "dp3-61",
     "name": "Raticate",
     "imageUrl": "https://images.pokemontcg.io/dp3/61.png",
     "subtype": "Stage 1",
@@ -3344,7 +3405,8 @@
     "nationalPokedexNumber": 20
   },
   {
-    "id": "dp3-62",
+    "setOrder":34,
+	"id": "dp3-62",
     "name": "Roselia",
     "imageUrl": "https://images.pokemontcg.io/dp3/62.png",
     "subtype": "Basic",
@@ -3397,7 +3459,8 @@
     ]
   },
   {
-    "id": "dp3-63",
+    "setOrder":34,
+	"id": "dp3-63",
     "name": "Sableye",
     "imageUrl": "https://images.pokemontcg.io/dp3/63.png",
     "subtype": "Basic",
@@ -3448,7 +3511,8 @@
     "nationalPokedexNumber": 302
   },
   {
-    "id": "dp3-64",
+    "setOrder":34,
+	"id": "dp3-64",
     "name": "Shelgon",
     "imageUrl": "https://images.pokemontcg.io/dp3/64.png",
     "subtype": "Stage 1",
@@ -3511,7 +3575,8 @@
     ]
   },
   {
-    "id": "dp3-65",
+    "setOrder":34,
+	"id": "dp3-65",
     "name": "Skiploom",
     "imageUrl": "https://images.pokemontcg.io/dp3/65.png",
     "subtype": "Stage 1",
@@ -3564,7 +3629,8 @@
     ]
   },
   {
-    "id": "dp3-66",
+    "setOrder":34,
+	"id": "dp3-66",
     "name": "Smeargle",
     "imageUrl": "https://images.pokemontcg.io/dp3/66.png",
     "subtype": "Basic",
@@ -3614,7 +3680,8 @@
     "nationalPokedexNumber": 235
   },
   {
-    "id": "dp3-67",
+    "setOrder":34,
+	"id": "dp3-67",
     "name": "Smoochum",
     "imageUrl": "https://images.pokemontcg.io/dp3/67.png",
     "subtype": "Basic",
@@ -3663,7 +3730,8 @@
     ]
   },
   {
-    "id": "dp3-68",
+    "setOrder":34,
+	"id": "dp3-68",
     "name": "Unown K",
     "imageUrl": "https://images.pokemontcg.io/dp3/68.png",
     "subtype": "Basic",
@@ -3709,7 +3777,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp3-69",
+    "setOrder":34,
+	"id": "dp3-69",
     "name": "Unown N",
     "imageUrl": "https://images.pokemontcg.io/dp3/69.png",
     "subtype": "Basic",
@@ -3755,7 +3824,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp3-70",
+    "setOrder":34,
+	"id": "dp3-70",
     "name": "Unown O",
     "imageUrl": "https://images.pokemontcg.io/dp3/70.png",
     "subtype": "Basic",
@@ -3801,7 +3871,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp3-71",
+    "setOrder":34,
+	"id": "dp3-71",
     "name": "Unown X",
     "imageUrl": "https://images.pokemontcg.io/dp3/71.png",
     "subtype": "Basic",
@@ -3847,7 +3918,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp3-72",
+    "setOrder":34,
+	"id": "dp3-72",
     "name": "Unown Z",
     "imageUrl": "https://images.pokemontcg.io/dp3/72.png",
     "subtype": "Basic",
@@ -3894,7 +3966,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "dp3-73",
+    "setOrder":34,
+	"id": "dp3-73",
     "name": "Venomoth",
     "imageUrl": "https://images.pokemontcg.io/dp3/73.png",
     "subtype": "Stage 1",
@@ -3948,7 +4021,8 @@
     "nationalPokedexNumber": 49
   },
   {
-    "id": "dp3-74",
+    "setOrder":34,
+	"id": "dp3-74",
     "name": "Vibrava",
     "imageUrl": "https://images.pokemontcg.io/dp3/74.png",
     "subtype": "Stage 1",
@@ -4010,7 +4084,8 @@
     ]
   },
   {
-    "id": "dp3-75",
+    "setOrder":34,
+	"id": "dp3-75",
     "name": "Wartortle",
     "imageUrl": "https://images.pokemontcg.io/dp3/75.png",
     "subtype": "Stage 1",
@@ -4067,7 +4142,8 @@
     ]
   },
   {
-    "id": "dp3-76",
+    "setOrder":34,
+	"id": "dp3-76",
     "name": "Bagon",
     "imageUrl": "https://images.pokemontcg.io/dp3/76.png",
     "subtype": "Basic",
@@ -4127,7 +4203,8 @@
     ]
   },
   {
-    "id": "dp3-77",
+    "setOrder":34,
+	"id": "dp3-77",
     "name": "Bulbasaur",
     "imageUrl": "https://images.pokemontcg.io/dp3/77.png",
     "subtype": "Basic",
@@ -4181,7 +4258,8 @@
     ]
   },
   {
-    "id": "dp3-78",
+    "setOrder":34,
+	"id": "dp3-78",
     "name": "Burmy Plant Cloak",
     "imageUrl": "https://images.pokemontcg.io/dp3/78.png",
     "subtype": "Basic",
@@ -4230,7 +4308,8 @@
     ]
   },
   {
-    "id": "dp3-79",
+    "setOrder":34,
+	"id": "dp3-79",
     "name": "Burmy Sandy Cloak",
     "imageUrl": "https://images.pokemontcg.io/dp3/79.png",
     "subtype": "Basic",
@@ -4279,7 +4358,8 @@
     ]
   },
   {
-    "id": "dp3-80",
+    "setOrder":34,
+	"id": "dp3-80",
     "name": "Burmy Trash Cloak",
     "imageUrl": "https://images.pokemontcg.io/dp3/80.png",
     "subtype": "Basic",
@@ -4328,7 +4408,8 @@
     ]
   },
   {
-    "id": "dp3-81",
+    "setOrder":34,
+	"id": "dp3-81",
     "name": "Carvanha",
     "imageUrl": "https://images.pokemontcg.io/dp3/81.png",
     "subtype": "Basic",
@@ -4388,7 +4469,8 @@
     ]
   },
   {
-    "id": "dp3-82",
+    "setOrder":34,
+	"id": "dp3-82",
     "name": "Charmander",
     "imageUrl": "https://images.pokemontcg.io/dp3/82.png",
     "subtype": "Basic",
@@ -4442,7 +4524,8 @@
     ]
   },
   {
-    "id": "dp3-83",
+    "setOrder":34,
+	"id": "dp3-83",
     "name": "Clefairy",
     "imageUrl": "https://images.pokemontcg.io/dp3/83.png",
     "subtype": "Basic",
@@ -4489,7 +4572,8 @@
     ]
   },
   {
-    "id": "dp3-84",
+    "setOrder":34,
+	"id": "dp3-84",
     "name": "Corsola",
     "imageUrl": "https://images.pokemontcg.io/dp3/84.png",
     "subtype": "Basic",
@@ -4540,7 +4624,8 @@
     "nationalPokedexNumber": 222
   },
   {
-    "id": "dp3-85",
+    "setOrder":34,
+	"id": "dp3-85",
     "name": "Diglett",
     "imageUrl": "https://images.pokemontcg.io/dp3/85.png",
     "subtype": "Basic",
@@ -4600,7 +4685,8 @@
     ]
   },
   {
-    "id": "dp3-86",
+    "setOrder":34,
+	"id": "dp3-86",
     "name": "Duskull",
     "imageUrl": "https://images.pokemontcg.io/dp3/86.png",
     "subtype": "Basic",
@@ -4653,7 +4739,8 @@
     ]
   },
   {
-    "id": "dp3-87",
+    "setOrder":34,
+	"id": "dp3-87",
     "name": "Electabuzz",
     "imageUrl": "https://images.pokemontcg.io/dp3/87.png",
     "subtype": "Basic",
@@ -4715,7 +4802,8 @@
     ]
   },
   {
-    "id": "dp3-88",
+    "setOrder":34,
+	"id": "dp3-88",
     "name": "Grimer",
     "imageUrl": "https://images.pokemontcg.io/dp3/88.png",
     "subtype": "Basic",
@@ -4769,7 +4857,8 @@
     ]
   },
   {
-    "id": "dp3-89",
+    "setOrder":34,
+	"id": "dp3-89",
     "name": "Growlithe",
     "imageUrl": "https://images.pokemontcg.io/dp3/89.png",
     "subtype": "Basic",
@@ -4824,7 +4913,8 @@
     ]
   },
   {
-    "id": "dp3-90",
+    "setOrder":34,
+	"id": "dp3-90",
     "name": "Hoppip",
     "imageUrl": "https://images.pokemontcg.io/dp3/90.png",
     "subtype": "Basic",
@@ -4879,7 +4969,8 @@
     ]
   },
   {
-    "id": "dp3-91",
+    "setOrder":34,
+	"id": "dp3-91",
     "name": "Lickitung",
     "imageUrl": "https://images.pokemontcg.io/dp3/91.png",
     "subtype": "Basic",
@@ -4935,7 +5026,8 @@
     ]
   },
   {
-    "id": "dp3-92",
+    "setOrder":34,
+	"id": "dp3-92",
     "name": "Lotad",
     "imageUrl": "https://images.pokemontcg.io/dp3/92.png",
     "subtype": "Basic",
@@ -4989,7 +5081,8 @@
     ]
   },
   {
-    "id": "dp3-93",
+    "setOrder":34,
+	"id": "dp3-93",
     "name": "Magmar",
     "imageUrl": "https://images.pokemontcg.io/dp3/93.png",
     "subtype": "Basic",
@@ -5044,7 +5137,8 @@
     ]
   },
   {
-    "id": "dp3-94",
+    "setOrder":34,
+	"id": "dp3-94",
     "name": "Mareep",
     "imageUrl": "https://images.pokemontcg.io/dp3/94.png",
     "subtype": "Basic",
@@ -5104,7 +5198,8 @@
     ]
   },
   {
-    "id": "dp3-95",
+    "setOrder":34,
+	"id": "dp3-95",
     "name": "Murkrow",
     "imageUrl": "https://images.pokemontcg.io/dp3/95.png",
     "subtype": "Basic",
@@ -5158,7 +5253,8 @@
     ]
   },
   {
-    "id": "dp3-96",
+    "setOrder":34,
+	"id": "dp3-96",
     "name": "Natu",
     "imageUrl": "https://images.pokemontcg.io/dp3/96.png",
     "subtype": "Basic",
@@ -5217,7 +5313,8 @@
     ]
   },
   {
-    "id": "dp3-97",
+    "setOrder":34,
+	"id": "dp3-97",
     "name": "Nidoran♂",
     "imageUrl": "https://images.pokemontcg.io/dp3/97.png",
     "subtype": "Basic",
@@ -5270,7 +5367,8 @@
     ]
   },
   {
-    "id": "dp3-98",
+    "setOrder":34,
+	"id": "dp3-98",
     "name": "Phanpy",
     "imageUrl": "https://images.pokemontcg.io/dp3/98.png",
     "subtype": "Basic",
@@ -5330,7 +5428,8 @@
     ]
   },
   {
-    "id": "dp3-99",
+    "setOrder":34,
+	"id": "dp3-99",
     "name": "Pidgey",
     "imageUrl": "https://images.pokemontcg.io/dp3/99.png",
     "subtype": "Basic",
@@ -5390,7 +5489,8 @@
     ]
   },
   {
-    "id": "dp3-100",
+    "setOrder":34,
+	"id": "dp3-100",
     "name": "Psyduck",
     "imageUrl": "https://images.pokemontcg.io/dp3/100.png",
     "subtype": "Basic",
@@ -5443,7 +5543,8 @@
     ]
   },
   {
-    "id": "dp3-101",
+    "setOrder":34,
+	"id": "dp3-101",
     "name": "Qwilfish",
     "imageUrl": "https://images.pokemontcg.io/dp3/101.png",
     "subtype": "Basic",
@@ -5490,7 +5591,8 @@
     "nationalPokedexNumber": 211
   },
   {
-    "id": "dp3-102",
+    "setOrder":34,
+	"id": "dp3-102",
     "name": "Ralts",
     "imageUrl": "https://images.pokemontcg.io/dp3/102.png",
     "subtype": "Basic",
@@ -5543,7 +5645,8 @@
     ]
   },
   {
-    "id": "dp3-103",
+    "setOrder":34,
+	"id": "dp3-103",
     "name": "Rattata",
     "imageUrl": "https://images.pokemontcg.io/dp3/103.png",
     "subtype": "Basic",
@@ -5593,7 +5696,8 @@
     ]
   },
   {
-    "id": "dp3-104",
+    "setOrder":34,
+	"id": "dp3-104",
     "name": "Sentret",
     "imageUrl": "https://images.pokemontcg.io/dp3/104.png",
     "subtype": "Basic",
@@ -5646,7 +5750,8 @@
     ]
   },
   {
-    "id": "dp3-105",
+    "setOrder":34,
+	"id": "dp3-105",
     "name": "Shellder",
     "imageUrl": "https://images.pokemontcg.io/dp3/105.png",
     "subtype": "Basic",
@@ -5700,7 +5805,8 @@
     ]
   },
   {
-    "id": "dp3-106",
+    "setOrder":34,
+	"id": "dp3-106",
     "name": "Shellos East Sea",
     "imageUrl": "https://images.pokemontcg.io/dp3/106.png",
     "subtype": "Basic",
@@ -5754,7 +5860,8 @@
     ]
   },
   {
-    "id": "dp3-107",
+    "setOrder":34,
+	"id": "dp3-107",
     "name": "Shellos West Sea",
     "imageUrl": "https://images.pokemontcg.io/dp3/107.png",
     "subtype": "Basic",
@@ -5807,7 +5914,8 @@
     ]
   },
   {
-    "id": "dp3-108",
+    "setOrder":34,
+	"id": "dp3-108",
     "name": "Shroomish",
     "imageUrl": "https://images.pokemontcg.io/dp3/108.png",
     "subtype": "Basic",
@@ -5867,7 +5975,8 @@
     ]
   },
   {
-    "id": "dp3-109",
+    "setOrder":34,
+	"id": "dp3-109",
     "name": "Shuckle",
     "imageUrl": "https://images.pokemontcg.io/dp3/109.png",
     "subtype": "Basic",
@@ -5914,7 +6023,8 @@
     "nationalPokedexNumber": 213
   },
   {
-    "id": "dp3-110",
+    "setOrder":34,
+	"id": "dp3-110",
     "name": "Shuppet",
     "imageUrl": "https://images.pokemontcg.io/dp3/110.png",
     "subtype": "Basic",
@@ -5974,7 +6084,8 @@
     ]
   },
   {
-    "id": "dp3-111",
+    "setOrder":34,
+	"id": "dp3-111",
     "name": "Spinda",
     "imageUrl": "https://images.pokemontcg.io/dp3/111.png",
     "subtype": "Basic",
@@ -6024,7 +6135,8 @@
     "nationalPokedexNumber": 327
   },
   {
-    "id": "dp3-112",
+    "setOrder":34,
+	"id": "dp3-112",
     "name": "Squirtle",
     "imageUrl": "https://images.pokemontcg.io/dp3/112.png",
     "subtype": "Basic",
@@ -6078,7 +6190,8 @@
     ]
   },
   {
-    "id": "dp3-113",
+    "setOrder":34,
+	"id": "dp3-113",
     "name": "Stantler",
     "imageUrl": "https://images.pokemontcg.io/dp3/113.png",
     "subtype": "Basic",
@@ -6129,7 +6242,8 @@
     "nationalPokedexNumber": 234
   },
   {
-    "id": "dp3-114",
+    "setOrder":34,
+	"id": "dp3-114",
     "name": "Sunkern",
     "imageUrl": "https://images.pokemontcg.io/dp3/114.png",
     "subtype": "Basic",
@@ -6188,7 +6302,8 @@
     ]
   },
   {
-    "id": "dp3-115",
+    "setOrder":34,
+	"id": "dp3-115",
     "name": "Trapinch",
     "imageUrl": "https://images.pokemontcg.io/dp3/115.png",
     "subtype": "Basic",
@@ -6247,7 +6362,8 @@
     ]
   },
   {
-    "id": "dp3-116",
+    "setOrder":34,
+	"id": "dp3-116",
     "name": "Venonat",
     "imageUrl": "https://images.pokemontcg.io/dp3/116.png",
     "subtype": "Basic",
@@ -6300,7 +6416,8 @@
     ]
   },
   {
-    "id": "dp3-117",
+    "setOrder":34,
+	"id": "dp3-117",
     "name": "Voltorb",
     "imageUrl": "https://images.pokemontcg.io/dp3/117.png",
     "subtype": "Basic",
@@ -6360,7 +6477,8 @@
     ]
   },
   {
-    "id": "dp3-118",
+    "setOrder":34,
+	"id": "dp3-118",
     "name": "Wooper",
     "imageUrl": "https://images.pokemontcg.io/dp3/118.png",
     "subtype": "Basic",
@@ -6419,7 +6537,8 @@
     ]
   },
   {
-    "id": "dp3-119",
+    "setOrder":34,
+	"id": "dp3-119",
     "name": "Bebe's Search",
     "imageUrl": "https://images.pokemontcg.io/dp3/119.png",
     "subtype": "Supporter",
@@ -6438,7 +6557,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp3/119_hires.png"
   },
   {
-    "id": "dp3-120",
+    "setOrder":34,
+	"id": "dp3-120",
     "name": "Night Maintenance",
     "imageUrl": "https://images.pokemontcg.io/dp3/120.png",
     "subtype": "Item",
@@ -6456,7 +6576,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp3/120_hires.png"
   },
   {
-    "id": "dp3-121",
+    "setOrder":34,
+	"id": "dp3-121",
     "name": "PlusPower",
     "imageUrl": "https://images.pokemontcg.io/dp3/121.png",
     "subtype": "Item",
@@ -6474,7 +6595,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp3/121_hires.png"
   },
   {
-    "id": "dp3-122",
+    "setOrder":34,
+	"id": "dp3-122",
     "name": "Professor Oak's Visit",
     "imageUrl": "https://images.pokemontcg.io/dp3/122.png",
     "subtype": "Supporter",
@@ -6493,7 +6615,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp3/122_hires.png"
   },
   {
-    "id": "dp3-123",
+    "setOrder":34,
+	"id": "dp3-123",
     "name": "Professor Rowan",
     "imageUrl": "https://images.pokemontcg.io/dp3/123.png",
     "subtype": "Supporter",
@@ -6512,7 +6635,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp3/123_hires.png"
   },
   {
-    "id": "dp3-124",
+    "setOrder":34,
+	"id": "dp3-124",
     "name": "Rival",
     "imageUrl": "https://images.pokemontcg.io/dp3/124.png",
     "subtype": "Supporter",
@@ -6531,7 +6655,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp3/124_hires.png"
   },
   {
-    "id": "dp3-125",
+    "setOrder":34,
+	"id": "dp3-125",
     "name": "Roseanne's Research",
     "imageUrl": "https://images.pokemontcg.io/dp3/125.png",
     "subtype": "Supporter",
@@ -6550,7 +6675,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp3/125_hires.png"
   },
   {
-    "id": "dp3-126",
+    "setOrder":34,
+	"id": "dp3-126",
     "name": "Team Galactic's Mars",
     "imageUrl": "https://images.pokemontcg.io/dp3/126.png",
     "subtype": "Supporter",
@@ -6569,7 +6695,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp3/126_hires.png"
   },
   {
-    "id": "dp3-127",
+    "setOrder":34,
+	"id": "dp3-127",
     "name": "Potion",
     "imageUrl": "https://images.pokemontcg.io/dp3/127.png",
     "subtype": "Item",
@@ -6587,7 +6714,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp3/127_hires.png"
   },
   {
-    "id": "dp3-128",
+    "setOrder":34,
+	"id": "dp3-128",
     "name": "Switch",
     "imageUrl": "https://images.pokemontcg.io/dp3/128.png",
     "subtype": "Item",
@@ -6605,7 +6733,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp3/128_hires.png"
   },
   {
-    "id": "dp3-129",
+    "setOrder":34,
+	"id": "dp3-129",
     "name": "Darkness Energy",
     "imageUrl": "https://images.pokemontcg.io/dp3/129.png",
     "subtype": "Special",
@@ -6622,7 +6751,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp3/129_hires.png"
   },
   {
-    "id": "dp3-130",
+    "setOrder":34,
+	"id": "dp3-130",
     "name": "Metal Energy",
     "imageUrl": "https://images.pokemontcg.io/dp3/130.png",
     "subtype": "Special",
@@ -6639,7 +6769,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp3/130_hires.png"
   },
   {
-    "id": "dp3-131",
+    "setOrder":34,
+	"id": "dp3-131",
     "name": "Gardevoir",
     "imageUrl": "https://images.pokemontcg.io/dp3/131.png",
     "subtype": "Level Up",
@@ -6690,7 +6821,8 @@
     "nationalPokedexNumber": 282
   },
   {
-    "id": "dp3-132",
+    "setOrder":34,
+	"id": "dp3-132",
     "name": "Honchkrow",
     "imageUrl": "https://images.pokemontcg.io/dp3/132.png",
     "subtype": "Level Up",

--- a/json/cards/Shining Legends.json
+++ b/json/cards/Shining Legends.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "sm35-1",
+    "setOrder":75,
+	"id": "sm35-1",
     "name": "Bulbasaur",
     "imageUrl": "https://images.pokemontcg.io/sm35/1.png",
     "subtype": "Basic",
@@ -45,7 +46,8 @@
     ]
   },
   {
-    "id": "sm35-2",
+    "setOrder":75,
+	"id": "sm35-2",
     "name": "Ivysaur",
     "imageUrl": "https://images.pokemontcg.io/sm35/2.png",
     "subtype": "Stage 1",
@@ -105,7 +107,8 @@
     ]
   },
   {
-    "id": "sm35-3",
+    "setOrder":75,
+	"id": "sm35-3",
     "name": "Venusaur",
     "imageUrl": "https://images.pokemontcg.io/sm35/3.png",
     "subtype": "Stage 2",
@@ -157,7 +160,8 @@
     "nationalPokedexNumber": 3
   },
   {
-    "id": "sm35-4",
+    "setOrder":75,
+	"id": "sm35-4",
     "name": "Shroomish",
     "imageUrl": "https://images.pokemontcg.io/sm35/4.png",
     "subtype": "Basic",
@@ -201,7 +205,8 @@
     ]
   },
   {
-    "id": "sm35-5",
+    "setOrder":75,
+	"id": "sm35-5",
     "name": "Breloom",
     "imageUrl": "https://images.pokemontcg.io/sm35/5.png",
     "subtype": "Stage 1",
@@ -254,7 +259,8 @@
     "nationalPokedexNumber": 286
   },
   {
-    "id": "sm35-6",
+    "setOrder":75,
+	"id": "sm35-6",
     "name": "Carnivine",
     "imageUrl": "https://images.pokemontcg.io/sm35/6.png",
     "subtype": "Basic",
@@ -305,7 +311,8 @@
     "nationalPokedexNumber": 455
   },
   {
-    "id": "sm35-7",
+    "setOrder":75,
+	"id": "sm35-7",
     "name": "Shaymin (Sky Forme)",
     "imageUrl": "https://images.pokemontcg.io/sm35/7.png",
     "subtype": "Basic",
@@ -355,7 +362,8 @@
     "nationalPokedexNumber": 492
   },
   {
-    "id": "sm35-8",
+    "setOrder":75,
+	"id": "sm35-8",
     "name": "Virizion",
     "imageUrl": "https://images.pokemontcg.io/sm35/8.png",
     "subtype": "Basic",
@@ -406,7 +414,8 @@
     "nationalPokedexNumber": 640
   },
   {
-    "id": "sm35-9",
+    "setOrder":75,
+	"id": "sm35-9",
     "name": "Shining Genesect",
     "imageUrl": "https://images.pokemontcg.io/sm35/9.png",
     "subtype": "Basic",
@@ -454,7 +463,8 @@
     "nationalPokedexNumber": 649
   },
   {
-    "id": "sm35-10",
+    "setOrder":75,
+	"id": "sm35-10",
     "name": "Entei-GX",
     "imageUrl": "https://images.pokemontcg.io/sm35/10.png",
     "subtype": "GX",
@@ -522,7 +532,8 @@
     "nationalPokedexNumber": 244
   },
   {
-    "id": "sm35-11",
+    "setOrder":75,
+	"id": "sm35-11",
     "name": "Torkoal",
     "imageUrl": "https://images.pokemontcg.io/sm35/11.png",
     "subtype": "Basic",
@@ -576,7 +587,8 @@
     "nationalPokedexNumber": 324
   },
   {
-    "id": "sm35-12",
+    "setOrder":75,
+	"id": "sm35-12",
     "name": "Larvesta",
     "imageUrl": "https://images.pokemontcg.io/sm35/12.png",
     "subtype": "Basic",
@@ -622,7 +634,8 @@
     ]
   },
   {
-    "id": "sm35-13",
+    "setOrder":75,
+	"id": "sm35-13",
     "name": "Volcarona",
     "imageUrl": "https://images.pokemontcg.io/sm35/13.png",
     "subtype": "Stage 1",
@@ -669,7 +682,8 @@
     "nationalPokedexNumber": 637
   },
   {
-    "id": "sm35-14",
+    "setOrder":75,
+	"id": "sm35-14",
     "name": "Reshiram",
     "imageUrl": "https://images.pokemontcg.io/sm35/14.png",
     "subtype": "Basic",
@@ -723,7 +737,8 @@
     "nationalPokedexNumber": 643
   },
   {
-    "id": "sm35-15",
+    "setOrder":75,
+	"id": "sm35-15",
     "name": "Litten",
     "imageUrl": "https://images.pokemontcg.io/sm35/15.png",
     "subtype": "Basic",
@@ -766,7 +781,8 @@
     ]
   },
   {
-    "id": "sm35-16",
+    "setOrder":75,
+	"id": "sm35-16",
     "name": "Torracat",
     "imageUrl": "https://images.pokemontcg.io/sm35/16.png",
     "subtype": "Stage 1",
@@ -820,7 +836,8 @@
     ]
   },
   {
-    "id": "sm35-17",
+    "setOrder":75,
+	"id": "sm35-17",
     "name": "Incineroar",
     "imageUrl": "https://images.pokemontcg.io/sm35/17.png",
     "subtype": "Stage 2",
@@ -874,7 +891,8 @@
     "nationalPokedexNumber": 727
   },
   {
-    "id": "sm35-18",
+    "setOrder":75,
+	"id": "sm35-18",
     "name": "Totodile",
     "imageUrl": "https://images.pokemontcg.io/sm35/18.png",
     "subtype": "Basic",
@@ -927,7 +945,8 @@
     ]
   },
   {
-    "id": "sm35-19",
+    "setOrder":75,
+	"id": "sm35-19",
     "name": "Croconaw",
     "imageUrl": "https://images.pokemontcg.io/sm35/19.png",
     "subtype": "Stage 1",
@@ -980,7 +999,8 @@
     ]
   },
   {
-    "id": "sm35-20",
+    "setOrder":75,
+	"id": "sm35-20",
     "name": "Feraligatr",
     "imageUrl": "https://images.pokemontcg.io/sm35/20.png",
     "subtype": "Stage 2",
@@ -1037,7 +1057,8 @@
     "nationalPokedexNumber": 160
   },
   {
-    "id": "sm35-21",
+    "setOrder":75,
+	"id": "sm35-21",
     "name": "Qwilfish",
     "imageUrl": "https://images.pokemontcg.io/sm35/21.png",
     "subtype": "Basic",
@@ -1087,7 +1108,8 @@
     "nationalPokedexNumber": 211
   },
   {
-    "id": "sm35-22",
+    "setOrder":75,
+	"id": "sm35-22",
     "name": "Buizel",
     "imageUrl": "https://images.pokemontcg.io/sm35/22.png",
     "subtype": "Basic",
@@ -1141,7 +1163,8 @@
     ]
   },
   {
-    "id": "sm35-23",
+    "setOrder":75,
+	"id": "sm35-23",
     "name": "Floatzel",
     "imageUrl": "https://images.pokemontcg.io/sm35/23.png",
     "subtype": "Stage 1",
@@ -1193,7 +1216,8 @@
     "nationalPokedexNumber": 419
   },
   {
-    "id": "sm35-24",
+    "setOrder":75,
+	"id": "sm35-24",
     "name": "Palkia",
     "imageUrl": "https://images.pokemontcg.io/sm35/24.png",
     "subtype": "Basic",
@@ -1246,7 +1270,8 @@
     "nationalPokedexNumber": 484
   },
   {
-    "id": "sm35-25",
+    "setOrder":75,
+	"id": "sm35-25",
     "name": "Manaphy",
     "imageUrl": "https://images.pokemontcg.io/sm35/25.png",
     "subtype": "Basic",
@@ -1292,7 +1317,8 @@
     "nationalPokedexNumber": 490
   },
   {
-    "id": "sm35-26",
+    "setOrder":75,
+	"id": "sm35-26",
     "name": "Keldeo",
     "imageUrl": "https://images.pokemontcg.io/sm35/26.png",
     "subtype": "Basic",
@@ -1343,7 +1369,8 @@
     "nationalPokedexNumber": 647
   },
   {
-    "id": "sm35-27",
+    "setOrder":75,
+	"id": "sm35-27",
     "name": "Shining Volcanion",
     "imageUrl": "https://images.pokemontcg.io/sm35/27.png",
     "subtype": "Basic",
@@ -1399,7 +1426,8 @@
     "nationalPokedexNumber": 721
   },
   {
-    "id": "sm35-28",
+    "setOrder":75,
+	"id": "sm35-28",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/sm35/28.png",
     "subtype": "Basic",
@@ -1448,7 +1476,8 @@
     ]
   },
   {
-    "id": "sm35-29",
+    "setOrder":75,
+	"id": "sm35-29",
     "name": "Raichu-GX",
     "imageUrl": "https://images.pokemontcg.io/sm35/29.png",
     "subtype": "GX",
@@ -1522,7 +1551,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "sm35-30",
+    "setOrder":75,
+	"id": "sm35-30",
     "name": "Voltorb",
     "imageUrl": "https://images.pokemontcg.io/sm35/30.png",
     "subtype": "Basic",
@@ -1571,7 +1601,8 @@
     ]
   },
   {
-    "id": "sm35-31",
+    "setOrder":75,
+	"id": "sm35-31",
     "name": "Electrode",
     "imageUrl": "https://images.pokemontcg.io/sm35/31.png",
     "subtype": "Stage 1",
@@ -1615,7 +1646,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "sm35-32",
+    "setOrder":75,
+	"id": "sm35-32",
     "name": "Raikou",
     "imageUrl": "https://images.pokemontcg.io/sm35/32.png",
     "subtype": "Basic",
@@ -1673,7 +1705,8 @@
     "nationalPokedexNumber": 243
   },
   {
-    "id": "sm35-33",
+    "setOrder":75,
+	"id": "sm35-33",
     "name": "Plusle",
     "imageUrl": "https://images.pokemontcg.io/sm35/33.png",
     "subtype": "Basic",
@@ -1719,7 +1752,8 @@
     "nationalPokedexNumber": 311
   },
   {
-    "id": "sm35-34",
+    "setOrder":75,
+	"id": "sm35-34",
     "name": "Minun",
     "imageUrl": "https://images.pokemontcg.io/sm35/34.png",
     "subtype": "Basic",
@@ -1774,7 +1808,8 @@
     "nationalPokedexNumber": 312
   },
   {
-    "id": "sm35-35",
+    "setOrder":75,
+	"id": "sm35-35",
     "name": "Zekrom",
     "imageUrl": "https://images.pokemontcg.io/sm35/35.png",
     "subtype": "Basic",
@@ -1834,7 +1869,8 @@
     "nationalPokedexNumber": 644
   },
   {
-    "id": "sm35-36",
+    "setOrder":75,
+	"id": "sm35-36",
     "name": "Ekans",
     "imageUrl": "https://images.pokemontcg.io/sm35/36.png",
     "subtype": "Basic",
@@ -1878,7 +1914,8 @@
     ]
   },
   {
-    "id": "sm35-37",
+    "setOrder":75,
+	"id": "sm35-37",
     "name": "Arbok",
     "imageUrl": "https://images.pokemontcg.io/sm35/37.png",
     "subtype": "Stage 1",
@@ -1928,7 +1965,8 @@
     "nationalPokedexNumber": 24
   },
   {
-    "id": "sm35-38",
+    "setOrder":75,
+	"id": "sm35-38",
     "name": "Jynx",
     "imageUrl": "https://images.pokemontcg.io/sm35/38.png",
     "subtype": "Basic",
@@ -1978,7 +2016,8 @@
     "nationalPokedexNumber": 124
   },
   {
-    "id": "sm35-39",
+    "setOrder":75,
+	"id": "sm35-39",
     "name": "Mewtwo-GX",
     "imageUrl": "https://images.pokemontcg.io/sm35/39.png",
     "subtype": "GX",
@@ -2044,7 +2083,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "sm35-40",
+    "setOrder":75,
+	"id": "sm35-40",
     "name": "Shining Mew",
     "imageUrl": "https://images.pokemontcg.io/sm35/40.png",
     "subtype": "Basic",
@@ -2090,7 +2130,8 @@
     "nationalPokedexNumber": 151
   },
   {
-    "id": "sm35-41",
+    "setOrder":75,
+	"id": "sm35-41",
     "name": "Latios",
     "imageUrl": "https://images.pokemontcg.io/sm35/41.png",
     "subtype": "Basic",
@@ -2142,7 +2183,8 @@
     "nationalPokedexNumber": 381
   },
   {
-    "id": "sm35-42",
+    "setOrder":75,
+	"id": "sm35-42",
     "name": "Shining Jirachi",
     "imageUrl": "https://images.pokemontcg.io/sm35/42.png",
     "subtype": "Basic",
@@ -2182,7 +2224,8 @@
     "nationalPokedexNumber": 385
   },
   {
-    "id": "sm35-43",
+    "setOrder":75,
+	"id": "sm35-43",
     "name": "Golett",
     "imageUrl": "https://images.pokemontcg.io/sm35/43.png",
     "subtype": "Basic",
@@ -2235,7 +2278,8 @@
     ]
   },
   {
-    "id": "sm35-44",
+    "setOrder":75,
+	"id": "sm35-44",
     "name": "Golurk",
     "imageUrl": "https://images.pokemontcg.io/sm35/44.png",
     "subtype": "Stage 1",
@@ -2299,7 +2343,8 @@
     "nationalPokedexNumber": 623
   },
   {
-    "id": "sm35-45",
+    "setOrder":75,
+	"id": "sm35-45",
     "name": "Marshadow",
     "imageUrl": "https://images.pokemontcg.io/sm35/45.png",
     "subtype": "Basic",
@@ -2351,7 +2396,8 @@
     "nationalPokedexNumber": 802
   },
   {
-    "id": "sm35-46",
+    "setOrder":75,
+	"id": "sm35-46",
     "name": "Stunfisk",
     "imageUrl": "https://images.pokemontcg.io/sm35/46.png",
     "subtype": "Basic",
@@ -2405,7 +2451,8 @@
     "nationalPokedexNumber": 618
   },
   {
-    "id": "sm35-47",
+    "setOrder":75,
+	"id": "sm35-47",
     "name": "Spiritomb",
     "imageUrl": "https://images.pokemontcg.io/sm35/47.png",
     "subtype": "Basic",
@@ -2446,7 +2493,8 @@
     "nationalPokedexNumber": 442
   },
   {
-    "id": "sm35-48",
+    "setOrder":75,
+	"id": "sm35-48",
     "name": "Purrloin",
     "imageUrl": "https://images.pokemontcg.io/sm35/48.png",
     "subtype": "Basic",
@@ -2505,7 +2553,8 @@
     ]
   },
   {
-    "id": "sm35-49",
+    "setOrder":75,
+	"id": "sm35-49",
     "name": "Liepard",
     "imageUrl": "https://images.pokemontcg.io/sm35/49.png",
     "subtype": "Stage 1",
@@ -2562,7 +2611,8 @@
     "nationalPokedexNumber": 510
   },
   {
-    "id": "sm35-50",
+    "setOrder":75,
+	"id": "sm35-50",
     "name": "Scraggy",
     "imageUrl": "https://images.pokemontcg.io/sm35/50.png",
     "subtype": "Basic",
@@ -2621,7 +2671,8 @@
     ]
   },
   {
-    "id": "sm35-51",
+    "setOrder":75,
+	"id": "sm35-51",
     "name": "Scrafty",
     "imageUrl": "https://images.pokemontcg.io/sm35/51.png",
     "subtype": "Stage 1",
@@ -2681,7 +2732,8 @@
     "nationalPokedexNumber": 560
   },
   {
-    "id": "sm35-52",
+    "setOrder":75,
+	"id": "sm35-52",
     "name": "Zorua",
     "imageUrl": "https://images.pokemontcg.io/sm35/52.png",
     "subtype": "Basic",
@@ -2740,7 +2792,8 @@
     ]
   },
   {
-    "id": "sm35-53",
+    "setOrder":75,
+	"id": "sm35-53",
     "name": "Zoroark-GX",
     "imageUrl": "https://images.pokemontcg.io/sm35/53.png",
     "subtype": "GX",
@@ -2808,7 +2861,8 @@
     "nationalPokedexNumber": 571
   },
   {
-    "id": "sm35-54",
+    "setOrder":75,
+	"id": "sm35-54",
     "name": "Yveltal",
     "imageUrl": "https://images.pokemontcg.io/sm35/54.png",
     "subtype": "Basic",
@@ -2867,7 +2921,8 @@
     "nationalPokedexNumber": 717
   },
   {
-    "id": "sm35-55",
+    "setOrder":75,
+	"id": "sm35-55",
     "name": "Hoopa(Hoopa Unbound)",
     "imageUrl": "https://images.pokemontcg.io/sm35/55.png",
     "subtype": "Basic",
@@ -2920,7 +2975,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm35/55_hires.png"
   },
   {
-    "id": "sm35-56",
+    "setOrder":75,
+	"id": "sm35-56",
     "name": "Shining Rayquaza",
     "imageUrl": "https://images.pokemontcg.io/sm35/56.png",
     "subtype": "Basic",
@@ -2974,7 +3030,8 @@
     "nationalPokedexNumber": 384
   },
   {
-    "id": "sm35-57",
+    "setOrder":75,
+	"id": "sm35-57",
     "name": "Shining Arceus",
     "imageUrl": "https://images.pokemontcg.io/sm35/57.png",
     "subtype": "Basic",
@@ -3023,7 +3080,8 @@
     "nationalPokedexNumber": 493
   },
   {
-    "id": "sm35-58",
+    "setOrder":75,
+	"id": "sm35-58",
     "name": "Damage Mover",
     "imageUrl": "https://images.pokemontcg.io/sm35/58.png",
     "subtype": "Item",
@@ -3040,7 +3098,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm35/58_hires.png"
   },
   {
-    "id": "sm35-59",
+    "setOrder":75,
+	"id": "sm35-59",
     "name": "Energy Retrieval",
     "imageUrl": "https://images.pokemontcg.io/sm35/59.png",
     "subtype": "Item",
@@ -3057,7 +3116,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm35/59_hires.png"
   },
   {
-    "id": "sm35-60",
+    "setOrder":75,
+	"id": "sm35-60",
     "name": "Great Ball",
     "imageUrl": "https://images.pokemontcg.io/sm35/60.png",
     "subtype": "Item",
@@ -3074,7 +3134,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm35/60_hires.png"
   },
   {
-    "id": "sm35-61",
+    "setOrder":75,
+	"id": "sm35-61",
     "name": "Hau",
     "imageUrl": "https://images.pokemontcg.io/sm35/61.png",
     "subtype": "Supporter",
@@ -3091,7 +3152,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm35/61_hires.png"
   },
   {
-    "id": "sm35-62",
+    "setOrder":75,
+	"id": "sm35-62",
     "name": "Lillie",
     "imageUrl": "https://images.pokemontcg.io/sm35/62.png",
     "subtype": "Supporter",
@@ -3108,7 +3170,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm35/62_hires.png"
   },
   {
-    "id": "sm35-63",
+    "setOrder":75,
+	"id": "sm35-63",
     "name": "Pokémon Breeder",
     "imageUrl": "https://images.pokemontcg.io/sm35/63.png",
     "subtype": "Supporter",
@@ -3125,7 +3188,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm35/63_hires.png"
   },
   {
-    "id": "sm35-64",
+    "setOrder":75,
+	"id": "sm35-64",
     "name": "Pokémon Catcher",
     "imageUrl": "https://images.pokemontcg.io/sm35/64.png",
     "subtype": "Item",
@@ -3142,7 +3206,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm35/64_hires.png"
   },
   {
-    "id": "sm35-65",
+    "setOrder":75,
+	"id": "sm35-65",
     "name": "Sophocles",
     "imageUrl": "https://images.pokemontcg.io/sm35/65.png",
     "subtype": "Supporter",
@@ -3159,7 +3224,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm35/65_hires.png"
   },
   {
-    "id": "sm35-66",
+    "setOrder":75,
+	"id": "sm35-66",
     "name": "Super Scoop Up",
     "imageUrl": "https://images.pokemontcg.io/sm35/66.png",
     "subtype": "Item",
@@ -3176,7 +3242,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm35/66_hires.png"
   },
   {
-    "id": "sm35-67",
+    "setOrder":75,
+	"id": "sm35-67",
     "name": "Switch",
     "imageUrl": "https://images.pokemontcg.io/sm35/67.png",
     "subtype": "Item",
@@ -3193,7 +3260,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm35/67_hires.png"
   },
   {
-    "id": "sm35-68",
+    "setOrder":75,
+	"id": "sm35-68",
     "name": "Ultra Ball",
     "imageUrl": "https://images.pokemontcg.io/sm35/68.png",
     "subtype": "Item",
@@ -3210,7 +3278,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm35/68_hires.png"
   },
   {
-    "id": "sm35-69",
+    "setOrder":75,
+	"id": "sm35-69",
     "name": "Double Colorless Energy",
     "imageUrl": "https://images.pokemontcg.io/sm35/69.png",
     "subtype": "Special",
@@ -3227,7 +3296,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm35/69_hires.png"
   },
   {
-    "id": "sm35-70",
+    "setOrder":75,
+	"id": "sm35-70",
     "name": "Warp Energy",
     "imageUrl": "https://images.pokemontcg.io/sm35/70.png",
     "subtype": "Special",
@@ -3244,7 +3314,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm35/70_hires.png"
   },
   {
-    "id": "sm35-71",
+    "setOrder":75,
+	"id": "sm35-71",
     "name": "Entei-GX",
     "imageUrl": "https://images.pokemontcg.io/sm35/71.png",
     "subtype": "GX",
@@ -3312,7 +3383,8 @@
     "nationalPokedexNumber": 244
   },
   {
-    "id": "sm35-72",
+    "setOrder":75,
+	"id": "sm35-72",
     "name": "Mewtwo-GX",
     "imageUrl": "https://images.pokemontcg.io/sm35/72.png",
     "subtype": "GX",
@@ -3378,7 +3450,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "sm35-73",
+    "setOrder":75,
+	"id": "sm35-73",
     "name": "Pokémon Breeder",
     "imageUrl": "https://images.pokemontcg.io/sm35/73.png",
     "subtype": "Supporter",
@@ -3395,7 +3468,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm35/73_hires.png"
   },
   {
-    "id": "sm35-74",
+    "setOrder":75,
+	"id": "sm35-74",
     "name": "Entei-GX",
     "imageUrl": "https://images.pokemontcg.io/sm35/74.png",
     "subtype": "GX",
@@ -3463,7 +3537,8 @@
     "nationalPokedexNumber": 244
   },
   {
-    "id": "sm35-75",
+    "setOrder":75,
+	"id": "sm35-75",
     "name": "Raichu-GX",
     "imageUrl": "https://images.pokemontcg.io/sm35/75.png",
     "subtype": "GX",
@@ -3537,7 +3612,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "sm35-76",
+    "setOrder":75,
+	"id": "sm35-76",
     "name": "Mewtwo-GX",
     "imageUrl": "https://images.pokemontcg.io/sm35/76.png",
     "subtype": "GX",
@@ -3603,7 +3679,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "sm35-77",
+    "setOrder":75,
+	"id": "sm35-77",
     "name": "Zoroark-GX",
     "imageUrl": "https://images.pokemontcg.io/sm35/77.png",
     "subtype": "GX",
@@ -3671,7 +3748,8 @@
     "nationalPokedexNumber": 571
   },
   {
-    "id": "sm35-78",
+    "setOrder":75,
+	"id": "sm35-78",
     "name": "Mewtwo-GX",
     "imageUrl": "https://images.pokemontcg.io/sm35/78.png",
     "subtype": "GX",

--- a/json/cards/Skyridge.json
+++ b/json/cards/Skyridge.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "ecard3-151",
+    "setOrder":15,
+	"id": "ecard3-151",
     "name": "Alakazam",
     "imageUrl": "https://images.pokemontcg.io/ecard3/151.png",
     "subtype": "Stage 2",
@@ -49,7 +50,8 @@
     "nationalPokedexNumber": 65
   },
   {
-    "id": "ecard3-1",
+    "setOrder":15,
+	"id": "ecard3-1",
     "name": "Aerodactyl",
     "imageUrl": "https://images.pokemontcg.io/ecard3/1.png",
     "subtype": "Stage 1",
@@ -96,7 +98,8 @@
     "nationalPokedexNumber": 142
   },
   {
-    "id": "ecard3-152",
+    "setOrder":15,
+	"id": "ecard3-152",
     "name": "Arcanine",
     "imageUrl": "https://images.pokemontcg.io/ecard3/152.png",
     "subtype": "Stage 1",
@@ -154,7 +157,8 @@
     "nationalPokedexNumber": 59
   },
   {
-    "id": "ecard3-2",
+    "setOrder":15,
+	"id": "ecard3-2",
     "name": "Alakazam",
     "imageUrl": "https://images.pokemontcg.io/ecard3/2.png",
     "subtype": "Stage 2",
@@ -203,7 +207,8 @@
     "nationalPokedexNumber": 65
   },
   {
-    "id": "ecard3-153",
+    "setOrder":15,
+	"id": "ecard3-153",
     "name": "Articuno",
     "imageUrl": "https://images.pokemontcg.io/ecard3/153.png",
     "subtype": "Basic",
@@ -267,7 +272,8 @@
     "nationalPokedexNumber": 144
   },
   {
-    "id": "ecard3-3",
+    "setOrder":15,
+	"id": "ecard3-3",
     "name": "Arcanine",
     "imageUrl": "https://images.pokemontcg.io/ecard3/3.png",
     "subtype": "Stage 1",
@@ -325,7 +331,8 @@
     "nationalPokedexNumber": 59
   },
   {
-    "id": "ecard3-154",
+    "setOrder":15,
+	"id": "ecard3-154",
     "name": "Beedrill",
     "imageUrl": "https://images.pokemontcg.io/ecard3/154.png",
     "subtype": "Stage 2",
@@ -369,7 +376,8 @@
     "nationalPokedexNumber": 15
   },
   {
-    "id": "ecard3-4",
+    "setOrder":15,
+	"id": "ecard3-4",
     "name": "Articuno",
     "imageUrl": "https://images.pokemontcg.io/ecard3/4.png",
     "subtype": "Basic",
@@ -433,7 +441,8 @@
     "nationalPokedexNumber": 144
   },
   {
-    "id": "ecard3-5",
+    "setOrder":15,
+	"id": "ecard3-5",
     "name": "Beedrill",
     "imageUrl": "https://images.pokemontcg.io/ecard3/5.png",
     "subtype": "Stage 2",
@@ -477,7 +486,8 @@
     "nationalPokedexNumber": 15
   },
   {
-    "id": "ecard3-155",
+    "setOrder":15,
+	"id": "ecard3-155",
     "name": "Crobat",
     "imageUrl": "https://images.pokemontcg.io/ecard3/155.png",
     "subtype": "Stage 2",
@@ -522,7 +532,8 @@
     "nationalPokedexNumber": 169
   },
   {
-    "id": "ecard3-6",
+    "setOrder":15,
+	"id": "ecard3-6",
     "name": "Crobat",
     "imageUrl": "https://images.pokemontcg.io/ecard3/6.png",
     "subtype": "Stage 2",
@@ -567,7 +578,8 @@
     "nationalPokedexNumber": 169
   },
   {
-    "id": "ecard3-156",
+    "setOrder":15,
+	"id": "ecard3-156",
     "name": "Dewgong",
     "imageUrl": "https://images.pokemontcg.io/ecard3/156.png",
     "subtype": "Stage 1",
@@ -622,7 +634,8 @@
     "nationalPokedexNumber": 87
   },
   {
-    "id": "ecard3-7",
+    "setOrder":15,
+	"id": "ecard3-7",
     "name": "Dewgong",
     "imageUrl": "https://images.pokemontcg.io/ecard3/7.png",
     "subtype": "Stage 1",
@@ -677,7 +690,8 @@
     "nationalPokedexNumber": 87
   },
   {
-    "id": "ecard3-157",
+    "setOrder":15,
+	"id": "ecard3-157",
     "name": "Flareon",
     "imageUrl": "https://images.pokemontcg.io/ecard3/157.png",
     "subtype": "Stage 1",
@@ -734,7 +748,8 @@
     "nationalPokedexNumber": 136
   },
   {
-    "id": "ecard3-8",
+    "setOrder":15,
+	"id": "ecard3-8",
     "name": "Flareon",
     "imageUrl": "https://images.pokemontcg.io/ecard3/8.png",
     "subtype": "Stage 1",
@@ -791,7 +806,8 @@
     "nationalPokedexNumber": 136
   },
   {
-    "id": "ecard3-158",
+    "setOrder":15,
+	"id": "ecard3-158",
     "name": "Forretress",
     "imageUrl": "https://images.pokemontcg.io/ecard3/158.png",
     "subtype": "Stage 1",
@@ -851,7 +867,8 @@
     "nationalPokedexNumber": 205
   },
   {
-    "id": "ecard3-159",
+    "setOrder":15,
+	"id": "ecard3-159",
     "name": "Gengar",
     "imageUrl": "https://images.pokemontcg.io/ecard3/159.png",
     "subtype": "Stage 2",
@@ -907,7 +924,8 @@
     "nationalPokedexNumber": 94
   },
   {
-    "id": "ecard3-9",
+    "setOrder":15,
+	"id": "ecard3-9",
     "name": "Forretress",
     "imageUrl": "https://images.pokemontcg.io/ecard3/9.png",
     "subtype": "Stage 1",
@@ -967,7 +985,8 @@
     "nationalPokedexNumber": 205
   },
   {
-    "id": "ecard3-10",
+    "setOrder":15,
+	"id": "ecard3-10",
     "name": "Gengar",
     "imageUrl": "https://images.pokemontcg.io/ecard3/10.png",
     "subtype": "Stage 2",
@@ -1023,7 +1042,8 @@
     "nationalPokedexNumber": 94
   },
   {
-    "id": "ecard3-160",
+    "setOrder":15,
+	"id": "ecard3-160",
     "name": "Gyarados",
     "imageUrl": "https://images.pokemontcg.io/ecard3/160.png",
     "subtype": "Stage 1",
@@ -1073,7 +1093,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "ecard3-161",
+    "setOrder":15,
+	"id": "ecard3-161",
     "name": "Houndoom",
     "imageUrl": "https://images.pokemontcg.io/ecard3/161.png",
     "subtype": "Stage 1",
@@ -1132,7 +1153,8 @@
     "nationalPokedexNumber": 229
   },
   {
-    "id": "ecard3-11",
+    "setOrder":15,
+	"id": "ecard3-11",
     "name": "Gyarados",
     "imageUrl": "https://images.pokemontcg.io/ecard3/11.png",
     "subtype": "Stage 1",
@@ -1182,7 +1204,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "ecard3-162",
+    "setOrder":15,
+	"id": "ecard3-162",
     "name": "Jolteon",
     "imageUrl": "https://images.pokemontcg.io/ecard3/162.png",
     "subtype": "Stage 1",
@@ -1236,7 +1259,8 @@
     "nationalPokedexNumber": 135
   },
   {
-    "id": "ecard3-12",
+    "setOrder":15,
+	"id": "ecard3-12",
     "name": "Houndoom",
     "imageUrl": "https://images.pokemontcg.io/ecard3/12.png",
     "subtype": "Stage 1",
@@ -1295,7 +1319,8 @@
     "nationalPokedexNumber": 229
   },
   {
-    "id": "ecard3-163",
+    "setOrder":15,
+	"id": "ecard3-163",
     "name": "Kabutops",
     "imageUrl": "https://images.pokemontcg.io/ecard3/163.png",
     "subtype": "Stage 2",
@@ -1344,7 +1369,8 @@
     "nationalPokedexNumber": 141
   },
   {
-    "id": "ecard3-13",
+    "setOrder":15,
+	"id": "ecard3-13",
     "name": "Jolteon",
     "imageUrl": "https://images.pokemontcg.io/ecard3/13.png",
     "subtype": "Stage 1",
@@ -1398,7 +1424,8 @@
     "nationalPokedexNumber": 135
   },
   {
-    "id": "ecard3-14",
+    "setOrder":15,
+	"id": "ecard3-14",
     "name": "Kabutops",
     "imageUrl": "https://images.pokemontcg.io/ecard3/14.png",
     "subtype": "Stage 2",
@@ -1447,7 +1474,8 @@
     "nationalPokedexNumber": 141
   },
   {
-    "id": "ecard3-164",
+    "setOrder":15,
+	"id": "ecard3-164",
     "name": "Ledian",
     "imageUrl": "https://images.pokemontcg.io/ecard3/164.png",
     "subtype": "Stage 1",
@@ -1496,7 +1524,8 @@
     "nationalPokedexNumber": 166
   },
   {
-    "id": "ecard3-165",
+    "setOrder":15,
+	"id": "ecard3-165",
     "name": "Machamp",
     "imageUrl": "https://images.pokemontcg.io/ecard3/165.png",
     "subtype": "Stage 2",
@@ -1556,7 +1585,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "ecard3-15",
+    "setOrder":15,
+	"id": "ecard3-15",
     "name": "Ledian",
     "imageUrl": "https://images.pokemontcg.io/ecard3/15.png",
     "subtype": "Stage 1",
@@ -1605,7 +1635,8 @@
     "nationalPokedexNumber": 166
   },
   {
-    "id": "ecard3-16",
+    "setOrder":15,
+	"id": "ecard3-16",
     "name": "Machamp",
     "imageUrl": "https://images.pokemontcg.io/ecard3/16.png",
     "subtype": "Stage 2",
@@ -1665,7 +1696,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "ecard3-166",
+    "setOrder":15,
+	"id": "ecard3-166",
     "name": "Magcargo",
     "imageUrl": "https://images.pokemontcg.io/ecard3/166.png",
     "subtype": "Stage 1",
@@ -1721,7 +1753,8 @@
     "nationalPokedexNumber": 219
   },
   {
-    "id": "ecard3-167",
+    "setOrder":15,
+	"id": "ecard3-167",
     "name": "Magcargo",
     "imageUrl": "https://images.pokemontcg.io/ecard3/167.png",
     "subtype": "Stage 1",
@@ -1771,7 +1804,8 @@
     "nationalPokedexNumber": 219
   },
   {
-    "id": "ecard3-17",
+    "setOrder":15,
+	"id": "ecard3-17",
     "name": "Magcargo",
     "imageUrl": "https://images.pokemontcg.io/ecard3/17.png",
     "subtype": "Stage 1",
@@ -1827,7 +1861,8 @@
     "nationalPokedexNumber": 219
   },
   {
-    "id": "ecard3-18",
+    "setOrder":15,
+	"id": "ecard3-18",
     "name": "Magcargo",
     "imageUrl": "https://images.pokemontcg.io/ecard3/18.png",
     "subtype": "Stage 1",
@@ -1877,7 +1912,8 @@
     "nationalPokedexNumber": 219
   },
   {
-    "id": "ecard3-168",
+    "setOrder":15,
+	"id": "ecard3-168",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/ecard3/168.png",
     "subtype": "Stage 1",
@@ -1928,7 +1964,8 @@
     ]
   },
   {
-    "id": "ecard3-19",
+    "setOrder":15,
+	"id": "ecard3-19",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/ecard3/19.png",
     "subtype": "Stage 1",
@@ -1979,7 +2016,8 @@
     ]
   },
   {
-    "id": "ecard3-169",
+    "setOrder":15,
+	"id": "ecard3-169",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/ecard3/169.png",
     "subtype": "Stage 1",
@@ -2041,7 +2079,8 @@
     ]
   },
   {
-    "id": "ecard3-20",
+    "setOrder":15,
+	"id": "ecard3-20",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/ecard3/20.png",
     "subtype": "Stage 1",
@@ -2104,7 +2143,8 @@
     ]
   },
   {
-    "id": "ecard3-170",
+    "setOrder":15,
+	"id": "ecard3-170",
     "name": "Moltres",
     "imageUrl": "https://images.pokemontcg.io/ecard3/170.png",
     "subtype": "Basic",
@@ -2168,7 +2208,8 @@
     "nationalPokedexNumber": 146
   },
   {
-    "id": "ecard3-21",
+    "setOrder":15,
+	"id": "ecard3-21",
     "name": "Moltres",
     "imageUrl": "https://images.pokemontcg.io/ecard3/21.png",
     "subtype": "Basic",
@@ -2232,7 +2273,8 @@
     "nationalPokedexNumber": 146
   },
   {
-    "id": "ecard3-171",
+    "setOrder":15,
+	"id": "ecard3-171",
     "name": "Nidoqueen",
     "imageUrl": "https://images.pokemontcg.io/ecard3/171.png",
     "subtype": "Stage 2",
@@ -2282,7 +2324,8 @@
     "nationalPokedexNumber": 31
   },
   {
-    "id": "ecard3-22",
+    "setOrder":15,
+	"id": "ecard3-22",
     "name": "Nidoqueen",
     "imageUrl": "https://images.pokemontcg.io/ecard3/22.png",
     "subtype": "Stage 2",
@@ -2332,7 +2375,8 @@
     "nationalPokedexNumber": 31
   },
   {
-    "id": "ecard3-172",
+    "setOrder":15,
+	"id": "ecard3-172",
     "name": "Piloswine",
     "imageUrl": "https://images.pokemontcg.io/ecard3/172.png",
     "subtype": "Stage 1",
@@ -2392,7 +2436,8 @@
     ]
   },
   {
-    "id": "ecard3-173",
+    "setOrder":15,
+	"id": "ecard3-173",
     "name": "Politoed",
     "imageUrl": "https://images.pokemontcg.io/ecard3/173.png",
     "subtype": "Stage 2",
@@ -2458,7 +2503,8 @@
     "nationalPokedexNumber": 186
   },
   {
-    "id": "ecard3-23",
+    "setOrder":15,
+	"id": "ecard3-23",
     "name": "Omastar",
     "imageUrl": "https://images.pokemontcg.io/ecard3/23.png",
     "subtype": "Stage 2",
@@ -2507,7 +2553,8 @@
     "nationalPokedexNumber": 139
   },
   {
-    "id": "ecard3-24",
+    "setOrder":15,
+	"id": "ecard3-24",
     "name": "Piloswine",
     "imageUrl": "https://images.pokemontcg.io/ecard3/24.png",
     "subtype": "Stage 1",
@@ -2567,7 +2614,8 @@
     ]
   },
   {
-    "id": "ecard3-174",
+    "setOrder":15,
+	"id": "ecard3-174",
     "name": "Poliwrath",
     "imageUrl": "https://images.pokemontcg.io/ecard3/174.png",
     "subtype": "Stage 2",
@@ -2616,7 +2664,8 @@
     "nationalPokedexNumber": 62
   },
   {
-    "id": "ecard3-175",
+    "setOrder":15,
+	"id": "ecard3-175",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/ecard3/175.png",
     "subtype": "Stage 1",
@@ -2669,7 +2718,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "ecard3-25",
+    "setOrder":15,
+	"id": "ecard3-25",
     "name": "Politoed",
     "imageUrl": "https://images.pokemontcg.io/ecard3/25.png",
     "subtype": "Stage 2",
@@ -2735,7 +2785,8 @@
     "nationalPokedexNumber": 186
   },
   {
-    "id": "ecard3-176",
+    "setOrder":15,
+	"id": "ecard3-176",
     "name": "Raikou",
     "imageUrl": "https://images.pokemontcg.io/ecard3/176.png",
     "subtype": "Basic",
@@ -2782,7 +2833,8 @@
     "nationalPokedexNumber": 243
   },
   {
-    "id": "ecard3-26",
+    "setOrder":15,
+	"id": "ecard3-26",
     "name": "Poliwrath",
     "imageUrl": "https://images.pokemontcg.io/ecard3/26.png",
     "subtype": "Stage 2",
@@ -2831,7 +2883,8 @@
     "nationalPokedexNumber": 62
   },
   {
-    "id": "ecard3-177",
+    "setOrder":15,
+	"id": "ecard3-177",
     "name": "Rhydon",
     "imageUrl": "https://images.pokemontcg.io/ecard3/177.png",
     "subtype": "Stage 1",
@@ -2897,7 +2950,8 @@
     ]
   },
   {
-    "id": "ecard3-27",
+    "setOrder":15,
+	"id": "ecard3-27",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/ecard3/27.png",
     "subtype": "Stage 1",
@@ -2950,7 +3004,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "ecard3-178",
+    "setOrder":15,
+	"id": "ecard3-178",
     "name": "Starmie",
     "imageUrl": "https://images.pokemontcg.io/ecard3/178.png",
     "subtype": "Stage 1",
@@ -3002,7 +3057,8 @@
     "nationalPokedexNumber": 121
   },
   {
-    "id": "ecard3-28",
+    "setOrder":15,
+	"id": "ecard3-28",
     "name": "Raikou",
     "imageUrl": "https://images.pokemontcg.io/ecard3/28.png",
     "subtype": "Basic",
@@ -3049,7 +3105,8 @@
     "nationalPokedexNumber": 243
   },
   {
-    "id": "ecard3-179",
+    "setOrder":15,
+	"id": "ecard3-179",
     "name": "Steelix",
     "imageUrl": "https://images.pokemontcg.io/ecard3/179.png",
     "subtype": "Stage 1",
@@ -3118,7 +3175,8 @@
     "nationalPokedexNumber": 208
   },
   {
-    "id": "ecard3-29",
+    "setOrder":15,
+	"id": "ecard3-29",
     "name": "Rhydon",
     "imageUrl": "https://images.pokemontcg.io/ecard3/29.png",
     "subtype": "Stage 1",
@@ -3184,7 +3242,8 @@
     ]
   },
   {
-    "id": "ecard3-180",
+    "setOrder":15,
+	"id": "ecard3-180",
     "name": "Umbreon",
     "imageUrl": "https://images.pokemontcg.io/ecard3/180.png",
     "subtype": "Stage 1",
@@ -3237,7 +3296,8 @@
     "nationalPokedexNumber": 197
   },
   {
-    "id": "ecard3-30",
+    "setOrder":15,
+	"id": "ecard3-30",
     "name": "Starmie",
     "imageUrl": "https://images.pokemontcg.io/ecard3/30.png",
     "subtype": "Stage 1",
@@ -3289,7 +3349,8 @@
     "nationalPokedexNumber": 121
   },
   {
-    "id": "ecard3-181",
+    "setOrder":15,
+	"id": "ecard3-181",
     "name": "Vaporeon",
     "imageUrl": "https://images.pokemontcg.io/ecard3/181.png",
     "subtype": "Stage 1",
@@ -3347,7 +3408,8 @@
     "nationalPokedexNumber": 134
   },
   {
-    "id": "ecard3-31",
+    "setOrder":15,
+	"id": "ecard3-31",
     "name": "Steelix",
     "imageUrl": "https://images.pokemontcg.io/ecard3/31.png",
     "subtype": "Stage 1",
@@ -3416,7 +3478,8 @@
     "nationalPokedexNumber": 208
   },
   {
-    "id": "ecard3-32",
+    "setOrder":15,
+	"id": "ecard3-32",
     "name": "Umbreon",
     "imageUrl": "https://images.pokemontcg.io/ecard3/32.png",
     "subtype": "Stage 1",
@@ -3469,7 +3532,8 @@
     "nationalPokedexNumber": 197
   },
   {
-    "id": "ecard3-182",
+    "setOrder":15,
+	"id": "ecard3-182",
     "name": "Xatu",
     "imageUrl": "https://images.pokemontcg.io/ecard3/182.png",
     "subtype": "Stage 1",
@@ -3517,7 +3581,8 @@
     "nationalPokedexNumber": 178
   },
   {
-    "id": "ecard3-33",
+    "setOrder":15,
+	"id": "ecard3-33",
     "name": "Vaporeon",
     "imageUrl": "https://images.pokemontcg.io/ecard3/33.png",
     "subtype": "Stage 1",
@@ -3575,7 +3640,8 @@
     "nationalPokedexNumber": 134
   },
   {
-    "id": "ecard3-34",
+    "setOrder":15,
+	"id": "ecard3-34",
     "name": "Wigglytuff",
     "imageUrl": "https://images.pokemontcg.io/ecard3/34.png",
     "subtype": "Stage 1",
@@ -3623,7 +3689,8 @@
     "nationalPokedexNumber": 40
   },
   {
-    "id": "ecard3-35",
+    "setOrder":15,
+	"id": "ecard3-35",
     "name": "Xatu",
     "imageUrl": "https://images.pokemontcg.io/ecard3/35.png",
     "subtype": "Stage 1",
@@ -3671,7 +3738,8 @@
     "nationalPokedexNumber": 178
   },
   {
-    "id": "ecard3-36",
+    "setOrder":15,
+	"id": "ecard3-36",
     "name": "Electrode",
     "imageUrl": "https://images.pokemontcg.io/ecard3/36.png",
     "subtype": "Stage 1",
@@ -3725,7 +3793,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "ecard3-37",
+    "setOrder":15,
+	"id": "ecard3-37",
     "name": "Kabuto",
     "imageUrl": "https://images.pokemontcg.io/ecard3/37.png",
     "subtype": "Stage 1",
@@ -3774,7 +3843,8 @@
     ]
   },
   {
-    "id": "ecard3-38",
+    "setOrder":15,
+	"id": "ecard3-38",
     "name": "Machoke",
     "imageUrl": "https://images.pokemontcg.io/ecard3/38.png",
     "subtype": "Stage 1",
@@ -3829,7 +3899,8 @@
     ]
   },
   {
-    "id": "ecard3-39",
+    "setOrder":15,
+	"id": "ecard3-39",
     "name": "Misdreavus",
     "imageUrl": "https://images.pokemontcg.io/ecard3/39.png",
     "subtype": "Basic",
@@ -3888,7 +3959,8 @@
     ]
   },
   {
-    "id": "ecard3-40",
+    "setOrder":15,
+	"id": "ecard3-40",
     "name": "Noctowl",
     "imageUrl": "https://images.pokemontcg.io/ecard3/40.png",
     "subtype": "Stage 1",
@@ -3938,7 +4010,8 @@
     "nationalPokedexNumber": 164
   },
   {
-    "id": "ecard3-41",
+    "setOrder":15,
+	"id": "ecard3-41",
     "name": "Omanyte",
     "imageUrl": "https://images.pokemontcg.io/ecard3/41.png",
     "subtype": "Stage 1",
@@ -3994,7 +4067,8 @@
     ]
   },
   {
-    "id": "ecard3-42",
+    "setOrder":15,
+	"id": "ecard3-42",
     "name": "Persian",
     "imageUrl": "https://images.pokemontcg.io/ecard3/42.png",
     "subtype": "Stage 1",
@@ -4043,7 +4117,8 @@
     "nationalPokedexNumber": 53
   },
   {
-    "id": "ecard3-43",
+    "setOrder":15,
+	"id": "ecard3-43",
     "name": "Piloswine",
     "imageUrl": "https://images.pokemontcg.io/ecard3/43.png",
     "subtype": "Stage 1",
@@ -4109,7 +4184,8 @@
     ]
   },
   {
-    "id": "ecard3-44",
+    "setOrder":15,
+	"id": "ecard3-44",
     "name": "Starmie",
     "imageUrl": "https://images.pokemontcg.io/ecard3/44.png",
     "subtype": "Stage 1",
@@ -4161,7 +4237,8 @@
     "nationalPokedexNumber": 121
   },
   {
-    "id": "ecard3-45",
+    "setOrder":15,
+	"id": "ecard3-45",
     "name": "Wobbuffet",
     "imageUrl": "https://images.pokemontcg.io/ecard3/45.png",
     "subtype": "Basic",
@@ -4208,7 +4285,8 @@
     "nationalPokedexNumber": 202
   },
   {
-    "id": "ecard3-46",
+    "setOrder":15,
+	"id": "ecard3-46",
     "name": "Abra",
     "imageUrl": "https://images.pokemontcg.io/ecard3/46.png",
     "subtype": "Basic",
@@ -4257,7 +4335,8 @@
     ]
   },
   {
-    "id": "ecard3-47",
+    "setOrder":15,
+	"id": "ecard3-47",
     "name": "Buried Fossil",
     "imageUrl": "https://images.pokemontcg.io/ecard3/47.png",
     "subtype": "Basic",
@@ -4289,7 +4368,8 @@
     ]
   },
   {
-    "id": "ecard3-48",
+    "setOrder":15,
+	"id": "ecard3-48",
     "name": "Cleffa",
     "imageUrl": "https://images.pokemontcg.io/ecard3/48.png",
     "subtype": "Basic",
@@ -4329,7 +4409,8 @@
     ]
   },
   {
-    "id": "ecard3-49",
+    "setOrder":15,
+	"id": "ecard3-49",
     "name": "Delibird",
     "imageUrl": "https://images.pokemontcg.io/ecard3/49.png",
     "subtype": "Basic",
@@ -4379,7 +4460,8 @@
     "nationalPokedexNumber": 225
   },
   {
-    "id": "ecard3-50",
+    "setOrder":15,
+	"id": "ecard3-50",
     "name": "Diglett",
     "imageUrl": "https://images.pokemontcg.io/ecard3/50.png",
     "subtype": "Basic",
@@ -4428,7 +4510,8 @@
     ]
   },
   {
-    "id": "ecard3-51",
+    "setOrder":15,
+	"id": "ecard3-51",
     "name": "Ditto",
     "imageUrl": "https://images.pokemontcg.io/ecard3/51.png",
     "subtype": "Basic",
@@ -4473,7 +4556,8 @@
     "nationalPokedexNumber": 132
   },
   {
-    "id": "ecard3-52",
+    "setOrder":15,
+	"id": "ecard3-52",
     "name": "Dugtrio",
     "imageUrl": "https://images.pokemontcg.io/ecard3/52.png",
     "subtype": "Stage 1",
@@ -4532,7 +4616,8 @@
     "nationalPokedexNumber": 51
   },
   {
-    "id": "ecard3-53",
+    "setOrder":15,
+	"id": "ecard3-53",
     "name": "Dunsparce",
     "imageUrl": "https://images.pokemontcg.io/ecard3/53.png",
     "subtype": "Basic",
@@ -4577,7 +4662,8 @@
     "nationalPokedexNumber": 206
   },
   {
-    "id": "ecard3-54",
+    "setOrder":15,
+	"id": "ecard3-54",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/ecard3/54.png",
     "subtype": "Basic",
@@ -4637,7 +4723,8 @@
     ]
   },
   {
-    "id": "ecard3-55",
+    "setOrder":15,
+	"id": "ecard3-55",
     "name": "Farfetch'd",
     "imageUrl": "https://images.pokemontcg.io/ecard3/55.png",
     "subtype": "Basic",
@@ -4692,7 +4779,8 @@
     "nationalPokedexNumber": 83
   },
   {
-    "id": "ecard3-56",
+    "setOrder":15,
+	"id": "ecard3-56",
     "name": "Forretress",
     "imageUrl": "https://images.pokemontcg.io/ecard3/56.png",
     "subtype": "Stage 1",
@@ -4751,7 +4839,8 @@
     "nationalPokedexNumber": 205
   },
   {
-    "id": "ecard3-57",
+    "setOrder":15,
+	"id": "ecard3-57",
     "name": "Gastly",
     "imageUrl": "https://images.pokemontcg.io/ecard3/57.png",
     "subtype": "Basic",
@@ -4800,7 +4889,8 @@
     ]
   },
   {
-    "id": "ecard3-58",
+    "setOrder":15,
+	"id": "ecard3-58",
     "name": "Girafarig",
     "imageUrl": "https://images.pokemontcg.io/ecard3/58.png",
     "subtype": "Basic",
@@ -4850,7 +4940,8 @@
     "nationalPokedexNumber": 203
   },
   {
-    "id": "ecard3-59",
+    "setOrder":15,
+	"id": "ecard3-59",
     "name": "Gligar",
     "imageUrl": "https://images.pokemontcg.io/ecard3/59.png",
     "subtype": "Basic",
@@ -4903,7 +4994,8 @@
     ]
   },
   {
-    "id": "ecard3-60",
+    "setOrder":15,
+	"id": "ecard3-60",
     "name": "Golbat",
     "imageUrl": "https://images.pokemontcg.io/ecard3/60.png",
     "subtype": "Stage 1",
@@ -4959,7 +5051,8 @@
     ]
   },
   {
-    "id": "ecard3-61",
+    "setOrder":15,
+	"id": "ecard3-61",
     "name": "Granbull",
     "imageUrl": "https://images.pokemontcg.io/ecard3/61.png",
     "subtype": "Stage 1",
@@ -5013,7 +5106,8 @@
     "nationalPokedexNumber": 210
   },
   {
-    "id": "ecard3-62",
+    "setOrder":15,
+	"id": "ecard3-62",
     "name": "Growlithe",
     "imageUrl": "https://images.pokemontcg.io/ecard3/62.png",
     "subtype": "Basic",
@@ -5066,7 +5160,8 @@
     ]
   },
   {
-    "id": "ecard3-63",
+    "setOrder":15,
+	"id": "ecard3-63",
     "name": "Haunter",
     "imageUrl": "https://images.pokemontcg.io/ecard3/63.png",
     "subtype": "Stage 1",
@@ -5128,7 +5223,8 @@
     ]
   },
   {
-    "id": "ecard3-64",
+    "setOrder":15,
+	"id": "ecard3-64",
     "name": "Heracross",
     "imageUrl": "https://images.pokemontcg.io/ecard3/64.png",
     "subtype": "Basic",
@@ -5180,7 +5276,8 @@
     "nationalPokedexNumber": 214
   },
   {
-    "id": "ecard3-65",
+    "setOrder":15,
+	"id": "ecard3-65",
     "name": "Hoothoot",
     "imageUrl": "https://images.pokemontcg.io/ecard3/65.png",
     "subtype": "Basic",
@@ -5238,7 +5335,8 @@
     ]
   },
   {
-    "id": "ecard3-66",
+    "setOrder":15,
+	"id": "ecard3-66",
     "name": "Houndour",
     "imageUrl": "https://images.pokemontcg.io/ecard3/66.png",
     "subtype": "Basic",
@@ -5290,7 +5388,8 @@
     ]
   },
   {
-    "id": "ecard3-67",
+    "setOrder":15,
+	"id": "ecard3-67",
     "name": "Igglybuff",
     "imageUrl": "https://images.pokemontcg.io/ecard3/67.png",
     "subtype": "Basic",
@@ -5330,7 +5429,8 @@
     ]
   },
   {
-    "id": "ecard3-68",
+    "setOrder":15,
+	"id": "ecard3-68",
     "name": "Jigglypuff",
     "imageUrl": "https://images.pokemontcg.io/ecard3/68.png",
     "subtype": "Basic",
@@ -5383,7 +5483,8 @@
     ]
   },
   {
-    "id": "ecard3-69",
+    "setOrder":15,
+	"id": "ecard3-69",
     "name": "Kadabra",
     "imageUrl": "https://images.pokemontcg.io/ecard3/69.png",
     "subtype": "Stage 1",
@@ -5438,7 +5539,8 @@
     ]
   },
   {
-    "id": "ecard3-70",
+    "setOrder":15,
+	"id": "ecard3-70",
     "name": "Kakuna",
     "imageUrl": "https://images.pokemontcg.io/ecard3/70.png",
     "subtype": "Stage 1",
@@ -5488,7 +5590,8 @@
     ]
   },
   {
-    "id": "ecard3-71",
+    "setOrder":15,
+	"id": "ecard3-71",
     "name": "Lapras",
     "imageUrl": "https://images.pokemontcg.io/ecard3/71.png",
     "subtype": "Basic",
@@ -5541,7 +5644,8 @@
     "nationalPokedexNumber": 131
   },
   {
-    "id": "ecard3-72",
+    "setOrder":15,
+	"id": "ecard3-72",
     "name": "Ledyba",
     "imageUrl": "https://images.pokemontcg.io/ecard3/72.png",
     "subtype": "Basic",
@@ -5599,7 +5703,8 @@
     ]
   },
   {
-    "id": "ecard3-73",
+    "setOrder":15,
+	"id": "ecard3-73",
     "name": "Ledyba",
     "imageUrl": "https://images.pokemontcg.io/ecard3/73.png",
     "subtype": "Basic",
@@ -5652,7 +5757,8 @@
     ]
   },
   {
-    "id": "ecard3-74",
+    "setOrder":15,
+	"id": "ecard3-74",
     "name": "Machop",
     "imageUrl": "https://images.pokemontcg.io/ecard3/74.png",
     "subtype": "Basic",
@@ -5705,7 +5811,8 @@
     ]
   },
   {
-    "id": "ecard3-75",
+    "setOrder":15,
+	"id": "ecard3-75",
     "name": "Magikarp",
     "imageUrl": "https://images.pokemontcg.io/ecard3/75.png",
     "subtype": "Basic",
@@ -5757,7 +5864,8 @@
     ]
   },
   {
-    "id": "ecard3-76",
+    "setOrder":15,
+	"id": "ecard3-76",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/ecard3/76.png",
     "subtype": "Basic",
@@ -5809,7 +5917,8 @@
     ]
   },
   {
-    "id": "ecard3-77",
+    "setOrder":15,
+	"id": "ecard3-77",
     "name": "Mantine",
     "imageUrl": "https://images.pokemontcg.io/ecard3/77.png",
     "subtype": "Basic",
@@ -5867,7 +5976,8 @@
     "nationalPokedexNumber": 226
   },
   {
-    "id": "ecard3-78",
+    "setOrder":15,
+	"id": "ecard3-78",
     "name": "Meowth",
     "imageUrl": "https://images.pokemontcg.io/ecard3/78.png",
     "subtype": "Basic",
@@ -5910,7 +6020,8 @@
     ]
   },
   {
-    "id": "ecard3-79",
+    "setOrder":15,
+	"id": "ecard3-79",
     "name": "Murkrow",
     "imageUrl": "https://images.pokemontcg.io/ecard3/79.png",
     "subtype": "Basic",
@@ -5969,7 +6080,8 @@
     ]
   },
   {
-    "id": "ecard3-80",
+    "setOrder":15,
+	"id": "ecard3-80",
     "name": "Natu",
     "imageUrl": "https://images.pokemontcg.io/ecard3/80.png",
     "subtype": "Basic",
@@ -6022,7 +6134,8 @@
     ]
   },
   {
-    "id": "ecard3-81",
+    "setOrder":15,
+	"id": "ecard3-81",
     "name": "Nidoran♀",
     "imageUrl": "https://images.pokemontcg.io/ecard3/81.png",
     "subtype": "Basic",
@@ -6074,7 +6187,8 @@
     ]
   },
   {
-    "id": "ecard3-82",
+    "setOrder":15,
+	"id": "ecard3-82",
     "name": "Nidoran♀",
     "imageUrl": "https://images.pokemontcg.io/ecard3/82.png",
     "subtype": "Basic",
@@ -6118,7 +6232,8 @@
     ]
   },
   {
-    "id": "ecard3-83",
+    "setOrder":15,
+	"id": "ecard3-83",
     "name": "Nidorina",
     "imageUrl": "https://images.pokemontcg.io/ecard3/83.png",
     "subtype": "Stage 1",
@@ -6175,7 +6290,8 @@
     ]
   },
   {
-    "id": "ecard3-84",
+    "setOrder":15,
+	"id": "ecard3-84",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/ecard3/84.png",
     "subtype": "Basic",
@@ -6219,7 +6335,8 @@
     ]
   },
   {
-    "id": "ecard3-85",
+    "setOrder":15,
+	"id": "ecard3-85",
     "name": "Pineco",
     "imageUrl": "https://images.pokemontcg.io/ecard3/85.png",
     "subtype": "Basic",
@@ -6262,7 +6379,8 @@
     ]
   },
   {
-    "id": "ecard3-86",
+    "setOrder":15,
+	"id": "ecard3-86",
     "name": "Pineco",
     "imageUrl": "https://images.pokemontcg.io/ecard3/86.png",
     "subtype": "Basic",
@@ -6303,7 +6421,8 @@
     ]
   },
   {
-    "id": "ecard3-87",
+    "setOrder":15,
+	"id": "ecard3-87",
     "name": "Poliwag",
     "imageUrl": "https://images.pokemontcg.io/ecard3/87.png",
     "subtype": "Basic",
@@ -6353,7 +6472,8 @@
     ]
   },
   {
-    "id": "ecard3-88",
+    "setOrder":15,
+	"id": "ecard3-88",
     "name": "Poliwhirl",
     "imageUrl": "https://images.pokemontcg.io/ecard3/88.png",
     "subtype": "Stage 1",
@@ -6409,7 +6529,8 @@
     ]
   },
   {
-    "id": "ecard3-89",
+    "setOrder":15,
+	"id": "ecard3-89",
     "name": "Raticate",
     "imageUrl": "https://images.pokemontcg.io/ecard3/89.png",
     "subtype": "Stage 1",
@@ -6460,7 +6581,8 @@
     "nationalPokedexNumber": 20
   },
   {
-    "id": "ecard3-90",
+    "setOrder":15,
+	"id": "ecard3-90",
     "name": "Rattata",
     "imageUrl": "https://images.pokemontcg.io/ecard3/90.png",
     "subtype": "Basic",
@@ -6512,7 +6634,8 @@
     ]
   },
   {
-    "id": "ecard3-91",
+    "setOrder":15,
+	"id": "ecard3-91",
     "name": "Rhyhorn",
     "imageUrl": "https://images.pokemontcg.io/ecard3/91.png",
     "subtype": "Basic",
@@ -6572,7 +6695,8 @@
     ]
   },
   {
-    "id": "ecard3-92",
+    "setOrder":15,
+	"id": "ecard3-92",
     "name": "Sandshrew",
     "imageUrl": "https://images.pokemontcg.io/ecard3/92.png",
     "subtype": "Basic",
@@ -6630,7 +6754,8 @@
     ]
   },
   {
-    "id": "ecard3-93",
+    "setOrder":15,
+	"id": "ecard3-93",
     "name": "Sandslash",
     "imageUrl": "https://images.pokemontcg.io/ecard3/93.png",
     "subtype": "Stage 1",
@@ -6689,7 +6814,8 @@
     "nationalPokedexNumber": 28
   },
   {
-    "id": "ecard3-94",
+    "setOrder":15,
+	"id": "ecard3-94",
     "name": "Seel",
     "imageUrl": "https://images.pokemontcg.io/ecard3/94.png",
     "subtype": "Basic",
@@ -6732,7 +6858,8 @@
     ]
   },
   {
-    "id": "ecard3-95",
+    "setOrder":15,
+	"id": "ecard3-95",
     "name": "Seel",
     "imageUrl": "https://images.pokemontcg.io/ecard3/95.png",
     "subtype": "Basic",
@@ -6785,7 +6912,8 @@
     ]
   },
   {
-    "id": "ecard3-96",
+    "setOrder":15,
+	"id": "ecard3-96",
     "name": "Shuckle",
     "imageUrl": "https://images.pokemontcg.io/ecard3/96.png",
     "subtype": "Basic",
@@ -6832,7 +6960,8 @@
     "nationalPokedexNumber": 213
   },
   {
-    "id": "ecard3-97",
+    "setOrder":15,
+	"id": "ecard3-97",
     "name": "Skarmory",
     "imageUrl": "https://images.pokemontcg.io/ecard3/97.png",
     "subtype": "Basic",
@@ -6890,7 +7019,8 @@
     "nationalPokedexNumber": 227
   },
   {
-    "id": "ecard3-98",
+    "setOrder":15,
+	"id": "ecard3-98",
     "name": "Slugma",
     "imageUrl": "https://images.pokemontcg.io/ecard3/98.png",
     "subtype": "Basic",
@@ -6943,7 +7073,8 @@
     ]
   },
   {
-    "id": "ecard3-99",
+    "setOrder":15,
+	"id": "ecard3-99",
     "name": "Slugma",
     "imageUrl": "https://images.pokemontcg.io/ecard3/99.png",
     "subtype": "Basic",
@@ -6988,7 +7119,8 @@
     ]
   },
   {
-    "id": "ecard3-100",
+    "setOrder":15,
+	"id": "ecard3-100",
     "name": "Snorlax",
     "imageUrl": "https://images.pokemontcg.io/ecard3/100.png",
     "subtype": "Basic",
@@ -7037,7 +7169,8 @@
     "nationalPokedexNumber": 143
   },
   {
-    "id": "ecard3-101",
+    "setOrder":15,
+	"id": "ecard3-101",
     "name": "Snubbull",
     "imageUrl": "https://images.pokemontcg.io/ecard3/101.png",
     "subtype": "Basic",
@@ -7090,7 +7223,8 @@
     ]
   },
   {
-    "id": "ecard3-102",
+    "setOrder":15,
+	"id": "ecard3-102",
     "name": "Stantler",
     "imageUrl": "https://images.pokemontcg.io/ecard3/102.png",
     "subtype": "Basic",
@@ -7140,7 +7274,8 @@
     "nationalPokedexNumber": 234
   },
   {
-    "id": "ecard3-103",
+    "setOrder":15,
+	"id": "ecard3-103",
     "name": "Staryu",
     "imageUrl": "https://images.pokemontcg.io/ecard3/103.png",
     "subtype": "Basic",
@@ -7192,7 +7327,8 @@
     ]
   },
   {
-    "id": "ecard3-104",
+    "setOrder":15,
+	"id": "ecard3-104",
     "name": "Staryu",
     "imageUrl": "https://images.pokemontcg.io/ecard3/104.png",
     "subtype": "Basic",
@@ -7245,7 +7381,8 @@
     ]
   },
   {
-    "id": "ecard3-105",
+    "setOrder":15,
+	"id": "ecard3-105",
     "name": "Sunflora",
     "imageUrl": "https://images.pokemontcg.io/ecard3/105.png",
     "subtype": "Stage 1",
@@ -7304,7 +7441,8 @@
     "nationalPokedexNumber": 192
   },
   {
-    "id": "ecard3-106",
+    "setOrder":15,
+	"id": "ecard3-106",
     "name": "Sunkern",
     "imageUrl": "https://images.pokemontcg.io/ecard3/106.png",
     "subtype": "Basic",
@@ -7362,7 +7500,8 @@
     ]
   },
   {
-    "id": "ecard3-107",
+    "setOrder":15,
+	"id": "ecard3-107",
     "name": "Swinub",
     "imageUrl": "https://images.pokemontcg.io/ecard3/107.png",
     "subtype": "Basic",
@@ -7414,7 +7553,8 @@
     ]
   },
   {
-    "id": "ecard3-108",
+    "setOrder":15,
+	"id": "ecard3-108",
     "name": "Swinub",
     "imageUrl": "https://images.pokemontcg.io/ecard3/108.png",
     "subtype": "Basic",
@@ -7473,7 +7613,8 @@
     ]
   },
   {
-    "id": "ecard3-109",
+    "setOrder":15,
+	"id": "ecard3-109",
     "name": "Teddiursa",
     "imageUrl": "https://images.pokemontcg.io/ecard3/109.png",
     "subtype": "Basic",
@@ -7526,7 +7667,8 @@
     ]
   },
   {
-    "id": "ecard3-110",
+    "setOrder":15,
+	"id": "ecard3-110",
     "name": "Ursaring",
     "imageUrl": "https://images.pokemontcg.io/ecard3/110.png",
     "subtype": "Stage 1",
@@ -7582,7 +7724,8 @@
     "nationalPokedexNumber": 217
   },
   {
-    "id": "ecard3-111",
+    "setOrder":15,
+	"id": "ecard3-111",
     "name": "Venomoth",
     "imageUrl": "https://images.pokemontcg.io/ecard3/111.png",
     "subtype": "Stage 1",
@@ -7632,7 +7775,8 @@
     "nationalPokedexNumber": 49
   },
   {
-    "id": "ecard3-112",
+    "setOrder":15,
+	"id": "ecard3-112",
     "name": "Venonat",
     "imageUrl": "https://images.pokemontcg.io/ecard3/112.png",
     "subtype": "Basic",
@@ -7685,7 +7829,8 @@
     ]
   },
   {
-    "id": "ecard3-113",
+    "setOrder":15,
+	"id": "ecard3-113",
     "name": "Voltorb",
     "imageUrl": "https://images.pokemontcg.io/ecard3/113.png",
     "subtype": "Basic",
@@ -7738,7 +7883,8 @@
     ]
   },
   {
-    "id": "ecard3-114",
+    "setOrder":15,
+	"id": "ecard3-114",
     "name": "Weedle",
     "imageUrl": "https://images.pokemontcg.io/ecard3/114.png",
     "subtype": "Basic",
@@ -7781,7 +7927,8 @@
     ]
   },
   {
-    "id": "ecard3-115",
+    "setOrder":15,
+	"id": "ecard3-115",
     "name": "Weedle",
     "imageUrl": "https://images.pokemontcg.io/ecard3/115.png",
     "subtype": "Basic",
@@ -7833,7 +7980,8 @@
     ]
   },
   {
-    "id": "ecard3-116",
+    "setOrder":15,
+	"id": "ecard3-116",
     "name": "Yanma",
     "imageUrl": "https://images.pokemontcg.io/ecard3/116.png",
     "subtype": "Basic",
@@ -7894,7 +8042,8 @@
     ]
   },
   {
-    "id": "ecard3-117",
+    "setOrder":15,
+	"id": "ecard3-117",
     "name": "Zubat",
     "imageUrl": "https://images.pokemontcg.io/ecard3/117.png",
     "subtype": "Basic",
@@ -7952,7 +8101,8 @@
     ]
   },
   {
-    "id": "ecard3-118",
+    "setOrder":15,
+	"id": "ecard3-118",
     "name": "Zubat",
     "imageUrl": "https://images.pokemontcg.io/ecard3/118.png",
     "subtype": "Basic",
@@ -8005,7 +8155,8 @@
     ]
   },
   {
-    "id": "ecard3-119",
+    "setOrder":15,
+	"id": "ecard3-119",
     "name": "Ancient Ruins",
     "imageUrl": "https://images.pokemontcg.io/ecard3/119.png",
     "subtype": "",
@@ -8022,7 +8173,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/119_hires.png"
   },
   {
-    "id": "ecard3-120",
+    "setOrder":15,
+	"id": "ecard3-120",
     "name": "Relic Hunter",
     "imageUrl": "https://images.pokemontcg.io/ecard3/120.png",
     "subtype": "",
@@ -8039,7 +8191,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/120_hires.png"
   },
   {
-    "id": "ecard3-121",
+    "setOrder":15,
+	"id": "ecard3-121",
     "name": "Apricorn Maker",
     "imageUrl": "https://images.pokemontcg.io/ecard3/121.png",
     "subtype": "",
@@ -8056,7 +8209,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/121_hires.png"
   },
   {
-    "id": "ecard3-122",
+    "setOrder":15,
+	"id": "ecard3-122",
     "name": "Crystal Shard",
     "imageUrl": "https://images.pokemontcg.io/ecard3/122.png",
     "subtype": "",
@@ -8073,7 +8227,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/122_hires.png"
   },
   {
-    "id": "ecard3-123",
+    "setOrder":15,
+	"id": "ecard3-123",
     "name": "Desert Shaman",
     "imageUrl": "https://images.pokemontcg.io/ecard3/123.png",
     "subtype": "",
@@ -8090,7 +8245,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/123_hires.png"
   },
   {
-    "id": "ecard3-124",
+    "setOrder":15,
+	"id": "ecard3-124",
     "name": "Fast Ball",
     "imageUrl": "https://images.pokemontcg.io/ecard3/124.png",
     "subtype": "",
@@ -8107,7 +8263,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/124_hires.png"
   },
   {
-    "id": "ecard3-125",
+    "setOrder":15,
+	"id": "ecard3-125",
     "name": "Fisherman",
     "imageUrl": "https://images.pokemontcg.io/ecard3/125.png",
     "subtype": "",
@@ -8124,7 +8281,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/125_hires.png"
   },
   {
-    "id": "ecard3-126",
+    "setOrder":15,
+	"id": "ecard3-126",
     "name": "Friend Ball",
     "imageUrl": "https://images.pokemontcg.io/ecard3/126.png",
     "subtype": "",
@@ -8141,7 +8299,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/126_hires.png"
   },
   {
-    "id": "ecard3-127",
+    "setOrder":15,
+	"id": "ecard3-127",
     "name": "Hyper Potion",
     "imageUrl": "https://images.pokemontcg.io/ecard3/127.png",
     "subtype": "",
@@ -8158,7 +8317,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/127_hires.png"
   },
   {
-    "id": "ecard3-128",
+    "setOrder":15,
+	"id": "ecard3-128",
     "name": "Lure Ball",
     "imageUrl": "https://images.pokemontcg.io/ecard3/128.png",
     "subtype": "",
@@ -8175,7 +8335,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/128_hires.png"
   },
   {
-    "id": "ecard3-129",
+    "setOrder":15,
+	"id": "ecard3-129",
     "name": "Miracle Sphere Alpha",
     "imageUrl": "https://images.pokemontcg.io/ecard3/129.png",
     "subtype": "",
@@ -8192,7 +8353,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/129_hires.png"
   },
   {
-    "id": "ecard3-130",
+    "setOrder":15,
+	"id": "ecard3-130",
     "name": "Miracle Sphere Beta",
     "imageUrl": "https://images.pokemontcg.io/ecard3/130.png",
     "subtype": "",
@@ -8209,7 +8371,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/130_hires.png"
   },
   {
-    "id": "ecard3-131",
+    "setOrder":15,
+	"id": "ecard3-131",
     "name": "Miracle Sphere Gamma",
     "imageUrl": "https://images.pokemontcg.io/ecard3/131.png",
     "subtype": "",
@@ -8226,7 +8389,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/131_hires.png"
   },
   {
-    "id": "ecard3-132",
+    "setOrder":15,
+	"id": "ecard3-132",
     "name": "Mirage Stadium",
     "imageUrl": "https://images.pokemontcg.io/ecard3/132.png",
     "subtype": "",
@@ -8243,7 +8407,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/132_hires.png"
   },
   {
-    "id": "ecard3-133",
+    "setOrder":15,
+	"id": "ecard3-133",
     "name": "Mystery Plate Alpha",
     "imageUrl": "https://images.pokemontcg.io/ecard3/133.png",
     "subtype": "",
@@ -8260,7 +8425,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/133_hires.png"
   },
   {
-    "id": "ecard3-134",
+    "setOrder":15,
+	"id": "ecard3-134",
     "name": "Mystery Plate Beta",
     "imageUrl": "https://images.pokemontcg.io/ecard3/134.png",
     "subtype": "",
@@ -8277,7 +8443,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/134_hires.png"
   },
   {
-    "id": "ecard3-135",
+    "setOrder":15,
+	"id": "ecard3-135",
     "name": "Mystery Plate Gamma",
     "imageUrl": "https://images.pokemontcg.io/ecard3/135.png",
     "subtype": "",
@@ -8294,7 +8461,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/135_hires.png"
   },
   {
-    "id": "ecard3-136",
+    "setOrder":15,
+	"id": "ecard3-136",
     "name": "Mystery Plate Delta",
     "imageUrl": "https://images.pokemontcg.io/ecard3/136.png",
     "subtype": "",
@@ -8311,7 +8479,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/136_hires.png"
   },
   {
-    "id": "ecard3-137",
+    "setOrder":15,
+	"id": "ecard3-137",
     "name": "Mystery Zone",
     "imageUrl": "https://images.pokemontcg.io/ecard3/137.png",
     "subtype": "",
@@ -8328,7 +8497,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/137_hires.png"
   },
   {
-    "id": "ecard3-138",
+    "setOrder":15,
+	"id": "ecard3-138",
     "name": "Oracle",
     "imageUrl": "https://images.pokemontcg.io/ecard3/138.png",
     "subtype": "",
@@ -8345,7 +8515,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/138_hires.png"
   },
   {
-    "id": "ecard3-139",
+    "setOrder":15,
+	"id": "ecard3-139",
     "name": "Star Piece",
     "imageUrl": "https://images.pokemontcg.io/ecard3/139.png",
     "subtype": "",
@@ -8362,7 +8533,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/139_hires.png"
   },
   {
-    "id": "ecard3-140",
+    "setOrder":15,
+	"id": "ecard3-140",
     "name": "Underground Expedition",
     "imageUrl": "https://images.pokemontcg.io/ecard3/140.png",
     "subtype": "",
@@ -8379,7 +8551,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/140_hires.png"
   },
   {
-    "id": "ecard3-141",
+    "setOrder":15,
+	"id": "ecard3-141",
     "name": "Underground Lake",
     "imageUrl": "https://images.pokemontcg.io/ecard3/141.png",
     "subtype": "",
@@ -8396,7 +8569,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/141_hires.png"
   },
   {
-    "id": "ecard3-142",
+    "setOrder":15,
+	"id": "ecard3-142",
     "name": "Bounce Energy",
     "imageUrl": "https://images.pokemontcg.io/ecard3/142.png",
     "subtype": "Special",
@@ -8413,7 +8587,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/142_hires.png"
   },
   {
-    "id": "ecard3-143",
+    "setOrder":15,
+	"id": "ecard3-143",
     "name": "Cyclone Energy",
     "imageUrl": "https://images.pokemontcg.io/ecard3/143.png",
     "subtype": "Special",
@@ -8430,7 +8605,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/143_hires.png"
   },
   {
-    "id": "ecard3-144",
+    "setOrder":15,
+	"id": "ecard3-144",
     "name": "Retro Energy",
     "imageUrl": "https://images.pokemontcg.io/ecard3/144.png",
     "subtype": "Special",
@@ -8447,7 +8623,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ecard3/144_hires.png"
   },
   {
-    "id": "ecard3-145",
+    "setOrder":15,
+	"id": "ecard3-145",
     "name": "Celebi",
     "imageUrl": "https://images.pokemontcg.io/ecard3/145.png",
     "subtype": "Basic",
@@ -8504,7 +8681,8 @@
     "nationalPokedexNumber": 251
   },
   {
-    "id": "ecard3-146",
+    "setOrder":15,
+	"id": "ecard3-146",
     "name": "Charizard",
     "imageUrl": "https://images.pokemontcg.io/ecard3/146.png",
     "subtype": "Stage 2",
@@ -8567,7 +8745,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "ecard3-147",
+    "setOrder":15,
+	"id": "ecard3-147",
     "name": "Crobat",
     "imageUrl": "https://images.pokemontcg.io/ecard3/147.png",
     "subtype": "Stage 2",
@@ -8623,7 +8802,8 @@
     "nationalPokedexNumber": 169
   },
   {
-    "id": "ecard3-148",
+    "setOrder":15,
+	"id": "ecard3-148",
     "name": "Golem",
     "imageUrl": "https://images.pokemontcg.io/ecard3/148.png",
     "subtype": "Stage 2",
@@ -8686,7 +8866,8 @@
     "nationalPokedexNumber": 76
   },
   {
-    "id": "ecard3-149",
+    "setOrder":15,
+	"id": "ecard3-149",
     "name": "Ho-oh",
     "imageUrl": "https://images.pokemontcg.io/ecard3/149.png",
     "subtype": "Basic",
@@ -8746,7 +8927,8 @@
     "nationalPokedexNumber": 250
   },
   {
-    "id": "ecard3-150",
+    "setOrder":15,
+	"id": "ecard3-150",
     "name": "Kabutops",
     "imageUrl": "https://images.pokemontcg.io/ecard3/150.png",
     "subtype": "Stage 2",

--- a/json/cards/Steam Siege.json
+++ b/json/cards/Steam Siege.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "xy11-1",
+    "setOrder":70,
+	"id": "xy11-1",
     "name": "Tangela",
     "imageUrl": "https://images.pokemontcg.io/xy11/1.png",
     "subtype": "Basic",
@@ -57,7 +58,8 @@
     ]
   },
   {
-    "id": "xy11-2",
+    "setOrder":70,
+	"id": "xy11-2",
     "name": "Tangrowth",
     "imageUrl": "https://images.pokemontcg.io/xy11/2.png",
     "subtype": "Stage 1",
@@ -115,7 +117,8 @@
     "nationalPokedexNumber": 465
   },
   {
-    "id": "xy11-3",
+    "setOrder":70,
+	"id": "xy11-3",
     "name": "Hoppip",
     "imageUrl": "https://images.pokemontcg.io/xy11/3.png",
     "subtype": "Basic",
@@ -158,7 +161,8 @@
     ]
   },
   {
-    "id": "xy11-4",
+    "setOrder":70,
+	"id": "xy11-4",
     "name": "Skiploom",
     "imageUrl": "https://images.pokemontcg.io/xy11/4.png",
     "subtype": "Stage 1",
@@ -202,7 +206,8 @@
     ]
   },
   {
-    "id": "xy11-5",
+    "setOrder":70,
+	"id": "xy11-5",
     "name": "Jumpluff",
     "imageUrl": "https://images.pokemontcg.io/xy11/5.png",
     "subtype": "Stage 2",
@@ -252,7 +257,8 @@
     "nationalPokedexNumber": 189
   },
   {
-    "id": "xy11-6",
+    "setOrder":70,
+	"id": "xy11-6",
     "name": "Yanma",
     "imageUrl": "https://images.pokemontcg.io/xy11/6.png",
     "subtype": "Basic",
@@ -312,7 +318,8 @@
     ]
   },
   {
-    "id": "xy11-7",
+    "setOrder":70,
+	"id": "xy11-7",
     "name": "Yanmega",
     "imageUrl": "https://images.pokemontcg.io/xy11/7.png",
     "subtype": "Stage 1",
@@ -363,7 +370,8 @@
     "nationalPokedexNumber": 469
   },
   {
-    "id": "xy11-8",
+    "setOrder":70,
+	"id": "xy11-8",
     "name": "Yanmega BREAK",
     "imageUrl": "https://images.pokemontcg.io/xy11/8.png",
     "subtype": "BREAK",
@@ -400,7 +408,8 @@
     "nationalPokedexNumber": 469
   },
   {
-    "id": "xy11-9",
+    "setOrder":70,
+	"id": "xy11-9",
     "name": "Seedot",
     "imageUrl": "https://images.pokemontcg.io/xy11/9.png",
     "subtype": "Basic",
@@ -443,7 +452,8 @@
     ]
   },
   {
-    "id": "xy11-10",
+    "setOrder":70,
+	"id": "xy11-10",
     "name": "Nuzleaf",
     "imageUrl": "https://images.pokemontcg.io/xy11/10.png",
     "subtype": "Stage 1",
@@ -497,7 +507,8 @@
     ]
   },
   {
-    "id": "xy11-11",
+    "setOrder":70,
+	"id": "xy11-11",
     "name": "Shiftry",
     "imageUrl": "https://images.pokemontcg.io/xy11/11.png",
     "subtype": "Stage 2",
@@ -550,7 +561,8 @@
     "nationalPokedexNumber": 275
   },
   {
-    "id": "xy11-12",
+    "setOrder":70,
+	"id": "xy11-12",
     "name": "Foongus",
     "imageUrl": "https://images.pokemontcg.io/xy11/12.png",
     "subtype": "Basic",
@@ -598,7 +610,8 @@
     ]
   },
   {
-    "id": "xy11-13",
+    "setOrder":70,
+	"id": "xy11-13",
     "name": "Amoonguss",
     "imageUrl": "https://images.pokemontcg.io/xy11/13.png",
     "subtype": "Stage 1",
@@ -650,7 +663,8 @@
     "nationalPokedexNumber": 591
   },
   {
-    "id": "xy11-14",
+    "setOrder":70,
+	"id": "xy11-14",
     "name": "Larvesta",
     "imageUrl": "https://images.pokemontcg.io/xy11/14.png",
     "subtype": "Basic",
@@ -695,7 +709,8 @@
     ]
   },
   {
-    "id": "xy11-15",
+    "setOrder":70,
+	"id": "xy11-15",
     "name": "Volcarona",
     "imageUrl": "https://images.pokemontcg.io/xy11/15.png",
     "subtype": "Stage 1",
@@ -748,7 +763,8 @@
     "nationalPokedexNumber": 637
   },
   {
-    "id": "xy11-16",
+    "setOrder":70,
+	"id": "xy11-16",
     "name": "Ponyta",
     "imageUrl": "https://images.pokemontcg.io/xy11/16.png",
     "subtype": "Basic",
@@ -800,7 +816,8 @@
     ]
   },
   {
-    "id": "xy11-17",
+    "setOrder":70,
+	"id": "xy11-17",
     "name": "Rapidash",
     "imageUrl": "https://images.pokemontcg.io/xy11/17.png",
     "subtype": "Stage 1",
@@ -851,7 +868,8 @@
     "nationalPokedexNumber": 78
   },
   {
-    "id": "xy11-18",
+    "setOrder":70,
+	"id": "xy11-18",
     "name": "Chimchar",
     "imageUrl": "https://images.pokemontcg.io/xy11/18.png",
     "subtype": "Basic",
@@ -904,7 +922,8 @@
     ]
   },
   {
-    "id": "xy11-19",
+    "setOrder":70,
+	"id": "xy11-19",
     "name": "Monferno",
     "imageUrl": "https://images.pokemontcg.io/xy11/19.png",
     "subtype": "Stage 1",
@@ -958,7 +977,8 @@
     ]
   },
   {
-    "id": "xy11-20",
+    "setOrder":70,
+	"id": "xy11-20",
     "name": "Infernape",
     "imageUrl": "https://images.pokemontcg.io/xy11/20.png",
     "subtype": "Stage 2",
@@ -1010,7 +1030,8 @@
     "nationalPokedexNumber": 392
   },
   {
-    "id": "xy11-21",
+    "setOrder":70,
+	"id": "xy11-21",
     "name": "Talonflame BREAK",
     "imageUrl": "https://images.pokemontcg.io/xy11/21.png",
     "subtype": "BREAK",
@@ -1046,7 +1067,8 @@
     "nationalPokedexNumber": 663
   },
   {
-    "id": "xy11-22",
+    "setOrder":70,
+	"id": "xy11-22",
     "name": "Litleo",
     "imageUrl": "https://images.pokemontcg.io/xy11/22.png",
     "subtype": "Basic",
@@ -1090,7 +1112,8 @@
     ]
   },
   {
-    "id": "xy11-23",
+    "setOrder":70,
+	"id": "xy11-23",
     "name": "Pyroar",
     "imageUrl": "https://images.pokemontcg.io/xy11/23.png",
     "subtype": "Stage 1",
@@ -1144,7 +1167,8 @@
     "nationalPokedexNumber": 668
   },
   {
-    "id": "xy11-24",
+    "setOrder":70,
+	"id": "xy11-24",
     "name": "Pyroar BREAK",
     "imageUrl": "https://images.pokemontcg.io/xy11/24.png",
     "subtype": "BREAK",
@@ -1181,7 +1205,8 @@
     "nationalPokedexNumber": 668
   },
   {
-    "id": "xy11-25",
+    "setOrder":70,
+	"id": "xy11-25",
     "name": "Volcanion",
     "imageUrl": "https://images.pokemontcg.io/xy11/25.png",
     "subtype": "Basic",
@@ -1233,7 +1258,8 @@
     "nationalPokedexNumber": 721
   },
   {
-    "id": "xy11-26",
+    "setOrder":70,
+	"id": "xy11-26",
     "name": "Volcanion-EX",
     "imageUrl": "https://images.pokemontcg.io/xy11/26.png",
     "subtype": "EX",
@@ -1286,7 +1312,8 @@
     "nationalPokedexNumber": 721
   },
   {
-    "id": "xy11-27",
+    "setOrder":70,
+	"id": "xy11-27",
     "name": "Mantine",
     "imageUrl": "https://images.pokemontcg.io/xy11/27.png",
     "subtype": "Basic",
@@ -1343,7 +1370,8 @@
     "nationalPokedexNumber": 226
   },
   {
-    "id": "xy11-28",
+    "setOrder":70,
+	"id": "xy11-28",
     "name": "Shellos",
     "imageUrl": "https://images.pokemontcg.io/xy11/28.png",
     "subtype": "Basic",
@@ -1387,7 +1415,8 @@
     ]
   },
   {
-    "id": "xy11-29",
+    "setOrder":70,
+	"id": "xy11-29",
     "name": "Gastrodon",
     "imageUrl": "https://images.pokemontcg.io/xy11/29.png",
     "subtype": "Stage 1",
@@ -1440,7 +1469,8 @@
     "nationalPokedexNumber": 423
   },
   {
-    "id": "xy11-30",
+    "setOrder":70,
+	"id": "xy11-30",
     "name": "Oshawott",
     "imageUrl": "https://images.pokemontcg.io/xy11/30.png",
     "subtype": "Basic",
@@ -1484,7 +1514,8 @@
     ]
   },
   {
-    "id": "xy11-31",
+    "setOrder":70,
+	"id": "xy11-31",
     "name": "Dewott",
     "imageUrl": "https://images.pokemontcg.io/xy11/31.png",
     "subtype": "Stage 1",
@@ -1530,7 +1561,8 @@
     ]
   },
   {
-    "id": "xy11-32",
+    "setOrder":70,
+	"id": "xy11-32",
     "name": "Samurott",
     "imageUrl": "https://images.pokemontcg.io/xy11/32.png",
     "subtype": "Stage 2",
@@ -1584,7 +1616,8 @@
     "nationalPokedexNumber": 503
   },
   {
-    "id": "xy11-33",
+    "setOrder":70,
+	"id": "xy11-33",
     "name": "Clauncher",
     "imageUrl": "https://images.pokemontcg.io/xy11/33.png",
     "subtype": "Basic",
@@ -1627,7 +1660,8 @@
     ]
   },
   {
-    "id": "xy11-34",
+    "setOrder":70,
+	"id": "xy11-34",
     "name": "Clawitzer",
     "imageUrl": "https://images.pokemontcg.io/xy11/34.png",
     "subtype": "Stage 1",
@@ -1676,7 +1710,8 @@
     "nationalPokedexNumber": 693
   },
   {
-    "id": "xy11-35",
+    "setOrder":70,
+	"id": "xy11-35",
     "name": "Clawitzer BREAK",
     "imageUrl": "https://images.pokemontcg.io/xy11/35.png",
     "subtype": "BREAK",
@@ -1711,7 +1746,8 @@
     "nationalPokedexNumber": 693
   },
   {
-    "id": "xy11-36",
+    "setOrder":70,
+	"id": "xy11-36",
     "name": "Bergmite",
     "imageUrl": "https://images.pokemontcg.io/xy11/36.png",
     "subtype": "Basic",
@@ -1765,7 +1801,8 @@
     ]
   },
   {
-    "id": "xy11-37",
+    "setOrder":70,
+	"id": "xy11-37",
     "name": "Avalugg",
     "imageUrl": "https://images.pokemontcg.io/xy11/37.png",
     "subtype": "Stage 1",
@@ -1821,7 +1858,8 @@
     "nationalPokedexNumber": 713
   },
   {
-    "id": "xy11-38",
+    "setOrder":70,
+	"id": "xy11-38",
     "name": "Mareep",
     "imageUrl": "https://images.pokemontcg.io/xy11/38.png",
     "subtype": "Basic",
@@ -1880,7 +1918,8 @@
     ]
   },
   {
-    "id": "xy11-39",
+    "setOrder":70,
+	"id": "xy11-39",
     "name": "Flaaffy",
     "imageUrl": "https://images.pokemontcg.io/xy11/39.png",
     "subtype": "Stage 1",
@@ -1942,7 +1981,8 @@
     ]
   },
   {
-    "id": "xy11-40",
+    "setOrder":70,
+	"id": "xy11-40",
     "name": "Ampharos",
     "imageUrl": "https://images.pokemontcg.io/xy11/40.png",
     "subtype": "Stage 2",
@@ -1997,7 +2037,8 @@
     "nationalPokedexNumber": 181
   },
   {
-    "id": "xy11-41",
+    "setOrder":70,
+	"id": "xy11-41",
     "name": "Joltik",
     "imageUrl": "https://images.pokemontcg.io/xy11/41.png",
     "subtype": "Basic",
@@ -2043,7 +2084,8 @@
     ]
   },
   {
-    "id": "xy11-42",
+    "setOrder":70,
+	"id": "xy11-42",
     "name": "Galvantula",
     "imageUrl": "https://images.pokemontcg.io/xy11/42.png",
     "subtype": "Stage 1",
@@ -2100,7 +2142,8 @@
     "nationalPokedexNumber": 596
   },
   {
-    "id": "xy11-43",
+    "setOrder":70,
+	"id": "xy11-43",
     "name": "Nidoran♂",
     "imageUrl": "https://images.pokemontcg.io/xy11/43.png",
     "subtype": "Basic",
@@ -2153,7 +2196,8 @@
     ]
   },
   {
-    "id": "xy11-44",
+    "setOrder":70,
+	"id": "xy11-44",
     "name": "Nidorino",
     "imageUrl": "https://images.pokemontcg.io/xy11/44.png",
     "subtype": "Stage 1",
@@ -2210,7 +2254,8 @@
     ]
   },
   {
-    "id": "xy11-45",
+    "setOrder":70,
+	"id": "xy11-45",
     "name": "Nidoking",
     "imageUrl": "https://images.pokemontcg.io/xy11/45.png",
     "subtype": "Stage 2",
@@ -2261,7 +2306,8 @@
     "nationalPokedexNumber": 34
   },
   {
-    "id": "xy11-46",
+    "setOrder":70,
+	"id": "xy11-46",
     "name": "Drifloon",
     "imageUrl": "https://images.pokemontcg.io/xy11/46.png",
     "subtype": "Basic",
@@ -2310,7 +2356,8 @@
     ]
   },
   {
-    "id": "xy11-47",
+    "setOrder":70,
+	"id": "xy11-47",
     "name": "Drifblim",
     "imageUrl": "https://images.pokemontcg.io/xy11/47.png",
     "subtype": "Stage 1",
@@ -2368,7 +2415,8 @@
     "nationalPokedexNumber": 426
   },
   {
-    "id": "xy11-48",
+    "setOrder":70,
+	"id": "xy11-48",
     "name": "Litwick",
     "imageUrl": "https://images.pokemontcg.io/xy11/48.png",
     "subtype": "Basic",
@@ -2417,7 +2465,8 @@
     ]
   },
   {
-    "id": "xy11-49",
+    "setOrder":70,
+	"id": "xy11-49",
     "name": "Lampent",
     "imageUrl": "https://images.pokemontcg.io/xy11/49.png",
     "subtype": "Stage 1",
@@ -2477,7 +2526,8 @@
     ]
   },
   {
-    "id": "xy11-50",
+    "setOrder":70,
+	"id": "xy11-50",
     "name": "Chandelure",
     "imageUrl": "https://images.pokemontcg.io/xy11/50.png",
     "subtype": "Stage 2",
@@ -2531,7 +2581,8 @@
     "nationalPokedexNumber": 609
   },
   {
-    "id": "xy11-51",
+    "setOrder":70,
+	"id": "xy11-51",
     "name": "Hoopa",
     "imageUrl": "https://images.pokemontcg.io/xy11/51.png",
     "subtype": "Basic",
@@ -2583,7 +2634,8 @@
     "nationalPokedexNumber": 720
   },
   {
-    "id": "xy11-52",
+    "setOrder":70,
+	"id": "xy11-52",
     "name": "Mankey",
     "imageUrl": "https://images.pokemontcg.io/xy11/52.png",
     "subtype": "Basic",
@@ -2635,7 +2687,8 @@
     ]
   },
   {
-    "id": "xy11-53",
+    "setOrder":70,
+	"id": "xy11-53",
     "name": "Primeape",
     "imageUrl": "https://images.pokemontcg.io/xy11/53.png",
     "subtype": "Stage 1",
@@ -2686,7 +2739,8 @@
     "nationalPokedexNumber": 57
   },
   {
-    "id": "xy11-54",
+    "setOrder":70,
+	"id": "xy11-54",
     "name": "Nosepass",
     "imageUrl": "https://images.pokemontcg.io/xy11/54.png",
     "subtype": "Basic",
@@ -2741,7 +2795,8 @@
     ]
   },
   {
-    "id": "xy11-55",
+    "setOrder":70,
+	"id": "xy11-55",
     "name": "Probopass",
     "imageUrl": "https://images.pokemontcg.io/xy11/55.png",
     "subtype": "Stage 1",
@@ -2796,7 +2851,8 @@
     "nationalPokedexNumber": 476
   },
   {
-    "id": "xy11-56",
+    "setOrder":70,
+	"id": "xy11-56",
     "name": "Anorith",
     "imageUrl": "https://images.pokemontcg.io/xy11/56.png",
     "subtype": "Restored",
@@ -2847,7 +2903,8 @@
     ]
   },
   {
-    "id": "xy11-57",
+    "setOrder":70,
+	"id": "xy11-57",
     "name": "Armaldo",
     "imageUrl": "https://images.pokemontcg.io/xy11/57.png",
     "subtype": "Stage 1",
@@ -2900,7 +2957,8 @@
     "nationalPokedexNumber": 348
   },
   {
-    "id": "xy11-58",
+    "setOrder":70,
+	"id": "xy11-58",
     "name": "Croagunk",
     "imageUrl": "https://images.pokemontcg.io/xy11/58.png",
     "subtype": "Basic",
@@ -2943,7 +3001,8 @@
     ]
   },
   {
-    "id": "xy11-59",
+    "setOrder":70,
+	"id": "xy11-59",
     "name": "Toxicroak",
     "imageUrl": "https://images.pokemontcg.io/xy11/59.png",
     "subtype": "Stage 1",
@@ -2991,7 +3050,8 @@
     "nationalPokedexNumber": 454
   },
   {
-    "id": "xy11-60",
+    "setOrder":70,
+	"id": "xy11-60",
     "name": "Sneasel",
     "imageUrl": "https://images.pokemontcg.io/xy11/60.png",
     "subtype": "Basic",
@@ -3040,7 +3100,8 @@
     ]
   },
   {
-    "id": "xy11-61",
+    "setOrder":70,
+	"id": "xy11-61",
     "name": "Weavile",
     "imageUrl": "https://images.pokemontcg.io/xy11/61.png",
     "subtype": "Stage 1",
@@ -3093,7 +3154,8 @@
     "nationalPokedexNumber": 461
   },
   {
-    "id": "xy11-62",
+    "setOrder":70,
+	"id": "xy11-62",
     "name": "Spiritomb",
     "imageUrl": "https://images.pokemontcg.io/xy11/62.png",
     "subtype": "Basic",
@@ -3137,7 +3199,8 @@
     "nationalPokedexNumber": 442
   },
   {
-    "id": "xy11-63",
+    "setOrder":70,
+	"id": "xy11-63",
     "name": "Pawniard",
     "imageUrl": "https://images.pokemontcg.io/xy11/63.png",
     "subtype": "Basic",
@@ -3186,7 +3249,8 @@
     ]
   },
   {
-    "id": "xy11-64",
+    "setOrder":70,
+	"id": "xy11-64",
     "name": "Bisharp",
     "imageUrl": "https://images.pokemontcg.io/xy11/64.png",
     "subtype": "Stage 1",
@@ -3245,7 +3309,8 @@
     "nationalPokedexNumber": 625
   },
   {
-    "id": "xy11-65",
+    "setOrder":70,
+	"id": "xy11-65",
     "name": "Yveltal",
     "imageUrl": "https://images.pokemontcg.io/xy11/65.png",
     "subtype": "Basic",
@@ -3303,7 +3368,8 @@
     "nationalPokedexNumber": 717
   },
   {
-    "id": "xy11-66",
+    "setOrder":70,
+	"id": "xy11-66",
     "name": "Yveltal BREAK",
     "imageUrl": "https://images.pokemontcg.io/xy11/66.png",
     "subtype": "BREAK",
@@ -3340,7 +3406,8 @@
     "nationalPokedexNumber": 717
   },
   {
-    "id": "xy11-67",
+    "setOrder":70,
+	"id": "xy11-67",
     "name": "Steelix-EX",
     "imageUrl": "https://images.pokemontcg.io/xy11/67.png",
     "subtype": "EX",
@@ -3409,7 +3476,8 @@
     "evolvesTo": "M Steelix-EX"
   },
   {
-    "id": "xy11-68",
+    "setOrder":70,
+	"id": "xy11-68",
     "name": "M Steelix-EX",
     "imageUrl": "https://images.pokemontcg.io/xy11/68.png",
     "subtype": "MEGA",
@@ -3468,7 +3536,8 @@
     "nationalPokedexNumber": 208
   },
   {
-    "id": "xy11-69",
+    "setOrder":70,
+	"id": "xy11-69",
     "name": "Shieldon",
     "imageUrl": "https://images.pokemontcg.io/xy11/69.png",
     "subtype": "Restored",
@@ -3533,7 +3602,8 @@
     ]
   },
   {
-    "id": "xy11-70",
+    "setOrder":70,
+	"id": "xy11-70",
     "name": "Bastiodon",
     "imageUrl": "https://images.pokemontcg.io/xy11/70.png",
     "subtype": "Stage 1",
@@ -3596,7 +3666,8 @@
     "nationalPokedexNumber": 411
   },
   {
-    "id": "xy11-71",
+    "setOrder":70,
+	"id": "xy11-71",
     "name": "Klink",
     "imageUrl": "https://images.pokemontcg.io/xy11/71.png",
     "subtype": "Basic",
@@ -3646,7 +3717,8 @@
     ]
   },
   {
-    "id": "xy11-72",
+    "setOrder":70,
+	"id": "xy11-72",
     "name": "Klang",
     "imageUrl": "https://images.pokemontcg.io/xy11/72.png",
     "subtype": "Stage 1",
@@ -3709,7 +3781,8 @@
     ]
   },
   {
-    "id": "xy11-73",
+    "setOrder":70,
+	"id": "xy11-73",
     "name": "Klinklang",
     "imageUrl": "https://images.pokemontcg.io/xy11/73.png",
     "subtype": "Stage 2",
@@ -3765,7 +3838,8 @@
     "nationalPokedexNumber": 601
   },
   {
-    "id": "xy11-74",
+    "setOrder":70,
+	"id": "xy11-74",
     "name": "Cobalion",
     "imageUrl": "https://images.pokemontcg.io/xy11/74.png",
     "subtype": "Basic",
@@ -3822,7 +3896,8 @@
     "nationalPokedexNumber": 638
   },
   {
-    "id": "xy11-75",
+    "setOrder":70,
+	"id": "xy11-75",
     "name": "Magearna-EX",
     "imageUrl": "https://images.pokemontcg.io/xy11/75.png",
     "subtype": "EX",
@@ -3878,7 +3953,8 @@
     "nationalPokedexNumber": 801
   },
   {
-    "id": "xy11-76",
+    "setOrder":70,
+	"id": "xy11-76",
     "name": "Marill",
     "imageUrl": "https://images.pokemontcg.io/xy11/76.png",
     "subtype": "Basic",
@@ -3927,7 +4003,8 @@
     ]
   },
   {
-    "id": "xy11-77",
+    "setOrder":70,
+	"id": "xy11-77",
     "name": "Azumarill",
     "imageUrl": "https://images.pokemontcg.io/xy11/77.png",
     "subtype": "Stage 1",
@@ -3988,7 +4065,8 @@
     "nationalPokedexNumber": 184
   },
   {
-    "id": "xy11-78",
+    "setOrder":70,
+	"id": "xy11-78",
     "name": "Gardevoir-EX",
     "imageUrl": "https://images.pokemontcg.io/xy11/78.png",
     "subtype": "EX",
@@ -4051,7 +4129,8 @@
     "evolvesTo": "M Gardevoir-EX"
   },
   {
-    "id": "xy11-79",
+    "setOrder":70,
+	"id": "xy11-79",
     "name": "M Gardevoir-EX",
     "imageUrl": "https://images.pokemontcg.io/xy11/79.png",
     "subtype": "MEGA",
@@ -4105,7 +4184,8 @@
     "nationalPokedexNumber": 282
   },
   {
-    "id": "xy11-80",
+    "setOrder":70,
+	"id": "xy11-80",
     "name": "Klefki",
     "imageUrl": "https://images.pokemontcg.io/xy11/80.png",
     "subtype": "Basic",
@@ -4157,7 +4237,8 @@
     "nationalPokedexNumber": 707
   },
   {
-    "id": "xy11-81",
+    "setOrder":70,
+	"id": "xy11-81",
     "name": "Xerneas",
     "imageUrl": "https://images.pokemontcg.io/xy11/81.png",
     "subtype": "Basic",
@@ -4215,7 +4296,8 @@
     "nationalPokedexNumber": 716
   },
   {
-    "id": "xy11-82",
+    "setOrder":70,
+	"id": "xy11-82",
     "name": "Xerneas BREAK",
     "imageUrl": "https://images.pokemontcg.io/xy11/82.png",
     "subtype": "BREAK",
@@ -4251,7 +4333,8 @@
     "nationalPokedexNumber": 716
   },
   {
-    "id": "xy11-83",
+    "setOrder":70,
+	"id": "xy11-83",
     "name": "Druddigon",
     "imageUrl": "https://images.pokemontcg.io/xy11/83.png",
     "subtype": "Basic",
@@ -4304,7 +4387,8 @@
     "nationalPokedexNumber": 621
   },
   {
-    "id": "xy11-84",
+    "setOrder":70,
+	"id": "xy11-84",
     "name": "Deino",
     "imageUrl": "https://images.pokemontcg.io/xy11/84.png",
     "subtype": "Basic",
@@ -4358,7 +4442,8 @@
     ]
   },
   {
-    "id": "xy11-85",
+    "setOrder":70,
+	"id": "xy11-85",
     "name": "Zweilous",
     "imageUrl": "https://images.pokemontcg.io/xy11/85.png",
     "subtype": "Stage 1",
@@ -4415,7 +4500,8 @@
     ]
   },
   {
-    "id": "xy11-86",
+    "setOrder":70,
+	"id": "xy11-86",
     "name": "Hydreigon",
     "imageUrl": "https://images.pokemontcg.io/xy11/86.png",
     "subtype": "Stage 2",
@@ -4470,7 +4556,8 @@
     "nationalPokedexNumber": 635
   },
   {
-    "id": "xy11-87",
+    "setOrder":70,
+	"id": "xy11-87",
     "name": "Hydreigon BREAK",
     "imageUrl": "https://images.pokemontcg.io/xy11/87.png",
     "subtype": "BREAK",
@@ -4514,7 +4601,8 @@
     "nationalPokedexNumber": 635
   },
   {
-    "id": "xy11-88",
+    "setOrder":70,
+	"id": "xy11-88",
     "name": "Meowth",
     "imageUrl": "https://images.pokemontcg.io/xy11/88.png",
     "subtype": "Basic",
@@ -4567,7 +4655,8 @@
     ]
   },
   {
-    "id": "xy11-89",
+    "setOrder":70,
+	"id": "xy11-89",
     "name": "Persian",
     "imageUrl": "https://images.pokemontcg.io/xy11/89.png",
     "subtype": "Stage 1",
@@ -4618,7 +4707,8 @@
     "nationalPokedexNumber": 53
   },
   {
-    "id": "xy11-90",
+    "setOrder":70,
+	"id": "xy11-90",
     "name": "Aipom",
     "imageUrl": "https://images.pokemontcg.io/xy11/90.png",
     "subtype": "Basic",
@@ -4671,7 +4761,8 @@
     ]
   },
   {
-    "id": "xy11-91",
+    "setOrder":70,
+	"id": "xy11-91",
     "name": "Ambipom",
     "imageUrl": "https://images.pokemontcg.io/xy11/91.png",
     "subtype": "Stage 1",
@@ -4723,7 +4814,8 @@
     "nationalPokedexNumber": 424
   },
   {
-    "id": "xy11-92",
+    "setOrder":70,
+	"id": "xy11-92",
     "name": "Rufflet",
     "imageUrl": "https://images.pokemontcg.io/xy11/92.png",
     "subtype": "Basic",
@@ -4772,7 +4864,8 @@
     ]
   },
   {
-    "id": "xy11-93",
+    "setOrder":70,
+	"id": "xy11-93",
     "name": "Braviary",
     "imageUrl": "https://images.pokemontcg.io/xy11/93.png",
     "subtype": "Stage 1",
@@ -4832,7 +4925,8 @@
     "nationalPokedexNumber": 628
   },
   {
-    "id": "xy11-94",
+    "setOrder":70,
+	"id": "xy11-94",
     "name": "Fletchling",
     "imageUrl": "https://images.pokemontcg.io/xy11/94.png",
     "subtype": "Basic",
@@ -4881,7 +4975,8 @@
     ]
   },
   {
-    "id": "xy11-95",
+    "setOrder":70,
+	"id": "xy11-95",
     "name": "Fletchinder",
     "imageUrl": "https://images.pokemontcg.io/xy11/95.png",
     "subtype": "Stage 1",
@@ -4931,7 +5026,8 @@
     ]
   },
   {
-    "id": "xy11-96",
+    "setOrder":70,
+	"id": "xy11-96",
     "name": "Talonflame",
     "imageUrl": "https://images.pokemontcg.io/xy11/96.png",
     "subtype": "Stage 2",
@@ -4980,7 +5076,8 @@
     "nationalPokedexNumber": 663
   },
   {
-    "id": "xy11-97",
+    "setOrder":70,
+	"id": "xy11-97",
     "name": "Hawlucha",
     "imageUrl": "https://images.pokemontcg.io/xy11/97.png",
     "subtype": "Basic",
@@ -5032,7 +5129,8 @@
     "nationalPokedexNumber": 701
   },
   {
-    "id": "xy11-98",
+    "setOrder":70,
+	"id": "xy11-98",
     "name": "Armor Fossil Shieldon",
     "imageUrl": "https://images.pokemontcg.io/xy11/98.png",
     "subtype": "Item",
@@ -5049,7 +5147,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy11/98_hires.png"
   },
   {
-    "id": "xy11-99",
+    "setOrder":70,
+	"id": "xy11-99",
     "name": "Captivating Poké Puff",
     "imageUrl": "https://images.pokemontcg.io/xy11/99.png",
     "subtype": "Item",
@@ -5066,7 +5165,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy11/99_hires.png"
   },
   {
-    "id": "xy11-100",
+    "setOrder":70,
+	"id": "xy11-100",
     "name": "Claw Fossil Anorith",
     "imageUrl": "https://images.pokemontcg.io/xy11/100.png",
     "subtype": "Item",
@@ -5083,7 +5183,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy11/100_hires.png"
   },
   {
-    "id": "xy11-101",
+    "setOrder":70,
+	"id": "xy11-101",
     "name": "Gardevoir Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xy11/101.png",
     "subtype": "Pokémon Tool",
@@ -5100,7 +5201,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy11/101_hires.png"
   },
   {
-    "id": "xy11-102",
+    "setOrder":70,
+	"id": "xy11-102",
     "name": "Greedy Dice",
     "imageUrl": "https://images.pokemontcg.io/xy11/102.png",
     "subtype": "Item",
@@ -5117,7 +5219,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy11/102_hires.png"
   },
   {
-    "id": "xy11-103",
+    "setOrder":70,
+	"id": "xy11-103",
     "name": "Ninja Boy",
     "imageUrl": "https://images.pokemontcg.io/xy11/103.png",
     "subtype": "Supporter",
@@ -5134,7 +5237,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy11/103_hires.png"
   },
   {
-    "id": "xy11-104",
+    "setOrder":70,
+	"id": "xy11-104",
     "name": "Pokémon Ranger",
     "imageUrl": "https://images.pokemontcg.io/xy11/104.png",
     "subtype": "Supporter",
@@ -5151,7 +5255,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy11/104_hires.png"
   },
   {
-    "id": "xy11-105",
+    "setOrder":70,
+	"id": "xy11-105",
     "name": "Special Charge",
     "imageUrl": "https://images.pokemontcg.io/xy11/105.png",
     "subtype": "Item",
@@ -5168,7 +5273,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy11/105_hires.png"
   },
   {
-    "id": "xy11-106",
+    "setOrder":70,
+	"id": "xy11-106",
     "name": "Steelix Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xy11/106.png",
     "subtype": "Pokémon Tool",
@@ -5185,7 +5291,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy11/106_hires.png"
   },
   {
-    "id": "xy11-107",
+    "setOrder":70,
+	"id": "xy11-107",
     "name": "Volcanion-EX",
     "imageUrl": "https://images.pokemontcg.io/xy11/107.png",
     "subtype": "EX",
@@ -5238,7 +5345,8 @@
     "nationalPokedexNumber": 721
   },
   {
-    "id": "xy11-108",
+    "setOrder":70,
+	"id": "xy11-108",
     "name": "Steelix-EX",
     "imageUrl": "https://images.pokemontcg.io/xy11/108.png",
     "subtype": "EX",
@@ -5307,7 +5415,8 @@
     "evolvesTo": "M Steelix-EX"
   },
   {
-    "id": "xy11-109",
+    "setOrder":70,
+	"id": "xy11-109",
     "name": "M Steelix-EX",
     "imageUrl": "https://images.pokemontcg.io/xy11/109.png",
     "subtype": "MEGA",
@@ -5366,7 +5475,8 @@
     "nationalPokedexNumber": 208
   },
   {
-    "id": "xy11-110",
+    "setOrder":70,
+	"id": "xy11-110",
     "name": "Magearna-EX",
     "imageUrl": "https://images.pokemontcg.io/xy11/110.png",
     "subtype": "EX",
@@ -5422,7 +5532,8 @@
     "nationalPokedexNumber": 801
   },
   {
-    "id": "xy11-111",
+    "setOrder":70,
+	"id": "xy11-111",
     "name": "Gardevoir-EX",
     "imageUrl": "https://images.pokemontcg.io/xy11/111.png",
     "subtype": "EX",
@@ -5485,7 +5596,8 @@
     "evolvesTo": "M Gardevoir-EX"
   },
   {
-    "id": "xy11-112",
+    "setOrder":70,
+	"id": "xy11-112",
     "name": "M Gardevoir-EX",
     "imageUrl": "https://images.pokemontcg.io/xy11/112.png",
     "subtype": "MEGA",
@@ -5539,7 +5651,8 @@
     "nationalPokedexNumber": 282
   },
   {
-    "id": "xy11-113",
+    "setOrder":70,
+	"id": "xy11-113",
     "name": "Pokémon Ranger",
     "imageUrl": "https://images.pokemontcg.io/xy11/113.png",
     "subtype": "Supporter",
@@ -5556,7 +5669,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy11/113_hires.png"
   },
   {
-    "id": "xy11-114",
+    "setOrder":70,
+	"id": "xy11-114",
     "name": "Professor Sycamore",
     "imageUrl": "https://images.pokemontcg.io/xy11/114.png",
     "subtype": "Supporter",
@@ -5573,7 +5687,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy11/114_hires.png"
   },
   {
-    "id": "xy11-115",
+    "setOrder":70,
+	"id": "xy11-115",
     "name": "Volcanion-EX",
     "imageUrl": "https://images.pokemontcg.io/xy11/115.png",
     "subtype": "EX",
@@ -5626,7 +5741,8 @@
     "nationalPokedexNumber": 721
   },
   {
-    "id": "xy11-116",
+    "setOrder":70,
+	"id": "xy11-116",
     "name": "Gardevoir-EX",
     "imageUrl": "https://images.pokemontcg.io/xy11/116.png",
     "subtype": "EX",

--- a/json/cards/Stormfront.json
+++ b/json/cards/Stormfront.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "dp7-1",
+    "setOrder":38,
+	"id": "dp7-1",
     "name": "Dusknoir",
     "imageUrl": "https://images.pokemontcg.io/dp7/1.png",
     "subtype": "Stage 2",
@@ -67,7 +68,8 @@
     "nationalPokedexNumber": 477
   },
   {
-    "id": "dp7-2",
+    "setOrder":38,
+	"id": "dp7-2",
     "name": "Empoleon",
     "imageUrl": "https://images.pokemontcg.io/dp7/2.png",
     "subtype": "Stage 2",
@@ -127,7 +129,8 @@
     "nationalPokedexNumber": 395
   },
   {
-    "id": "dp7-3",
+    "setOrder":38,
+	"id": "dp7-3",
     "name": "Infernape",
     "imageUrl": "https://images.pokemontcg.io/dp7/3.png",
     "subtype": "Stage 2",
@@ -184,7 +187,8 @@
     "nationalPokedexNumber": 392
   },
   {
-    "id": "dp7-4",
+    "setOrder":38,
+	"id": "dp7-4",
     "name": "Lumineon",
     "imageUrl": "https://images.pokemontcg.io/dp7/4.png",
     "subtype": "Stage 1",
@@ -237,7 +241,8 @@
     "nationalPokedexNumber": 457
   },
   {
-    "id": "dp7-5",
+    "setOrder":38,
+	"id": "dp7-5",
     "name": "Magnezone",
     "imageUrl": "https://images.pokemontcg.io/dp7/5.png",
     "subtype": "Stage 2",
@@ -303,7 +308,8 @@
     "nationalPokedexNumber": 462
   },
   {
-    "id": "dp7-6",
+    "setOrder":38,
+	"id": "dp7-6",
     "name": "Magnezone",
     "imageUrl": "https://images.pokemontcg.io/dp7/6.png",
     "subtype": "Stage 2",
@@ -360,7 +366,8 @@
     "nationalPokedexNumber": 462
   },
   {
-    "id": "dp7-7",
+    "setOrder":38,
+	"id": "dp7-7",
     "name": "Mismagius",
     "imageUrl": "https://images.pokemontcg.io/dp7/7.png",
     "subtype": "Stage 1",
@@ -418,7 +425,8 @@
     "nationalPokedexNumber": 429
   },
   {
-    "id": "dp7-8",
+    "setOrder":38,
+	"id": "dp7-8",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/dp7/8.png",
     "subtype": "Stage 1",
@@ -485,7 +493,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "dp7-9",
+    "setOrder":38,
+	"id": "dp7-9",
     "name": "Regigigas",
     "imageUrl": "https://images.pokemontcg.io/dp7/9.png",
     "subtype": "Basic",
@@ -547,7 +556,8 @@
     "nationalPokedexNumber": 486
   },
   {
-    "id": "dp7-10",
+    "setOrder":38,
+	"id": "dp7-10",
     "name": "Sceptile",
     "imageUrl": "https://images.pokemontcg.io/dp7/10.png",
     "subtype": "Stage 2",
@@ -613,7 +623,8 @@
     "nationalPokedexNumber": 254
   },
   {
-    "id": "dp7-11",
+    "setOrder":38,
+	"id": "dp7-11",
     "name": "Torterra",
     "imageUrl": "https://images.pokemontcg.io/dp7/11.png",
     "subtype": "Stage 2",
@@ -682,7 +693,8 @@
     "nationalPokedexNumber": 389
   },
   {
-    "id": "dp7-12",
+    "setOrder":38,
+	"id": "dp7-12",
     "name": "Abomasnow",
     "imageUrl": "https://images.pokemontcg.io/dp7/12.png",
     "subtype": "Stage 1",
@@ -743,7 +755,8 @@
     "nationalPokedexNumber": 460
   },
   {
-    "id": "dp7-13",
+    "setOrder":38,
+	"id": "dp7-13",
     "name": "Bronzong",
     "imageUrl": "https://images.pokemontcg.io/dp7/13.png",
     "subtype": "Stage 1",
@@ -810,7 +823,8 @@
     "nationalPokedexNumber": 437
   },
   {
-    "id": "dp7-14",
+    "setOrder":38,
+	"id": "dp7-14",
     "name": "Cherrim",
     "imageUrl": "https://images.pokemontcg.io/dp7/14.png",
     "subtype": "Stage 1",
@@ -874,7 +888,8 @@
     "nationalPokedexNumber": 421
   },
   {
-    "id": "dp7-15",
+    "setOrder":38,
+	"id": "dp7-15",
     "name": "Drapion",
     "imageUrl": "https://images.pokemontcg.io/dp7/15.png",
     "subtype": "Stage 1",
@@ -939,7 +954,8 @@
     "nationalPokedexNumber": 452
   },
   {
-    "id": "dp7-16",
+    "setOrder":38,
+	"id": "dp7-16",
     "name": "Drifblim",
     "imageUrl": "https://images.pokemontcg.io/dp7/16.png",
     "subtype": "Stage 1",
@@ -1003,7 +1019,8 @@
     "nationalPokedexNumber": 426
   },
   {
-    "id": "dp7-17",
+    "setOrder":38,
+	"id": "dp7-17",
     "name": "Dusknoir",
     "imageUrl": "https://images.pokemontcg.io/dp7/17.png",
     "subtype": "Stage 2",
@@ -1059,7 +1076,8 @@
     "nationalPokedexNumber": 477
   },
   {
-    "id": "dp7-18",
+    "setOrder":38,
+	"id": "dp7-18",
     "name": "Gengar",
     "imageUrl": "https://images.pokemontcg.io/dp7/18.png",
     "subtype": "Stage 2",
@@ -1119,7 +1137,8 @@
     "nationalPokedexNumber": 94
   },
   {
-    "id": "dp7-19",
+    "setOrder":38,
+	"id": "dp7-19",
     "name": "Gyarados",
     "imageUrl": "https://images.pokemontcg.io/dp7/19.png",
     "subtype": "Stage 1",
@@ -1192,7 +1211,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "dp7-20",
+    "setOrder":38,
+	"id": "dp7-20",
     "name": "Machamp",
     "imageUrl": "https://images.pokemontcg.io/dp7/20.png",
     "subtype": "Stage 2",
@@ -1257,7 +1277,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "dp7-21",
+    "setOrder":38,
+	"id": "dp7-21",
     "name": "Mamoswine",
     "imageUrl": "https://images.pokemontcg.io/dp7/21.png",
     "subtype": "Stage 2",
@@ -1323,7 +1344,8 @@
     "nationalPokedexNumber": 473
   },
   {
-    "id": "dp7-22",
+    "setOrder":38,
+	"id": "dp7-22",
     "name": "Rapidash",
     "imageUrl": "https://images.pokemontcg.io/dp7/22.png",
     "subtype": "Stage 1",
@@ -1378,7 +1400,8 @@
     "nationalPokedexNumber": 78
   },
   {
-    "id": "dp7-23",
+    "setOrder":38,
+	"id": "dp7-23",
     "name": "Roserade",
     "imageUrl": "https://images.pokemontcg.io/dp7/23.png",
     "subtype": "Stage 1",
@@ -1437,7 +1460,8 @@
     "nationalPokedexNumber": 407
   },
   {
-    "id": "dp7-24",
+    "setOrder":38,
+	"id": "dp7-24",
     "name": "Salamence",
     "imageUrl": "https://images.pokemontcg.io/dp7/24.png",
     "subtype": "Stage 2",
@@ -1505,7 +1529,8 @@
     "nationalPokedexNumber": 373
   },
   {
-    "id": "dp7-25",
+    "setOrder":38,
+	"id": "dp7-25",
     "name": "Scizor",
     "imageUrl": "https://images.pokemontcg.io/dp7/25.png",
     "subtype": "Stage 1",
@@ -1563,7 +1588,8 @@
     "nationalPokedexNumber": 212
   },
   {
-    "id": "dp7-26",
+    "setOrder":38,
+	"id": "dp7-26",
     "name": "Skuntank",
     "imageUrl": "https://images.pokemontcg.io/dp7/26.png",
     "subtype": "Stage 1",
@@ -1629,7 +1655,8 @@
     "nationalPokedexNumber": 435
   },
   {
-    "id": "dp7-27",
+    "setOrder":38,
+	"id": "dp7-27",
     "name": "Staraptor",
     "imageUrl": "https://images.pokemontcg.io/dp7/27.png",
     "subtype": "Stage 2",
@@ -1690,7 +1717,8 @@
     "nationalPokedexNumber": 398
   },
   {
-    "id": "dp7-28",
+    "setOrder":38,
+	"id": "dp7-28",
     "name": "Steelix",
     "imageUrl": "https://images.pokemontcg.io/dp7/28.png",
     "subtype": "Stage 1",
@@ -1753,7 +1781,8 @@
     "nationalPokedexNumber": 208
   },
   {
-    "id": "dp7-29",
+    "setOrder":38,
+	"id": "dp7-29",
     "name": "Tangrowth",
     "imageUrl": "https://images.pokemontcg.io/dp7/29.png",
     "subtype": "Stage 1",
@@ -1821,7 +1850,8 @@
     "nationalPokedexNumber": 465
   },
   {
-    "id": "dp7-30",
+    "setOrder":38,
+	"id": "dp7-30",
     "name": "Tyranitar",
     "imageUrl": "https://images.pokemontcg.io/dp7/30.png",
     "subtype": "Stage 2",
@@ -1891,7 +1921,8 @@
     "nationalPokedexNumber": 248
   },
   {
-    "id": "dp7-31",
+    "setOrder":38,
+	"id": "dp7-31",
     "name": "Vespiquen",
     "imageUrl": "https://images.pokemontcg.io/dp7/31.png",
     "subtype": "Stage 1",
@@ -1954,7 +1985,8 @@
     "nationalPokedexNumber": 416
   },
   {
-    "id": "dp7-32",
+    "setOrder":38,
+	"id": "dp7-32",
     "name": "Bibarel",
     "imageUrl": "https://images.pokemontcg.io/dp7/32.png",
     "subtype": "Stage 1",
@@ -2014,7 +2046,8 @@
     "nationalPokedexNumber": 400
   },
   {
-    "id": "dp7-33",
+    "setOrder":38,
+	"id": "dp7-33",
     "name": "Budew",
     "imageUrl": "https://images.pokemontcg.io/dp7/33.png",
     "subtype": "Basic",
@@ -2063,7 +2096,8 @@
     ]
   },
   {
-    "id": "dp7-34",
+    "setOrder":38,
+	"id": "dp7-34",
     "name": "Dusclops",
     "imageUrl": "https://images.pokemontcg.io/dp7/34.png",
     "subtype": "Stage 1",
@@ -2125,7 +2159,8 @@
     ]
   },
   {
-    "id": "dp7-35",
+    "setOrder":38,
+	"id": "dp7-35",
     "name": "Dusclops",
     "imageUrl": "https://images.pokemontcg.io/dp7/35.png",
     "subtype": "Stage 1",
@@ -2188,7 +2223,8 @@
     ]
   },
   {
-    "id": "dp7-36",
+    "setOrder":38,
+	"id": "dp7-36",
     "name": "Electrode",
     "imageUrl": "https://images.pokemontcg.io/dp7/36.png",
     "subtype": "Stage 1",
@@ -2249,7 +2285,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "dp7-37",
+    "setOrder":38,
+	"id": "dp7-37",
     "name": "Electrode",
     "imageUrl": "https://images.pokemontcg.io/dp7/37.png",
     "subtype": "Stage 1",
@@ -2304,7 +2341,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "dp7-38",
+    "setOrder":38,
+	"id": "dp7-38",
     "name": "Farfetch'd",
     "imageUrl": "https://images.pokemontcg.io/dp7/38.png",
     "subtype": "Basic",
@@ -2360,7 +2398,8 @@
     "nationalPokedexNumber": 83
   },
   {
-    "id": "dp7-39",
+    "setOrder":38,
+	"id": "dp7-39",
     "name": "Grovyle",
     "imageUrl": "https://images.pokemontcg.io/dp7/39.png",
     "subtype": "Stage 1",
@@ -2422,7 +2461,8 @@
     ]
   },
   {
-    "id": "dp7-40",
+    "setOrder":38,
+	"id": "dp7-40",
     "name": "Haunter",
     "imageUrl": "https://images.pokemontcg.io/dp7/40.png",
     "subtype": "Stage 1",
@@ -2482,7 +2522,8 @@
     ]
   },
   {
-    "id": "dp7-41",
+    "setOrder":38,
+	"id": "dp7-41",
     "name": "Machoke",
     "imageUrl": "https://images.pokemontcg.io/dp7/41.png",
     "subtype": "Stage 1",
@@ -2538,7 +2579,8 @@
     ]
   },
   {
-    "id": "dp7-42",
+    "setOrder":38,
+	"id": "dp7-42",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/dp7/42.png",
     "subtype": "Stage 1",
@@ -2601,7 +2643,8 @@
     ]
   },
   {
-    "id": "dp7-43",
+    "setOrder":38,
+	"id": "dp7-43",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/dp7/43.png",
     "subtype": "Stage 1",
@@ -2664,7 +2707,8 @@
     ]
   },
   {
-    "id": "dp7-44",
+    "setOrder":38,
+	"id": "dp7-44",
     "name": "Miltank",
     "imageUrl": "https://images.pokemontcg.io/dp7/44.png",
     "subtype": "Basic",
@@ -2724,7 +2768,8 @@
     "nationalPokedexNumber": 241
   },
   {
-    "id": "dp7-45",
+    "setOrder":38,
+	"id": "dp7-45",
     "name": "Pichu",
     "imageUrl": "https://images.pokemontcg.io/dp7/45.png",
     "subtype": "Basic",
@@ -2779,7 +2824,8 @@
     ]
   },
   {
-    "id": "dp7-46",
+    "setOrder":38,
+	"id": "dp7-46",
     "name": "Piloswine",
     "imageUrl": "https://images.pokemontcg.io/dp7/46.png",
     "subtype": "Stage 1",
@@ -2845,7 +2891,8 @@
     ]
   },
   {
-    "id": "dp7-47",
+    "setOrder":38,
+	"id": "dp7-47",
     "name": "Pupitar",
     "imageUrl": "https://images.pokemontcg.io/dp7/47.png",
     "subtype": "Stage 1",
@@ -2902,7 +2949,8 @@
     ]
   },
   {
-    "id": "dp7-48",
+    "setOrder":38,
+	"id": "dp7-48",
     "name": "Sableye",
     "imageUrl": "https://images.pokemontcg.io/dp7/48.png",
     "subtype": "Basic",
@@ -2957,7 +3005,8 @@
     "nationalPokedexNumber": 302
   },
   {
-    "id": "dp7-49",
+    "setOrder":38,
+	"id": "dp7-49",
     "name": "Scyther",
     "imageUrl": "https://images.pokemontcg.io/dp7/49.png",
     "subtype": "Basic",
@@ -3014,7 +3063,8 @@
     ]
   },
   {
-    "id": "dp7-50",
+    "setOrder":38,
+	"id": "dp7-50",
     "name": "Shelgon",
     "imageUrl": "https://images.pokemontcg.io/dp7/50.png",
     "subtype": "Stage 1",
@@ -3078,7 +3128,8 @@
     ]
   },
   {
-    "id": "dp7-51",
+    "setOrder":38,
+	"id": "dp7-51",
     "name": "Skarmory",
     "imageUrl": "https://images.pokemontcg.io/dp7/51.png",
     "subtype": "Basic",
@@ -3136,7 +3187,8 @@
     "nationalPokedexNumber": 227
   },
   {
-    "id": "dp7-52",
+    "setOrder":38,
+	"id": "dp7-52",
     "name": "Staravia",
     "imageUrl": "https://images.pokemontcg.io/dp7/52.png",
     "subtype": "Stage 1",
@@ -3196,7 +3248,8 @@
     ]
   },
   {
-    "id": "dp7-53",
+    "setOrder":38,
+	"id": "dp7-53",
     "name": "Bagon",
     "imageUrl": "https://images.pokemontcg.io/dp7/53.png",
     "subtype": "Basic",
@@ -3256,7 +3309,8 @@
     ]
   },
   {
-    "id": "dp7-54",
+    "setOrder":38,
+	"id": "dp7-54",
     "name": "Bidoof",
     "imageUrl": "https://images.pokemontcg.io/dp7/54.png",
     "subtype": "Basic",
@@ -3310,7 +3364,8 @@
     ]
   },
   {
-    "id": "dp7-55",
+    "setOrder":38,
+	"id": "dp7-55",
     "name": "Bronzor",
     "imageUrl": "https://images.pokemontcg.io/dp7/55.png",
     "subtype": "Basic",
@@ -3371,7 +3426,8 @@
     ]
   },
   {
-    "id": "dp7-56",
+    "setOrder":38,
+	"id": "dp7-56",
     "name": "Cherubi",
     "imageUrl": "https://images.pokemontcg.io/dp7/56.png",
     "subtype": "Basic",
@@ -3430,7 +3486,8 @@
     ]
   },
   {
-    "id": "dp7-57",
+    "setOrder":38,
+	"id": "dp7-57",
     "name": "Combee",
     "imageUrl": "https://images.pokemontcg.io/dp7/57.png",
     "subtype": "Basic",
@@ -3480,7 +3537,8 @@
     ]
   },
   {
-    "id": "dp7-58",
+    "setOrder":38,
+	"id": "dp7-58",
     "name": "Drifloon",
     "imageUrl": "https://images.pokemontcg.io/dp7/58.png",
     "subtype": "Basic",
@@ -3539,7 +3597,8 @@
     ]
   },
   {
-    "id": "dp7-59",
+    "setOrder":38,
+	"id": "dp7-59",
     "name": "Duskull",
     "imageUrl": "https://images.pokemontcg.io/dp7/59.png",
     "subtype": "Basic",
@@ -3599,7 +3658,8 @@
     ]
   },
   {
-    "id": "dp7-60",
+    "setOrder":38,
+	"id": "dp7-60",
     "name": "Duskull",
     "imageUrl": "https://images.pokemontcg.io/dp7/60.png",
     "subtype": "Basic",
@@ -3659,7 +3719,8 @@
     ]
   },
   {
-    "id": "dp7-61",
+    "setOrder":38,
+	"id": "dp7-61",
     "name": "Finneon",
     "imageUrl": "https://images.pokemontcg.io/dp7/61.png",
     "subtype": "Basic",
@@ -3712,7 +3773,8 @@
     ]
   },
   {
-    "id": "dp7-62",
+    "setOrder":38,
+	"id": "dp7-62",
     "name": "Gastly",
     "imageUrl": "https://images.pokemontcg.io/dp7/62.png",
     "subtype": "Basic",
@@ -3771,7 +3833,8 @@
     ]
   },
   {
-    "id": "dp7-63",
+    "setOrder":38,
+	"id": "dp7-63",
     "name": "Larvitar",
     "imageUrl": "https://images.pokemontcg.io/dp7/63.png",
     "subtype": "Basic",
@@ -3831,7 +3894,8 @@
     ]
   },
   {
-    "id": "dp7-64",
+    "setOrder":38,
+	"id": "dp7-64",
     "name": "Machop",
     "imageUrl": "https://images.pokemontcg.io/dp7/64.png",
     "subtype": "Basic",
@@ -3885,7 +3949,8 @@
     ]
   },
   {
-    "id": "dp7-65",
+    "setOrder":38,
+	"id": "dp7-65",
     "name": "Magikarp",
     "imageUrl": "https://images.pokemontcg.io/dp7/65.png",
     "subtype": "Basic",
@@ -3938,7 +4003,8 @@
     ]
   },
   {
-    "id": "dp7-66",
+    "setOrder":38,
+	"id": "dp7-66",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/dp7/66.png",
     "subtype": "Basic",
@@ -3989,7 +4055,8 @@
     ]
   },
   {
-    "id": "dp7-67",
+    "setOrder":38,
+	"id": "dp7-67",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/dp7/67.png",
     "subtype": "Basic",
@@ -4049,7 +4116,8 @@
     ]
   },
   {
-    "id": "dp7-68",
+    "setOrder":38,
+	"id": "dp7-68",
     "name": "Misdreavus",
     "imageUrl": "https://images.pokemontcg.io/dp7/68.png",
     "subtype": "Basic",
@@ -4108,7 +4176,8 @@
     ]
   },
   {
-    "id": "dp7-69",
+    "setOrder":38,
+	"id": "dp7-69",
     "name": "Onix",
     "imageUrl": "https://images.pokemontcg.io/dp7/69.png",
     "subtype": "Basic",
@@ -4165,7 +4234,8 @@
     ]
   },
   {
-    "id": "dp7-70",
+    "setOrder":38,
+	"id": "dp7-70",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/dp7/70.png",
     "subtype": "Basic",
@@ -4228,7 +4298,8 @@
     ]
   },
   {
-    "id": "dp7-71",
+    "setOrder":38,
+	"id": "dp7-71",
     "name": "Ponyta",
     "imageUrl": "https://images.pokemontcg.io/dp7/71.png",
     "subtype": "Basic",
@@ -4282,7 +4353,8 @@
     ]
   },
   {
-    "id": "dp7-72",
+    "setOrder":38,
+	"id": "dp7-72",
     "name": "Roselia",
     "imageUrl": "https://images.pokemontcg.io/dp7/72.png",
     "subtype": "Basic",
@@ -4336,7 +4408,8 @@
     ]
   },
   {
-    "id": "dp7-73",
+    "setOrder":38,
+	"id": "dp7-73",
     "name": "Skorupi",
     "imageUrl": "https://images.pokemontcg.io/dp7/73.png",
     "subtype": "Basic",
@@ -4391,7 +4464,8 @@
     ]
   },
   {
-    "id": "dp7-74",
+    "setOrder":38,
+	"id": "dp7-74",
     "name": "Snover",
     "imageUrl": "https://images.pokemontcg.io/dp7/74.png",
     "subtype": "Basic",
@@ -4444,7 +4518,8 @@
     ]
   },
   {
-    "id": "dp7-75",
+    "setOrder":38,
+	"id": "dp7-75",
     "name": "Starly",
     "imageUrl": "https://images.pokemontcg.io/dp7/75.png",
     "subtype": "Basic",
@@ -4503,7 +4578,8 @@
     ]
   },
   {
-    "id": "dp7-76",
+    "setOrder":38,
+	"id": "dp7-76",
     "name": "Stunky",
     "imageUrl": "https://images.pokemontcg.io/dp7/76.png",
     "subtype": "Basic",
@@ -4563,7 +4639,8 @@
     ]
   },
   {
-    "id": "dp7-77",
+    "setOrder":38,
+	"id": "dp7-77",
     "name": "Swinub",
     "imageUrl": "https://images.pokemontcg.io/dp7/77.png",
     "subtype": "Basic",
@@ -4622,7 +4699,8 @@
     ]
   },
   {
-    "id": "dp7-78",
+    "setOrder":38,
+	"id": "dp7-78",
     "name": "Tangela",
     "imageUrl": "https://images.pokemontcg.io/dp7/78.png",
     "subtype": "Basic",
@@ -4682,7 +4760,8 @@
     ]
   },
   {
-    "id": "dp7-79",
+    "setOrder":38,
+	"id": "dp7-79",
     "name": "Treecko",
     "imageUrl": "https://images.pokemontcg.io/dp7/79.png",
     "subtype": "Basic",
@@ -4741,7 +4820,8 @@
     ]
   },
   {
-    "id": "dp7-80",
+    "setOrder":38,
+	"id": "dp7-80",
     "name": "Voltorb",
     "imageUrl": "https://images.pokemontcg.io/dp7/80.png",
     "subtype": "Basic",
@@ -4800,7 +4880,8 @@
     ]
   },
   {
-    "id": "dp7-81",
+    "setOrder":38,
+	"id": "dp7-81",
     "name": "Voltorb",
     "imageUrl": "https://images.pokemontcg.io/dp7/81.png",
     "subtype": "Basic",
@@ -4859,7 +4940,8 @@
     ]
   },
   {
-    "id": "dp7-82",
+    "setOrder":38,
+	"id": "dp7-82",
     "name": "Conductive Quarry",
     "imageUrl": "https://images.pokemontcg.io/dp7/82.png",
     "subtype": "Stadium",
@@ -4877,7 +4959,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp7/82_hires.png"
   },
   {
-    "id": "dp7-83",
+    "setOrder":38,
+	"id": "dp7-83",
     "name": "Energy Link",
     "imageUrl": "https://images.pokemontcg.io/dp7/83.png",
     "subtype": "Pokémon Tool",
@@ -4896,7 +4979,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp7/83_hires.png"
   },
   {
-    "id": "dp7-84",
+    "setOrder":38,
+	"id": "dp7-84",
     "name": "Energy Switch",
     "imageUrl": "https://images.pokemontcg.io/dp7/84.png",
     "subtype": "Item",
@@ -4914,7 +4998,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp7/84_hires.png"
   },
   {
-    "id": "dp7-85",
+    "setOrder":38,
+	"id": "dp7-85",
     "name": "Great Ball",
     "imageUrl": "https://images.pokemontcg.io/dp7/85.png",
     "subtype": "Item",
@@ -4932,7 +5017,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp7/85_hires.png"
   },
   {
-    "id": "dp7-86",
+    "setOrder":38,
+	"id": "dp7-86",
     "name": "Luxury Ball",
     "imageUrl": "https://images.pokemontcg.io/dp7/86.png",
     "subtype": "Item",
@@ -4950,7 +5036,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp7/86_hires.png"
   },
   {
-    "id": "dp7-87",
+    "setOrder":38,
+	"id": "dp7-87",
     "name": "Marley's Request",
     "imageUrl": "https://images.pokemontcg.io/dp7/87.png",
     "subtype": "Supporter",
@@ -4969,7 +5056,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp7/87_hires.png"
   },
   {
-    "id": "dp7-88",
+    "setOrder":38,
+	"id": "dp7-88",
     "name": "Poké Blower +",
     "imageUrl": "https://images.pokemontcg.io/dp7/88.png",
     "subtype": "Item",
@@ -4987,7 +5075,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp7/88_hires.png"
   },
   {
-    "id": "dp7-89",
+    "setOrder":38,
+	"id": "dp7-89",
     "name": "Poké Drawer +",
     "imageUrl": "https://images.pokemontcg.io/dp7/89.png",
     "subtype": "Item",
@@ -5005,7 +5094,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp7/89_hires.png"
   },
   {
-    "id": "dp7-90",
+    "setOrder":38,
+	"id": "dp7-90",
     "name": "Poké Healer +",
     "imageUrl": "https://images.pokemontcg.io/dp7/90.png",
     "subtype": "Item",
@@ -5023,7 +5113,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp7/90_hires.png"
   },
   {
-    "id": "dp7-91",
+    "setOrder":38,
+	"id": "dp7-91",
     "name": "Premier Ball",
     "imageUrl": "https://images.pokemontcg.io/dp7/91.png",
     "subtype": "Item",
@@ -5041,7 +5132,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp7/91_hires.png"
   },
   {
-    "id": "dp7-92",
+    "setOrder":38,
+	"id": "dp7-92",
     "name": "Potion",
     "imageUrl": "https://images.pokemontcg.io/dp7/92.png",
     "subtype": "Item",
@@ -5059,7 +5151,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp7/92_hires.png"
   },
   {
-    "id": "dp7-93",
+    "setOrder":38,
+	"id": "dp7-93",
     "name": "Switch",
     "imageUrl": "https://images.pokemontcg.io/dp7/93.png",
     "subtype": "Item",
@@ -5077,7 +5170,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp7/93_hires.png"
   },
   {
-    "id": "dp7-94",
+    "setOrder":38,
+	"id": "dp7-94",
     "name": "Cyclone Energy",
     "imageUrl": "https://images.pokemontcg.io/dp7/94.png",
     "subtype": "Special",
@@ -5094,7 +5188,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp7/94_hires.png"
   },
   {
-    "id": "dp7-95",
+    "setOrder":38,
+	"id": "dp7-95",
     "name": "Warp Energy",
     "imageUrl": "https://images.pokemontcg.io/dp7/95.png",
     "subtype": "Special",
@@ -5111,7 +5206,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/dp7/95_hires.png"
   },
   {
-    "id": "dp7-96",
+    "setOrder":38,
+	"id": "dp7-96",
     "name": "Dusknoir",
     "imageUrl": "https://images.pokemontcg.io/dp7/96.png",
     "subtype": "Level Up",
@@ -5157,7 +5253,8 @@
     "nationalPokedexNumber": 477
   },
   {
-    "id": "dp7-97",
+    "setOrder":38,
+	"id": "dp7-97",
     "name": "Heatran",
     "imageUrl": "https://images.pokemontcg.io/dp7/97.png",
     "subtype": "Level Up",
@@ -5198,7 +5295,8 @@
     "nationalPokedexNumber": 485
   },
   {
-    "id": "dp7-98",
+    "setOrder":38,
+	"id": "dp7-98",
     "name": "Machamp",
     "imageUrl": "https://images.pokemontcg.io/dp7/98.png",
     "subtype": "Level Up",
@@ -5251,7 +5349,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "dp7-99",
+    "setOrder":38,
+	"id": "dp7-99",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/dp7/99.png",
     "subtype": "Level Up",
@@ -5305,7 +5404,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "dp7-100",
+    "setOrder":38,
+	"id": "dp7-100",
     "name": "Regigigas",
     "imageUrl": "https://images.pokemontcg.io/dp7/100.png",
     "subtype": "Level Up",
@@ -5360,7 +5460,8 @@
     "nationalPokedexNumber": 486
   },
   {
-    "id": "dp7-101",
+    "setOrder":38,
+	"id": "dp7-101",
     "name": "Charmander",
     "imageUrl": "https://images.pokemontcg.io/dp7/101.png",
     "subtype": "Basic",
@@ -5414,7 +5515,8 @@
     ]
   },
   {
-    "id": "dp7-102",
+    "setOrder":38,
+	"id": "dp7-102",
     "name": "Charmeleon",
     "imageUrl": "https://images.pokemontcg.io/dp7/102.png",
     "subtype": "Stage 1",
@@ -5472,7 +5574,8 @@
     ]
   },
   {
-    "id": "dp7-103",
+    "setOrder":38,
+	"id": "dp7-103",
     "name": "Charizard",
     "imageUrl": "https://images.pokemontcg.io/dp7/103.png",
     "subtype": "Stage 2",
@@ -5530,7 +5633,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "dp7-SH1",
+    "setOrder":38,
+	"id": "dp7-SH1",
     "name": "Drifloon",
     "imageUrl": "https://images.pokemontcg.io/dp7/SH1.png",
     "subtype": "Basic",
@@ -5592,7 +5696,8 @@
     ]
   },
   {
-    "id": "dp7-SH2",
+    "setOrder":38,
+	"id": "dp7-SH2",
     "name": "Duskull",
     "imageUrl": "https://images.pokemontcg.io/dp7/SH2.png",
     "subtype": "Basic",
@@ -5662,7 +5767,8 @@
     ]
   },
   {
-    "id": "dp7-SH3",
+    "setOrder":38,
+	"id": "dp7-SH3",
     "name": "Voltorb",
     "imageUrl": "https://images.pokemontcg.io/dp7/SH3.png",
     "subtype": "Basic",

--- a/json/cards/Sun & Moon Black Star Promos.json
+++ b/json/cards/Sun & Moon Black Star Promos.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "smp-SM01",
+    "setOrder":1004,
+	"id": "smp-SM01",
     "name": "Rowlet",
     "imageUrl": "https://images.pokemontcg.io/smp/SM01.png",
     "subtype": "Basic",
@@ -43,7 +44,8 @@
     ]
   },
   {
-    "id": "smp-SM02",
+    "setOrder":1004,
+	"id": "smp-SM02",
     "name": "Litten",
     "imageUrl": "https://images.pokemontcg.io/smp/SM02.png",
     "subtype": "Basic",
@@ -87,7 +89,8 @@
     ]
   },
   {
-    "id": "smp-SM03",
+    "setOrder":1004,
+	"id": "smp-SM03",
     "name": "Popplio",
     "imageUrl": "https://images.pokemontcg.io/smp/SM03.png",
     "subtype": "Basic",
@@ -130,7 +133,8 @@
     ]
   },
   {
-    "id": "smp-SM04",
+    "setOrder":1004,
+	"id": "smp-SM04",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/smp/SM04.png",
     "subtype": "Basic",
@@ -190,7 +194,8 @@
     ]
   },
   {
-    "id": "smp-SM05",
+    "setOrder":1004,
+	"id": "smp-SM05",
     "name": "Snorlax-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM05.png",
     "subtype": "GX",
@@ -264,7 +269,8 @@
     "nationalPokedexNumber": 143
   },
   {
-    "id": "smp-SM06",
+    "setOrder":1004,
+	"id": "smp-SM06",
     "name": "Rockruff",
     "imageUrl": "https://images.pokemontcg.io/smp/SM06.png",
     "subtype": "Basic",
@@ -317,7 +323,8 @@
     ]
   },
   {
-    "id": "smp-SM07",
+    "setOrder":1004,
+	"id": "smp-SM07",
     "name": "Pikipek",
     "imageUrl": "https://images.pokemontcg.io/smp/SM07.png",
     "subtype": "Basic",
@@ -367,7 +374,8 @@
     ]
   },
   {
-    "id": "smp-SM08",
+    "setOrder":1004,
+	"id": "smp-SM08",
     "name": "Litten",
     "imageUrl": "https://images.pokemontcg.io/smp/SM08.png",
     "subtype": "Basic",
@@ -420,7 +428,8 @@
     ]
   },
   {
-    "id": "smp-SM09",
+    "setOrder":1004,
+	"id": "smp-SM09",
     "name": "Togedemaru",
     "imageUrl": "https://images.pokemontcg.io/smp/SM09.png",
     "subtype": "Basic",
@@ -475,7 +484,8 @@
     "nationalPokedexNumber": 777
   },
   {
-    "id": "smp-SM10",
+    "setOrder":1004,
+	"id": "smp-SM10",
     "name": "Shiinotic",
     "imageUrl": "https://images.pokemontcg.io/smp/SM10.png",
     "subtype": "Stage 1",
@@ -523,7 +533,8 @@
     "nationalPokedexNumber": 756
   },
   {
-    "id": "smp-SM11",
+    "setOrder":1004,
+	"id": "smp-SM11",
     "name": "Bruxish",
     "imageUrl": "https://images.pokemontcg.io/smp/SM11.png",
     "subtype": "Basic",
@@ -575,7 +586,8 @@
     "nationalPokedexNumber": 779
   },
   {
-    "id": "smp-SM12",
+    "setOrder":1004,
+	"id": "smp-SM12",
     "name": "Passimian",
     "imageUrl": "https://images.pokemontcg.io/smp/SM12.png",
     "subtype": "Basic",
@@ -625,7 +637,8 @@
     "nationalPokedexNumber": 766
   },
   {
-    "id": "smp-SM13",
+    "setOrder":1004,
+	"id": "smp-SM13",
     "name": "Oranguru",
     "imageUrl": "https://images.pokemontcg.io/smp/SM13.png",
     "subtype": "Basic",
@@ -673,7 +686,8 @@
     "nationalPokedexNumber": 765
   },
   {
-    "id": "smp-SM14",
+    "setOrder":1004,
+	"id": "smp-SM14",
     "name": "Lycanroc-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM14.png",
     "subtype": "GX",
@@ -740,7 +754,8 @@
     "nationalPokedexNumber": 745
   },
   {
-    "id": "smp-SM15",
+    "setOrder":1004,
+	"id": "smp-SM15",
     "name": "Zygarde",
     "imageUrl": "https://images.pokemontcg.io/smp/SM15.png",
     "subtype": "Basic",
@@ -796,7 +811,8 @@
     "nationalPokedexNumber": 718
   },
   {
-    "id": "smp-SM16",
+    "setOrder":1004,
+	"id": "smp-SM16",
     "name": "Solgaleo-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM16.png",
     "subtype": "GX",
@@ -864,7 +880,8 @@
     "nationalPokedexNumber": 791
   },
   {
-    "id": "smp-SM17",
+    "setOrder":1004,
+	"id": "smp-SM17",
     "name": "Lunala-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM17.png",
     "subtype": "GX",
@@ -934,7 +951,8 @@
     "nationalPokedexNumber": 792
   },
   {
-    "id": "smp-SM18",
+    "setOrder":1004,
+	"id": "smp-SM18",
     "name": "Alolan Sandslash",
     "imageUrl": "https://images.pokemontcg.io/smp/SM18.png",
     "subtype": "Stage 1",
@@ -983,7 +1001,8 @@
     "nationalPokedexNumber": 28
   },
   {
-    "id": "smp-SM19",
+    "setOrder":1004,
+	"id": "smp-SM19",
     "name": "Oricorio",
     "imageUrl": "https://images.pokemontcg.io/smp/SM19.png",
     "subtype": "Basic",
@@ -1038,7 +1057,8 @@
     "nationalPokedexNumber": 741
   },
   {
-    "id": "smp-SM20",
+    "setOrder":1004,
+	"id": "smp-SM20",
     "name": "Mudsdale",
     "imageUrl": "https://images.pokemontcg.io/smp/SM20.png",
     "subtype": "Stage 1",
@@ -1096,7 +1116,8 @@
     "nationalPokedexNumber": 750
   },
   {
-    "id": "smp-SM21",
+    "setOrder":1004,
+	"id": "smp-SM21",
     "name": "Drampa",
     "imageUrl": "https://images.pokemontcg.io/smp/SM21.png",
     "subtype": "Basic",
@@ -1148,7 +1169,8 @@
     "nationalPokedexNumber": 780
   },
   {
-    "id": "smp-SM22",
+    "setOrder":1004,
+	"id": "smp-SM22",
     "name": "Rowlet",
     "imageUrl": "https://images.pokemontcg.io/smp/SM22.png",
     "subtype": "Basic",
@@ -1201,7 +1223,8 @@
     ]
   },
   {
-    "id": "smp-SM23",
+    "setOrder":1004,
+	"id": "smp-SM23",
     "name": "Litten",
     "imageUrl": "https://images.pokemontcg.io/smp/SM23.png",
     "subtype": "Basic",
@@ -1254,7 +1277,8 @@
     ]
   },
   {
-    "id": "smp-SM24",
+    "setOrder":1004,
+	"id": "smp-SM24",
     "name": "Popplio",
     "imageUrl": "https://images.pokemontcg.io/smp/SM24.png",
     "subtype": "Basic",
@@ -1307,7 +1331,8 @@
     ]
   },
   {
-    "id": "smp-SM25",
+    "setOrder":1004,
+	"id": "smp-SM25",
     "name": "Lurantis",
     "imageUrl": "https://images.pokemontcg.io/smp/SM25.png",
     "subtype": "Stage 1",
@@ -1356,7 +1381,8 @@
     "nationalPokedexNumber": 754
   },
   {
-    "id": "smp-SM26",
+    "setOrder":1004,
+	"id": "smp-SM26",
     "name": "Tsareena",
     "imageUrl": "https://images.pokemontcg.io/smp/SM26.png",
     "subtype": "Stage 2",
@@ -1405,7 +1431,8 @@
     "nationalPokedexNumber": 763
   },
   {
-    "id": "smp-SM27",
+    "setOrder":1004,
+	"id": "smp-SM27",
     "name": "Turtonator",
     "imageUrl": "https://images.pokemontcg.io/smp/SM27.png",
     "subtype": "Basic",
@@ -1459,7 +1486,8 @@
     "nationalPokedexNumber": 776
   },
   {
-    "id": "smp-SM28",
+    "setOrder":1004,
+	"id": "smp-SM28",
     "name": "Vikavolt",
     "imageUrl": "https://images.pokemontcg.io/smp/SM28.png",
     "subtype": "Stage 2",
@@ -1516,7 +1544,8 @@
     "nationalPokedexNumber": 738
   },
   {
-    "id": "smp-SM29",
+    "setOrder":1004,
+	"id": "smp-SM29",
     "name": "Mimikyu",
     "imageUrl": "https://images.pokemontcg.io/smp/SM29.png",
     "subtype": "Basic",
@@ -1560,7 +1589,8 @@
     "nationalPokedexNumber": 778
   },
   {
-    "id": "smp-SM30",
+    "setOrder":1004,
+	"id": "smp-SM30",
     "name": "Tapu Koko",
     "imageUrl": "https://images.pokemontcg.io/smp/SM30.png",
     "subtype": "Basic",
@@ -1614,7 +1644,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/smp/SM30_hires.png"
   },
   {
-    "id": "smp-SM31",
+    "setOrder":1004,
+	"id": "smp-SM31",
     "name": "Tapu Koko",
     "imageUrl": "https://images.pokemontcg.io/smp/SM31.png",
     "subtype": "Basic",
@@ -1668,7 +1699,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/smp/SM31_hires.png"
   },
   {
-    "id": "smp-SM32",
+    "setOrder":1004,
+	"id": "smp-SM32",
     "name": "Tapu Bulu-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM32.png",
     "subtype": "GX",
@@ -1729,7 +1761,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/smp/SM32_hires.png"
   },
   {
-    "id": "smp-SM33",
+    "setOrder":1004,
+	"id": "smp-SM33",
     "name": "Tapu Koko-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM33.png",
     "subtype": "GX",
@@ -1785,7 +1818,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/smp/SM33_hires.png"
   },
   {
-    "id": "smp-SM34",
+    "setOrder":1004,
+	"id": "smp-SM34",
     "name": "Bewear-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM34.png",
     "subtype": "GX",
@@ -1858,7 +1892,8 @@
     "nationalPokedexNumber": 760
   },
   {
-    "id": "smp-SM35",
+    "setOrder":1004,
+	"id": "smp-SM35",
     "name": "Espeon-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM35.png",
     "subtype": "GX",
@@ -1924,7 +1959,8 @@
     "nationalPokedexNumber": 196
   },
   {
-    "id": "smp-SM36",
+    "setOrder":1004,
+	"id": "smp-SM36",
     "name": "Umbreon-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM36.png",
     "subtype": "GX",
@@ -1996,7 +2032,8 @@
     "nationalPokedexNumber": 197
   },
   {
-    "id": "smp-SM37",
+    "setOrder":1004,
+	"id": "smp-SM37",
     "name": "Decidueye-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM37.png",
     "subtype": "GX",
@@ -2058,7 +2095,8 @@
     "nationalPokedexNumber": 724
   },
   {
-    "id": "smp-SM38",
+    "setOrder":1004,
+	"id": "smp-SM38",
     "name": "Incineroar-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM38.png",
     "subtype": "GX",
@@ -2127,7 +2165,8 @@
     "nationalPokedexNumber": 727
   },
   {
-    "id": "smp-SM39",
+    "setOrder":1004,
+	"id": "smp-SM39",
     "name": "Primarina-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM39.png",
     "subtype": "GX",
@@ -2196,7 +2235,8 @@
     "nationalPokedexNumber": 730
   },
   {
-    "id": "smp-SM40",
+    "setOrder":1004,
+	"id": "smp-SM40",
     "name": "Jangmo-o",
     "imageUrl": "https://images.pokemontcg.io/smp/SM40.png",
     "subtype": "Basic",
@@ -2250,7 +2290,8 @@
     ]
   },
   {
-    "id": "smp-SM41",
+    "setOrder":1004,
+	"id": "smp-SM41",
     "name": "Komala",
     "imageUrl": "https://images.pokemontcg.io/smp/SM41.png",
     "subtype": "Basic",
@@ -2298,7 +2339,8 @@
     "nationalPokedexNumber": 775
   },
   {
-    "id": "smp-SM42",
+    "setOrder":1004,
+	"id": "smp-SM42",
     "name": "Cosmog",
     "imageUrl": "https://images.pokemontcg.io/smp/SM42.png",
     "subtype": "Basic",
@@ -2341,7 +2383,8 @@
     ]
   },
   {
-    "id": "smp-SM43",
+    "setOrder":1004,
+	"id": "smp-SM43",
     "name": "Alolan Meowth",
     "imageUrl": "https://images.pokemontcg.io/smp/SM43.png",
     "subtype": "Basic",
@@ -2400,7 +2443,8 @@
     ]
   },
   {
-    "id": "smp-SM44",
+    "setOrder":1004,
+	"id": "smp-SM44",
     "name": "Togedemaru",
     "imageUrl": "https://images.pokemontcg.io/smp/SM44.png",
     "subtype": "Basic",
@@ -2457,7 +2501,8 @@
     "nationalPokedexNumber": 777
   },
   {
-    "id": "smp-SM45",
+    "setOrder":1004,
+	"id": "smp-SM45",
     "name": "Tapu Lele",
     "nationalPokedexNumber": 785,
     "imageUrl": "https://images.pokemontcg.io/smp/SM45.png",
@@ -2506,7 +2551,8 @@
     ]
   },
   {
-    "id": "smp-SM46",
+    "setOrder":1004,
+	"id": "smp-SM46",
     "name": "Seviper",
     "imageUrl": "https://images.pokemontcg.io/smp/SM46.png",
     "subtype": "Basic",
@@ -2554,7 +2600,8 @@
     "nationalPokedexNumber": 336
   },
   {
-    "id": "smp-SM47",
+    "setOrder":1004,
+	"id": "smp-SM47",
     "name": "Crabominable",
     "imageUrl": "https://images.pokemontcg.io/smp/SM47.png",
     "subtype": "Stage 1",
@@ -2609,7 +2656,8 @@
     "nationalPokedexNumber": 740
   },
   {
-    "id": "smp-SM48",
+    "setOrder":1004,
+	"id": "smp-SM48",
     "name": "Zygarde",
     "imageUrl": "https://images.pokemontcg.io/smp/SM48.png",
     "subtype": "Basic",
@@ -2666,7 +2714,8 @@
     "nationalPokedexNumber": 718
   },
   {
-    "id": "smp-SM49",
+    "setOrder":1004,
+	"id": "smp-SM49",
     "name": "Bewear",
     "imageUrl": "https://images.pokemontcg.io/smp/SM49.png",
     "subtype": "Stage 1",
@@ -2720,7 +2769,8 @@
     "nationalPokedexNumber": 760
   },
   {
-    "id": "smp-SM50",
+    "setOrder":1004,
+	"id": "smp-SM50",
     "name": "Tapu Koko-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM50.png",
     "subtype": "GX",
@@ -2776,7 +2826,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/smp/SM50_hires.png"
   },
   {
-    "id": "smp-SM51",
+    "setOrder":1004,
+	"id": "smp-SM51",
     "name": "Alolan Meowth",
     "imageUrl": "https://images.pokemontcg.io/smp/SM51.png",
     "subtype": "Basic",
@@ -2834,7 +2885,8 @@
     ]
   },
   {
-    "id": "smp-SM52",
+    "setOrder":1004,
+	"id": "smp-SM52",
     "name": "Golisopod",
     "imageUrl": "https://images.pokemontcg.io/smp/SM52.png",
     "subtype": "Stage 1",
@@ -2883,7 +2935,8 @@
     "nationalPokedexNumber": 768
   },
   {
-    "id": "smp-SM53",
+    "setOrder":1004,
+	"id": "smp-SM53",
     "name": "Dhelmise",
     "imageUrl": "https://images.pokemontcg.io/smp/SM53.png",
     "subtype": "Basic",
@@ -2937,7 +2990,8 @@
     "nationalPokedexNumber": 781
   },
   {
-    "id": "smp-SM54",
+    "setOrder":1004,
+	"id": "smp-SM54",
     "name": "Lucario",
     "imageUrl": "https://images.pokemontcg.io/smp/SM54.png",
     "subtype": "Stage 1",
@@ -2985,7 +3039,8 @@
     "nationalPokedexNumber": 448
   },
   {
-    "id": "smp-SM55",
+    "setOrder":1004,
+	"id": "smp-SM55",
     "name": "Decidueye",
     "imageUrl": "https://images.pokemontcg.io/smp/SM55.png",
     "subtype": "Stage 2",
@@ -3037,7 +3092,8 @@
     "nationalPokedexNumber": 724
   },
   {
-    "id": "smp-SM56",
+    "setOrder":1004,
+	"id": "smp-SM56",
     "name": "Tsareena-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM56.png",
     "subtype": "GX",
@@ -3105,7 +3161,8 @@
     "nationalPokedexNumber": 763
   },
   {
-    "id": "smp-SM57",
+    "setOrder":1004,
+	"id": "smp-SM57",
     "name": "Ho-Oh-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM57.png",
     "subtype": "GX",
@@ -3181,7 +3238,8 @@
     "nationalPokedexNumber": 250
   },
   {
-    "id": "smp-SM58",
+    "setOrder":1004,
+	"id": "smp-SM58",
     "name": "Necrozma-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM58.png",
     "subtype": "GX",
@@ -3244,7 +3302,8 @@
     "nationalPokedexNumber": 800
   },
   {
-    "id": "smp-SM59",
+    "setOrder":1004,
+	"id": "smp-SM59",
     "name": "Marshadow-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM59.png",
     "subtype": "GX",
@@ -3304,7 +3363,8 @@
     "nationalPokedexNumber": 802
   },
   {
-    "id": "smp-SM60",
+    "setOrder":1004,
+	"id": "smp-SM60",
     "name": "Charizard-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM60.png",
     "subtype": "GX",
@@ -3376,7 +3436,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "smp-SM61",
+    "setOrder":1004,
+	"id": "smp-SM61",
     "name": "Tapu Bulu",
     "nationalPokedexNumber": 786,
     "imageUrl": "https://images.pokemontcg.io/smp/SM61.png",
@@ -3428,7 +3489,8 @@
     ]
   },
   {
-    "id": "smp-SM62",
+    "setOrder":1004,
+	"id": "smp-SM62",
     "name": "Golisopod-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM62.png",
     "subtype": "GX",
@@ -3497,7 +3559,8 @@
     "nationalPokedexNumber": 768
   },
   {
-    "id": "smp-SM63",
+    "setOrder":1004,
+	"id": "smp-SM63",
     "name": "Salazzle-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM63.png",
     "subtype": "GX",
@@ -3564,7 +3627,8 @@
     "nationalPokedexNumber": 758
   },
   {
-    "id": "smp-SM64",
+    "setOrder":1004,
+	"id": "smp-SM64",
     "name": "Silvally",
     "imageUrl": "https://images.pokemontcg.io/smp/SM64.png",
     "subtype": "Stage 1",
@@ -3616,7 +3680,8 @@
     "nationalPokedexNumber": 773
   },
   {
-    "id": "smp-SM65",
+    "setOrder":1004,
+	"id": "smp-SM65",
     "name": "Alolan Raichu",
     "imageUrl": "https://images.pokemontcg.io/smp/SM65.png",
     "subtype": "Stage 1",
@@ -3674,7 +3739,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "smp-SM66",
+    "setOrder":1004,
+	"id": "smp-SM66",
     "name": "Pheromosa-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM66.png",
     "subtype": "GX",
@@ -3737,7 +3803,8 @@
     "nationalPokedexNumber": 795
   },
   {
-    "id": "smp-SM67",
+    "setOrder":1004,
+	"id": "smp-SM67",
     "name": "Celesteela-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM67.png",
     "subtype": "GX",
@@ -3815,7 +3882,8 @@
     "nationalPokedexNumber": 797
   },
   {
-    "id": "smp-SM68",
+    "setOrder":1004,
+	"id": "smp-SM68",
     "name": "Xurkitree-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM68.png",
     "subtype": "GX",
@@ -3881,7 +3949,8 @@
     "nationalPokedexNumber": 796
   },
   {
-    "id": "smp-SM69",
+    "setOrder":1004,
+	"id": "smp-SM69",
     "name": "Buzzwole-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM69.png",
     "subtype": "GX",
@@ -3948,7 +4017,8 @@
     "nationalPokedexNumber": 794
   },
   {
-    "id": "smp-SM70",
+    "setOrder":1004,
+	"id": "smp-SM70",
     "name": "Shining Ho-Oh",
     "imageUrl": "https://images.pokemontcg.io/smp/SM70.png",
     "subtype": "Basic",
@@ -4003,7 +4073,8 @@
     "nationalPokedexNumber": 250
   },
   {
-    "id": "smp-SM71",
+    "setOrder":1004,
+	"id": "smp-SM71",
     "name": "Kommo-o-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM71.png",
     "subtype": "GX",
@@ -4073,7 +4144,8 @@
     "nationalPokedexNumber": 784
   },
   {
-    "id": "smp-SM72",
+    "setOrder":1004,
+	"id": "smp-SM72",
     "name": "Alolan Raichu",
     "imageUrl": "https://images.pokemontcg.io/smp/SM72.png",
     "subtype": "Stage 1",
@@ -4128,7 +4200,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "smp-SM73",
+    "setOrder":1004,
+	"id": "smp-SM73",
     "name": "Salazzle",
     "imageUrl": "https://images.pokemontcg.io/smp/SM73.png",
     "subtype": "Stage 1",
@@ -4178,7 +4251,8 @@
     "nationalPokedexNumber": 758
   },
   {
-    "id": "smp-SM74",
+    "setOrder":1004,
+	"id": "smp-SM74",
     "name": "Regirock",
     "imageUrl": "https://images.pokemontcg.io/smp/SM74.png",
     "subtype": "Basic",
@@ -4227,7 +4301,8 @@
     "nationalPokedexNumber": 377
   },
   {
-    "id": "smp-SM75",
+    "setOrder":1004,
+	"id": "smp-SM75",
     "name": "Registeel",
     "imageUrl": "https://images.pokemontcg.io/smp/SM75.png",
     "subtype": "Basic",
@@ -4286,7 +4361,8 @@
     "nationalPokedexNumber": 379
   },
   {
-    "id": "smp-SM76",
+    "setOrder":1004,
+	"id": "smp-SM76",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/smp/SM76.png",
     "subtype": "Basic",
@@ -4346,7 +4422,8 @@
     ]
   },
   {
-    "id": "smp-SM77",
+    "setOrder":1004,
+	"id": "smp-SM77",
     "name": "Mewtwo",
     "imageUrl": "https://images.pokemontcg.io/smp/SM77.png",
     "subtype": "Basic",
@@ -4394,7 +4471,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "smp-SM78",
+    "setOrder":1004,
+	"id": "smp-SM78",
     "name": "Champions Festival",
     "imageUrl": "https://images.pokemontcg.io/smp/SM78.png",
     "subtype": "Stadium",
@@ -4411,7 +4489,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/smp/SM78_hires.png"
   },
   {
-    "id": "smp-SM79",
+    "setOrder":1004,
+	"id": "smp-SM79",
     "name": "Shining Celebi",
     "imageUrl": "https://images.pokemontcg.io/smp/SM79.png",
     "subtype": "Basic",
@@ -4457,7 +4536,8 @@
     "nationalPokedexNumber": 251
   },
   {
-    "id": "smp-SM80",
+    "setOrder":1004,
+	"id": "smp-SM80",
     "name": "Ho-Oh-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM80.png",
     "subtype": "GX",
@@ -4532,7 +4612,8 @@
     "nationalPokedexNumber": 250
   },
   {
-    "id": "smp-SM81",
+    "setOrder":1004,
+	"id": "smp-SM81",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/smp/SM81.png",
     "subtype": "Basic",
@@ -4592,7 +4673,8 @@
     ]
   },
   {
-    "id": "smp-SM82",
+    "setOrder":1004,
+	"id": "smp-SM82",
     "name": "Shining Lugia",
     "imageUrl": "https://images.pokemontcg.io/smp/SM82.png",
     "subtype": "Basic",
@@ -4653,7 +4735,8 @@
     "nationalPokedexNumber": 249
   },
   {
-    "id": "smp-SM83",
+    "setOrder":1004,
+	"id": "smp-SM83",
     "name": "Zorua",
     "imageUrl": "https://images.pokemontcg.io/smp/SM83.png",
     "subtype": "Basic",
@@ -4712,7 +4795,8 @@
     ]
   },
   {
-    "id": "smp-SM84",
+    "setOrder":1004,
+	"id": "smp-SM84",
     "name": "Zoroark-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM84.png",
     "subtype": "GX",
@@ -4779,7 +4863,8 @@
     "nationalPokedexNumber": 571
   },
   {
-    "id": "smp-SM85",
+    "setOrder":1004,
+	"id": "smp-SM85",
     "name": "Marshadow",
     "imageUrl": "https://images.pokemontcg.io/smp/SM85.png",
     "subtype": "Basic",
@@ -4831,7 +4916,8 @@
     "nationalPokedexNumber": 802
   },
   {
-    "id": "smp-SM86",
+    "setOrder":1004,
+	"id": "smp-SM86",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/smp/SM86.png",
     "subtype": "Basic",
@@ -4890,7 +4976,8 @@
     ]
   },
   {
-    "id": "smp-SM87",
+    "setOrder":1004,
+	"id": "smp-SM87",
     "name": "Latias",
     "imageUrl": "https://images.pokemontcg.io/smp/SM87.png",
     "subtype": "Basic",
@@ -4935,7 +5022,8 @@
     "nationalPokedexNumber": 380
   },
   {
-    "id": "smp-SM88",
+    "setOrder":1004,
+	"id": "smp-SM88",
     "name": "Latios",
     "imageUrl": "https://images.pokemontcg.io/smp/SM88.png",
     "subtype": "Basic",
@@ -4987,7 +5075,8 @@
     "nationalPokedexNumber": 381
   },
   {
-    "id": "smp-SM89",
+    "setOrder":1004,
+	"id": "smp-SM89",
     "name": "Zoroark",
     "imageUrl": "https://images.pokemontcg.io/smp/SM89.png",
     "subtype": "Stage 1",
@@ -5047,7 +5136,8 @@
     "nationalPokedexNumber": 571
   },
   {
-    "id": "smp-SM90",
+    "setOrder":1004,
+	"id": "smp-SM90",
     "name": "Raichu-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM90.png",
     "subtype": "GX",
@@ -5120,7 +5210,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "smp-SM91",
+    "setOrder":1004,
+	"id": "smp-SM91",
     "name": "Silvally-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM91.png",
     "subtype": "GX",
@@ -5183,7 +5274,8 @@
     "nationalPokedexNumber": 773
   },
   {
-    "id": "smp-SM92",
+    "setOrder":1004,
+	"id": "smp-SM92",
     "name": "Tapu Fini",
     "nationalPokedexNumber": 787,
     "imageUrl": "https://images.pokemontcg.io/smp/SM92.png",
@@ -5235,7 +5327,8 @@
     ]
   },
   {
-    "id": "smp-SM93",
+    "setOrder":1004,
+	"id": "smp-SM93",
     "name": "Marshadow",
     "imageUrl": "https://images.pokemontcg.io/smp/SM93.png",
     "subtype": "Basic",
@@ -5291,7 +5384,8 @@
     "nationalPokedexNumber": 802
   },
   {
-    "id": "smp-SM98",
+    "setOrder":1004,
+	"id": "smp-SM98",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/smp/SM98.png",
     "subtype": "Basic",
@@ -5350,7 +5444,8 @@
     ]
   },
   {
-    "id": "smp-SM99",
+    "setOrder":1004,
+	"id": "smp-SM99",
     "name": "Mimikyu",
     "imageUrl": "https://images.pokemontcg.io/smp/SM99.png",
     "subtype": "Basic",
@@ -5394,7 +5489,8 @@
     "nationalPokedexNumber": 778
   },
   {
-    "id": "smp-SM100",
+    "setOrder":1004,
+	"id": "smp-SM100",
     "name": "Lucario-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM100.png",
     "subtype": "GX",
@@ -5460,7 +5556,8 @@
     "nationalPokedexNumber": 448
   },
   {
-    "id": "smp-SM101",
+    "setOrder":1004,
+	"id": "smp-SM101",
     "name": "Dawn Wings Necrozma-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM101.png",
     "subtype": "GX",
@@ -5528,7 +5625,8 @@
     "nationalPokedexNumber": 800
   },
   {
-    "id": "smp-SM102",
+    "setOrder":1004,
+	"id": "smp-SM102",
     "name": "Dusk Mane Necrozma-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM102.png",
     "subtype": "GX",
@@ -5604,7 +5702,8 @@
     "nationalPokedexNumber": 800
   },
   {
-    "id": "smp-SM105",
+    "setOrder":1004,
+	"id": "smp-SM105",
     "name": "Lycanroc",
     "imageUrl": "https://images.pokemontcg.io/smp/SM105.png",
     "subtype": "Stage 1",
@@ -5658,7 +5757,8 @@
     "nationalPokedexNumber": 745
   },
   {
-    "id": "smp-SM106",
+    "setOrder":1004,
+	"id": "smp-SM106",
     "name": "Dawn Wings Necrozma",
     "imageUrl": "https://images.pokemontcg.io/smp/SM106.png",
     "subtype": "Basic",
@@ -5716,7 +5816,8 @@
     "nationalPokedexNumber": 800
   },
   {
-    "id": "smp-SM107",
+    "setOrder":1004,
+	"id": "smp-SM107",
     "name": "Dusk Mane Necrozma",
     "imageUrl": "https://images.pokemontcg.io/smp/SM107.png",
     "subtype": "Basic",
@@ -5774,7 +5875,8 @@
     "nationalPokedexNumber": 800
   },
   {
-    "id": "smp-SM108",
+    "setOrder":1004,
+	"id": "smp-SM108",
     "name": "Ash's Pikachu",
     "imageUrl": "https://images.pokemontcg.io/smp/SM108.png",
     "subtype": "Basic",
@@ -5834,7 +5936,8 @@
     ]
   },
   {
-    "id": "smp-SM109",
+    "setOrder":1004,
+	"id": "smp-SM109",
     "name": "Ash's Pikachu",
     "imageUrl": "https://images.pokemontcg.io/smp/SM109.png",
     "subtype": "Basic",
@@ -5894,7 +5997,8 @@
     ]
   },
   {
-    "id": "smp-SM110",
+    "setOrder":1004,
+	"id": "smp-SM110",
     "name": "Ash's Pikachu",
     "imageUrl": "https://images.pokemontcg.io/smp/SM110.png",
     "subtype": "Basic",
@@ -5954,7 +6058,8 @@
     ]
   },
   {
-    "id": "smp-SM111",
+    "setOrder":1004,
+	"id": "smp-SM111",
     "name": "Ash's Pikachu",
     "imageUrl": "https://images.pokemontcg.io/smp/SM111.png",
     "subtype": "Basic",
@@ -6014,7 +6119,8 @@
     ]
   },
   {
-    "id": "smp-SM112",
+    "setOrder":1004,
+	"id": "smp-SM112",
     "name": "Ash's Pikachu",
     "imageUrl": "https://images.pokemontcg.io/smp/SM112.png",
     "subtype": "Basic",
@@ -6074,7 +6180,8 @@
     ]
   },
   {
-    "id": "smp-SM113",
+    "setOrder":1004,
+	"id": "smp-SM113",
     "name": "Ash's Pikachu",
     "imageUrl": "https://images.pokemontcg.io/smp/SM113.png",
     "subtype": "Basic",
@@ -6134,7 +6241,8 @@
     ]
   },
   {
-    "id": "smp-SM114",
+    "setOrder":1004,
+	"id": "smp-SM114",
     "name": "Ash's Pikachu",
     "imageUrl": "https://images.pokemontcg.io/smp/SM114.png",
     "subtype": "Basic",
@@ -6194,7 +6302,8 @@
     ]
   },
   {
-    "id": "smp-SM133",
+    "setOrder":1004,
+	"id": "smp-SM133",
     "name": "Thundurus-GX",
     "nationalPokedexNumber": 641,
     "imageUrl": "https://images.pokemontcg.io/smp/SM133.png",
@@ -6262,7 +6371,8 @@
     ]
   },
   {
-    "id": "smp-SM134",
+    "setOrder":1004,
+	"id": "smp-SM134",
     "name": "Tornadus-GX",
     "nationalPokedexNumber": 640,
     "imageUrl": "https://images.pokemontcg.io/smp/SM134.png",

--- a/json/cards/Sun & Moon.json
+++ b/json/cards/Sun & Moon.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "sm1-1",
+    "setOrder":72,
+	"id": "sm1-1",
     "name": "Caterpie",
     "imageUrl": "https://images.pokemontcg.io/sm1/1.png",
     "subtype": "Basic",
@@ -53,7 +54,8 @@
     ]
   },
   {
-    "id": "sm1-2",
+    "setOrder":72,
+	"id": "sm1-2",
     "name": "Metapod",
     "imageUrl": "https://images.pokemontcg.io/sm1/2.png",
     "subtype": "Stage 1",
@@ -110,7 +112,8 @@
     ]
   },
   {
-    "id": "sm1-3",
+    "setOrder":72,
+	"id": "sm1-3",
     "name": "Butterfree",
     "imageUrl": "https://images.pokemontcg.io/sm1/3.png",
     "subtype": "Stage 2",
@@ -162,7 +165,8 @@
     "nationalPokedexNumber": 12
   },
   {
-    "id": "sm1-4",
+    "setOrder":72,
+	"id": "sm1-4",
     "name": "Paras",
     "imageUrl": "https://images.pokemontcg.io/sm1/4.png",
     "subtype": "Basic",
@@ -206,7 +210,8 @@
     ]
   },
   {
-    "id": "sm1-5",
+    "setOrder":72,
+	"id": "sm1-5",
     "name": "Parasect",
     "imageUrl": "https://images.pokemontcg.io/sm1/5.png",
     "subtype": "Stage 1",
@@ -261,7 +266,8 @@
     "nationalPokedexNumber": 47
   },
   {
-    "id": "sm1-6",
+    "setOrder":72,
+	"id": "sm1-6",
     "name": "Pinsir",
     "imageUrl": "https://images.pokemontcg.io/sm1/6.png",
     "subtype": "Basic",
@@ -313,7 +319,8 @@
     "nationalPokedexNumber": 127
   },
   {
-    "id": "sm1-7",
+    "setOrder":72,
+	"id": "sm1-7",
     "name": "Surskit",
     "imageUrl": "https://images.pokemontcg.io/sm1/7.png",
     "subtype": "Basic",
@@ -356,7 +363,8 @@
     ]
   },
   {
-    "id": "sm1-8",
+    "setOrder":72,
+	"id": "sm1-8",
     "name": "Masquerain",
     "imageUrl": "https://images.pokemontcg.io/sm1/8.png",
     "subtype": "Stage 1",
@@ -394,7 +402,8 @@
     "nationalPokedexNumber": 284
   },
   {
-    "id": "sm1-9",
+    "setOrder":72,
+	"id": "sm1-9",
     "name": "Rowlet",
     "imageUrl": "https://images.pokemontcg.io/sm1/9.png",
     "subtype": "Basic",
@@ -447,7 +456,8 @@
     ]
   },
   {
-    "id": "sm1-10",
+    "setOrder":72,
+	"id": "sm1-10",
     "name": "Dartrix",
     "imageUrl": "https://images.pokemontcg.io/sm1/10.png",
     "subtype": "Stage 1",
@@ -502,7 +512,8 @@
     ]
   },
   {
-    "id": "sm1-11",
+    "setOrder":72,
+	"id": "sm1-11",
     "name": "Decidueye",
     "imageUrl": "https://images.pokemontcg.io/sm1/11.png",
     "subtype": "Stage 2",
@@ -554,7 +565,8 @@
     "nationalPokedexNumber": 724
   },
   {
-    "id": "sm1-12",
+    "setOrder":72,
+	"id": "sm1-12",
     "name": "Decidueye-GX",
     "imageUrl": "https://images.pokemontcg.io/sm1/12.png",
     "subtype": "GX",
@@ -616,7 +628,8 @@
     "nationalPokedexNumber": 724
   },
   {
-    "id": "sm1-13",
+    "setOrder":72,
+	"id": "sm1-13",
     "name": "Grubbin",
     "imageUrl": "https://images.pokemontcg.io/sm1/13.png",
     "subtype": "Basic",
@@ -661,7 +674,8 @@
     ]
   },
   {
-    "id": "sm1-14",
+    "setOrder":72,
+	"id": "sm1-14",
     "name": "Fomantis",
     "imageUrl": "https://images.pokemontcg.io/sm1/14.png",
     "subtype": "Basic",
@@ -714,7 +728,8 @@
     ]
   },
   {
-    "id": "sm1-15",
+    "setOrder":72,
+	"id": "sm1-15",
     "name": "Lurantis-GX",
     "imageUrl": "https://images.pokemontcg.io/sm1/15.png",
     "subtype": "GX",
@@ -780,7 +795,8 @@
     "nationalPokedexNumber": 754
   },
   {
-    "id": "sm1-16",
+    "setOrder":72,
+	"id": "sm1-16",
     "name": "Morelull",
     "imageUrl": "https://images.pokemontcg.io/sm1/16.png",
     "subtype": "Basic",
@@ -832,7 +848,8 @@
     ]
   },
   {
-    "id": "sm1-17",
+    "setOrder":72,
+	"id": "sm1-17",
     "name": "Shiinotic",
     "imageUrl": "https://images.pokemontcg.io/sm1/17.png",
     "subtype": "Stage 1",
@@ -880,7 +897,8 @@
     "nationalPokedexNumber": 756
   },
   {
-    "id": "sm1-18",
+    "setOrder":72,
+	"id": "sm1-18",
     "name": "Bounsweet",
     "imageUrl": "https://images.pokemontcg.io/sm1/18.png",
     "subtype": "Basic",
@@ -932,7 +950,8 @@
     ]
   },
   {
-    "id": "sm1-19",
+    "setOrder":72,
+	"id": "sm1-19",
     "name": "Steenee",
     "imageUrl": "https://images.pokemontcg.io/sm1/19.png",
     "subtype": "Stage 1",
@@ -987,7 +1006,8 @@
     ]
   },
   {
-    "id": "sm1-20",
+    "setOrder":72,
+	"id": "sm1-20",
     "name": "Tsareena",
     "imageUrl": "https://images.pokemontcg.io/sm1/20.png",
     "subtype": "Stage 2",
@@ -1036,7 +1056,8 @@
     "nationalPokedexNumber": 763
   },
   {
-    "id": "sm1-21",
+    "setOrder":72,
+	"id": "sm1-21",
     "name": "Growlithe",
     "imageUrl": "https://images.pokemontcg.io/sm1/21.png",
     "subtype": "Basic",
@@ -1082,7 +1103,8 @@
     ]
   },
   {
-    "id": "sm1-22",
+    "setOrder":72,
+	"id": "sm1-22",
     "name": "Arcanine",
     "imageUrl": "https://images.pokemontcg.io/sm1/22.png",
     "subtype": "Stage 1",
@@ -1138,7 +1160,8 @@
     "nationalPokedexNumber": 59
   },
   {
-    "id": "sm1-23",
+    "setOrder":72,
+	"id": "sm1-23",
     "name": "Torkoal",
     "imageUrl": "https://images.pokemontcg.io/sm1/23.png",
     "subtype": "Basic",
@@ -1190,7 +1213,8 @@
     "nationalPokedexNumber": 324
   },
   {
-    "id": "sm1-24",
+    "setOrder":72,
+	"id": "sm1-24",
     "name": "Litten",
     "imageUrl": "https://images.pokemontcg.io/sm1/24.png",
     "subtype": "Basic",
@@ -1243,7 +1267,8 @@
     ]
   },
   {
-    "id": "sm1-25",
+    "setOrder":72,
+	"id": "sm1-25",
     "name": "Torracat",
     "imageUrl": "https://images.pokemontcg.io/sm1/25.png",
     "subtype": "Stage 1",
@@ -1299,7 +1324,8 @@
     ]
   },
   {
-    "id": "sm1-26",
+    "setOrder":72,
+	"id": "sm1-26",
     "name": "Incineroar",
     "imageUrl": "https://images.pokemontcg.io/sm1/26.png",
     "subtype": "Stage 2",
@@ -1354,7 +1380,8 @@
     "nationalPokedexNumber": 727
   },
   {
-    "id": "sm1-27",
+    "setOrder":72,
+	"id": "sm1-27",
     "name": "Incineroar-GX",
     "imageUrl": "https://images.pokemontcg.io/sm1/27.png",
     "subtype": "GX",
@@ -1423,7 +1450,8 @@
     "nationalPokedexNumber": 727
   },
   {
-    "id": "sm1-28",
+    "setOrder":72,
+	"id": "sm1-28",
     "name": "Psyduck",
     "imageUrl": "https://images.pokemontcg.io/sm1/28.png",
     "subtype": "Basic",
@@ -1467,7 +1495,8 @@
     ]
   },
   {
-    "id": "sm1-29",
+    "setOrder":72,
+	"id": "sm1-29",
     "name": "Golduck",
     "imageUrl": "https://images.pokemontcg.io/sm1/29.png",
     "subtype": "Stage 1",
@@ -1514,7 +1543,8 @@
     "nationalPokedexNumber": 55
   },
   {
-    "id": "sm1-30",
+    "setOrder":72,
+	"id": "sm1-30",
     "name": "Poliwag",
     "imageUrl": "https://images.pokemontcg.io/sm1/30.png",
     "subtype": "Basic",
@@ -1568,7 +1598,8 @@
     ]
   },
   {
-    "id": "sm1-31",
+    "setOrder":72,
+	"id": "sm1-31",
     "name": "Poliwhirl",
     "imageUrl": "https://images.pokemontcg.io/sm1/31.png",
     "subtype": "Stage 1",
@@ -1626,7 +1657,8 @@
     ]
   },
   {
-    "id": "sm1-32",
+    "setOrder":72,
+	"id": "sm1-32",
     "name": "Poliwrath",
     "imageUrl": "https://images.pokemontcg.io/sm1/32.png",
     "subtype": "Stage 2",
@@ -1680,7 +1712,8 @@
     "nationalPokedexNumber": 62
   },
   {
-    "id": "sm1-33",
+    "setOrder":72,
+	"id": "sm1-33",
     "name": "Shellder",
     "imageUrl": "https://images.pokemontcg.io/sm1/33.png",
     "subtype": "Basic",
@@ -1724,7 +1757,8 @@
     ]
   },
   {
-    "id": "sm1-34",
+    "setOrder":72,
+	"id": "sm1-34",
     "name": "Cloyster",
     "imageUrl": "https://images.pokemontcg.io/sm1/34.png",
     "subtype": "Stage 1",
@@ -1779,7 +1813,8 @@
     "nationalPokedexNumber": 91
   },
   {
-    "id": "sm1-35",
+    "setOrder":72,
+	"id": "sm1-35",
     "name": "Lapras-GX",
     "imageUrl": "https://images.pokemontcg.io/sm1/35.png",
     "subtype": "GX",
@@ -1846,7 +1881,8 @@
     "nationalPokedexNumber": 131
   },
   {
-    "id": "sm1-36",
+    "setOrder":72,
+	"id": "sm1-36",
     "name": "Corsola",
     "imageUrl": "https://images.pokemontcg.io/sm1/36.png",
     "subtype": "Basic",
@@ -1897,7 +1933,8 @@
     "nationalPokedexNumber": 222
   },
   {
-    "id": "sm1-37",
+    "setOrder":72,
+	"id": "sm1-37",
     "name": "Wingull",
     "imageUrl": "https://images.pokemontcg.io/sm1/37.png",
     "subtype": "Basic",
@@ -1946,7 +1983,8 @@
     ]
   },
   {
-    "id": "sm1-38",
+    "setOrder":72,
+	"id": "sm1-38",
     "name": "Pelipper",
     "imageUrl": "https://images.pokemontcg.io/sm1/38.png",
     "subtype": "Stage 1",
@@ -2005,7 +2043,8 @@
     "nationalPokedexNumber": 279
   },
   {
-    "id": "sm1-39",
+    "setOrder":72,
+	"id": "sm1-39",
     "name": "Popplio",
     "imageUrl": "https://images.pokemontcg.io/sm1/39.png",
     "subtype": "Basic",
@@ -2058,7 +2097,8 @@
     ]
   },
   {
-    "id": "sm1-40",
+    "setOrder":72,
+	"id": "sm1-40",
     "name": "Brionne",
     "imageUrl": "https://images.pokemontcg.io/sm1/40.png",
     "subtype": "Stage 1",
@@ -2115,7 +2155,8 @@
     ]
   },
   {
-    "id": "sm1-41",
+    "setOrder":72,
+	"id": "sm1-41",
     "name": "Primarina",
     "imageUrl": "https://images.pokemontcg.io/sm1/41.png",
     "subtype": "Stage 2",
@@ -2169,7 +2210,8 @@
     "nationalPokedexNumber": 730
   },
   {
-    "id": "sm1-42",
+    "setOrder":72,
+	"id": "sm1-42",
     "name": "Primarina-GX",
     "imageUrl": "https://images.pokemontcg.io/sm1/42.png",
     "subtype": "GX",
@@ -2238,7 +2280,8 @@
     "nationalPokedexNumber": 730
   },
   {
-    "id": "sm1-43",
+    "setOrder":72,
+	"id": "sm1-43",
     "name": "Crabominable",
     "imageUrl": "https://images.pokemontcg.io/sm1/43.png",
     "subtype": "Stage 1",
@@ -2296,7 +2339,8 @@
     "nationalPokedexNumber": 740
   },
   {
-    "id": "sm1-44",
+    "setOrder":72,
+	"id": "sm1-44",
     "name": "Wishiwashi",
     "imageUrl": "https://images.pokemontcg.io/sm1/44.png",
     "subtype": "Basic",
@@ -2341,7 +2385,8 @@
     "nationalPokedexNumber": 746
   },
   {
-    "id": "sm1-45",
+    "setOrder":72,
+	"id": "sm1-45",
     "name": "Dewpider",
     "imageUrl": "https://images.pokemontcg.io/sm1/45.png",
     "subtype": "Basic",
@@ -2384,7 +2429,8 @@
     ]
   },
   {
-    "id": "sm1-46",
+    "setOrder":72,
+	"id": "sm1-46",
     "name": "Araquanid",
     "imageUrl": "https://images.pokemontcg.io/sm1/46.png",
     "subtype": "Stage 1",
@@ -2433,7 +2479,8 @@
     "nationalPokedexNumber": 752
   },
   {
-    "id": "sm1-47",
+    "setOrder":72,
+	"id": "sm1-47",
     "name": "Pyukumuku",
     "imageUrl": "https://images.pokemontcg.io/sm1/47.png",
     "subtype": "Basic",
@@ -2478,7 +2525,8 @@
     "nationalPokedexNumber": 771
   },
   {
-    "id": "sm1-48",
+    "setOrder":72,
+	"id": "sm1-48",
     "name": "Bruxish",
     "imageUrl": "https://images.pokemontcg.io/sm1/48.png",
     "subtype": "Basic",
@@ -2530,7 +2578,8 @@
     "nationalPokedexNumber": 779
   },
   {
-    "id": "sm1-49",
+    "setOrder":72,
+	"id": "sm1-49",
     "name": "Chinchou",
     "imageUrl": "https://images.pokemontcg.io/sm1/49.png",
     "subtype": "Basic",
@@ -2590,7 +2639,8 @@
     ]
   },
   {
-    "id": "sm1-50",
+    "setOrder":72,
+	"id": "sm1-50",
     "name": "Lanturn",
     "imageUrl": "https://images.pokemontcg.io/sm1/50.png",
     "subtype": "Stage 1",
@@ -2649,7 +2699,8 @@
     "nationalPokedexNumber": 171
   },
   {
-    "id": "sm1-51",
+    "setOrder":72,
+	"id": "sm1-51",
     "name": "Charjabug",
     "imageUrl": "https://images.pokemontcg.io/sm1/51.png",
     "subtype": "Stage 1",
@@ -2713,7 +2764,8 @@
     ]
   },
   {
-    "id": "sm1-52",
+    "setOrder":72,
+	"id": "sm1-52",
     "name": "Vikavolt",
     "imageUrl": "https://images.pokemontcg.io/sm1/52.png",
     "subtype": "Stage 2",
@@ -2770,7 +2822,8 @@
     "nationalPokedexNumber": 738
   },
   {
-    "id": "sm1-53",
+    "setOrder":72,
+	"id": "sm1-53",
     "name": "Togedemaru",
     "imageUrl": "https://images.pokemontcg.io/sm1/53.png",
     "subtype": "Basic",
@@ -2825,7 +2878,8 @@
     "nationalPokedexNumber": 777
   },
   {
-    "id": "sm1-54",
+    "setOrder":72,
+	"id": "sm1-54",
     "name": "Zubat",
     "imageUrl": "https://images.pokemontcg.io/sm1/54.png",
     "subtype": "Basic",
@@ -2874,7 +2928,8 @@
     ]
   },
   {
-    "id": "sm1-55",
+    "setOrder":72,
+	"id": "sm1-55",
     "name": "Golbat",
     "imageUrl": "https://images.pokemontcg.io/sm1/55.png",
     "subtype": "Stage 1",
@@ -2931,7 +2986,8 @@
     ]
   },
   {
-    "id": "sm1-56",
+    "setOrder":72,
+	"id": "sm1-56",
     "name": "Crobat",
     "imageUrl": "https://images.pokemontcg.io/sm1/56.png",
     "subtype": "Stage 2",
@@ -2986,7 +3042,8 @@
     "nationalPokedexNumber": 169
   },
   {
-    "id": "sm1-57",
+    "setOrder":72,
+	"id": "sm1-57",
     "name": "Alolan Grimer",
     "imageUrl": "https://images.pokemontcg.io/sm1/57.png",
     "subtype": "Basic",
@@ -3042,7 +3099,8 @@
     ]
   },
   {
-    "id": "sm1-58",
+    "setOrder":72,
+	"id": "sm1-58",
     "name": "Alolan Muk",
     "imageUrl": "https://images.pokemontcg.io/sm1/58.png",
     "subtype": "Stage 1",
@@ -3094,7 +3152,8 @@
     "nationalPokedexNumber": 89
   },
   {
-    "id": "sm1-59",
+    "setOrder":72,
+	"id": "sm1-59",
     "name": "Drowzee",
     "imageUrl": "https://images.pokemontcg.io/sm1/59.png",
     "subtype": "Basic",
@@ -3148,7 +3207,8 @@
     ]
   },
   {
-    "id": "sm1-60",
+    "setOrder":72,
+	"id": "sm1-60",
     "name": "Hypno",
     "imageUrl": "https://images.pokemontcg.io/sm1/60.png",
     "subtype": "Stage 1",
@@ -3202,7 +3262,8 @@
     "nationalPokedexNumber": 97
   },
   {
-    "id": "sm1-61",
+    "setOrder":72,
+	"id": "sm1-61",
     "name": "Espeon-GX",
     "imageUrl": "https://images.pokemontcg.io/sm1/61.png",
     "subtype": "GX",
@@ -3269,7 +3330,8 @@
     "nationalPokedexNumber": 196
   },
   {
-    "id": "sm1-62",
+    "setOrder":72,
+	"id": "sm1-62",
     "name": "Mareanie",
     "imageUrl": "https://images.pokemontcg.io/sm1/62.png",
     "subtype": "Basic",
@@ -3312,7 +3374,8 @@
     ]
   },
   {
-    "id": "sm1-63",
+    "setOrder":72,
+	"id": "sm1-63",
     "name": "Toxapex",
     "imageUrl": "https://images.pokemontcg.io/sm1/63.png",
     "subtype": "Stage 1",
@@ -3362,7 +3425,8 @@
     "nationalPokedexNumber": 748
   },
   {
-    "id": "sm1-64",
+    "setOrder":72,
+	"id": "sm1-64",
     "name": "Cosmog",
     "imageUrl": "https://images.pokemontcg.io/sm1/64.png",
     "subtype": "Basic",
@@ -3405,7 +3469,8 @@
     ]
   },
   {
-    "id": "sm1-65",
+    "setOrder":72,
+	"id": "sm1-65",
     "name": "Cosmoem",
     "imageUrl": "https://images.pokemontcg.io/sm1/65.png",
     "subtype": "Stage 1",
@@ -3452,7 +3517,8 @@
     ]
   },
   {
-    "id": "sm1-66",
+    "setOrder":72,
+	"id": "sm1-66",
     "name": "Lunala-GX",
     "imageUrl": "https://images.pokemontcg.io/sm1/66.png",
     "subtype": "GX",
@@ -3523,7 +3589,8 @@
     "nationalPokedexNumber": 792
   },
   {
-    "id": "sm1-67",
+    "setOrder":72,
+	"id": "sm1-67",
     "name": "Makuhita",
     "imageUrl": "https://images.pokemontcg.io/sm1/67.png",
     "subtype": "Basic",
@@ -3577,7 +3644,8 @@
     ]
   },
   {
-    "id": "sm1-68",
+    "setOrder":72,
+	"id": "sm1-68",
     "name": "Hariyama",
     "imageUrl": "https://images.pokemontcg.io/sm1/68.png",
     "subtype": "Stage 1",
@@ -3635,7 +3703,8 @@
     "nationalPokedexNumber": 297
   },
   {
-    "id": "sm1-69",
+    "setOrder":72,
+	"id": "sm1-69",
     "name": "Roggenrola",
     "imageUrl": "https://images.pokemontcg.io/sm1/69.png",
     "subtype": "Basic",
@@ -3681,7 +3750,8 @@
     ]
   },
   {
-    "id": "sm1-70",
+    "setOrder":72,
+	"id": "sm1-70",
     "name": "Boldore",
     "imageUrl": "https://images.pokemontcg.io/sm1/70.png",
     "subtype": "Stage 1",
@@ -3740,7 +3810,8 @@
     ]
   },
   {
-    "id": "sm1-71",
+    "setOrder":72,
+	"id": "sm1-71",
     "name": "Gigalith",
     "imageUrl": "https://images.pokemontcg.io/sm1/71.png",
     "subtype": "Stage 2",
@@ -3797,7 +3868,8 @@
     "nationalPokedexNumber": 526
   },
   {
-    "id": "sm1-72",
+    "setOrder":72,
+	"id": "sm1-72",
     "name": "Crabrawler",
     "imageUrl": "https://images.pokemontcg.io/sm1/72.png",
     "subtype": "Basic",
@@ -3853,7 +3925,8 @@
     ]
   },
   {
-    "id": "sm1-73",
+    "setOrder":72,
+	"id": "sm1-73",
     "name": "Passimian",
     "imageUrl": "https://images.pokemontcg.io/sm1/73.png",
     "subtype": "Basic",
@@ -3903,7 +3976,8 @@
     "nationalPokedexNumber": 766
   },
   {
-    "id": "sm1-74",
+    "setOrder":72,
+	"id": "sm1-74",
     "name": "Sandygast",
     "imageUrl": "https://images.pokemontcg.io/sm1/74.png",
     "subtype": "Basic",
@@ -3959,7 +4033,8 @@
     ]
   },
   {
-    "id": "sm1-75",
+    "setOrder":72,
+	"id": "sm1-75",
     "name": "Palossand",
     "imageUrl": "https://images.pokemontcg.io/sm1/75.png",
     "subtype": "Stage 1",
@@ -4011,7 +4086,8 @@
     "nationalPokedexNumber": 770
   },
   {
-    "id": "sm1-76",
+    "setOrder":72,
+	"id": "sm1-76",
     "name": "Alolan Rattata",
     "imageUrl": "https://images.pokemontcg.io/sm1/76.png",
     "subtype": "Basic",
@@ -4057,7 +4133,8 @@
     ]
   },
   {
-    "id": "sm1-77",
+    "setOrder":72,
+	"id": "sm1-77",
     "name": "Alolan Raticate",
     "imageUrl": "https://images.pokemontcg.io/sm1/77.png",
     "subtype": "Stage 1",
@@ -4118,7 +4195,8 @@
     "nationalPokedexNumber": 20
   },
   {
-    "id": "sm1-78",
+    "setOrder":72,
+	"id": "sm1-78",
     "name": "Alolan Meowth",
     "imageUrl": "https://images.pokemontcg.io/sm1/78.png",
     "subtype": "Basic",
@@ -4167,7 +4245,8 @@
     ]
   },
   {
-    "id": "sm1-79",
+    "setOrder":72,
+	"id": "sm1-79",
     "name": "Alolan Persian",
     "imageUrl": "https://images.pokemontcg.io/sm1/79.png",
     "subtype": "Stage 1",
@@ -4223,7 +4302,8 @@
     "nationalPokedexNumber": 53
   },
   {
-    "id": "sm1-80",
+    "setOrder":72,
+	"id": "sm1-80",
     "name": "Umbreon-GX",
     "imageUrl": "https://images.pokemontcg.io/sm1/80.png",
     "subtype": "GX",
@@ -4296,7 +4376,8 @@
     "nationalPokedexNumber": 197
   },
   {
-    "id": "sm1-81",
+    "setOrder":72,
+	"id": "sm1-81",
     "name": "Carvanha",
     "imageUrl": "https://images.pokemontcg.io/sm1/81.png",
     "subtype": "Basic",
@@ -4355,7 +4436,8 @@
     ]
   },
   {
-    "id": "sm1-82",
+    "setOrder":72,
+	"id": "sm1-82",
     "name": "Sharpedo",
     "imageUrl": "https://images.pokemontcg.io/sm1/82.png",
     "subtype": "Stage 1",
@@ -4406,7 +4488,8 @@
     "nationalPokedexNumber": 319
   },
   {
-    "id": "sm1-83",
+    "setOrder":72,
+	"id": "sm1-83",
     "name": "Sandile",
     "imageUrl": "https://images.pokemontcg.io/sm1/83.png",
     "subtype": "Basic",
@@ -4468,7 +4551,8 @@
     ]
   },
   {
-    "id": "sm1-84",
+    "setOrder":72,
+	"id": "sm1-84",
     "name": "Krokorok",
     "imageUrl": "https://images.pokemontcg.io/sm1/84.png",
     "subtype": "Stage 1",
@@ -4531,7 +4615,8 @@
     ]
   },
   {
-    "id": "sm1-85",
+    "setOrder":72,
+	"id": "sm1-85",
     "name": "Krookodile",
     "imageUrl": "https://images.pokemontcg.io/sm1/85.png",
     "subtype": "Stage 2",
@@ -4592,7 +4677,8 @@
     "nationalPokedexNumber": 553
   },
   {
-    "id": "sm1-86",
+    "setOrder":72,
+	"id": "sm1-86",
     "name": "Alolan Diglett",
     "imageUrl": "https://images.pokemontcg.io/sm1/86.png",
     "subtype": "Basic",
@@ -4650,7 +4736,8 @@
     ]
   },
   {
-    "id": "sm1-87",
+    "setOrder":72,
+	"id": "sm1-87",
     "name": "Alolan Dugtrio",
     "imageUrl": "https://images.pokemontcg.io/sm1/87.png",
     "subtype": "Stage 1",
@@ -4705,7 +4792,8 @@
     "nationalPokedexNumber": 51
   },
   {
-    "id": "sm1-88",
+    "setOrder":72,
+	"id": "sm1-88",
     "name": "Skarmory",
     "imageUrl": "https://images.pokemontcg.io/sm1/88.png",
     "subtype": "Basic",
@@ -4763,7 +4851,8 @@
     "nationalPokedexNumber": 227
   },
   {
-    "id": "sm1-89",
+    "setOrder":72,
+	"id": "sm1-89",
     "name": "Solgaleo-GX",
     "imageUrl": "https://images.pokemontcg.io/sm1/89.png",
     "subtype": "GX",
@@ -4832,7 +4921,8 @@
     "nationalPokedexNumber": 791
   },
   {
-    "id": "sm1-90",
+    "setOrder":72,
+	"id": "sm1-90",
     "name": "Snubbull",
     "imageUrl": "https://images.pokemontcg.io/sm1/90.png",
     "subtype": "Basic",
@@ -4881,7 +4971,8 @@
     ]
   },
   {
-    "id": "sm1-91",
+    "setOrder":72,
+	"id": "sm1-91",
     "name": "Granbull",
     "imageUrl": "https://images.pokemontcg.io/sm1/91.png",
     "subtype": "Stage 1",
@@ -4940,7 +5031,8 @@
     "nationalPokedexNumber": 210
   },
   {
-    "id": "sm1-92",
+    "setOrder":72,
+	"id": "sm1-92",
     "name": "Cutiefly",
     "imageUrl": "https://images.pokemontcg.io/sm1/92.png",
     "subtype": "Basic",
@@ -4989,7 +5081,8 @@
     ]
   },
   {
-    "id": "sm1-93",
+    "setOrder":72,
+	"id": "sm1-93",
     "name": "Ribombee",
     "imageUrl": "https://images.pokemontcg.io/sm1/93.png",
     "subtype": "Stage 1",
@@ -5041,7 +5134,8 @@
     "nationalPokedexNumber": 743
   },
   {
-    "id": "sm1-94",
+    "setOrder":72,
+	"id": "sm1-94",
     "name": "Dratini",
     "imageUrl": "https://images.pokemontcg.io/sm1/94.png",
     "subtype": "Basic",
@@ -5094,7 +5188,8 @@
     ]
   },
   {
-    "id": "sm1-95",
+    "setOrder":72,
+	"id": "sm1-95",
     "name": "Dragonair",
     "imageUrl": "https://images.pokemontcg.io/sm1/95.png",
     "subtype": "Stage 1",
@@ -5150,7 +5245,8 @@
     ]
   },
   {
-    "id": "sm1-96",
+    "setOrder":72,
+	"id": "sm1-96",
     "name": "Dragonite",
     "imageUrl": "https://images.pokemontcg.io/sm1/96.png",
     "subtype": "Stage 2",
@@ -5208,7 +5304,8 @@
     "nationalPokedexNumber": 149
   },
   {
-    "id": "sm1-97",
+    "setOrder":72,
+	"id": "sm1-97",
     "name": "Spearow",
     "imageUrl": "https://images.pokemontcg.io/sm1/97.png",
     "subtype": "Basic",
@@ -5257,7 +5354,8 @@
     ]
   },
   {
-    "id": "sm1-98",
+    "setOrder":72,
+	"id": "sm1-98",
     "name": "Fearow",
     "imageUrl": "https://images.pokemontcg.io/sm1/98.png",
     "subtype": "Stage 1",
@@ -5313,7 +5411,8 @@
     "nationalPokedexNumber": 22
   },
   {
-    "id": "sm1-99",
+    "setOrder":72,
+	"id": "sm1-99",
     "name": "Kangaskhan",
     "imageUrl": "https://images.pokemontcg.io/sm1/99.png",
     "subtype": "Basic",
@@ -5367,7 +5466,8 @@
     "nationalPokedexNumber": 115
   },
   {
-    "id": "sm1-100",
+    "setOrder":72,
+	"id": "sm1-100",
     "name": "Tauros-GX",
     "imageUrl": "https://images.pokemontcg.io/sm1/100.png",
     "subtype": "GX",
@@ -5434,7 +5534,8 @@
     "nationalPokedexNumber": 128
   },
   {
-    "id": "sm1-101",
+    "setOrder":72,
+	"id": "sm1-101",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/sm1/101.png",
     "subtype": "Basic",
@@ -5490,7 +5591,8 @@
     ]
   },
   {
-    "id": "sm1-102",
+    "setOrder":72,
+	"id": "sm1-102",
     "name": "Spinda",
     "imageUrl": "https://images.pokemontcg.io/sm1/102.png",
     "subtype": "Basic",
@@ -5530,7 +5632,8 @@
     "nationalPokedexNumber": 327
   },
   {
-    "id": "sm1-103",
+    "setOrder":72,
+	"id": "sm1-103",
     "name": "Lillipup",
     "imageUrl": "https://images.pokemontcg.io/sm1/103.png",
     "subtype": "Basic",
@@ -5583,7 +5686,8 @@
     ]
   },
   {
-    "id": "sm1-104",
+    "setOrder":72,
+	"id": "sm1-104",
     "name": "Herdier",
     "imageUrl": "https://images.pokemontcg.io/sm1/104.png",
     "subtype": "Stage 1",
@@ -5634,7 +5738,8 @@
     ]
   },
   {
-    "id": "sm1-105",
+    "setOrder":72,
+	"id": "sm1-105",
     "name": "Stoutland",
     "imageUrl": "https://images.pokemontcg.io/sm1/105.png",
     "subtype": "Stage 2",
@@ -5691,7 +5796,8 @@
     "nationalPokedexNumber": 508
   },
   {
-    "id": "sm1-106",
+    "setOrder":72,
+	"id": "sm1-106",
     "name": "Pikipek",
     "imageUrl": "https://images.pokemontcg.io/sm1/106.png",
     "subtype": "Basic",
@@ -5740,7 +5846,8 @@
     ]
   },
   {
-    "id": "sm1-107",
+    "setOrder":72,
+	"id": "sm1-107",
     "name": "Trumbeak",
     "imageUrl": "https://images.pokemontcg.io/sm1/107.png",
     "subtype": "Stage 1",
@@ -5790,7 +5897,8 @@
     ]
   },
   {
-    "id": "sm1-108",
+    "setOrder":72,
+	"id": "sm1-108",
     "name": "Toucannon",
     "imageUrl": "https://images.pokemontcg.io/sm1/108.png",
     "subtype": "Stage 2",
@@ -5850,7 +5958,8 @@
     "nationalPokedexNumber": 733
   },
   {
-    "id": "sm1-109",
+    "setOrder":72,
+	"id": "sm1-109",
     "name": "Yungoos",
     "imageUrl": "https://images.pokemontcg.io/sm1/109.png",
     "subtype": "Basic",
@@ -5903,7 +6012,8 @@
     ]
   },
   {
-    "id": "sm1-110",
+    "setOrder":72,
+	"id": "sm1-110",
     "name": "Gumshoos-GX",
     "imageUrl": "https://images.pokemontcg.io/sm1/110.png",
     "subtype": "GX",
@@ -5965,7 +6075,8 @@
     "nationalPokedexNumber": 735
   },
   {
-    "id": "sm1-111",
+    "setOrder":72,
+	"id": "sm1-111",
     "name": "Stufful",
     "imageUrl": "https://images.pokemontcg.io/sm1/111.png",
     "subtype": "Basic",
@@ -6010,7 +6121,8 @@
     ]
   },
   {
-    "id": "sm1-112",
+    "setOrder":72,
+	"id": "sm1-112",
     "name": "Bewear",
     "imageUrl": "https://images.pokemontcg.io/sm1/112.png",
     "subtype": "Stage 1",
@@ -6065,7 +6177,8 @@
     "nationalPokedexNumber": 760
   },
   {
-    "id": "sm1-113",
+    "setOrder":72,
+	"id": "sm1-113",
     "name": "Oranguru",
     "imageUrl": "https://images.pokemontcg.io/sm1/113.png",
     "subtype": "Basic",
@@ -6113,7 +6226,8 @@
     "nationalPokedexNumber": 765
   },
   {
-    "id": "sm1-114",
+    "setOrder":72,
+	"id": "sm1-114",
     "name": "Big Malasada",
     "imageUrl": "https://images.pokemontcg.io/sm1/114.png",
     "subtype": "Item",
@@ -6130,7 +6244,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/114_hires.png"
   },
   {
-    "id": "sm1-115",
+    "setOrder":72,
+	"id": "sm1-115",
     "name": "Crushing Hammer",
     "imageUrl": "https://images.pokemontcg.io/sm1/115.png",
     "subtype": "Item",
@@ -6147,7 +6262,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/115_hires.png"
   },
   {
-    "id": "sm1-116",
+    "setOrder":72,
+	"id": "sm1-116",
     "name": "Energy Retrieval",
     "imageUrl": "https://images.pokemontcg.io/sm1/116.png",
     "subtype": "Item",
@@ -6164,7 +6280,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/116_hires.png"
   },
   {
-    "id": "sm1-117",
+    "setOrder":72,
+	"id": "sm1-117",
     "name": "Energy Switch",
     "imageUrl": "https://images.pokemontcg.io/sm1/117.png",
     "subtype": "Item",
@@ -6181,7 +6298,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/117_hires.png"
   },
   {
-    "id": "sm1-118",
+    "setOrder":72,
+	"id": "sm1-118",
     "name": "Exp. Share",
     "imageUrl": "https://images.pokemontcg.io/sm1/118.png",
     "subtype": "Pokémon Tool",
@@ -6198,7 +6316,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/118_hires.png"
   },
   {
-    "id": "sm1-119",
+    "setOrder":72,
+	"id": "sm1-119",
     "name": "Great Ball",
     "imageUrl": "https://images.pokemontcg.io/sm1/119.png",
     "subtype": "Item",
@@ -6215,7 +6334,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/119_hires.png"
   },
   {
-    "id": "sm1-120",
+    "setOrder":72,
+	"id": "sm1-120",
     "name": "Hau",
     "imageUrl": "https://images.pokemontcg.io/sm1/120.png",
     "subtype": "Supporter",
@@ -6232,7 +6352,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/120_hires.png"
   },
   {
-    "id": "sm1-121",
+    "setOrder":72,
+	"id": "sm1-121",
     "name": "Ilima",
     "imageUrl": "https://images.pokemontcg.io/sm1/121.png",
     "subtype": "Supporter",
@@ -6249,7 +6370,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/121_hires.png"
   },
   {
-    "id": "sm1-122",
+    "setOrder":72,
+	"id": "sm1-122",
     "name": "Lillie",
     "imageUrl": "https://images.pokemontcg.io/sm1/122.png",
     "subtype": "Supporter",
@@ -6266,7 +6388,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/122_hires.png"
   },
   {
-    "id": "sm1-123",
+    "setOrder":72,
+	"id": "sm1-123",
     "name": "Nest Ball",
     "imageUrl": "https://images.pokemontcg.io/sm1/123.png",
     "subtype": "Item",
@@ -6283,7 +6406,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/123_hires.png"
   },
   {
-    "id": "sm1-124",
+    "setOrder":72,
+	"id": "sm1-124",
     "name": "Poison Barb",
     "imageUrl": "https://images.pokemontcg.io/sm1/124.png",
     "subtype": "Pokémon Tool",
@@ -6300,7 +6424,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/124_hires.png"
   },
   {
-    "id": "sm1-125",
+    "setOrder":72,
+	"id": "sm1-125",
     "name": "Poké Ball",
     "imageUrl": "https://images.pokemontcg.io/sm1/125.png",
     "subtype": "Item",
@@ -6317,7 +6442,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/125_hires.png"
   },
   {
-    "id": "sm1-126",
+    "setOrder":72,
+	"id": "sm1-126",
     "name": "Pokémon Catcher",
     "imageUrl": "https://images.pokemontcg.io/sm1/126.png",
     "subtype": "Item",
@@ -6334,7 +6460,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/126_hires.png"
   },
   {
-    "id": "sm1-127",
+    "setOrder":72,
+	"id": "sm1-127",
     "name": "Potion",
     "imageUrl": "https://images.pokemontcg.io/sm1/127.png",
     "subtype": "Item",
@@ -6351,7 +6478,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/127_hires.png"
   },
   {
-    "id": "sm1-128",
+    "setOrder":72,
+	"id": "sm1-128",
     "name": "Professor Kukui",
     "imageUrl": "https://images.pokemontcg.io/sm1/128.png",
     "subtype": "Supporter",
@@ -6368,7 +6496,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/128_hires.png"
   },
   {
-    "id": "sm1-129",
+    "setOrder":72,
+	"id": "sm1-129",
     "name": "Rare Candy",
     "imageUrl": "https://images.pokemontcg.io/sm1/129.png",
     "subtype": "Item",
@@ -6385,7 +6514,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/129_hires.png"
   },
   {
-    "id": "sm1-130",
+    "setOrder":72,
+	"id": "sm1-130",
     "name": "Repel",
     "imageUrl": "https://images.pokemontcg.io/sm1/130.png",
     "subtype": "Item",
@@ -6402,7 +6532,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/130_hires.png"
   },
   {
-    "id": "sm1-131",
+    "setOrder":72,
+	"id": "sm1-131",
     "name": "Rotom Dex",
     "imageUrl": "https://images.pokemontcg.io/sm1/131.png",
     "subtype": "Item",
@@ -6419,7 +6550,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/131_hires.png"
   },
   {
-    "id": "sm1-132",
+    "setOrder":72,
+	"id": "sm1-132",
     "name": "Switch",
     "imageUrl": "https://images.pokemontcg.io/sm1/132.png",
     "subtype": "Item",
@@ -6436,7 +6568,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/132_hires.png"
   },
   {
-    "id": "sm1-133",
+    "setOrder":72,
+	"id": "sm1-133",
     "name": "Team Skull Grunt",
     "imageUrl": "https://images.pokemontcg.io/sm1/133.png",
     "subtype": "Supporter",
@@ -6453,7 +6586,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/133_hires.png"
   },
   {
-    "id": "sm1-134",
+    "setOrder":72,
+	"id": "sm1-134",
     "name": "Timer Ball",
     "imageUrl": "https://images.pokemontcg.io/sm1/134.png",
     "subtype": "Item",
@@ -6470,7 +6604,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/134_hires.png"
   },
   {
-    "id": "sm1-135",
+    "setOrder":72,
+	"id": "sm1-135",
     "name": "Ultra Ball",
     "imageUrl": "https://images.pokemontcg.io/sm1/135.png",
     "subtype": "Item",
@@ -6487,7 +6622,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/135_hires.png"
   },
   {
-    "id": "sm1-136",
+    "setOrder":72,
+	"id": "sm1-136",
     "name": "Double Colorless Energy",
     "imageUrl": "https://images.pokemontcg.io/sm1/136.png",
     "subtype": "Special",
@@ -6504,7 +6640,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/136_hires.png"
   },
   {
-    "id": "sm1-137",
+    "setOrder":72,
+	"id": "sm1-137",
     "name": "Rainbow Energy",
     "imageUrl": "https://images.pokemontcg.io/sm1/137.png",
     "subtype": "Special",
@@ -6521,7 +6658,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/137_hires.png"
   },
   {
-    "id": "sm1-138",
+    "setOrder":72,
+	"id": "sm1-138",
     "name": "Lurantis-GX",
     "imageUrl": "https://images.pokemontcg.io/sm1/138.png",
     "subtype": "GX",
@@ -6587,7 +6725,8 @@
     "nationalPokedexNumber": 754
   },
   {
-    "id": "sm1-139",
+    "setOrder":72,
+	"id": "sm1-139",
     "name": "Lapras-GX",
     "imageUrl": "https://images.pokemontcg.io/sm1/139.png",
     "subtype": "GX",
@@ -6654,7 +6793,8 @@
     "nationalPokedexNumber": 131
   },
   {
-    "id": "sm1-140",
+    "setOrder":72,
+	"id": "sm1-140",
     "name": "Espeon-GX",
     "imageUrl": "https://images.pokemontcg.io/sm1/140.png",
     "subtype": "GX",
@@ -6721,7 +6861,8 @@
     "nationalPokedexNumber": 196
   },
   {
-    "id": "sm1-141",
+    "setOrder":72,
+	"id": "sm1-141",
     "name": "Lunala-GX",
     "imageUrl": "https://images.pokemontcg.io/sm1/141.png",
     "subtype": "GX",
@@ -6792,7 +6933,8 @@
     "nationalPokedexNumber": 792
   },
   {
-    "id": "sm1-142",
+    "setOrder":72,
+	"id": "sm1-142",
     "name": "Umbreon-GX",
     "imageUrl": "https://images.pokemontcg.io/sm1/142.png",
     "subtype": "GX",
@@ -6865,7 +7007,8 @@
     "nationalPokedexNumber": 197
   },
   {
-    "id": "sm1-143",
+    "setOrder":72,
+	"id": "sm1-143",
     "name": "Solgaleo-GX",
     "imageUrl": "https://images.pokemontcg.io/sm1/143.png",
     "subtype": "GX",
@@ -6934,7 +7077,8 @@
     "nationalPokedexNumber": 791
   },
   {
-    "id": "sm1-144",
+    "setOrder":72,
+	"id": "sm1-144",
     "name": "Tauros-GX",
     "imageUrl": "https://images.pokemontcg.io/sm1/144.png",
     "subtype": "GX",
@@ -7001,7 +7145,8 @@
     "nationalPokedexNumber": 128
   },
   {
-    "id": "sm1-145",
+    "setOrder":72,
+	"id": "sm1-145",
     "name": "Gumshoos-GX",
     "imageUrl": "https://images.pokemontcg.io/sm1/145.png",
     "subtype": "GX",
@@ -7063,7 +7208,8 @@
     "nationalPokedexNumber": 735
   },
   {
-    "id": "sm1-146",
+    "setOrder":72,
+	"id": "sm1-146",
     "name": "Ilima",
     "imageUrl": "https://images.pokemontcg.io/sm1/146.png",
     "subtype": "Supporter",
@@ -7080,7 +7226,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/146_hires.png"
   },
   {
-    "id": "sm1-147",
+    "setOrder":72,
+	"id": "sm1-147",
     "name": "Lillie",
     "imageUrl": "https://images.pokemontcg.io/sm1/147.png",
     "subtype": "Supporter",
@@ -7097,7 +7244,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/147_hires.png"
   },
   {
-    "id": "sm1-148",
+    "setOrder":72,
+	"id": "sm1-148",
     "name": "Professor Kukui",
     "imageUrl": "https://images.pokemontcg.io/sm1/148.png",
     "subtype": "Supporter",
@@ -7114,7 +7262,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/148_hires.png"
   },
   {
-    "id": "sm1-149",
+    "setOrder":72,
+	"id": "sm1-149",
     "name": "Team Skull Grunt",
     "imageUrl": "https://images.pokemontcg.io/sm1/149.png",
     "subtype": "Supporter",
@@ -7131,7 +7280,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/149_hires.png"
   },
   {
-    "id": "sm1-150",
+    "setOrder":72,
+	"id": "sm1-150",
     "name": "Lurantis-GX",
     "imageUrl": "https://images.pokemontcg.io/sm1/150.png",
     "subtype": "GX",
@@ -7197,7 +7347,8 @@
     "nationalPokedexNumber": 754
   },
   {
-    "id": "sm1-151",
+    "setOrder":72,
+	"id": "sm1-151",
     "name": "Lapras-GX",
     "imageUrl": "https://images.pokemontcg.io/sm1/151.png",
     "subtype": "GX",
@@ -7264,7 +7415,8 @@
     "nationalPokedexNumber": 131
   },
   {
-    "id": "sm1-152",
+    "setOrder":72,
+	"id": "sm1-152",
     "name": "Espeon-GX",
     "imageUrl": "https://images.pokemontcg.io/sm1/152.png",
     "subtype": "GX",
@@ -7331,7 +7483,8 @@
     "nationalPokedexNumber": 196
   },
   {
-    "id": "sm1-153",
+    "setOrder":72,
+	"id": "sm1-153",
     "name": "Lunala-GX",
     "imageUrl": "https://images.pokemontcg.io/sm1/153.png",
     "subtype": "GX",
@@ -7402,7 +7555,8 @@
     "nationalPokedexNumber": 792
   },
   {
-    "id": "sm1-154",
+    "setOrder":72,
+	"id": "sm1-154",
     "name": "Umbreon-GX",
     "imageUrl": "https://images.pokemontcg.io/sm1/154.png",
     "subtype": "GX",
@@ -7475,7 +7629,8 @@
     "nationalPokedexNumber": 197
   },
   {
-    "id": "sm1-155",
+    "setOrder":72,
+	"id": "sm1-155",
     "name": "Solgaleo-GX",
     "imageUrl": "https://images.pokemontcg.io/sm1/155.png",
     "subtype": "GX",
@@ -7544,7 +7699,8 @@
     "nationalPokedexNumber": 791
   },
   {
-    "id": "sm1-156",
+    "setOrder":72,
+	"id": "sm1-156",
     "name": "Tauros-GX",
     "imageUrl": "https://images.pokemontcg.io/sm1/156.png",
     "subtype": "GX",
@@ -7611,7 +7767,8 @@
     "nationalPokedexNumber": 128
   },
   {
-    "id": "sm1-157",
+    "setOrder":72,
+	"id": "sm1-157",
     "name": "Gumshoos-GX",
     "imageUrl": "https://images.pokemontcg.io/sm1/157.png",
     "subtype": "GX",
@@ -7673,7 +7830,8 @@
     "nationalPokedexNumber": 735
   },
   {
-    "id": "sm1-158",
+    "setOrder":72,
+	"id": "sm1-158",
     "name": "Nest Ball",
     "imageUrl": "https://images.pokemontcg.io/sm1/158.png",
     "subtype": "Item",
@@ -7690,7 +7848,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/158_hires.png"
   },
   {
-    "id": "sm1-159",
+    "setOrder":72,
+	"id": "sm1-159",
     "name": "Rotom Dex",
     "imageUrl": "https://images.pokemontcg.io/sm1/159.png",
     "subtype": "Item",
@@ -7707,7 +7866,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/159.png"
   },
   {
-    "id": "sm1-160",
+    "setOrder":72,
+	"id": "sm1-160",
     "name": "Switch",
     "imageUrl": "https://images.pokemontcg.io/sm1/160.png",
     "subtype": "Item",
@@ -7724,7 +7884,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/160_hires.png"
   },
   {
-    "id": "sm1-161",
+    "setOrder":72,
+	"id": "sm1-161",
     "name": "Ultra Ball",
     "imageUrl": "https://images.pokemontcg.io/sm1/161.png",
     "subtype": "Item",
@@ -7741,7 +7902,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/161_hires.png"
   },
   {
-    "id": "sm1-162",
+    "setOrder":72,
+	"id": "sm1-162",
     "name": "Psychic Energy",
     "imageUrl": "https://images.pokemontcg.io/sm1/162.png",
     "subtype": "Basic",
@@ -7755,7 +7917,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/162_hires.png"
   },
   {
-    "id": "sm1-163",
+    "setOrder":72,
+	"id": "sm1-163",
     "name": "Metal Energy",
     "imageUrl": "https://images.pokemontcg.io/sm1/163.png",
     "subtype": "Basic",
@@ -7769,7 +7932,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/163_hires.png"
   },
   {
-    "id": "sm1-164",
+    "setOrder":72,
+	"id": "sm1-164",
     "name": "Grass Energy",
     "imageUrl": "https://images.pokemontcg.io/sm1/164.png",
     "subtype": "Basic",
@@ -7783,7 +7947,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/164_hires.png"
   },
   {
-    "id": "sm1-165",
+    "setOrder":72,
+	"id": "sm1-165",
     "name": "Fire Energy",
     "imageUrl": "https://images.pokemontcg.io/sm1/165.png",
     "subtype": "Basic",
@@ -7797,7 +7962,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/165_hires.png"
   },
   {
-    "id": "sm1-166",
+    "setOrder":72,
+	"id": "sm1-166",
     "name": "Water Energy",
     "imageUrl": "https://images.pokemontcg.io/sm1/166.png",
     "subtype": "Basic",
@@ -7811,7 +7977,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/166_hires.png"
   },
   {
-    "id": "sm1-167",
+    "setOrder":72,
+	"id": "sm1-167",
     "name": "Lightning Energy",
     "imageUrl": "https://images.pokemontcg.io/sm1/167.png",
     "subtype": "Basic",
@@ -7825,7 +7992,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/167_hires.png"
   },
   {
-    "id": "sm1-168",
+    "setOrder":72,
+	"id": "sm1-168",
     "name": "Psychic Energy",
     "imageUrl": "https://images.pokemontcg.io/sm1/168.png",
     "subtype": "Basic",
@@ -7839,7 +8007,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/168_hires.png"
   },
   {
-    "id": "sm1-169",
+    "setOrder":72,
+	"id": "sm1-169",
     "name": "Fighting Energy",
     "imageUrl": "https://images.pokemontcg.io/sm1/169.png",
     "subtype": "Basic",
@@ -7853,7 +8022,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/169_hires.png"
   },
   {
-    "id": "sm1-170",
+    "setOrder":72,
+	"id": "sm1-170",
     "name": "Darkness Energy",
     "imageUrl": "https://images.pokemontcg.io/sm1/170.png",
     "subtype": "Basic",
@@ -7867,7 +8037,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/170_hires.png"
   },
   {
-    "id": "sm1-171",
+    "setOrder":72,
+	"id": "sm1-171",
     "name": "Metal Energy",
     "imageUrl": "https://images.pokemontcg.io/sm1/171.png",
     "subtype": "Basic",
@@ -7881,7 +8052,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm1/171_hires.png"
   },
   {
-    "id": "sm1-172",
+    "setOrder":72,
+	"id": "sm1-172",
     "name": "Fairy Energy",
     "imageUrl": "https://images.pokemontcg.io/sm1/172.png",
     "subtype": "Basic",

--- a/json/cards/Supreme Victors.json
+++ b/json/cards/Supreme Victors.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "pl3-1",
+    "setOrder":41,
+	"id": "pl3-1",
     "name": "Absol G",
     "imageUrl": "https://images.pokemontcg.io/pl3/1.png",
     "subtype": "Basic",
@@ -58,7 +59,8 @@
     "nationalPokedexNumber": 359
   },
   {
-    "id": "pl3-2",
+    "setOrder":41,
+	"id": "pl3-2",
     "name": "Blaziken FB",
     "imageUrl": "https://images.pokemontcg.io/pl3/2.png",
     "subtype": "Basic",
@@ -109,7 +111,8 @@
     "nationalPokedexNumber": 257
   },
   {
-    "id": "pl3-3",
+    "setOrder":41,
+	"id": "pl3-3",
     "name": "Drifblim FB",
     "imageUrl": "https://images.pokemontcg.io/pl3/3.png",
     "subtype": "Basic",
@@ -164,7 +167,8 @@
     "nationalPokedexNumber": 426
   },
   {
-    "id": "pl3-4",
+    "setOrder":41,
+	"id": "pl3-4",
     "name": "Electivire FB",
     "imageUrl": "https://images.pokemontcg.io/pl3/4.png",
     "subtype": "Basic",
@@ -224,7 +228,8 @@
     "nationalPokedexNumber": 466
   },
   {
-    "id": "pl3-5",
+    "setOrder":41,
+	"id": "pl3-5",
     "name": "Garchomp",
     "imageUrl": "https://images.pokemontcg.io/pl3/5.png",
     "subtype": "Stage 2",
@@ -280,7 +285,8 @@
     "nationalPokedexNumber": 445
   },
   {
-    "id": "pl3-6",
+    "setOrder":41,
+	"id": "pl3-6",
     "name": "Magmortar",
     "imageUrl": "https://images.pokemontcg.io/pl3/6.png",
     "subtype": "Stage 1",
@@ -340,7 +346,8 @@
     "nationalPokedexNumber": 467
   },
   {
-    "id": "pl3-7",
+    "setOrder":41,
+	"id": "pl3-7",
     "name": "Metagross",
     "imageUrl": "https://images.pokemontcg.io/pl3/7.png",
     "subtype": "Stage 2",
@@ -397,7 +404,8 @@
     "nationalPokedexNumber": 376
   },
   {
-    "id": "pl3-8",
+    "setOrder":41,
+	"id": "pl3-8",
     "name": "Rayquaza C",
     "imageUrl": "https://images.pokemontcg.io/pl3/8.png",
     "subtype": "Basic",
@@ -458,7 +466,8 @@
     "nationalPokedexNumber": 384
   },
   {
-    "id": "pl3-9",
+    "setOrder":41,
+	"id": "pl3-9",
     "name": "Regigigas FB",
     "imageUrl": "https://images.pokemontcg.io/pl3/9.png",
     "subtype": "Basic",
@@ -516,7 +525,8 @@
     "nationalPokedexNumber": 486
   },
   {
-    "id": "pl3-10",
+    "setOrder":41,
+	"id": "pl3-10",
     "name": "Rhyperior",
     "imageUrl": "https://images.pokemontcg.io/pl3/10.png",
     "subtype": "Stage 2",
@@ -580,7 +590,8 @@
     "nationalPokedexNumber": 464
   },
   {
-    "id": "pl3-11",
+    "setOrder":41,
+	"id": "pl3-11",
     "name": "Staraptor FB",
     "imageUrl": "https://images.pokemontcg.io/pl3/11.png",
     "subtype": "Basic",
@@ -638,7 +649,8 @@
     "nationalPokedexNumber": 398
   },
   {
-    "id": "pl3-12",
+    "setOrder":41,
+	"id": "pl3-12",
     "name": "Swampert",
     "imageUrl": "https://images.pokemontcg.io/pl3/12.png",
     "subtype": "Stage 2",
@@ -700,7 +712,8 @@
     "nationalPokedexNumber": 260
   },
   {
-    "id": "pl3-13",
+    "setOrder":41,
+	"id": "pl3-13",
     "name": "Venusaur",
     "imageUrl": "https://images.pokemontcg.io/pl3/13.png",
     "subtype": "Stage 2",
@@ -762,7 +775,8 @@
     "nationalPokedexNumber": 3
   },
   {
-    "id": "pl3-14",
+    "setOrder":41,
+	"id": "pl3-14",
     "name": "Yanmega",
     "imageUrl": "https://images.pokemontcg.io/pl3/14.png",
     "subtype": "Stage 1",
@@ -825,7 +839,8 @@
     "nationalPokedexNumber": 469
   },
   {
-    "id": "pl3-15",
+    "setOrder":41,
+	"id": "pl3-15",
     "name": "Arcanine G",
     "imageUrl": "https://images.pokemontcg.io/pl3/15.png",
     "subtype": "Basic",
@@ -874,7 +889,8 @@
     "nationalPokedexNumber": 59
   },
   {
-    "id": "pl3-16",
+    "setOrder":41,
+	"id": "pl3-16",
     "name": "Articuno",
     "imageUrl": "https://images.pokemontcg.io/pl3/16.png",
     "subtype": "Basic",
@@ -936,7 +952,8 @@
     "nationalPokedexNumber": 144
   },
   {
-    "id": "pl3-17",
+    "setOrder":41,
+	"id": "pl3-17",
     "name": "Butterfree FB",
     "imageUrl": "https://images.pokemontcg.io/pl3/17.png",
     "subtype": "Basic",
@@ -990,7 +1007,8 @@
     "nationalPokedexNumber": 12
   },
   {
-    "id": "pl3-18",
+    "setOrder":41,
+	"id": "pl3-18",
     "name": "Camerupt",
     "imageUrl": "https://images.pokemontcg.io/pl3/18.png",
     "subtype": "Stage 1",
@@ -1048,7 +1066,8 @@
     "nationalPokedexNumber": 323
   },
   {
-    "id": "pl3-19",
+    "setOrder":41,
+	"id": "pl3-19",
     "name": "Camerupt G",
     "imageUrl": "https://images.pokemontcg.io/pl3/19.png",
     "subtype": "Basic",
@@ -1104,7 +1123,8 @@
     "nationalPokedexNumber": 323
   },
   {
-    "id": "pl3-20",
+    "setOrder":41,
+	"id": "pl3-20",
     "name": "Charizard G",
     "imageUrl": "https://images.pokemontcg.io/pl3/20.png",
     "subtype": "Basic",
@@ -1165,7 +1185,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "pl3-21",
+    "setOrder":41,
+	"id": "pl3-21",
     "name": "Chimecho",
     "imageUrl": "https://images.pokemontcg.io/pl3/21.png",
     "subtype": "Basic",
@@ -1215,7 +1236,8 @@
     "nationalPokedexNumber": 358
   },
   {
-    "id": "pl3-22",
+    "setOrder":41,
+	"id": "pl3-22",
     "name": "Claydol",
     "imageUrl": "https://images.pokemontcg.io/pl3/22.png",
     "subtype": "Stage 1",
@@ -1268,7 +1290,8 @@
     "nationalPokedexNumber": 344
   },
   {
-    "id": "pl3-23",
+    "setOrder":41,
+	"id": "pl3-23",
     "name": "Crawdaunt G",
     "imageUrl": "https://images.pokemontcg.io/pl3/23.png",
     "subtype": "Basic",
@@ -1320,7 +1343,8 @@
     "nationalPokedexNumber": 342
   },
   {
-    "id": "pl3-24",
+    "setOrder":41,
+	"id": "pl3-24",
     "name": "Dewgong",
     "imageUrl": "https://images.pokemontcg.io/pl3/24.png",
     "subtype": "Stage 1",
@@ -1382,7 +1406,8 @@
     "nationalPokedexNumber": 87
   },
   {
-    "id": "pl3-25",
+    "setOrder":41,
+	"id": "pl3-25",
     "name": "Dodrio",
     "imageUrl": "https://images.pokemontcg.io/pl3/25.png",
     "subtype": "Stage 1",
@@ -1434,7 +1459,8 @@
     "nationalPokedexNumber": 85
   },
   {
-    "id": "pl3-26",
+    "setOrder":41,
+	"id": "pl3-26",
     "name": "Dusknoir FB",
     "imageUrl": "https://images.pokemontcg.io/pl3/26.png",
     "subtype": "Basic",
@@ -1494,7 +1520,8 @@
     "nationalPokedexNumber": 477
   },
   {
-    "id": "pl3-27",
+    "setOrder":41,
+	"id": "pl3-27",
     "name": "Empoleon FB",
     "imageUrl": "https://images.pokemontcg.io/pl3/27.png",
     "subtype": "Basic",
@@ -1548,7 +1575,8 @@
     "nationalPokedexNumber": 395
   },
   {
-    "id": "pl3-28",
+    "setOrder":41,
+	"id": "pl3-28",
     "name": "Exploud",
     "imageUrl": "https://images.pokemontcg.io/pl3/28.png",
     "subtype": "Stage 2",
@@ -1608,7 +1636,8 @@
     "nationalPokedexNumber": 295
   },
   {
-    "id": "pl3-29",
+    "setOrder":41,
+	"id": "pl3-29",
     "name": "Honchkrow",
     "imageUrl": "https://images.pokemontcg.io/pl3/29.png",
     "subtype": "Stage 1",
@@ -1663,7 +1692,8 @@
     "nationalPokedexNumber": 430
   },
   {
-    "id": "pl3-30",
+    "setOrder":41,
+	"id": "pl3-30",
     "name": "Lickilicky C",
     "imageUrl": "https://images.pokemontcg.io/pl3/30.png",
     "subtype": "Basic",
@@ -1716,7 +1746,8 @@
     "nationalPokedexNumber": 463
   },
   {
-    "id": "pl3-31",
+    "setOrder":41,
+	"id": "pl3-31",
     "name": "Lucario C",
     "imageUrl": "https://images.pokemontcg.io/pl3/31.png",
     "subtype": "Basic",
@@ -1769,7 +1800,8 @@
     "nationalPokedexNumber": 448
   },
   {
-    "id": "pl3-32",
+    "setOrder":41,
+	"id": "pl3-32",
     "name": "Lunatone",
     "imageUrl": "https://images.pokemontcg.io/pl3/32.png",
     "subtype": "Basic",
@@ -1813,7 +1845,8 @@
     "nationalPokedexNumber": 337
   },
   {
-    "id": "pl3-33",
+    "setOrder":41,
+	"id": "pl3-33",
     "name": "Mawile",
     "imageUrl": "https://images.pokemontcg.io/pl3/33.png",
     "subtype": "Basic",
@@ -1880,7 +1913,8 @@
     "nationalPokedexNumber": 303
   },
   {
-    "id": "pl3-34",
+    "setOrder":41,
+	"id": "pl3-34",
     "name": "Medicham",
     "imageUrl": "https://images.pokemontcg.io/pl3/34.png",
     "subtype": "Stage 1",
@@ -1934,7 +1968,8 @@
     "nationalPokedexNumber": 308
   },
   {
-    "id": "pl3-35",
+    "setOrder":41,
+	"id": "pl3-35",
     "name": "Milotic C",
     "imageUrl": "https://images.pokemontcg.io/pl3/35.png",
     "subtype": "Basic",
@@ -1986,7 +2021,8 @@
     "nationalPokedexNumber": 350
   },
   {
-    "id": "pl3-36",
+    "setOrder":41,
+	"id": "pl3-36",
     "name": "Moltres",
     "imageUrl": "https://images.pokemontcg.io/pl3/36.png",
     "subtype": "Basic",
@@ -2047,7 +2083,8 @@
     "nationalPokedexNumber": 146
   },
   {
-    "id": "pl3-37",
+    "setOrder":41,
+	"id": "pl3-37",
     "name": "Mr. Mime",
     "imageUrl": "https://images.pokemontcg.io/pl3/37.png",
     "subtype": "Basic",
@@ -2088,7 +2125,8 @@
     "nationalPokedexNumber": 122
   },
   {
-    "id": "pl3-38",
+    "setOrder":41,
+	"id": "pl3-38",
     "name": "Parasect",
     "imageUrl": "https://images.pokemontcg.io/pl3/38.png",
     "subtype": "Stage 1",
@@ -2141,7 +2179,8 @@
     "nationalPokedexNumber": 47
   },
   {
-    "id": "pl3-39",
+    "setOrder":41,
+	"id": "pl3-39",
     "name": "Primeape",
     "imageUrl": "https://images.pokemontcg.io/pl3/39.png",
     "subtype": "Stage 1",
@@ -2194,7 +2233,8 @@
     "nationalPokedexNumber": 57
   },
   {
-    "id": "pl3-40",
+    "setOrder":41,
+	"id": "pl3-40",
     "name": "Roserade C",
     "imageUrl": "https://images.pokemontcg.io/pl3/40.png",
     "subtype": "Basic",
@@ -2243,7 +2283,8 @@
     "nationalPokedexNumber": 407
   },
   {
-    "id": "pl3-41",
+    "setOrder":41,
+	"id": "pl3-41",
     "name": "Sableye G",
     "imageUrl": "https://images.pokemontcg.io/pl3/41.png",
     "subtype": "Basic",
@@ -2294,7 +2335,8 @@
     "nationalPokedexNumber": 302
   },
   {
-    "id": "pl3-42",
+    "setOrder":41,
+	"id": "pl3-42",
     "name": "Sandslash",
     "imageUrl": "https://images.pokemontcg.io/pl3/42.png",
     "subtype": "Stage 1",
@@ -2349,7 +2391,8 @@
     "nationalPokedexNumber": 28
   },
   {
-    "id": "pl3-43",
+    "setOrder":41,
+	"id": "pl3-43",
     "name": "Seaking",
     "imageUrl": "https://images.pokemontcg.io/pl3/43.png",
     "subtype": "Stage 1",
@@ -2400,7 +2443,8 @@
     "nationalPokedexNumber": 119
   },
   {
-    "id": "pl3-44",
+    "setOrder":41,
+	"id": "pl3-44",
     "name": "Shedinja",
     "imageUrl": "https://images.pokemontcg.io/pl3/44.png",
     "subtype": "Stage 1",
@@ -2447,7 +2491,8 @@
     "nationalPokedexNumber": 292
   },
   {
-    "id": "pl3-45",
+    "setOrder":41,
+	"id": "pl3-45",
     "name": "Solrock",
     "imageUrl": "https://images.pokemontcg.io/pl3/45.png",
     "subtype": "Basic",
@@ -2494,7 +2539,8 @@
     "nationalPokedexNumber": 338
   },
   {
-    "id": "pl3-46",
+    "setOrder":41,
+	"id": "pl3-46",
     "name": "Spinda",
     "imageUrl": "https://images.pokemontcg.io/pl3/46.png",
     "subtype": "Basic",
@@ -2544,7 +2590,8 @@
     "nationalPokedexNumber": 327
   },
   {
-    "id": "pl3-47",
+    "setOrder":41,
+	"id": "pl3-47",
     "name": "Wailord",
     "imageUrl": "https://images.pokemontcg.io/pl3/47.png",
     "subtype": "Stage 1",
@@ -2603,7 +2650,8 @@
     "nationalPokedexNumber": 321
   },
   {
-    "id": "pl3-48",
+    "setOrder":41,
+	"id": "pl3-48",
     "name": "Zapdos",
     "imageUrl": "https://images.pokemontcg.io/pl3/48.png",
     "subtype": "Basic",
@@ -2665,7 +2713,8 @@
     "nationalPokedexNumber": 145
   },
   {
-    "id": "pl3-49",
+    "setOrder":41,
+	"id": "pl3-49",
     "name": "Altaria C",
     "imageUrl": "https://images.pokemontcg.io/pl3/49.png",
     "subtype": "Basic",
@@ -2723,7 +2772,8 @@
     "nationalPokedexNumber": 334
   },
   {
-    "id": "pl3-50",
+    "setOrder":41,
+	"id": "pl3-50",
     "name": "Arcanine",
     "imageUrl": "https://images.pokemontcg.io/pl3/50.png",
     "subtype": "Stage 1",
@@ -2780,7 +2830,8 @@
     "nationalPokedexNumber": 59
   },
   {
-    "id": "pl3-51",
+    "setOrder":41,
+	"id": "pl3-51",
     "name": "Bibarel",
     "imageUrl": "https://images.pokemontcg.io/pl3/51.png",
     "subtype": "Stage 1",
@@ -2836,7 +2887,8 @@
     "nationalPokedexNumber": 400
   },
   {
-    "id": "pl3-52",
+    "setOrder":41,
+	"id": "pl3-52",
     "name": "Breloom",
     "imageUrl": "https://images.pokemontcg.io/pl3/52.png",
     "subtype": "Stage 1",
@@ -2888,7 +2940,8 @@
     "nationalPokedexNumber": 286
   },
   {
-    "id": "pl3-53",
+    "setOrder":41,
+	"id": "pl3-53",
     "name": "Carnivine",
     "imageUrl": "https://images.pokemontcg.io/pl3/53.png",
     "subtype": "Basic",
@@ -2948,7 +3001,8 @@
     "nationalPokedexNumber": 455
   },
   {
-    "id": "pl3-54",
+    "setOrder":41,
+	"id": "pl3-54",
     "name": "Chatot G",
     "imageUrl": "https://images.pokemontcg.io/pl3/54.png",
     "subtype": "Basic",
@@ -3000,7 +3054,8 @@
     "nationalPokedexNumber": 441
   },
   {
-    "id": "pl3-55",
+    "setOrder":41,
+	"id": "pl3-55",
     "name": "Cherrim",
     "imageUrl": "https://images.pokemontcg.io/pl3/55.png",
     "subtype": "Stage 1",
@@ -3057,7 +3112,8 @@
     "nationalPokedexNumber": 421
   },
   {
-    "id": "pl3-56",
+    "setOrder":41,
+	"id": "pl3-56",
     "name": "Dragonite FB",
     "imageUrl": "https://images.pokemontcg.io/pl3/56.png",
     "subtype": "Basic",
@@ -3120,7 +3176,8 @@
     "nationalPokedexNumber": 149
   },
   {
-    "id": "pl3-57",
+    "setOrder":41,
+	"id": "pl3-57",
     "name": "Drifblim",
     "imageUrl": "https://images.pokemontcg.io/pl3/57.png",
     "subtype": "Stage 1",
@@ -3180,7 +3237,8 @@
     "nationalPokedexNumber": 426
   },
   {
-    "id": "pl3-58",
+    "setOrder":41,
+	"id": "pl3-58",
     "name": "Floatzel",
     "imageUrl": "https://images.pokemontcg.io/pl3/58.png",
     "subtype": "Stage 1",
@@ -3234,7 +3292,8 @@
     "nationalPokedexNumber": 419
   },
   {
-    "id": "pl3-59",
+    "setOrder":41,
+	"id": "pl3-59",
     "name": "Gabite",
     "imageUrl": "https://images.pokemontcg.io/pl3/59.png",
     "subtype": "Stage 1",
@@ -3289,7 +3348,8 @@
     ]
   },
   {
-    "id": "pl3-60",
+    "setOrder":41,
+	"id": "pl3-60",
     "name": "Garchomp C",
     "imageUrl": "https://images.pokemontcg.io/pl3/60.png",
     "subtype": "Basic",
@@ -3342,7 +3402,8 @@
     "nationalPokedexNumber": 445
   },
   {
-    "id": "pl3-61",
+    "setOrder":41,
+	"id": "pl3-61",
     "name": "Hippopotas",
     "imageUrl": "https://images.pokemontcg.io/pl3/61.png",
     "subtype": "Basic",
@@ -3399,7 +3460,8 @@
     ]
   },
   {
-    "id": "pl3-62",
+    "setOrder":41,
+	"id": "pl3-62",
     "name": "Ivysaur",
     "imageUrl": "https://images.pokemontcg.io/pl3/62.png",
     "subtype": "Stage 1",
@@ -3452,7 +3514,8 @@
     ]
   },
   {
-    "id": "pl3-63",
+    "setOrder":41,
+	"id": "pl3-63",
     "name": "Lopunny",
     "imageUrl": "https://images.pokemontcg.io/pl3/63.png",
     "subtype": "Stage 1",
@@ -3505,7 +3568,8 @@
     "nationalPokedexNumber": 428
   },
   {
-    "id": "pl3-64",
+    "setOrder":41,
+	"id": "pl3-64",
     "name": "Loudred",
     "imageUrl": "https://images.pokemontcg.io/pl3/64.png",
     "subtype": "Stage 1",
@@ -3563,7 +3627,8 @@
     ]
   },
   {
-    "id": "pl3-65",
+    "setOrder":41,
+	"id": "pl3-65",
     "name": "Magmar",
     "imageUrl": "https://images.pokemontcg.io/pl3/65.png",
     "subtype": "Basic",
@@ -3617,7 +3682,8 @@
     ]
   },
   {
-    "id": "pl3-66",
+    "setOrder":41,
+	"id": "pl3-66",
     "name": "Manectric G",
     "imageUrl": "https://images.pokemontcg.io/pl3/66.png",
     "subtype": "Basic",
@@ -3674,7 +3740,8 @@
     "nationalPokedexNumber": 310
   },
   {
-    "id": "pl3-67",
+    "setOrder":41,
+	"id": "pl3-67",
     "name": "Marshtomp",
     "imageUrl": "https://images.pokemontcg.io/pl3/67.png",
     "subtype": "Stage 1",
@@ -3726,7 +3793,8 @@
     ]
   },
   {
-    "id": "pl3-68",
+    "setOrder":41,
+	"id": "pl3-68",
     "name": "Masquerain",
     "imageUrl": "https://images.pokemontcg.io/pl3/68.png",
     "subtype": "Stage 1",
@@ -3776,7 +3844,8 @@
     "nationalPokedexNumber": 284
   },
   {
-    "id": "pl3-69",
+    "setOrder":41,
+	"id": "pl3-69",
     "name": "Metang",
     "imageUrl": "https://images.pokemontcg.io/pl3/69.png",
     "subtype": "Stage 1",
@@ -3835,7 +3904,8 @@
     ]
   },
   {
-    "id": "pl3-70",
+    "setOrder":41,
+	"id": "pl3-70",
     "name": "Milotic",
     "imageUrl": "https://images.pokemontcg.io/pl3/70.png",
     "subtype": "Stage 1",
@@ -3889,7 +3959,8 @@
     "nationalPokedexNumber": 350
   },
   {
-    "id": "pl3-71",
+    "setOrder":41,
+	"id": "pl3-71",
     "name": "Minun",
     "imageUrl": "https://images.pokemontcg.io/pl3/71.png",
     "subtype": "Basic",
@@ -3945,7 +4016,8 @@
     "nationalPokedexNumber": 312
   },
   {
-    "id": "pl3-72",
+    "setOrder":41,
+	"id": "pl3-72",
     "name": "Murkrow",
     "imageUrl": "https://images.pokemontcg.io/pl3/72.png",
     "subtype": "Basic",
@@ -4005,7 +4077,8 @@
     ]
   },
   {
-    "id": "pl3-73",
+    "setOrder":41,
+	"id": "pl3-73",
     "name": "Ninjask",
     "imageUrl": "https://images.pokemontcg.io/pl3/73.png",
     "subtype": "Stage 1",
@@ -4062,7 +4135,8 @@
     ]
   },
   {
-    "id": "pl3-74",
+    "setOrder":41,
+	"id": "pl3-74",
     "name": "Numel",
     "imageUrl": "https://images.pokemontcg.io/pl3/74.png",
     "subtype": "Basic",
@@ -4118,7 +4192,8 @@
     ]
   },
   {
-    "id": "pl3-75",
+    "setOrder":41,
+	"id": "pl3-75",
     "name": "Pinsir",
     "imageUrl": "https://images.pokemontcg.io/pl3/75.png",
     "subtype": "Basic",
@@ -4172,7 +4247,8 @@
     "nationalPokedexNumber": 127
   },
   {
-    "id": "pl3-76",
+    "setOrder":41,
+	"id": "pl3-76",
     "name": "Plusle",
     "imageUrl": "https://images.pokemontcg.io/pl3/76.png",
     "subtype": "Basic",
@@ -4228,7 +4304,8 @@
     "nationalPokedexNumber": 311
   },
   {
-    "id": "pl3-77",
+    "setOrder":41,
+	"id": "pl3-77",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/pl3/77.png",
     "subtype": "Stage 1",
@@ -4284,7 +4361,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "pl3-78",
+    "setOrder":41,
+	"id": "pl3-78",
     "name": "Raticate G",
     "imageUrl": "https://images.pokemontcg.io/pl3/78.png",
     "subtype": "Basic",
@@ -4331,7 +4409,8 @@
     "nationalPokedexNumber": 20
   },
   {
-    "id": "pl3-79",
+    "setOrder":41,
+	"id": "pl3-79",
     "name": "Relicanth",
     "imageUrl": "https://images.pokemontcg.io/pl3/79.png",
     "subtype": "Basic",
@@ -4382,7 +4461,8 @@
     "nationalPokedexNumber": 369
   },
   {
-    "id": "pl3-80",
+    "setOrder":41,
+	"id": "pl3-80",
     "name": "Rhydon",
     "imageUrl": "https://images.pokemontcg.io/pl3/80.png",
     "subtype": "Stage 1",
@@ -4446,7 +4526,8 @@
     ]
   },
   {
-    "id": "pl3-81",
+    "setOrder":41,
+	"id": "pl3-81",
     "name": "Roserade",
     "imageUrl": "https://images.pokemontcg.io/pl3/81.png",
     "subtype": "Stage 1",
@@ -4500,7 +4581,8 @@
     "nationalPokedexNumber": 407
   },
   {
-    "id": "pl3-82",
+    "setOrder":41,
+	"id": "pl3-82",
     "name": "Rotom",
     "imageUrl": "https://images.pokemontcg.io/pl3/82.png",
     "subtype": "Basic",
@@ -4557,7 +4639,8 @@
     "nationalPokedexNumber": 479
   },
   {
-    "id": "pl3-83",
+    "setOrder":41,
+	"id": "pl3-83",
     "name": "Skarmory FB",
     "imageUrl": "https://images.pokemontcg.io/pl3/83.png",
     "subtype": "Basic",
@@ -4614,7 +4697,8 @@
     "nationalPokedexNumber": 227
   },
   {
-    "id": "pl3-84",
+    "setOrder":41,
+	"id": "pl3-84",
     "name": "Spiritomb C",
     "imageUrl": "https://images.pokemontcg.io/pl3/84.png",
     "subtype": "Basic",
@@ -4665,7 +4749,8 @@
     "nationalPokedexNumber": 442
   },
   {
-    "id": "pl3-85",
+    "setOrder":41,
+	"id": "pl3-85",
     "name": "Staravia",
     "imageUrl": "https://images.pokemontcg.io/pl3/85.png",
     "subtype": "Stage 1",
@@ -4728,7 +4813,8 @@
     ]
   },
   {
-    "id": "pl3-86",
+    "setOrder":41,
+	"id": "pl3-86",
     "name": "Togekiss C",
     "imageUrl": "https://images.pokemontcg.io/pl3/86.png",
     "subtype": "Basic",
@@ -4782,7 +4868,8 @@
     "nationalPokedexNumber": 468
   },
   {
-    "id": "pl3-87",
+    "setOrder":41,
+	"id": "pl3-87",
     "name": "Wailmer",
     "imageUrl": "https://images.pokemontcg.io/pl3/87.png",
     "subtype": "Basic",
@@ -4840,7 +4927,8 @@
     ]
   },
   {
-    "id": "pl3-88",
+    "setOrder":41,
+	"id": "pl3-88",
     "name": "Yanma",
     "imageUrl": "https://images.pokemontcg.io/pl3/88.png",
     "subtype": "Basic",
@@ -4899,7 +4987,8 @@
     ]
   },
   {
-    "id": "pl3-89",
+    "setOrder":41,
+	"id": "pl3-89",
     "name": "Baltoy",
     "imageUrl": "https://images.pokemontcg.io/pl3/89.png",
     "subtype": "Basic",
@@ -4953,7 +5042,8 @@
     ]
   },
   {
-    "id": "pl3-90",
+    "setOrder":41,
+	"id": "pl3-90",
     "name": "Beldum",
     "imageUrl": "https://images.pokemontcg.io/pl3/90.png",
     "subtype": "Basic",
@@ -5013,7 +5103,8 @@
     ]
   },
   {
-    "id": "pl3-91",
+    "setOrder":41,
+	"id": "pl3-91",
     "name": "Bidoof",
     "imageUrl": "https://images.pokemontcg.io/pl3/91.png",
     "subtype": "Basic",
@@ -5058,7 +5149,8 @@
     ]
   },
   {
-    "id": "pl3-92",
+    "setOrder":41,
+	"id": "pl3-92",
     "name": "Buizel",
     "imageUrl": "https://images.pokemontcg.io/pl3/92.png",
     "subtype": "Basic",
@@ -5112,7 +5204,8 @@
     ]
   },
   {
-    "id": "pl3-93",
+    "setOrder":41,
+	"id": "pl3-93",
     "name": "Bulbasaur",
     "imageUrl": "https://images.pokemontcg.io/pl3/93.png",
     "subtype": "Basic",
@@ -5166,7 +5259,8 @@
     ]
   },
   {
-    "id": "pl3-94",
+    "setOrder":41,
+	"id": "pl3-94",
     "name": "Buneary",
     "imageUrl": "https://images.pokemontcg.io/pl3/94.png",
     "subtype": "Basic",
@@ -5220,7 +5314,8 @@
     ]
   },
   {
-    "id": "pl3-95",
+    "setOrder":41,
+	"id": "pl3-95",
     "name": "Chatot",
     "imageUrl": "https://images.pokemontcg.io/pl3/95.png",
     "subtype": "Basic",
@@ -5277,7 +5372,8 @@
     "nationalPokedexNumber": 441
   },
   {
-    "id": "pl3-96",
+    "setOrder":41,
+	"id": "pl3-96",
     "name": "Cherubi",
     "imageUrl": "https://images.pokemontcg.io/pl3/96.png",
     "subtype": "Basic",
@@ -5336,7 +5432,8 @@
     ]
   },
   {
-    "id": "pl3-97",
+    "setOrder":41,
+	"id": "pl3-97",
     "name": "Chimchar",
     "imageUrl": "https://images.pokemontcg.io/pl3/97.png",
     "subtype": "Basic",
@@ -5390,7 +5487,8 @@
     ]
   },
   {
-    "id": "pl3-98",
+    "setOrder":41,
+	"id": "pl3-98",
     "name": "Chingling",
     "imageUrl": "https://images.pokemontcg.io/pl3/98.png",
     "subtype": "Basic",
@@ -5439,7 +5537,8 @@
     ]
   },
   {
-    "id": "pl3-99",
+    "setOrder":41,
+	"id": "pl3-99",
     "name": "Combee",
     "imageUrl": "https://images.pokemontcg.io/pl3/99.png",
     "subtype": "Basic",
@@ -5499,7 +5598,8 @@
     ]
   },
   {
-    "id": "pl3-100",
+    "setOrder":41,
+	"id": "pl3-100",
     "name": "Corphish",
     "imageUrl": "https://images.pokemontcg.io/pl3/100.png",
     "subtype": "Basic",
@@ -5552,7 +5652,8 @@
     ]
   },
   {
-    "id": "pl3-101",
+    "setOrder":41,
+	"id": "pl3-101",
     "name": "Croagunk",
     "imageUrl": "https://images.pokemontcg.io/pl3/101.png",
     "subtype": "Basic",
@@ -5606,7 +5707,8 @@
     ]
   },
   {
-    "id": "pl3-102",
+    "setOrder":41,
+	"id": "pl3-102",
     "name": "Doduo",
     "imageUrl": "https://images.pokemontcg.io/pl3/102.png",
     "subtype": "Basic",
@@ -5653,7 +5755,8 @@
     ]
   },
   {
-    "id": "pl3-103",
+    "setOrder":41,
+	"id": "pl3-103",
     "name": "Drifloon",
     "imageUrl": "https://images.pokemontcg.io/pl3/103.png",
     "subtype": "Basic",
@@ -5712,7 +5815,8 @@
     ]
   },
   {
-    "id": "pl3-104",
+    "setOrder":41,
+	"id": "pl3-104",
     "name": "Feebas",
     "imageUrl": "https://images.pokemontcg.io/pl3/104.png",
     "subtype": "Basic",
@@ -5765,7 +5869,8 @@
     ]
   },
   {
-    "id": "pl3-105",
+    "setOrder":41,
+	"id": "pl3-105",
     "name": "Geodude",
     "imageUrl": "https://images.pokemontcg.io/pl3/105.png",
     "subtype": "Basic",
@@ -5820,7 +5925,8 @@
     ]
   },
   {
-    "id": "pl3-106",
+    "setOrder":41,
+	"id": "pl3-106",
     "name": "Gible",
     "imageUrl": "https://images.pokemontcg.io/pl3/106.png",
     "subtype": "Basic",
@@ -5873,7 +5979,8 @@
     ]
   },
   {
-    "id": "pl3-107",
+    "setOrder":41,
+	"id": "pl3-107",
     "name": "Goldeen",
     "imageUrl": "https://images.pokemontcg.io/pl3/107.png",
     "subtype": "Basic",
@@ -5926,7 +6033,8 @@
     ]
   },
   {
-    "id": "pl3-108",
+    "setOrder":41,
+	"id": "pl3-108",
     "name": "Growlithe",
     "imageUrl": "https://images.pokemontcg.io/pl3/108.png",
     "subtype": "Basic",
@@ -5981,7 +6089,8 @@
     ]
   },
   {
-    "id": "pl3-109",
+    "setOrder":41,
+	"id": "pl3-109",
     "name": "Kricketot",
     "imageUrl": "https://images.pokemontcg.io/pl3/109.png",
     "subtype": "Basic",
@@ -6035,7 +6144,8 @@
     ]
   },
   {
-    "id": "pl3-110",
+    "setOrder":41,
+	"id": "pl3-110",
     "name": "Magikarp",
     "imageUrl": "https://images.pokemontcg.io/pl3/110.png",
     "subtype": "Basic",
@@ -6079,7 +6189,8 @@
     ]
   },
   {
-    "id": "pl3-111",
+    "setOrder":41,
+	"id": "pl3-111",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/pl3/111.png",
     "subtype": "Basic",
@@ -6139,7 +6250,8 @@
     ]
   },
   {
-    "id": "pl3-112",
+    "setOrder":41,
+	"id": "pl3-112",
     "name": "Mankey",
     "imageUrl": "https://images.pokemontcg.io/pl3/112.png",
     "subtype": "Basic",
@@ -6183,7 +6295,8 @@
     ]
   },
   {
-    "id": "pl3-113",
+    "setOrder":41,
+	"id": "pl3-113",
     "name": "Meditite",
     "imageUrl": "https://images.pokemontcg.io/pl3/113.png",
     "subtype": "Basic",
@@ -6237,7 +6350,8 @@
     ]
   },
   {
-    "id": "pl3-114",
+    "setOrder":41,
+	"id": "pl3-114",
     "name": "Meowth",
     "imageUrl": "https://images.pokemontcg.io/pl3/114.png",
     "subtype": "Basic",
@@ -6292,7 +6406,8 @@
     ]
   },
   {
-    "id": "pl3-115",
+    "setOrder":41,
+	"id": "pl3-115",
     "name": "Mime Jr.",
     "imageUrl": "https://images.pokemontcg.io/pl3/115.png",
     "subtype": "Basic",
@@ -6338,7 +6453,8 @@
     "nationalPokedexNumber": 439
   },
   {
-    "id": "pl3-116",
+    "setOrder":41,
+	"id": "pl3-116",
     "name": "Mudkip",
     "imageUrl": "https://images.pokemontcg.io/pl3/116.png",
     "subtype": "Basic",
@@ -6392,7 +6508,8 @@
     ]
   },
   {
-    "id": "pl3-117",
+    "setOrder":41,
+	"id": "pl3-117",
     "name": "Nincada",
     "imageUrl": "https://images.pokemontcg.io/pl3/117.png",
     "subtype": "Basic",
@@ -6445,7 +6562,8 @@
     ]
   },
   {
-    "id": "pl3-118",
+    "setOrder":41,
+	"id": "pl3-118",
     "name": "Pachirisu",
     "imageUrl": "https://images.pokemontcg.io/pl3/118.png",
     "subtype": "Basic",
@@ -6501,7 +6619,8 @@
     "nationalPokedexNumber": 417
   },
   {
-    "id": "pl3-119",
+    "setOrder":41,
+	"id": "pl3-119",
     "name": "Paras",
     "imageUrl": "https://images.pokemontcg.io/pl3/119.png",
     "subtype": "Basic",
@@ -6554,7 +6673,8 @@
     ]
   },
   {
-    "id": "pl3-120",
+    "setOrder":41,
+	"id": "pl3-120",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/pl3/120.png",
     "subtype": "Basic",
@@ -6614,7 +6734,8 @@
     ]
   },
   {
-    "id": "pl3-121",
+    "setOrder":41,
+	"id": "pl3-121",
     "name": "Piplup",
     "imageUrl": "https://images.pokemontcg.io/pl3/121.png",
     "subtype": "Basic",
@@ -6668,7 +6789,8 @@
     ]
   },
   {
-    "id": "pl3-122",
+    "setOrder":41,
+	"id": "pl3-122",
     "name": "Rhyhorn",
     "imageUrl": "https://images.pokemontcg.io/pl3/122.png",
     "subtype": "Basic",
@@ -6731,7 +6853,8 @@
     ]
   },
   {
-    "id": "pl3-123",
+    "setOrder":41,
+	"id": "pl3-123",
     "name": "Roselia",
     "imageUrl": "https://images.pokemontcg.io/pl3/123.png",
     "subtype": "Basic",
@@ -6785,7 +6908,8 @@
     ]
   },
   {
-    "id": "pl3-124",
+    "setOrder":41,
+	"id": "pl3-124",
     "name": "Sandshrew",
     "imageUrl": "https://images.pokemontcg.io/pl3/124.png",
     "subtype": "Basic",
@@ -6835,7 +6959,8 @@
     ]
   },
   {
-    "id": "pl3-125",
+    "setOrder":41,
+	"id": "pl3-125",
     "name": "Seel",
     "imageUrl": "https://images.pokemontcg.io/pl3/125.png",
     "subtype": "Basic",
@@ -6890,7 +7015,8 @@
     ]
   },
   {
-    "id": "pl3-126",
+    "setOrder":41,
+	"id": "pl3-126",
     "name": "Shinx",
     "imageUrl": "https://images.pokemontcg.io/pl3/126.png",
     "subtype": "Basic",
@@ -6941,7 +7067,8 @@
     ]
   },
   {
-    "id": "pl3-127",
+    "setOrder":41,
+	"id": "pl3-127",
     "name": "Shroomish",
     "imageUrl": "https://images.pokemontcg.io/pl3/127.png",
     "subtype": "Basic",
@@ -7001,7 +7128,8 @@
     ]
   },
   {
-    "id": "pl3-128",
+    "setOrder":41,
+	"id": "pl3-128",
     "name": "Skorupi",
     "imageUrl": "https://images.pokemontcg.io/pl3/128.png",
     "subtype": "Basic",
@@ -7058,7 +7186,8 @@
     ]
   },
   {
-    "id": "pl3-129",
+    "setOrder":41,
+	"id": "pl3-129",
     "name": "Starly",
     "imageUrl": "https://images.pokemontcg.io/pl3/129.png",
     "subtype": "Basic",
@@ -7109,7 +7238,8 @@
     ]
   },
   {
-    "id": "pl3-130",
+    "setOrder":41,
+	"id": "pl3-130",
     "name": "Surskit",
     "imageUrl": "https://images.pokemontcg.io/pl3/130.png",
     "subtype": "Basic",
@@ -7153,7 +7283,8 @@
     ]
   },
   {
-    "id": "pl3-131",
+    "setOrder":41,
+	"id": "pl3-131",
     "name": "Turtwig",
     "imageUrl": "https://images.pokemontcg.io/pl3/131.png",
     "subtype": "Basic",
@@ -7215,7 +7346,8 @@
     ]
   },
   {
-    "id": "pl3-132",
+    "setOrder":41,
+	"id": "pl3-132",
     "name": "Whismur",
     "imageUrl": "https://images.pokemontcg.io/pl3/132.png",
     "subtype": "Basic",
@@ -7269,7 +7401,8 @@
     ]
   },
   {
-    "id": "pl3-133",
+    "setOrder":41,
+	"id": "pl3-133",
     "name": "Zubat",
     "imageUrl": "https://images.pokemontcg.io/pl3/133.png",
     "subtype": "Basic",
@@ -7319,7 +7452,8 @@
     ]
   },
   {
-    "id": "pl3-134",
+    "setOrder":41,
+	"id": "pl3-134",
     "name": "Battle Tower",
     "imageUrl": "https://images.pokemontcg.io/pl3/134.png",
     "subtype": "Stadium",
@@ -7337,7 +7471,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl3/134_hires.png"
   },
   {
-    "id": "pl3-135",
+    "setOrder":41,
+	"id": "pl3-135",
     "name": "Champion's Room",
     "imageUrl": "https://images.pokemontcg.io/pl3/135.png",
     "subtype": "Stadium",
@@ -7355,7 +7490,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl3/135_hires.png"
   },
   {
-    "id": "pl3-136",
+    "setOrder":41,
+	"id": "pl3-136",
     "name": "Cynthia's Guidance",
     "imageUrl": "https://images.pokemontcg.io/pl3/136.png",
     "subtype": "Supporter",
@@ -7374,7 +7510,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl3/136_hires.png"
   },
   {
-    "id": "pl3-137",
+    "setOrder":41,
+	"id": "pl3-137",
     "name": "Cyrus's Initiative",
     "imageUrl": "https://images.pokemontcg.io/pl3/137.png",
     "subtype": "Supporter",
@@ -7393,7 +7530,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl3/137_hires.png"
   },
   {
-    "id": "pl3-138",
+    "setOrder":41,
+	"id": "pl3-138",
     "name": "Night Teleporter",
     "imageUrl": "https://images.pokemontcg.io/pl3/138.png",
     "subtype": "Item",
@@ -7411,7 +7549,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl3/138_hires.png"
   },
   {
-    "id": "pl3-139",
+    "setOrder":41,
+	"id": "pl3-139",
     "name": "Palmer's Contribution",
     "imageUrl": "https://images.pokemontcg.io/pl3/139.png",
     "subtype": "Supporter",
@@ -7430,7 +7569,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl3/139_hires.png"
   },
   {
-    "id": "pl3-140",
+    "setOrder":41,
+	"id": "pl3-140",
     "name": "VS Seeker",
     "imageUrl": "https://images.pokemontcg.io/pl3/140.png",
     "subtype": "Item",
@@ -7448,7 +7588,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/pl3/140_hires.png"
   },
   {
-    "id": "pl3-141",
+    "setOrder":41,
+	"id": "pl3-141",
     "name": "Absol G",
     "imageUrl": "https://images.pokemontcg.io/pl3/141.png",
     "subtype": "Level Up",
@@ -7504,7 +7645,8 @@
     "nationalPokedexNumber": 359
   },
   {
-    "id": "pl3-142",
+    "setOrder":41,
+	"id": "pl3-142",
     "name": "Blaziken FB",
     "imageUrl": "https://images.pokemontcg.io/pl3/142.png",
     "subtype": "Level Up",
@@ -7554,7 +7696,8 @@
     "nationalPokedexNumber": 257
   },
   {
-    "id": "pl3-143",
+    "setOrder":41,
+	"id": "pl3-143",
     "name": "Charizard G",
     "imageUrl": "https://images.pokemontcg.io/pl3/143.png",
     "subtype": "Level Up",
@@ -7615,7 +7758,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "pl3-144",
+    "setOrder":41,
+	"id": "pl3-144",
     "name": "Electivire FB",
     "imageUrl": "https://images.pokemontcg.io/pl3/144.png",
     "subtype": "Level Up",
@@ -7674,7 +7818,8 @@
     "nationalPokedexNumber": 466
   },
   {
-    "id": "pl3-145",
+    "setOrder":41,
+	"id": "pl3-145",
     "name": "Garchomp C",
     "imageUrl": "https://images.pokemontcg.io/pl3/145.png",
     "subtype": "Level Up",
@@ -7722,7 +7867,8 @@
     "nationalPokedexNumber": 445
   },
   {
-    "id": "pl3-146",
+    "setOrder":41,
+	"id": "pl3-146",
     "name": "Rayquaza C",
     "imageUrl": "https://images.pokemontcg.io/pl3/146.png",
     "subtype": "Level Up",
@@ -7782,7 +7928,8 @@
     "nationalPokedexNumber": 384
   },
   {
-    "id": "pl3-147",
+    "setOrder":41,
+	"id": "pl3-147",
     "name": "Staraptor FB",
     "imageUrl": "https://images.pokemontcg.io/pl3/147.png",
     "subtype": "Level Up",
@@ -7836,7 +7983,8 @@
     "nationalPokedexNumber": 398
   },
   {
-    "id": "pl3-148",
+    "setOrder":41,
+	"id": "pl3-148",
     "name": "Articuno",
     "imageUrl": "https://images.pokemontcg.io/pl3/148.png",
     "subtype": "Basic",
@@ -7879,7 +8027,8 @@
     "nationalPokedexNumber": 144
   },
   {
-    "id": "pl3-149",
+    "setOrder":41,
+	"id": "pl3-149",
     "name": "Moltres",
     "imageUrl": "https://images.pokemontcg.io/pl3/149.png",
     "subtype": "Basic",
@@ -7922,7 +8071,8 @@
     "nationalPokedexNumber": 146
   },
   {
-    "id": "pl3-150",
+    "setOrder":41,
+	"id": "pl3-150",
     "name": "Zapdos",
     "imageUrl": "https://images.pokemontcg.io/pl3/150.png",
     "subtype": "Basic",
@@ -7965,7 +8115,8 @@
     "nationalPokedexNumber": 145
   },
   {
-    "id": "pl3-SH7",
+    "setOrder":41,
+	"id": "pl3-SH7",
     "name": "Milotic",
     "imageUrl": "https://images.pokemontcg.io/pl3/SH7.png",
     "subtype": "Stage 1",
@@ -8014,7 +8165,8 @@
     "nationalPokedexNumber": 350
   },
   {
-    "id": "pl3-SH8",
+    "setOrder":41,
+	"id": "pl3-SH8",
     "name": "Relicanth",
     "imageUrl": "https://images.pokemontcg.io/pl3/SH8.png",
     "subtype": "Basic",
@@ -8067,7 +8219,8 @@
     "nationalPokedexNumber": 369
   },
   {
-    "id": "pl3-SH9",
+    "setOrder":41,
+	"id": "pl3-SH9",
     "name": "Yanma",
     "imageUrl": "https://images.pokemontcg.io/pl3/SH9.png",
     "subtype": "Basic",

--- a/json/cards/Team Magma vs Team Aqua.json
+++ b/json/cards/Team Magma vs Team Aqua.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "ex4-1",
+    "setOrder":19,
+	"id": "ex4-1",
     "name": "Team Aqua's Cacturne",
     "imageUrl": "https://images.pokemontcg.io/ex4/1.png",
     "subtype": "Stage 1",
@@ -53,7 +54,8 @@
     "nationalPokedexNumber": 332
   },
   {
-    "id": "ex4-2",
+    "setOrder":19,
+	"id": "ex4-2",
     "name": "Team Aqua's Crawdaunt",
     "imageUrl": "https://images.pokemontcg.io/ex4/2.png",
     "subtype": "Stage 1",
@@ -106,7 +108,8 @@
     "nationalPokedexNumber": 342
   },
   {
-    "id": "ex4-3",
+    "setOrder":19,
+	"id": "ex4-3",
     "name": "Team Aqua's Kyogre",
     "imageUrl": "https://images.pokemontcg.io/ex4/3.png",
     "subtype": "Basic",
@@ -166,7 +169,8 @@
     "nationalPokedexNumber": 382
   },
   {
-    "id": "ex4-4",
+    "setOrder":19,
+	"id": "ex4-4",
     "name": "Team Aqua's Manectric",
     "imageUrl": "https://images.pokemontcg.io/ex4/4.png",
     "subtype": "Stage 1",
@@ -220,7 +224,8 @@
     "nationalPokedexNumber": 310
   },
   {
-    "id": "ex4-5",
+    "setOrder":19,
+	"id": "ex4-5",
     "name": "Team Aqua's Sharpedo",
     "imageUrl": "https://images.pokemontcg.io/ex4/5.png",
     "subtype": "Stage 1",
@@ -270,7 +275,8 @@
     "nationalPokedexNumber": 319
   },
   {
-    "id": "ex4-6",
+    "setOrder":19,
+	"id": "ex4-6",
     "name": "Team Aqua's Walrein",
     "imageUrl": "https://images.pokemontcg.io/ex4/6.png",
     "subtype": "Stage 2",
@@ -328,7 +334,8 @@
     "nationalPokedexNumber": 365
   },
   {
-    "id": "ex4-7",
+    "setOrder":19,
+	"id": "ex4-7",
     "name": "Team Magma's Aggron",
     "imageUrl": "https://images.pokemontcg.io/ex4/7.png",
     "subtype": "Stage 2",
@@ -386,7 +393,8 @@
     "nationalPokedexNumber": 306
   },
   {
-    "id": "ex4-8",
+    "setOrder":19,
+	"id": "ex4-8",
     "name": "Team Magma's Claydol",
     "imageUrl": "https://images.pokemontcg.io/ex4/8.png",
     "subtype": "Stage 1",
@@ -435,7 +443,8 @@
     "nationalPokedexNumber": 344
   },
   {
-    "id": "ex4-9",
+    "setOrder":19,
+	"id": "ex4-9",
     "name": "Team Magma's Groudon",
     "imageUrl": "https://images.pokemontcg.io/ex4/9.png",
     "subtype": "Basic",
@@ -495,7 +504,8 @@
     "nationalPokedexNumber": 383
   },
   {
-    "id": "ex4-10",
+    "setOrder":19,
+	"id": "ex4-10",
     "name": "Team Magma's Houndoom",
     "imageUrl": "https://images.pokemontcg.io/ex4/10.png",
     "subtype": "Stage 1",
@@ -548,7 +558,8 @@
     "nationalPokedexNumber": 229
   },
   {
-    "id": "ex4-11",
+    "setOrder":19,
+	"id": "ex4-11",
     "name": "Team Magma's Rhydon",
     "imageUrl": "https://images.pokemontcg.io/ex4/11.png",
     "subtype": "Stage 1",
@@ -605,7 +616,8 @@
     ]
   },
   {
-    "id": "ex4-12",
+    "setOrder":19,
+	"id": "ex4-12",
     "name": "Team Magma's Torkoal",
     "imageUrl": "https://images.pokemontcg.io/ex4/12.png",
     "subtype": "Basic",
@@ -657,7 +669,8 @@
     "nationalPokedexNumber": 324
   },
   {
-    "id": "ex4-13",
+    "setOrder":19,
+	"id": "ex4-13",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/ex4/13.png",
     "subtype": "Stage 1",
@@ -709,7 +722,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "ex4-14",
+    "setOrder":19,
+	"id": "ex4-14",
     "name": "Team Aqua's Crawdaunt",
     "imageUrl": "https://images.pokemontcg.io/ex4/14.png",
     "subtype": "Stage 1",
@@ -761,7 +775,8 @@
     "nationalPokedexNumber": 342
   },
   {
-    "id": "ex4-15",
+    "setOrder":19,
+	"id": "ex4-15",
     "name": "Team Aqua's Mightyena",
     "imageUrl": "https://images.pokemontcg.io/ex4/15.png",
     "subtype": "Stage 1",
@@ -819,7 +834,8 @@
     "nationalPokedexNumber": 262
   },
   {
-    "id": "ex4-16",
+    "setOrder":19,
+	"id": "ex4-16",
     "name": "Team Aqua's Sealeo",
     "imageUrl": "https://images.pokemontcg.io/ex4/16.png",
     "subtype": "Stage 1",
@@ -872,7 +888,8 @@
     ]
   },
   {
-    "id": "ex4-17",
+    "setOrder":19,
+	"id": "ex4-17",
     "name": "Team Aqua's Seviper",
     "imageUrl": "https://images.pokemontcg.io/ex4/17.png",
     "subtype": "Basic",
@@ -924,7 +941,8 @@
     "nationalPokedexNumber": 336
   },
   {
-    "id": "ex4-18",
+    "setOrder":19,
+	"id": "ex4-18",
     "name": "Team Aqua's Sharpedo",
     "imageUrl": "https://images.pokemontcg.io/ex4/18.png",
     "subtype": "Stage 1",
@@ -973,7 +991,8 @@
     "nationalPokedexNumber": 319
   },
   {
-    "id": "ex4-19",
+    "setOrder":19,
+	"id": "ex4-19",
     "name": "Team Magma's Camerupt",
     "imageUrl": "https://images.pokemontcg.io/ex4/19.png",
     "subtype": "Stage 1",
@@ -1021,7 +1040,8 @@
     "nationalPokedexNumber": 323
   },
   {
-    "id": "ex4-20",
+    "setOrder":19,
+	"id": "ex4-20",
     "name": "Team Magma's Lairon",
     "imageUrl": "https://images.pokemontcg.io/ex4/20.png",
     "subtype": "Stage 1",
@@ -1076,7 +1096,8 @@
     ]
   },
   {
-    "id": "ex4-21",
+    "setOrder":19,
+	"id": "ex4-21",
     "name": "Team Magma's Mightyena",
     "imageUrl": "https://images.pokemontcg.io/ex4/21.png",
     "subtype": "Stage 1",
@@ -1133,7 +1154,8 @@
     "nationalPokedexNumber": 262
   },
   {
-    "id": "ex4-22",
+    "setOrder":19,
+	"id": "ex4-22",
     "name": "Team Magma's Rhydon",
     "imageUrl": "https://images.pokemontcg.io/ex4/22.png",
     "subtype": "Stage 1",
@@ -1189,7 +1211,8 @@
     ]
   },
   {
-    "id": "ex4-23",
+    "setOrder":19,
+	"id": "ex4-23",
     "name": "Team Magma's Zangoose",
     "imageUrl": "https://images.pokemontcg.io/ex4/23.png",
     "subtype": "Basic",
@@ -1240,7 +1263,8 @@
     "nationalPokedexNumber": 335
   },
   {
-    "id": "ex4-24",
+    "setOrder":19,
+	"id": "ex4-24",
     "name": "Team Aqua's Cacnea",
     "imageUrl": "https://images.pokemontcg.io/ex4/24.png",
     "subtype": "Basic",
@@ -1294,7 +1318,8 @@
     ]
   },
   {
-    "id": "ex4-25",
+    "setOrder":19,
+	"id": "ex4-25",
     "name": "Team Aqua's Carvanha",
     "imageUrl": "https://images.pokemontcg.io/ex4/25.png",
     "subtype": "Basic",
@@ -1343,7 +1368,8 @@
     ]
   },
   {
-    "id": "ex4-26",
+    "setOrder":19,
+	"id": "ex4-26",
     "name": "Team Aqua's Corphish",
     "imageUrl": "https://images.pokemontcg.io/ex4/26.png",
     "subtype": "Basic",
@@ -1396,7 +1422,8 @@
     ]
   },
   {
-    "id": "ex4-27",
+    "setOrder":19,
+	"id": "ex4-27",
     "name": "Team Aqua's Electrike",
     "imageUrl": "https://images.pokemontcg.io/ex4/27.png",
     "subtype": "Basic",
@@ -1455,7 +1482,8 @@
     ]
   },
   {
-    "id": "ex4-28",
+    "setOrder":19,
+	"id": "ex4-28",
     "name": "Team Aqua's Lanturn",
     "imageUrl": "https://images.pokemontcg.io/ex4/28.png",
     "subtype": "Stage 1",
@@ -1508,7 +1536,8 @@
     "nationalPokedexNumber": 171
   },
   {
-    "id": "ex4-29",
+    "setOrder":19,
+	"id": "ex4-29",
     "name": "Team Aqua's Manectric",
     "imageUrl": "https://images.pokemontcg.io/ex4/29.png",
     "subtype": "Stage 1",
@@ -1566,7 +1595,8 @@
     "nationalPokedexNumber": 310
   },
   {
-    "id": "ex4-30",
+    "setOrder":19,
+	"id": "ex4-30",
     "name": "Team Aqua's Mightyena",
     "imageUrl": "https://images.pokemontcg.io/ex4/30.png",
     "subtype": "Stage 1",
@@ -1622,7 +1652,8 @@
     "nationalPokedexNumber": 262
   },
   {
-    "id": "ex4-31",
+    "setOrder":19,
+	"id": "ex4-31",
     "name": "Team Aqua's Sealeo",
     "imageUrl": "https://images.pokemontcg.io/ex4/31.png",
     "subtype": "Stage 1",
@@ -1678,7 +1709,8 @@
     ]
   },
   {
-    "id": "ex4-32",
+    "setOrder":19,
+	"id": "ex4-32",
     "name": "Team Magma's Baltoy",
     "imageUrl": "https://images.pokemontcg.io/ex4/32.png",
     "subtype": "Basic",
@@ -1731,7 +1763,8 @@
     ]
   },
   {
-    "id": "ex4-33",
+    "setOrder":19,
+	"id": "ex4-33",
     "name": "Team Magma's Claydol",
     "imageUrl": "https://images.pokemontcg.io/ex4/33.png",
     "subtype": "Stage 1",
@@ -1783,7 +1816,8 @@
     "nationalPokedexNumber": 344
   },
   {
-    "id": "ex4-34",
+    "setOrder":19,
+	"id": "ex4-34",
     "name": "Team Magma's Houndoom",
     "imageUrl": "https://images.pokemontcg.io/ex4/34.png",
     "subtype": "Stage 1",
@@ -1835,7 +1869,8 @@
     "nationalPokedexNumber": 229
   },
   {
-    "id": "ex4-35",
+    "setOrder":19,
+	"id": "ex4-35",
     "name": "Team Magma's Houndour",
     "imageUrl": "https://images.pokemontcg.io/ex4/35.png",
     "subtype": "Basic",
@@ -1888,7 +1923,8 @@
     ]
   },
   {
-    "id": "ex4-36",
+    "setOrder":19,
+	"id": "ex4-36",
     "name": "Team Magma's Lairon",
     "imageUrl": "https://images.pokemontcg.io/ex4/36.png",
     "subtype": "Stage 1",
@@ -1942,7 +1978,8 @@
     ]
   },
   {
-    "id": "ex4-37",
+    "setOrder":19,
+	"id": "ex4-37",
     "name": "Team Magma's Mightyena",
     "imageUrl": "https://images.pokemontcg.io/ex4/37.png",
     "subtype": "Stage 1",
@@ -1994,7 +2031,8 @@
     "nationalPokedexNumber": 262
   },
   {
-    "id": "ex4-38",
+    "setOrder":19,
+	"id": "ex4-38",
     "name": "Team Magma's Rhyhorn",
     "imageUrl": "https://images.pokemontcg.io/ex4/38.png",
     "subtype": "Basic",
@@ -2048,7 +2086,8 @@
     ]
   },
   {
-    "id": "ex4-39",
+    "setOrder":19,
+	"id": "ex4-39",
     "name": "Bulbasaur",
     "imageUrl": "https://images.pokemontcg.io/ex4/39.png",
     "subtype": "Basic",
@@ -2100,7 +2139,8 @@
     ]
   },
   {
-    "id": "ex4-40",
+    "setOrder":19,
+	"id": "ex4-40",
     "name": "Cubone",
     "imageUrl": "https://images.pokemontcg.io/ex4/40.png",
     "subtype": "Basic",
@@ -2143,7 +2183,8 @@
     ]
   },
   {
-    "id": "ex4-41",
+    "setOrder":19,
+	"id": "ex4-41",
     "name": "Jigglypuff",
     "imageUrl": "https://images.pokemontcg.io/ex4/41.png",
     "subtype": "Basic",
@@ -2196,7 +2237,8 @@
     ]
   },
   {
-    "id": "ex4-42",
+    "setOrder":19,
+	"id": "ex4-42",
     "name": "Meowth",
     "imageUrl": "https://images.pokemontcg.io/ex4/42.png",
     "subtype": "Basic",
@@ -2249,7 +2291,8 @@
     ]
   },
   {
-    "id": "ex4-43",
+    "setOrder":19,
+	"id": "ex4-43",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/ex4/43.png",
     "subtype": "Basic",
@@ -2302,7 +2345,8 @@
     ]
   },
   {
-    "id": "ex4-44",
+    "setOrder":19,
+	"id": "ex4-44",
     "name": "Psyduck",
     "imageUrl": "https://images.pokemontcg.io/ex4/44.png",
     "subtype": "Basic",
@@ -2354,7 +2398,8 @@
     ]
   },
   {
-    "id": "ex4-45",
+    "setOrder":19,
+	"id": "ex4-45",
     "name": "Slowpoke",
     "imageUrl": "https://images.pokemontcg.io/ex4/45.png",
     "subtype": "Basic",
@@ -2408,7 +2453,8 @@
     ]
   },
   {
-    "id": "ex4-46",
+    "setOrder":19,
+	"id": "ex4-46",
     "name": "Squirtle",
     "imageUrl": "https://images.pokemontcg.io/ex4/46.png",
     "subtype": "Basic",
@@ -2456,7 +2502,8 @@
     ]
   },
   {
-    "id": "ex4-47",
+    "setOrder":19,
+	"id": "ex4-47",
     "name": "Team Aqua's Carvanha",
     "imageUrl": "https://images.pokemontcg.io/ex4/47.png",
     "subtype": "Basic",
@@ -2509,7 +2556,8 @@
     ]
   },
   {
-    "id": "ex4-48",
+    "setOrder":19,
+	"id": "ex4-48",
     "name": "Team Aqua's Carvanha",
     "imageUrl": "https://images.pokemontcg.io/ex4/48.png",
     "subtype": "Basic",
@@ -2562,7 +2610,8 @@
     ]
   },
   {
-    "id": "ex4-49",
+    "setOrder":19,
+	"id": "ex4-49",
     "name": "Team Aqua's Chinchou",
     "imageUrl": "https://images.pokemontcg.io/ex4/49.png",
     "subtype": "Basic",
@@ -2621,7 +2670,8 @@
     ]
   },
   {
-    "id": "ex4-50",
+    "setOrder":19,
+	"id": "ex4-50",
     "name": "Team Aqua's Corphish",
     "imageUrl": "https://images.pokemontcg.io/ex4/50.png",
     "subtype": "Basic",
@@ -2664,7 +2714,8 @@
     ]
   },
   {
-    "id": "ex4-51",
+    "setOrder":19,
+	"id": "ex4-51",
     "name": "Team Aqua's Corphish",
     "imageUrl": "https://images.pokemontcg.io/ex4/51.png",
     "subtype": "Basic",
@@ -2717,7 +2768,8 @@
     ]
   },
   {
-    "id": "ex4-52",
+    "setOrder":19,
+	"id": "ex4-52",
     "name": "Team Aqua's Electrike",
     "imageUrl": "https://images.pokemontcg.io/ex4/52.png",
     "subtype": "Basic",
@@ -2776,7 +2828,8 @@
     ]
   },
   {
-    "id": "ex4-53",
+    "setOrder":19,
+	"id": "ex4-53",
     "name": "Team Aqua's Electrike",
     "imageUrl": "https://images.pokemontcg.io/ex4/53.png",
     "subtype": "Basic",
@@ -2835,7 +2888,8 @@
     ]
   },
   {
-    "id": "ex4-54",
+    "setOrder":19,
+	"id": "ex4-54",
     "name": "Team Aqua's Poochyena",
     "imageUrl": "https://images.pokemontcg.io/ex4/54.png",
     "subtype": "Basic",
@@ -2894,7 +2948,8 @@
     ]
   },
   {
-    "id": "ex4-55",
+    "setOrder":19,
+	"id": "ex4-55",
     "name": "Team Aqua's Poochyena",
     "imageUrl": "https://images.pokemontcg.io/ex4/55.png",
     "subtype": "Basic",
@@ -2953,7 +3008,8 @@
     ]
   },
   {
-    "id": "ex4-56",
+    "setOrder":19,
+	"id": "ex4-56",
     "name": "Team Aqua's Spheal",
     "imageUrl": "https://images.pokemontcg.io/ex4/56.png",
     "subtype": "Basic",
@@ -2996,7 +3052,8 @@
     ]
   },
   {
-    "id": "ex4-57",
+    "setOrder":19,
+	"id": "ex4-57",
     "name": "Team Aqua's Spheal",
     "imageUrl": "https://images.pokemontcg.io/ex4/57.png",
     "subtype": "Basic",
@@ -3049,7 +3106,8 @@
     ]
   },
   {
-    "id": "ex4-58",
+    "setOrder":19,
+	"id": "ex4-58",
     "name": "Team Magma's Aron",
     "imageUrl": "https://images.pokemontcg.io/ex4/58.png",
     "subtype": "Basic",
@@ -3102,7 +3160,8 @@
     ]
   },
   {
-    "id": "ex4-59",
+    "setOrder":19,
+	"id": "ex4-59",
     "name": "Team Magma's Aron",
     "imageUrl": "https://images.pokemontcg.io/ex4/59.png",
     "subtype": "Basic",
@@ -3145,7 +3204,8 @@
     ]
   },
   {
-    "id": "ex4-60",
+    "setOrder":19,
+	"id": "ex4-60",
     "name": "Team Magma's Baltoy",
     "imageUrl": "https://images.pokemontcg.io/ex4/60.png",
     "subtype": "Basic",
@@ -3198,7 +3258,8 @@
     ]
   },
   {
-    "id": "ex4-61",
+    "setOrder":19,
+	"id": "ex4-61",
     "name": "Team Magma's Baltoy",
     "imageUrl": "https://images.pokemontcg.io/ex4/61.png",
     "subtype": "Basic",
@@ -3251,7 +3312,8 @@
     ]
   },
   {
-    "id": "ex4-62",
+    "setOrder":19,
+	"id": "ex4-62",
     "name": "Team Magma's Houndour",
     "imageUrl": "https://images.pokemontcg.io/ex4/62.png",
     "subtype": "Basic",
@@ -3304,7 +3366,8 @@
     ]
   },
   {
-    "id": "ex4-63",
+    "setOrder":19,
+	"id": "ex4-63",
     "name": "Team Magma's Houndour",
     "imageUrl": "https://images.pokemontcg.io/ex4/63.png",
     "subtype": "Basic",
@@ -3357,7 +3420,8 @@
     ]
   },
   {
-    "id": "ex4-64",
+    "setOrder":19,
+	"id": "ex4-64",
     "name": "Team Magma's Numel",
     "imageUrl": "https://images.pokemontcg.io/ex4/64.png",
     "subtype": "Basic",
@@ -3410,7 +3474,8 @@
     ]
   },
   {
-    "id": "ex4-65",
+    "setOrder":19,
+	"id": "ex4-65",
     "name": "Team Magma's Poochyena",
     "imageUrl": "https://images.pokemontcg.io/ex4/65.png",
     "subtype": "Basic",
@@ -3459,7 +3524,8 @@
     ]
   },
   {
-    "id": "ex4-66",
+    "setOrder":19,
+	"id": "ex4-66",
     "name": "Team Magma's Poochyena",
     "imageUrl": "https://images.pokemontcg.io/ex4/66.png",
     "subtype": "Basic",
@@ -3518,7 +3584,8 @@
     ]
   },
   {
-    "id": "ex4-67",
+    "setOrder":19,
+	"id": "ex4-67",
     "name": "Team Magma's Rhyhorn",
     "imageUrl": "https://images.pokemontcg.io/ex4/67.png",
     "subtype": "Basic",
@@ -3571,7 +3638,8 @@
     ]
   },
   {
-    "id": "ex4-68",
+    "setOrder":19,
+	"id": "ex4-68",
     "name": "Team Magma's Rhyhorn",
     "imageUrl": "https://images.pokemontcg.io/ex4/68.png",
     "subtype": "Basic",
@@ -3625,7 +3693,8 @@
     ]
   },
   {
-    "id": "ex4-69",
+    "setOrder":19,
+	"id": "ex4-69",
     "name": "Team Aqua Schemer",
     "imageUrl": "https://images.pokemontcg.io/ex4/69.png",
     "subtype": "Supporter",
@@ -3644,7 +3713,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/69_hires.png"
   },
   {
-    "id": "ex4-70",
+    "setOrder":19,
+	"id": "ex4-70",
     "name": "Team Magma Schemer",
     "imageUrl": "https://images.pokemontcg.io/ex4/70.png",
     "subtype": "Supporter",
@@ -3663,7 +3733,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/70_hires.png"
   },
   {
-    "id": "ex4-71",
+    "setOrder":19,
+	"id": "ex4-71",
     "name": "Archie",
     "imageUrl": "https://images.pokemontcg.io/ex4/71.png",
     "subtype": "Supporter",
@@ -3682,7 +3753,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/71_hires.png"
   },
   {
-    "id": "ex4-72",
+    "setOrder":19,
+	"id": "ex4-72",
     "name": "Dual Ball",
     "imageUrl": "https://images.pokemontcg.io/ex4/72.png",
     "subtype": "Item",
@@ -3700,7 +3772,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/72_hires.png"
   },
   {
-    "id": "ex4-73",
+    "setOrder":19,
+	"id": "ex4-73",
     "name": "Maxie",
     "imageUrl": "https://images.pokemontcg.io/ex4/73.png",
     "subtype": "Supporter",
@@ -3719,7 +3792,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/73_hires.png"
   },
   {
-    "id": "ex4-74",
+    "setOrder":19,
+	"id": "ex4-74",
     "name": "Strength Charm",
     "imageUrl": "https://images.pokemontcg.io/ex4/74.png",
     "subtype": "Pokémon Tool",
@@ -3738,7 +3812,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/74_hires.png"
   },
   {
-    "id": "ex4-75",
+    "setOrder":19,
+	"id": "ex4-75",
     "name": "Team Aqua Ball",
     "imageUrl": "https://images.pokemontcg.io/ex4/75.png",
     "subtype": "Item",
@@ -3756,7 +3831,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/75_hires.png"
   },
   {
-    "id": "ex4-76",
+    "setOrder":19,
+	"id": "ex4-76",
     "name": "Team Aqua Belt",
     "imageUrl": "https://images.pokemontcg.io/ex4/76.png",
     "subtype": "Pokémon Tool",
@@ -3775,7 +3851,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/76_hires.png"
   },
   {
-    "id": "ex4-77",
+    "setOrder":19,
+	"id": "ex4-77",
     "name": "Team Aqua Conspirator",
     "imageUrl": "https://images.pokemontcg.io/ex4/77.png",
     "subtype": "Supporter",
@@ -3794,7 +3871,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/77_hires.png"
   },
   {
-    "id": "ex4-78",
+    "setOrder":19,
+	"id": "ex4-78",
     "name": "Team Aqua Hideout",
     "imageUrl": "https://images.pokemontcg.io/ex4/78.png",
     "subtype": "Stadium",
@@ -3813,7 +3891,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/78_hires.png"
   },
   {
-    "id": "ex4-79",
+    "setOrder":19,
+	"id": "ex4-79",
     "name": "Team Aqua's Technical Machine 01",
     "imageUrl": "https://images.pokemontcg.io/ex4/79.png",
     "subtype": "Item",
@@ -3831,7 +3910,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/79_hires.png"
   },
   {
-    "id": "ex4-80",
+    "setOrder":19,
+	"id": "ex4-80",
     "name": "Team Magma Ball",
     "imageUrl": "https://images.pokemontcg.io/ex4/80.png",
     "subtype": "Item",
@@ -3849,7 +3929,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/80_hires.png"
   },
   {
-    "id": "ex4-81",
+    "setOrder":19,
+	"id": "ex4-81",
     "name": "Team Magma Belt",
     "imageUrl": "https://images.pokemontcg.io/ex4/81.png",
     "subtype": "Pokémon Tool",
@@ -3868,7 +3949,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/81_hires.png"
   },
   {
-    "id": "ex4-82",
+    "setOrder":19,
+	"id": "ex4-82",
     "name": "Team Magma Conspirator",
     "imageUrl": "https://images.pokemontcg.io/ex4/82.png",
     "subtype": "Supporter",
@@ -3887,7 +3969,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/82_hires.png"
   },
   {
-    "id": "ex4-83",
+    "setOrder":19,
+	"id": "ex4-83",
     "name": "Team Magma Hideout",
     "imageUrl": "https://images.pokemontcg.io/ex4/83.png",
     "subtype": "Stadium",
@@ -3906,7 +3989,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/83_hires.png"
   },
   {
-    "id": "ex4-84",
+    "setOrder":19,
+	"id": "ex4-84",
     "name": "Team Magma's Technical Machine 01",
     "imageUrl": "https://images.pokemontcg.io/ex4/84.png",
     "subtype": "Item",
@@ -3924,7 +4008,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/84_hires.png"
   },
   {
-    "id": "ex4-85",
+    "setOrder":19,
+	"id": "ex4-85",
     "name": "Warp Point",
     "imageUrl": "https://images.pokemontcg.io/ex4/85.png",
     "subtype": "Item",
@@ -3942,7 +4027,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/85_hires.png"
   },
   {
-    "id": "ex4-86",
+    "setOrder":19,
+	"id": "ex4-86",
     "name": "Aqua Energy",
     "imageUrl": "https://images.pokemontcg.io/ex4/86.png",
     "subtype": "Special",
@@ -3959,7 +4045,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/86_hires.png"
   },
   {
-    "id": "ex4-87",
+    "setOrder":19,
+	"id": "ex4-87",
     "name": "Magma Energy",
     "imageUrl": "https://images.pokemontcg.io/ex4/87.png",
     "subtype": "Special",
@@ -3976,7 +4063,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/87_hires.png"
   },
   {
-    "id": "ex4-88",
+    "setOrder":19,
+	"id": "ex4-88",
     "name": "Double Rainbow Energy",
     "imageUrl": "https://images.pokemontcg.io/ex4/88.png",
     "subtype": "Special",
@@ -3993,7 +4081,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex4/88_hires.png"
   },
   {
-    "id": "ex4-89",
+    "setOrder":19,
+	"id": "ex4-89",
     "name": "Blaziken ex",
     "imageUrl": "https://images.pokemontcg.io/ex4/89.png",
     "subtype": "EX",
@@ -4055,7 +4144,8 @@
     "nationalPokedexNumber": 257
   },
   {
-    "id": "ex4-90",
+    "setOrder":19,
+	"id": "ex4-90",
     "name": "Cradily ex",
     "imageUrl": "https://images.pokemontcg.io/ex4/90.png",
     "subtype": "EX",
@@ -4122,7 +4212,8 @@
     "nationalPokedexNumber": 346
   },
   {
-    "id": "ex4-91",
+    "setOrder":19,
+	"id": "ex4-91",
     "name": "Entei ex",
     "imageUrl": "https://images.pokemontcg.io/ex4/91.png",
     "subtype": "EX",
@@ -4178,7 +4269,8 @@
     "nationalPokedexNumber": 244
   },
   {
-    "id": "ex4-92",
+    "setOrder":19,
+	"id": "ex4-92",
     "name": "Raikou ex",
     "imageUrl": "https://images.pokemontcg.io/ex4/92.png",
     "subtype": "EX",
@@ -4234,7 +4326,8 @@
     "nationalPokedexNumber": 243
   },
   {
-    "id": "ex4-93",
+    "setOrder":19,
+	"id": "ex4-93",
     "name": "Sceptile ex",
     "imageUrl": "https://images.pokemontcg.io/ex4/93.png",
     "subtype": "EX",
@@ -4313,7 +4406,8 @@
     "nationalPokedexNumber": 254
   },
   {
-    "id": "ex4-94",
+    "setOrder":19,
+	"id": "ex4-94",
     "name": "Suicune ex",
     "imageUrl": "https://images.pokemontcg.io/ex4/94.png",
     "subtype": "EX",
@@ -4369,7 +4463,8 @@
     "nationalPokedexNumber": 245
   },
   {
-    "id": "ex4-95",
+    "setOrder":19,
+	"id": "ex4-95",
     "name": "Swampert ex",
     "imageUrl": "https://images.pokemontcg.io/ex4/95.png",
     "subtype": "EX",

--- a/json/cards/Team Rocket Returns.json
+++ b/json/cards/Team Rocket Returns.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "ex7-1",
+    "setOrder":22,
+	"id": "ex7-1",
     "name": "Azumarill",
     "imageUrl": "https://images.pokemontcg.io/ex7/1.png",
     "subtype": "Stage 1",
@@ -47,7 +48,8 @@
     "nationalPokedexNumber": 184
   },
   {
-    "id": "ex7-2",
+    "setOrder":22,
+	"id": "ex7-2",
     "name": "Dark Ampharos",
     "imageUrl": "https://images.pokemontcg.io/ex7/2.png",
     "subtype": "Stage 2",
@@ -107,7 +109,8 @@
     "nationalPokedexNumber": 181
   },
   {
-    "id": "ex7-3",
+    "setOrder":22,
+	"id": "ex7-3",
     "name": "Dark Crobat",
     "imageUrl": "https://images.pokemontcg.io/ex7/3.png",
     "subtype": "Stage 2",
@@ -171,7 +174,8 @@
     "nationalPokedexNumber": 169
   },
   {
-    "id": "ex7-4",
+    "setOrder":22,
+	"id": "ex7-4",
     "name": "Dark Electrode",
     "imageUrl": "https://images.pokemontcg.io/ex7/4.png",
     "subtype": "Stage 1",
@@ -218,7 +222,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "ex7-5",
+    "setOrder":22,
+	"id": "ex7-5",
     "name": "Dark Houndoom",
     "imageUrl": "https://images.pokemontcg.io/ex7/5.png",
     "subtype": "Stage 1",
@@ -286,7 +291,8 @@
     "nationalPokedexNumber": 229
   },
   {
-    "id": "ex7-6",
+    "setOrder":22,
+	"id": "ex7-6",
     "name": "Dark Hypno",
     "imageUrl": "https://images.pokemontcg.io/ex7/6.png",
     "subtype": "Stage 1",
@@ -338,7 +344,8 @@
     "nationalPokedexNumber": 97
   },
   {
-    "id": "ex7-7",
+    "setOrder":22,
+	"id": "ex7-7",
     "name": "Dark Marowak",
     "imageUrl": "https://images.pokemontcg.io/ex7/7.png",
     "subtype": "Stage 1",
@@ -392,7 +399,8 @@
     "nationalPokedexNumber": 105
   },
   {
-    "id": "ex7-8",
+    "setOrder":22,
+	"id": "ex7-8",
     "name": "Dark Octillery",
     "imageUrl": "https://images.pokemontcg.io/ex7/8.png",
     "subtype": "Stage 1",
@@ -444,7 +452,8 @@
     "nationalPokedexNumber": 224
   },
   {
-    "id": "ex7-9",
+    "setOrder":22,
+	"id": "ex7-9",
     "name": "Dark Slowking",
     "imageUrl": "https://images.pokemontcg.io/ex7/9.png",
     "subtype": "Stage 1",
@@ -492,7 +501,8 @@
     "nationalPokedexNumber": 199
   },
   {
-    "id": "ex7-10",
+    "setOrder":22,
+	"id": "ex7-10",
     "name": "Dark Steelix",
     "imageUrl": "https://images.pokemontcg.io/ex7/10.png",
     "subtype": "Stage 1",
@@ -556,7 +566,8 @@
     "nationalPokedexNumber": 208
   },
   {
-    "id": "ex7-11",
+    "setOrder":22,
+	"id": "ex7-11",
     "name": "Jumpluff",
     "imageUrl": "https://images.pokemontcg.io/ex7/11.png",
     "subtype": "Stage 2",
@@ -605,7 +616,8 @@
     "nationalPokedexNumber": 189
   },
   {
-    "id": "ex7-12",
+    "setOrder":22,
+	"id": "ex7-12",
     "name": "Kingdra",
     "imageUrl": "https://images.pokemontcg.io/ex7/12.png",
     "subtype": "Stage 2",
@@ -664,7 +676,8 @@
     "nationalPokedexNumber": 230
   },
   {
-    "id": "ex7-13",
+    "setOrder":22,
+	"id": "ex7-13",
     "name": "Piloswine",
     "imageUrl": "https://images.pokemontcg.io/ex7/13.png",
     "subtype": "Stage 1",
@@ -722,7 +735,8 @@
     ]
   },
   {
-    "id": "ex7-14",
+    "setOrder":22,
+	"id": "ex7-14",
     "name": "Togetic",
     "imageUrl": "https://images.pokemontcg.io/ex7/14.png",
     "subtype": "Stage 1",
@@ -789,7 +803,8 @@
     ]
   },
   {
-    "id": "ex7-15",
+    "setOrder":22,
+	"id": "ex7-15",
     "name": "Dark Dragonite",
     "imageUrl": "https://images.pokemontcg.io/ex7/15.png",
     "subtype": "Stage 2",
@@ -858,7 +873,8 @@
     "nationalPokedexNumber": 149
   },
   {
-    "id": "ex7-16",
+    "setOrder":22,
+	"id": "ex7-16",
     "name": "Dark Muk",
     "imageUrl": "https://images.pokemontcg.io/ex7/16.png",
     "subtype": "Stage 1",
@@ -916,7 +932,8 @@
     "nationalPokedexNumber": 89
   },
   {
-    "id": "ex7-17",
+    "setOrder":22,
+	"id": "ex7-17",
     "name": "Dark Raticate",
     "imageUrl": "https://images.pokemontcg.io/ex7/17.png",
     "subtype": "Stage 1",
@@ -964,7 +981,8 @@
     "nationalPokedexNumber": 20
   },
   {
-    "id": "ex7-18",
+    "setOrder":22,
+	"id": "ex7-18",
     "name": "Dark Sandslash",
     "imageUrl": "https://images.pokemontcg.io/ex7/18.png",
     "subtype": "Stage 1",
@@ -1010,7 +1028,8 @@
     "nationalPokedexNumber": 28
   },
   {
-    "id": "ex7-19",
+    "setOrder":22,
+	"id": "ex7-19",
     "name": "Dark Tyranitar",
     "imageUrl": "https://images.pokemontcg.io/ex7/19.png",
     "subtype": "Stage 2",
@@ -1082,7 +1101,8 @@
     "nationalPokedexNumber": 248
   },
   {
-    "id": "ex7-20",
+    "setOrder":22,
+	"id": "ex7-20",
     "name": "Dark Tyranitar",
     "imageUrl": "https://images.pokemontcg.io/ex7/20.png",
     "subtype": "Stage 2",
@@ -1133,7 +1153,8 @@
     "nationalPokedexNumber": 248
   },
   {
-    "id": "ex7-21",
+    "setOrder":22,
+	"id": "ex7-21",
     "name": "Delibird",
     "imageUrl": "https://images.pokemontcg.io/ex7/21.png",
     "subtype": "Basic",
@@ -1179,7 +1200,8 @@
     "nationalPokedexNumber": 225
   },
   {
-    "id": "ex7-22",
+    "setOrder":22,
+	"id": "ex7-22",
     "name": "Furret",
     "imageUrl": "https://images.pokemontcg.io/ex7/22.png",
     "subtype": "Stage 1",
@@ -1230,7 +1252,8 @@
     "nationalPokedexNumber": 162
   },
   {
-    "id": "ex7-23",
+    "setOrder":22,
+	"id": "ex7-23",
     "name": "Ledian",
     "imageUrl": "https://images.pokemontcg.io/ex7/23.png",
     "subtype": "Stage 1",
@@ -1288,7 +1311,8 @@
     "nationalPokedexNumber": 166
   },
   {
-    "id": "ex7-24",
+    "setOrder":22,
+	"id": "ex7-24",
     "name": "Magby",
     "imageUrl": "https://images.pokemontcg.io/ex7/24.png",
     "subtype": "Basic",
@@ -1336,7 +1360,8 @@
     ]
   },
   {
-    "id": "ex7-25",
+    "setOrder":22,
+	"id": "ex7-25",
     "name": "Misdreavus",
     "imageUrl": "https://images.pokemontcg.io/ex7/25.png",
     "subtype": "Basic",
@@ -1391,7 +1416,8 @@
     ]
   },
   {
-    "id": "ex7-26",
+    "setOrder":22,
+	"id": "ex7-26",
     "name": "Quagsire",
     "imageUrl": "https://images.pokemontcg.io/ex7/26.png",
     "subtype": "Stage 1",
@@ -1438,7 +1464,8 @@
     "nationalPokedexNumber": 195
   },
   {
-    "id": "ex7-27",
+    "setOrder":22,
+	"id": "ex7-27",
     "name": "Qwilfish",
     "imageUrl": "https://images.pokemontcg.io/ex7/27.png",
     "subtype": "Basic",
@@ -1484,7 +1511,8 @@
     "nationalPokedexNumber": 211
   },
   {
-    "id": "ex7-28",
+    "setOrder":22,
+	"id": "ex7-28",
     "name": "Yanma",
     "imageUrl": "https://images.pokemontcg.io/ex7/28.png",
     "subtype": "Basic",
@@ -1542,7 +1570,8 @@
     ]
   },
   {
-    "id": "ex7-29",
+    "setOrder":22,
+	"id": "ex7-29",
     "name": "Dark Arbok",
     "imageUrl": "https://images.pokemontcg.io/ex7/29.png",
     "subtype": "Stage 1",
@@ -1594,7 +1623,8 @@
     "nationalPokedexNumber": 24
   },
   {
-    "id": "ex7-30",
+    "setOrder":22,
+	"id": "ex7-30",
     "name": "Dark Ariados",
     "imageUrl": "https://images.pokemontcg.io/ex7/30.png",
     "subtype": "Stage 1",
@@ -1647,7 +1677,8 @@
     "nationalPokedexNumber": 168
   },
   {
-    "id": "ex7-31",
+    "setOrder":22,
+	"id": "ex7-31",
     "name": "Dark Dragonair",
     "imageUrl": "https://images.pokemontcg.io/ex7/31.png",
     "subtype": "Stage 1",
@@ -1707,7 +1738,8 @@
     ]
   },
   {
-    "id": "ex7-32",
+    "setOrder":22,
+	"id": "ex7-32",
     "name": "Dark Dragonair",
     "imageUrl": "https://images.pokemontcg.io/ex7/32.png",
     "subtype": "Stage 1",
@@ -1778,7 +1810,8 @@
     ]
   },
   {
-    "id": "ex7-33",
+    "setOrder":22,
+	"id": "ex7-33",
     "name": "Dark Flaaffy",
     "imageUrl": "https://images.pokemontcg.io/ex7/33.png",
     "subtype": "Stage 1",
@@ -1833,7 +1866,8 @@
     ]
   },
   {
-    "id": "ex7-34",
+    "setOrder":22,
+	"id": "ex7-34",
     "name": "Dark Golbat",
     "imageUrl": "https://images.pokemontcg.io/ex7/34.png",
     "subtype": "Stage 1",
@@ -1875,7 +1909,8 @@
     ]
   },
   {
-    "id": "ex7-35",
+    "setOrder":22,
+	"id": "ex7-35",
     "name": "Dark Golduck",
     "imageUrl": "https://images.pokemontcg.io/ex7/35.png",
     "subtype": "Stage 1",
@@ -1929,7 +1964,8 @@
     "nationalPokedexNumber": 55
   },
   {
-    "id": "ex7-36",
+    "setOrder":22,
+	"id": "ex7-36",
     "name": "Dark Gyarados",
     "imageUrl": "https://images.pokemontcg.io/ex7/36.png",
     "subtype": "Stage 1",
@@ -1990,7 +2026,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "ex7-37",
+    "setOrder":22,
+	"id": "ex7-37",
     "name": "Dark Houndoom",
     "imageUrl": "https://images.pokemontcg.io/ex7/37.png",
     "subtype": "Stage 1",
@@ -2039,7 +2076,8 @@
     "nationalPokedexNumber": 229
   },
   {
-    "id": "ex7-38",
+    "setOrder":22,
+	"id": "ex7-38",
     "name": "Dark Magcargo",
     "imageUrl": "https://images.pokemontcg.io/ex7/38.png",
     "subtype": "Stage 1",
@@ -2093,7 +2131,8 @@
     "nationalPokedexNumber": 219
   },
   {
-    "id": "ex7-39",
+    "setOrder":22,
+	"id": "ex7-39",
     "name": "Dark Magneton",
     "imageUrl": "https://images.pokemontcg.io/ex7/39.png",
     "subtype": "Stage 1",
@@ -2150,7 +2189,8 @@
     ]
   },
   {
-    "id": "ex7-40",
+    "setOrder":22,
+	"id": "ex7-40",
     "name": "Dark Pupitar",
     "imageUrl": "https://images.pokemontcg.io/ex7/40.png",
     "subtype": "Stage 1",
@@ -2205,7 +2245,8 @@
     ]
   },
   {
-    "id": "ex7-41",
+    "setOrder":22,
+	"id": "ex7-41",
     "name": "Dark Pupitar",
     "imageUrl": "https://images.pokemontcg.io/ex7/41.png",
     "subtype": "Stage 1",
@@ -2263,7 +2304,8 @@
     ]
   },
   {
-    "id": "ex7-42",
+    "setOrder":22,
+	"id": "ex7-42",
     "name": "Dark Weezing",
     "imageUrl": "https://images.pokemontcg.io/ex7/42.png",
     "subtype": "Stage 1",
@@ -2322,7 +2364,8 @@
     "nationalPokedexNumber": 110
   },
   {
-    "id": "ex7-43",
+    "setOrder":22,
+	"id": "ex7-43",
     "name": "Heracross",
     "imageUrl": "https://images.pokemontcg.io/ex7/43.png",
     "subtype": "Basic",
@@ -2368,7 +2411,8 @@
     "nationalPokedexNumber": 214
   },
   {
-    "id": "ex7-44",
+    "setOrder":22,
+	"id": "ex7-44",
     "name": "Magmar",
     "imageUrl": "https://images.pokemontcg.io/ex7/44.png",
     "subtype": "Basic",
@@ -2422,7 +2466,8 @@
     ]
   },
   {
-    "id": "ex7-45",
+    "setOrder":22,
+	"id": "ex7-45",
     "name": "Mantine",
     "imageUrl": "https://images.pokemontcg.io/ex7/45.png",
     "subtype": "Basic",
@@ -2468,7 +2513,8 @@
     "nationalPokedexNumber": 226
   },
   {
-    "id": "ex7-46",
+    "setOrder":22,
+	"id": "ex7-46",
     "name": "Rocket's Meowth",
     "imageUrl": "https://images.pokemontcg.io/ex7/46.png",
     "subtype": "Basic",
@@ -2521,7 +2567,8 @@
     ]
   },
   {
-    "id": "ex7-47",
+    "setOrder":22,
+	"id": "ex7-47",
     "name": "Rocket's Wobbuffet",
     "imageUrl": "https://images.pokemontcg.io/ex7/47.png",
     "subtype": "Basic",
@@ -2571,7 +2618,8 @@
     "nationalPokedexNumber": 202
   },
   {
-    "id": "ex7-48",
+    "setOrder":22,
+	"id": "ex7-48",
     "name": "Seadra",
     "imageUrl": "https://images.pokemontcg.io/ex7/48.png",
     "subtype": "Stage 1",
@@ -2627,7 +2675,8 @@
     ]
   },
   {
-    "id": "ex7-49",
+    "setOrder":22,
+	"id": "ex7-49",
     "name": "Skiploom",
     "imageUrl": "https://images.pokemontcg.io/ex7/49.png",
     "subtype": "Stage 1",
@@ -2679,7 +2728,8 @@
     ]
   },
   {
-    "id": "ex7-50",
+    "setOrder":22,
+	"id": "ex7-50",
     "name": "Togepi",
     "imageUrl": "https://images.pokemontcg.io/ex7/50.png",
     "subtype": "Basic",
@@ -2732,7 +2782,8 @@
     ]
   },
   {
-    "id": "ex7-51",
+    "setOrder":22,
+	"id": "ex7-51",
     "name": "Cubone",
     "imageUrl": "https://images.pokemontcg.io/ex7/51.png",
     "subtype": "Basic",
@@ -2784,7 +2835,8 @@
     ]
   },
   {
-    "id": "ex7-52",
+    "setOrder":22,
+	"id": "ex7-52",
     "name": "Dratini",
     "imageUrl": "https://images.pokemontcg.io/ex7/52.png",
     "subtype": "Basic",
@@ -2821,7 +2873,8 @@
     ]
   },
   {
-    "id": "ex7-53",
+    "setOrder":22,
+	"id": "ex7-53",
     "name": "Dratini",
     "imageUrl": "https://images.pokemontcg.io/ex7/53.png",
     "subtype": "Basic",
@@ -2884,7 +2937,8 @@
     ]
   },
   {
-    "id": "ex7-54",
+    "setOrder":22,
+	"id": "ex7-54",
     "name": "Drowzee",
     "imageUrl": "https://images.pokemontcg.io/ex7/54.png",
     "subtype": "Basic",
@@ -2932,7 +2986,8 @@
     ]
   },
   {
-    "id": "ex7-55",
+    "setOrder":22,
+	"id": "ex7-55",
     "name": "Ekans",
     "imageUrl": "https://images.pokemontcg.io/ex7/55.png",
     "subtype": "Basic",
@@ -2975,7 +3030,8 @@
     ]
   },
   {
-    "id": "ex7-56",
+    "setOrder":22,
+	"id": "ex7-56",
     "name": "Grimer",
     "imageUrl": "https://images.pokemontcg.io/ex7/56.png",
     "subtype": "Basic",
@@ -3028,7 +3084,8 @@
     ]
   },
   {
-    "id": "ex7-57",
+    "setOrder":22,
+	"id": "ex7-57",
     "name": "Hoppip",
     "imageUrl": "https://images.pokemontcg.io/ex7/57.png",
     "subtype": "Basic",
@@ -3082,7 +3139,8 @@
     ]
   },
   {
-    "id": "ex7-58",
+    "setOrder":22,
+	"id": "ex7-58",
     "name": "Horsea",
     "imageUrl": "https://images.pokemontcg.io/ex7/58.png",
     "subtype": "Basic",
@@ -3135,7 +3193,8 @@
     ]
   },
   {
-    "id": "ex7-59",
+    "setOrder":22,
+	"id": "ex7-59",
     "name": "Houndour",
     "imageUrl": "https://images.pokemontcg.io/ex7/59.png",
     "subtype": "Basic",
@@ -3188,7 +3247,8 @@
     ]
   },
   {
-    "id": "ex7-60",
+    "setOrder":22,
+	"id": "ex7-60",
     "name": "Houndour",
     "imageUrl": "https://images.pokemontcg.io/ex7/60.png",
     "subtype": "Basic",
@@ -3236,7 +3296,8 @@
     ]
   },
   {
-    "id": "ex7-61",
+    "setOrder":22,
+	"id": "ex7-61",
     "name": "Koffing",
     "imageUrl": "https://images.pokemontcg.io/ex7/61.png",
     "subtype": "Basic",
@@ -3284,7 +3345,8 @@
     ]
   },
   {
-    "id": "ex7-62",
+    "setOrder":22,
+	"id": "ex7-62",
     "name": "Larvitar",
     "imageUrl": "https://images.pokemontcg.io/ex7/62.png",
     "subtype": "Basic",
@@ -3328,7 +3390,8 @@
     ]
   },
   {
-    "id": "ex7-63",
+    "setOrder":22,
+	"id": "ex7-63",
     "name": "Larvitar",
     "imageUrl": "https://images.pokemontcg.io/ex7/63.png",
     "subtype": "Basic",
@@ -3381,7 +3444,8 @@
     ]
   },
   {
-    "id": "ex7-64",
+    "setOrder":22,
+	"id": "ex7-64",
     "name": "Ledyba",
     "imageUrl": "https://images.pokemontcg.io/ex7/64.png",
     "subtype": "Basic",
@@ -3434,7 +3498,8 @@
     ]
   },
   {
-    "id": "ex7-65",
+    "setOrder":22,
+	"id": "ex7-65",
     "name": "Magikarp",
     "imageUrl": "https://images.pokemontcg.io/ex7/65.png",
     "subtype": "Basic",
@@ -3477,7 +3542,8 @@
     ]
   },
   {
-    "id": "ex7-66",
+    "setOrder":22,
+	"id": "ex7-66",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/ex7/66.png",
     "subtype": "Basic",
@@ -3520,7 +3586,8 @@
     ]
   },
   {
-    "id": "ex7-67",
+    "setOrder":22,
+	"id": "ex7-67",
     "name": "Mareep",
     "imageUrl": "https://images.pokemontcg.io/ex7/67.png",
     "subtype": "Basic",
@@ -3573,7 +3640,8 @@
     ]
   },
   {
-    "id": "ex7-68",
+    "setOrder":22,
+	"id": "ex7-68",
     "name": "Marill",
     "imageUrl": "https://images.pokemontcg.io/ex7/68.png",
     "subtype": "Basic",
@@ -3616,7 +3684,8 @@
     ]
   },
   {
-    "id": "ex7-69",
+    "setOrder":22,
+	"id": "ex7-69",
     "name": "Onix",
     "imageUrl": "https://images.pokemontcg.io/ex7/69.png",
     "subtype": "Basic",
@@ -3671,7 +3740,8 @@
     ]
   },
   {
-    "id": "ex7-70",
+    "setOrder":22,
+	"id": "ex7-70",
     "name": "Psyduck",
     "imageUrl": "https://images.pokemontcg.io/ex7/70.png",
     "subtype": "Basic",
@@ -3723,7 +3793,8 @@
     ]
   },
   {
-    "id": "ex7-71",
+    "setOrder":22,
+	"id": "ex7-71",
     "name": "Rattata",
     "imageUrl": "https://images.pokemontcg.io/ex7/71.png",
     "subtype": "Basic",
@@ -3771,7 +3842,8 @@
     ]
   },
   {
-    "id": "ex7-72",
+    "setOrder":22,
+	"id": "ex7-72",
     "name": "Rattata",
     "imageUrl": "https://images.pokemontcg.io/ex7/72.png",
     "subtype": "Basic",
@@ -3823,7 +3895,8 @@
     ]
   },
   {
-    "id": "ex7-73",
+    "setOrder":22,
+	"id": "ex7-73",
     "name": "Remoraid",
     "imageUrl": "https://images.pokemontcg.io/ex7/73.png",
     "subtype": "Basic",
@@ -3875,7 +3948,8 @@
     ]
   },
   {
-    "id": "ex7-74",
+    "setOrder":22,
+	"id": "ex7-74",
     "name": "Sandshrew",
     "imageUrl": "https://images.pokemontcg.io/ex7/74.png",
     "subtype": "Basic",
@@ -3928,7 +4002,8 @@
     ]
   },
   {
-    "id": "ex7-75",
+    "setOrder":22,
+	"id": "ex7-75",
     "name": "Sentret",
     "imageUrl": "https://images.pokemontcg.io/ex7/75.png",
     "subtype": "Basic",
@@ -3980,7 +4055,8 @@
     ]
   },
   {
-    "id": "ex7-76",
+    "setOrder":22,
+	"id": "ex7-76",
     "name": "Slowpoke",
     "imageUrl": "https://images.pokemontcg.io/ex7/76.png",
     "subtype": "Basic",
@@ -4029,7 +4105,8 @@
     ]
   },
   {
-    "id": "ex7-77",
+    "setOrder":22,
+	"id": "ex7-77",
     "name": "Slugma",
     "imageUrl": "https://images.pokemontcg.io/ex7/77.png",
     "subtype": "Basic",
@@ -4083,7 +4160,8 @@
     ]
   },
   {
-    "id": "ex7-78",
+    "setOrder":22,
+	"id": "ex7-78",
     "name": "Spinarak",
     "imageUrl": "https://images.pokemontcg.io/ex7/78.png",
     "subtype": "Basic",
@@ -4136,7 +4214,8 @@
     ]
   },
   {
-    "id": "ex7-79",
+    "setOrder":22,
+	"id": "ex7-79",
     "name": "Swinub",
     "imageUrl": "https://images.pokemontcg.io/ex7/79.png",
     "subtype": "Basic",
@@ -4189,7 +4268,8 @@
     ]
   },
   {
-    "id": "ex7-80",
+    "setOrder":22,
+	"id": "ex7-80",
     "name": "Voltorb",
     "imageUrl": "https://images.pokemontcg.io/ex7/80.png",
     "subtype": "Basic",
@@ -4241,7 +4321,8 @@
     ]
   },
   {
-    "id": "ex7-81",
+    "setOrder":22,
+	"id": "ex7-81",
     "name": "Wooper",
     "imageUrl": "https://images.pokemontcg.io/ex7/81.png",
     "subtype": "Basic",
@@ -4289,7 +4370,8 @@
     ]
   },
   {
-    "id": "ex7-82",
+    "setOrder":22,
+	"id": "ex7-82",
     "name": "Zubat",
     "imageUrl": "https://images.pokemontcg.io/ex7/82.png",
     "subtype": "Basic",
@@ -4342,7 +4424,8 @@
     ]
   },
   {
-    "id": "ex7-83",
+    "setOrder":22,
+	"id": "ex7-83",
     "name": "Copycat",
     "imageUrl": "https://images.pokemontcg.io/ex7/83.png",
     "subtype": "Supporter",
@@ -4361,7 +4444,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex7/83_hires.png"
   },
   {
-    "id": "ex7-84",
+    "setOrder":22,
+	"id": "ex7-84",
     "name": "Pokémon Retriever",
     "imageUrl": "https://images.pokemontcg.io/ex7/84.png",
     "subtype": "Rocket's Secret Machine",
@@ -4378,7 +4462,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex7/84_hires.png"
   },
   {
-    "id": "ex7-85",
+    "setOrder":22,
+	"id": "ex7-85",
     "name": "Pow! Hand Extension",
     "imageUrl": "https://images.pokemontcg.io/ex7/85.png",
     "subtype": "Rocket's Secret Machine",
@@ -4396,7 +4481,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex7/85_hires.png"
   },
   {
-    "id": "ex7-86",
+    "setOrder":22,
+	"id": "ex7-86",
     "name": "Rocket's Admin.",
     "imageUrl": "https://images.pokemontcg.io/ex7/86.png",
     "subtype": "Supporter",
@@ -4415,7 +4501,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex7/86_hires.png"
   },
   {
-    "id": "ex7-87",
+    "setOrder":22,
+	"id": "ex7-87",
     "name": "Rocket's Hideout",
     "imageUrl": "https://images.pokemontcg.io/ex7/87.png",
     "subtype": "Stadium",
@@ -4434,7 +4521,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex7/87_hires.png"
   },
   {
-    "id": "ex7-88",
+    "setOrder":22,
+	"id": "ex7-88",
     "name": "Rocket's Mission",
     "imageUrl": "https://images.pokemontcg.io/ex7/88.png",
     "subtype": "Supporter",
@@ -4453,7 +4541,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex7/88_hires.png"
   },
   {
-    "id": "ex7-89",
+    "setOrder":22,
+	"id": "ex7-89",
     "name": "Rocket's Poké Ball",
     "imageUrl": "https://images.pokemontcg.io/ex7/89.png",
     "subtype": "Item",
@@ -4471,7 +4560,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex7/89_hires.png"
   },
   {
-    "id": "ex7-90",
+    "setOrder":22,
+	"id": "ex7-90",
     "name": "Rocket's Tricky Gym",
     "imageUrl": "https://images.pokemontcg.io/ex7/90.png",
     "subtype": "Stadium",
@@ -4501,7 +4591,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex7/90_hires.png"
   },
   {
-    "id": "ex7-91",
+    "setOrder":22,
+	"id": "ex7-91",
     "name": "Surprise! Time Machine",
     "imageUrl": "https://images.pokemontcg.io/ex7/91.png",
     "subtype": "Rocket's Secret Machine",
@@ -4518,7 +4609,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex7/91_hires.png"
   },
   {
-    "id": "ex7-92",
+    "setOrder":22,
+	"id": "ex7-92",
     "name": "Swoop! Teleporter",
     "imageUrl": "https://images.pokemontcg.io/ex7/92.png",
     "subtype": "Rocket's Secret Machine",
@@ -4535,7 +4627,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex7/92_hires.png"
   },
   {
-    "id": "ex7-93",
+    "setOrder":22,
+	"id": "ex7-93",
     "name": "Venture Bomb",
     "imageUrl": "https://images.pokemontcg.io/ex7/93.png",
     "subtype": "Rocket's Secret Machine",
@@ -4552,7 +4645,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex7/93_hires.png"
   },
   {
-    "id": "ex7-94",
+    "setOrder":22,
+	"id": "ex7-94",
     "name": "Dark Metal Energy",
     "imageUrl": "https://images.pokemontcg.io/ex7/94.png",
     "subtype": "Special",
@@ -4569,7 +4663,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex7/94_hires.png"
   },
   {
-    "id": "ex7-95",
+    "setOrder":22,
+	"id": "ex7-95",
     "name": "R Energy",
     "imageUrl": "https://images.pokemontcg.io/ex7/95.png",
     "subtype": "Special",
@@ -4586,7 +4681,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex7/95_hires.png"
   },
   {
-    "id": "ex7-96",
+    "setOrder":22,
+	"id": "ex7-96",
     "name": "Rocket's Articuno ex",
     "imageUrl": "https://images.pokemontcg.io/ex7/96.png",
     "subtype": "EX",
@@ -4643,7 +4739,8 @@
     "nationalPokedexNumber": 144
   },
   {
-    "id": "ex7-97",
+    "setOrder":22,
+	"id": "ex7-97",
     "name": "Rocket's Entei ex",
     "imageUrl": "https://images.pokemontcg.io/ex7/97.png",
     "subtype": "EX",
@@ -4700,7 +4797,8 @@
     "nationalPokedexNumber": 244
   },
   {
-    "id": "ex7-98",
+    "setOrder":22,
+	"id": "ex7-98",
     "name": "Rocket's Hitmonchan ex",
     "imageUrl": "https://images.pokemontcg.io/ex7/98.png",
     "subtype": "EX",
@@ -4757,7 +4855,8 @@
     "nationalPokedexNumber": 107
   },
   {
-    "id": "ex7-99",
+    "setOrder":22,
+	"id": "ex7-99",
     "name": "Rocket's Mewtwo ex",
     "imageUrl": "https://images.pokemontcg.io/ex7/99.png",
     "subtype": "EX",
@@ -4822,7 +4921,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "ex7-100",
+    "setOrder":22,
+	"id": "ex7-100",
     "name": "Rocket's Moltres ex",
     "imageUrl": "https://images.pokemontcg.io/ex7/100.png",
     "subtype": "EX",
@@ -4881,7 +4981,8 @@
     "nationalPokedexNumber": 146
   },
   {
-    "id": "ex7-101",
+    "setOrder":22,
+	"id": "ex7-101",
     "name": "Rocket's Scizor ex",
     "imageUrl": "https://images.pokemontcg.io/ex7/101.png",
     "subtype": "EX",
@@ -4936,7 +5037,8 @@
     "nationalPokedexNumber": 212
   },
   {
-    "id": "ex7-102",
+    "setOrder":22,
+	"id": "ex7-102",
     "name": "Rocket's Scyther ex",
     "imageUrl": "https://images.pokemontcg.io/ex7/102.png",
     "subtype": "EX",
@@ -5002,7 +5104,8 @@
     ]
   },
   {
-    "id": "ex7-103",
+    "setOrder":22,
+	"id": "ex7-103",
     "name": "Rocket's Sneasel ex",
     "imageUrl": "https://images.pokemontcg.io/ex7/103.png",
     "subtype": "EX",
@@ -5063,7 +5166,8 @@
     ]
   },
   {
-    "id": "ex7-104",
+    "setOrder":22,
+	"id": "ex7-104",
     "name": "Rocket's Snorlax ex",
     "imageUrl": "https://images.pokemontcg.io/ex7/104.png",
     "subtype": "EX",
@@ -5124,7 +5228,8 @@
     "nationalPokedexNumber": 143
   },
   {
-    "id": "ex7-105",
+    "setOrder":22,
+	"id": "ex7-105",
     "name": "Rocket's Suicune ex",
     "imageUrl": "https://images.pokemontcg.io/ex7/105.png",
     "subtype": "EX",
@@ -5181,7 +5286,8 @@
     "nationalPokedexNumber": 245
   },
   {
-    "id": "ex7-106",
+    "setOrder":22,
+	"id": "ex7-106",
     "name": "Rocket's Zapdos ex",
     "imageUrl": "https://images.pokemontcg.io/ex7/106.png",
     "subtype": "EX",
@@ -5238,7 +5344,8 @@
     "nationalPokedexNumber": 145
   },
   {
-    "id": "ex7-107",
+    "setOrder":22,
+	"id": "ex7-107",
     "name": "Mudkip Star",
     "imageUrl": "https://images.pokemontcg.io/ex7/107.png",
     "subtype": "Basic",
@@ -5291,7 +5398,8 @@
     ]
   },
   {
-    "id": "ex7-108",
+    "setOrder":22,
+	"id": "ex7-108",
     "name": "Torchic Star",
     "imageUrl": "https://images.pokemontcg.io/ex7/108.png",
     "subtype": "Basic",
@@ -5344,7 +5452,8 @@
     ]
   },
   {
-    "id": "ex7-109",
+    "setOrder":22,
+	"id": "ex7-109",
     "name": "Treecko Star",
     "imageUrl": "https://images.pokemontcg.io/ex7/109.png",
     "subtype": "Basic",

--- a/json/cards/Team Rocket.json
+++ b/json/cards/Team Rocket.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "base5-1",
+    "setOrder":5,
+	"id": "base5-1",
     "name": "Dark Alakazam",
     "imageUrl": "https://images.pokemontcg.io/base5/1.png",
     "subtype": "Stage 2",
@@ -57,7 +58,8 @@
     "nationalPokedexNumber": 65
   },
   {
-    "id": "base5-2",
+    "setOrder":5,
+	"id": "base5-2",
     "name": "Dark Arbok",
     "imageUrl": "https://images.pokemontcg.io/base5/2.png",
     "subtype": "Stage 1",
@@ -112,7 +114,8 @@
     "nationalPokedexNumber": 24
   },
   {
-    "id": "base5-3",
+    "setOrder":5,
+	"id": "base5-3",
     "name": "Dark Blastoise",
     "imageUrl": "https://images.pokemontcg.io/base5/3.png",
     "subtype": "Stage 2",
@@ -167,7 +170,8 @@
     "nationalPokedexNumber": 9
   },
   {
-    "id": "base5-4",
+    "setOrder":5,
+	"id": "base5-4",
     "name": "Dark Charizard",
     "imageUrl": "https://images.pokemontcg.io/base5/4.png",
     "subtype": "Stage 2",
@@ -227,7 +231,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "base5-5",
+    "setOrder":5,
+	"id": "base5-5",
     "name": "Dark Dragonite",
     "imageUrl": "https://images.pokemontcg.io/base5/5.png",
     "subtype": "Stage 2",
@@ -278,7 +283,8 @@
     "nationalPokedexNumber": 149
   },
   {
-    "id": "base5-6",
+    "setOrder":5,
+	"id": "base5-6",
     "name": "Dark Dugtrio",
     "imageUrl": "https://images.pokemontcg.io/base5/6.png",
     "subtype": "Stage 1",
@@ -333,7 +339,8 @@
     "nationalPokedexNumber": 51
   },
   {
-    "id": "base5-7",
+    "setOrder":5,
+	"id": "base5-7",
     "name": "Dark Golbat",
     "imageUrl": "https://images.pokemontcg.io/base5/7.png",
     "subtype": "Stage 1",
@@ -387,7 +394,8 @@
     ]
   },
   {
-    "id": "base5-8",
+    "setOrder":5,
+	"id": "base5-8",
     "name": "Dark Gyarados",
     "imageUrl": "https://images.pokemontcg.io/base5/8.png",
     "subtype": "Stage 1",
@@ -443,7 +451,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "base5-9",
+    "setOrder":5,
+	"id": "base5-9",
     "name": "Dark Hypno",
     "imageUrl": "https://images.pokemontcg.io/base5/9.png",
     "subtype": "Stage 1",
@@ -497,7 +506,8 @@
     "nationalPokedexNumber": 97
   },
   {
-    "id": "base5-10",
+    "setOrder":5,
+	"id": "base5-10",
     "name": "Dark Machamp",
     "imageUrl": "https://images.pokemontcg.io/base5/10.png",
     "subtype": "Stage 2",
@@ -554,7 +564,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "base5-11",
+    "setOrder":5,
+	"id": "base5-11",
     "name": "Dark Magneton",
     "imageUrl": "https://images.pokemontcg.io/base5/11.png",
     "subtype": "Stage 1",
@@ -611,7 +622,8 @@
     ]
   },
   {
-    "id": "base5-12",
+    "setOrder":5,
+	"id": "base5-12",
     "name": "Dark Slowbro",
     "imageUrl": "https://images.pokemontcg.io/base5/12.png",
     "subtype": "Stage 1",
@@ -660,7 +672,8 @@
     "nationalPokedexNumber": 80
   },
   {
-    "id": "base5-13",
+    "setOrder":5,
+	"id": "base5-13",
     "name": "Dark Vileplume",
     "imageUrl": "https://images.pokemontcg.io/base5/13.png",
     "subtype": "Stage 2",
@@ -710,7 +723,8 @@
     "nationalPokedexNumber": 45
   },
   {
-    "id": "base5-14",
+    "setOrder":5,
+	"id": "base5-14",
     "name": "Dark Weezing",
     "imageUrl": "https://images.pokemontcg.io/base5/14.png",
     "subtype": "Stage 1",
@@ -764,7 +778,8 @@
     "nationalPokedexNumber": 110
   },
   {
-    "id": "base5-15",
+    "setOrder":5,
+	"id": "base5-15",
     "name": "Here Comes Team Rocket!",
     "imageUrl": "https://images.pokemontcg.io/base5/15.png",
     "subtype": "",
@@ -781,7 +796,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base5/15_hires.png"
   },
   {
-    "id": "base5-16",
+    "setOrder":5,
+	"id": "base5-16",
     "name": "Rocket's Sneak Attack",
     "imageUrl": "https://images.pokemontcg.io/base5/16.png",
     "subtype": "",
@@ -798,7 +814,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base5/16_hires.png"
   },
   {
-    "id": "base5-17",
+    "setOrder":5,
+	"id": "base5-17",
     "name": "Rainbow Energy",
     "imageUrl": "https://images.pokemontcg.io/base5/17.png",
     "subtype": "",
@@ -815,7 +832,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base5/17_hires.png"
   },
   {
-    "id": "base5-18",
+    "setOrder":5,
+	"id": "base5-18",
     "name": "Dark Alakazam",
     "imageUrl": "https://images.pokemontcg.io/base5/18.png",
     "subtype": "Stage 2",
@@ -872,7 +890,8 @@
     "nationalPokedexNumber": 65
   },
   {
-    "id": "base5-19",
+    "setOrder":5,
+	"id": "base5-19",
     "name": "Dark Arbok",
     "imageUrl": "https://images.pokemontcg.io/base5/19.png",
     "subtype": "Stage 1",
@@ -927,7 +946,8 @@
     "nationalPokedexNumber": 24
   },
   {
-    "id": "base5-20",
+    "setOrder":5,
+	"id": "base5-20",
     "name": "Dark Blastoise",
     "imageUrl": "https://images.pokemontcg.io/base5/20.png",
     "subtype": "Stage 2",
@@ -982,7 +1002,8 @@
     "nationalPokedexNumber": 9
   },
   {
-    "id": "base5-21",
+    "setOrder":5,
+	"id": "base5-21",
     "name": "Dark Charizard",
     "imageUrl": "https://images.pokemontcg.io/base5/21.png",
     "subtype": "Stage 2",
@@ -1042,7 +1063,8 @@
     "nationalPokedexNumber": 6
   },
   {
-    "id": "base5-22",
+    "setOrder":5,
+	"id": "base5-22",
     "name": "Dark Dragonite",
     "imageUrl": "https://images.pokemontcg.io/base5/22.png",
     "subtype": "Stage 2",
@@ -1093,7 +1115,8 @@
     "nationalPokedexNumber": 149
   },
   {
-    "id": "base5-23",
+    "setOrder":5,
+	"id": "base5-23",
     "name": "Dark Dugtrio",
     "imageUrl": "https://images.pokemontcg.io/base5/23.png",
     "subtype": "Stage 1",
@@ -1148,7 +1171,8 @@
     "nationalPokedexNumber": 51
   },
   {
-    "id": "base5-24",
+    "setOrder":5,
+	"id": "base5-24",
     "name": "Dark Golbat",
     "imageUrl": "https://images.pokemontcg.io/base5/24.png",
     "subtype": "Stage 1",
@@ -1202,7 +1226,8 @@
     ]
   },
   {
-    "id": "base5-25",
+    "setOrder":5,
+	"id": "base5-25",
     "name": "Dark Gyarados",
     "imageUrl": "https://images.pokemontcg.io/base5/25.png",
     "subtype": "Stage 1",
@@ -1258,7 +1283,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "base5-26",
+    "setOrder":5,
+	"id": "base5-26",
     "name": "Dark Hypno",
     "imageUrl": "https://images.pokemontcg.io/base5/26.png",
     "subtype": "Stage 1",
@@ -1312,7 +1338,8 @@
     "nationalPokedexNumber": 97
   },
   {
-    "id": "base5-27",
+    "setOrder":5,
+	"id": "base5-27",
     "name": "Dark Machamp",
     "imageUrl": "https://images.pokemontcg.io/base5/27.png",
     "subtype": "Stage 2",
@@ -1369,7 +1396,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "base5-28",
+    "setOrder":5,
+	"id": "base5-28",
     "name": "Dark Magneton",
     "imageUrl": "https://images.pokemontcg.io/base5/28.png",
     "subtype": "Stage 1",
@@ -1426,7 +1454,8 @@
     ]
   },
   {
-    "id": "base5-29",
+    "setOrder":5,
+	"id": "base5-29",
     "name": "Dark Slowbro",
     "imageUrl": "https://images.pokemontcg.io/base5/29.png",
     "subtype": "Stage 1",
@@ -1475,7 +1504,8 @@
     "nationalPokedexNumber": 80
   },
   {
-    "id": "base5-30",
+    "setOrder":5,
+	"id": "base5-30",
     "name": "Dark Vileplume",
     "imageUrl": "https://images.pokemontcg.io/base5/30.png",
     "subtype": "Stage 2",
@@ -1525,7 +1555,8 @@
     "nationalPokedexNumber": 45
   },
   {
-    "id": "base5-31",
+    "setOrder":5,
+	"id": "base5-31",
     "name": "Dark Weezing",
     "imageUrl": "https://images.pokemontcg.io/base5/31.png",
     "subtype": "Stage 1",
@@ -1579,7 +1610,8 @@
     "nationalPokedexNumber": 110
   },
   {
-    "id": "base5-32",
+    "setOrder":5,
+	"id": "base5-32",
     "name": "Dark Charmeleon",
     "imageUrl": "https://images.pokemontcg.io/base5/32.png",
     "subtype": "Stage 1",
@@ -1637,7 +1669,8 @@
     ]
   },
   {
-    "id": "base5-33",
+    "setOrder":5,
+	"id": "base5-33",
     "name": "Dark Dragonair",
     "imageUrl": "https://images.pokemontcg.io/base5/33.png",
     "subtype": "Stage 1",
@@ -1690,7 +1723,8 @@
     ]
   },
   {
-    "id": "base5-34",
+    "setOrder":5,
+	"id": "base5-34",
     "name": "Dark Electrode",
     "imageUrl": "https://images.pokemontcg.io/base5/34.png",
     "subtype": "Stage 1",
@@ -1742,7 +1776,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "base5-35",
+    "setOrder":5,
+	"id": "base5-35",
     "name": "Dark Flareon",
     "imageUrl": "https://images.pokemontcg.io/base5/35.png",
     "subtype": "Stage 1",
@@ -1794,7 +1829,8 @@
     "nationalPokedexNumber": 136
   },
   {
-    "id": "base5-36",
+    "setOrder":5,
+	"id": "base5-36",
     "name": "Dark Gloom",
     "imageUrl": "https://images.pokemontcg.io/base5/36.png",
     "subtype": "Stage 1",
@@ -1847,7 +1883,8 @@
     ]
   },
   {
-    "id": "base5-37",
+    "setOrder":5,
+	"id": "base5-37",
     "name": "Dark Golduck",
     "imageUrl": "https://images.pokemontcg.io/base5/37.png",
     "subtype": "Stage 1",
@@ -1901,7 +1938,8 @@
     "nationalPokedexNumber": 55
   },
   {
-    "id": "base5-38",
+    "setOrder":5,
+	"id": "base5-38",
     "name": "Dark Jolteon",
     "imageUrl": "https://images.pokemontcg.io/base5/38.png",
     "subtype": "Stage 1",
@@ -1954,7 +1992,8 @@
     "nationalPokedexNumber": 135
   },
   {
-    "id": "base5-39",
+    "setOrder":5,
+	"id": "base5-39",
     "name": "Dark Kadabra",
     "imageUrl": "https://images.pokemontcg.io/base5/39.png",
     "subtype": "Stage 1",
@@ -2006,7 +2045,8 @@
     ]
   },
   {
-    "id": "base5-40",
+    "setOrder":5,
+	"id": "base5-40",
     "name": "Dark Machoke",
     "imageUrl": "https://images.pokemontcg.io/base5/40.png",
     "subtype": "Stage 1",
@@ -2065,7 +2105,8 @@
     ]
   },
   {
-    "id": "base5-41",
+    "setOrder":5,
+	"id": "base5-41",
     "name": "Dark Muk",
     "imageUrl": "https://images.pokemontcg.io/base5/41.png",
     "subtype": "Stage 1",
@@ -2114,7 +2155,8 @@
     "nationalPokedexNumber": 89
   },
   {
-    "id": "base5-42",
+    "setOrder":5,
+	"id": "base5-42",
     "name": "Dark Persian",
     "imageUrl": "https://images.pokemontcg.io/base5/42.png",
     "subtype": "Stage 1",
@@ -2169,7 +2211,8 @@
     "nationalPokedexNumber": 53
   },
   {
-    "id": "base5-43",
+    "setOrder":5,
+	"id": "base5-43",
     "name": "Dark Primeape",
     "imageUrl": "https://images.pokemontcg.io/base5/43.png",
     "subtype": "Stage 1",
@@ -2217,7 +2260,8 @@
     "nationalPokedexNumber": 57
   },
   {
-    "id": "base5-44",
+    "setOrder":5,
+	"id": "base5-44",
     "name": "Dark Rapidash",
     "imageUrl": "https://images.pokemontcg.io/base5/44.png",
     "subtype": "Stage 1",
@@ -2267,7 +2311,8 @@
     "nationalPokedexNumber": 78
   },
   {
-    "id": "base5-45",
+    "setOrder":5,
+	"id": "base5-45",
     "name": "Dark Vaporeon",
     "imageUrl": "https://images.pokemontcg.io/base5/45.png",
     "subtype": "Stage 1",
@@ -2322,7 +2367,8 @@
     "nationalPokedexNumber": 134
   },
   {
-    "id": "base5-46",
+    "setOrder":5,
+	"id": "base5-46",
     "name": "Dark Wartortle",
     "imageUrl": "https://images.pokemontcg.io/base5/46.png",
     "subtype": "Stage 1",
@@ -2377,7 +2423,8 @@
     ]
   },
   {
-    "id": "base5-47",
+    "setOrder":5,
+	"id": "base5-47",
     "name": "Magikarp",
     "imageUrl": "https://images.pokemontcg.io/base5/47.png",
     "subtype": "Basic",
@@ -2432,7 +2479,8 @@
     ]
   },
   {
-    "id": "base5-48",
+    "setOrder":5,
+	"id": "base5-48",
     "name": "Porygon",
     "imageUrl": "https://images.pokemontcg.io/base5/48.png",
     "subtype": "Basic",
@@ -2490,7 +2538,8 @@
     ]
   },
   {
-    "id": "base5-49",
+    "setOrder":5,
+	"id": "base5-49",
     "name": "Abra",
     "imageUrl": "https://images.pokemontcg.io/base5/49.png",
     "subtype": "Basic",
@@ -2543,7 +2592,8 @@
     ]
   },
   {
-    "id": "base5-50",
+    "setOrder":5,
+	"id": "base5-50",
     "name": "Charmander",
     "imageUrl": "https://images.pokemontcg.io/base5/50.png",
     "subtype": "Basic",
@@ -2592,7 +2642,8 @@
     ]
   },
   {
-    "id": "base5-51",
+    "setOrder":5,
+	"id": "base5-51",
     "name": "Dark Raticate",
     "imageUrl": "https://images.pokemontcg.io/base5/51.png",
     "subtype": "Stage 1",
@@ -2652,7 +2703,8 @@
     "nationalPokedexNumber": 20
   },
   {
-    "id": "base5-52",
+    "setOrder":5,
+	"id": "base5-52",
     "name": "Diglett",
     "imageUrl": "https://images.pokemontcg.io/base5/52.png",
     "subtype": "Basic",
@@ -2709,7 +2761,8 @@
     ]
   },
   {
-    "id": "base5-53",
+    "setOrder":5,
+	"id": "base5-53",
     "name": "Dratini",
     "imageUrl": "https://images.pokemontcg.io/base5/53.png",
     "subtype": "Basic",
@@ -2754,7 +2807,8 @@
     ]
   },
   {
-    "id": "base5-54",
+    "setOrder":5,
+	"id": "base5-54",
     "name": "Drowzee",
     "imageUrl": "https://images.pokemontcg.io/base5/54.png",
     "subtype": "Basic",
@@ -2804,7 +2858,8 @@
     ]
   },
   {
-    "id": "base5-55",
+    "setOrder":5,
+	"id": "base5-55",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/base5/55.png",
     "subtype": "Basic",
@@ -2871,7 +2926,8 @@
     ]
   },
   {
-    "id": "base5-56",
+    "setOrder":5,
+	"id": "base5-56",
     "name": "Ekans",
     "imageUrl": "https://images.pokemontcg.io/base5/56.png",
     "subtype": "Basic",
@@ -2925,7 +2981,8 @@
     ]
   },
   {
-    "id": "base5-57",
+    "setOrder":5,
+	"id": "base5-57",
     "name": "Grimer",
     "imageUrl": "https://images.pokemontcg.io/base5/57.png",
     "subtype": "Basic",
@@ -2979,7 +3036,8 @@
     ]
   },
   {
-    "id": "base5-58",
+    "setOrder":5,
+	"id": "base5-58",
     "name": "Koffing",
     "imageUrl": "https://images.pokemontcg.io/base5/58.png",
     "subtype": "Basic",
@@ -3033,7 +3091,8 @@
     ]
   },
   {
-    "id": "base5-59",
+    "setOrder":5,
+	"id": "base5-59",
     "name": "Machop",
     "imageUrl": "https://images.pokemontcg.io/base5/59.png",
     "subtype": "Basic",
@@ -3089,7 +3148,8 @@
     ]
   },
   {
-    "id": "base5-60",
+    "setOrder":5,
+	"id": "base5-60",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/base5/60.png",
     "subtype": "Basic",
@@ -3144,7 +3204,8 @@
     ]
   },
   {
-    "id": "base5-61",
+    "setOrder":5,
+	"id": "base5-61",
     "name": "Mankey",
     "imageUrl": "https://images.pokemontcg.io/base5/61.png",
     "subtype": "Basic",
@@ -3195,7 +3256,8 @@
     ]
   },
   {
-    "id": "base5-62",
+    "setOrder":5,
+	"id": "base5-62",
     "name": "Meowth",
     "imageUrl": "https://images.pokemontcg.io/base5/62.png",
     "subtype": "Basic",
@@ -3246,7 +3308,8 @@
     ]
   },
   {
-    "id": "base5-63",
+    "setOrder":5,
+	"id": "base5-63",
     "name": "Oddish",
     "imageUrl": "https://images.pokemontcg.io/base5/63.png",
     "subtype": "Basic",
@@ -3299,7 +3362,8 @@
     ]
   },
   {
-    "id": "base5-64",
+    "setOrder":5,
+	"id": "base5-64",
     "name": "Ponyta",
     "imageUrl": "https://images.pokemontcg.io/base5/64.png",
     "subtype": "Basic",
@@ -3344,7 +3408,8 @@
     ]
   },
   {
-    "id": "base5-65",
+    "setOrder":5,
+	"id": "base5-65",
     "name": "Psyduck",
     "imageUrl": "https://images.pokemontcg.io/base5/65.png",
     "subtype": "Basic",
@@ -3398,7 +3463,8 @@
     ]
   },
   {
-    "id": "base5-66",
+    "setOrder":5,
+	"id": "base5-66",
     "name": "Rattata",
     "imageUrl": "https://images.pokemontcg.io/base5/66.png",
     "subtype": "Basic",
@@ -3450,7 +3516,8 @@
     ]
   },
   {
-    "id": "base5-67",
+    "setOrder":5,
+	"id": "base5-67",
     "name": "Slowpoke",
     "imageUrl": "https://images.pokemontcg.io/base5/67.png",
     "subtype": "Basic",
@@ -3504,7 +3571,8 @@
     ]
   },
   {
-    "id": "base5-68",
+    "setOrder":5,
+	"id": "base5-68",
     "name": "Squirtle",
     "imageUrl": "https://images.pokemontcg.io/base5/68.png",
     "subtype": "Basic",
@@ -3549,7 +3617,8 @@
     ]
   },
   {
-    "id": "base5-69",
+    "setOrder":5,
+	"id": "base5-69",
     "name": "Voltorb",
     "imageUrl": "https://images.pokemontcg.io/base5/69.png",
     "subtype": "Basic",
@@ -3593,7 +3662,8 @@
     ]
   },
   {
-    "id": "base5-70",
+    "setOrder":5,
+	"id": "base5-70",
     "name": "Zubat",
     "imageUrl": "https://images.pokemontcg.io/base5/70.png",
     "subtype": "Basic",
@@ -3650,7 +3720,8 @@
     ]
   },
   {
-    "id": "base5-71",
+    "setOrder":5,
+	"id": "base5-71",
     "name": "Here Comes Team Rocket!",
     "imageUrl": "https://images.pokemontcg.io/base5/71.png",
     "subtype": "",
@@ -3667,7 +3738,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base5/71_hires.png"
   },
   {
-    "id": "base5-72",
+    "setOrder":5,
+	"id": "base5-72",
     "name": "Rocket's Sneak Attack",
     "imageUrl": "https://images.pokemontcg.io/base5/72.png",
     "subtype": "",
@@ -3684,7 +3756,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base5/72_hires.png"
   },
   {
-    "id": "base5-73",
+    "setOrder":5,
+	"id": "base5-73",
     "name": "The Boss's Way",
     "imageUrl": "https://images.pokemontcg.io/base5/73.png",
     "subtype": "",
@@ -3701,7 +3774,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base5/73_hires.png"
   },
   {
-    "id": "base5-74",
+    "setOrder":5,
+	"id": "base5-74",
     "name": "Challenge!",
     "imageUrl": "https://images.pokemontcg.io/base5/74.png",
     "subtype": "",
@@ -3718,7 +3792,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base5/74_hires.png"
   },
   {
-    "id": "base5-75",
+    "setOrder":5,
+	"id": "base5-75",
     "name": "Digger",
     "imageUrl": "https://images.pokemontcg.io/base5/75.png",
     "subtype": "",
@@ -3735,7 +3810,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base5/75_hires.png"
   },
   {
-    "id": "base5-76",
+    "setOrder":5,
+	"id": "base5-76",
     "name": "Imposter Oak's Revenge",
     "imageUrl": "https://images.pokemontcg.io/base5/76.png",
     "subtype": "",
@@ -3752,7 +3828,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base5/76_hires.png"
   },
   {
-    "id": "base5-77",
+    "setOrder":5,
+	"id": "base5-77",
     "name": "Nightly Garbage Run",
     "imageUrl": "https://images.pokemontcg.io/base5/77.png",
     "subtype": "",
@@ -3769,7 +3846,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base5/77_hires.png"
   },
   {
-    "id": "base5-78",
+    "setOrder":5,
+	"id": "base5-78",
     "name": "Goop Gas Attack",
     "imageUrl": "https://images.pokemontcg.io/base5/78.png",
     "subtype": "",
@@ -3786,7 +3864,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base5/78_hires.png"
   },
   {
-    "id": "base5-79",
+    "setOrder":5,
+	"id": "base5-79",
     "name": "Sleep!",
     "imageUrl": "https://images.pokemontcg.io/base5/79.png",
     "subtype": "",
@@ -3803,7 +3882,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base5/79_hires.png"
   },
   {
-    "id": "base5-80",
+    "setOrder":5,
+	"id": "base5-80",
     "name": "Rainbow Energy",
     "imageUrl": "https://images.pokemontcg.io/base5/80.png",
     "subtype": "Special",
@@ -3820,7 +3900,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base5/80_hires.png"
   },
   {
-    "id": "base5-81",
+    "setOrder":5,
+	"id": "base5-81",
     "name": "Full Heal Energy",
     "imageUrl": "https://images.pokemontcg.io/base5/81.png",
     "subtype": "Special",
@@ -3837,7 +3918,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base5/81_hires.png"
   },
   {
-    "id": "base5-82",
+    "setOrder":5,
+	"id": "base5-82",
     "name": "Potion Energy",
     "imageUrl": "https://images.pokemontcg.io/base5/82.png",
     "subtype": "Special",
@@ -3854,7 +3936,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/base5/82_hires.png"
   },
   {
-    "id": "base5-83",
+    "setOrder":5,
+	"id": "base5-83",
     "name": "Dark Raichu",
     "imageUrl": "https://images.pokemontcg.io/base5/83.png",
     "subtype": "Stage 1",

--- a/json/cards/Ultra Prism.json
+++ b/json/cards/Ultra Prism.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "sm5-1",
+    "setOrder":77,
+	"id": "sm5-1",
     "name": "Exeggcute",
     "imageUrl": "https://images.pokemontcg.io/sm5/1.png",
     "subtype": "Basic",
@@ -43,7 +44,8 @@
     ]
   },
   {
-    "id": "sm5-2",
+    "setOrder":77,
+	"id": "sm5-2",
     "name": "Yanma",
     "imageUrl": "https://images.pokemontcg.io/sm5/2.png",
     "subtype": "Basic",
@@ -93,7 +95,8 @@
     ]
   },
   {
-    "id": "sm5-3",
+    "setOrder":77,
+	"id": "sm5-3",
     "name": "Yanmega",
     "imageUrl": "https://images.pokemontcg.io/sm5/3.png",
     "subtype": "Stage 1",
@@ -152,7 +155,8 @@
     "nationalPokedexNumber": 469
   },
   {
-    "id": "sm5-4",
+    "setOrder":77,
+	"id": "sm5-4",
     "name": "Roselia",
     "imageUrl": "https://images.pokemontcg.io/sm5/4.png",
     "subtype": "Basic",
@@ -196,7 +200,8 @@
     ]
   },
   {
-    "id": "sm5-5",
+    "setOrder":77,
+	"id": "sm5-5",
     "name": "Roserade",
     "imageUrl": "https://images.pokemontcg.io/sm5/5.png",
     "subtype": "Stage 1",
@@ -248,7 +253,8 @@
     "nationalPokedexNumber": 407
   },
   {
-    "id": "sm5-6",
+    "setOrder":77,
+	"id": "sm5-6",
     "name": "Turtwig",
     "imageUrl": "https://images.pokemontcg.io/sm5/6.png",
     "subtype": "Basic",
@@ -302,7 +308,8 @@
     ]
   },
   {
-    "id": "sm5-7",
+    "setOrder":77,
+	"id": "sm5-7",
     "name": "Turtwig",
     "imageUrl": "https://images.pokemontcg.io/sm5/7.png",
     "subtype": "Basic",
@@ -358,7 +365,8 @@
     ]
   },
   {
-    "id": "sm5-8",
+    "setOrder":77,
+	"id": "sm5-8",
     "name": "Grotle",
     "imageUrl": "https://images.pokemontcg.io/sm5/8.png",
     "subtype": "Stage 1",
@@ -418,7 +426,8 @@
     ]
   },
   {
-    "id": "sm5-9",
+    "setOrder":77,
+	"id": "sm5-9",
     "name": "Torterra",
     "imageUrl": "https://images.pokemontcg.io/sm5/9.png",
     "subtype": "Stage 2",
@@ -476,7 +485,8 @@
     "nationalPokedexNumber": 389
   },
   {
-    "id": "sm5-10",
+    "setOrder":77,
+	"id": "sm5-10",
     "name": "Cherubi",
     "imageUrl": "https://images.pokemontcg.io/sm5/10.png",
     "subtype": "Basic",
@@ -519,7 +529,8 @@
     ]
   },
   {
-    "id": "sm5-11",
+    "setOrder":77,
+	"id": "sm5-11",
     "name": "Cherrim",
     "imageUrl": "https://images.pokemontcg.io/sm5/11.png",
     "subtype": "Stage 1",
@@ -565,7 +576,8 @@
     "nationalPokedexNumber": 421
   },
   {
-    "id": "sm5-12",
+    "setOrder":77,
+	"id": "sm5-12",
     "name": "Carnivine",
     "imageUrl": "https://images.pokemontcg.io/sm5/12.png",
     "subtype": "Basic",
@@ -616,7 +628,8 @@
     "nationalPokedexNumber": 455
   },
   {
-    "id": "sm5-13",
+    "setOrder":77,
+	"id": "sm5-13",
     "name": "Leafeon-GX",
     "imageUrl": "https://images.pokemontcg.io/sm5/13.png",
     "subtype": "GX",
@@ -678,7 +691,8 @@
     "nationalPokedexNumber": 470
   },
   {
-    "id": "sm5-14",
+    "setOrder":77,
+	"id": "sm5-14",
     "name": "Mow Rotom",
     "imageUrl": "https://images.pokemontcg.io/sm5/14.png",
     "subtype": "Basic",
@@ -725,7 +739,8 @@
     "nationalPokedexNumber": 479
   },
   {
-    "id": "sm5-15",
+    "setOrder":77,
+	"id": "sm5-15",
     "name": "Shaymin",
     "imageUrl": "https://images.pokemontcg.io/sm5/15.png",
     "subtype": "Basic",
@@ -775,7 +790,8 @@
     "nationalPokedexNumber": 492
   },
   {
-    "id": "sm5-16",
+    "setOrder":77,
+	"id": "sm5-16",
     "name": "Dewpider",
     "imageUrl": "https://images.pokemontcg.io/sm5/16.png",
     "subtype": "Basic",
@@ -818,7 +834,8 @@
     ]
   },
   {
-    "id": "sm5-17",
+    "setOrder":77,
+	"id": "sm5-17",
     "name": "Araquanid",
     "imageUrl": "https://images.pokemontcg.io/sm5/17.png",
     "subtype": "Stage 1",
@@ -867,7 +884,8 @@
     "nationalPokedexNumber": 752
   },
   {
-    "id": "sm5-18",
+    "setOrder":77,
+	"id": "sm5-18",
     "name": "Magmar",
     "imageUrl": "https://images.pokemontcg.io/sm5/18.png",
     "subtype": "Basic",
@@ -922,7 +940,8 @@
     ]
   },
   {
-    "id": "sm5-19",
+    "setOrder":77,
+	"id": "sm5-19",
     "name": "Magmortar",
     "imageUrl": "https://images.pokemontcg.io/sm5/19.png",
     "subtype": "Stage 1",
@@ -972,7 +991,8 @@
     "nationalPokedexNumber": 467
   },
   {
-    "id": "sm5-20",
+    "setOrder":77,
+	"id": "sm5-20",
     "name": "Chimchar",
     "imageUrl": "https://images.pokemontcg.io/sm5/20.png",
     "subtype": "Basic",
@@ -1012,7 +1032,8 @@
     ]
   },
   {
-    "id": "sm5-21",
+    "setOrder":77,
+	"id": "sm5-21",
     "name": "Chimchar",
     "imageUrl": "https://images.pokemontcg.io/sm5/21.png",
     "subtype": "Basic",
@@ -1055,7 +1076,8 @@
     ]
   },
   {
-    "id": "sm5-22",
+    "setOrder":77,
+	"id": "sm5-22",
     "name": "Monferno",
     "imageUrl": "https://images.pokemontcg.io/sm5/22.png",
     "subtype": "Stage 1",
@@ -1099,7 +1121,8 @@
     ]
   },
   {
-    "id": "sm5-23",
+    "setOrder":77,
+	"id": "sm5-23",
     "name": "Infernape",
     "imageUrl": "https://images.pokemontcg.io/sm5/23.png",
     "subtype": "Stage 2",
@@ -1146,7 +1169,8 @@
     "nationalPokedexNumber": 392
   },
   {
-    "id": "sm5-24",
+    "setOrder":77,
+	"id": "sm5-24",
     "name": "Heat Rotom",
     "imageUrl": "https://images.pokemontcg.io/sm5/24.png",
     "subtype": "Basic",
@@ -1193,7 +1217,8 @@
     "nationalPokedexNumber": 479
   },
   {
-    "id": "sm5-25",
+    "setOrder":77,
+	"id": "sm5-25",
     "name": "Salandit",
     "imageUrl": "https://images.pokemontcg.io/sm5/25.png",
     "subtype": "Basic",
@@ -1246,7 +1271,8 @@
     ]
   },
   {
-    "id": "sm5-26",
+    "setOrder":77,
+	"id": "sm5-26",
     "name": "Salazzle",
     "imageUrl": "https://images.pokemontcg.io/sm5/26.png",
     "subtype": "Stage 1",
@@ -1297,7 +1323,8 @@
     "nationalPokedexNumber": 758
   },
   {
-    "id": "sm5-27",
+    "setOrder":77,
+	"id": "sm5-27",
     "name": "Turtonator",
     "imageUrl": "https://images.pokemontcg.io/sm5/27.png",
     "subtype": "Basic",
@@ -1352,7 +1379,8 @@
     "nationalPokedexNumber": 776
   },
   {
-    "id": "sm5-28",
+    "setOrder":77,
+	"id": "sm5-28",
     "name": "Alolan Sandshrew",
     "imageUrl": "https://images.pokemontcg.io/sm5/28.png",
     "subtype": "Basic",
@@ -1395,7 +1423,8 @@
     ]
   },
   {
-    "id": "sm5-29",
+    "setOrder":77,
+	"id": "sm5-29",
     "name": "Alolan Sandslash",
     "imageUrl": "https://images.pokemontcg.io/sm5/29.png",
     "subtype": "Stage 1",
@@ -1447,7 +1476,8 @@
     "nationalPokedexNumber": 28
   },
   {
-    "id": "sm5-30",
+    "setOrder":77,
+	"id": "sm5-30",
     "name": "Alolan Vulpix",
     "imageUrl": "https://images.pokemontcg.io/sm5/30.png",
     "subtype": "Basic",
@@ -1499,7 +1529,8 @@
     ]
   },
   {
-    "id": "sm5-31",
+    "setOrder":77,
+	"id": "sm5-31",
     "name": "Piplup",
     "imageUrl": "https://images.pokemontcg.io/sm5/31.png",
     "subtype": "Basic",
@@ -1542,7 +1573,8 @@
     ]
   },
   {
-    "id": "sm5-32",
+    "setOrder":77,
+	"id": "sm5-32",
     "name": "Piplup",
     "imageUrl": "https://images.pokemontcg.io/sm5/32.png",
     "subtype": "Basic",
@@ -1595,7 +1627,8 @@
     ]
   },
   {
-    "id": "sm5-33",
+    "setOrder":77,
+	"id": "sm5-33",
     "name": "Prinplup",
     "imageUrl": "https://images.pokemontcg.io/sm5/33.png",
     "subtype": "Stage 1",
@@ -1650,7 +1683,8 @@
     ]
   },
   {
-    "id": "sm5-34",
+    "setOrder":77,
+	"id": "sm5-34",
     "name": "Empoleon",
     "imageUrl": "https://images.pokemontcg.io/sm5/34.png",
     "subtype": "Stage 2",
@@ -1704,7 +1738,8 @@
     "nationalPokedexNumber": 395
   },
   {
-    "id": "sm5-35",
+    "setOrder":77,
+	"id": "sm5-35",
     "name": "Buizel",
     "imageUrl": "https://images.pokemontcg.io/sm5/35.png",
     "subtype": "Basic",
@@ -1748,7 +1783,8 @@
     ]
   },
   {
-    "id": "sm5-36",
+    "setOrder":77,
+	"id": "sm5-36",
     "name": "Floatzel",
     "imageUrl": "https://images.pokemontcg.io/sm5/36.png",
     "subtype": "Stage 1",
@@ -1799,7 +1835,8 @@
     "nationalPokedexNumber": 419
   },
   {
-    "id": "sm5-37",
+    "setOrder":77,
+	"id": "sm5-37",
     "name": "Snover",
     "imageUrl": "https://images.pokemontcg.io/sm5/37.png",
     "subtype": "Basic",
@@ -1845,7 +1882,8 @@
     ]
   },
   {
-    "id": "sm5-38",
+    "setOrder":77,
+	"id": "sm5-38",
     "name": "Abomasnow",
     "imageUrl": "https://images.pokemontcg.io/sm5/38.png",
     "subtype": "Stage 1",
@@ -1896,7 +1934,8 @@
     "nationalPokedexNumber": 460
   },
   {
-    "id": "sm5-39",
+    "setOrder":77,
+	"id": "sm5-39",
     "name": "Glaceon-GX",
     "imageUrl": "https://images.pokemontcg.io/sm5/39.png",
     "subtype": "GX",
@@ -1960,7 +1999,8 @@
     "nationalPokedexNumber": 471
   },
   {
-    "id": "sm5-40",
+    "setOrder":77,
+	"id": "sm5-40",
     "name": "Wash Rotom",
     "imageUrl": "https://images.pokemontcg.io/sm5/40.png",
     "subtype": "Basic",
@@ -2007,7 +2047,8 @@
     "nationalPokedexNumber": 479
   },
   {
-    "id": "sm5-41",
+    "setOrder":77,
+	"id": "sm5-41",
     "name": "Frost Rotom",
     "imageUrl": "https://images.pokemontcg.io/sm5/41.png",
     "subtype": "Basic",
@@ -2053,7 +2094,8 @@
     "nationalPokedexNumber": 479
   },
   {
-    "id": "sm5-42",
+    "setOrder":77,
+	"id": "sm5-42",
     "name": "Manaphy",
     "imageUrl": "https://images.pokemontcg.io/sm5/42.png",
     "subtype": "Basic",
@@ -2102,7 +2144,8 @@
     "nationalPokedexNumber": 490
   },
   {
-    "id": "sm5-43",
+    "setOrder":77,
+	"id": "sm5-43",
     "name": "Electabuzz",
     "imageUrl": "https://images.pokemontcg.io/sm5/43.png",
     "subtype": "Basic",
@@ -2164,7 +2207,8 @@
     ]
   },
   {
-    "id": "sm5-44",
+    "setOrder":77,
+	"id": "sm5-44",
     "name": "Electivire",
     "imageUrl": "https://images.pokemontcg.io/sm5/44.png",
     "subtype": "Stage 1",
@@ -2228,7 +2272,8 @@
     "nationalPokedexNumber": 466
   },
   {
-    "id": "sm5-45",
+    "setOrder":77,
+	"id": "sm5-45",
     "name": "Shinx",
     "imageUrl": "https://images.pokemontcg.io/sm5/45.png",
     "subtype": "Basic",
@@ -2282,7 +2327,8 @@
     ]
   },
   {
-    "id": "sm5-46",
+    "setOrder":77,
+	"id": "sm5-46",
     "name": "Shinx",
     "imageUrl": "https://images.pokemontcg.io/sm5/46.png",
     "subtype": "Basic",
@@ -2331,7 +2377,8 @@
     ]
   },
   {
-    "id": "sm5-47",
+    "setOrder":77,
+	"id": "sm5-47",
     "name": "Luxio",
     "imageUrl": "https://images.pokemontcg.io/sm5/47.png",
     "subtype": "Stage 1",
@@ -2381,7 +2428,8 @@
     ]
   },
   {
-    "id": "sm5-48",
+    "setOrder":77,
+	"id": "sm5-48",
     "name": "Luxray",
     "imageUrl": "https://images.pokemontcg.io/sm5/48.png",
     "subtype": "Stage 2",
@@ -2432,7 +2480,8 @@
     "nationalPokedexNumber": 405
   },
   {
-    "id": "sm5-49",
+    "setOrder":77,
+	"id": "sm5-49",
     "name": "Pachirisu",
     "imageUrl": "https://images.pokemontcg.io/sm5/49.png",
     "subtype": "Basic",
@@ -2487,7 +2536,8 @@
     "nationalPokedexNumber": 417
   },
   {
-    "id": "sm5-50",
+    "setOrder":77,
+	"id": "sm5-50",
     "name": "Rotom",
     "imageUrl": "https://images.pokemontcg.io/sm5/50.png",
     "subtype": "Basic",
@@ -2540,7 +2590,8 @@
     "nationalPokedexNumber": 479
   },
   {
-    "id": "sm5-51",
+    "setOrder":77,
+	"id": "sm5-51",
     "name": "Drifloon",
     "imageUrl": "https://images.pokemontcg.io/sm5/51.png",
     "subtype": "Basic",
@@ -2598,7 +2649,8 @@
     ]
   },
   {
-    "id": "sm5-52",
+    "setOrder":77,
+	"id": "sm5-52",
     "name": "Drifblim",
     "imageUrl": "https://images.pokemontcg.io/sm5/52.png",
     "subtype": "Stage 1",
@@ -2657,7 +2709,8 @@
     "nationalPokedexNumber": 426
   },
   {
-    "id": "sm5-53",
+    "setOrder":77,
+	"id": "sm5-53",
     "name": "Spiritomb",
     "imageUrl": "https://images.pokemontcg.io/sm5/53.png",
     "subtype": "Basic",
@@ -2700,7 +2753,8 @@
     "nationalPokedexNumber": 442
   },
   {
-    "id": "sm5-54",
+    "setOrder":77,
+	"id": "sm5-54",
     "name": "Skorupi",
     "imageUrl": "https://images.pokemontcg.io/sm5/54.png",
     "subtype": "Basic",
@@ -2754,7 +2808,8 @@
     ]
   },
   {
-    "id": "sm5-55",
+    "setOrder":77,
+	"id": "sm5-55",
     "name": "Drapion",
     "imageUrl": "https://images.pokemontcg.io/sm5/55.png",
     "subtype": "Stage 1",
@@ -2800,7 +2855,8 @@
     "nationalPokedexNumber": 452
   },
   {
-    "id": "sm5-56",
+    "setOrder":77,
+	"id": "sm5-56",
     "name": "Croagunk",
     "imageUrl": "https://images.pokemontcg.io/sm5/56.png",
     "subtype": "Basic",
@@ -2843,7 +2899,8 @@
     ]
   },
   {
-    "id": "sm5-57",
+    "setOrder":77,
+	"id": "sm5-57",
     "name": "Toxicroak",
     "imageUrl": "https://images.pokemontcg.io/sm5/57.png",
     "subtype": "Stage 1",
@@ -2895,7 +2952,8 @@
     "nationalPokedexNumber": 454
   },
   {
-    "id": "sm5-58",
+    "setOrder":77,
+	"id": "sm5-58",
     "name": "Giratina ◇",
     "imageUrl": "https://images.pokemontcg.io/sm5/58.png",
     "subtype": "Basic",
@@ -2953,7 +3011,8 @@
     "nationalPokedexNumber": 487
   },
   {
-    "id": "sm5-59",
+    "setOrder":77,
+	"id": "sm5-59",
     "name": "Cresselia",
     "imageUrl": "https://images.pokemontcg.io/sm5/59.png",
     "subtype": "Basic",
@@ -3004,7 +3063,8 @@
     "nationalPokedexNumber": 488
   },
   {
-    "id": "sm5-60",
+    "setOrder":77,
+	"id": "sm5-60",
     "name": "Cosmog",
     "imageUrl": "https://images.pokemontcg.io/sm5/60.png",
     "subtype": "Basic",
@@ -3047,7 +3107,8 @@
     ]
   },
   {
-    "id": "sm5-61",
+    "setOrder":77,
+	"id": "sm5-61",
     "name": "Cosmoem",
     "imageUrl": "https://images.pokemontcg.io/sm5/61.png",
     "subtype": "Stage 1",
@@ -3094,7 +3155,8 @@
     ]
   },
   {
-    "id": "sm5-62",
+    "setOrder":77,
+	"id": "sm5-62",
     "name": "Lunala ◇",
     "imageUrl": "https://images.pokemontcg.io/sm5/62.png",
     "subtype": "Basic",
@@ -3157,7 +3219,8 @@
     "nationalPokedexNumber": 792
   },
   {
-    "id": "sm5-63",
+    "setOrder":77,
+	"id": "sm5-63",
     "name": "Dawn Wings Necrozma-GX",
     "imageUrl": "https://images.pokemontcg.io/sm5/63.png",
     "subtype": "GX",
@@ -3226,7 +3289,8 @@
     "nationalPokedexNumber": 800
   },
   {
-    "id": "sm5-64",
+    "setOrder":77,
+	"id": "sm5-64",
     "name": "Cranidos",
     "imageUrl": "https://images.pokemontcg.io/sm5/64.png",
     "subtype": "Stage 1",
@@ -3280,7 +3344,8 @@
     ]
   },
   {
-    "id": "sm5-65",
+    "setOrder":77,
+	"id": "sm5-65",
     "name": "Rampardos",
     "imageUrl": "https://images.pokemontcg.io/sm5/65.png",
     "subtype": "Stage 2",
@@ -3333,7 +3398,8 @@
     "nationalPokedexNumber": 409
   },
   {
-    "id": "sm5-66",
+    "setOrder":77,
+	"id": "sm5-66",
     "name": "Riolu",
     "imageUrl": "https://images.pokemontcg.io/sm5/66.png",
     "subtype": "Basic",
@@ -3385,7 +3451,8 @@
     ]
   },
   {
-    "id": "sm5-67",
+    "setOrder":77,
+	"id": "sm5-67",
     "name": "Lucario",
     "imageUrl": "https://images.pokemontcg.io/sm5/67.png",
     "subtype": "Stage 1",
@@ -3432,7 +3499,8 @@
     "nationalPokedexNumber": 448
   },
   {
-    "id": "sm5-68",
+    "setOrder":77,
+	"id": "sm5-68",
     "name": "Hippopotas",
     "imageUrl": "https://images.pokemontcg.io/sm5/68.png",
     "subtype": "Basic",
@@ -3479,7 +3547,8 @@
     ]
   },
   {
-    "id": "sm5-69",
+    "setOrder":77,
+	"id": "sm5-69",
     "name": "Hippowdon",
     "imageUrl": "https://images.pokemontcg.io/sm5/69.png",
     "subtype": "Stage 1",
@@ -3537,7 +3606,8 @@
     "nationalPokedexNumber": 450
   },
   {
-    "id": "sm5-70",
+    "setOrder":77,
+	"id": "sm5-70",
     "name": "Passimian",
     "imageUrl": "https://images.pokemontcg.io/sm5/70.png",
     "subtype": "Basic",
@@ -3583,7 +3653,8 @@
     "nationalPokedexNumber": 766
   },
   {
-    "id": "sm5-71",
+    "setOrder":77,
+	"id": "sm5-71",
     "name": "Murkrow",
     "imageUrl": "https://images.pokemontcg.io/sm5/71.png",
     "subtype": "Basic",
@@ -3632,7 +3703,8 @@
     ]
   },
   {
-    "id": "sm5-72",
+    "setOrder":77,
+	"id": "sm5-72",
     "name": "Honchkrow",
     "imageUrl": "https://images.pokemontcg.io/sm5/72.png",
     "subtype": "Stage 1",
@@ -3690,7 +3762,8 @@
     "nationalPokedexNumber": 430
   },
   {
-    "id": "sm5-73",
+    "setOrder":77,
+	"id": "sm5-73",
     "name": "Sneasel",
     "imageUrl": "https://images.pokemontcg.io/sm5/73.png",
     "subtype": "Basic",
@@ -3748,7 +3821,8 @@
     ]
   },
   {
-    "id": "sm5-74",
+    "setOrder":77,
+	"id": "sm5-74",
     "name": "Weavile",
     "imageUrl": "https://images.pokemontcg.io/sm5/74.png",
     "subtype": "Stage 1",
@@ -3804,7 +3878,8 @@
     "nationalPokedexNumber": 461
   },
   {
-    "id": "sm5-75",
+    "setOrder":77,
+	"id": "sm5-75",
     "name": "Stunky",
     "imageUrl": "https://images.pokemontcg.io/sm5/75.png",
     "subtype": "Basic",
@@ -3854,7 +3929,8 @@
     ]
   },
   {
-    "id": "sm5-76",
+    "setOrder":77,
+	"id": "sm5-76",
     "name": "Skuntank",
     "imageUrl": "https://images.pokemontcg.io/sm5/76.png",
     "subtype": "Stage 1",
@@ -3915,7 +3991,8 @@
     "nationalPokedexNumber": 435
   },
   {
-    "id": "sm5-77",
+    "setOrder":77,
+	"id": "sm5-77",
     "name": "Darkrai ◇",
     "imageUrl": "https://images.pokemontcg.io/sm5/77.png",
     "subtype": "Basic",
@@ -3973,7 +4050,8 @@
     "nationalPokedexNumber": 491
   },
   {
-    "id": "sm5-78",
+    "setOrder":77,
+	"id": "sm5-78",
     "name": "Alolan Diglett",
     "imageUrl": "https://images.pokemontcg.io/sm5/78.png",
     "subtype": "Basic",
@@ -4022,7 +4100,8 @@
     ]
   },
   {
-    "id": "sm5-79",
+    "setOrder":77,
+	"id": "sm5-79",
     "name": "Alolan Dugtrio",
     "imageUrl": "https://images.pokemontcg.io/sm5/79.png",
     "subtype": "Stage 1",
@@ -4069,7 +4148,8 @@
     "nationalPokedexNumber": 51
   },
   {
-    "id": "sm5-80",
+    "setOrder":77,
+	"id": "sm5-80",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/sm5/80.png",
     "subtype": "Basic",
@@ -4127,7 +4207,8 @@
     ]
   },
   {
-    "id": "sm5-81",
+    "setOrder":77,
+	"id": "sm5-81",
     "name": "Magnemite",
     "imageUrl": "https://images.pokemontcg.io/sm5/81.png",
     "subtype": "Basic",
@@ -4182,7 +4263,8 @@
     ]
   },
   {
-    "id": "sm5-82",
+    "setOrder":77,
+	"id": "sm5-82",
     "name": "Magneton",
     "imageUrl": "https://images.pokemontcg.io/sm5/82.png",
     "subtype": "Stage 1",
@@ -4244,7 +4326,8 @@
     ]
   },
   {
-    "id": "sm5-83",
+    "setOrder":77,
+	"id": "sm5-83",
     "name": "Magnezone",
     "imageUrl": "https://images.pokemontcg.io/sm5/83.png",
     "subtype": "Stage 2",
@@ -4300,7 +4383,8 @@
     "nationalPokedexNumber": 462
   },
   {
-    "id": "sm5-84",
+    "setOrder":77,
+	"id": "sm5-84",
     "name": "Shieldon",
     "imageUrl": "https://images.pokemontcg.io/sm5/84.png",
     "subtype": "Stage 1",
@@ -4363,7 +4447,8 @@
     ]
   },
   {
-    "id": "sm5-85",
+    "setOrder":77,
+	"id": "sm5-85",
     "name": "Bastiodon",
     "imageUrl": "https://images.pokemontcg.io/sm5/85.png",
     "subtype": "Stage 2",
@@ -4419,7 +4504,8 @@
     "nationalPokedexNumber": 411
   },
   {
-    "id": "sm5-86",
+    "setOrder":77,
+	"id": "sm5-86",
     "name": "Bronzor",
     "imageUrl": "https://images.pokemontcg.io/sm5/86.png",
     "subtype": "Basic",
@@ -4479,7 +4565,8 @@
     ]
   },
   {
-    "id": "sm5-87",
+    "setOrder":77,
+	"id": "sm5-87",
     "name": "Bronzong",
     "imageUrl": "https://images.pokemontcg.io/sm5/87.png",
     "subtype": "Stage 1",
@@ -4539,7 +4626,8 @@
     "nationalPokedexNumber": 437
   },
   {
-    "id": "sm5-88",
+    "setOrder":77,
+	"id": "sm5-88",
     "name": "Heatran",
     "imageUrl": "https://images.pokemontcg.io/sm5/88.png",
     "subtype": "Basic",
@@ -4599,7 +4687,8 @@
     "nationalPokedexNumber": 485
   },
   {
-    "id": "sm5-89",
+    "setOrder":77,
+	"id": "sm5-89",
     "name": "Solgaleo ◇",
     "imageUrl": "https://images.pokemontcg.io/sm5/89.png",
     "subtype": "Basic",
@@ -4662,7 +4751,8 @@
     "nationalPokedexNumber": 791
   },
   {
-    "id": "sm5-90",
+    "setOrder":77,
+	"id": "sm5-90",
     "name": "Dusk Mane Necrozma-GX",
     "imageUrl": "https://images.pokemontcg.io/sm5/90.png",
     "subtype": "GX",
@@ -4739,7 +4829,8 @@
     "nationalPokedexNumber": 800
   },
   {
-    "id": "sm5-91",
+    "setOrder":77,
+	"id": "sm5-91",
     "name": "Magearna",
     "imageUrl": "https://images.pokemontcg.io/sm5/91.png",
     "subtype": "Basic",
@@ -4792,7 +4883,8 @@
     "nationalPokedexNumber": 801
   },
   {
-    "id": "sm5-92",
+    "setOrder":77,
+	"id": "sm5-92",
     "name": "Morelull",
     "imageUrl": "https://images.pokemontcg.io/sm5/92.png",
     "subtype": "Basic",
@@ -4850,7 +4942,8 @@
     ]
   },
   {
-    "id": "sm5-93",
+    "setOrder":77,
+	"id": "sm5-93",
     "name": "Shiinotic",
     "imageUrl": "https://images.pokemontcg.io/sm5/93.png",
     "subtype": "Stage 1",
@@ -4904,7 +4997,8 @@
     "nationalPokedexNumber": 756
   },
   {
-    "id": "sm5-94",
+    "setOrder":77,
+	"id": "sm5-94",
     "name": "Tapu Lele",
     "imageUrl": "https://images.pokemontcg.io/sm5/94.png",
     "subtype": "Basic",
@@ -4959,7 +5053,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/94_hires.png"
   },
   {
-    "id": "sm5-95",
+    "setOrder":77,
+	"id": "sm5-95",
     "name": "Alolan Exeggutor",
     "imageUrl": "https://images.pokemontcg.io/sm5/95.png",
     "subtype": "Stage 1",
@@ -5013,7 +5108,8 @@
     "nationalPokedexNumber": 103
   },
   {
-    "id": "sm5-96",
+    "setOrder":77,
+	"id": "sm5-96",
     "name": "Gible",
     "imageUrl": "https://images.pokemontcg.io/sm5/96.png",
     "subtype": "Basic",
@@ -5056,7 +5152,8 @@
     ]
   },
   {
-    "id": "sm5-97",
+    "setOrder":77,
+	"id": "sm5-97",
     "name": "Gible",
     "imageUrl": "https://images.pokemontcg.io/sm5/97.png",
     "subtype": "Basic",
@@ -5105,7 +5202,8 @@
     ]
   },
   {
-    "id": "sm5-98",
+    "setOrder":77,
+	"id": "sm5-98",
     "name": "Gabite",
     "imageUrl": "https://images.pokemontcg.io/sm5/98.png",
     "subtype": "Stage 1",
@@ -5159,7 +5257,8 @@
     ]
   },
   {
-    "id": "sm5-99",
+    "setOrder":77,
+	"id": "sm5-99",
     "name": "Garchomp",
     "imageUrl": "https://images.pokemontcg.io/sm5/99.png",
     "subtype": "Stage 2",
@@ -5209,7 +5308,8 @@
     "nationalPokedexNumber": 445
   },
   {
-    "id": "sm5-100",
+    "setOrder":77,
+	"id": "sm5-100",
     "name": "Dialga-GX",
     "imageUrl": "https://images.pokemontcg.io/sm5/100.png",
     "subtype": "GX",
@@ -5279,7 +5379,8 @@
     "nationalPokedexNumber": 483
   },
   {
-    "id": "sm5-101",
+    "setOrder":77,
+	"id": "sm5-101",
     "name": "Palkia-GX",
     "imageUrl": "https://images.pokemontcg.io/sm5/101.png",
     "subtype": "GX",
@@ -5349,7 +5450,8 @@
     "nationalPokedexNumber": 484
   },
   {
-    "id": "sm5-102",
+    "setOrder":77,
+	"id": "sm5-102",
     "name": "Lickitung",
     "imageUrl": "https://images.pokemontcg.io/sm5/102.png",
     "subtype": "Basic",
@@ -5405,7 +5507,8 @@
     ]
   },
   {
-    "id": "sm5-103",
+    "setOrder":77,
+	"id": "sm5-103",
     "name": "Lickilicky",
     "imageUrl": "https://images.pokemontcg.io/sm5/103.png",
     "subtype": "Stage 1",
@@ -5462,7 +5565,8 @@
     "nationalPokedexNumber": 463
   },
   {
-    "id": "sm5-104",
+    "setOrder":77,
+	"id": "sm5-104",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/sm5/104.png",
     "subtype": "Basic",
@@ -5512,7 +5616,8 @@
     ]
   },
   {
-    "id": "sm5-105",
+    "setOrder":77,
+	"id": "sm5-105",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/sm5/105.png",
     "subtype": "Basic",
@@ -5563,7 +5668,8 @@
     ]
   },
   {
-    "id": "sm5-106",
+    "setOrder":77,
+	"id": "sm5-106",
     "name": "Buneary",
     "imageUrl": "https://images.pokemontcg.io/sm5/106.png",
     "subtype": "Basic",
@@ -5615,7 +5721,8 @@
     ]
   },
   {
-    "id": "sm5-107",
+    "setOrder":77,
+	"id": "sm5-107",
     "name": "Lopunny",
     "imageUrl": "https://images.pokemontcg.io/sm5/107.png",
     "subtype": "Stage 1",
@@ -5666,7 +5773,8 @@
     "nationalPokedexNumber": 428
   },
   {
-    "id": "sm5-108",
+    "setOrder":77,
+	"id": "sm5-108",
     "name": "Glameow",
     "imageUrl": "https://images.pokemontcg.io/sm5/108.png",
     "subtype": "Basic",
@@ -5709,7 +5817,8 @@
     ]
   },
   {
-    "id": "sm5-109",
+    "setOrder":77,
+	"id": "sm5-109",
     "name": "Purugly",
     "imageUrl": "https://images.pokemontcg.io/sm5/109.png",
     "subtype": "Stage 1",
@@ -5762,7 +5871,8 @@
     "nationalPokedexNumber": 432
   },
   {
-    "id": "sm5-110",
+    "setOrder":77,
+	"id": "sm5-110",
     "name": "Fan Rotom",
     "imageUrl": "https://images.pokemontcg.io/sm5/110.png",
     "subtype": "Basic",
@@ -5812,7 +5922,8 @@
     "nationalPokedexNumber": 479
   },
   {
-    "id": "sm5-111",
+    "setOrder":77,
+	"id": "sm5-111",
     "name": "Shaymin",
     "imageUrl": "https://images.pokemontcg.io/sm5/111.png",
     "subtype": "Basic",
@@ -5867,7 +5978,8 @@
     "nationalPokedexNumber": 492
   },
   {
-    "id": "sm5-112",
+    "setOrder":77,
+	"id": "sm5-112",
     "name": "Yungoos",
     "imageUrl": "https://images.pokemontcg.io/sm5/112.png",
     "subtype": "Basic",
@@ -5920,7 +6032,8 @@
     ]
   },
   {
-    "id": "sm5-113",
+    "setOrder":77,
+	"id": "sm5-113",
     "name": "Gumshoos",
     "imageUrl": "https://images.pokemontcg.io/sm5/113.png",
     "subtype": "Stage 1",
@@ -5974,7 +6087,8 @@
     "nationalPokedexNumber": 735
   },
   {
-    "id": "sm5-114",
+    "setOrder":77,
+	"id": "sm5-114",
     "name": "Oranguru",
     "imageUrl": "https://images.pokemontcg.io/sm5/114.png",
     "subtype": "Basic",
@@ -6026,7 +6140,8 @@
     "nationalPokedexNumber": 765
   },
   {
-    "id": "sm5-115",
+    "setOrder":77,
+	"id": "sm5-115",
     "name": "Type: Null",
     "imageUrl": "https://images.pokemontcg.io/sm5/115.png",
     "subtype": "Basic",
@@ -6078,7 +6193,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/115_hires.png"
   },
   {
-    "id": "sm5-116",
+    "setOrder":77,
+	"id": "sm5-116",
     "name": "Silvally-GX",
     "imageUrl": "https://images.pokemontcg.io/sm5/116.png",
     "subtype": "GX",
@@ -6142,7 +6258,8 @@
     "nationalPokedexNumber": 773
   },
   {
-    "id": "sm5-117",
+    "setOrder":77,
+	"id": "sm5-117",
     "name": "Drampa",
     "imageUrl": "https://images.pokemontcg.io/sm5/117.png",
     "subtype": "Basic",
@@ -6196,7 +6313,8 @@
     "nationalPokedexNumber": 780
   },
   {
-    "id": "sm5-118",
+    "setOrder":77,
+	"id": "sm5-118",
     "name": "Ancient Crystal",
     "imageUrl": "https://images.pokemontcg.io/sm5/118.png",
     "subtype": "Pokémon Tool",
@@ -6213,7 +6331,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/118_hires.png"
   },
   {
-    "id": "sm5-119",
+    "setOrder":77,
+	"id": "sm5-119",
     "name": "Cynthia",
     "imageUrl": "https://images.pokemontcg.io/sm5/119.png",
     "subtype": "Supporter",
@@ -6230,7 +6349,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/119_hires.png"
   },
   {
-    "id": "sm5-120",
+    "setOrder":77,
+	"id": "sm5-120",
     "name": "Cyrus ◇",
     "imageUrl": "https://images.pokemontcg.io/sm5/120.png",
     "subtype": "Supporter",
@@ -6248,7 +6368,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/120_hires.png"
   },
   {
-    "id": "sm5-121",
+    "setOrder":77,
+	"id": "sm5-121",
     "name": "Electric Memory",
     "imageUrl": "https://images.pokemontcg.io/sm5/121.png",
     "subtype": "Pokémon Tool",
@@ -6265,7 +6386,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/121_hires.png"
   },
   {
-    "id": "sm5-122",
+    "setOrder":77,
+	"id": "sm5-122",
     "name": "Escape Board",
     "imageUrl": "https://images.pokemontcg.io/sm5/122.png",
     "subtype": "Pokémon Tool",
@@ -6282,7 +6404,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/122_hires.png"
   },
   {
-    "id": "sm5-123",
+    "setOrder":77,
+	"id": "sm5-123",
     "name": "Fire Memory",
     "imageUrl": "https://images.pokemontcg.io/sm5/123.png",
     "subtype": "Pokémon Tool",
@@ -6299,7 +6422,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/123_hires.png"
   },
   {
-    "id": "sm5-124",
+    "setOrder":77,
+	"id": "sm5-124",
     "name": "Gardenia",
     "imageUrl": "https://images.pokemontcg.io/sm5/124.png",
     "subtype": "Supporter",
@@ -6316,7 +6440,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/124_hires.png"
   },
   {
-    "id": "sm5-125",
+    "setOrder":77,
+	"id": "sm5-125",
     "name": "Lillie",
     "imageUrl": "https://images.pokemontcg.io/sm5/125.png",
     "subtype": "Supporter",
@@ -6333,7 +6458,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/125_hires.png"
   },
   {
-    "id": "sm5-126",
+    "setOrder":77,
+	"id": "sm5-126",
     "name": "Looker",
     "imageUrl": "https://images.pokemontcg.io/sm5/126.png",
     "subtype": "Supporter",
@@ -6350,7 +6476,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/126_hires.png"
   },
   {
-    "id": "sm5-127",
+    "setOrder":77,
+	"id": "sm5-127",
     "name": "Looker Whistle",
     "imageUrl": "https://images.pokemontcg.io/sm5/127.png",
     "subtype": "Item",
@@ -6367,7 +6494,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/127_hires.png"
   },
   {
-    "id": "sm5-128",
+    "setOrder":77,
+	"id": "sm5-128",
     "name": "Mars",
     "imageUrl": "https://images.pokemontcg.io/sm5/128.png",
     "subtype": "Supporter",
@@ -6384,7 +6512,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/128_hires.png"
   },
   {
-    "id": "sm5-129",
+    "setOrder":77,
+	"id": "sm5-129",
     "name": "Missing Clover",
     "imageUrl": "https://images.pokemontcg.io/sm5/129.png",
     "subtype": "Item",
@@ -6401,7 +6530,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/129_hires.png"
   },
   {
-    "id": "sm5-130",
+    "setOrder":77,
+	"id": "sm5-130",
     "name": "Mt. Coronet",
     "imageUrl": "https://images.pokemontcg.io/sm5/130.png",
     "subtype": "Stadium",
@@ -6418,7 +6548,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/130_hires.png"
   },
   {
-    "id": "sm5-131",
+    "setOrder":77,
+	"id": "sm5-131",
     "name": "Order Pad",
     "imageUrl": "https://images.pokemontcg.io/sm5/131.png",
     "subtype": "Item",
@@ -6435,7 +6566,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/131_hires.png"
   },
   {
-    "id": "sm5-132",
+    "setOrder":77,
+	"id": "sm5-132",
     "name": "Pal Pad",
     "imageUrl": "https://images.pokemontcg.io/sm5/132.png",
     "subtype": "Item",
@@ -6452,7 +6584,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/132_hires.png"
   },
   {
-    "id": "sm5-133",
+    "setOrder":77,
+	"id": "sm5-133",
     "name": "Pokémon Fan Club",
     "imageUrl": "https://images.pokemontcg.io/sm5/133.png",
     "subtype": "Supporter",
@@ -6469,7 +6602,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/133_hires.png"
   },
   {
-    "id": "sm5-134",
+    "setOrder":77,
+	"id": "sm5-134",
     "name": "Unidentified Fossil",
     "imageUrl": "https://images.pokemontcg.io/sm5/134.png",
     "subtype": "Item",
@@ -6486,7 +6620,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/134_hires.png"
   },
   {
-    "id": "sm5-135",
+    "setOrder":77,
+	"id": "sm5-135",
     "name": "Volkner",
     "imageUrl": "https://images.pokemontcg.io/sm5/135.png",
     "subtype": "Supporter",
@@ -6503,7 +6638,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/135_hires.png"
   },
   {
-    "id": "sm5-136",
+    "setOrder":77,
+	"id": "sm5-136",
     "name": "Super Boost Energy ◇",
     "imageUrl": "https://images.pokemontcg.io/sm5/136.png",
     "subtype": "Special",
@@ -6521,7 +6657,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/136_hires.png"
   },
   {
-    "id": "sm5-137",
+    "setOrder":77,
+	"id": "sm5-137",
     "name": "Unit Energy GrassFireWater",
     "imageUrl": "https://images.pokemontcg.io/sm5/137.png",
     "subtype": "Special",
@@ -6538,7 +6675,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/137_hires.png"
   },
   {
-    "id": "sm5-138",
+    "setOrder":77,
+	"id": "sm5-138",
     "name": "Unit Energy LightningPsychicMetal",
     "imageUrl": "https://images.pokemontcg.io/sm5/138.png",
     "subtype": "Special",
@@ -6555,7 +6693,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/138_hires.png"
   },
   {
-    "id": "sm5-139",
+    "setOrder":77,
+	"id": "sm5-139",
     "name": "Leafeon-GX",
     "imageUrl": "https://images.pokemontcg.io/sm5/139.png",
     "subtype": "GX",
@@ -6617,7 +6756,8 @@
     "nationalPokedexNumber": 470
   },
   {
-    "id": "sm5-140",
+    "setOrder":77,
+	"id": "sm5-140",
     "name": "Pheromosa-GX",
     "imageUrl": "https://images.pokemontcg.io/sm5/140.png",
     "subtype": "GX",
@@ -6681,7 +6821,8 @@
     "nationalPokedexNumber": 795
   },
   {
-    "id": "sm5-141",
+    "setOrder":77,
+	"id": "sm5-141",
     "name": "Glaceon-GX",
     "imageUrl": "https://images.pokemontcg.io/sm5/141.png",
     "subtype": "GX",
@@ -6745,7 +6886,8 @@
     "nationalPokedexNumber": 471
   },
   {
-    "id": "sm5-142",
+    "setOrder":77,
+	"id": "sm5-142",
     "name": "Xurkitree-GX",
     "imageUrl": "https://images.pokemontcg.io/sm5/142.png",
     "subtype": "GX",
@@ -6812,7 +6954,8 @@
     "nationalPokedexNumber": 796
   },
   {
-    "id": "sm5-143",
+    "setOrder":77,
+	"id": "sm5-143",
     "name": "Dawn Wings Necrozma-GX",
     "imageUrl": "https://images.pokemontcg.io/sm5/143.png",
     "subtype": "GX",
@@ -6881,7 +7024,8 @@
     "nationalPokedexNumber": 800
   },
   {
-    "id": "sm5-144",
+    "setOrder":77,
+	"id": "sm5-144",
     "name": "Celesteela-GX",
     "imageUrl": "https://images.pokemontcg.io/sm5/144.png",
     "subtype": "GX",
@@ -6960,7 +7104,8 @@
     "nationalPokedexNumber": 797
   },
   {
-    "id": "sm5-145",
+    "setOrder":77,
+	"id": "sm5-145",
     "name": "Dusk Mane Necrozma-GX",
     "imageUrl": "https://images.pokemontcg.io/sm5/145.png",
     "subtype": "GX",
@@ -7037,7 +7182,8 @@
     "nationalPokedexNumber": 800
   },
   {
-    "id": "sm5-146",
+    "setOrder":77,
+	"id": "sm5-146",
     "name": "Dialga-GX",
     "imageUrl": "https://images.pokemontcg.io/sm5/146.png",
     "subtype": "GX",
@@ -7107,7 +7253,8 @@
     "nationalPokedexNumber": 483
   },
   {
-    "id": "sm5-147",
+    "setOrder":77,
+	"id": "sm5-147",
     "name": "Palkia-GX",
     "imageUrl": "https://images.pokemontcg.io/sm5/147.png",
     "subtype": "GX",
@@ -7177,7 +7324,8 @@
     "nationalPokedexNumber": 484
   },
   {
-    "id": "sm5-148",
+    "setOrder":77,
+	"id": "sm5-148",
     "name": "Cynthia",
     "imageUrl": "https://images.pokemontcg.io/sm5/148.png",
     "subtype": "Supporter",
@@ -7194,7 +7342,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/148_hires.png"
   },
   {
-    "id": "sm5-149",
+    "setOrder":77,
+	"id": "sm5-149",
     "name": "Gardenia",
     "imageUrl": "https://images.pokemontcg.io/sm5/149.png",
     "subtype": "Supporter",
@@ -7211,7 +7360,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/149_hires.png"
   },
   {
-    "id": "sm5-150",
+    "setOrder":77,
+	"id": "sm5-150",
     "name": "Lana",
     "imageUrl": "https://images.pokemontcg.io/sm5/150.png",
     "subtype": "Supporter",
@@ -7229,7 +7379,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/150_hires.png"
   },
   {
-    "id": "sm5-151",
+    "setOrder":77,
+	"id": "sm5-151",
     "name": "Lillie",
     "imageUrl": "https://images.pokemontcg.io/sm5/151.png",
     "subtype": "Supporter",
@@ -7247,7 +7398,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/151_hires.png"
   },
   {
-    "id": "sm5-152",
+    "setOrder":77,
+	"id": "sm5-152",
     "name": "Looker",
     "imageUrl": "https://images.pokemontcg.io/sm5/152.png",
     "subtype": "Supporter",
@@ -7264,7 +7416,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/152_hires.png"
   },
   {
-    "id": "sm5-153",
+    "setOrder":77,
+	"id": "sm5-153",
     "name": "Lusamine",
     "imageUrl": "https://images.pokemontcg.io/sm5/153.png",
     "subtype": "Supporter",
@@ -7281,7 +7434,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/153_hires.png"
   },
   {
-    "id": "sm5-154",
+    "setOrder":77,
+	"id": "sm5-154",
     "name": "Mars",
     "imageUrl": "https://images.pokemontcg.io/sm5/154.png",
     "subtype": "Supporter",
@@ -7298,7 +7452,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/154_hires.png"
   },
   {
-    "id": "sm5-155",
+    "setOrder":77,
+	"id": "sm5-155",
     "name": "Pokémon Fan Club",
     "imageUrl": "https://images.pokemontcg.io/sm5/155.png",
     "subtype": "Supporter",
@@ -7315,7 +7470,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/sm5/155_hires.png"
   },
   {
-    "id": "sm5-156",
+    "setOrder":77,
+	"id": "sm5-156",
     "name": "Volkner",
     "imageUrl": "https://images.pokemontcg.io/sm5/156.png",
     "subtype": "Supporter",

--- a/json/cards/Unseen Forces.json
+++ b/json/cards/Unseen Forces.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "ex10-1",
+    "setOrder":25,
+	"id": "ex10-1",
     "name": "Ampharos",
     "imageUrl": "https://images.pokemontcg.io/ex10/1.png",
     "subtype": "Stage 2",
@@ -55,7 +56,8 @@
     "nationalPokedexNumber": 181
   },
   {
-    "id": "ex10-2",
+    "setOrder":25,
+	"id": "ex10-2",
     "name": "Ariados",
     "imageUrl": "https://images.pokemontcg.io/ex10/2.png",
     "subtype": "Stage 1",
@@ -105,7 +107,8 @@
     "nationalPokedexNumber": 168
   },
   {
-    "id": "ex10-3",
+    "setOrder":25,
+	"id": "ex10-3",
     "name": "Bellossom",
     "imageUrl": "https://images.pokemontcg.io/ex10/3.png",
     "subtype": "Stage 2",
@@ -163,7 +166,8 @@
     "nationalPokedexNumber": 182
   },
   {
-    "id": "ex10-4",
+    "setOrder":25,
+	"id": "ex10-4",
     "name": "Feraligatr",
     "imageUrl": "https://images.pokemontcg.io/ex10/4.png",
     "subtype": "Stage 2",
@@ -222,7 +226,8 @@
     "nationalPokedexNumber": 160
   },
   {
-    "id": "ex10-5",
+    "setOrder":25,
+	"id": "ex10-5",
     "name": "Flareon",
     "imageUrl": "https://images.pokemontcg.io/ex10/5.png",
     "subtype": "Stage 1",
@@ -274,7 +279,8 @@
     "nationalPokedexNumber": 136
   },
   {
-    "id": "ex10-6",
+    "setOrder":25,
+	"id": "ex10-6",
     "name": "Forretress",
     "imageUrl": "https://images.pokemontcg.io/ex10/6.png",
     "subtype": "Stage 1",
@@ -334,7 +340,8 @@
     "nationalPokedexNumber": 205
   },
   {
-    "id": "ex10-7",
+    "setOrder":25,
+	"id": "ex10-7",
     "name": "Houndoom",
     "imageUrl": "https://images.pokemontcg.io/ex10/7.png",
     "subtype": "Stage 1",
@@ -392,7 +399,8 @@
     "nationalPokedexNumber": 229
   },
   {
-    "id": "ex10-8",
+    "setOrder":25,
+	"id": "ex10-8",
     "name": "Jolteon",
     "imageUrl": "https://images.pokemontcg.io/ex10/8.png",
     "subtype": "Stage 1",
@@ -447,7 +455,8 @@
     "nationalPokedexNumber": 135
   },
   {
-    "id": "ex10-9",
+    "setOrder":25,
+	"id": "ex10-9",
     "name": "Meganium",
     "imageUrl": "https://images.pokemontcg.io/ex10/9.png",
     "subtype": "Stage 2",
@@ -503,7 +512,8 @@
     "nationalPokedexNumber": 154
   },
   {
-    "id": "ex10-10",
+    "setOrder":25,
+	"id": "ex10-10",
     "name": "Octillery",
     "imageUrl": "https://images.pokemontcg.io/ex10/10.png",
     "subtype": "Stage 1",
@@ -559,7 +569,8 @@
     "nationalPokedexNumber": 224
   },
   {
-    "id": "ex10-11",
+    "setOrder":25,
+	"id": "ex10-11",
     "name": "Poliwrath",
     "imageUrl": "https://images.pokemontcg.io/ex10/11.png",
     "subtype": "Stage 2",
@@ -618,7 +629,8 @@
     "nationalPokedexNumber": 62
   },
   {
-    "id": "ex10-12",
+    "setOrder":25,
+	"id": "ex10-12",
     "name": "Porygon2",
     "imageUrl": "https://images.pokemontcg.io/ex10/12.png",
     "subtype": "Stage 1",
@@ -678,7 +690,8 @@
     ]
   },
   {
-    "id": "ex10-13",
+    "setOrder":25,
+	"id": "ex10-13",
     "name": "Slowbro",
     "imageUrl": "https://images.pokemontcg.io/ex10/13.png",
     "subtype": "Stage 1",
@@ -736,7 +749,8 @@
     "nationalPokedexNumber": 80
   },
   {
-    "id": "ex10-14",
+    "setOrder":25,
+	"id": "ex10-14",
     "name": "Slowking",
     "imageUrl": "https://images.pokemontcg.io/ex10/14.png",
     "subtype": "Stage 1",
@@ -783,7 +797,8 @@
     "nationalPokedexNumber": 199
   },
   {
-    "id": "ex10-15",
+    "setOrder":25,
+	"id": "ex10-15",
     "name": "Sudowoodo",
     "imageUrl": "https://images.pokemontcg.io/ex10/15.png",
     "subtype": "Basic",
@@ -834,7 +849,8 @@
     "nationalPokedexNumber": 185
   },
   {
-    "id": "ex10-16",
+    "setOrder":25,
+	"id": "ex10-16",
     "name": "Sunflora",
     "imageUrl": "https://images.pokemontcg.io/ex10/16.png",
     "subtype": "Stage 1",
@@ -891,7 +907,8 @@
     "nationalPokedexNumber": 192
   },
   {
-    "id": "ex10-17",
+    "setOrder":25,
+	"id": "ex10-17",
     "name": "Typhlosion",
     "imageUrl": "https://images.pokemontcg.io/ex10/17.png",
     "subtype": "Stage 2",
@@ -948,7 +965,8 @@
     "nationalPokedexNumber": 157
   },
   {
-    "id": "ex10-18",
+    "setOrder":25,
+	"id": "ex10-18",
     "name": "Ursaring",
     "imageUrl": "https://images.pokemontcg.io/ex10/18.png",
     "subtype": "Stage 1",
@@ -1007,7 +1025,8 @@
     "nationalPokedexNumber": 217
   },
   {
-    "id": "ex10-19",
+    "setOrder":25,
+	"id": "ex10-19",
     "name": "Vaporeon",
     "imageUrl": "https://images.pokemontcg.io/ex10/19.png",
     "subtype": "Stage 1",
@@ -1059,7 +1078,8 @@
     "nationalPokedexNumber": 134
   },
   {
-    "id": "ex10-20",
+    "setOrder":25,
+	"id": "ex10-20",
     "name": "Chansey",
     "imageUrl": "https://images.pokemontcg.io/ex10/20.png",
     "subtype": "Basic",
@@ -1113,7 +1133,8 @@
     ]
   },
   {
-    "id": "ex10-21",
+    "setOrder":25,
+	"id": "ex10-21",
     "name": "Cleffa",
     "imageUrl": "https://images.pokemontcg.io/ex10/21.png",
     "subtype": "Basic",
@@ -1161,7 +1182,8 @@
     ]
   },
   {
-    "id": "ex10-22",
+    "setOrder":25,
+	"id": "ex10-22",
     "name": "Electabuzz",
     "imageUrl": "https://images.pokemontcg.io/ex10/22.png",
     "subtype": "Basic",
@@ -1222,7 +1244,8 @@
     ]
   },
   {
-    "id": "ex10-23",
+    "setOrder":25,
+	"id": "ex10-23",
     "name": "Elekid",
     "imageUrl": "https://images.pokemontcg.io/ex10/23.png",
     "subtype": "Basic",
@@ -1270,7 +1293,8 @@
     ]
   },
   {
-    "id": "ex10-24",
+    "setOrder":25,
+	"id": "ex10-24",
     "name": "Hitmonchan",
     "imageUrl": "https://images.pokemontcg.io/ex10/24.png",
     "subtype": "Basic",
@@ -1327,7 +1351,8 @@
     "nationalPokedexNumber": 107
   },
   {
-    "id": "ex10-25",
+    "setOrder":25,
+	"id": "ex10-25",
     "name": "Hitmonlee",
     "imageUrl": "https://images.pokemontcg.io/ex10/25.png",
     "subtype": "Basic",
@@ -1383,7 +1408,8 @@
     "nationalPokedexNumber": 106
   },
   {
-    "id": "ex10-26",
+    "setOrder":25,
+	"id": "ex10-26",
     "name": "Hitmontop",
     "imageUrl": "https://images.pokemontcg.io/ex10/26.png",
     "subtype": "Basic",
@@ -1441,7 +1467,8 @@
     "nationalPokedexNumber": 237
   },
   {
-    "id": "ex10-27",
+    "setOrder":25,
+	"id": "ex10-27",
     "name": "Ho-Oh",
     "imageUrl": "https://images.pokemontcg.io/ex10/27.png",
     "subtype": "Basic",
@@ -1495,7 +1522,8 @@
     "nationalPokedexNumber": 250
   },
   {
-    "id": "ex10-28",
+    "setOrder":25,
+	"id": "ex10-28",
     "name": "Jynx",
     "imageUrl": "https://images.pokemontcg.io/ex10/28.png",
     "subtype": "Basic",
@@ -1551,7 +1579,8 @@
     "nationalPokedexNumber": 124
   },
   {
-    "id": "ex10-29",
+    "setOrder":25,
+	"id": "ex10-29",
     "name": "Lugia",
     "imageUrl": "https://images.pokemontcg.io/ex10/29.png",
     "subtype": "Basic",
@@ -1594,7 +1623,8 @@
     "nationalPokedexNumber": 249
   },
   {
-    "id": "ex10-30",
+    "setOrder":25,
+	"id": "ex10-30",
     "name": "Murkrow",
     "imageUrl": "https://images.pokemontcg.io/ex10/30.png",
     "subtype": "Basic",
@@ -1653,7 +1683,8 @@
     ]
   },
   {
-    "id": "ex10-31",
+    "setOrder":25,
+	"id": "ex10-31",
     "name": "Smoochum",
     "imageUrl": "https://images.pokemontcg.io/ex10/31.png",
     "subtype": "Basic",
@@ -1701,7 +1732,8 @@
     ]
   },
   {
-    "id": "ex10-32",
+    "setOrder":25,
+	"id": "ex10-32",
     "name": "Stantler",
     "imageUrl": "https://images.pokemontcg.io/ex10/32.png",
     "subtype": "Basic",
@@ -1751,7 +1783,8 @@
     "nationalPokedexNumber": 234
   },
   {
-    "id": "ex10-33",
+    "setOrder":25,
+	"id": "ex10-33",
     "name": "Tyrogue",
     "imageUrl": "https://images.pokemontcg.io/ex10/33.png",
     "subtype": "Basic",
@@ -1801,7 +1834,8 @@
     ]
   },
   {
-    "id": "ex10-34",
+    "setOrder":25,
+	"id": "ex10-34",
     "name": "Aipom",
     "imageUrl": "https://images.pokemontcg.io/ex10/34.png",
     "subtype": "Basic",
@@ -1849,7 +1883,8 @@
     ]
   },
   {
-    "id": "ex10-35",
+    "setOrder":25,
+	"id": "ex10-35",
     "name": "Bayleef",
     "imageUrl": "https://images.pokemontcg.io/ex10/35.png",
     "subtype": "Stage 1",
@@ -1910,7 +1945,8 @@
     ]
   },
   {
-    "id": "ex10-36",
+    "setOrder":25,
+	"id": "ex10-36",
     "name": "Clefable",
     "imageUrl": "https://images.pokemontcg.io/ex10/36.png",
     "subtype": "Stage 1",
@@ -1961,7 +1997,8 @@
     "nationalPokedexNumber": 36
   },
   {
-    "id": "ex10-37",
+    "setOrder":25,
+	"id": "ex10-37",
     "name": "Corsola",
     "imageUrl": "https://images.pokemontcg.io/ex10/37.png",
     "subtype": "Basic",
@@ -2010,7 +2047,8 @@
     "nationalPokedexNumber": 222
   },
   {
-    "id": "ex10-38",
+    "setOrder":25,
+	"id": "ex10-38",
     "name": "Croconaw",
     "imageUrl": "https://images.pokemontcg.io/ex10/38.png",
     "subtype": "Stage 1",
@@ -2066,7 +2104,8 @@
     ]
   },
   {
-    "id": "ex10-39",
+    "setOrder":25,
+	"id": "ex10-39",
     "name": "Granbull",
     "imageUrl": "https://images.pokemontcg.io/ex10/39.png",
     "subtype": "Stage 1",
@@ -2126,7 +2165,8 @@
     "nationalPokedexNumber": 210
   },
   {
-    "id": "ex10-40",
+    "setOrder":25,
+	"id": "ex10-40",
     "name": "Lanturn",
     "imageUrl": "https://images.pokemontcg.io/ex10/40.png",
     "subtype": "Stage 1",
@@ -2178,7 +2218,8 @@
     "nationalPokedexNumber": 171
   },
   {
-    "id": "ex10-41",
+    "setOrder":25,
+	"id": "ex10-41",
     "name": "Magcargo",
     "imageUrl": "https://images.pokemontcg.io/ex10/41.png",
     "subtype": "Stage 1",
@@ -2237,7 +2278,8 @@
     "nationalPokedexNumber": 219
   },
   {
-    "id": "ex10-42",
+    "setOrder":25,
+	"id": "ex10-42",
     "name": "Miltank",
     "imageUrl": "https://images.pokemontcg.io/ex10/42.png",
     "subtype": "Basic",
@@ -2292,7 +2334,8 @@
     "nationalPokedexNumber": 241
   },
   {
-    "id": "ex10-43",
+    "setOrder":25,
+	"id": "ex10-43",
     "name": "Noctowl",
     "imageUrl": "https://images.pokemontcg.io/ex10/43.png",
     "subtype": "Stage 1",
@@ -2349,7 +2392,8 @@
     "nationalPokedexNumber": 164
   },
   {
-    "id": "ex10-44",
+    "setOrder":25,
+	"id": "ex10-44",
     "name": "Quagsire",
     "imageUrl": "https://images.pokemontcg.io/ex10/44.png",
     "subtype": "Stage 1",
@@ -2407,7 +2451,8 @@
     "nationalPokedexNumber": 195
   },
   {
-    "id": "ex10-45",
+    "setOrder":25,
+	"id": "ex10-45",
     "name": "Quilava",
     "imageUrl": "https://images.pokemontcg.io/ex10/45.png",
     "subtype": "Stage 1",
@@ -2463,7 +2508,8 @@
     ]
   },
   {
-    "id": "ex10-46",
+    "setOrder":25,
+	"id": "ex10-46",
     "name": "Scyther",
     "imageUrl": "https://images.pokemontcg.io/ex10/46.png",
     "subtype": "Basic",
@@ -2516,7 +2562,8 @@
     ]
   },
   {
-    "id": "ex10-47",
+    "setOrder":25,
+	"id": "ex10-47",
     "name": "Shuckle",
     "imageUrl": "https://images.pokemontcg.io/ex10/47.png",
     "subtype": "Basic",
@@ -2562,7 +2609,8 @@
     "nationalPokedexNumber": 213
   },
   {
-    "id": "ex10-48",
+    "setOrder":25,
+	"id": "ex10-48",
     "name": "Smeargle",
     "imageUrl": "https://images.pokemontcg.io/ex10/48.png",
     "subtype": "Basic",
@@ -2607,7 +2655,8 @@
     "nationalPokedexNumber": 235
   },
   {
-    "id": "ex10-49",
+    "setOrder":25,
+	"id": "ex10-49",
     "name": "Xatu",
     "imageUrl": "https://images.pokemontcg.io/ex10/49.png",
     "subtype": "Stage 1",
@@ -2658,7 +2707,8 @@
     "nationalPokedexNumber": 178
   },
   {
-    "id": "ex10-50",
+    "setOrder":25,
+	"id": "ex10-50",
     "name": "Yanma",
     "imageUrl": "https://images.pokemontcg.io/ex10/50.png",
     "subtype": "Basic",
@@ -2711,7 +2761,8 @@
     ]
   },
   {
-    "id": "ex10-51",
+    "setOrder":25,
+	"id": "ex10-51",
     "name": "Chikorita",
     "imageUrl": "https://images.pokemontcg.io/ex10/51.png",
     "subtype": "Basic",
@@ -2770,7 +2821,8 @@
     ]
   },
   {
-    "id": "ex10-52",
+    "setOrder":25,
+	"id": "ex10-52",
     "name": "Chinchou",
     "imageUrl": "https://images.pokemontcg.io/ex10/52.png",
     "subtype": "Basic",
@@ -2822,7 +2874,8 @@
     ]
   },
   {
-    "id": "ex10-53",
+    "setOrder":25,
+	"id": "ex10-53",
     "name": "Clefairy",
     "imageUrl": "https://images.pokemontcg.io/ex10/53.png",
     "subtype": "Basic",
@@ -2875,7 +2928,8 @@
     ]
   },
   {
-    "id": "ex10-54",
+    "setOrder":25,
+	"id": "ex10-54",
     "name": "Cyndaquil",
     "imageUrl": "https://images.pokemontcg.io/ex10/54.png",
     "subtype": "Basic",
@@ -2928,7 +2982,8 @@
     ]
   },
   {
-    "id": "ex10-55",
+    "setOrder":25,
+	"id": "ex10-55",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/ex10/55.png",
     "subtype": "Basic",
@@ -2983,7 +3038,8 @@
     ]
   },
   {
-    "id": "ex10-56",
+    "setOrder":25,
+	"id": "ex10-56",
     "name": "Flaaffy",
     "imageUrl": "https://images.pokemontcg.io/ex10/56.png",
     "subtype": "Stage 1",
@@ -3044,7 +3100,8 @@
     ]
   },
   {
-    "id": "ex10-57",
+    "setOrder":25,
+	"id": "ex10-57",
     "name": "Gligar",
     "imageUrl": "https://images.pokemontcg.io/ex10/57.png",
     "subtype": "Basic",
@@ -3092,7 +3149,8 @@
     ]
   },
   {
-    "id": "ex10-58",
+    "setOrder":25,
+	"id": "ex10-58",
     "name": "Gloom",
     "imageUrl": "https://images.pokemontcg.io/ex10/58.png",
     "subtype": "Stage 1",
@@ -3138,7 +3196,8 @@
     ]
   },
   {
-    "id": "ex10-59",
+    "setOrder":25,
+	"id": "ex10-59",
     "name": "Hoothoot",
     "imageUrl": "https://images.pokemontcg.io/ex10/59.png",
     "subtype": "Basic",
@@ -3197,7 +3256,8 @@
     ]
   },
   {
-    "id": "ex10-60",
+    "setOrder":25,
+	"id": "ex10-60",
     "name": "Houndour",
     "imageUrl": "https://images.pokemontcg.io/ex10/60.png",
     "subtype": "Basic",
@@ -3240,7 +3300,8 @@
     ]
   },
   {
-    "id": "ex10-61",
+    "setOrder":25,
+	"id": "ex10-61",
     "name": "Larvitar",
     "imageUrl": "https://images.pokemontcg.io/ex10/61.png",
     "subtype": "Basic",
@@ -3293,7 +3354,8 @@
     ]
   },
   {
-    "id": "ex10-62",
+    "setOrder":25,
+	"id": "ex10-62",
     "name": "Mareep",
     "imageUrl": "https://images.pokemontcg.io/ex10/62.png",
     "subtype": "Basic",
@@ -3342,7 +3404,8 @@
     ]
   },
   {
-    "id": "ex10-63",
+    "setOrder":25,
+	"id": "ex10-63",
     "name": "Natu",
     "imageUrl": "https://images.pokemontcg.io/ex10/63.png",
     "subtype": "Basic",
@@ -3385,7 +3448,8 @@
     ]
   },
   {
-    "id": "ex10-64",
+    "setOrder":25,
+	"id": "ex10-64",
     "name": "Oddish",
     "imageUrl": "https://images.pokemontcg.io/ex10/64.png",
     "subtype": "Basic",
@@ -3428,7 +3492,8 @@
     ]
   },
   {
-    "id": "ex10-65",
+    "setOrder":25,
+	"id": "ex10-65",
     "name": "Onix",
     "imageUrl": "https://images.pokemontcg.io/ex10/65.png",
     "subtype": "Basic",
@@ -3483,7 +3548,8 @@
     ]
   },
   {
-    "id": "ex10-66",
+    "setOrder":25,
+	"id": "ex10-66",
     "name": "Pineco",
     "imageUrl": "https://images.pokemontcg.io/ex10/66.png",
     "subtype": "Basic",
@@ -3526,7 +3592,8 @@
     ]
   },
   {
-    "id": "ex10-67",
+    "setOrder":25,
+	"id": "ex10-67",
     "name": "Poliwag",
     "imageUrl": "https://images.pokemontcg.io/ex10/67.png",
     "subtype": "Basic",
@@ -3578,7 +3645,8 @@
     ]
   },
   {
-    "id": "ex10-68",
+    "setOrder":25,
+	"id": "ex10-68",
     "name": "Poliwhirl",
     "imageUrl": "https://images.pokemontcg.io/ex10/68.png",
     "subtype": "Stage 1",
@@ -3624,7 +3692,8 @@
     ]
   },
   {
-    "id": "ex10-69",
+    "setOrder":25,
+	"id": "ex10-69",
     "name": "Porygon",
     "imageUrl": "https://images.pokemontcg.io/ex10/69.png",
     "subtype": "Basic",
@@ -3667,7 +3736,8 @@
     ]
   },
   {
-    "id": "ex10-70",
+    "setOrder":25,
+	"id": "ex10-70",
     "name": "Pupitar",
     "imageUrl": "https://images.pokemontcg.io/ex10/70.png",
     "subtype": "Stage 1",
@@ -3720,7 +3790,8 @@
     ]
   },
   {
-    "id": "ex10-71",
+    "setOrder":25,
+	"id": "ex10-71",
     "name": "Remoraid",
     "imageUrl": "https://images.pokemontcg.io/ex10/71.png",
     "subtype": "Basic",
@@ -3772,7 +3843,8 @@
     ]
   },
   {
-    "id": "ex10-72",
+    "setOrder":25,
+	"id": "ex10-72",
     "name": "Slowpoke",
     "imageUrl": "https://images.pokemontcg.io/ex10/72.png",
     "subtype": "Basic",
@@ -3826,7 +3898,8 @@
     ]
   },
   {
-    "id": "ex10-73",
+    "setOrder":25,
+	"id": "ex10-73",
     "name": "Slugma",
     "imageUrl": "https://images.pokemontcg.io/ex10/73.png",
     "subtype": "Basic",
@@ -3878,7 +3951,8 @@
     ]
   },
   {
-    "id": "ex10-74",
+    "setOrder":25,
+	"id": "ex10-74",
     "name": "Snubbull",
     "imageUrl": "https://images.pokemontcg.io/ex10/74.png",
     "subtype": "Basic",
@@ -3921,7 +3995,8 @@
     ]
   },
   {
-    "id": "ex10-75",
+    "setOrder":25,
+	"id": "ex10-75",
     "name": "Spinarak",
     "imageUrl": "https://images.pokemontcg.io/ex10/75.png",
     "subtype": "Basic",
@@ -3974,7 +4049,8 @@
     ]
   },
   {
-    "id": "ex10-76",
+    "setOrder":25,
+	"id": "ex10-76",
     "name": "Sunkern",
     "imageUrl": "https://images.pokemontcg.io/ex10/76.png",
     "subtype": "Basic",
@@ -4033,7 +4109,8 @@
     ]
   },
   {
-    "id": "ex10-77",
+    "setOrder":25,
+	"id": "ex10-77",
     "name": "Teddiursa",
     "imageUrl": "https://images.pokemontcg.io/ex10/77.png",
     "subtype": "Basic",
@@ -4085,7 +4162,8 @@
     ]
   },
   {
-    "id": "ex10-78",
+    "setOrder":25,
+	"id": "ex10-78",
     "name": "Totodile",
     "imageUrl": "https://images.pokemontcg.io/ex10/78.png",
     "subtype": "Basic",
@@ -4128,7 +4206,8 @@
     ]
   },
   {
-    "id": "ex10-79",
+    "setOrder":25,
+	"id": "ex10-79",
     "name": "Wooper",
     "imageUrl": "https://images.pokemontcg.io/ex10/79.png",
     "subtype": "Basic",
@@ -4181,7 +4260,8 @@
     ]
   },
   {
-    "id": "ex10-80",
+    "setOrder":25,
+	"id": "ex10-80",
     "name": "Curse Powder",
     "imageUrl": "https://images.pokemontcg.io/ex10/80.png",
     "subtype": "Item",
@@ -4200,7 +4280,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/80_hires.png"
   },
   {
-    "id": "ex10-81",
+    "setOrder":25,
+	"id": "ex10-81",
     "name": "Energy Recycle System",
     "imageUrl": "https://images.pokemontcg.io/ex10/81.png",
     "subtype": "Item",
@@ -4218,7 +4299,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/81_hires.png"
   },
   {
-    "id": "ex10-82",
+    "setOrder":25,
+	"id": "ex10-82",
     "name": "Energy Removal 2",
     "imageUrl": "https://images.pokemontcg.io/ex10/82.png",
     "subtype": "Item",
@@ -4236,7 +4318,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/82_hires.png"
   },
   {
-    "id": "ex10-83",
+    "setOrder":25,
+	"id": "ex10-83",
     "name": "Energy Root",
     "imageUrl": "https://images.pokemontcg.io/ex10/83.png",
     "subtype": "Pokémon Tool",
@@ -4255,7 +4338,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/83_hires.png"
   },
   {
-    "id": "ex10-84",
+    "setOrder":25,
+	"id": "ex10-84",
     "name": "Energy Switch",
     "imageUrl": "https://images.pokemontcg.io/ex10/84.png",
     "subtype": "Item",
@@ -4273,7 +4357,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/84_hires.png"
   },
   {
-    "id": "ex10-85",
+    "setOrder":25,
+	"id": "ex10-85",
     "name": "Fluffy Berry",
     "imageUrl": "https://images.pokemontcg.io/ex10/85.png",
     "subtype": "Pokémon Tool",
@@ -4292,7 +4377,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/85_hires.png"
   },
   {
-    "id": "ex10-86",
+    "setOrder":25,
+	"id": "ex10-86",
     "name": "Mary's Request",
     "imageUrl": "https://images.pokemontcg.io/ex10/86.png",
     "subtype": "Supporter",
@@ -4311,7 +4397,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/86_hires.png"
   },
   {
-    "id": "ex10-87",
+    "setOrder":25,
+	"id": "ex10-87",
     "name": "Poké Ball",
     "imageUrl": "https://images.pokemontcg.io/ex10/87.png",
     "subtype": "Item",
@@ -4329,7 +4416,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/87_hires.png"
   },
   {
-    "id": "ex10-88",
+    "setOrder":25,
+	"id": "ex10-88",
     "name": "Pokémon Reversal",
     "imageUrl": "https://images.pokemontcg.io/ex10/88.png",
     "subtype": "Item",
@@ -4347,7 +4435,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/88_hires.png"
   },
   {
-    "id": "ex10-89",
+    "setOrder":25,
+	"id": "ex10-89",
     "name": "Professor Elm's Training Method",
     "imageUrl": "https://images.pokemontcg.io/ex10/89.png",
     "subtype": "Supporter",
@@ -4366,7 +4455,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/89_hires.png"
   },
   {
-    "id": "ex10-90",
+    "setOrder":25,
+	"id": "ex10-90",
     "name": "Protective Orb",
     "imageUrl": "https://images.pokemontcg.io/ex10/90.png",
     "subtype": "Pokémon Tool",
@@ -4385,7 +4475,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/90_hires.png"
   },
   {
-    "id": "ex10-91",
+    "setOrder":25,
+	"id": "ex10-91",
     "name": "Sitrus Berry",
     "imageUrl": "https://images.pokemontcg.io/ex10/91.png",
     "subtype": "Pokémon Tool",
@@ -4404,7 +4495,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/91_hires.png"
   },
   {
-    "id": "ex10-92",
+    "setOrder":25,
+	"id": "ex10-92",
     "name": "Solid Rage",
     "imageUrl": "https://images.pokemontcg.io/ex10/92.png",
     "subtype": "Pokémon Tool",
@@ -4423,7 +4515,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/92_hires.png"
   },
   {
-    "id": "ex10-93",
+    "setOrder":25,
+	"id": "ex10-93",
     "name": "Warp Point",
     "imageUrl": "https://images.pokemontcg.io/ex10/93.png",
     "subtype": "Item",
@@ -4441,7 +4534,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/93_hires.png"
   },
   {
-    "id": "ex10-94",
+    "setOrder":25,
+	"id": "ex10-94",
     "name": "Energy Search",
     "imageUrl": "https://images.pokemontcg.io/ex10/94.png",
     "subtype": "Item",
@@ -4459,7 +4553,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/94_hires.png"
   },
   {
-    "id": "ex10-95",
+    "setOrder":25,
+	"id": "ex10-95",
     "name": "Potion",
     "imageUrl": "https://images.pokemontcg.io/ex10/95.png",
     "subtype": "Item",
@@ -4477,7 +4572,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/95_hires.png"
   },
   {
-    "id": "ex10-96",
+    "setOrder":25,
+	"id": "ex10-96",
     "name": "Darkness Energy",
     "imageUrl": "https://images.pokemontcg.io/ex10/96.png",
     "subtype": "Special",
@@ -4494,7 +4590,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/96_hires.png"
   },
   {
-    "id": "ex10-97",
+    "setOrder":25,
+	"id": "ex10-97",
     "name": "Metal Energy",
     "imageUrl": "https://images.pokemontcg.io/ex10/97.png",
     "subtype": "Special",
@@ -4511,7 +4608,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/97_hires.png"
   },
   {
-    "id": "ex10-98",
+    "setOrder":25,
+	"id": "ex10-98",
     "name": "Boost Energy",
     "imageUrl": "https://images.pokemontcg.io/ex10/98.png",
     "subtype": "Special",
@@ -4528,7 +4626,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/98_hires.png"
   },
   {
-    "id": "ex10-99",
+    "setOrder":25,
+	"id": "ex10-99",
     "name": "Cyclone Energy",
     "imageUrl": "https://images.pokemontcg.io/ex10/99.png",
     "subtype": "Special",
@@ -4545,7 +4644,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/99_hires.png"
   },
   {
-    "id": "ex10-100",
+    "setOrder":25,
+	"id": "ex10-100",
     "name": "Warp Energy",
     "imageUrl": "https://images.pokemontcg.io/ex10/100.png",
     "subtype": "Special",
@@ -4562,7 +4662,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/ex10/100_hires.png"
   },
   {
-    "id": "ex10-101",
+    "setOrder":25,
+	"id": "ex10-101",
     "name": "Blissey ex",
     "imageUrl": "https://images.pokemontcg.io/ex10/101.png",
     "subtype": "EX",
@@ -4624,7 +4725,8 @@
     "nationalPokedexNumber": 242
   },
   {
-    "id": "ex10-102",
+    "setOrder":25,
+	"id": "ex10-102",
     "name": "Espeon ex",
     "imageUrl": "https://images.pokemontcg.io/ex10/102.png",
     "subtype": "EX",
@@ -4683,7 +4785,8 @@
     "nationalPokedexNumber": 196
   },
   {
-    "id": "ex10-103",
+    "setOrder":25,
+	"id": "ex10-103",
     "name": "Feraligatr ex",
     "imageUrl": "https://images.pokemontcg.io/ex10/103.png",
     "subtype": "EX",
@@ -4748,7 +4851,8 @@
     "nationalPokedexNumber": 160
   },
   {
-    "id": "ex10-104",
+    "setOrder":25,
+	"id": "ex10-104",
     "name": "Ho-Oh ex",
     "imageUrl": "https://images.pokemontcg.io/ex10/104.png",
     "subtype": "Basic",
@@ -4797,7 +4901,8 @@
     "nationalPokedexNumber": 250
   },
   {
-    "id": "ex10-105",
+    "setOrder":25,
+	"id": "ex10-105",
     "name": "Lugia ex",
     "imageUrl": "https://images.pokemontcg.io/ex10/105.png",
     "subtype": "EX",
@@ -4854,7 +4959,8 @@
     "nationalPokedexNumber": 249
   },
   {
-    "id": "ex10-106",
+    "setOrder":25,
+	"id": "ex10-106",
     "name": "Meganium ex",
     "imageUrl": "https://images.pokemontcg.io/ex10/106.png",
     "subtype": "EX",
@@ -4930,7 +5036,8 @@
     "nationalPokedexNumber": 154
   },
   {
-    "id": "ex10-107",
+    "setOrder":25,
+	"id": "ex10-107",
     "name": "Politoed ex",
     "imageUrl": "https://images.pokemontcg.io/ex10/107.png",
     "subtype": "EX",
@@ -5001,7 +5108,8 @@
     "nationalPokedexNumber": 186
   },
   {
-    "id": "ex10-108",
+    "setOrder":25,
+	"id": "ex10-108",
     "name": "Scizor ex",
     "imageUrl": "https://images.pokemontcg.io/ex10/108.png",
     "subtype": "EX",
@@ -5069,7 +5177,8 @@
     "nationalPokedexNumber": 212
   },
   {
-    "id": "ex10-109",
+    "setOrder":25,
+	"id": "ex10-109",
     "name": "Steelix ex",
     "imageUrl": "https://images.pokemontcg.io/ex10/109.png",
     "subtype": "EX",
@@ -5151,7 +5260,8 @@
     "nationalPokedexNumber": 208
   },
   {
-    "id": "ex10-110",
+    "setOrder":25,
+	"id": "ex10-110",
     "name": "Typhlosion ex",
     "imageUrl": "https://images.pokemontcg.io/ex10/110.png",
     "subtype": "EX",
@@ -5208,7 +5318,8 @@
     "nationalPokedexNumber": 157
   },
   {
-    "id": "ex10-111",
+    "setOrder":25,
+	"id": "ex10-111",
     "name": "Tyranitar ex",
     "imageUrl": "https://images.pokemontcg.io/ex10/111.png",
     "subtype": "EX",
@@ -5297,7 +5408,8 @@
     "nationalPokedexNumber": 248
   },
   {
-    "id": "ex10-112",
+    "setOrder":25,
+	"id": "ex10-112",
     "name": "Umbreon ex",
     "imageUrl": "https://images.pokemontcg.io/ex10/112.png",
     "subtype": "EX",
@@ -5364,7 +5476,8 @@
     "nationalPokedexNumber": 197
   },
   {
-    "id": "ex10-113",
+    "setOrder":25,
+	"id": "ex10-113",
     "name": "Entei Star",
     "imageUrl": "https://images.pokemontcg.io/ex10/113.png",
     "subtype": "Basic",
@@ -5419,7 +5532,8 @@
     "nationalPokedexNumber": 244
   },
   {
-    "id": "ex10-114",
+    "setOrder":25,
+	"id": "ex10-114",
     "name": "Raikou Star",
     "imageUrl": "https://images.pokemontcg.io/ex10/114.png",
     "subtype": "Basic",
@@ -5474,7 +5588,8 @@
     "nationalPokedexNumber": 243
   },
   {
-    "id": "ex10-115",
+    "setOrder":25,
+	"id": "ex10-115",
     "name": "Suicune Star",
     "imageUrl": "https://images.pokemontcg.io/ex10/115.png",
     "subtype": "Basic",
@@ -5529,7 +5644,8 @@
     "nationalPokedexNumber": 245
   },
   {
-    "id": "ex10-116",
+    "setOrder":25,
+	"id": "ex10-116",
     "name": "Rocket's Persian ex",
     "imageUrl": "https://images.pokemontcg.io/ex10/116.png",
     "subtype": "Stage 1",
@@ -5581,7 +5697,8 @@
     "nationalPokedexNumber": 53
   },
   {
-    "id": "ex10-117",
+    "setOrder":25,
+	"id": "ex10-117",
     "name": "Celebi ex",
     "imageUrl": "https://images.pokemontcg.io/ex10/117.png",
     "subtype": "Basic",
@@ -5635,7 +5752,8 @@
     "nationalPokedexNumber": 251
   },
   {
-    "id": "ex10-A",
+    "setOrder":25,
+	"id": "ex10-A",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/A.png",
     "subtype": "Basic",
@@ -5680,7 +5798,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "ex10-B",
+    "setOrder":25,
+	"id": "ex10-B",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/B.png",
     "subtype": "Basic",
@@ -5726,7 +5845,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "ex10-C",
+    "setOrder":25,
+	"id": "ex10-C",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/C.png",
     "subtype": "Basic",
@@ -5770,7 +5890,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "ex10-D",
+    "setOrder":25,
+	"id": "ex10-D",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/D.png",
     "subtype": "Basic",
@@ -5814,7 +5935,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "ex10-E",
+    "setOrder":25,
+	"id": "ex10-E",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/E.png",
     "subtype": "Basic",
@@ -5858,7 +5980,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "ex10-F",
+    "setOrder":25,
+	"id": "ex10-F",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/F.png",
     "subtype": "Basic",
@@ -5904,7 +6027,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "ex10-G",
+    "setOrder":25,
+	"id": "ex10-G",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/G.png",
     "subtype": "Basic",
@@ -5949,7 +6073,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "ex10-H",
+    "setOrder":25,
+	"id": "ex10-H",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/H.png",
     "subtype": "Basic",
@@ -5993,7 +6118,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "ex10-I",
+    "setOrder":25,
+	"id": "ex10-I",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/I.png",
     "subtype": "Basic",
@@ -6038,7 +6164,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "ex10-J",
+    "setOrder":25,
+	"id": "ex10-J",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/J.png",
     "subtype": "Basic",
@@ -6082,7 +6209,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "ex10-K",
+    "setOrder":25,
+	"id": "ex10-K",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/K.png",
     "subtype": "Basic",
@@ -6128,7 +6256,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "ex10-L",
+    "setOrder":25,
+	"id": "ex10-L",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/L.png",
     "subtype": "Basic",
@@ -6173,7 +6302,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "ex10-M",
+    "setOrder":25,
+	"id": "ex10-M",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/M.png",
     "subtype": "Basic",
@@ -6217,7 +6347,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "ex10-N",
+    "setOrder":25,
+	"id": "ex10-N",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/N.png",
     "subtype": "Basic",
@@ -6261,7 +6392,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "ex10-O",
+    "setOrder":25,
+	"id": "ex10-O",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/O.png",
     "subtype": "Basic",
@@ -6307,7 +6439,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "ex10-P",
+    "setOrder":25,
+	"id": "ex10-P",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/P.png",
     "subtype": "Basic",
@@ -6352,7 +6485,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "ex10-Q",
+    "setOrder":25,
+	"id": "ex10-Q",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/Q.png",
     "subtype": "Basic",
@@ -6396,7 +6530,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "ex10-R",
+    "setOrder":25,
+	"id": "ex10-R",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/R.png",
     "subtype": "Basic",
@@ -6441,7 +6576,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "ex10-S",
+    "setOrder":25,
+	"id": "ex10-S",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/S.png",
     "subtype": "Basic",
@@ -6486,7 +6622,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "ex10-T",
+    "setOrder":25,
+	"id": "ex10-T",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/T.png",
     "subtype": "Basic",
@@ -6531,7 +6668,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "ex10-U",
+    "setOrder":25,
+	"id": "ex10-U",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/U.png",
     "subtype": "Basic",
@@ -6577,7 +6715,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "ex10-V",
+    "setOrder":25,
+	"id": "ex10-V",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/V.png",
     "subtype": "Basic",
@@ -6624,7 +6763,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "ex10-W",
+    "setOrder":25,
+	"id": "ex10-W",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/W.png",
     "subtype": "Basic",
@@ -6670,7 +6810,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "ex10-X",
+    "setOrder":25,
+	"id": "ex10-X",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/X.png",
     "subtype": "Basic",
@@ -6716,7 +6857,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "ex10-Y",
+    "setOrder":25,
+	"id": "ex10-Y",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/Y.png",
     "subtype": "Basic",
@@ -6761,7 +6903,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "ex10-Z",
+    "setOrder":25,
+	"id": "ex10-Z",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/Z.png",
     "subtype": "Basic",
@@ -6805,7 +6948,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "ex10-!",
+    "setOrder":25,
+	"id": "ex10-!",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/!.png",
     "subtype": "Basic",
@@ -6849,7 +6993,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "ex10-?",
+    "setOrder":25,
+	"id": "ex10-?",
     "name": "Unown",
     "imageUrl": "https://images.pokemontcg.io/ex10/question.png",
     "subtype": "Basic",

--- a/json/cards/Wizards Black Star Promos.json
+++ b/json/cards/Wizards Black Star Promos.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "basep-1",
+    "setOrder":1001,
+	"id": "basep-1",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/basep/1.png",
     "subtype": "Basic",
@@ -53,7 +54,8 @@
     ]
   },
   {
-    "id": "basep-2",
+    "setOrder":1001,
+	"id": "basep-2",
     "name": "Electabuzz",
     "imageUrl": "https://images.pokemontcg.io/basep/2.png",
     "subtype": "Basic",
@@ -107,7 +109,8 @@
     ]
   },
   {
-    "id": "basep-3",
+    "setOrder":1001,
+	"id": "basep-3",
     "name": "Mewtwo",
     "imageUrl": "https://images.pokemontcg.io/basep/3.png",
     "subtype": "Basic",
@@ -159,7 +162,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "basep-4",
+    "setOrder":1001,
+	"id": "basep-4",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/basep/4.png",
     "subtype": "Basic",
@@ -213,7 +217,8 @@
     ]
   },
   {
-    "id": "basep-5",
+    "setOrder":1001,
+	"id": "basep-5",
     "name": "Dragonite",
     "imageUrl": "https://images.pokemontcg.io/basep/5.png",
     "subtype": "Stage 2",
@@ -262,7 +267,8 @@
     "nationalPokedexNumber": 149
   },
   {
-    "id": "basep-6",
+    "setOrder":1001,
+	"id": "basep-6",
     "name": "Arcanine",
     "imageUrl": "https://images.pokemontcg.io/basep/6.png",
     "subtype": "Stage 1",
@@ -314,7 +320,8 @@
     "nationalPokedexNumber": 59
   },
   {
-    "id": "basep-7",
+    "setOrder":1001,
+	"id": "basep-7",
     "name": "Jigglypuff",
     "imageUrl": "https://images.pokemontcg.io/basep/7.png",
     "subtype": "Basic",
@@ -374,7 +381,8 @@
     ]
   },
   {
-    "id": "basep-8",
+    "setOrder":1001,
+	"id": "basep-8",
     "name": "Mew",
     "imageUrl": "https://images.pokemontcg.io/basep/8.png",
     "subtype": "Basic",
@@ -424,7 +432,8 @@
     "nationalPokedexNumber": 151
   },
   {
-    "id": "basep-9",
+    "setOrder":1001,
+	"id": "basep-9",
     "name": "Mew",
     "imageUrl": "https://images.pokemontcg.io/basep/9.png",
     "subtype": "Basic",
@@ -474,7 +483,8 @@
     "nationalPokedexNumber": 151
   },
   {
-    "id": "basep-10",
+    "setOrder":1001,
+	"id": "basep-10",
     "name": "Meowth",
     "imageUrl": "https://images.pokemontcg.io/basep/10.png",
     "subtype": "Basic",
@@ -524,7 +534,8 @@
     ]
   },
   {
-    "id": "basep-11",
+    "setOrder":1001,
+	"id": "basep-11",
     "name": "Eevee",
     "imageUrl": "https://images.pokemontcg.io/basep/11.png",
     "subtype": "Basic",
@@ -582,7 +593,8 @@
     ]
   },
   {
-    "id": "basep-12",
+    "setOrder":1001,
+	"id": "basep-12",
     "name": "Mewtwo",
     "imageUrl": "https://images.pokemontcg.io/basep/12.png",
     "subtype": "Basic",
@@ -633,7 +645,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "basep-13",
+    "setOrder":1001,
+	"id": "basep-13",
     "name": "Venusaur",
     "imageUrl": "https://images.pokemontcg.io/basep/13.png",
     "subtype": "Stage 2",
@@ -682,7 +695,8 @@
     "nationalPokedexNumber": 3
   },
   {
-    "id": "basep-14",
+    "setOrder":1001,
+	"id": "basep-14",
     "name": "Mewtwo",
     "imageUrl": "https://images.pokemontcg.io/basep/14.png",
     "subtype": "Basic",
@@ -734,7 +748,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "basep-15",
+    "setOrder":1001,
+	"id": "basep-15",
     "name": "Cool Porygon",
     "imageUrl": "https://images.pokemontcg.io/basep/15.png",
     "subtype": "Basic",
@@ -796,7 +811,8 @@
     ]
   },
   {
-    "id": "basep-16",
+    "setOrder":1001,
+	"id": "basep-16",
     "name": "Computer Error",
     "imageUrl": "https://images.pokemontcg.io/basep/16.png",
     "subtype": "",
@@ -812,7 +828,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/basep/16_hires.png"
   },
   {
-    "id": "basep-17",
+    "setOrder":1001,
+	"id": "basep-17",
     "name": "Dark Persian",
     "imageUrl": "https://images.pokemontcg.io/basep/17.png",
     "subtype": "Stage 1",
@@ -866,7 +883,8 @@
     "nationalPokedexNumber": 53
   },
   {
-    "id": "basep-18",
+    "setOrder":1001,
+	"id": "basep-18",
     "name": "Team Rocket's Meowth",
     "imageUrl": "https://images.pokemontcg.io/basep/18.png",
     "subtype": "Basic",
@@ -916,7 +934,8 @@
     ]
   },
   {
-    "id": "basep-19",
+    "setOrder":1001,
+	"id": "basep-19",
     "name": "Sabrina's Abra",
     "imageUrl": "https://images.pokemontcg.io/basep/19.png",
     "subtype": "Basic",
@@ -966,7 +985,8 @@
     ]
   },
   {
-    "id": "basep-20",
+    "setOrder":1001,
+	"id": "basep-20",
     "name": "Psyduck",
     "imageUrl": "https://images.pokemontcg.io/basep/20.png",
     "subtype": "Basic",
@@ -1018,7 +1038,8 @@
     ]
   },
   {
-    "id": "basep-21",
+    "setOrder":1001,
+	"id": "basep-21",
     "name": "Moltres",
     "imageUrl": "https://images.pokemontcg.io/basep/21.png",
     "subtype": "Basic",
@@ -1060,7 +1081,8 @@
     "nationalPokedexNumber": 146
   },
   {
-    "id": "basep-22",
+    "setOrder":1001,
+	"id": "basep-22",
     "name": "Articuno",
     "imageUrl": "https://images.pokemontcg.io/basep/22.png",
     "subtype": "Basic",
@@ -1102,7 +1124,8 @@
     "nationalPokedexNumber": 144
   },
   {
-    "id": "basep-23",
+    "setOrder":1001,
+	"id": "basep-23",
     "name": "Zapdos",
     "imageUrl": "https://images.pokemontcg.io/basep/23.png",
     "subtype": "Basic",
@@ -1144,7 +1167,8 @@
     "nationalPokedexNumber": 145
   },
   {
-    "id": "basep-24",
+    "setOrder":1001,
+	"id": "basep-24",
     "name": "___________'s Pikachu",
     "imageUrl": "https://images.pokemontcg.io/basep/24.png",
     "subtype": "Basic",
@@ -1188,7 +1212,8 @@
     ]
   },
   {
-    "id": "basep-25",
+    "setOrder":1001,
+	"id": "basep-25",
     "name": "Flying Pikachu",
     "imageUrl": "https://images.pokemontcg.io/basep/25.png",
     "subtype": "Basic",
@@ -1242,7 +1267,8 @@
     ]
   },
   {
-    "id": "basep-26",
+    "setOrder":1001,
+	"id": "basep-26",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/basep/26.png",
     "subtype": "Basic",
@@ -1295,7 +1321,8 @@
     ]
   },
   {
-    "id": "basep-27",
+    "setOrder":1001,
+	"id": "basep-27",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/basep/27.png",
     "subtype": "Basic",
@@ -1345,7 +1372,8 @@
     ]
   },
   {
-    "id": "basep-28",
+    "setOrder":1001,
+	"id": "basep-28",
     "name": "Surfing Pikachu",
     "imageUrl": "https://images.pokemontcg.io/basep/28.png",
     "subtype": "Basic",
@@ -1389,7 +1417,8 @@
     ]
   },
   {
-    "id": "basep-29",
+    "setOrder":1001,
+	"id": "basep-29",
     "name": "Marill",
     "imageUrl": "https://images.pokemontcg.io/basep/29.png",
     "subtype": "Basic",
@@ -1434,7 +1463,8 @@
     ]
   },
   {
-    "id": "basep-30",
+    "setOrder":1001,
+	"id": "basep-30",
     "name": "Togepi",
     "imageUrl": "https://images.pokemontcg.io/basep/30.png",
     "subtype": "Basic",
@@ -1487,7 +1517,8 @@
     ]
   },
   {
-    "id": "basep-31",
+    "setOrder":1001,
+	"id": "basep-31",
     "name": "Cleffa",
     "imageUrl": "https://images.pokemontcg.io/basep/31.png",
     "subtype": "Basic",
@@ -1524,7 +1555,8 @@
     ]
   },
   {
-    "id": "basep-32",
+    "setOrder":1001,
+	"id": "basep-32",
     "name": "Smeargle",
     "imageUrl": "https://images.pokemontcg.io/basep/32.png",
     "subtype": "Basic",
@@ -1567,7 +1599,8 @@
     "nationalPokedexNumber": 235
   },
   {
-    "id": "basep-33",
+    "setOrder":1001,
+	"id": "basep-33",
     "name": "Scizor",
     "imageUrl": "https://images.pokemontcg.io/basep/33.png",
     "subtype": "Stage 1",
@@ -1626,7 +1659,8 @@
     "nationalPokedexNumber": 212
   },
   {
-    "id": "basep-34",
+    "setOrder":1001,
+	"id": "basep-34",
     "name": "Entei",
     "imageUrl": "https://images.pokemontcg.io/basep/34.png",
     "subtype": "Basic",
@@ -1673,7 +1707,8 @@
     "nationalPokedexNumber": 244
   },
   {
-    "id": "basep-35",
+    "setOrder":1001,
+	"id": "basep-35",
     "name": "Pichu",
     "imageUrl": "https://images.pokemontcg.io/basep/35.png",
     "subtype": "Basic",
@@ -1710,7 +1745,8 @@
     ]
   },
   {
-    "id": "basep-36",
+    "setOrder":1001,
+	"id": "basep-36",
     "name": "Igglybuff",
     "imageUrl": "https://images.pokemontcg.io/basep/36.png",
     "subtype": "Basic",
@@ -1747,7 +1783,8 @@
     ]
   },
   {
-    "id": "basep-37",
+    "setOrder":1001,
+	"id": "basep-37",
     "name": "Hitmontop",
     "imageUrl": "https://images.pokemontcg.io/basep/37.png",
     "subtype": "Basic",
@@ -1799,7 +1836,8 @@
     "nationalPokedexNumber": 237
   },
   {
-    "id": "basep-38",
+    "setOrder":1001,
+	"id": "basep-38",
     "name": "Unown [J]",
     "imageUrl": "https://images.pokemontcg.io/basep/38.png",
     "subtype": "Basic",
@@ -1844,7 +1882,8 @@
     "nationalPokedexNumber": 201
   },
   {
-    "id": "basep-39",
+    "setOrder":1001,
+	"id": "basep-39",
     "name": "Misdreavus",
     "imageUrl": "https://images.pokemontcg.io/basep/39.png",
     "subtype": "Basic",
@@ -1897,7 +1936,8 @@
     ]
   },
   {
-    "id": "basep-40",
+    "setOrder":1001,
+	"id": "basep-40",
     "name": "Pokémon Center",
     "imageUrl": "https://images.pokemontcg.io/basep/40.png",
     "subtype": "",
@@ -1913,7 +1953,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/basep/40_hires.png"
   },
   {
-    "id": "basep-41",
+    "setOrder":1001,
+	"id": "basep-41",
     "name": "Lucky Stadium",
     "imageUrl": "https://images.pokemontcg.io/basep/41.png",
     "subtype": "",
@@ -1929,7 +1970,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/basep/41_hires.png"
   },
   {
-    "id": "basep-42",
+    "setOrder":1001,
+	"id": "basep-42",
     "name": "Pokémon Tower",
     "imageUrl": "https://images.pokemontcg.io/basep/42.png",
     "subtype": "",
@@ -1945,7 +1987,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/basep/42_hires.png"
   },
   {
-    "id": "basep-43",
+    "setOrder":1001,
+	"id": "basep-43",
     "name": "Machamp",
     "imageUrl": "https://images.pokemontcg.io/basep/43.png",
     "subtype": "Stage 2",
@@ -2001,7 +2044,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "basep-44",
+    "setOrder":1001,
+	"id": "basep-44",
     "name": "Magmar",
     "imageUrl": "https://images.pokemontcg.io/basep/44.png",
     "subtype": "Basic",
@@ -2056,7 +2100,8 @@
     ]
   },
   {
-    "id": "basep-45",
+    "setOrder":1001,
+	"id": "basep-45",
     "name": "Scyther",
     "imageUrl": "https://images.pokemontcg.io/basep/45.png",
     "subtype": "Basic",
@@ -2106,7 +2151,8 @@
     ]
   },
   {
-    "id": "basep-46",
+    "setOrder":1001,
+	"id": "basep-46",
     "name": "Electabuzz",
     "imageUrl": "https://images.pokemontcg.io/basep/46.png",
     "subtype": "Basic",
@@ -2159,7 +2205,8 @@
     ]
   },
   {
-    "id": "basep-47",
+    "setOrder":1001,
+	"id": "basep-47",
     "name": "Mew",
     "imageUrl": "https://images.pokemontcg.io/basep/47.png",
     "subtype": "Basic",
@@ -2204,7 +2251,8 @@
     "nationalPokedexNumber": 151
   },
   {
-    "id": "basep-48",
+    "setOrder":1001,
+	"id": "basep-48",
     "name": "Articuno",
     "imageUrl": "https://images.pokemontcg.io/basep/48.png",
     "subtype": "Basic",
@@ -2253,7 +2301,8 @@
     "nationalPokedexNumber": 144
   },
   {
-    "id": "basep-49",
+    "setOrder":1001,
+	"id": "basep-49",
     "name": "Snorlax",
     "imageUrl": "https://images.pokemontcg.io/basep/49.png",
     "subtype": "Basic",
@@ -2310,7 +2359,8 @@
     "nationalPokedexNumber": 143
   },
   {
-    "id": "basep-50",
+    "setOrder":1001,
+	"id": "basep-50",
     "name": "Celebi",
     "imageUrl": "https://images.pokemontcg.io/basep/50.png",
     "subtype": "Basic",
@@ -2350,7 +2400,8 @@
     "nationalPokedexNumber": 251
   },
   {
-    "id": "basep-51",
+    "setOrder":1001,
+	"id": "basep-51",
     "name": "Rapidash",
     "imageUrl": "https://images.pokemontcg.io/basep/51.png",
     "subtype": "Stage 1",
@@ -2399,7 +2450,8 @@
     "nationalPokedexNumber": 78
   },
   {
-    "id": "basep-52",
+    "setOrder":1001,
+	"id": "basep-52",
     "name": "Ho-oh",
     "imageUrl": "https://images.pokemontcg.io/basep/52.png",
     "subtype": "Basic",
@@ -2448,7 +2500,8 @@
     "nationalPokedexNumber": 250
   },
   {
-    "id": "basep-53",
+    "setOrder":1001,
+	"id": "basep-53",
     "name": "Suicune",
     "imageUrl": "https://images.pokemontcg.io/basep/53.png",
     "subtype": "Basic",

--- a/json/cards/XY Black Star Promos.json
+++ b/json/cards/XY Black Star Promos.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "xyp-XY01",
+    "setOrder":1003,
+	"id": "xyp-XY01",
     "name": "Chespin",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY01.png",
     "subtype": "Basic",
@@ -53,7 +54,8 @@
     ]
   },
   {
-    "id": "xyp-XY02",
+    "setOrder":1003,
+	"id": "xyp-XY02",
     "name": "Fennekin",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY02.png",
     "subtype": "Basic",
@@ -106,7 +108,8 @@
     ]
   },
   {
-    "id": "xyp-XY03",
+    "setOrder":1003,
+	"id": "xyp-XY03",
     "name": "Froakie",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY03.png",
     "subtype": "Basic",
@@ -159,7 +162,8 @@
     ]
   },
   {
-    "id": "xyp-XY04",
+    "setOrder":1003,
+	"id": "xyp-XY04",
     "name": "Sylveon",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY04.png",
     "subtype": "Stage 1",
@@ -217,7 +221,8 @@
     "nationalPokedexNumber": 700
   },
   {
-    "id": "xyp-XY05",
+    "setOrder":1003,
+	"id": "xyp-XY05",
     "name": "Xerneas",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY05.png",
     "subtype": "Basic",
@@ -275,7 +280,8 @@
     "nationalPokedexNumber": 716
   },
   {
-    "id": "xyp-XY06",
+    "setOrder":1003,
+	"id": "xyp-XY06",
     "name": "Yveltal",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY06.png",
     "subtype": "Basic",
@@ -333,7 +339,8 @@
     "nationalPokedexNumber": 717
   },
   {
-    "id": "xyp-XY07",
+    "setOrder":1003,
+	"id": "xyp-XY07",
     "name": "Xerneas-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY07.png",
     "subtype": "EX",
@@ -397,7 +404,8 @@
     "nationalPokedexNumber": 716
   },
   {
-    "id": "xyp-XY08",
+    "setOrder":1003,
+	"id": "xyp-XY08",
     "name": "Yveltal-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY08.png",
     "subtype": "EX",
@@ -459,7 +467,8 @@
     "nationalPokedexNumber": 717
   },
   {
-    "id": "xyp-XY09",
+    "setOrder":1003,
+	"id": "xyp-XY09",
     "name": "Garchomp-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY09.png",
     "subtype": "EX",
@@ -516,7 +525,8 @@
     "evolvesTo": "M Garchomp-EX"
   },
   {
-    "id": "xyp-XY10",
+    "setOrder":1003,
+	"id": "xyp-XY10",
     "name": "Dragalge",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY10.png",
     "subtype": "Stage 1",
@@ -564,7 +574,8 @@
     "nationalPokedexNumber": 691
   },
   {
-    "id": "xyp-XY11",
+    "setOrder":1003,
+	"id": "xyp-XY11",
     "name": "Skiddo",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY11.png",
     "subtype": "Basic",
@@ -609,7 +620,8 @@
     ]
   },
   {
-    "id": "xyp-XY12",
+    "setOrder":1003,
+	"id": "xyp-XY12",
     "name": "Honedge",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY12.png",
     "subtype": "Basic",
@@ -669,7 +681,8 @@
     ]
   },
   {
-    "id": "xyp-XY13",
+    "setOrder":1003,
+	"id": "xyp-XY13",
     "name": "Machamp",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY13.png",
     "subtype": "Stage 2",
@@ -718,7 +731,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "xyp-XY14",
+    "setOrder":1003,
+	"id": "xyp-XY14",
     "name": "Trevenant",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY14.png",
     "subtype": "Stage 1",
@@ -778,7 +792,8 @@
     "nationalPokedexNumber": 709
   },
   {
-    "id": "xyp-XY15",
+    "setOrder":1003,
+	"id": "xyp-XY15",
     "name": "Slurpuff",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY15.png",
     "subtype": "Stage 1",
@@ -838,7 +853,8 @@
     "nationalPokedexNumber": 685
   },
   {
-    "id": "xyp-XY16",
+    "setOrder":1003,
+	"id": "xyp-XY16",
     "name": "Gogoat",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY16.png",
     "subtype": "Stage 1",
@@ -893,7 +909,8 @@
     "nationalPokedexNumber": 673
   },
   {
-    "id": "xyp-XY17",
+    "setOrder":1003,
+	"id": "xyp-XY17",
     "name": "Charizard-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY17.png",
     "subtype": "EX",
@@ -952,7 +969,8 @@
     "evolvesTo": "M Charizard-EX"
   },
   {
-    "id": "xyp-XY18",
+    "setOrder":1003,
+	"id": "xyp-XY18",
     "name": "Chesnaught-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY18.png",
     "subtype": "EX",
@@ -1012,7 +1030,8 @@
     "nationalPokedexNumber": 652
   },
   {
-    "id": "xyp-XY19",
+    "setOrder":1003,
+	"id": "xyp-XY19",
     "name": "Delphox-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY19.png",
     "subtype": "EX",
@@ -1068,7 +1087,8 @@
     "nationalPokedexNumber": 655
   },
   {
-    "id": "xyp-XY20",
+    "setOrder":1003,
+	"id": "xyp-XY20",
     "name": "Greninja-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY20.png",
     "subtype": "EX",
@@ -1122,7 +1142,8 @@
     "nationalPokedexNumber": 658
   },
   {
-    "id": "xyp-XY21",
+    "setOrder":1003,
+	"id": "xyp-XY21",
     "name": "Bronzong",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY21.png",
     "subtype": "Stage 1",
@@ -1178,7 +1199,8 @@
     "nationalPokedexNumber": 437
   },
   {
-    "id": "xyp-XY22",
+    "setOrder":1003,
+	"id": "xyp-XY22",
     "name": "Darkrai",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY22.png",
     "subtype": "Basic",
@@ -1236,7 +1258,8 @@
     "nationalPokedexNumber": 491
   },
   {
-    "id": "xyp-XY23",
+    "setOrder":1003,
+	"id": "xyp-XY23",
     "name": "Shiftry",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY23.png",
     "subtype": "Stage 2",
@@ -1289,7 +1312,8 @@
     "nationalPokedexNumber": 275
   },
   {
-    "id": "xyp-XY24",
+    "setOrder":1003,
+	"id": "xyp-XY24",
     "name": "Greninja",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY24.png",
     "subtype": "Stage 2",
@@ -1342,7 +1366,8 @@
     "nationalPokedexNumber": 658
   },
   {
-    "id": "xyp-XY25",
+    "setOrder":1003,
+	"id": "xyp-XY25",
     "name": "Krookodile-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY25.png",
     "subtype": "EX",
@@ -1407,7 +1432,8 @@
     "nationalPokedexNumber": 553
   },
   {
-    "id": "xyp-XY26",
+    "setOrder":1003,
+	"id": "xyp-XY26",
     "name": "Pyroar",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY26.png",
     "subtype": "Stage 1",
@@ -1462,7 +1488,8 @@
     "nationalPokedexNumber": 668
   },
   {
-    "id": "xyp-XY27",
+    "setOrder":1003,
+	"id": "xyp-XY27",
     "name": "Champions Festival",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY27.png",
     "subtype": "Stadium",
@@ -1480,7 +1507,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xyp/XY27_hires.png"
   },
   {
-    "id": "xyp-XY28",
+    "setOrder":1003,
+	"id": "xyp-XY28",
     "name": "Venusaur-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY28.png",
     "subtype": "EX",
@@ -1541,7 +1569,8 @@
     "evolvesTo": "M Venusaur-EX"
   },
   {
-    "id": "xyp-XY29",
+    "setOrder":1003,
+	"id": "xyp-XY29",
     "name": "Charizard-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY29.png",
     "subtype": "EX",
@@ -1598,7 +1627,8 @@
     "evolvesTo": "M Charizard-EX"
   },
   {
-    "id": "xyp-XY30",
+    "setOrder":1003,
+	"id": "xyp-XY30",
     "name": "Blastoise-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY30.png",
     "subtype": "EX",
@@ -1656,7 +1686,8 @@
     "evolvesTo": "M Blastoise-EX"
   },
   {
-    "id": "xyp-XY31",
+    "setOrder":1003,
+	"id": "xyp-XY31",
     "name": "Xerneas",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY31.png",
     "subtype": "Basic",
@@ -1717,7 +1748,8 @@
     "nationalPokedexNumber": 716
   },
   {
-    "id": "xyp-XY32",
+    "setOrder":1003,
+	"id": "xyp-XY32",
     "name": "Yveltal",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY32.png",
     "subtype": "Basic",
@@ -1778,7 +1810,8 @@
     "nationalPokedexNumber": 717
   },
   {
-    "id": "xyp-XY33",
+    "setOrder":1003,
+	"id": "xyp-XY33",
     "name": "Trevor",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY33.png",
     "subtype": "Supporter",
@@ -1795,7 +1828,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xyp/XY33_hires.png"
   },
   {
-    "id": "xyp-XY34",
+    "setOrder":1003,
+	"id": "xyp-XY34",
     "name": "Metagross-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY34.png",
     "subtype": "EX",
@@ -1861,7 +1895,8 @@
     "evolvesTo": "M Metagross-EX"
   },
   {
-    "id": "xyp-XY35",
+    "setOrder":1003,
+	"id": "xyp-XY35",
     "name": "M Metagross-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY35.png",
     "subtype": "MEGA",
@@ -1917,7 +1952,8 @@
     "nationalPokedexNumber": 376
   },
   {
-    "id": "xyp-XY36",
+    "setOrder":1003,
+	"id": "xyp-XY36",
     "name": "Treecko",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY36.png",
     "subtype": "Basic",
@@ -1960,7 +1996,8 @@
     ]
   },
   {
-    "id": "xyp-XY37",
+    "setOrder":1003,
+	"id": "xyp-XY37",
     "name": "Torchic",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY37.png",
     "subtype": "Basic",
@@ -2003,7 +2040,8 @@
     ]
   },
   {
-    "id": "xyp-XY38",
+    "setOrder":1003,
+	"id": "xyp-XY38",
     "name": "Mudkip",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY38.png",
     "subtype": "Basic",
@@ -2056,7 +2094,8 @@
     ]
   },
   {
-    "id": "xyp-XY39",
+    "setOrder":1003,
+	"id": "xyp-XY39",
     "name": "Kingdra",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY39.png",
     "subtype": "Stage 2",
@@ -2112,7 +2151,8 @@
     "nationalPokedexNumber": 230
   },
   {
-    "id": "xyp-XY40",
+    "setOrder":1003,
+	"id": "xyp-XY40",
     "name": "Ditto",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY40.png",
     "subtype": "Basic",
@@ -2158,7 +2198,8 @@
     "nationalPokedexNumber": 132
   },
   {
-    "id": "xyp-XY41",
+    "setOrder":1003,
+	"id": "xyp-XY41",
     "name": "Kyogre-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY41.png",
     "subtype": "EX",
@@ -2217,7 +2258,8 @@
     "nationalPokedexNumber": 382
   },
   {
-    "id": "xyp-XY42",
+    "setOrder":1003,
+	"id": "xyp-XY42",
     "name": "Groudon-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY42.png",
     "subtype": "EX",
@@ -2276,7 +2318,8 @@
     "nationalPokedexNumber": 383
   },
   {
-    "id": "xyp-XY43",
+    "setOrder":1003,
+	"id": "xyp-XY43",
     "name": "Diancie-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY43.png",
     "subtype": "EX",
@@ -2339,7 +2382,8 @@
     "evolvesTo": "M Diancie-EX"
   },
   {
-    "id": "xyp-XY44",
+    "setOrder":1003,
+	"id": "xyp-XY44",
     "name": "M Diancie-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY44.png",
     "subtype": "MEGA",
@@ -2393,7 +2437,8 @@
     "nationalPokedexNumber": 719
   },
   {
-    "id": "xyp-XY45",
+    "setOrder":1003,
+	"id": "xyp-XY45",
     "name": "Gallade-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY45.png",
     "subtype": "EX",
@@ -2452,7 +2497,8 @@
     "evolvesTo": "M Gallade-EX"
   },
   {
-    "id": "xyp-XY46",
+    "setOrder":1003,
+	"id": "xyp-XY46",
     "name": "Altaria",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY46.png",
     "subtype": "Stage 1",
@@ -2509,7 +2555,8 @@
     "nationalPokedexNumber": 334
   },
   {
-    "id": "xyp-XY47",
+    "setOrder":1003,
+	"id": "xyp-XY47",
     "name": "Heliolisk",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY47.png",
     "subtype": "Stage 1",
@@ -2563,7 +2610,8 @@
     "nationalPokedexNumber": 695
   },
   {
-    "id": "xyp-XY48",
+    "setOrder":1003,
+	"id": "xyp-XY48",
     "name": "Meowstic",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY48.png",
     "subtype": "Stage 1",
@@ -2611,7 +2659,8 @@
     "nationalPokedexNumber": 678
   },
   {
-    "id": "xyp-XY49",
+    "setOrder":1003,
+	"id": "xyp-XY49",
     "name": "Regirock",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY49.png",
     "subtype": "Basic",
@@ -2665,7 +2714,8 @@
     "nationalPokedexNumber": 377
   },
   {
-    "id": "xyp-XY50",
+    "setOrder":1003,
+	"id": "xyp-XY50",
     "name": "Pangoro",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY50.png",
     "subtype": "Stage 1",
@@ -2715,7 +2765,8 @@
     "nationalPokedexNumber": 675
   },
   {
-    "id": "xyp-XY51",
+    "setOrder":1003,
+	"id": "xyp-XY51",
     "name": "Kyogre",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY51.png",
     "subtype": "Basic",
@@ -2771,7 +2822,8 @@
     "nationalPokedexNumber": 382
   },
   {
-    "id": "xyp-XY52",
+    "setOrder":1003,
+	"id": "xyp-XY52",
     "name": "Groudon",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY52.png",
     "subtype": "Basic",
@@ -2827,7 +2879,8 @@
     "nationalPokedexNumber": 383
   },
   {
-    "id": "xyp-XY53",
+    "setOrder":1003,
+	"id": "xyp-XY53",
     "name": "Sceptile-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY53.png",
     "subtype": "EX",
@@ -2882,7 +2935,8 @@
     "evolvesTo": "M Sceptile-EX"
   },
   {
-    "id": "xyp-XY54",
+    "setOrder":1003,
+	"id": "xyp-XY54",
     "name": "Blaziken-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY54.png",
     "subtype": "EX",
@@ -2940,7 +2994,8 @@
     "evolvesTo": "M Blaziken-EX"
   },
   {
-    "id": "xyp-XY55",
+    "setOrder":1003,
+	"id": "xyp-XY55",
     "name": "Swampert-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY55.png",
     "subtype": "EX",
@@ -3000,7 +3055,8 @@
     "evolvesTo": "M Swampert-EX"
   },
   {
-    "id": "xyp-XY56",
+    "setOrder":1003,
+	"id": "xyp-XY56",
     "name": "Blissey",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY56.png",
     "subtype": "Stage 1",
@@ -3055,7 +3111,8 @@
     "nationalPokedexNumber": 242
   },
   {
-    "id": "xyp-XY57",
+    "setOrder":1003,
+	"id": "xyp-XY57",
     "name": "Fearow",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY57.png",
     "subtype": "Stage 1",
@@ -3113,7 +3170,8 @@
     "nationalPokedexNumber": 22
   },
   {
-    "id": "xyp-XY58",
+    "setOrder":1003,
+	"id": "xyp-XY58",
     "name": "Malamar",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY58.png",
     "subtype": "Stage 1",
@@ -3168,7 +3226,8 @@
     "nationalPokedexNumber": 687
   },
   {
-    "id": "xyp-XY59",
+    "setOrder":1003,
+	"id": "xyp-XY59",
     "name": "Salamence",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY59.png",
     "subtype": "Stage 2",
@@ -3222,7 +3281,8 @@
     "nationalPokedexNumber": 373
   },
   {
-    "id": "xyp-XY60",
+    "setOrder":1003,
+	"id": "xyp-XY60",
     "name": "Gyarados",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY60.png",
     "subtype": "Stage 1",
@@ -3282,7 +3342,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "xyp-XY61",
+    "setOrder":1003,
+	"id": "xyp-XY61",
     "name": "Flygon-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY61.png",
     "subtype": "Basic",
@@ -3334,7 +3395,8 @@
     "nationalPokedexNumber": 330
   },
   {
-    "id": "xyp-XY62",
+    "setOrder":1003,
+	"id": "xyp-XY62",
     "name": "Absol-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY62.png",
     "subtype": "EX",
@@ -3396,7 +3458,8 @@
     "evolvesTo": "M Absol-EX"
   },
   {
-    "id": "xyp-XY63",
+    "setOrder":1003,
+	"id": "xyp-XY63",
     "name": "M Absol-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY63.png",
     "subtype": "MEGA",
@@ -3449,7 +3512,8 @@
     "nationalPokedexNumber": 359
   },
   {
-    "id": "xyp-XY64",
+    "setOrder":1003,
+	"id": "xyp-XY64",
     "name": "Rayquaza",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY64.png",
     "subtype": "Basic",
@@ -3499,7 +3563,8 @@
     "nationalPokedexNumber": 384
   },
   {
-    "id": "xyp-XY65",
+    "setOrder":1003,
+	"id": "xyp-XY65",
     "name": "Latios",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY65.png",
     "subtype": "EX",
@@ -3552,7 +3617,8 @@
     "evolvesTo": "M Latios"
   },
   {
-    "id": "xyp-XY66",
+    "setOrder":1003,
+	"id": "xyp-XY66",
     "name": "Rayquaza-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY66.png",
     "subtype": "EX",
@@ -3616,7 +3682,8 @@
     "evolvesTo": "M Rayquaza-EX"
   },
   {
-    "id": "xyp-XY67",
+    "setOrder":1003,
+	"id": "xyp-XY67",
     "name": "Jirachi",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY67.png",
     "subtype": "Basic",
@@ -3672,7 +3739,8 @@
     "nationalPokedexNumber": 385
   },
   {
-    "id": "xyp-XY67a",
+    "setOrder":1003,
+	"id": "xyp-XY67a",
     "name": "Jirachi",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY67a.png",
     "subtype": "Basic",
@@ -3728,7 +3796,8 @@
     "nationalPokedexNumber": 385
   },
   {
-    "id": "xyp-XY68",
+    "setOrder":1003,
+	"id": "xyp-XY68",
     "name": "Chesnaught",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY68.png",
     "subtype": "Stage 2",
@@ -3786,7 +3855,8 @@
     "nationalPokedexNumber": 652
   },
   {
-    "id": "xyp-XY69",
+    "setOrder":1003,
+	"id": "xyp-XY69",
     "name": "Rayquaza-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY69.png",
     "subtype": "EX",
@@ -3850,7 +3920,8 @@
     "evolvesTo": "M Rayquaza-EX"
   },
   {
-    "id": "xyp-XY70",
+    "setOrder":1003,
+	"id": "xyp-XY70",
     "name": "Tyrantrum-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY70.png",
     "subtype": "EX",
@@ -3903,7 +3974,8 @@
     "nationalPokedexNumber": 697
   },
   {
-    "id": "xyp-XY71",
+    "setOrder":1003,
+	"id": "xyp-XY71",
     "name": "Hoopa-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY71.png",
     "subtype": "EX",
@@ -3954,7 +4026,8 @@
     "nationalPokedexNumber": 720
   },
   {
-    "id": "xyp-XY72",
+    "setOrder":1003,
+	"id": "xyp-XY72",
     "name": "Latios-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY72.png",
     "subtype": "EX",
@@ -4011,7 +4084,8 @@
     "evolvesTo": "M Latios-EX"
   },
   {
-    "id": "xyp-XY73",
+    "setOrder":1003,
+	"id": "xyp-XY73",
     "name": "Rayquaza-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY73.png",
     "subtype": "EX",
@@ -4069,7 +4143,8 @@
     "evolvesTo": "M Rayquaza-EX"
   },
   {
-    "id": "xyp-XY74",
+    "setOrder":1003,
+	"id": "xyp-XY74",
     "name": "Reshiram",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY74.png",
     "subtype": "Basic",
@@ -4123,7 +4198,8 @@
     "nationalPokedexNumber": 643
   },
   {
-    "id": "xyp-XY75",
+    "setOrder":1003,
+	"id": "xyp-XY75",
     "name": "Palkia",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY75.png",
     "subtype": "Basic",
@@ -4177,7 +4253,8 @@
     "nationalPokedexNumber": 484
   },
   {
-    "id": "xyp-XY76",
+    "setOrder":1003,
+	"id": "xyp-XY76",
     "name": "Zekrom",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY76.png",
     "subtype": "Basic",
@@ -4237,7 +4314,8 @@
     "nationalPokedexNumber": 644
   },
   {
-    "id": "xyp-XY77",
+    "setOrder":1003,
+	"id": "xyp-XY77",
     "name": "Dialga",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY77.png",
     "subtype": "Basic",
@@ -4297,7 +4375,8 @@
     "nationalPokedexNumber": 483
   },
   {
-    "id": "xyp-XY78",
+    "setOrder":1003,
+	"id": "xyp-XY78",
     "name": "Latias",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY78.png",
     "subtype": "Basic",
@@ -4348,7 +4427,8 @@
     "nationalPokedexNumber": 380
   },
   {
-    "id": "xyp-XY79",
+    "setOrder":1003,
+	"id": "xyp-XY79",
     "name": "Latios",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY79.png",
     "subtype": "Basic",
@@ -4400,7 +4480,8 @@
     "nationalPokedexNumber": 381
   },
   {
-    "id": "xyp-XY80",
+    "setOrder":1003,
+	"id": "xyp-XY80",
     "name": "Black Kyurem",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY80.png",
     "subtype": "Basic",
@@ -4456,7 +4537,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "xyp-XY81",
+    "setOrder":1003,
+	"id": "xyp-XY81",
     "name": "White Kyurem",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY81.png",
     "subtype": "Basic",
@@ -4512,7 +4594,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "xyp-XY82",
+    "setOrder":1003,
+	"id": "xyp-XY82",
     "name": "Regigigas",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY82.png",
     "subtype": "Basic",
@@ -4563,7 +4646,8 @@
     "nationalPokedexNumber": 486
   },
   {
-    "id": "xyp-XY83",
+    "setOrder":1003,
+	"id": "xyp-XY83",
     "name": "Arceus",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY83.png",
     "subtype": "Basic",
@@ -4615,7 +4699,8 @@
     "nationalPokedexNumber": 493
   },
   {
-    "id": "xyp-XY84",
+    "setOrder":1003,
+	"id": "xyp-XY84",
     "name": "Pikachu-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY84.png",
     "subtype": "EX",
@@ -4678,7 +4763,8 @@
     ]
   },
   {
-    "id": "xyp-XY85",
+    "setOrder":1003,
+	"id": "xyp-XY85",
     "name": "Hoopa-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY85.png",
     "subtype": "EX",
@@ -4733,7 +4819,8 @@
     "nationalPokedexNumber": 720
   },
   {
-    "id": "xyp-XY86",
+    "setOrder":1003,
+	"id": "xyp-XY86",
     "name": "M Blaziken-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY86.png",
     "subtype": "MEGA",
@@ -4782,7 +4869,8 @@
     "nationalPokedexNumber": 257
   },
   {
-    "id": "xyp-XY87",
+    "setOrder":1003,
+	"id": "xyp-XY87",
     "name": "M Swampert-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY87.png",
     "subtype": "MEGA",
@@ -4832,7 +4920,8 @@
     "nationalPokedexNumber": 260
   },
   {
-    "id": "xyp-XY88",
+    "setOrder":1003,
+	"id": "xyp-XY88",
     "name": "Chespin",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY88.png",
     "subtype": "Basic",
@@ -4877,7 +4966,8 @@
     ]
   },
   {
-    "id": "xyp-XY89",
+    "setOrder":1003,
+	"id": "xyp-XY89",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY89.png",
     "subtype": "Basic",
@@ -4937,7 +5027,8 @@
     ]
   },
   {
-    "id": "xyp-XY90",
+    "setOrder":1003,
+	"id": "xyp-XY90",
     "name": "Hoopa",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY90.png",
     "subtype": "Basic",
@@ -4988,7 +5079,8 @@
     "nationalPokedexNumber": 720
   },
   {
-    "id": "xyp-XY91",
+    "setOrder":1003,
+	"id": "xyp-XY91",
     "name": "Champions Festival",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY91.png",
     "subtype": "Stadium",
@@ -5005,7 +5097,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xyp/XY91_hires.png"
   },
   {
-    "id": "xyp-XY92",
+    "setOrder":1003,
+	"id": "xyp-XY92",
     "name": "Sableye",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY92.png",
     "subtype": "Basic",
@@ -5050,7 +5143,8 @@
     "nationalPokedexNumber": 302
   },
   {
-    "id": "xyp-XY93",
+    "setOrder":1003,
+	"id": "xyp-XY93",
     "name": "Celebi",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY93.png",
     "subtype": "Basic",
@@ -5095,7 +5189,8 @@
     "nationalPokedexNumber": 251
   },
   {
-    "id": "xyp-XY94",
+    "setOrder":1003,
+	"id": "xyp-XY94",
     "name": "Trevenant",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY94.png",
     "subtype": "Stage 1",
@@ -5138,7 +5233,8 @@
     "nationalPokedexNumber": 709
   },
   {
-    "id": "xyp-XY95",
+    "setOrder":1003,
+	"id": "xyp-XY95",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY95.png",
     "subtype": "Basic",
@@ -5197,7 +5293,8 @@
     ]
   },
   {
-    "id": "xyp-XY96",
+    "setOrder":1003,
+	"id": "xyp-XY96",
     "name": "Umbreon",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY96.png",
     "subtype": "Stage 1",
@@ -5246,7 +5343,8 @@
     "nationalPokedexNumber": 197
   },
   {
-    "id": "xyp-XY97",
+    "setOrder":1003,
+	"id": "xyp-XY97",
     "name": "Aerodactyl-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY97.png",
     "subtype": "EX",
@@ -5308,7 +5406,8 @@
     "evolvesTo": "M Aerodactyl-EX"
   },
   {
-    "id": "xyp-XY98",
+    "setOrder":1003,
+	"id": "xyp-XY98",
     "name": "M Aerodactyl-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY98.png",
     "subtype": "MEGA",
@@ -5361,7 +5460,8 @@
     "nationalPokedexNumber": 142
   },
   {
-    "id": "xyp-XY99",
+    "setOrder":1003,
+	"id": "xyp-XY99",
     "name": "Aerodactyl Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY99.png",
     "subtype": "Pokémon Tool",
@@ -5378,7 +5478,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xyp/XY99_hires.png"
   },
   {
-    "id": "xyp-XY100",
+    "setOrder":1003,
+	"id": "xyp-XY100",
     "name": "Mewtwo",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY100.png",
     "subtype": "Basic",
@@ -5420,7 +5521,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "xyp-XY101",
+    "setOrder":1003,
+	"id": "xyp-XY101",
     "name": "Mewtwo",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY101.png",
     "subtype": "Basic",
@@ -5462,7 +5564,8 @@
     "nationalPokedexNumber": 150
   },
   {
-    "id": "xyp-XY102",
+    "setOrder":1003,
+	"id": "xyp-XY102",
     "name": "Aurorus-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY102.png",
     "subtype": "EX",
@@ -5515,7 +5618,8 @@
     "nationalPokedexNumber": 699
   },
   {
-    "id": "xyp-XY103",
+    "setOrder":1003,
+	"id": "xyp-XY103",
     "name": "Mawile-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY103.png",
     "subtype": "EX",
@@ -5577,7 +5681,8 @@
     "evolvesTo": "M Mawile-EX"
   },
   {
-    "id": "xyp-XY104",
+    "setOrder":1003,
+	"id": "xyp-XY104",
     "name": "M Mawile-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY104.png",
     "subtype": "MEGA",
@@ -5631,7 +5736,8 @@
     "nationalPokedexNumber": 303
   },
   {
-    "id": "xyp-XY105",
+    "setOrder":1003,
+	"id": "xyp-XY105",
     "name": "Mawile Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY105.png",
     "subtype": "Pokémon Tool",
@@ -5648,7 +5754,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xyp/XY105_hires.png"
   },
   {
-    "id": "xyp-XY106",
+    "setOrder":1003,
+	"id": "xyp-XY106",
     "name": "Gyarados-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY106.png",
     "subtype": "EX",
@@ -5695,7 +5802,8 @@
     "evolvesTo": "M Gyarados-EX"
   },
   {
-    "id": "xyp-XY107",
+    "setOrder":1003,
+	"id": "xyp-XY107",
     "name": "Mewtwo-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY107.png",
     "subtype": "EX",
@@ -5740,7 +5848,8 @@
     "evolvesTo": "M Mewtwo-EX"
   },
   {
-    "id": "xyp-XY108",
+    "setOrder":1003,
+	"id": "xyp-XY108",
     "name": "Machamp-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY108.png",
     "subtype": "EX",
@@ -5786,7 +5895,8 @@
     "nationalPokedexNumber": 68
   },
   {
-    "id": "xyp-XY109",
+    "setOrder":1003,
+	"id": "xyp-XY109",
     "name": "Gyarados",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY109.png",
     "subtype": "Stage 1",
@@ -5843,7 +5953,8 @@
     "nationalPokedexNumber": 130
   },
   {
-    "id": "xyp-XY110",
+    "setOrder":1003,
+	"id": "xyp-XY110",
     "name": "Mew",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY110.png",
     "subtype": "Basic",
@@ -5883,7 +5994,8 @@
     "nationalPokedexNumber": 151
   },
   {
-    "id": "xyp-XY111",
+    "setOrder":1003,
+	"id": "xyp-XY111",
     "name": "Celebi",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY111.png",
     "subtype": "Basic",
@@ -5923,7 +6035,8 @@
     "nationalPokedexNumber": 251
   },
   {
-    "id": "xyp-XY112",
+    "setOrder":1003,
+	"id": "xyp-XY112",
     "name": "Jirachi",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY112.png",
     "subtype": "Basic",
@@ -5969,7 +6082,8 @@
     "nationalPokedexNumber": 385
   },
   {
-    "id": "xyp-XY113",
+    "setOrder":1003,
+	"id": "xyp-XY113",
     "name": "Manaphy",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY113.png",
     "subtype": "Basic",
@@ -6019,7 +6133,8 @@
     "nationalPokedexNumber": 490
   },
   {
-    "id": "xyp-XY114",
+    "setOrder":1003,
+	"id": "xyp-XY114",
     "name": "Darkrai",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY114.png",
     "subtype": "Basic",
@@ -6078,7 +6193,8 @@
     "nationalPokedexNumber": 491
   },
   {
-    "id": "xyp-XY115",
+    "setOrder":1003,
+	"id": "xyp-XY115",
     "name": "Shaymin",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY115.png",
     "subtype": "Basic",
@@ -6130,7 +6246,8 @@
     "nationalPokedexNumber": 492
   },
   {
-    "id": "xyp-XY116",
+    "setOrder":1003,
+	"id": "xyp-XY116",
     "name": "Arceus",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY116.png",
     "subtype": "Basic",
@@ -6183,7 +6300,8 @@
     "nationalPokedexNumber": 493
   },
   {
-    "id": "xyp-XY117",
+    "setOrder":1003,
+	"id": "xyp-XY117",
     "name": "Victini",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY117.png",
     "subtype": "Basic",
@@ -6233,7 +6351,8 @@
     "nationalPokedexNumber": 494
   },
   {
-    "id": "xyp-XY118",
+    "setOrder":1003,
+	"id": "xyp-XY118",
     "name": "Keldeo",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY118.png",
     "subtype": "Basic",
@@ -6280,7 +6399,8 @@
     "nationalPokedexNumber": 647
   },
   {
-    "id": "xyp-XY119",
+    "setOrder":1003,
+	"id": "xyp-XY119",
     "name": "Genesect",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY119.png",
     "subtype": "Basic",
@@ -6339,7 +6459,8 @@
     "nationalPokedexNumber": 649
   },
   {
-    "id": "xyp-XY120",
+    "setOrder":1003,
+	"id": "xyp-XY120",
     "name": "Meloetta",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY120.png",
     "subtype": "Basic",
@@ -6389,7 +6510,8 @@
     "nationalPokedexNumber": 648
   },
   {
-    "id": "xyp-XY121",
+    "setOrder":1003,
+	"id": "xyp-XY121",
     "name": "Charizard-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY121.png",
     "subtype": "EX",
@@ -6434,7 +6556,8 @@
     "evolvesTo": "M Charizard-EX"
   },
   {
-    "id": "xyp-XY122",
+    "setOrder":1003,
+	"id": "xyp-XY122",
     "name": "Blastoise-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY122.png",
     "subtype": "EX",
@@ -6492,7 +6615,8 @@
     "evolvesTo": "M Blastoise-EX"
   },
   {
-    "id": "xyp-XY123",
+    "setOrder":1003,
+	"id": "xyp-XY123",
     "name": "Venusaur-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY123.png",
     "subtype": "EX",
@@ -6553,7 +6677,8 @@
     "evolvesTo": "M Venusaur-EX"
   },
   {
-    "id": "xyp-XY124",
+    "setOrder":1003,
+	"id": "xyp-XY124",
     "name": "Pikachu-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY124.png",
     "subtype": "EX",
@@ -6616,7 +6741,8 @@
     ]
   },
   {
-    "id": "xyp-XY125",
+    "setOrder":1003,
+	"id": "xyp-XY125",
     "name": "Mewtwo-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY125.png",
     "subtype": "EX",
@@ -6674,7 +6800,8 @@
     "evolvesTo": "M Mewtwo-EX"
   },
   {
-    "id": "xyp-XY126",
+    "setOrder":1003,
+	"id": "xyp-XY126",
     "name": "Mew-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY126.png",
     "subtype": "EX",
@@ -6722,7 +6849,8 @@
     "nationalPokedexNumber": 151
   },
   {
-    "id": "xyp-XY127",
+    "setOrder":1003,
+	"id": "xyp-XY127",
     "name": "Moltres",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY127.png",
     "subtype": "Basic",
@@ -6780,7 +6908,8 @@
     "nationalPokedexNumber": 146
   },
   {
-    "id": "xyp-XY128",
+    "setOrder":1003,
+	"id": "xyp-XY128",
     "name": "White Kyurem",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY128.png",
     "subtype": "Basic",
@@ -6834,7 +6963,8 @@
     "nationalPokedexNumber": 646
   },
   {
-    "id": "xyp-XY129",
+    "setOrder":1003,
+	"id": "xyp-XY129",
     "name": "Zygarde",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY129.png",
     "subtype": "Basic",
@@ -6887,7 +7017,8 @@
     "nationalPokedexNumber": 718
   },
   {
-    "id": "xyp-XY130",
+    "setOrder":1003,
+	"id": "xyp-XY130",
     "name": "Tyranitar",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY130.png",
     "subtype": "Stage 2",
@@ -6946,7 +7077,8 @@
     "nationalPokedexNumber": 248
   },
   {
-    "id": "xyp-XY131",
+    "setOrder":1003,
+	"id": "xyp-XY131",
     "name": "Pansear",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY131.png",
     "subtype": "Basic",
@@ -6989,7 +7121,8 @@
     ]
   },
   {
-    "id": "xyp-XY132",
+    "setOrder":1003,
+	"id": "xyp-XY132",
     "name": "Gastly",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY132.png",
     "subtype": "Basic",
@@ -7038,7 +7171,8 @@
     ]
   },
   {
-    "id": "xyp-XY133",
+    "setOrder":1003,
+	"id": "xyp-XY133",
     "name": "Ash-Greninja-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY133.png",
     "subtype": "EX",
@@ -7093,7 +7227,8 @@
     "nationalPokedexNumber": 658
   },
   {
-    "id": "xyp-XY134",
+    "setOrder":1003,
+	"id": "xyp-XY134",
     "name": "Empoleon BREAK",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY134.png",
     "subtype": "BREAK",
@@ -7129,7 +7264,8 @@
     "nationalPokedexNumber": 395
   },
   {
-    "id": "xyp-XY135",
+    "setOrder":1003,
+	"id": "xyp-XY135",
     "name": "Beheeyem BREAK",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY135.png",
     "subtype": "BREAK",
@@ -7166,7 +7302,8 @@
     "nationalPokedexNumber": 606
   },
   {
-    "id": "xyp-XY136",
+    "setOrder":1003,
+	"id": "xyp-XY136",
     "name": "Noctowl BREAK",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY136.png",
     "subtype": "BREAK",
@@ -7203,7 +7340,8 @@
     "nationalPokedexNumber": 164
   },
   {
-    "id": "xyp-XY137",
+    "setOrder":1003,
+	"id": "xyp-XY137",
     "name": "Vivillon",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY137.png",
     "subtype": "Stage 2",
@@ -7253,7 +7391,8 @@
     "nationalPokedexNumber": 666
   },
   {
-    "id": "xyp-XY138",
+    "setOrder":1003,
+	"id": "xyp-XY138",
     "name": "Froakie",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY138.png",
     "subtype": "Basic",
@@ -7296,7 +7435,8 @@
     ]
   },
   {
-    "id": "xyp-XY139",
+    "setOrder":1003,
+	"id": "xyp-XY139",
     "name": "Floette",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY139.png",
     "subtype": "Stage 1",
@@ -7356,7 +7496,8 @@
     ]
   },
   {
-    "id": "xyp-XY140",
+    "setOrder":1003,
+	"id": "xyp-XY140",
     "name": "Lucario",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY140.png",
     "subtype": "Stage 1",
@@ -7409,7 +7550,8 @@
     "nationalPokedexNumber": 448
   },
   {
-    "id": "xyp-XY141",
+    "setOrder":1003,
+	"id": "xyp-XY141",
     "name": "Rayquaza",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY141.png",
     "subtype": "Basic",
@@ -7463,7 +7605,8 @@
     "nationalPokedexNumber": 384
   },
   {
-    "id": "xyp-XY142",
+    "setOrder":1003,
+	"id": "xyp-XY142",
     "name": "Azelf",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY142.png",
     "subtype": "Basic",
@@ -7514,7 +7657,8 @@
     "nationalPokedexNumber": 482
   },
   {
-    "id": "xyp-XY143",
+    "setOrder":1003,
+	"id": "xyp-XY143",
     "name": "Magikarp",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY143.png",
     "subtype": "Basic",
@@ -7557,7 +7701,8 @@
     ]
   },
   {
-    "id": "xyp-XY144",
+    "setOrder":1003,
+	"id": "xyp-XY144",
     "name": "Yanmega",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY144.png",
     "subtype": "Stage 1",
@@ -7608,7 +7753,8 @@
     "nationalPokedexNumber": 469
   },
   {
-    "id": "xyp-XY145",
+    "setOrder":1003,
+	"id": "xyp-XY145",
     "name": "Volcanion",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY145.png",
     "subtype": "Basic",
@@ -7660,7 +7806,8 @@
     "nationalPokedexNumber": 721
   },
   {
-    "id": "xyp-XY146",
+    "setOrder":1003,
+	"id": "xyp-XY146",
     "name": "Clawitzer",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY146.png",
     "subtype": "Stage 1",
@@ -7709,7 +7856,8 @@
     "nationalPokedexNumber": 693
   },
   {
-    "id": "xyp-XY147",
+    "setOrder":1003,
+	"id": "xyp-XY147",
     "name": "Hoopa",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY147.png",
     "subtype": "Basic",
@@ -7761,7 +7909,8 @@
     "nationalPokedexNumber": 720
   },
   {
-    "id": "xyp-XY148",
+    "setOrder":1003,
+	"id": "xyp-XY148",
     "name": "Shaymin-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY148.png",
     "subtype": "EX",
@@ -7812,7 +7961,8 @@
     "nationalPokedexNumber": 492
   },
   {
-    "id": "xyp-XY149",
+    "setOrder":1003,
+	"id": "xyp-XY149",
     "name": "Xerneas-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY149.png",
     "subtype": "EX",
@@ -7876,7 +8026,8 @@
     "nationalPokedexNumber": 716
   },
   {
-    "id": "xyp-XY150",
+    "setOrder":1003,
+	"id": "xyp-XY150",
     "name": "Yveltal-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY150.png",
     "subtype": "EX",
@@ -7938,7 +8089,8 @@
     "nationalPokedexNumber": 717
   },
   {
-    "id": "xyp-XY150a",
+    "setOrder":1003,
+	"id": "xyp-XY150a",
     "name": "Yveltal-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY150a.png",
     "subtype": "EX",
@@ -8000,7 +8152,8 @@
     "nationalPokedexNumber": 717
   },
   {
-    "id": "xyp-XY151",
+    "setOrder":1003,
+	"id": "xyp-XY151",
     "name": "Zygarde-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY151.png",
     "subtype": "EX",
@@ -8066,7 +8219,8 @@
     "nationalPokedexNumber": 718
   },
   {
-    "id": "xyp-XY152",
+    "setOrder":1003,
+	"id": "xyp-XY152",
     "name": "Zygarde",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY152.png",
     "subtype": "Basic",
@@ -8119,7 +8273,8 @@
     "nationalPokedexNumber": 718
   },
   {
-    "id": "xyp-XY153",
+    "setOrder":1003,
+	"id": "xyp-XY153",
     "name": "Ho-Oh",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY153.png",
     "subtype": "Basic",
@@ -8178,7 +8333,8 @@
     "nationalPokedexNumber": 250
   },
   {
-    "id": "xyp-XY154",
+    "setOrder":1003,
+	"id": "xyp-XY154",
     "name": "Ho-Oh BREAK",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY154.png",
     "subtype": "BREAK",
@@ -8217,7 +8373,8 @@
     "nationalPokedexNumber": 250
   },
   {
-    "id": "xyp-XY155",
+    "setOrder":1003,
+	"id": "xyp-XY155",
     "name": "Wobbuffet BREAK",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY155.png",
     "subtype": "BREAK",
@@ -8259,7 +8416,8 @@
     "nationalPokedexNumber": 202
   },
   {
-    "id": "xyp-XY156",
+    "setOrder":1003,
+	"id": "xyp-XY156",
     "name": "Lugia",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY156.png",
     "subtype": "Basic",
@@ -8319,7 +8477,8 @@
     "nationalPokedexNumber": 249
   },
   {
-    "id": "xyp-XY157",
+    "setOrder":1003,
+	"id": "xyp-XY157",
     "name": "Beedrill-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY157.png",
     "subtype": "EX",
@@ -8373,7 +8532,8 @@
     "evolvesTo": "M Beedrill-EX"
   },
   {
-    "id": "xyp-XY158",
+    "setOrder":1003,
+	"id": "xyp-XY158",
     "name": "M Beedrill-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY158.png",
     "subtype": "MEGA",
@@ -8416,7 +8576,8 @@
     "nationalPokedexNumber": 15
   },
   {
-    "id": "xyp-XY159",
+    "setOrder":1003,
+	"id": "xyp-XY159",
     "name": "Beedrill Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY159.png",
     "subtype": "Pokémon Tool",
@@ -8433,7 +8594,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xyp/XY159_hires.png"
   },
   {
-    "id": "xyp-XY160",
+    "setOrder":1003,
+	"id": "xyp-XY160",
     "name": "Black Kyurem",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY160.png",
     "subtype": "Basic",
@@ -8487,7 +8649,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xyp/XY160_hires.png"
   },
   {
-    "id": "xyp-XY161",
+    "setOrder":1003,
+	"id": "xyp-XY161",
     "name": "Braixen",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY161.png",
     "subtype": "Stage 1",
@@ -8535,7 +8698,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xyp/XY161_hires.png"
   },
   {
-    "id": "xyp-XY164",
+    "setOrder":1003,
+	"id": "xyp-XY164",
     "name": "Volcanion",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY164.png",
     "subtype": "Basic",
@@ -8592,7 +8756,8 @@
     "nationalPokedexNumber": 721
   },
   {
-    "id": "xyp-XY165",
+    "setOrder":1003,
+	"id": "xyp-XY165",
     "name": "Magearna",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY165.png",
     "subtype": "Basic",
@@ -8647,7 +8812,8 @@
     "nationalPokedexNumber": 801
   },
   {
-    "id": "xyp-XY167",
+    "setOrder":1003,
+	"id": "xyp-XY167",
     "name": "Garchomp-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY167.png",
     "subtype": "EX",
@@ -8704,7 +8870,8 @@
     "evolvesTo": "M Garchomp-EX"
   },
   {
-    "id": "xyp-XY168",
+    "setOrder":1003,
+	"id": "xyp-XY168",
     "name": "M Garchomp-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY168.png",
     "subtype": "MEGA",
@@ -8749,7 +8916,8 @@
     "nationalPokedexNumber": 445
   },
   {
-    "id": "xyp-XY169",
+    "setOrder":1003,
+	"id": "xyp-XY169",
     "name": "Garchomp Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY169.png",
     "subtype": "Pokémon Tool",
@@ -8766,7 +8934,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xyp/XY169_hires.png"
   },
   {
-    "id": "xyp-XY170",
+    "setOrder":1003,
+	"id": "xyp-XY170",
     "name": "Salamence-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY170.png",
     "subtype": "EX",
@@ -8825,7 +8994,8 @@
     "evolvesTo": "M Salamence-EX"
   },
   {
-    "id": "xyp-XY171",
+    "setOrder":1003,
+	"id": "xyp-XY171",
     "name": "M Salamence-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY171.png",
     "subtype": "MEGA",
@@ -8873,7 +9043,8 @@
     "nationalPokedexNumber": 373
   },
   {
-    "id": "xyp-XY172",
+    "setOrder":1003,
+	"id": "xyp-XY172",
     "name": "Salamence Spirit Link",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY172.png",
     "subtype": "Pokémon Tool",
@@ -8890,7 +9061,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xyp/XY172_hires.png"
   },
   {
-    "id": "xyp-XY173",
+    "setOrder":1003,
+	"id": "xyp-XY173",
     "name": "Volcanion-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY173.png",
     "subtype": "EX",
@@ -8939,7 +9111,8 @@
     "nationalPokedexNumber": 721
   },
   {
-    "id": "xyp-XY174",
+    "setOrder":1003,
+	"id": "xyp-XY174",
     "name": "Pikachu-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY174.png",
     "subtype": "EX",
@@ -9003,7 +9176,8 @@
     ]
   },
   {
-    "id": "xyp-XY175",
+    "setOrder":1003,
+	"id": "xyp-XY175",
     "name": "Magearna-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY175.png",
     "subtype": "EX",
@@ -9059,7 +9233,8 @@
     "nationalPokedexNumber": 801
   },
   {
-    "id": "xyp-XY176",
+    "setOrder":1003,
+	"id": "xyp-XY176",
     "name": "Champions Festival",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY176.png",
     "subtype": "Stadium",
@@ -9076,7 +9251,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xyp/XY176_hires.png"
   },
   {
-    "id": "xyp-XY177",
+    "setOrder":1003,
+	"id": "xyp-XY177",
     "name": "Karen",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY177.png",
     "subtype": "Supporter",
@@ -9093,7 +9269,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xyp/XY177_hires.png"
   },
   {
-    "id": "xyp-XY177a",
+    "setOrder":1003,
+	"id": "xyp-XY177a",
     "name": "Karen",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY177a.png",
     "subtype": "Supporter",
@@ -9110,7 +9287,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xyp/XY177a_hires.png"
   },
   {
-    "id": "xyp-XY178",
+    "setOrder":1003,
+	"id": "xyp-XY178",
     "name": "Absol",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY178.png",
     "subtype": "Basic",
@@ -9163,7 +9341,8 @@
     "nationalPokedexNumber": 359
   },
   {
-    "id": "xyp-XY184",
+    "setOrder":1003,
+	"id": "xyp-XY184",
     "name": "Giratina",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY184.png",
     "subtype": "Basic",
@@ -9218,7 +9397,8 @@
     "nationalPokedexNumber": 487
   },
   {
-    "id": "xyp-XY181",
+    "setOrder":1003,
+	"id": "xyp-XY181",
     "name": "Crobat BREAK",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY181.png",
     "subtype": "BREAK",
@@ -9255,7 +9435,8 @@
     "nationalPokedexNumber": 169
   },
   {
-    "id": "xyp-XY183",
+    "setOrder":1003,
+	"id": "xyp-XY183",
     "name": "Mewtwo-EX",
     "imageUrl": "https://images.pokemontcg.io/xyp/XY183.png",
     "subtype": "EX",

--- a/json/cards/XY.json
+++ b/json/cards/XY.json
@@ -1,6 +1,7 @@
 [
   {
-    "id": "xy1-1",
+    "setOrder":59,
+	"id": "xy1-1",
     "name": "Venusaur-EX",
     "imageUrl": "https://images.pokemontcg.io/xy1/1.png",
     "subtype": "EX",
@@ -61,7 +62,8 @@
     "evolvesTo": "M Venusaur-EX"
   },
   {
-    "id": "xy1-2",
+    "setOrder":59,
+	"id": "xy1-2",
     "name": "M Venusaur-EX",
     "imageUrl": "https://images.pokemontcg.io/xy1/2.png",
     "subtype": "MEGA",
@@ -112,7 +114,8 @@
     "nationalPokedexNumber": 3
   },
   {
-    "id": "xy1-3",
+    "setOrder":59,
+	"id": "xy1-3",
     "name": "Weedle",
     "imageUrl": "https://images.pokemontcg.io/xy1/3.png",
     "subtype": "Basic",
@@ -155,7 +158,8 @@
     ]
   },
   {
-    "id": "xy1-4",
+    "setOrder":59,
+	"id": "xy1-4",
     "name": "Kakuna",
     "imageUrl": "https://images.pokemontcg.io/xy1/4.png",
     "subtype": "Stage 1",
@@ -200,7 +204,8 @@
     ]
   },
   {
-    "id": "xy1-5",
+    "setOrder":59,
+	"id": "xy1-5",
     "name": "Beedrill",
     "imageUrl": "https://images.pokemontcg.io/xy1/5.png",
     "subtype": "Stage 2",
@@ -251,7 +256,8 @@
     "nationalPokedexNumber": 15
   },
   {
-    "id": "xy1-6",
+    "setOrder":59,
+	"id": "xy1-6",
     "name": "Ledyba",
     "imageUrl": "https://images.pokemontcg.io/xy1/6.png",
     "subtype": "Basic",
@@ -295,7 +301,8 @@
     ]
   },
   {
-    "id": "xy1-7",
+    "setOrder":59,
+	"id": "xy1-7",
     "name": "Ledian",
     "imageUrl": "https://images.pokemontcg.io/xy1/7.png",
     "subtype": "Stage 1",
@@ -346,7 +353,8 @@
     "nationalPokedexNumber": 166
   },
   {
-    "id": "xy1-8",
+    "setOrder":59,
+	"id": "xy1-8",
     "name": "Volbeat",
     "imageUrl": "https://images.pokemontcg.io/xy1/8.png",
     "subtype": "Basic",
@@ -396,7 +404,8 @@
     "nationalPokedexNumber": 313
   },
   {
-    "id": "xy1-9",
+    "setOrder":59,
+	"id": "xy1-9",
     "name": "Illumise",
     "imageUrl": "https://images.pokemontcg.io/xy1/9.png",
     "subtype": "Basic",
@@ -446,7 +455,8 @@
     "nationalPokedexNumber": 314
   },
   {
-    "id": "xy1-10",
+    "setOrder":59,
+	"id": "xy1-10",
     "name": "Pansage",
     "imageUrl": "https://images.pokemontcg.io/xy1/10.png",
     "subtype": "Basic",
@@ -499,7 +509,8 @@
     ]
   },
   {
-    "id": "xy1-11",
+    "setOrder":59,
+	"id": "xy1-11",
     "name": "Simisage",
     "imageUrl": "https://images.pokemontcg.io/xy1/11.png",
     "subtype": "Stage 1",
@@ -551,7 +562,8 @@
     "nationalPokedexNumber": 512
   },
   {
-    "id": "xy1-12",
+    "setOrder":59,
+	"id": "xy1-12",
     "name": "Chespin",
     "imageUrl": "https://images.pokemontcg.io/xy1/12.png",
     "subtype": "Basic",
@@ -595,7 +607,8 @@
     ]
   },
   {
-    "id": "xy1-13",
+    "setOrder":59,
+	"id": "xy1-13",
     "name": "Quilladin",
     "imageUrl": "https://images.pokemontcg.io/xy1/13.png",
     "subtype": "Stage 1",
@@ -652,7 +665,8 @@
     ]
   },
   {
-    "id": "xy1-14",
+    "setOrder":59,
+	"id": "xy1-14",
     "name": "Chesnaught",
     "imageUrl": "https://images.pokemontcg.io/xy1/14.png",
     "subtype": "Stage 2",
@@ -704,7 +718,8 @@
     "nationalPokedexNumber": 652
   },
   {
-    "id": "xy1-15",
+    "setOrder":59,
+	"id": "xy1-15",
     "name": "Scatterbug",
     "imageUrl": "https://images.pokemontcg.io/xy1/15.png",
     "subtype": "Basic",
@@ -747,7 +762,8 @@
     ]
   },
   {
-    "id": "xy1-16",
+    "setOrder":59,
+	"id": "xy1-16",
     "name": "Spewpa",
     "imageUrl": "https://images.pokemontcg.io/xy1/16.png",
     "subtype": "Stage 1",
@@ -804,7 +820,8 @@
     ]
   },
   {
-    "id": "xy1-17",
+    "setOrder":59,
+	"id": "xy1-17",
     "name": "Vivillon",
     "imageUrl": "https://images.pokemontcg.io/xy1/17.png",
     "subtype": "Stage 2",
@@ -856,7 +873,8 @@
     "nationalPokedexNumber": 666
   },
   {
-    "id": "xy1-18",
+    "setOrder":59,
+	"id": "xy1-18",
     "name": "Skiddo",
     "imageUrl": "https://images.pokemontcg.io/xy1/18.png",
     "subtype": "Basic",
@@ -911,7 +929,8 @@
     ]
   },
   {
-    "id": "xy1-19",
+    "setOrder":59,
+	"id": "xy1-19",
     "name": "Gogoat",
     "imageUrl": "https://images.pokemontcg.io/xy1/19.png",
     "subtype": "Stage 1",
@@ -964,7 +983,8 @@
     "nationalPokedexNumber": 673
   },
   {
-    "id": "xy1-20",
+    "setOrder":59,
+	"id": "xy1-20",
     "name": "Slugma",
     "imageUrl": "https://images.pokemontcg.io/xy1/20.png",
     "subtype": "Basic",
@@ -1010,7 +1030,8 @@
     ]
   },
   {
-    "id": "xy1-21",
+    "setOrder":59,
+	"id": "xy1-21",
     "name": "Magcargo",
     "imageUrl": "https://images.pokemontcg.io/xy1/21.png",
     "subtype": "Stage 1",
@@ -1065,7 +1086,8 @@
     "nationalPokedexNumber": 219
   },
   {
-    "id": "xy1-22",
+    "setOrder":59,
+	"id": "xy1-22",
     "name": "Pansear",
     "imageUrl": "https://images.pokemontcg.io/xy1/22.png",
     "subtype": "Basic",
@@ -1118,7 +1140,8 @@
     ]
   },
   {
-    "id": "xy1-23",
+    "setOrder":59,
+	"id": "xy1-23",
     "name": "Simisear",
     "imageUrl": "https://images.pokemontcg.io/xy1/23.png",
     "subtype": "Stage 1",
@@ -1170,7 +1193,8 @@
     "nationalPokedexNumber": 514
   },
   {
-    "id": "xy1-24",
+    "setOrder":59,
+	"id": "xy1-24",
     "name": "Fennekin",
     "imageUrl": "https://images.pokemontcg.io/xy1/24.png",
     "subtype": "Basic",
@@ -1213,7 +1237,8 @@
     ]
   },
   {
-    "id": "xy1-25",
+    "setOrder":59,
+	"id": "xy1-25",
     "name": "Braixen",
     "imageUrl": "https://images.pokemontcg.io/xy1/25.png",
     "subtype": "Stage 1",
@@ -1267,7 +1292,8 @@
     ]
   },
   {
-    "id": "xy1-26",
+    "setOrder":59,
+	"id": "xy1-26",
     "name": "Delphox",
     "imageUrl": "https://images.pokemontcg.io/xy1/26.png",
     "subtype": "Stage 2",
@@ -1316,7 +1342,8 @@
     "nationalPokedexNumber": 655
   },
   {
-    "id": "xy1-27",
+    "setOrder":59,
+	"id": "xy1-27",
     "name": "Fletchinder",
     "imageUrl": "https://images.pokemontcg.io/xy1/27.png",
     "subtype": "Stage 1",
@@ -1376,7 +1403,8 @@
     ]
   },
   {
-    "id": "xy1-28",
+    "setOrder":59,
+	"id": "xy1-28",
     "name": "Talonflame",
     "imageUrl": "https://images.pokemontcg.io/xy1/28.png",
     "subtype": "Stage 2",
@@ -1430,7 +1458,8 @@
     "nationalPokedexNumber": 663
   },
   {
-    "id": "xy1-29",
+    "setOrder":59,
+	"id": "xy1-29",
     "name": "Blastoise-EX",
     "imageUrl": "https://images.pokemontcg.io/xy1/29.png",
     "subtype": "EX",
@@ -1488,7 +1517,8 @@
     "evolvesTo": "M Blastoise-EX"
   },
   {
-    "id": "xy1-30",
+    "setOrder":59,
+	"id": "xy1-30",
     "name": "M Blastoise-EX",
     "imageUrl": "https://images.pokemontcg.io/xy1/30.png",
     "subtype": "MEGA",
@@ -1537,7 +1567,8 @@
     "nationalPokedexNumber": 9
   },
   {
-    "id": "xy1-31",
+    "setOrder":59,
+	"id": "xy1-31",
     "name": "Shellder",
     "imageUrl": "https://images.pokemontcg.io/xy1/31.png",
     "subtype": "Basic",
@@ -1581,7 +1612,8 @@
     ]
   },
   {
-    "id": "xy1-32",
+    "setOrder":59,
+	"id": "xy1-32",
     "name": "Cloyster",
     "imageUrl": "https://images.pokemontcg.io/xy1/32.png",
     "subtype": "Stage 1",
@@ -1636,7 +1668,8 @@
     "nationalPokedexNumber": 91
   },
   {
-    "id": "xy1-33",
+    "setOrder":59,
+	"id": "xy1-33",
     "name": "Staryu",
     "imageUrl": "https://images.pokemontcg.io/xy1/33.png",
     "subtype": "Basic",
@@ -1680,7 +1713,8 @@
     ]
   },
   {
-    "id": "xy1-34",
+    "setOrder":59,
+	"id": "xy1-34",
     "name": "Starmie",
     "imageUrl": "https://images.pokemontcg.io/xy1/34.png",
     "subtype": "Stage 1",
@@ -1732,7 +1766,8 @@
     "nationalPokedexNumber": 121
   },
   {
-    "id": "xy1-35",
+    "setOrder":59,
+	"id": "xy1-35",
     "name": "Lapras",
     "imageUrl": "https://images.pokemontcg.io/xy1/35.png",
     "subtype": "Basic",
@@ -1783,7 +1818,8 @@
     "nationalPokedexNumber": 131
   },
   {
-    "id": "xy1-36",
+    "setOrder":59,
+	"id": "xy1-36",
     "name": "Corsola",
     "imageUrl": "https://images.pokemontcg.io/xy1/36.png",
     "subtype": "Basic",
@@ -1833,7 +1869,8 @@
     "nationalPokedexNumber": 222
   },
   {
-    "id": "xy1-37",
+    "setOrder":59,
+	"id": "xy1-37",
     "name": "Panpour",
     "imageUrl": "https://images.pokemontcg.io/xy1/37.png",
     "subtype": "Basic",
@@ -1886,7 +1923,8 @@
     ]
   },
   {
-    "id": "xy1-38",
+    "setOrder":59,
+	"id": "xy1-38",
     "name": "Simipour",
     "imageUrl": "https://images.pokemontcg.io/xy1/38.png",
     "subtype": "Stage 1",
@@ -1938,7 +1976,8 @@
     "nationalPokedexNumber": 516
   },
   {
-    "id": "xy1-39",
+    "setOrder":59,
+	"id": "xy1-39",
     "name": "Froakie",
     "imageUrl": "https://images.pokemontcg.io/xy1/39.png",
     "subtype": "Basic",
@@ -1981,7 +2020,8 @@
     ]
   },
   {
-    "id": "xy1-40",
+    "setOrder":59,
+	"id": "xy1-40",
     "name": "Frogadier",
     "imageUrl": "https://images.pokemontcg.io/xy1/40.png",
     "subtype": "Stage 1",
@@ -2026,7 +2066,8 @@
     ]
   },
   {
-    "id": "xy1-41",
+    "setOrder":59,
+	"id": "xy1-41",
     "name": "Greninja",
     "imageUrl": "https://images.pokemontcg.io/xy1/41.png",
     "subtype": "Stage 2",
@@ -2072,7 +2113,8 @@
     "nationalPokedexNumber": 658
   },
   {
-    "id": "xy1-42",
+    "setOrder":59,
+	"id": "xy1-42",
     "name": "Pikachu",
     "imageUrl": "https://images.pokemontcg.io/xy1/42.png",
     "subtype": "Basic",
@@ -2131,7 +2173,8 @@
     ]
   },
   {
-    "id": "xy1-43",
+    "setOrder":59,
+	"id": "xy1-43",
     "name": "Raichu",
     "imageUrl": "https://images.pokemontcg.io/xy1/43.png",
     "subtype": "Stage 1",
@@ -2187,7 +2230,8 @@
     "nationalPokedexNumber": 26
   },
   {
-    "id": "xy1-44",
+    "setOrder":59,
+	"id": "xy1-44",
     "name": "Voltorb",
     "imageUrl": "https://images.pokemontcg.io/xy1/44.png",
     "subtype": "Basic",
@@ -2235,7 +2279,8 @@
     ]
   },
   {
-    "id": "xy1-45",
+    "setOrder":59,
+	"id": "xy1-45",
     "name": "Electrode",
     "imageUrl": "https://images.pokemontcg.io/xy1/45.png",
     "subtype": "Stage 1",
@@ -2286,7 +2331,8 @@
     "nationalPokedexNumber": 101
   },
   {
-    "id": "xy1-46",
+    "setOrder":59,
+	"id": "xy1-46",
     "name": "Emolga-EX",
     "imageUrl": "https://images.pokemontcg.io/xy1/46.png",
     "subtype": "EX",
@@ -2343,7 +2389,8 @@
     "nationalPokedexNumber": 587
   },
   {
-    "id": "xy1-47",
+    "setOrder":59,
+	"id": "xy1-47",
     "name": "Ekans",
     "imageUrl": "https://images.pokemontcg.io/xy1/47.png",
     "subtype": "Basic",
@@ -2388,7 +2435,8 @@
     ]
   },
   {
-    "id": "xy1-48",
+    "setOrder":59,
+	"id": "xy1-48",
     "name": "Arbok",
     "imageUrl": "https://images.pokemontcg.io/xy1/48.png",
     "subtype": "Stage 1",
@@ -2440,7 +2488,8 @@
     "nationalPokedexNumber": 24
   },
   {
-    "id": "xy1-49",
+    "setOrder":59,
+	"id": "xy1-49",
     "name": "Spoink",
     "imageUrl": "https://images.pokemontcg.io/xy1/49.png",
     "subtype": "Basic",
@@ -2483,7 +2532,8 @@
     ]
   },
   {
-    "id": "xy1-50",
+    "setOrder":59,
+	"id": "xy1-50",
     "name": "Grumpig",
     "imageUrl": "https://images.pokemontcg.io/xy1/50.png",
     "subtype": "Stage 1",
@@ -2537,7 +2587,8 @@
     "nationalPokedexNumber": 326
   },
   {
-    "id": "xy1-51",
+    "setOrder":59,
+	"id": "xy1-51",
     "name": "Venipede",
     "imageUrl": "https://images.pokemontcg.io/xy1/51.png",
     "subtype": "Basic",
@@ -2583,7 +2634,8 @@
     ]
   },
   {
-    "id": "xy1-52",
+    "setOrder":59,
+	"id": "xy1-52",
     "name": "Whirlipede",
     "imageUrl": "https://images.pokemontcg.io/xy1/52.png",
     "subtype": "Stage 1",
@@ -2630,7 +2682,8 @@
     ]
   },
   {
-    "id": "xy1-53",
+    "setOrder":59,
+	"id": "xy1-53",
     "name": "Scolipede",
     "imageUrl": "https://images.pokemontcg.io/xy1/53.png",
     "subtype": "Stage 2",
@@ -2685,7 +2738,8 @@
     "nationalPokedexNumber": 545
   },
   {
-    "id": "xy1-54",
+    "setOrder":59,
+	"id": "xy1-54",
     "name": "Phantump",
     "imageUrl": "https://images.pokemontcg.io/xy1/54.png",
     "subtype": "Basic",
@@ -2746,7 +2800,8 @@
     ]
   },
   {
-    "id": "xy1-55",
+    "setOrder":59,
+	"id": "xy1-55",
     "name": "Trevenant",
     "imageUrl": "https://images.pokemontcg.io/xy1/55.png",
     "subtype": "Stage 1",
@@ -2802,7 +2857,8 @@
     "nationalPokedexNumber": 709
   },
   {
-    "id": "xy1-56",
+    "setOrder":59,
+	"id": "xy1-56",
     "name": "Pumpkaboo",
     "imageUrl": "https://images.pokemontcg.io/xy1/56.png",
     "subtype": "Basic",
@@ -2852,7 +2908,8 @@
     ]
   },
   {
-    "id": "xy1-57",
+    "setOrder":59,
+	"id": "xy1-57",
     "name": "Gourgeist",
     "imageUrl": "https://images.pokemontcg.io/xy1/57.png",
     "subtype": "Stage 1",
@@ -2910,7 +2967,8 @@
     "nationalPokedexNumber": 711
   },
   {
-    "id": "xy1-58",
+    "setOrder":59,
+	"id": "xy1-58",
     "name": "Diglett",
     "imageUrl": "https://images.pokemontcg.io/xy1/58.png",
     "subtype": "Basic",
@@ -2963,7 +3021,8 @@
     ]
   },
   {
-    "id": "xy1-59",
+    "setOrder":59,
+	"id": "xy1-59",
     "name": "Dugtrio",
     "imageUrl": "https://images.pokemontcg.io/xy1/59.png",
     "subtype": "Stage 1",
@@ -3015,7 +3074,8 @@
     "nationalPokedexNumber": 51
   },
   {
-    "id": "xy1-60",
+    "setOrder":59,
+	"id": "xy1-60",
     "name": "Rhyhorn",
     "imageUrl": "https://images.pokemontcg.io/xy1/60.png",
     "subtype": "Basic",
@@ -3071,7 +3131,8 @@
     ]
   },
   {
-    "id": "xy1-61",
+    "setOrder":59,
+	"id": "xy1-61",
     "name": "Rhydon",
     "imageUrl": "https://images.pokemontcg.io/xy1/61.png",
     "subtype": "Stage 1",
@@ -3131,7 +3192,8 @@
     ]
   },
   {
-    "id": "xy1-62",
+    "setOrder":59,
+	"id": "xy1-62",
     "name": "Rhyperior",
     "imageUrl": "https://images.pokemontcg.io/xy1/62.png",
     "subtype": "Stage 2",
@@ -3187,7 +3249,8 @@
     "nationalPokedexNumber": 464
   },
   {
-    "id": "xy1-63",
+    "setOrder":59,
+	"id": "xy1-63",
     "name": "Lunatone",
     "imageUrl": "https://images.pokemontcg.io/xy1/63.png",
     "subtype": "Basic",
@@ -3237,7 +3300,8 @@
     "nationalPokedexNumber": 337
   },
   {
-    "id": "xy1-64",
+    "setOrder":59,
+	"id": "xy1-64",
     "name": "Solrock",
     "imageUrl": "https://images.pokemontcg.io/xy1/64.png",
     "subtype": "Basic",
@@ -3289,7 +3353,8 @@
     "nationalPokedexNumber": 338
   },
   {
-    "id": "xy1-65",
+    "setOrder":59,
+	"id": "xy1-65",
     "name": "Timburr",
     "imageUrl": "https://images.pokemontcg.io/xy1/65.png",
     "subtype": "Basic",
@@ -3334,7 +3399,8 @@
     ]
   },
   {
-    "id": "xy1-66",
+    "setOrder":59,
+	"id": "xy1-66",
     "name": "Gurdurr",
     "imageUrl": "https://images.pokemontcg.io/xy1/66.png",
     "subtype": "Stage 1",
@@ -3392,7 +3458,8 @@
     ]
   },
   {
-    "id": "xy1-67",
+    "setOrder":59,
+	"id": "xy1-67",
     "name": "Conkeldurr",
     "imageUrl": "https://images.pokemontcg.io/xy1/67.png",
     "subtype": "Stage 2",
@@ -3446,7 +3513,8 @@
     "nationalPokedexNumber": 534
   },
   {
-    "id": "xy1-68",
+    "setOrder":59,
+	"id": "xy1-68",
     "name": "Sableye",
     "imageUrl": "https://images.pokemontcg.io/xy1/68.png",
     "subtype": "Basic",
@@ -3490,7 +3558,8 @@
     "nationalPokedexNumber": 302
   },
   {
-    "id": "xy1-69",
+    "setOrder":59,
+	"id": "xy1-69",
     "name": "Sandile",
     "imageUrl": "https://images.pokemontcg.io/xy1/69.png",
     "subtype": "Basic",
@@ -3553,7 +3622,8 @@
     ]
   },
   {
-    "id": "xy1-70",
+    "setOrder":59,
+	"id": "xy1-70",
     "name": "Krokorok",
     "imageUrl": "https://images.pokemontcg.io/xy1/70.png",
     "subtype": "Stage 1",
@@ -3617,7 +3687,8 @@
     ]
   },
   {
-    "id": "xy1-71",
+    "setOrder":59,
+	"id": "xy1-71",
     "name": "Krookodile",
     "imageUrl": "https://images.pokemontcg.io/xy1/71.png",
     "subtype": "Stage 2",
@@ -3680,7 +3751,8 @@
     "nationalPokedexNumber": 553
   },
   {
-    "id": "xy1-72",
+    "setOrder":59,
+	"id": "xy1-72",
     "name": "Zorua",
     "imageUrl": "https://images.pokemontcg.io/xy1/72.png",
     "subtype": "Basic",
@@ -3739,7 +3811,8 @@
     ]
   },
   {
-    "id": "xy1-73",
+    "setOrder":59,
+	"id": "xy1-73",
     "name": "Zoroark",
     "imageUrl": "https://images.pokemontcg.io/xy1/73.png",
     "subtype": "Stage 1",
@@ -3797,7 +3870,8 @@
     "nationalPokedexNumber": 571
   },
   {
-    "id": "xy1-74",
+    "setOrder":59,
+	"id": "xy1-74",
     "name": "Inkay",
     "imageUrl": "https://images.pokemontcg.io/xy1/74.png",
     "subtype": "Basic",
@@ -3851,7 +3925,8 @@
     ]
   },
   {
-    "id": "xy1-75",
+    "setOrder":59,
+	"id": "xy1-75",
     "name": "Inkay",
     "imageUrl": "https://images.pokemontcg.io/xy1/75.png",
     "subtype": "Basic",
@@ -3910,7 +3985,8 @@
     ]
   },
   {
-    "id": "xy1-76",
+    "setOrder":59,
+	"id": "xy1-76",
     "name": "Malamar",
     "imageUrl": "https://images.pokemontcg.io/xy1/76.png",
     "subtype": "Stage 1",
@@ -3968,7 +4044,8 @@
     "nationalPokedexNumber": 687
   },
   {
-    "id": "xy1-77",
+    "setOrder":59,
+	"id": "xy1-77",
     "name": "Malamar",
     "imageUrl": "https://images.pokemontcg.io/xy1/77.png",
     "subtype": "Stage 1",
@@ -4027,7 +4104,8 @@
     "nationalPokedexNumber": 687
   },
   {
-    "id": "xy1-78",
+    "setOrder":59,
+	"id": "xy1-78",
     "name": "Yveltal",
     "imageUrl": "https://images.pokemontcg.io/xy1/78.png",
     "subtype": "Basic",
@@ -4085,7 +4163,8 @@
     "nationalPokedexNumber": 717
   },
   {
-    "id": "xy1-79",
+    "setOrder":59,
+	"id": "xy1-79",
     "name": "Yveltal-EX",
     "imageUrl": "https://images.pokemontcg.io/xy1/79.png",
     "subtype": "EX",
@@ -4147,7 +4226,8 @@
     "nationalPokedexNumber": 717
   },
   {
-    "id": "xy1-80",
+    "setOrder":59,
+	"id": "xy1-80",
     "name": "Skarmory-EX",
     "imageUrl": "https://images.pokemontcg.io/xy1/80.png",
     "subtype": "EX",
@@ -4208,7 +4288,8 @@
     "nationalPokedexNumber": 227
   },
   {
-    "id": "xy1-81",
+    "setOrder":59,
+	"id": "xy1-81",
     "name": "Pawniard",
     "imageUrl": "https://images.pokemontcg.io/xy1/81.png",
     "subtype": "Basic",
@@ -4267,7 +4348,8 @@
     ]
   },
   {
-    "id": "xy1-82",
+    "setOrder":59,
+	"id": "xy1-82",
     "name": "Bisharp",
     "imageUrl": "https://images.pokemontcg.io/xy1/82.png",
     "subtype": "Stage 1",
@@ -4325,7 +4407,8 @@
     "nationalPokedexNumber": 625
   },
   {
-    "id": "xy1-83",
+    "setOrder":59,
+	"id": "xy1-83",
     "name": "Honedge",
     "imageUrl": "https://images.pokemontcg.io/xy1/83.png",
     "subtype": "Basic",
@@ -4375,7 +4458,8 @@
     ]
   },
   {
-    "id": "xy1-84",
+    "setOrder":59,
+	"id": "xy1-84",
     "name": "Doublade",
     "imageUrl": "https://images.pokemontcg.io/xy1/84.png",
     "subtype": "Stage 1",
@@ -4427,7 +4511,8 @@
     ]
   },
   {
-    "id": "xy1-85",
+    "setOrder":59,
+	"id": "xy1-85",
     "name": "Aegislash",
     "imageUrl": "https://images.pokemontcg.io/xy1/85.png",
     "subtype": "Stage 2",
@@ -4484,7 +4569,8 @@
     "nationalPokedexNumber": 681
   },
   {
-    "id": "xy1-86",
+    "setOrder":59,
+	"id": "xy1-86",
     "name": "Aegislash",
     "imageUrl": "https://images.pokemontcg.io/xy1/86.png",
     "subtype": "Stage 2",
@@ -4541,7 +4627,8 @@
     "nationalPokedexNumber": 681
   },
   {
-    "id": "xy1-87",
+    "setOrder":59,
+	"id": "xy1-87",
     "name": "Jigglypuff",
     "imageUrl": "https://images.pokemontcg.io/xy1/87.png",
     "subtype": "Basic",
@@ -4599,7 +4686,8 @@
     ]
   },
   {
-    "id": "xy1-88",
+    "setOrder":59,
+	"id": "xy1-88",
     "name": "Jigglypuff",
     "imageUrl": "https://images.pokemontcg.io/xy1/88.png",
     "subtype": "Basic",
@@ -4650,7 +4738,8 @@
     ]
   },
   {
-    "id": "xy1-89",
+    "setOrder":59,
+	"id": "xy1-89",
     "name": "Wigglytuff",
     "imageUrl": "https://images.pokemontcg.io/xy1/89.png",
     "subtype": "Stage 1",
@@ -4708,7 +4797,8 @@
     "nationalPokedexNumber": 40
   },
   {
-    "id": "xy1-90",
+    "setOrder":59,
+	"id": "xy1-90",
     "name": "Wigglytuff",
     "imageUrl": "https://images.pokemontcg.io/xy1/90.png",
     "subtype": "Stage 1",
@@ -4767,7 +4857,8 @@
     "nationalPokedexNumber": 40
   },
   {
-    "id": "xy1-91",
+    "setOrder":59,
+	"id": "xy1-91",
     "name": "Mr. Mime",
     "imageUrl": "https://images.pokemontcg.io/xy1/91.png",
     "subtype": "Basic",
@@ -4826,7 +4917,8 @@
     "nationalPokedexNumber": 122
   },
   {
-    "id": "xy1-92",
+    "setOrder":59,
+	"id": "xy1-92",
     "name": "Spritzee",
     "imageUrl": "https://images.pokemontcg.io/xy1/92.png",
     "subtype": "Basic",
@@ -4885,7 +4977,8 @@
     ]
   },
   {
-    "id": "xy1-93",
+    "setOrder":59,
+	"id": "xy1-93",
     "name": "Aromatisse",
     "imageUrl": "https://images.pokemontcg.io/xy1/93.png",
     "subtype": "Stage 1",
@@ -4940,7 +5033,8 @@
     "nationalPokedexNumber": 683
   },
   {
-    "id": "xy1-94",
+    "setOrder":59,
+	"id": "xy1-94",
     "name": "Swirlix",
     "imageUrl": "https://images.pokemontcg.io/xy1/94.png",
     "subtype": "Basic",
@@ -4999,7 +5093,8 @@
     ]
   },
   {
-    "id": "xy1-95",
+    "setOrder":59,
+	"id": "xy1-95",
     "name": "Slurpuff",
     "imageUrl": "https://images.pokemontcg.io/xy1/95.png",
     "subtype": "Stage 1",
@@ -5053,7 +5148,8 @@
     "nationalPokedexNumber": 685
   },
   {
-    "id": "xy1-96",
+    "setOrder":59,
+	"id": "xy1-96",
     "name": "Xerneas",
     "imageUrl": "https://images.pokemontcg.io/xy1/96.png",
     "subtype": "Basic",
@@ -5111,7 +5207,8 @@
     "nationalPokedexNumber": 716
   },
   {
-    "id": "xy1-97",
+    "setOrder":59,
+	"id": "xy1-97",
     "name": "Xerneas-EX",
     "imageUrl": "https://images.pokemontcg.io/xy1/97.png",
     "subtype": "EX",
@@ -5175,7 +5272,8 @@
     "nationalPokedexNumber": 716
   },
   {
-    "id": "xy1-98",
+    "setOrder":59,
+	"id": "xy1-98",
     "name": "Doduo",
     "imageUrl": "https://images.pokemontcg.io/xy1/98.png",
     "subtype": "Basic",
@@ -5226,7 +5324,8 @@
     ]
   },
   {
-    "id": "xy1-99",
+    "setOrder":59,
+	"id": "xy1-99",
     "name": "Dodrio",
     "imageUrl": "https://images.pokemontcg.io/xy1/99.png",
     "subtype": "Stage 1",
@@ -5284,7 +5383,8 @@
     "nationalPokedexNumber": 85
   },
   {
-    "id": "xy1-100",
+    "setOrder":59,
+	"id": "xy1-100",
     "name": "Tauros",
     "imageUrl": "https://images.pokemontcg.io/xy1/100.png",
     "subtype": "Basic",
@@ -5336,7 +5436,8 @@
     "nationalPokedexNumber": 128
   },
   {
-    "id": "xy1-101",
+    "setOrder":59,
+	"id": "xy1-101",
     "name": "Dunsparce",
     "imageUrl": "https://images.pokemontcg.io/xy1/101.png",
     "subtype": "Basic",
@@ -5383,7 +5484,8 @@
     "nationalPokedexNumber": 206
   },
   {
-    "id": "xy1-102",
+    "setOrder":59,
+	"id": "xy1-102",
     "name": "Taillow",
     "imageUrl": "https://images.pokemontcg.io/xy1/102.png",
     "subtype": "Basic",
@@ -5433,7 +5535,8 @@
     ]
   },
   {
-    "id": "xy1-103",
+    "setOrder":59,
+	"id": "xy1-103",
     "name": "Swellow",
     "imageUrl": "https://images.pokemontcg.io/xy1/103.png",
     "subtype": "Stage 1",
@@ -5487,7 +5590,8 @@
     "nationalPokedexNumber": 277
   },
   {
-    "id": "xy1-104",
+    "setOrder":59,
+	"id": "xy1-104",
     "name": "Skitty",
     "imageUrl": "https://images.pokemontcg.io/xy1/104.png",
     "subtype": "Basic",
@@ -5539,7 +5643,8 @@
     ]
   },
   {
-    "id": "xy1-105",
+    "setOrder":59,
+	"id": "xy1-105",
     "name": "Delcatty",
     "imageUrl": "https://images.pokemontcg.io/xy1/105.png",
     "subtype": "Stage 1",
@@ -5590,7 +5695,8 @@
     "nationalPokedexNumber": 301
   },
   {
-    "id": "xy1-106",
+    "setOrder":59,
+	"id": "xy1-106",
     "name": "Bidoof",
     "imageUrl": "https://images.pokemontcg.io/xy1/106.png",
     "subtype": "Basic",
@@ -5636,7 +5742,8 @@
     ]
   },
   {
-    "id": "xy1-107",
+    "setOrder":59,
+	"id": "xy1-107",
     "name": "Bibarel",
     "imageUrl": "https://images.pokemontcg.io/xy1/107.png",
     "subtype": "Stage 1",
@@ -5691,7 +5798,8 @@
     "nationalPokedexNumber": 400
   },
   {
-    "id": "xy1-108",
+    "setOrder":59,
+	"id": "xy1-108",
     "name": "Lillipup",
     "imageUrl": "https://images.pokemontcg.io/xy1/108.png",
     "subtype": "Basic",
@@ -5744,7 +5852,8 @@
     ]
   },
   {
-    "id": "xy1-109",
+    "setOrder":59,
+	"id": "xy1-109",
     "name": "Herdier",
     "imageUrl": "https://images.pokemontcg.io/xy1/109.png",
     "subtype": "Stage 1",
@@ -5800,7 +5909,8 @@
     ]
   },
   {
-    "id": "xy1-110",
+    "setOrder":59,
+	"id": "xy1-110",
     "name": "Stoutland",
     "imageUrl": "https://images.pokemontcg.io/xy1/110.png",
     "subtype": "Stage 2",
@@ -5857,7 +5967,8 @@
     "nationalPokedexNumber": 508
   },
   {
-    "id": "xy1-111",
+    "setOrder":59,
+	"id": "xy1-111",
     "name": "Bunnelby",
     "imageUrl": "https://images.pokemontcg.io/xy1/111.png",
     "subtype": "Basic",
@@ -5901,7 +6012,8 @@
     ]
   },
   {
-    "id": "xy1-112",
+    "setOrder":59,
+	"id": "xy1-112",
     "name": "Diggersby",
     "imageUrl": "https://images.pokemontcg.io/xy1/112.png",
     "subtype": "Stage 1",
@@ -5955,7 +6067,8 @@
     "nationalPokedexNumber": 660
   },
   {
-    "id": "xy1-113",
+    "setOrder":59,
+	"id": "xy1-113",
     "name": "Fletchling",
     "imageUrl": "https://images.pokemontcg.io/xy1/113.png",
     "subtype": "Basic",
@@ -6014,7 +6127,8 @@
     ]
   },
   {
-    "id": "xy1-114",
+    "setOrder":59,
+	"id": "xy1-114",
     "name": "Furfrou",
     "imageUrl": "https://images.pokemontcg.io/xy1/114.png",
     "subtype": "Basic",
@@ -6061,7 +6175,8 @@
     "nationalPokedexNumber": 676
   },
   {
-    "id": "xy1-115",
+    "setOrder":59,
+	"id": "xy1-115",
     "name": "Cassius",
     "imageUrl": "https://images.pokemontcg.io/xy1/115.png",
     "subtype": "Supporter",
@@ -6078,7 +6193,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/115_hires.png"
   },
   {
-    "id": "xy1-116",
+    "setOrder":59,
+	"id": "xy1-116",
     "name": "Evosoda",
     "imageUrl": "https://images.pokemontcg.io/xy1/116.png",
     "subtype": "Item",
@@ -6095,7 +6211,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/116_hires.png"
   },
   {
-    "id": "xy1-117",
+    "setOrder":59,
+	"id": "xy1-117",
     "name": "Fairy Garden",
     "imageUrl": "https://images.pokemontcg.io/xy1/117.png",
     "subtype": "Stadium",
@@ -6112,7 +6229,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/117_hires.png"
   },
   {
-    "id": "xy1-118",
+    "setOrder":59,
+	"id": "xy1-118",
     "name": "Great Ball",
     "imageUrl": "https://images.pokemontcg.io/xy1/118.png",
     "subtype": "Item",
@@ -6129,7 +6247,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/118_hires.png"
   },
   {
-    "id": "xy1-119",
+    "setOrder":59,
+	"id": "xy1-119",
     "name": "Hard Charm",
     "imageUrl": "https://images.pokemontcg.io/xy1/119.png",
     "subtype": "Pokémon Tool",
@@ -6146,7 +6265,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/119_hires.png"
   },
   {
-    "id": "xy1-120",
+    "setOrder":59,
+	"id": "xy1-120",
     "name": "Max Revive",
     "imageUrl": "https://images.pokemontcg.io/xy1/120.png",
     "subtype": "Item",
@@ -6163,7 +6283,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/120_hires.png"
   },
   {
-    "id": "xy1-121",
+    "setOrder":59,
+	"id": "xy1-121",
     "name": "Muscle Band",
     "imageUrl": "https://images.pokemontcg.io/xy1/121.png",
     "subtype": "Pokémon Tool",
@@ -6180,7 +6301,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/121_hires.png"
   },
   {
-    "id": "xy1-122",
+    "setOrder":59,
+	"id": "xy1-122",
     "name": "Professor Sycamore",
     "imageUrl": "https://images.pokemontcg.io/xy1/122.png",
     "subtype": "Supporter",
@@ -6197,7 +6319,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/122_hires.png"
   },
   {
-    "id": "xy1-123",
+    "setOrder":59,
+	"id": "xy1-123",
     "name": "Professor's Letter",
     "imageUrl": "https://images.pokemontcg.io/xy1/123.png",
     "subtype": "Item",
@@ -6214,7 +6337,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/123_hires.png"
   },
   {
-    "id": "xy1-124",
+    "setOrder":59,
+	"id": "xy1-124",
     "name": "Red Card",
     "imageUrl": "https://images.pokemontcg.io/xy1/124.png",
     "subtype": "Item",
@@ -6231,7 +6355,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/124_hires.png"
   },
   {
-    "id": "xy1-125",
+    "setOrder":59,
+	"id": "xy1-125",
     "name": "Roller Skates",
     "imageUrl": "https://images.pokemontcg.io/xy1/125.png",
     "subtype": "Item",
@@ -6248,7 +6373,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/125_hires.png"
   },
   {
-    "id": "xy1-126",
+    "setOrder":59,
+	"id": "xy1-126",
     "name": "Shadow Circle",
     "imageUrl": "https://images.pokemontcg.io/xy1/126.png",
     "subtype": "Stadium",
@@ -6265,7 +6391,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/126_hires.png"
   },
   {
-    "id": "xy1-127",
+    "setOrder":59,
+	"id": "xy1-127",
     "name": "Shauna",
     "imageUrl": "https://images.pokemontcg.io/xy1/127.png",
     "subtype": "Supporter",
@@ -6282,7 +6409,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/127_hires.png"
   },
   {
-    "id": "xy1-128",
+    "setOrder":59,
+	"id": "xy1-128",
     "name": "Super Potion",
     "imageUrl": "https://images.pokemontcg.io/xy1/128.png",
     "subtype": "Item",
@@ -6299,7 +6427,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/128_hires.png"
   },
   {
-    "id": "xy1-129",
+    "setOrder":59,
+	"id": "xy1-129",
     "name": "Team Flare Grunt",
     "imageUrl": "https://images.pokemontcg.io/xy1/129.png",
     "subtype": "Supporter",
@@ -6316,7 +6445,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/129_hires.png"
   },
   {
-    "id": "xy1-130",
+    "setOrder":59,
+	"id": "xy1-130",
     "name": "Double Colorless Energy",
     "imageUrl": "https://images.pokemontcg.io/xy1/130.png",
     "subtype": "Special",
@@ -6333,7 +6463,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/130_hires.png"
   },
   {
-    "id": "xy1-131",
+    "setOrder":59,
+	"id": "xy1-131",
     "name": "Rainbow Energy",
     "imageUrl": "https://images.pokemontcg.io/xy1/131.png",
     "subtype": "Special",
@@ -6350,7 +6481,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/131_hires.png"
   },
   {
-    "id": "xy1-132",
+    "setOrder":59,
+	"id": "xy1-132",
     "name": "Grass Energy",
     "imageUrl": "https://images.pokemontcg.io/xy1/132.png",
     "subtype": "Basic",
@@ -6364,7 +6496,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/132_hires.png"
   },
   {
-    "id": "xy1-133",
+    "setOrder":59,
+	"id": "xy1-133",
     "name": "Fire Energy",
     "imageUrl": "https://images.pokemontcg.io/xy1/133.png",
     "subtype": "Basic",
@@ -6378,7 +6511,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/133_hires.png"
   },
   {
-    "id": "xy1-134",
+    "setOrder":59,
+	"id": "xy1-134",
     "name": "Water Energy",
     "imageUrl": "https://images.pokemontcg.io/xy1/134.png",
     "subtype": "Basic",
@@ -6392,7 +6526,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/134_hires.png"
   },
   {
-    "id": "xy1-135",
+    "setOrder":59,
+	"id": "xy1-135",
     "name": "Lightning Energy",
     "imageUrl": "https://images.pokemontcg.io/xy1/135.png",
     "subtype": "Basic",
@@ -6406,7 +6541,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/135_hires.png"
   },
   {
-    "id": "xy1-136",
+    "setOrder":59,
+	"id": "xy1-136",
     "name": "Psychic Energy",
     "imageUrl": "https://images.pokemontcg.io/xy1/136.png",
     "subtype": "Basic",
@@ -6420,7 +6556,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/136_hires.png"
   },
   {
-    "id": "xy1-137",
+    "setOrder":59,
+	"id": "xy1-137",
     "name": "Fighting Energy",
     "imageUrl": "https://images.pokemontcg.io/xy1/137.png",
     "subtype": "Basic",
@@ -6434,7 +6571,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/137_hires.png"
   },
   {
-    "id": "xy1-138",
+    "setOrder":59,
+	"id": "xy1-138",
     "name": "Darkness Energy",
     "imageUrl": "https://images.pokemontcg.io/xy1/138.png",
     "subtype": "Basic",
@@ -6448,7 +6586,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/138_hires.png"
   },
   {
-    "id": "xy1-139",
+    "setOrder":59,
+	"id": "xy1-139",
     "name": "Metal Energy",
     "imageUrl": "https://images.pokemontcg.io/xy1/139.png",
     "subtype": "Basic",
@@ -6462,7 +6601,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/139_hires.png"
   },
   {
-    "id": "xy1-140",
+    "setOrder":59,
+	"id": "xy1-140",
     "name": "Fairy Energy",
     "imageUrl": "https://images.pokemontcg.io/xy1/140.png",
     "subtype": "Basic",
@@ -6476,7 +6616,8 @@
     "imageUrlHiRes": "https://images.pokemontcg.io/xy1/140_hires.png"
   },
   {
-    "id": "xy1-141",
+    "setOrder":59,
+	"id": "xy1-141",
     "name": "Venusaur-EX",
     "imageUrl": "https://images.pokemontcg.io/xy1/141.png",
     "subtype": "EX",
@@ -6537,7 +6678,8 @@
     "evolvesTo": "M Venusaur-EX"
   },
   {
-    "id": "xy1-142",
+    "setOrder":59,
+	"id": "xy1-142",
     "name": "Blastoise-EX",
     "imageUrl": "https://images.pokemontcg.io/xy1/142.png",
     "subtype": "EX",
@@ -6595,7 +6737,8 @@
     "evolvesTo": "M Blastoise-EX"
   },
   {
-    "id": "xy1-143",
+    "setOrder":59,
+	"id": "xy1-143",
     "name": "Emolga-EX",
     "imageUrl": "https://images.pokemontcg.io/xy1/143.png",
     "subtype": "EX",
@@ -6652,7 +6795,8 @@
     "nationalPokedexNumber": 587
   },
   {
-    "id": "xy1-144",
+    "setOrder":59,
+	"id": "xy1-144",
     "name": "Yveltal-EX",
     "imageUrl": "https://images.pokemontcg.io/xy1/144.png",
     "subtype": "EX",
@@ -6714,7 +6858,8 @@
     "nationalPokedexNumber": 717
   },
   {
-    "id": "xy1-145",
+    "setOrder":59,
+	"id": "xy1-145",
     "name": "Skarmory-EX",
     "imageUrl": "https://images.pokemontcg.io/xy1/145.png",
     "subtype": "EX",
@@ -6775,7 +6920,8 @@
     "nationalPokedexNumber": 227
   },
   {
-    "id": "xy1-146",
+    "setOrder":59,
+	"id": "xy1-146",
     "name": "Xerneas-EX",
     "imageUrl": "https://images.pokemontcg.io/xy1/146.png",
     "subtype": "EX",


### PR DESCRIPTION
I have added an order value to each set so you will be able to easily sort the cards by newest or oldest as well as being able to exclude or include the promo cards when you search for a pokemon. the promo cards all have values greater than 1000 so you can easily exclude them however they will always be at the end if sorted by oldest first and the will be at the beginning if sorted by newest first. The large values also allow for more sets to be added in the future without interfering with the promo cards. 