### PR TITLE
Various fixes for Base/Neo sets

### DIFF
--- a/cards/en/base2.json
+++ b/cards/en/base2.json
@@ -3554,6 +3554,9 @@
     "artist": "Ken Sugimori",
     "rarity": "Common",
     "flavorText": "Although small, its venomous barbs make this Pokémon dangerous. The female has smaller horns.",
+    "nationalPokedexNumbers": [
+      29
+    ],
     "legalities": {
       "unlimited": "Legal"
     },

--- a/cards/en/base2.json
+++ b/cards/en/base2.json
@@ -363,6 +363,9 @@
     "artist": "Ken Sugimori",
     "rarity": "Rare Holo",
     "flavorText": "If interrupted while miming, it will slap around the enemy with its broad hands.",
+    "nationalPokedexNumbers": [
+      122
+    ],
     "legalities": {
       "unlimited": "Legal"
     },
@@ -1361,6 +1364,9 @@
     "artist": "Ken Sugimori",
     "rarity": "Rare",
     "flavorText": "If interrupted while miming, it will slap around the enemy with its broad hands.",
+    "nationalPokedexNumbers": [
+      122
+    ],
     "legalities": {
       "unlimited": "Legal"
     },

--- a/cards/en/base4.json
+++ b/cards/en/base4.json
@@ -1720,6 +1720,9 @@
     "artist": "Ken Sugimori",
     "rarity": "Rare",
     "flavorText": "If interrupted while miming, it will slap around the enemy with its broad hands.",
+    "nationalPokedexNumbers": [
+      122
+    ],
     "legalities": {
       "unlimited": "Legal"
     },

--- a/cards/en/base4.json
+++ b/cards/en/base4.json
@@ -5101,6 +5101,9 @@
     "artist": "Ken Sugimori",
     "rarity": "Common",
     "flavorText": "Although small, its venomous barbs make this Pokémon dangerous. The female has smaller horns.",
+    "nationalPokedexNumbers": [
+      29
+    ],
     "legalities": {
       "unlimited": "Legal"
     },
@@ -5149,6 +5152,9 @@
     "artist": "Ken Sugimori",
     "rarity": "Common",
     "flavorText": "Stiffens its ears to sense danger. The larger, more powerful of its horns secretes venom.",
+    "nationalPokedexNumbers": [
+      32
+    ],
     "legalities": {
       "unlimited": "Legal"
     },

--- a/cards/en/gym1.json
+++ b/cards/en/gym1.json
@@ -5358,6 +5358,9 @@
     "number": "94",
     "artist": "Ken Sugimori",
     "rarity": "Common",
+    "nationalPokedexNumbers": [
+      122
+    ],
     "legalities": {
       "unlimited": "Legal"
     },

--- a/cards/en/neo2.json
+++ b/cards/en/neo2.json
@@ -2824,7 +2824,7 @@
   },
   {
     "id": "neo2-47",
-    "name": "Unown Darkness",
+    "name": "Unown [D]",
     "supertype": "Pokémon",
     "subtypes": [
       "Basic"
@@ -2840,7 +2840,7 @@
     "abilities": [
       {
         "name": "[Darkness]",
-        "text": "Whenever a Darkness Pokémon damages 1 of your Pokémon, reduce that damage by 30 (after applying Weakness and Resistance). This power stops working if you have more than 1 Unown Darkness in play. (This power works even if Unown Darkness is Asleep, Confused, or Paralyzed.)",
+        "text": "Whenever a Darkness Pokémon damages 1 of your Pokémon, reduce that damage by 30 (after applying Weakness and Resistance). This power stops working if you have more than 1 Unown [D] in play. (This power works even if Unown [D] is Asleep, Confused, or Paralyzed.)",
         "type": "Pokémon Power"
       }
     ],
@@ -2882,7 +2882,7 @@
   },
   {
     "id": "neo2-48",
-    "name": "Unown Fighting",
+    "name": "Unown [F]",
     "supertype": "Pokémon",
     "subtypes": [
       "Basic"
@@ -2898,7 +2898,7 @@
     "abilities": [
       {
         "name": "[Find]",
-        "text": "Once during your turn (before your attack), if you have Unown Fighting, Unown [I], Unown Dragon, and Unown Darkness on your Bench, you may search your deck for a Trainer card. Show that card to your opponent, then put it into your hand. Shuffle your deck afterward.",
+        "text": "Once during your turn (before your attack), if you have Unown [F], Unown [I], Unown [N], and Unown [D] on your Bench, you may search your deck for a Trainer card. Show that card to your opponent, then put it into your hand. Shuffle your deck afterward.",
         "type": "Pokémon Power"
       }
     ],
@@ -2940,7 +2940,7 @@
   },
   {
     "id": "neo2-49",
-    "name": "Unown Metal",
+    "name": "Unown [M]",
     "supertype": "Pokémon",
     "subtypes": [
       "Basic"
@@ -2956,7 +2956,7 @@
     "abilities": [
       {
         "name": "[Metal]",
-        "text": "Whenever a Metal Pokémon damages 1 of your Pokémon, reduce that damage by 30 (after applying Weakness and Resistance). This power stops working if you have more than 1 Unown Metal in play. (This power works even if Unown Metal is Asleep, Confused, or Paralyzed.)",
+        "text": "Whenever a Metal Pokémon damages 1 of your Pokémon, reduce that damage by 30 (after applying Weakness and Resistance). This power stops working if you have more than 1 Unown [M] in play. (This power works even if Unown [M] is Asleep, Confused, or Paralyzed.)",
         "type": "Pokémon Power"
       }
     ],
@@ -2998,7 +2998,7 @@
   },
   {
     "id": "neo2-50",
-    "name": "Unown Dragon",
+    "name": "Unown [N]",
     "supertype": "Pokémon",
     "subtypes": [
       "Basic"
@@ -3014,7 +3014,7 @@
     "abilities": [
       {
         "name": "[Normal]",
-        "text": "Whenever a Colorless Pokémon damages 1 of your Pokémon, reduce that damage by 30 (after applying Weakness and Resistance). This power stops working if you have more than 1 Unown Dragon in play. (This power works even if Unown Dragon is Asleep, Confused, or Paralyzed.)",
+        "text": "Whenever a Colorless Pokémon damages 1 of your Pokémon, reduce that damage by 30 (after applying Weakness and Resistance). This power stops working if you have more than 1 Unown [N] in play. (This power works even if Unown [N] is Asleep, Confused, or Paralyzed.)",
         "type": "Pokémon Power"
       }
     ],
@@ -3072,7 +3072,7 @@
     "abilities": [
       {
         "name": "[Undo]",
-        "text": "Once during your turn (before your attack), if you have Unown [U], Unown Dragon, Unown Darkness, and Unown [O] on your Bench, you may return your Active Pokémon and all cards attached to it to your hand.",
+        "text": "Once during your turn (before your attack), if you have Unown [U], Unown [N], Unown [D], and Unown [O] on your Bench, you may return your Active Pokémon and all cards attached to it to your hand.",
         "type": "Pokémon Power"
       }
     ],


### PR DESCRIPTION
Found a few errors in some older sets.

- Fix names of Unown D, F, M, and N (for example, Unown [D] was called Unown Darkness)
- Add National Pokedex numbers for a few instances of Mr. Mime, Nidoran F, and Nidoran M