### PR TITLE
Fixing some hp and damage to be strings so the go sdk can marshal the json

### DIFF
--- a/json/cards/Detective Pikachu.json
+++ b/json/cards/Detective Pikachu.json
@@ -6,7 +6,7 @@
     "subtype": "Basic",
     "supertype": "Pokémon",
     "evolvesFrom": "",
-    "hp": 60,
+    "hp": "60",
     "retreatCost": [
       "Colorless"
     ],
@@ -54,7 +54,7 @@
       "text": "Once during your turn (before your attack), you may heal 30 damage from 1 of your Pokémon.",
       "type": "Ability"
     },
-    "hp": 140,
+    "hp": "140",
     "retreatCost": [
       "Colorless",
       "Colorless",
@@ -98,7 +98,7 @@
     "subtype": "Basic",
     "supertype": "Pokémon",
     "evolvesFrom": "",
-    "hp": 50,
+    "hp": "50",
     "retreatCost": [
       "Colorless"
     ],
@@ -141,7 +141,7 @@
     "subtype": "Basic",
     "supertype": "Pokémon",
     "evolvesFrom": "",
-    "hp": 60,
+    "hp": "60",
     "retreatCost": [
       "Colorless"
     ],
@@ -184,7 +184,7 @@
     "subtype": "Stage 2",
     "supertype": "Pokémon",
     "evolvesFrom": "Charmeleon",
-    "hp": 180,
+    "hp": "180",
     "retreatCost": [
       "Colorless",
       "Colorless",
@@ -245,7 +245,7 @@
       "text": "As long as this Pokémon is your Active Pokémon, all of your Pokémon take 30 less damage from your opponent's attacks (after applying Weakness and Resistance).",
       "type": "Ability"
     },
-    "hp": 120,
+    "hp": "120",
     "retreatCost": [
       "Colorless",
       "Colorless",
@@ -289,7 +289,7 @@
     "subtype": "Basic",
     "supertype": "Pokémon",
     "evolvesFrom": "",
-    "hp": 80,
+    "hp": "80",
     "retreatCost": [
       "Colorless",
       "Colorless",
@@ -334,7 +334,7 @@
     "subtype": "Basic",
     "supertype": "Pokémon",
     "evolvesFrom": "",
-    "hp": 30,
+    "hp": "30",
     "retreatCost": [
       "Colorless"
     ],
@@ -382,7 +382,7 @@
       "text": "If any damage is done to this Pokémon by attacks, flip a coin. If heads, prevent that damage.",
       "type": "Ability"
     },
-    "hp": 140,
+    "hp": "140",
     "retreatCost": [
       "Colorless"
     ],
@@ -423,7 +423,7 @@
     "subtype": "Basic",
     "supertype": "Pokémon",
     "evolvesFrom": "",
-    "hp": 90,
+    "hp": "90",
     "retreatCost": [
       "Colorless",
       "Colorless"
@@ -489,7 +489,7 @@
       "text": "When you play this Pokémon from your hand onto your Bench during your turn, you may switch 1 of your face-down Prize cards with the top card of your deck.",
       "type": "Ability"
     },
-    "hp": 80,
+    "hp": "80",
     "retreatCost": [
       "Colorless"
     ],
@@ -530,7 +530,7 @@
     "subtype": "Basic",
     "supertype": "Pokémon",
     "evolvesFrom": "",
-    "hp": 130,
+    "hp": "130",
     "retreatCost": [
       "Colorless",
       "Colorless"
@@ -583,7 +583,7 @@
     "subtype": "Stage 2",
     "supertype": "Pokémon",
     "evolvesFrom": "Machoke",
-    "hp": 160,
+    "hp": "160",
     "retreatCost": [
       "Colorless",
       "Colorless"
@@ -634,7 +634,7 @@
     "subtype": "Basic",
     "supertype": "Pokémon",
     "evolvesFrom": "",
-    "hp": 60,
+    "hp": "60",
     "retreatCost": [
       "Colorless"
     ],
@@ -683,7 +683,7 @@
     "subtype": "Basic",
     "supertype": "Pokémon",
     "evolvesFrom": "",
-    "hp": 70,
+    "hp": "70",
     "retreatCost": [
       "Colorless",
       "Colorless"
@@ -734,7 +734,7 @@
     "subtype": "Basic",
     "supertype": "Pokémon",
     "evolvesFrom": "",
-    "hp": 100,
+    "hp": "100",
     "retreatCost": [
       "Colorless",
       "Colorless",
@@ -780,7 +780,7 @@
     "subtype": "Basic",
     "supertype": "Pokémon",
     "evolvesFrom": "",
-    "hp": 60,
+    "hp": "60",
     "retreatCost": [
       "Colorless"
     ],
@@ -820,7 +820,7 @@
     "subtype": "Stage 2",
     "supertype": "Pokémon",
     "evolvesFrom": "Vigoroth",
-    "hp": 180,
+    "hp": "180",
     "retreatCost": [
       "Colorless",
       "Colorless",

--- a/json/cards/Sun & Moon Black Star Promos.json
+++ b/json/cards/Sun & Moon Black Star Promos.json
@@ -10194,7 +10194,7 @@
     "subtype": "Basic",
     "supertype": "Pokémon",
     "evolvesFrom": "",
-    "hp": 70,
+    "hp": "70",
     "retreatCost": [
       "Colorless",
       "Colorless"
@@ -10249,7 +10249,7 @@
     "subtype": "Basic",
     "supertype": "Pokémon",
     "evolvesFrom": "",
-    "hp": 70,
+    "hp": "70",
     "retreatCost": [
       "Colorless",
       "Colorless"
@@ -10294,7 +10294,7 @@
     "subtype": "Basic",
     "supertype": "Pokémon",
     "evolvesFrom": "",
-    "hp": 60,
+    "hp": "60",
     "retreatCost": [
       "Colorless"
     ],

--- a/json/cards/Unified Minds.json
+++ b/json/cards/Unified Minds.json
@@ -11143,7 +11143,7 @@
     "subtype": "Basic",
     "supertype": "Pokémon",
     "evolvesFrom": "",
-    "hp": 270,
+    "hp": "270",
     "retreatCost": [
       "Colorless",
       "Colorless",
@@ -11215,7 +11215,7 @@
       "text": "Once during your turn (before your attack), if this Pokémon was on the Bench and became your Active Pokémon this turn, you may move any number of {R} Energy attached to your Pokémon to this Pokémon.",
       "type": "Ability"
     },
-    "hp": 190,
+    "hp": "190",
     "retreatCost": [
       "Colorless",
       "Colorless",
@@ -11268,7 +11268,7 @@
     "subtype": "Basic",
     "supertype": "Pokémon",
     "evolvesFrom": "",
-    "hp": 250,
+    "hp": "250",
     "retreatCost": [
       "Colorless",
       "Colorless"
@@ -11329,7 +11329,7 @@
       "text": "Prevent all effects of attacks, including damage, done to this Pokémon by your opponent's Pokémon-GX or Pokémon-EX.",
       "type": "Ability"
     },
-    "hp": 170,
+    "hp": "170",
     "retreatCost": [
       "Colorless",
       "Colorless"
@@ -11383,7 +11383,7 @@
     "subtype": "Basic",
     "supertype": "Pokémon",
     "evolvesFrom": "",
-    "hp": 260,
+    "hp": "260",
     "retreatCost": [
       "Colorless",
       "Colorless"
@@ -11448,7 +11448,7 @@
       "text": "This Pokémon can use the attacks of any Pokémon-GX or Pokémon-EX on your Bench or in your discard pile. (You still need the necessary Energy to use each attack.)",
       "type": "Ability"
     },
-    "hp": 270,
+    "hp": "270",
     "retreatCost": [
       "Colorless",
       "Colorless"
@@ -11496,7 +11496,7 @@
       "text": "If you have 4 or fewer Pokémon in play, this Pokémon can't attack.",
       "type": "Ability"
     },
-    "hp": 170,
+    "hp": "170",
     "convertedRetreatCost": 0,
     "number": "243",
     "rarity": "Rare Secret",
@@ -11549,7 +11549,7 @@
       "text": "As long as this Pokémon is your Active Pokémon, your opponent's Basic Pokémon's attacks cost {C} more.",
       "type": "Ability"
     },
-    "hp": 210,
+    "hp": "210",
     "convertedRetreatCost": 0,
     "number": "244",
     "rarity": "Rare Secret",
@@ -11597,7 +11597,7 @@
     "subtype": "Basic",
     "supertype": "Pokémon",
     "evolvesFrom": "",
-    "hp": 280,
+    "hp": "280",
     "retreatCost": [
       "Colorless",
       "Colorless",
@@ -11668,7 +11668,7 @@
       "text": "When you play this Pokémon from your hand onto your Bench during your turn, you may have your opponent reveal their hand and put any number of Basic Pokémon you find there onto their Bench.",
       "type": "Ability"
     },
-    "hp": 170,
+    "hp": "170",
     "retreatCost": [
       "Colorless"
     ],
@@ -11725,7 +11725,7 @@
     "subtype": "Basic",
     "supertype": "Pokémon",
     "evolvesFrom": "",
-    "hp": 270,
+    "hp": "270",
     "retreatCost": [
       "Colorless",
       "Colorless",
@@ -11789,7 +11789,7 @@
     "subtype": "Stage 2",
     "supertype": "Pokémon",
     "evolvesFrom": "Dragonair",
-    "hp": 250,
+    "hp": "250",
     "retreatCost": [
       "Colorless",
       "Colorless"
@@ -11859,7 +11859,7 @@
       "text": "Once during your turn (before your attack), you may discard an Ultra Beast card from your hand. If you do, draw 3 cards.",
       "type": "Ability"
     },
-    "hp": 210,
+    "hp": "210",
     "retreatCost": [
       "Colorless"
     ],

--- a/json/cards/Unseen Forces.json
+++ b/json/cards/Unseen Forces.json
@@ -5890,7 +5890,7 @@
           "Colorless"
         ],
         "convertedEnergyCost": 2,
-        "damage": 10,
+        "damage": "10",
         "text": "Flip 3 coins. If 1 of them is heads, the Defending Pokémon is now Asleep. If 2 of them are heads, the Defending Pokémon is now Confused. If all of them are heads, the Defending Pokémon is now Paralyzed."
       }
     ],
@@ -6114,7 +6114,7 @@
           "Colorless"
         ],
         "convertedEnergyCost": 2,
-        "damage": 20,
+        "damage": "20",
         "text": "You may discard any Stadium card in play."
       }
     ],
@@ -6293,7 +6293,7 @@
           "Colorless"
         ],
         "convertedEnergyCost": 2,
-        "damage": 20,
+        "damage": "20",
         "text": "Return Unown and all Energy cards attached to it to your hand."
       }
     ],
@@ -6563,7 +6563,7 @@
           "Colorless"
         ],
         "convertedEnergyCost": 2,
-        "damage": 10,
+        "damage": "10",
         "text": "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
       }
     ],
@@ -6656,7 +6656,7 @@
           "Colorless"
         ],
         "convertedEnergyCost": 2,
-        "damage": 20,
+        "damage": "20",
         "text": "Flip a coin. If heads, search your discard pile for a card, show it to your opponent, and put it on top of your deck."
       }
     ],
@@ -6747,7 +6747,7 @@
           "Colorless"
         ],
         "convertedEnergyCost": 1,
-        "damage": 10,
+        "damage": "10",
         "text": "The Defending Pokémon is now Asleep."
       }
     ],

--- a/json/cards/XY Black Star Promos.json
+++ b/json/cards/XY Black Star Promos.json
@@ -5287,7 +5287,7 @@
         ],
         "name": "Land Crush",
         "text": "",
-        "damage": 70,
+        "damage": "70",
         "convertedEnergyCost": 3
       }
     ],


### PR DESCRIPTION
The hp and attack damages of some Pokemon are integers in the JSON when they should be strings. The Go SDK fails to parse the JSON because of this.