### PR TITLE
Added Alternate Art Dedenne GX from Unbroken Bonds

### DIFF
--- a/cards/en/sm10.json
+++ b/cards/en/sm10.json
@@ -11298,6 +11298,82 @@
     }
   },
   {
+    "id": "sm10-195a",
+    "name": "Dedenne-GX",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Basic",
+      "GX"
+    ],
+    "hp": "160",
+    "types": [
+      "Lightning"
+    ],
+    "rules": [
+      "Pokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
+    ],
+    "abilities": [
+      {
+        "name": "Dedechange",
+        "text": "When you play this Pokémon from your hand onto your Bench during your turn, you may discard your hand and draw 6 cards. You can't use more than 1 Dedechange Ability each turn.",
+        "type": "Ability"
+      }
+    ],
+    "attacks": [
+      {
+        "name": "Static Shock",
+        "cost": [
+          "Lightning",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 2,
+        "damage": "50",
+        "text": ""
+      },
+      {
+        "name": "Tingly Return-GX",
+        "cost": [
+          "Lightning",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 2,
+        "damage": "50",
+        "text": "Your opponent's Active Pokémon is now Paralyzed. Put this Pokémon and all cards attached to it into your hand. (You can't use more than 1 GX attack in a game.)"
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Fighting",
+        "value": "×2"
+      }
+    ],
+    "resistances": [
+      {
+        "type": "Metal",
+        "value": "-20"
+      }
+    ],
+    "retreatCost": [
+      "Colorless"
+    ],
+    "convertedRetreatCost": 1,
+    "number": "195",
+    "artist": "kanahei",
+    "rarity": "Rare Ultra",
+    "nationalPokedexNumbers": [
+      702
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "INSERT_NEW_IMAGE",
+      "large": "INSERT_NEW_IMAGE"
+    }
+  },
+  {
     "id": "sm10-196",
     "name": "Muk & Alolan Muk-GX",
     "supertype": "Pokémon",

--- a/cards/en/sm10.json
+++ b/cards/en/sm10.json
@@ -11369,8 +11369,8 @@
       "expanded": "Legal"
     },
     "images": {
-      "small": "INSERT_NEW_IMAGE",
-      "large": "INSERT_NEW_IMAGE"
+      "small": "https://images.pokemontcg.io/sm10/195a.png",
+      "large": "https://images.pokemontcg.io/sm10/195a_hires.png"
     }
   },
   {


### PR DESCRIPTION
A user from my app, [Dex](https://apps.apple.com/app/id1555489854), sent me a message letting me know that we're currently missing the [Alternate Art for Dedenne from Unbroken Bonds](https://shop.tcgplayer.com/pokemon/alternate-art-promos/dedenne-gx-195a-214).


This PR aims to fix this issue @adback03, it's only missing the images but I don't know how to help you with it.