### PR TITLE
Added missing SMP Promo SM201 (Reshiram & Charizard-GX)

### DIFF
--- a/json/cards/Sun & Moon Black Star Promos.json
+++ b/json/cards/Sun & Moon Black Star Promos.json
@@ -10345,5 +10345,75 @@
     "evolvesTo": [
       "Granbull"
     ]
+  },
+  {
+    "id": "smp-SM201",
+    "name": "Reshiram & Charizard-GX",
+    "imageUrl": "https://images.pokemontcg.io/smp/SM201.png",
+    "subtype": "TAG TEAM",
+    "supertype": "Pokémon",
+    "level": "GX",
+    "hp": "270",
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
+    "convertedRetreatCost": 3,
+    "number": "217",
+    "artist": "Ryota Murayama",
+    "rarity": "",
+    "series": "Sun & Moon",
+    "set": "SM Black Star Promos",
+    "setCode": "smp",
+    "text": [
+      "When your TAG TEAM is knocked out, your opponent takes 3 Prize Cards."
+    ],
+    "types": [
+      "Fire"
+    ],
+    "attacks": [
+      {
+        "cost": [
+          "Fire",
+          "Colorless"
+        ],
+        "name": "Outrage",
+        "text": "This attack does 10 more damage for each damage counter on this Pokémon.",
+        "damage": "30+",
+        "convertedEnergyCost": 2
+      },
+      {
+        "cost": [
+          "Fire",
+          "Fire",
+          "Fire",
+          "Colorless"
+        ],
+        "name": "Flare Strike",
+        "text": "This Pokémon can't use Flare Strike during your next turn.",
+        "damage": "230",
+        "convertedEnergyCost": 4
+      },
+      {
+        "cost": [
+          "Fire",
+          "Fire",
+          "Fire"
+        ],
+        "name": "Double Blaze-GX",
+        "text": "If this Pokémon has at least 3 extra Fire Energy attached to it (in addition to this attack's cost), this attack does 100 more damage, and this attack's damage isn't affected by any effects on your opponent's Active Pokémon. (You can't use more than 1 GX attack in a game.)",
+        "damage": "200+",
+        "convertedEnergyCost": 3
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Water",
+        "value": "×2"
+      }
+    ],
+    "imageUrlHiRes": "https://images.pokemontcg.io/smp/SM201_hires.png",
+    "nationalPokedexNumber": 6
   }
 ]

--- a/json/cards/Sun & Moon Black Star Promos.json
+++ b/json/cards/Sun & Moon Black Star Promos.json
@@ -9307,7 +9307,7 @@
     "id": "smp-SM166",
     "name": "Magikarp & Wailord-GX",
     "imageUrl": "https://images.pokemontcg.io/smp/SM166.png",
-    "subtype": "GX",
+    "subtype": "TAG TEAM",
     "supertype": "Pokémon",
     "level": "GX",
     "hp": "300",
@@ -9324,6 +9324,9 @@
     "series": "Sun & Moon",
     "set": "SM Black Star Promos",
     "setCode": "smp",
+    "text": [
+      "When your TAG TEAM is knocked out, your opponent takes 3 Prize Cards."
+    ],
     "types": [
       "Water"
     ],


### PR DESCRIPTION
Added the data for SMP Promo SM201 (Reshiram & Charizard-GX), mostly a clone of the same card at sm10-217. While at it, noticed that the file I was modifying had just one other tag team card, but it was not labelled as a tag team card, so I fixed that labeling too to make it consistent with other tag team cards (for smp-SM166).

Wasn't sure where to upload the images, but here is the large image of this card:
![SM201_hires](https://user-images.githubusercontent.com/5206489/66980928-208e3880-f067-11e9-9553-e4ea143fda26.jpg)
