### PR TITLE
Added missing Detective Pikachu Promos

### DIFF
--- a/json/cards/Sun & Moon Black Star Promos.json
+++ b/json/cards/Sun & Moon Black Star Promos.json
@@ -9877,5 +9877,414 @@
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/smp/SM178_hires.png",
     "nationalPokedexNumber": 809
+  },
+  {
+    "id": "smp-SM194",
+    "name": "Detective Pikachu",
+    "imageUrl": "https://images.pokemontcg.io/smp/SM194.png",
+    "subtype": "Basic",
+    "supertype": "Pokémon",
+    "hp": "90",
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
+    "convertedRetreatCost": 2,
+    "number": "SM194",
+    "artist": "MPC Film",
+    "rarity": "",
+    "series": "Sun & Moon",
+    "set": "SM Black Star Promos",
+    "setCode": "smp",
+    "types": [
+      "Lightning"
+    ],
+    "attacks": [
+      {
+        "convertedEnergyCost": 1,
+        "cost": [
+          "Lightning"
+        ],
+        "damage": "",
+        "name": "Brilliant Deduction",
+        "text": "Look at the top 4 cards of your deck and put 1 of them into your hand. Shuffle the other cards back into your deck."
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Fighting",
+        "value": "×2"
+      }
+    ],
+    "resistances": [
+      {
+        "type": "Metal",
+        "value": "-20"
+      }
+    ],
+    "imageUrlHiRes": "https://images.pokemontcg.io/smp/SM194_hires.png",
+    "nationalPokedexNumber": 25
+  },
+  {
+    "id": "smp-SM195",
+    "name": "Charizard-GX",
+    "imageUrl": "https://images.pokemontcg.io/smp/SM195.png",
+    "subtype": "GX",
+    "supertype": "Pokémon",
+    "level": "GX",
+    "evolvesFrom": "Charmeleon",
+    "hp": "250",
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
+    "convertedRetreatCost": 4,
+    "number": "SM195",
+    "artist": "Framestore",
+    "rarity": "",
+    "series": "Sun & Moon",
+    "set": "SM Black Star Promos",
+    "setCode": "smp",
+    "text": [
+      "When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
+    ],
+    "types": [
+      "Fire"
+    ],
+    "attacks": [
+      {
+        "name": "Raging Destruction",
+        "cost": [
+          "Fire"
+        ],
+        "convertedEnergyCost": 1,
+        "damage": "",
+        "text": "Discard the top 8 cards of your deck. If any of those cards are Fire Energy cards, attach them to this Pokémon."
+      },
+      {
+        "name": "Steam Artillery",
+        "cost": [
+          "Fire",
+          "Fire",
+          "Colorless",
+          "Colorless",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 5,
+        "damage": "200",
+        "text": ""
+      },
+      {
+        "name": "Dreadful Flames-GX",
+        "cost": [
+          "Fire",
+          "Fire",
+          "Colorless",
+          "Colorless",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 5,
+        "damage": "250",
+        "text": "Discard an Energy from each of your opponent's Pokémon. (You can't use more than 1 GX attack in a game.)"
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Water",
+        "value": "×2"
+      }
+    ],
+    "imageUrlHiRes": "https://images.pokemontcg.io/smp/SM195_hires.png",
+    "nationalPokedexNumber": 6
+  },
+  {
+    "id": "smp-SM196",
+    "name": "Mewtwo-GX",
+    "imageUrl": "https://images.pokemontcg.io/smp/SM196.png",
+    "subtype": "GX",
+    "supertype": "Pokémon",
+    "level": "GX",
+    "hp": "190",
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
+    "convertedRetreatCost": 2,
+    "number": "SM196",
+    "artist": "MPC Film",
+    "rarity": "",
+    "series": "Sun & Moon",
+    "set": "SM Black Star Promos",
+    "setCode": "smp",
+    "text": [
+      "When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
+    ],
+    "types": [
+      "Psychic"
+    ],
+    "attacks": [
+      {
+        "name": "Telekinesis",
+        "cost": [
+          "Psychic",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 2,
+        "damage": "",
+        "text": "This attack does 50 damage to 1 of your opponent's Pokémon. This damage isn't affected by Weakness or Resistance."
+      },
+      {
+        "name": "Reigning Pulse",
+        "cost": [
+          "Psychic",
+          "Psychic",
+          "Colorless",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 4,
+        "damage": "120",
+        "text": "Your opponent's Active Pokémon is now Confused."
+      },
+      {
+        "name": "Psychic Nova-GX",
+        "cost": [
+          "Psychic",
+          "Psychic",
+          "Colorless",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 4,
+        "damage": "180",
+        "text": "Prevent all damage done to this Pokémon by attacks during your opponent's next turn. (You can't use more than 1 GX attack in a game.)"
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Psychic",
+        "value": "×2"
+      }
+    ],
+    "imageUrlHiRes": "https://images.pokemontcg.io/smp/SM196_hires.png",
+    "nationalPokedexNumber": 150
+  },
+  {
+    "id": "smp-SM197",
+    "name": "Greninja-GX",
+    "imageUrl": "https://images.pokemontcg.io/smp/SM197.png",
+    "subtype": "GX",
+    "supertype": "Pokémon",
+    "evolvesFrom": "Frogadier",
+    "ability": {
+      "name": "Elusive Master",
+      "text": "Once during your turn (before your attack), if this Pokémon is the last card in your hand, you may play it onto your Bench. If you do, draw 3 cards.",
+      "type": "Ability"
+    },
+    "hp": "230",
+    "retreatCost": [
+      "Colorless"
+    ],
+    "convertedRetreatCost": 1,
+    "number": "SM197",
+    "artist": "MPC Film",
+    "rarity": "",
+    "series": "Sun & Moon",
+    "set": "SM Black Star Promos",
+    "setCode": "smp",
+    "text": [
+      "When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
+    ],
+    "types": [
+      "Water"
+    ],
+    "attacks": [
+      {
+        "name": "Mist Slash",
+        "cost": [
+          "Water",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 2,
+        "damage": "130",
+        "text": "This attack's damage isn't affected by Weakness, Resistance, or any other effects on your opponent's Active Pokémon."
+      },
+      {
+        "name": "Dark Mist-GX",
+        "cost": [
+          "Water"
+        ],
+        "convertedEnergyCost": 1,
+        "damage": "",
+        "text": "Put 1 of your opponent's Benched Pokémon and all cards attached to it into your opponent's hand. (You can't use more than 1 GX attack in a game.)"
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Grass",
+        "value": "×2"
+      }
+    ],
+    "imageUrlHiRes": "https://images.pokemontcg.io/smp/SM197_hires.png",
+    "nationalPokedexNumber": 658
+  },
+  {
+    "id": "smp-SM198",
+    "name": "Bulbasaur",
+    "imageUrl": "https://images.pokemontcg.io/smp/SM198.png",
+    "subtype": "Basic",
+    "supertype": "Pokémon",
+    "evolvesFrom": "",
+    "hp": 70,
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
+    "convertedRetreatCost": 2,
+    "number": "SM198",
+    "rarity": "",
+    "series": "Sun & Moon",
+    "set": "SM Black Star Promos",
+    "setCode": "smp",
+    "types": [
+      "Grass"
+    ],
+    "attacks": [
+      {
+        "convertedEnergyCost": 1,
+        "cost": [
+          "Colorless"
+        ],
+        "damage": "10",
+        "name": "Ram",
+        "text": ""
+      },
+      {
+        "convertedEnergyCost": 3,
+        "cost": [
+          "Grass",
+          "Grass",
+          "Colorless"
+        ],
+        "damage": "50",
+        "name": "Vine Whip",
+        "text": ""
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Fire",
+        "value": "×2"
+      }
+    ],
+    "imageUrlHiRes": "https://images.pokemontcg.io/smp/SM198_hires.png",
+    "nationalPokedexNumber": 1,
+    "evolvesTo": [
+      "Ivysaur"
+    ]
+  },
+  {
+    "id": "smp-SM199",
+    "name": "Psyduck",
+    "imageUrl": "https://images.pokemontcg.io/smp/SM199.png",
+    "subtype": "Basic",
+    "supertype": "Pokémon",
+    "evolvesFrom": "",
+    "hp": 70,
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
+    "convertedRetreatCost": 2,
+    "number": "SM199",
+    "rarity": "",
+    "series": "Sun & Moon",
+    "set": "SM Black Star Promos",
+    "setCode": "smp",
+    "types": [
+      "Water"
+    ],
+    "attacks": [
+      {
+        "convertedEnergyCost": 2,
+        "cost": [
+          "Water",
+          "Colorless"
+        ],
+        "damage": "30",
+        "name": "Scratch",
+        "text": ""
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Grass",
+        "value": "×2"
+      }
+    ],
+    "imageUrlHiRes": "https://images.pokemontcg.io/smp/SM199_hires.png",
+    "nationalPokedexNumber": 54,
+    "evolvesTo": [
+      "Golduck"
+    ]
+  },
+  {
+    "id": "smp-SM200",
+    "name": "Snubbull",
+    "imageUrl": "https://images.pokemontcg.io/smp/SM200.png",
+    "subtype": "Basic",
+    "supertype": "Pokémon",
+    "evolvesFrom": "",
+    "hp": 60,
+    "retreatCost": [
+      "Colorless"
+    ],
+    "convertedRetreatCost": 1,
+    "number": "SM200",
+    "rarity": "",
+    "series": "Sun & Moon",
+    "set": "SM Black Star Promos",
+    "setCode": "smp",
+    "types": [
+      "Fairy"
+    ],
+    "attacks": [
+      {
+        "convertedEnergyCost": 1,
+        "cost": [
+          "Fairy"
+        ],
+        "damage": "10",
+        "name": "Bite",
+        "text": ""
+      },
+      {
+        "convertedEnergyCost": 2,
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ],
+        "damage": "",
+        "name": "Paralyzing Gaze",
+        "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Metal",
+        "value": "×2"
+      }
+    ],
+    "resistances": [
+      {
+        "type": "Darkness",
+        "value": "-20"
+      }
+    ],
+    "imageUrlHiRes": "https://images.pokemontcg.io/smp/SM200_hires.png",
+    "nationalPokedexNumber": 209,
+    "evolvesTo": [
+      "Granbull"
+    ]
   }
 ]


### PR DESCRIPTION
Added the following:

* SM194 - Detective Pikachu - [Image](https://bulbapedia.bulbagarden.net/wiki/File:DetectivePikachuSMPromo194.jpg)
* SM195 - Charizard-GX - [Image](https://bulbapedia.bulbagarden.net/wiki/File:CharizardGXSMPromo195.jpg)
* SM196 - Mewtwo-GX - [Image](https://bulbapedia.bulbagarden.net/wiki/File:MewtwoGXSMPromo196.jpg)
* SM197 - Greninja-GX - [Image](https://bulbapedia.bulbagarden.net/wiki/File:GreninjaGXSMPromo197.jpg)
* SM198 - Bulbasaur - [Image](https://bulbapedia.bulbagarden.net/wiki/File:BulbasaurSMPromo198.jpg)
* SM199 - Psyduck - [Image](https://bulbapedia.bulbagarden.net/wiki/File:PsyduckSMPromo199.jpg)
* SM200 - Snubbull - [Image](https://bulbapedia.bulbagarden.net/wiki/File:SnubbullSMPromo200.jpg)