### PR TITLE
Corrected some deck card references

### DIFF
--- a/json/decks/HS—Triumphant.json
+++ b/json/decks/HS—Triumphant.json
@@ -115,7 +115,7 @@
                 "count": 2
             },
             {
-                "id": "hgss4-77",
+                "id": "hgss2-77",
                 "name": "Interviewer's Questions",
                 "rarity": "Uncommon",
                 "count": 2
@@ -268,13 +268,13 @@
                 "count": 2
             },
             {
-                "id": "hgss4-77",
+                "id": "hgss2-77",
                 "name": "Interviewer's Questions",
                 "rarity": "Uncommon",
                 "count": 2
             },
             {
-                "id": "hgss4-79",
+                "id": "hgss2-79",
                 "name": "Life Herb",
                 "rarity": "Uncommon",
                 "count": 2

--- a/json/decks/HS—Undaunted.json
+++ b/json/decks/HS—Undaunted.json
@@ -109,13 +109,13 @@
                 "count": 2
             },
             {
-                "id": "hgss4-77",
+                "id": "hgss2-77",
                 "name": "Interviewer's Questions",
                 "rarity": "Uncommon",
                 "count": 2
             },
             {
-                "id": "hgss4-79",
+                "id": "hgss2-79",
                 "name": "Life Herb",
                 "rarity": "Uncommon",
                 "count": 2
@@ -292,7 +292,7 @@
                 "count": 2
             },
             {
-                "id": "hgss4-77",
+                "id": "hgss2-77",
                 "name": "Interviewer's Questions",
                 "rarity": "Uncommon",
                 "count": 2

--- a/json/decks/Rebel Clash.json
+++ b/json/decks/Rebel Clash.json
@@ -41,7 +41,7 @@
         "count": 2
       },
       {
-        "id": "swsh2-127",
+        "id": "swsh1-127",
         "name": "Galarian Meowth",
         "rarity": "Common",
         "count": 3
@@ -71,37 +71,37 @@
         "count": 2
       },
       {
-        "id": "swsh2-164",
+        "id": "swsh1-164",
         "name": "Great Ball",
         "rarity": "Uncommon",
         "count": 2
       },
       {
-        "id": "swsh2-165",
+        "id": "swsh1-165",
         "name": "Hop",
         "rarity": "Uncommon",
         "count": 4
       },
       {
-        "id": "swsh2-170",
+        "id": "swsh1-170",
         "name": "Metal Saucer",
         "rarity": "Uncommon",
         "count": 2
       },
       {
-        "id": "swsh2-173",
+        "id": "swsh1-173",
         "name": "Poké Kid",
         "rarity": "Uncommon",
         "count": 2
       },
       {
-        "id": "swsh2-175",
+        "id": "swsh1-175",
         "name": "Pokémon Catcher",
         "rarity": "Uncommon",
         "count": 2
       },
       {
-        "id": "swsh2-178",
+        "id": "swsh1-178",
         "name": "Professor's Research",
         "rarity": "Rare",
         "count": 2
@@ -113,7 +113,7 @@
         "count": 2
       },
       {
-        "id": "swsh2-183",
+        "id": "swsh1-183",
         "name": "Switch",
         "rarity": "Uncommon",
         "count": 2
@@ -143,43 +143,43 @@
         "count": 1
       },
       {
-        "id": "swsh2-135",
+        "id": "swsh1-135",
         "name": "Corviknight",
         "rarity": "Rare",
         "count": 2
       },
       {
-        "id": "swsh2-151",
+        "id": "swsh1-151",
         "name": "Corvisquire",
         "rarity": "Uncommon",
         "count": 3
       },
       {
-        "id": "swsh2-150",
+        "id": "swsh1-150",
         "name": "Rookidee",
         "rarity": "Common",
         "count": 3
       },
       {
-        "id": "swsh2-134",
+        "id": "swsh1-134",
         "name": "Bisharp",
         "rarity": "Uncommon",
         "count": 2
       },
       {
-        "id": "swsh2-133",
+        "id": "swsh1-133",
         "name": "Pawniard",
         "rarity": "Common",
         "count": 3
       },
       {
-        "id": "swsh2-131",
+        "id": "swsh1-131",
         "name": "Ferrothorn",
         "rarity": "Uncommon",
         "count": 2
       },
       {
-        "id": "swsh2-130",
+        "id": "swsh1-130",
         "name": "Ferroseed",
         "rarity": "Common",
         "count": 3
@@ -197,37 +197,37 @@
         "count": 2
       },
       {
-        "id": "swsh2-164",
+        "id": "swsh1-164",
         "name": "Great Ball",
         "rarity": "Uncommon",
         "count": 2
       },
       {
-        "id": "swsh2-165",
+        "id": "swsh1-165",
         "name": "Hop",
         "rarity": "Uncommon",
         "count": 4
       },
       {
-        "id": "swsh2-170",
+        "id": "swsh1-170",
         "name": "Metal Saucer",
         "rarity": "Uncommon",
         "count": 2
       },
       {
-        "id": "swsh2-173",
+        "id": "swsh1-173",
         "name": "Poké Kid",
         "rarity": "Uncommon",
         "count": 2
       },
       {
-        "id": "swsh2-177",
+        "id": "swsh1-177",
         "name": "Potion",
         "rarity": "Uncommon",
         "count": 2
       },
       {
-        "id": "swsh2-178",
+        "id": "swsh1-178",
         "name": "Professor's Research",
         "rarity": "Rare",
         "count": 2
@@ -239,7 +239,7 @@
         "count": 2
       },
       {
-        "id": "swsh2-183",
+        "id": "swsh1-183",
         "name": "Switch",
         "rarity": "Uncommon",
         "count": 2


### PR DESCRIPTION
Fixes some places where the deck card id pointed to the wrong card in HS-Triumphant, HS-Undaunted, and Rebel Clash.