### PR TITLE
Fix nationalPokedexNumbers for TAG Team cards

### DIFF
--- a/cards/en/sm10.json
+++ b/cards/en/sm10.json
@@ -61,7 +61,8 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      794
+      794,
+      795
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -1220,7 +1221,8 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      6
+      6,
+      643
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -5030,7 +5032,8 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      68
+      68,
+      802
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -6554,7 +6557,8 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      571
+      571,
+      658
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -7405,7 +7409,8 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      448
+      448,
+      809
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -8081,7 +8086,8 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      282
+      282,
+      700
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -10907,7 +10913,8 @@
     "artist": "aky CG Works",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      794
+      794,
+      795
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -10981,7 +10988,8 @@
     "artist": "kirisAki",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      794
+      794,
+      795
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -11124,7 +11132,8 @@
     "artist": "aky CG Works",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      6
+      6,
+      643
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -11512,7 +11521,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      68
+      68,
+      802
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -11590,7 +11600,8 @@
     "artist": "You Iribi",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      68
+      68,
+      802
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -11661,7 +11672,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      571
+      571,
+      658
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -11732,7 +11744,8 @@
     "artist": "kodama",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      571
+      571,
+      658
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -11894,7 +11907,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      448
+      448,
+      809
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -11976,7 +11990,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      282
+      282,
+      700
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -12058,7 +12073,8 @@
     "artist": "Atsuko Nishida",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      282
+      282,
+      700
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -12507,7 +12523,8 @@
     "artist": "aky CG Works",
     "rarity": "Rare Rainbow",
     "nationalPokedexNumbers": [
-      794
+      794,
+      795
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -12650,7 +12667,8 @@
     "artist": "aky CG Works",
     "rarity": "Rare Rainbow",
     "nationalPokedexNumbers": [
-      6
+      6,
+      643
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -12955,7 +12973,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Rainbow",
     "nationalPokedexNumbers": [
-      68
+      68,
+      802
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -13026,7 +13045,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Rainbow",
     "nationalPokedexNumbers": [
-      571
+      571,
+      658
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -13188,7 +13208,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Rainbow",
     "nationalPokedexNumbers": [
-      448
+      448,
+      809
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -13270,7 +13291,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Rainbow",
     "nationalPokedexNumbers": [
-      282
+      282,
+      700
     ],
     "legalities": {
       "unlimited": "Legal",

--- a/cards/en/sm11.json
+++ b/cards/en/sm11.json
@@ -67,7 +67,8 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      103
+      103,
+      722
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -2054,7 +2055,8 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      54
+      54,
+      79
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -4251,7 +4253,8 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      150
+      150,
+      151
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -4318,7 +4321,8 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      196
+      196,
+      386
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -7536,7 +7540,8 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      197
+      197,
+      491
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -7615,7 +7620,8 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      248
+      248,
+      302
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -8910,7 +8916,8 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      445
+      445,
+      487
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -12131,7 +12138,8 @@
     "artist": "ConceptLab",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      103
+      103,
+      722
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -12211,7 +12219,8 @@
     "artist": "Naoyo Kimura",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      103
+      103,
+      722
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -12352,7 +12361,8 @@
     "artist": "ConceptLab",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      54
+      54,
+      79
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -12421,7 +12431,8 @@
     "artist": "Miki Tanaka",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      54
+      54,
+      79
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -12703,7 +12714,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      150
+      150,
+      151
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -12915,7 +12927,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      248
+      248,
+      302
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -12994,7 +13007,8 @@
     "artist": "chibi",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      248
+      248,
+      302
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -13147,7 +13161,8 @@
     "artist": "aky CG Works",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      445
+      445,
+      487
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -13521,7 +13536,8 @@
     "artist": "ConceptLab",
     "rarity": "Rare Rainbow",
     "nationalPokedexNumbers": [
-      103
+      103,
+      722
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -13662,7 +13678,8 @@
     "artist": "ConceptLab",
     "rarity": "Rare Rainbow",
     "nationalPokedexNumbers": [
-      54
+      54,
+      79
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -13871,7 +13888,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Rainbow",
     "nationalPokedexNumbers": [
-      150
+      150,
+      151
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -14083,7 +14101,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Rainbow",
     "nationalPokedexNumbers": [
-      248
+      248,
+      302
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -14236,7 +14255,8 @@
     "artist": "aky CG Works",
     "rarity": "Rare Rainbow",
     "nationalPokedexNumbers": [
-      445
+      445,
+      487
     ],
     "legalities": {
       "unlimited": "Legal",

--- a/cards/en/sm115.json
+++ b/cards/en/sm115.json
@@ -2702,7 +2702,9 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      144
+      144,
+      145,
+      146
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -3485,7 +3487,9 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      144
+      144,
+      145,
+      146
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -3606,7 +3610,9 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Rainbow",
     "nationalPokedexNumbers": [
-      144
+      144,
+      145,
+      146
     ],
     "legalities": {
       "unlimited": "Legal",

--- a/cards/en/sm12.json
+++ b/cards/en/sm12.json
@@ -66,7 +66,8 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      3
+      3,
+      495
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -1310,7 +1311,8 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      6
+      6,
+      654
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -2315,7 +2317,8 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      9
+      9,
+      393
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -4591,7 +4594,8 @@
     "artist": "Hideki Ishikawa",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      791
+      791,
+      792
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -8895,7 +8899,9 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      173
+      173,
+      174,
+      175
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -8970,7 +8976,9 @@
     "artist": "0313",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      173
+      173,
+      174,
+      175
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -9751,7 +9759,9 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      483
+      483,
+      484,
+      493
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -9819,7 +9829,8 @@
     "artist": "Naoki Saito",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      643
+      643,
+      644
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -9892,7 +9903,8 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      799
+      799,
+      804
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -10317,7 +10329,8 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      39
+      39,
+      428
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -12178,7 +12191,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      3
+      3,
+      495
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -12319,7 +12333,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      6
+      6,
+      654
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -12463,7 +12478,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      9
+      9,
+      393
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -12534,7 +12550,8 @@
     "artist": "Akira Komayama",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      9
+      9,
+      393
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -12602,7 +12619,8 @@
     "artist": "Hideki Ishikawa",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      791
+      791,
+      792
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -12900,7 +12918,9 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      483
+      483,
+      484,
+      493
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -12966,7 +12986,9 @@
     "artist": "Kouki Saitou",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      483
+      483,
+      484,
+      493
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -13034,7 +13056,8 @@
     "artist": "Naoki Saito",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      643
+      643,
+      644
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -13107,7 +13130,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      799
+      799,
+      804
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -13180,7 +13204,8 @@
     "artist": "Aya Kusube",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      799
+      799,
+      804
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -13247,7 +13272,8 @@
     "artist": "aky CG Works",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      39
+      39,
+      428
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -13314,7 +13340,8 @@
     "artist": "Shibuzoh.",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      39
+      39,
+      428
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -14412,7 +14439,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Rainbow",
     "nationalPokedexNumbers": [
-      3
+      3,
+      495
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -14553,7 +14581,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Rainbow",
     "nationalPokedexNumbers": [
-      6
+      6,
+      654
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -14697,7 +14726,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Rainbow",
     "nationalPokedexNumbers": [
-      9
+      9,
+      393
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -14765,7 +14795,8 @@
     "artist": "Hideki Ishikawa",
     "rarity": "Rare Rainbow",
     "nationalPokedexNumbers": [
-      791
+      791,
+      792
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -15063,7 +15094,9 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Rainbow",
     "nationalPokedexNumbers": [
-      483
+      483,
+      484,
+      493
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -15131,7 +15164,8 @@
     "artist": "Naoki Saito",
     "rarity": "Rare Rainbow",
     "nationalPokedexNumbers": [
-      643
+      643,
+      644
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -15204,7 +15238,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Rainbow",
     "nationalPokedexNumbers": [
-      799
+      799,
+      804
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -15271,7 +15306,8 @@
     "artist": "aky CG Works",
     "rarity": "Rare Rainbow",
     "nationalPokedexNumbers": [
-      39
+      39,
+      428
     ],
     "legalities": {
       "unlimited": "Legal",

--- a/cards/en/sm9.json
+++ b/cards/en/sm9.json
@@ -69,7 +69,8 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      3
+      3,
+      251
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -1968,7 +1969,8 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      25
+      25,
+      644
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -3282,7 +3284,8 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      94
+      94,
+      778
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -7028,7 +7031,8 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      380
+      380,
+      381
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -7462,7 +7466,8 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo GX",
     "nationalPokedexNumbers": [
-      133
+      133,
+      143
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -8984,7 +8989,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      3
+      3,
+      251
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -9056,7 +9062,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      129
+      129,
+      321
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -9128,7 +9135,8 @@
     "artist": "OOYAMA",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      129
+      129,
+      321
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -9205,7 +9213,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      25
+      25,
+      644
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -9355,7 +9364,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      94
+      94,
+      778
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -9425,7 +9435,8 @@
     "artist": "Midori Harada",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      94
+      94,
+      778
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -9728,7 +9739,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      380
+      380,
+      381
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -9793,7 +9805,8 @@
     "artist": "Sanosuke Sakuma",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      380
+      380,
+      381
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -9883,7 +9896,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
-      133
+      133,
+      143
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -10210,7 +10224,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Rainbow",
     "nationalPokedexNumbers": [
-      3
+      3,
+      251
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -10282,7 +10297,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Rainbow",
     "nationalPokedexNumbers": [
-      129
+      129,
+      321
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -10359,7 +10375,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Rainbow",
     "nationalPokedexNumbers": [
-      25
+      25,
+      644
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -10509,7 +10526,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Rainbow",
     "nationalPokedexNumbers": [
-      94
+      94,
+      778
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -10812,7 +10830,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Rainbow",
     "nationalPokedexNumbers": [
-      380
+      380,
+      381
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -10902,7 +10921,8 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Rainbow",
     "nationalPokedexNumbers": [
-      133
+      133,
+      143
     ],
     "legalities": {
       "unlimited": "Legal",

--- a/cards/en/smp.json
+++ b/cards/en/smp.json
@@ -11010,7 +11010,8 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
-      129
+      129,
+      321
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -11092,7 +11093,8 @@
     "artist": "Shin Nagasawa",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
-      3
+      3,
+      251
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -11169,7 +11171,8 @@
     "artist": "kawayoo",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
-      25
+      25,
+      644
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -11259,7 +11262,8 @@
     "artist": "Tomokazu Komiya",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
-      133
+      133,
+      143
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -12787,7 +12791,8 @@
     "artist": "sui",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
-      150
+      150,
+      151
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -12870,7 +12875,8 @@
     "artist": "nagimiso",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
-      448
+      448,
+      809
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -12947,7 +12953,8 @@
     "artist": "Anesaki Dynamic",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
-      445
+      445,
+      487
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -13501,7 +13508,8 @@
     "artist": "Ryota Murayama",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
-      6
+      6,
+      643
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -14066,7 +14074,9 @@
     "artist": "HYOGONOSUKE",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
-      144
+      144,
+      145,
+      146
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -14538,7 +14548,8 @@
     "artist": "Mitsuhiro Arita",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
-      477
+      477,
+      709
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -15281,7 +15292,8 @@
     "artist": "Yuka Morii",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
-      3
+      3,
+      495
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -15351,7 +15363,8 @@
     "artist": "Kagemaru Himeno",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
-      6
+      6,
+      654
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -16006,7 +16019,8 @@
     "artist": "Hasuno",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
-      196
+      196,
+      386
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -16077,7 +16091,8 @@
     "artist": "so-taro",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
-      197
+      197,
+      491
     ],
     "legalities": {
       "unlimited": "Legal",


### PR DESCRIPTION
Hi @adback03,

With your recent update to v2, you added the possibility for cards to support multiple national Pokédex numbers. It's of my best interest to fix this because my application, [Dex](https://apps.apple.com/app/id1555489854), has a Pokédex feature, and so it would be awesome if we could fix this for Sun & Moon's TAG Team as soon as possible.

Please let me know if there's something I can help you with.