### PR TITLE
Added English Data for Sword & Shield Theme Decks

### DIFF
--- a/json/decks/Rebel Clash.json
+++ b/json/decks/Rebel Clash.json
@@ -1,0 +1,254 @@
+[
+  {
+    "id": "d-swsh2-1",
+    "name": "Zacian",
+    "types": ["Metal"],
+    "cards": [
+      {
+        "id": "swsh2-139",
+        "name": "Zacian",
+        "rarity": "Rare Holo",
+        "count": 1
+      },
+      {
+        "id": "swsh2-139",
+        "name": "Zacian",
+        "rarity": "Rare",
+        "count": 1
+      },
+      {
+        "id": "swsh2-145",
+        "name": "Unfezant",
+        "rarity": "Rare",
+        "count": 2
+      },
+      {
+        "id": "swsh2-144",
+        "name": "Tranquill",
+        "rarity": "Uncommon",
+        "count": 3
+      },
+      {
+        "id": "swsh2-143",
+        "name": "Pidove",
+        "rarity": "Common",
+        "count": 3
+      },
+      {
+        "id": "swsh2-127",
+        "name": "Galarian Perrserker",
+        "rarity": "Rare",
+        "count": 2
+      },
+      {
+        "id": "swsh2-127",
+        "name": "Galarian Meowth",
+        "rarity": "Common",
+        "count": 3
+      },
+      {
+        "id": "swsh2-131",
+        "name": "Probopass",
+        "rarity": "Rare",
+        "count": 2
+      },
+      {
+        "id": "swsh2-96",
+        "name": "Nosepass",
+        "rarity": "Common",
+        "count": 3
+      },
+      {
+        "id": "swsh2-148",
+        "name": "Hawlucha",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "swsh2-158",
+        "name": "Dan",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "swsh2-164",
+        "name": "Great Ball",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "swsh2-165",
+        "name": "Hop",
+        "rarity": "Uncommon",
+        "count": 4
+      },
+      {
+        "id": "swsh2-170",
+        "name": "Metal Saucer",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "swsh2-173",
+        "name": "Poké Kid",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "swsh2-175",
+        "name": "Pokémon Catcher",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "swsh2-178",
+        "name": "Professor's Research",
+        "rarity": "Rare",
+        "count": 2
+      },
+      {
+        "id": "swsh2-167",
+        "name": "Sonia",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "swsh2-183",
+        "name": "Switch",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "sm1-163",
+        "name": "Metal Energy",
+        "count": 18
+      }
+    ]
+  },
+  {
+    "id": "d-swsh2-2",
+    "name": "Zamazenta",
+    "types": ["Metal"],
+    "cards": [
+      {
+        "id": "swsh2-140",
+        "name": "Zamazenta",
+        "rarity": "Rare Holo",
+        "count": 1
+      },
+      {
+        "id": "swsh2-140",
+        "name": "Zamazenta",
+        "rarity": "Rare",
+        "count": 1
+      },
+      {
+        "id": "swsh2-135",
+        "name": "Corviknight",
+        "rarity": "Rare",
+        "count": 2
+      },
+      {
+        "id": "swsh2-151",
+        "name": "Corvisquire",
+        "rarity": "Uncommon",
+        "count": 3
+      },
+      {
+        "id": "swsh2-150",
+        "name": "Rookidee",
+        "rarity": "Common",
+        "count": 3
+      },
+      {
+        "id": "swsh2-134",
+        "name": "Bisharp",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "swsh2-133",
+        "name": "Pawniard",
+        "rarity": "Common",
+        "count": 3
+      },
+      {
+        "id": "swsh2-131",
+        "name": "Ferrothorn",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "swsh2-130",
+        "name": "Ferroseed",
+        "rarity": "Common",
+        "count": 3
+      },
+      {
+        "id": "swsh2-138",
+        "name": "Duraludon",
+        "rarity": "Rare",
+        "count": 2
+      },
+      {
+        "id": "swsh2-158",
+        "name": "Dan",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "swsh2-164",
+        "name": "Great Ball",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "swsh2-165",
+        "name": "Hop",
+        "rarity": "Uncommon",
+        "count": 4
+      },
+      {
+        "id": "swsh2-170",
+        "name": "Metal Saucer",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "swsh2-173",
+        "name": "Poké Kid",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "swsh2-177",
+        "name": "Potion",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "swsh2-178",
+        "name": "Professor's Research",
+        "rarity": "Rare",
+        "count": 2
+      },
+      {
+        "id": "swsh2-167",
+        "name": "Sonia",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "swsh2-183",
+        "name": "Switch",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "sm1-163",
+        "name": "Metal Energy",
+        "count": 18
+      }
+    ]
+  }
+]

--- a/json/decks/Sword & Shield.json
+++ b/json/decks/Sword & Shield.json
@@ -1,0 +1,380 @@
+[
+  {
+    "id": "d-swsh1-1",
+    "name": "Rillaboom",
+    "types": ["Grass"],
+    "cards": [
+      {
+        "id": "swsh1-15",
+        "name": "Rillaboom",
+        "rarity": "Rare Holo",
+        "count": 1
+      },
+      {
+        "id": "swsh1-15",
+        "name": "Rillaboom",
+        "rarity": "Rare",
+        "count": 1
+      },
+      {
+        "id": "swsh1-13",
+        "name": "Thwackey",
+        "rarity": "Uncommon",
+        "count": 3
+      },
+      {
+        "id": "swsh1-11",
+        "name": "Grookey",
+        "rarity": "Common",
+        "count": 3
+      },
+      {
+        "id": "swsh1-21",
+        "name": "Eldegoss",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "swsh1-20",
+        "name": "Gossifleur",
+        "rarity": "Common",
+        "count": 3
+      },
+      {
+        "id": "swsh1-6",
+        "name": "Whimsicott",
+        "rarity": "Rare",
+        "count": 2
+      },
+      {
+        "id": "swsh1-5",
+        "name": "Cottonee",
+        "rarity": "Common",
+        "count": 3
+      },
+      {
+        "id": "swsh1-7",
+        "name": "Maractus",
+        "rarity": "Common",
+        "count": 2
+      },
+      {
+        "id": "swsh1-140",
+        "name": "Snorlax",
+        "rarity": "Rare",
+        "count": 2
+      },
+      {
+        "id": "swsh1-164",
+        "name": "Great Ball",
+        "rarity": "Uncommon",
+        "count": 4
+      },
+      {
+        "id": "swsh1-165",
+        "name": "Hop",
+        "rarity": "Uncommon",
+        "count": 4
+      },
+      {
+        "id": "swsh1-171",
+        "name": "Ordinary Rod",
+        "rarity": "Uncommon",
+        "count": 1
+      },
+      {
+        "id": "swsh1-173",
+        "name": "Poké Kid",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "swsh1-174",
+        "name": "Pokégear 3.0",
+        "rarity": "Uncommon",
+        "count": 1
+      },
+      {
+        "id": "swsh1-176",
+        "name": "Pokémon Center Lady",
+        "rarity": "Uncommon",
+        "count": 1
+      },
+      {
+        "id": "swsh1-177",
+        "name": "Potion",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "swsh1-178",
+        "name": "Professor's Research",
+        "rarity": "Uncommon",
+        "count": 3
+      },
+      {
+        "id": "swsh1-183",
+        "name": "Switch",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "sm1-164",
+        "name": "Grass Energy",
+        "count": 18
+      }
+    ]
+  },
+  {
+    "id": "d-swsh1-2",
+    "name": "Cinderace",
+    "types": ["Fire"],
+    "cards": [
+      {
+        "id": "swsh1-36",
+        "name": "Cinderace",
+        "rarity": "Rare Holo",
+        "count": 1
+      },
+      {
+        "id": "swsh1-36",
+        "name": "Cinderace",
+        "rarity": "Rare",
+        "count": 1
+      },
+      {
+        "id": "swsh1-33",
+        "name": "Raboot",
+        "rarity": "Uncommon",
+        "count": 3
+      },
+      {
+        "id": "swsh1-31",
+        "name": "Scorbunny",
+        "rarity": "Common",
+        "count": 3
+      },
+      {
+        "id": "swsh1-23",
+        "name": "Ninetales",
+        "rarity": "Rare",
+        "count": 2
+      },
+      {
+        "id": "swsh1-22",
+        "name": "Vulpix",
+        "rarity": "Common",
+        "count": 3
+      },
+      {
+        "id": "swsh1-154",
+        "name": "Dubwool",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "swsh1-153",
+        "name": "Wooloo",
+        "rarity": "Common",
+        "count": 3
+      },
+      {
+        "id": "swsh1-149",
+        "name": "Drampa",
+        "rarity": "Rare",
+        "count": 2
+      },
+      {
+        "id": "swsh1-100",
+        "name": "Sudowoodo",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "swsh1-157",
+        "name": "Bede",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "swsh1-164",
+        "name": "Great Ball",
+        "rarity": "Uncommon",
+        "count": 4
+      },
+      {
+        "id": "swsh1-165",
+        "name": "Hop",
+        "rarity": "Uncommon",
+        "count": 4
+      },
+      {
+        "id": "swsh1-171",
+        "name": "Ordinary Rod",
+        "rarity": "Uncommon",
+        "count": 1
+      },
+      {
+        "id": "swsh1-173",
+        "name": "Poké Kid",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "swsh1-174",
+        "name": "Pokégear 3.0",
+        "rarity": "Uncommon",
+        "count": 1
+      },
+      {
+        "id": "swsh1-175",
+        "name": "Pokémon Catcher",
+        "rarity": "Uncommon",
+        "count": 1
+      },
+      {
+        "id": "swsh1-178",
+        "name": "Professor's Research",
+        "rarity": "Uncommon",
+        "count": 3
+      },
+      {
+        "id": "swsh1-183",
+        "name": "Switch",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "sm1-165",
+        "name": "Fire Energy",
+        "count": 18
+      }
+    ]
+  },
+  {
+    "id": "d-swsh1-3",
+    "name": "Inteleon",
+    "types": ["Water"],
+    "cards": [
+      {
+        "id": "swsh1-59",
+        "name": "Inteleon",
+        "rarity": "Rare Holo",
+        "count": 1
+      },
+      {
+        "id": "swsh1-59",
+        "name": "Inteleon",
+        "rarity": "Rare",
+        "count": 1
+      },
+      {
+        "id": "swsh1-57",
+        "name": "Drizzile",
+        "rarity": "Uncommon",
+        "count": 3
+      },
+      {
+        "id": "swsh1-55",
+        "name": "Sobble",
+        "rarity": "Common",
+        "count": 3
+      },
+      {
+        "id": "swsh1-61",
+        "name": "Drednaw",
+        "rarity": "Rare",
+        "count": 2
+      },
+      {
+        "id": "swsh1-60",
+        "name": "Chewtle",
+        "rarity": "Common",
+        "count": 3
+      },
+      {
+        "id": "swsh1-44",
+        "name": "Kingler",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "swsh1-43",
+        "name": "Krabby",
+        "rarity": "Common",
+        "count": 3
+      },
+      {
+        "id": "swsh1-62",
+        "name": "Cramorant",
+        "rarity": "Rare",
+        "count": 2
+      },
+      {
+        "id": "swsh1-52",
+        "name": "Mantine",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "swsh1-162",
+        "name": "Energy Switch",
+        "rarity": "Uncommon",
+        "count": 1
+      },
+      {
+        "id": "swsh1-164",
+        "name": "Great Ball",
+        "rarity": "Uncommon",
+        "count": 4
+      },
+      {
+        "id": "swsh1-165",
+        "name": "Hop",
+        "rarity": "Uncommon",
+        "count": 4
+      },
+      {
+        "id": "swsh1-171",
+        "name": "Ordinary Rod",
+        "rarity": "Uncommon",
+        "count": 1
+      },
+      {
+        "id": "swsh1-173",
+        "name": "Poké Kid",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "swsh1-174",
+        "name": "Pokégear 3.0",
+        "rarity": "Uncommon",
+        "count": 1
+      },
+      {
+        "id": "swsh1-175",
+        "name": "Pokémon Catcher",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "swsh1-178",
+        "name": "Professor's Research",
+        "rarity": "Uncommon",
+        "count": 3
+      },
+      {
+        "id": "swsh1-183",
+        "name": "Switch",
+        "rarity": "Uncommon",
+        "count": 2
+      },
+      {
+        "id": "sm1-166",
+        "name": "Water Energy",
+        "count": 18
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This PR adds the following theme decks from the *Sword & Shield* series:

#### Sword & Shield
* [Rillaboom Theme Deck](https://bulbapedia.bulbagarden.net/wiki/Rillaboom_Theme_Deck_(TCG))
* [Cinderace Theme Deck](https://bulbapedia.bulbagarden.net/wiki/Cinderace_Theme_Deck_(TCG))
* [Inteleon Theme Deck](https://bulbapedia.bulbagarden.net/wiki/Inteleon_Theme_Deck_(TCG)) 

#### Rebel Clash
* [Zacian Theme Deck](https://bulbapedia.bulbagarden.net/wiki/Zacian_Theme_Deck_(TCG))
* [Zamazenta Theme Deck](https://bulbapedia.bulbagarden.net/wiki/Zamazenta_Theme_Deck_(TCG))

I've forked and modified the [script](https://github.com/Monbrey/pokemon-tcg-data-scraper) by @monbrey to fetch and format the data. I've also followed the convention used in #89. 

Energy cards point to the Sun and Moon prints since these are the most recent prints on the API. I've scraped and attached the latest prints from Bulbapedia for future releases. I'll be more than happy to update the energy cards as well. 

[Sword & Shield Energy Card Prints.zip](https://github.com/PokemonTCG/pokemon-tcg-data/files/5114963/Sword.Shield.Energy.Card.Prints.zip)