### PR TITLE
Adds card 74-80 to Champions Path

### DIFF
--- a/json/cards/Champions Path.json
+++ b/json/cards/Champions Path.json
@@ -3093,5 +3093,265 @@
       "Draw 3 cards."
     ],
     "imageUrlHiRes": "https://images.pokemontcg.io/swsh35/73_hires.png"
+  },
+  {
+    "id": "swsh35-74",
+    "name": "Charizard VMAX",
+    "imageUrl": "https://images.pokemontcg.io/swsh35/74.png",
+    "subtype": "VMAX",
+    "supertype": "Pokémon",
+    "evolvesFrom": "Charizard V",
+    "hp": 330,
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
+    "convertedRetreatCost": 3,
+    "number": "74",
+    "artist": "aky CG Works",
+    "rarity": "Rare Secret",
+    "series": "Sword & Shield",
+    "set": "Champions Path",
+    "setCode": "swsh35",
+    "types": [
+      "Fire"
+    ],
+    "attacks": [
+      {
+        "convertedEnergyCost": 3,
+        "cost": [
+          "Colorless",
+          "Colorless",
+          "Colorless"
+        ],
+        "damage": "100",
+        "name": "Claw Slash",
+        "text": ""
+      },
+      {
+        "convertedEnergyCost": 5,
+        "cost": [
+          "Fire",
+          "Fire",
+          "Fire",
+          "Colorless",
+          "Colorless"
+        ],
+        "damage": "300",
+        "name": "G-Max Wildfire",
+        "text": "Discard 2 Energy from this Pokémon."
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Water",
+        "value": "×2"
+      }
+    ],
+    "imageUrlHiRes": "https://images.pokemontcg.io/swsh35/74_hires.png",
+    "nationalPokedexNumber": 6
+  },
+  {
+    "id": "swsh35-75",
+    "name": "Drednaw VMAX",
+    "imageUrl": "https://images.pokemontcg.io/swsh35/75.png",
+    "subtype": "VMAX",
+    "supertype": "Pokémon",
+    "evolvesFrom": "Drednaw V",
+    "hp": 320,
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
+    "convertedRetreatCost": 4,
+    "number": "75",
+    "artist": "aky CG Works",
+    "rarity": "Rare Secret",
+    "series": "Sword & Shield",
+    "set": "Champions Path",
+    "setCode": "swsh35",
+    "types": [
+      "Water"
+    ],
+    "attacks": [
+      {
+        "convertedEnergyCost": 3,
+        "cost": [
+          "Water",
+          "Water",
+          "Colorless"
+        ],
+        "damage": "160+",
+        "name": "G-Max Headbutt",
+        "text": "Flip a coin. If heads, this attack does 80 more damage."
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Lightning",
+        "value": "×2"
+      }
+    ],
+    "imageUrlHiRes": "https://images.pokemontcg.io/swsh35/75_hires.png",
+    "nationalPokedexNumber": 834,
+    "ability": {
+      "name": "Solid Shell",
+      "text": "This Pokémon takes 30 less damage from attacks (after applying Weakness and Resistance).",
+      "type": "Ability"
+    }
+  },
+  {
+    "id": "swsh35-76",
+    "name": "Gardevoir VMAX",
+    "imageUrl": "https://images.pokemontcg.io/swsh35/76.png",
+    "subtype": "VMAX",
+    "supertype": "Pokémon",
+    "evolvesFrom": "Gardevoir V",
+    "hp": 320,
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
+    "convertedRetreatCost": 2,
+    "number": "76",
+    "artist": "5ban Graphics",
+    "rarity": "Rare Secret",
+    "series": "Sword & Shield",
+    "set": "Champions Path",
+    "setCode": "swsh35",
+    "types": [
+      "Psychic"
+    ],
+    "attacks": [
+      {
+        "convertedEnergyCost": 3,
+        "cost": [
+          "Psychic",
+          "Psychic",
+          "Colorless"
+        ],
+        "damage": "180",
+        "name": "Max Cure",
+        "text": "Heal 50 damage from this Pokémon."
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Metal",
+        "value": "×2"
+      }
+    ],
+    "imageUrlHiRes": "https://images.pokemontcg.io/swsh35/76_hires.png",
+    "nationalPokedexNumber": 282
+  },
+  {
+    "id": "swsh35-77",
+    "name": "Kabu",
+    "imageUrl": "https://images.pokemontcg.io/swsh35/77.png",
+    "subtype": "Supporter",
+    "supertype": "Trainer",
+    "number": "77",
+    "artist": "Hitoshi Ariga",
+    "rarity": "Rare Secret",
+    "series": "Sword & Shield",
+    "set": "Champions Path",
+    "setCode": "swsh35",
+    "imageUrlHiRes": "https://images.pokemontcg.io/swsh35/77_hires.png",
+    "text": [
+      "Shuffle your hand into your deck. Then, draw 4 cards. If your Active Pokémon is your only Pokémon in play, draw 8 cards instead."
+    ]
+  },
+  {
+    "id": "swsh35-78",
+    "name": "Piers",
+    "imageUrl": "https://images.pokemontcg.io/swsh35/78.png",
+    "subtype": "Supporter",
+    "supertype": "Trainer",
+    "number": "78",
+    "artist": "kirisAki",
+    "rarity": "Rare Secret",
+    "series": "Sword & Shield",
+    "set": "Champions Path",
+    "setCode": "swsh35",
+    "imageUrlHiRes": "https://images.pokemontcg.io/swsh35/78_hires.png",
+    "text": [
+      "Search your deck for an Energy card and a Darkness Pokémon, reveal them, and put them into your hand. Then, shuffle your deck."
+    ]
+  },
+  {
+    "id": "swsh35-79",
+    "name": "Charizard V",
+    "imageUrl": "https://images.pokemontcg.io/swsh35/79.png",
+    "subtype": "Basic",
+    "supertype": "Pokémon",
+    "hp": 220,
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
+    "convertedRetreatCost": 3,
+    "number": "79",
+    "artist": "5ban Graphics",
+    "rarity": "Rare Secret",
+    "series": "Sword & Shield",
+    "set": "Champions Path",
+    "setCode": "swsh35",
+    "types": [
+      "Fire"
+    ],
+    "attacks": [
+      {
+        "convertedEnergyCost": 3,
+        "cost": [
+          "Colorless",
+          "Colorless",
+          "Colorless"
+        ],
+        "damage": "80",
+        "name": "Claw Slash",
+        "text": ""
+      },
+      {
+        "convertedEnergyCost": 4,
+        "cost": [
+          "Fire",
+          "Fire",
+          "Colorless",
+          "Colorless"
+        ],
+        "damage": "220",
+        "name": "Fire Spin",
+        "text": "Discard 2 Energy from this Pokémon."
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Water",
+        "value": "×2"
+      }
+    ],
+    "imageUrlHiRes": "https://images.pokemontcg.io/swsh35/79_hires.png",
+    "nationalPokedexNumber": 6
+  },
+  {
+    "id": "swsh35-80",
+    "name": "Suspicious Food Tin",
+    "imageUrl": "https://images.pokemontcg.io/swsh35/80.png",
+    "subtype": "Item",
+    "supertype": "Trainer",
+    "number": "80",
+    "artist": "Ryo Ueda",
+    "rarity": "Rare Secret",
+    "series": "Sword & Shield",
+    "set": "Champions Path",
+    "setCode": "swsh35",
+    "imageUrlHiRes": "https://images.pokemontcg.io/swsh35/80_hires.png",
+    "text": [
+      "Heal 80 damage from 1 of your Pokémon that has at least 1 Psychic Energy attached. If you healed any damage in this way, discard a Psychic Energy from it."
+    ]
   }
 ]


### PR DESCRIPTION
Adds the missing card to Champions Path (74-80). See #154.
The data is pulled from kirbyUK/ptcgo-data, with the missing data manually added, and the image URLs are automatically generated.