### PR TITLE
Fix typo on xy7-4

### DIFF
--- a/cards/en/xy7.json
+++ b/cards/en/xy7.json
@@ -3,14 +3,22 @@
     "id": "xy7-1",
     "name": "Oddish",
     "supertype": "Pokémon",
-    "subtypes": ["Basic"],
+    "subtypes": [
+      "Basic"
+    ],
     "hp": "50",
-    "types": ["Grass"],
-    "evolvesTo": ["Gloom"],
+    "types": [
+      "Grass"
+    ],
+    "evolvesTo": [
+      "Gloom"
+    ],
     "attacks": [
       {
         "name": "Trip Over",
-        "cost": ["Grass"],
+        "cost": [
+          "Grass"
+        ],
         "convertedEnergyCost": 1,
         "damage": "10+",
         "text": "Flip a coin. If heads, this attack does 10 more damage."
@@ -22,13 +30,17 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "1",
     "artist": "MAHOU",
     "rarity": "Common",
     "flavorText": "Its scientific name is \"Oddium Wanderus.\" At night, it is said to walk nearly 1,000 feet on its two roots.",
-    "nationalPokedexNumbers": [43],
+    "nationalPokedexNumbers": [
+      43
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -42,15 +54,25 @@
     "id": "xy7-2",
     "name": "Gloom",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 1"],
+    "subtypes": [
+      "Stage 1"
+    ],
     "hp": "80",
-    "types": ["Grass"],
+    "types": [
+      "Grass"
+    ],
     "evolvesFrom": "Oddish",
-    "evolvesTo": ["Vileplume", "Bellossom"],
+    "evolvesTo": [
+      "Vileplume",
+      "Bellossom"
+    ],
     "attacks": [
       {
         "name": "Drool",
-        "cost": ["Grass", "Colorless"],
+        "cost": [
+          "Grass",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "20",
         "text": ""
@@ -62,13 +84,17 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "2",
     "artist": "Masakazu Fukuda",
     "rarity": "Uncommon",
     "flavorText": "The honey it drools from its mouth smells so atrocious, it can curl noses more than a mile away.",
-    "nationalPokedexNumbers": [44],
+    "nationalPokedexNumbers": [
+      44
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -82,9 +108,13 @@
     "id": "xy7-3",
     "name": "Vileplume",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 2"],
+    "subtypes": [
+      "Stage 2"
+    ],
     "hp": "130",
-    "types": ["Grass"],
+    "types": [
+      "Grass"
+    ],
     "evolvesFrom": "Gloom",
     "abilities": [
       {
@@ -96,7 +126,11 @@
     "attacks": [
       {
         "name": "Solar Beam",
-        "cost": ["Grass", "Grass", "Colorless"],
+        "cost": [
+          "Grass",
+          "Grass",
+          "Colorless"
+        ],
         "convertedEnergyCost": 3,
         "damage": "70",
         "text": ""
@@ -108,13 +142,19 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 3,
     "number": "3",
     "artist": "Midori Harada",
     "rarity": "Rare",
     "flavorText": "It has the world's largest petals. With every step, the petals shake out heavy clouds of toxic pollen.",
-    "nationalPokedexNumbers": [45],
+    "nationalPokedexNumbers": [
+      45
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -128,21 +168,30 @@
     "id": "xy7-4",
     "name": "Bellossom",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 2"],
+    "subtypes": [
+      "Stage 2"
+    ],
     "hp": "120",
-    "types": ["Grass"],
+    "types": [
+      "Grass"
+    ],
     "evolvesFrom": "Gloom",
     "attacks": [
       {
         "name": "Windmill",
-        "cost": ["Grass"],
+        "cost": [
+          "Grass"
+        ],
         "convertedEnergyCost": 1,
         "damage": "20",
         "text": "Switch this Pokémon with 1 of your Benched Pokémon."
       },
       {
         "name": "Flower Tornado",
-        "cost": ["Grass", "Colorless"],
+        "cost": [
+          "Grass",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "60",
         "text": "Move as many Grass Energy attached to your Pokémon to your other Pokémon in any way you like."
@@ -154,13 +203,17 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "4",
     "artist": "Mizue",
     "rarity": "Uncommon",
     "flavorText": "When the heavy rainfall season ends, it is drawn out by warm sunlight to dance in the open.",
-    "nationalPokedexNumbers": [182],
+    "nationalPokedexNumbers": [
+      182
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -174,14 +227,22 @@
     "id": "xy7-5",
     "name": "Spinarak",
     "supertype": "Pokémon",
-    "subtypes": ["Basic"],
+    "subtypes": [
+      "Basic"
+    ],
     "hp": "50",
-    "types": ["Grass"],
-    "evolvesTo": ["Ariados"],
+    "types": [
+      "Grass"
+    ],
+    "evolvesTo": [
+      "Ariados"
+    ],
     "attacks": [
       {
         "name": "String Shot",
-        "cost": ["Colorless"],
+        "cost": [
+          "Colorless"
+        ],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
@@ -193,13 +254,17 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "5",
     "artist": "Naoyo Kimura",
     "rarity": "Common",
     "flavorText": "It lies still in the same pose for days in its web, waiting for its unsuspecting prey to wander close.",
-    "nationalPokedexNumbers": [167],
+    "nationalPokedexNumbers": [
+      167
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -213,9 +278,13 @@
     "id": "xy7-6",
     "name": "Ariados",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 1"],
+    "subtypes": [
+      "Stage 1"
+    ],
     "hp": "70",
-    "types": ["Grass"],
+    "types": [
+      "Grass"
+    ],
     "evolvesFrom": "Spinarak",
     "abilities": [
       {
@@ -227,7 +296,10 @@
     "attacks": [
       {
         "name": "Impound",
-        "cost": ["Grass", "Colorless"],
+        "cost": [
+          "Grass",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "30",
         "text": "The Defending Pokémon can't retreat during your opponent's next turn."
@@ -239,13 +311,17 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "6",
     "artist": "Hajime Kusajima",
     "rarity": "Uncommon",
     "flavorText": "It attaches silk to its prey and sets it free. Later, it tracks the silk to the prey and its friends.",
-    "nationalPokedexNumbers": [168],
+    "nationalPokedexNumbers": [
+      168
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -259,24 +335,36 @@
     "id": "xy7-7",
     "name": "Sceptile-EX",
     "supertype": "Pokémon",
-    "subtypes": ["Basic", "EX"],
+    "subtypes": [
+      "Basic",
+      "EX"
+    ],
     "hp": "170",
-    "types": ["Grass"],
-    "evolvesTo": ["M Sceptile-EX"],
+    "types": [
+      "Grass"
+    ],
+    "evolvesTo": [
+      "M Sceptile-EX"
+    ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
       {
         "name": "Sleep Poison",
-        "cost": ["Grass"],
+        "cost": [
+          "Grass"
+        ],
         "convertedEnergyCost": 1,
         "damage": "10",
         "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Asleep and Poisoned."
       },
       {
         "name": "Unseen Claw",
-        "cost": ["Grass", "Colorless"],
+        "cost": [
+          "Grass",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "60+",
         "text": "If your opponent's Active Pokémon is affected by a Special Condition, this attack does 70 more damage."
@@ -288,12 +376,16 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "7",
     "artist": "Eske Yoshinob",
     "rarity": "Rare Holo EX",
-    "nationalPokedexNumbers": [254],
+    "nationalPokedexNumbers": [
+      254
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -307,9 +399,14 @@
     "id": "xy7-8",
     "name": "M Sceptile-EX",
     "supertype": "Pokémon",
-    "subtypes": ["MEGA", "EX"],
+    "subtypes": [
+      "MEGA",
+      "EX"
+    ],
     "hp": "220",
-    "types": ["Grass"],
+    "types": [
+      "Grass"
+    ],
     "evolvesFrom": "Sceptile-EX",
     "rules": [
       "Mega Evolution rule: When 1 of your Pokémon becomes a Mega Evolution Pokémon, your turn ends.",
@@ -322,7 +419,10 @@
     "attacks": [
       {
         "name": "Jagged Saber",
-        "cost": ["Grass", "Colorless"],
+        "cost": [
+          "Grass",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "100",
         "text": "You may attach up to 2 Grass Energy cards from your hand to your Benched Pokémon in any way you like. If you attached Energy to a Pokémon in this way, heal all damage from that Pokémon."
@@ -334,12 +434,17 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 2,
     "number": "8",
     "artist": "5ban Graphics",
     "rarity": "Rare Holo EX",
-    "nationalPokedexNumbers": [254],
+    "nationalPokedexNumbers": [
+      254
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -353,14 +458,22 @@
     "id": "xy7-9",
     "name": "Combee",
     "supertype": "Pokémon",
-    "subtypes": ["Basic"],
+    "subtypes": [
+      "Basic"
+    ],
     "hp": "40",
-    "types": ["Grass"],
-    "evolvesTo": ["Vespiquen"],
+    "types": [
+      "Grass"
+    ],
+    "evolvesTo": [
+      "Vespiquen"
+    ],
     "attacks": [
       {
         "name": "Bug Bite",
-        "cost": ["Grass"],
+        "cost": [
+          "Grass"
+        ],
         "convertedEnergyCost": 1,
         "damage": "10",
         "text": ""
@@ -372,13 +485,17 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "9",
     "artist": "Sumiyoshi Kizuki",
     "rarity": "Common",
     "flavorText": "It collects and delivers honey to its colony. At night, they cluster to form a beehive and sleep.",
-    "nationalPokedexNumbers": [415],
+    "nationalPokedexNumbers": [
+      415
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -392,21 +509,30 @@
     "id": "xy7-10",
     "name": "Vespiquen",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 1"],
+    "subtypes": [
+      "Stage 1"
+    ],
     "hp": "90",
-    "types": ["Grass"],
+    "types": [
+      "Grass"
+    ],
     "evolvesFrom": "Combee",
     "attacks": [
       {
         "name": "Intelligence Gathering",
-        "cost": ["Colorless"],
+        "cost": [
+          "Colorless"
+        ],
         "convertedEnergyCost": 1,
         "damage": "10",
         "text": "You may draw cards until you have 6 cards in your hand."
       },
       {
         "name": "Bee Revenge",
-        "cost": ["Colorless", "Colorless"],
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "20+",
         "text": "This attack does 10 more damage for each Pokémon in your discard pile."
@@ -422,7 +548,9 @@
     "artist": "kawayoo",
     "rarity": "Uncommon",
     "flavorText": "Its abdomen is a honeycomb for grubs. It raises its grubs on honey collected by Combee.",
-    "nationalPokedexNumbers": [416],
+    "nationalPokedexNumbers": [
+      416
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -436,9 +564,13 @@
     "id": "xy7-11",
     "name": "Vespiquen",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 1"],
+    "subtypes": [
+      "Stage 1"
+    ],
     "hp": "90",
-    "types": ["Grass"],
+    "types": [
+      "Grass"
+    ],
     "evolvesFrom": "Combee",
     "ancientTrait": {
       "name": "θ Double",
@@ -447,14 +579,19 @@
     "attacks": [
       {
         "name": "Bee Drain",
-        "cost": ["Grass"],
+        "cost": [
+          "Grass"
+        ],
         "convertedEnergyCost": 1,
         "damage": "20",
         "text": "Heal from this Pokémon the same amount of damage you did to your opponent's Active Pokémon."
       },
       {
         "name": "Fury Swipes",
-        "cost": ["Colorless", "Colorless"],
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "30×",
         "text": "Flip 3 coins. This attack does 30 damage times the number of heads."
@@ -466,13 +603,17 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "11",
     "artist": "Ayaka Yoshida",
     "rarity": "Rare",
     "flavorText": "Its abdomen is a honeycomb for grubs. It raises its grubs on honey collected by Combee.",
-    "nationalPokedexNumbers": [416],
+    "nationalPokedexNumbers": [
+      416
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -486,20 +627,29 @@
     "id": "xy7-12",
     "name": "Virizion",
     "supertype": "Pokémon",
-    "subtypes": ["Basic"],
+    "subtypes": [
+      "Basic"
+    ],
     "hp": "110",
-    "types": ["Grass"],
+    "types": [
+      "Grass"
+    ],
     "attacks": [
       {
         "name": "Bail Out",
-        "cost": ["Grass"],
+        "cost": [
+          "Grass"
+        ],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Put 2 Pokémon from your discard pile into your hand."
       },
       {
         "name": "Prize Count",
-        "cost": ["Grass", "Grass"],
+        "cost": [
+          "Grass",
+          "Grass"
+        ],
         "convertedEnergyCost": 2,
         "damage": "40+",
         "text": "If you have more Prize cards left than your opponent, this attack does 80 more damage."
@@ -511,13 +661,17 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "12",
     "artist": "match",
     "rarity": "Rare Holo",
     "flavorText": "Legends say this Pokémon confounded opponents with its swift movements.",
-    "nationalPokedexNumbers": [640],
+    "nationalPokedexNumbers": [
+      640
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -531,9 +685,13 @@
     "id": "xy7-13",
     "name": "Flareon",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 1"],
+    "subtypes": [
+      "Stage 1"
+    ],
     "hp": "90",
-    "types": ["Fire"],
+    "types": [
+      "Fire"
+    ],
     "evolvesFrom": "Eevee",
     "abilities": [
       {
@@ -545,7 +703,11 @@
     "attacks": [
       {
         "name": "Heat Breath",
-        "cost": ["Fire", "Colorless", "Colorless"],
+        "cost": [
+          "Fire",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 3,
         "damage": "60+",
         "text": "Flip a coin. If heads, this attack does 20 more damage."
@@ -557,13 +719,17 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "13",
     "artist": "sui",
     "rarity": "Uncommon",
     "flavorText": "It has a flame bag inside its body. After inhaling deeply, it blows out flames of nearly 3,000 degrees Fahrenheit.",
-    "nationalPokedexNumbers": [136],
+    "nationalPokedexNumbers": [
+      136
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -577,20 +743,29 @@
     "id": "xy7-14",
     "name": "Entei",
     "supertype": "Pokémon",
-    "subtypes": ["Basic"],
+    "subtypes": [
+      "Basic"
+    ],
     "hp": "120",
-    "types": ["Fire"],
+    "types": [
+      "Fire"
+    ],
     "attacks": [
       {
         "name": "Burning Roar",
-        "cost": ["Colorless"],
+        "cost": [
+          "Colorless"
+        ],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Discard the top 4 cards of your deck. If any of those cards are Fire Energy cards, attach them to your Pokémon in any way you like."
       },
       {
         "name": "Combat Blaze",
-        "cost": ["Fire", "Fire"],
+        "cost": [
+          "Fire",
+          "Fire"
+        ],
         "convertedEnergyCost": 2,
         "damage": "20+",
         "text": "This attack does 20 more damage for each of your opponent's Benched Pokémon."
@@ -602,13 +777,18 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 2,
     "number": "14",
     "artist": "Naoki Saito",
     "rarity": "Rare",
     "flavorText": "It is said that when it roars, a volcano erupts somewhere around the globe.",
-    "nationalPokedexNumbers": [244],
+    "nationalPokedexNumbers": [
+      244
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -622,9 +802,13 @@
     "id": "xy7-15",
     "name": "Entei",
     "supertype": "Pokémon",
-    "subtypes": ["Basic"],
+    "subtypes": [
+      "Basic"
+    ],
     "hp": "130",
-    "types": ["Fire"],
+    "types": [
+      "Fire"
+    ],
     "ancientTrait": {
       "name": "θ Double",
       "text": "This Pokémon may have up to 2 Pokémon Tool cards attached to it."
@@ -632,14 +816,22 @@
     "attacks": [
       {
         "name": "Flame Screen",
-        "cost": ["Fire", "Colorless"],
+        "cost": [
+          "Fire",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "30",
         "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 30 (after applying Weakness and Resistance)."
       },
       {
         "name": "Heat Tackle",
-        "cost": ["Fire", "Fire", "Colorless", "Colorless"],
+        "cost": [
+          "Fire",
+          "Fire",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 4,
         "damage": "130",
         "text": "Flip a coin. If tails, this Pokémon does 30 damage to itself."
@@ -651,13 +843,18 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 2,
     "number": "15",
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo",
     "flavorText": "It is said that when it roars, a volcano erupts somewhere around the globe.",
-    "nationalPokedexNumbers": [244],
+    "nationalPokedexNumbers": [
+      244
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -671,14 +868,23 @@
     "id": "xy7-16",
     "name": "Larvesta",
     "supertype": "Pokémon",
-    "subtypes": ["Basic"],
+    "subtypes": [
+      "Basic"
+    ],
     "hp": "70",
-    "types": ["Fire"],
-    "evolvesTo": ["Volcarona"],
+    "types": [
+      "Fire"
+    ],
+    "evolvesTo": [
+      "Volcarona"
+    ],
     "attacks": [
       {
         "name": "Combustion",
-        "cost": ["Fire", "Colorless"],
+        "cost": [
+          "Fire",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "30",
         "text": ""
@@ -690,13 +896,18 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 2,
     "number": "16",
     "artist": "Satoshi Shirai",
     "rarity": "Common",
     "flavorText": "The base of volcanoes is where they make their homes. They shoot fire from their five horns to repel attacking enemies.",
-    "nationalPokedexNumbers": [636],
+    "nationalPokedexNumbers": [
+      636
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -710,21 +921,30 @@
     "id": "xy7-17",
     "name": "Volcarona",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 1"],
+    "subtypes": [
+      "Stage 1"
+    ],
     "hp": "100",
-    "types": ["Fire"],
+    "types": [
+      "Fire"
+    ],
     "evolvesFrom": "Larvesta",
     "attacks": [
       {
         "name": "Solar Birth",
-        "cost": ["Colorless"],
+        "cost": [
+          "Colorless"
+        ],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Search your deck for a Basic Pokémon and put it onto your Bench. Then, search your deck for up to 2 basic Energy cards and attach them to that Pokémon. Shuffle your deck afterward."
       },
       {
         "name": "Flamethrower",
-        "cost": ["Fire", "Colorless"],
+        "cost": [
+          "Fire",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "60",
         "text": "Discard an Energy attached to this Pokémon."
@@ -736,13 +956,17 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "17",
     "artist": "Kyoko Umemoto",
     "rarity": "Rare Holo",
     "flavorText": "When volcanic ash darkened the atmosphere, it is said that Volcarona's fire provided a replacement for the sun.",
-    "nationalPokedexNumbers": [637],
+    "nationalPokedexNumbers": [
+      637
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -756,9 +980,13 @@
     "id": "xy7-18",
     "name": "Volcarona",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 1"],
+    "subtypes": [
+      "Stage 1"
+    ],
     "hp": "110",
-    "types": ["Fire"],
+    "types": [
+      "Fire"
+    ],
     "evolvesFrom": "Larvesta",
     "ancientTrait": {
       "name": "θ Stop",
@@ -767,14 +995,20 @@
     "attacks": [
       {
         "name": "Burning Scales",
-        "cost": ["Fire"],
+        "cost": [
+          "Fire"
+        ],
         "convertedEnergyCost": 1,
         "damage": "20+",
         "text": "Flip 2 coins. This attack does 20 more damage for each heads."
       },
       {
         "name": "Wind Wheel",
-        "cost": ["Fire", "Colorless", "Colorless"],
+        "cost": [
+          "Fire",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 3,
         "damage": "80",
         "text": "Your opponent switches his or her Active Pokémon with 1 of his or her Benched Pokémon."
@@ -786,13 +1020,18 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 2,
     "number": "18",
     "artist": "Kagemaru Himeno",
     "rarity": "Rare",
     "flavorText": "When volcanic ash darkened the atmosphere, it is said that Volcarona's fire provided a replacement for the sun.",
-    "nationalPokedexNumbers": [637],
+    "nationalPokedexNumbers": [
+      637
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -806,14 +1045,22 @@
     "id": "xy7-19",
     "name": "Magikarp",
     "supertype": "Pokémon",
-    "subtypes": ["Basic"],
+    "subtypes": [
+      "Basic"
+    ],
     "hp": "30",
-    "types": ["Water"],
-    "evolvesTo": ["Gyarados"],
+    "types": [
+      "Water"
+    ],
+    "evolvesTo": [
+      "Gyarados"
+    ],
     "attacks": [
       {
         "name": "Epic Splash",
-        "cost": ["Water"],
+        "cost": [
+          "Water"
+        ],
         "convertedEnergyCost": 1,
         "damage": "30",
         "text": "Flip 2 coins. If either of them is tails, this attack does nothing."
@@ -825,13 +1072,17 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "19",
     "artist": "Akira Komayama",
     "rarity": "Common",
     "flavorText": "In the distant past, it was somewhat stronger than the horribly weak descendants that exist today.",
-    "nationalPokedexNumbers": [129],
+    "nationalPokedexNumbers": [
+      129
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -845,21 +1096,34 @@
     "id": "xy7-20",
     "name": "Gyarados",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 1"],
+    "subtypes": [
+      "Stage 1"
+    ],
     "hp": "130",
-    "types": ["Water"],
+    "types": [
+      "Water"
+    ],
     "evolvesFrom": "Magikarp",
     "attacks": [
       {
         "name": "Berserker Splash",
-        "cost": ["Water", "Colorless", "Colorless"],
+        "cost": [
+          "Water",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 3,
         "damage": "80",
         "text": "This attack does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Aqua Tail",
-        "cost": ["Water", "Colorless", "Colorless", "Colorless"],
+        "cost": [
+          "Water",
+          "Colorless",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 4,
         "damage": "90+",
         "text": "Flip a coin for each Water Energy attached to this Pokémon. This attack does 30 more damage for each heads."
@@ -871,13 +1135,19 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 3,
     "number": "20",
     "artist": "Shin Nagasawa",
     "rarity": "Rare",
     "flavorText": "Rarely seen in the wild. Huge and vicious, it is capable of destroying entire cities in a rage.",
-    "nationalPokedexNumbers": [130],
+    "nationalPokedexNumbers": [
+      130
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -891,9 +1161,13 @@
     "id": "xy7-21",
     "name": "Gyarados",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 1"],
+    "subtypes": [
+      "Stage 1"
+    ],
     "hp": "130",
-    "types": ["Water"],
+    "types": [
+      "Water"
+    ],
     "evolvesFrom": "Magikarp",
     "ancientTrait": {
       "name": "θ Double",
@@ -902,14 +1176,22 @@
     "attacks": [
       {
         "name": "Full Retaliation",
-        "cost": ["Colorless", "Colorless"],
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "30+",
         "text": "This attack does 30 more damage for each damage counter on each of your Benched Magikarp."
       },
       {
         "name": "Thrash",
-        "cost": ["Water", "Water", "Colorless", "Colorless"],
+        "cost": [
+          "Water",
+          "Water",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 4,
         "damage": "100+",
         "text": "Flip a coin. If heads, this attack does 30 more damage. If tails, this Pokémon does 30 damage to itself."
@@ -921,13 +1203,19 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 3,
     "number": "21",
     "artist": "TOKIYA",
     "rarity": "Rare Holo",
     "flavorText": "Rarely seen in the wild. Huge and vicious, it is capable of destroying entire cities in a rage.",
-    "nationalPokedexNumbers": [130],
+    "nationalPokedexNumbers": [
+      130
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -941,9 +1229,13 @@
     "id": "xy7-22",
     "name": "Vaporeon",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 1"],
+    "subtypes": [
+      "Stage 1"
+    ],
     "hp": "90",
-    "types": ["Water"],
+    "types": [
+      "Water"
+    ],
     "evolvesFrom": "Eevee",
     "abilities": [
       {
@@ -955,7 +1247,11 @@
     "attacks": [
       {
         "name": "Hydro Splash",
-        "cost": ["Water", "Colorless", "Colorless"],
+        "cost": [
+          "Water",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 3,
         "damage": "70",
         "text": ""
@@ -967,13 +1263,18 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 2,
     "number": "22",
     "artist": "kirisAki",
     "rarity": "Uncommon",
     "flavorText": "It has evolved to be suitable for an aquatic life. It can invisibly melt away into water.",
-    "nationalPokedexNumbers": [134],
+    "nationalPokedexNumbers": [
+      134
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -987,20 +1288,29 @@
     "id": "xy7-23",
     "name": "Relicanth",
     "supertype": "Pokémon",
-    "subtypes": ["Basic"],
+    "subtypes": [
+      "Basic"
+    ],
     "hp": "90",
-    "types": ["Water"],
+    "types": [
+      "Water"
+    ],
     "attacks": [
       {
         "name": "Deep Sea Search",
-        "cost": ["Colorless"],
+        "cost": [
+          "Colorless"
+        ],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Search your deck for up to 2 Pokémon Tool cards, reveal them, and put them into your hand. Shuffle your deck afterward."
       },
       {
         "name": "Take Down",
-        "cost": ["Colorless", "Colorless"],
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "30",
         "text": "This Pokémon does 10 damage to itself."
@@ -1012,13 +1322,17 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "23",
     "artist": "Kagemaru Himeno",
     "rarity": "Common",
     "flavorText": "A rare Pokémon discovered during a deep-sea exploration. It has not changed in over 100 million years.",
-    "nationalPokedexNumbers": [369],
+    "nationalPokedexNumbers": [
+      369
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1032,20 +1346,31 @@
     "id": "xy7-24",
     "name": "Regice",
     "supertype": "Pokémon",
-    "subtypes": ["Basic"],
+    "subtypes": [
+      "Basic"
+    ],
     "hp": "120",
-    "types": ["Water"],
+    "types": [
+      "Water"
+    ],
     "attacks": [
       {
         "name": "Ice Beam",
-        "cost": ["Water", "Colorless"],
+        "cost": [
+          "Water",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "30",
         "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
       },
       {
         "name": "Resistance Blizzard",
-        "cost": ["Water", "Colorless", "Colorless"],
+        "cost": [
+          "Water",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 3,
         "damage": "70",
         "text": "During your opponent's next turn, prevent all effects of attacks, including damage, done to this Pokémon by Pokémon-EX."
@@ -1057,13 +1382,19 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 3,
     "number": "24",
     "artist": "Miki Tanaka",
     "rarity": "Rare",
     "flavorText": "Its body is made of ice from the ice age. It controls frigid air of -328 degrees Fahrenheit.",
-    "nationalPokedexNumbers": [378],
+    "nationalPokedexNumbers": [
+      378
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1077,23 +1408,37 @@
     "id": "xy7-25",
     "name": "Kyurem-EX",
     "supertype": "Pokémon",
-    "subtypes": ["Basic", "EX"],
+    "subtypes": [
+      "Basic",
+      "EX"
+    ],
     "hp": "180",
-    "types": ["Water"],
+    "types": [
+      "Water"
+    ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
       {
         "name": "Glaciate",
-        "cost": ["Water", "Water", "Colorless"],
+        "cost": [
+          "Water",
+          "Water",
+          "Colorless"
+        ],
         "convertedEnergyCost": 3,
         "damage": "",
         "text": "This attack does 30 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Icecalibur",
-        "cost": ["Water", "Water", "Water", "Colorless"],
+        "cost": [
+          "Water",
+          "Water",
+          "Water",
+          "Colorless"
+        ],
         "convertedEnergyCost": 4,
         "damage": "130",
         "text": "Discard an Energy attached to this Pokémon. The Defending Pokémon can't attack during your opponent's next turn."
@@ -1105,12 +1450,18 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 3,
     "number": "25",
     "artist": "PLANETA",
     "rarity": "Rare Holo EX",
-    "nationalPokedexNumbers": [646],
+    "nationalPokedexNumbers": [
+      646
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1124,9 +1475,13 @@
     "id": "xy7-26",
     "name": "Jolteon",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 1"],
+    "subtypes": [
+      "Stage 1"
+    ],
     "hp": "90",
-    "types": ["Lightning"],
+    "types": [
+      "Lightning"
+    ],
     "evolvesFrom": "Eevee",
     "abilities": [
       {
@@ -1138,7 +1493,11 @@
     "attacks": [
       {
         "name": "Thunder Blast",
-        "cost": ["Lightning", "Colorless", "Colorless"],
+        "cost": [
+          "Lightning",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 3,
         "damage": "80",
         "text": "Discard an Energy attached to this Pokémon."
@@ -1160,7 +1519,9 @@
     "artist": "Sanosuke Sakuma",
     "rarity": "Rare Holo",
     "flavorText": "It accumulates negative ions in the atmosphere to blast out 10,000-volt lightning bolts.",
-    "nationalPokedexNumbers": [135],
+    "nationalPokedexNumbers": [
+      135
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1174,24 +1535,38 @@
     "id": "xy7-27",
     "name": "Ampharos-EX",
     "supertype": "Pokémon",
-    "subtypes": ["Basic", "EX"],
+    "subtypes": [
+      "Basic",
+      "EX"
+    ],
     "hp": "170",
-    "types": ["Lightning"],
-    "evolvesTo": ["M Ampharos-EX"],
+    "types": [
+      "Lightning"
+    ],
+    "evolvesTo": [
+      "M Ampharos-EX"
+    ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
       {
         "name": "Thunder Rod",
-        "cost": ["Colorless"],
+        "cost": [
+          "Colorless"
+        ],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Look at the top 4 cards of your deck and attach as many Lightning Energy cards you find there as you like to this Pokémon. Shuffle the other cards back into your deck."
       },
       {
         "name": "Sparkling Tail",
-        "cost": ["Lightning", "Lightning", "Colorless", "Colorless"],
+        "cost": [
+          "Lightning",
+          "Lightning",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 4,
         "damage": "100",
         "text": "This attack's damage isn't affected by Weakness, Resistance, or any other effects on your opponent's Active Pokémon."
@@ -1209,12 +1584,17 @@
         "value": "-20"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 2,
     "number": "27",
     "artist": "Eske Yoshinob",
     "rarity": "Rare Holo EX",
-    "nationalPokedexNumbers": [181],
+    "nationalPokedexNumbers": [
+      181
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1228,9 +1608,14 @@
     "id": "xy7-28",
     "name": "M Ampharos-EX",
     "supertype": "Pokémon",
-    "subtypes": ["MEGA", "EX"],
+    "subtypes": [
+      "MEGA",
+      "EX"
+    ],
     "hp": "220",
-    "types": ["Lightning"],
+    "types": [
+      "Lightning"
+    ],
     "evolvesFrom": "Ampharos-EX",
     "rules": [
       "Mega Evolution rule: When 1 of your Pokémon becomes a Mega Evolution Pokémon, your turn ends.",
@@ -1239,7 +1624,12 @@
     "attacks": [
       {
         "name": "Exavolt",
-        "cost": ["Lightning", "Lightning", "Colorless", "Colorless"],
+        "cost": [
+          "Lightning",
+          "Lightning",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 4,
         "damage": "120+",
         "text": "You may do 50 more damage and leave your opponent's Active Pokémon Paralyzed. If you do, this Pokémon does 30 damage to itself."
@@ -1257,12 +1647,18 @@
         "value": "-20"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 3,
     "number": "28",
     "artist": "5ban Graphics",
     "rarity": "Rare Holo EX",
-    "nationalPokedexNumbers": [181],
+    "nationalPokedexNumbers": [
+      181
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1276,20 +1672,29 @@
     "id": "xy7-29",
     "name": "Rotom",
     "supertype": "Pokémon",
-    "subtypes": ["Basic"],
+    "subtypes": [
+      "Basic"
+    ],
     "hp": "70",
-    "types": ["Lightning"],
+    "types": [
+      "Lightning"
+    ],
     "attacks": [
       {
         "name": "Electro Ball",
-        "cost": ["Lightning"],
+        "cost": [
+          "Lightning"
+        ],
         "convertedEnergyCost": 1,
         "damage": "20",
         "text": ""
       },
       {
         "name": "Electric Mischief",
-        "cost": ["Colorless", "Colorless"],
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "",
         "text": "Flip 3 coins. For each heads, choose a random card from your opponent's hand. Your opponent reveals that card and shuffles it into his or her deck."
@@ -1307,13 +1712,17 @@
         "value": "-20"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "29",
     "artist": "Mizue",
     "rarity": "Uncommon",
     "flavorText": "Its body is composed of plasma. It is known to infiltrate electronic devices and wreak havoc.",
-    "nationalPokedexNumbers": [479],
+    "nationalPokedexNumbers": [
+      479
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1327,9 +1736,13 @@
     "id": "xy7-30",
     "name": "Unown",
     "supertype": "Pokémon",
-    "subtypes": ["Basic"],
+    "subtypes": [
+      "Basic"
+    ],
     "hp": "60",
-    "types": ["Psychic"],
+    "types": [
+      "Psychic"
+    ],
     "abilities": [
       {
         "name": "Farewell Letter",
@@ -1340,7 +1753,9 @@
     "attacks": [
       {
         "name": "Hidden Power",
-        "cost": ["Colorless"],
+        "cost": [
+          "Colorless"
+        ],
         "convertedEnergyCost": 1,
         "damage": "10",
         "text": ""
@@ -1352,13 +1767,17 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "30",
     "artist": "Akira Komayama",
     "rarity": "Common",
     "flavorText": "Shaped like ancient writing, it is a huge mystery whether language or Unown came first.",
-    "nationalPokedexNumbers": [201],
+    "nationalPokedexNumbers": [
+      201
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1372,21 +1791,32 @@
     "id": "xy7-31",
     "name": "Baltoy",
     "supertype": "Pokémon",
-    "subtypes": ["Basic"],
+    "subtypes": [
+      "Basic"
+    ],
     "hp": "60",
-    "types": ["Psychic"],
-    "evolvesTo": ["Claydol"],
+    "types": [
+      "Psychic"
+    ],
+    "evolvesTo": [
+      "Claydol"
+    ],
     "attacks": [
       {
         "name": "Slap",
-        "cost": ["Psychic"],
+        "cost": [
+          "Psychic"
+        ],
         "convertedEnergyCost": 1,
         "damage": "10",
         "text": ""
       },
       {
         "name": "Spinning Attack",
-        "cost": ["Psychic", "Colorless"],
+        "cost": [
+          "Psychic",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "20",
         "text": ""
@@ -1398,13 +1828,17 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "31",
     "artist": "Kouki Saitou",
     "rarity": "Common",
     "flavorText": "It moves by spinning on its foot. It is a rare Pokémon that was discovered in ancient ruins.",
-    "nationalPokedexNumbers": [343],
+    "nationalPokedexNumbers": [
+      343
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1418,10 +1852,16 @@
     "id": "xy7-32",
     "name": "Baltoy",
     "supertype": "Pokémon",
-    "subtypes": ["Basic"],
+    "subtypes": [
+      "Basic"
+    ],
     "hp": "60",
-    "types": ["Psychic"],
-    "evolvesTo": ["Claydol"],
+    "types": [
+      "Psychic"
+    ],
+    "evolvesTo": [
+      "Claydol"
+    ],
     "ancientTrait": {
       "name": "θ Stop",
       "text": "Prevent all effects of your opponent's Pokémon's Abilities done to this Pokémon."
@@ -1429,7 +1869,9 @@
     "attacks": [
       {
         "name": "Future Spin",
-        "cost": ["Psychic"],
+        "cost": [
+          "Psychic"
+        ],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Look at the top 3 cards of either player's deck and put them back on top of that player's deck in any order."
@@ -1441,13 +1883,17 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "32",
     "artist": "Ayaka Yoshida",
     "rarity": "Common",
     "flavorText": "It moves by spinning on its foot. It is a rare Pokémon that was discovered in ancient ruins.",
-    "nationalPokedexNumbers": [343],
+    "nationalPokedexNumbers": [
+      343
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1461,21 +1907,30 @@
     "id": "xy7-33",
     "name": "Claydol",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 1"],
+    "subtypes": [
+      "Stage 1"
+    ],
     "hp": "100",
-    "types": ["Psychic"],
+    "types": [
+      "Psychic"
+    ],
     "evolvesFrom": "Baltoy",
     "attacks": [
       {
         "name": "Rewind",
-        "cost": ["Psychic"],
+        "cost": [
+          "Psychic"
+        ],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Devolve each of your opponent's evolved Pokémon and put the highest Stage Evolution card on it into your opponent's hand."
       },
       {
         "name": "Hyper Beam",
-        "cost": ["Psychic", "Colorless"],
+        "cost": [
+          "Psychic",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "30",
         "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
@@ -1487,13 +1942,18 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 2,
     "number": "33",
     "artist": "Satoshi Shirai",
     "rarity": "Rare",
     "flavorText": "It is said that it originates from clay dolls made by an ancient civilization.",
-    "nationalPokedexNumbers": [344],
+    "nationalPokedexNumbers": [
+      344
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1507,14 +1967,23 @@
     "id": "xy7-34",
     "name": "Golett",
     "supertype": "Pokémon",
-    "subtypes": ["Basic"],
+    "subtypes": [
+      "Basic"
+    ],
     "hp": "90",
-    "types": ["Psychic"],
-    "evolvesTo": ["Golurk"],
+    "types": [
+      "Psychic"
+    ],
+    "evolvesTo": [
+      "Golurk"
+    ],
     "attacks": [
       {
         "name": "Smash Punch",
-        "cost": ["Colorless", "Colorless"],
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "30",
         "text": "Flip a coin. If tails, this attack does nothing."
@@ -1532,13 +2001,19 @@
         "value": "-20"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 3,
     "number": "34",
     "artist": "Sanosuke Sakuma",
     "rarity": "Common",
     "flavorText": "Ancient science fashioned this Pokémon from clay. It's been active for thousands of years.",
-    "nationalPokedexNumbers": [622],
+    "nationalPokedexNumbers": [
+      622
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1552,9 +2027,13 @@
     "id": "xy7-35",
     "name": "Golurk",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 1"],
+    "subtypes": [
+      "Stage 1"
+    ],
     "hp": "130",
-    "types": ["Psychic"],
+    "types": [
+      "Psychic"
+    ],
     "evolvesFrom": "Golett",
     "ancientTrait": {
       "name": "θ Stop",
@@ -1570,7 +2049,12 @@
     "attacks": [
       {
         "name": "Superpower",
-        "cost": ["Colorless", "Colorless", "Colorless", "Colorless"],
+        "cost": [
+          "Colorless",
+          "Colorless",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 4,
         "damage": "80+",
         "text": "You may do 40 more damage. If you do, this Pokémon does 20 damage to itself."
@@ -1588,13 +2072,20 @@
         "value": "-20"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 4,
     "number": "35",
     "artist": "kawayoo",
     "rarity": "Rare",
     "flavorText": "It flies across the sky at Mach speeds. Removing the seal on its chest makes its internal energy go out of control.",
-    "nationalPokedexNumbers": [623],
+    "nationalPokedexNumbers": [
+      623
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1608,9 +2099,14 @@
     "id": "xy7-36",
     "name": "Hoopa-EX",
     "supertype": "Pokémon",
-    "subtypes": ["Basic", "EX"],
+    "subtypes": [
+      "Basic",
+      "EX"
+    ],
     "hp": "170",
-    "types": ["Psychic"],
+    "types": [
+      "Psychic"
+    ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -1624,7 +2120,11 @@
     "attacks": [
       {
         "name": "Hyperspace Fury",
-        "cost": ["Psychic", "Psychic", "Psychic"],
+        "cost": [
+          "Psychic",
+          "Psychic",
+          "Psychic"
+        ],
         "convertedEnergyCost": 3,
         "damage": "",
         "text": "Discard 2 Energy attached to this Pokémon. This attack does 100 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
@@ -1636,12 +2136,17 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 2,
     "number": "36",
     "artist": "Ryota Murayama",
     "rarity": "Rare Holo EX",
-    "nationalPokedexNumbers": [720],
+    "nationalPokedexNumbers": [
+      720
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1655,23 +2160,35 @@
     "id": "xy7-37",
     "name": "Machamp-EX",
     "supertype": "Pokémon",
-    "subtypes": ["Basic", "EX"],
+    "subtypes": [
+      "Basic",
+      "EX"
+    ],
     "hp": "180",
-    "types": ["Fighting"],
+    "types": [
+      "Fighting"
+    ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
       {
         "name": "Steaming Mad",
-        "cost": ["Fighting", "Colorless"],
+        "cost": [
+          "Fighting",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "20×",
         "text": "This attack does 20 damage times the number of damage counters on this Pokémon. This Pokémon is now Confused."
       },
       {
         "name": "Crazy Hammer",
-        "cost": ["Fighting", "Fighting", "Colorless"],
+        "cost": [
+          "Fighting",
+          "Fighting",
+          "Colorless"
+        ],
         "convertedEnergyCost": 3,
         "damage": "80+",
         "text": "If this Pokémon is affected by a Special Condition, this attack does 80 more damage. Then, remove all Special Conditions from this Pokémon."
@@ -1683,12 +2200,18 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 3,
     "number": "37",
     "artist": "Eske Yoshinob",
     "rarity": "Rare Holo EX",
-    "nationalPokedexNumbers": [68],
+    "nationalPokedexNumbers": [
+      68
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1702,21 +2225,32 @@
     "id": "xy7-38",
     "name": "Wooper",
     "supertype": "Pokémon",
-    "subtypes": ["Basic"],
+    "subtypes": [
+      "Basic"
+    ],
     "hp": "60",
-    "types": ["Fighting"],
-    "evolvesTo": ["Quagsire"],
+    "types": [
+      "Fighting"
+    ],
+    "evolvesTo": [
+      "Quagsire"
+    ],
     "attacks": [
       {
         "name": "Nap",
-        "cost": ["Colorless"],
+        "cost": [
+          "Colorless"
+        ],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Heal 20 damage from this Pokémon."
       },
       {
         "name": "Wave Splash",
-        "cost": ["Water", "Colorless"],
+        "cost": [
+          "Water",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "20",
         "text": ""
@@ -1728,13 +2262,18 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 2,
     "number": "38",
     "artist": "Sumiyoshi Kizuki",
     "rarity": "Common",
     "flavorText": "When the temperature cools in the evening, they emerge from water to seek food along the shore.",
-    "nationalPokedexNumbers": [194],
+    "nationalPokedexNumbers": [
+      194
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1748,21 +2287,32 @@
     "id": "xy7-39",
     "name": "Quagsire",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 1"],
+    "subtypes": [
+      "Stage 1"
+    ],
     "hp": "110",
-    "types": ["Fighting"],
+    "types": [
+      "Fighting"
+    ],
     "evolvesFrom": "Wooper",
     "attacks": [
       {
         "name": "Wave Splash",
-        "cost": ["Water", "Colorless"],
+        "cost": [
+          "Water",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "30",
         "text": ""
       },
       {
         "name": "Landslide",
-        "cost": ["Water", "Colorless", "Colorless"],
+        "cost": [
+          "Water",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 3,
         "damage": "80",
         "text": "This attack's damage isn't affected by Resistance."
@@ -1774,13 +2324,19 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 3,
     "number": "39",
     "artist": "Naoyo Kimura",
     "rarity": "Common",
     "flavorText": "This carefree Pokémon has an easy-going nature. While swimming, it always bumps into boat hulls.",
-    "nationalPokedexNumbers": [195],
+    "nationalPokedexNumbers": [
+      195
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1794,20 +2350,31 @@
     "id": "xy7-40",
     "name": "Regirock",
     "supertype": "Pokémon",
-    "subtypes": ["Basic"],
+    "subtypes": [
+      "Basic"
+    ],
     "hp": "120",
-    "types": ["Fighting"],
+    "types": [
+      "Fighting"
+    ],
     "attacks": [
       {
         "name": "Rock Throw",
-        "cost": ["Fighting", "Colorless"],
+        "cost": [
+          "Fighting",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "40",
         "text": ""
       },
       {
         "name": "Unyielding Rock",
-        "cost": ["Fighting", "Colorless", "Colorless"],
+        "cost": [
+          "Fighting",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 3,
         "damage": "60+",
         "text": "If your opponent's Active Pokémon is a Pokémon-EX, this attack does 60 more damage."
@@ -1819,13 +2386,19 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 3,
     "number": "40",
     "artist": "Shin Nagasawa",
     "rarity": "Rare",
     "flavorText": "The same rocks that form its body have been found in ground layers around the world.",
-    "nationalPokedexNumbers": [377],
+    "nationalPokedexNumbers": [
+      377
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1839,21 +2412,32 @@
     "id": "xy7-41",
     "name": "Golurk",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 1"],
+    "subtypes": [
+      "Stage 1"
+    ],
     "hp": "130",
-    "types": ["Fighting"],
+    "types": [
+      "Fighting"
+    ],
     "evolvesFrom": "Golett",
     "attacks": [
       {
         "name": "Dig Out",
-        "cost": ["Colorless"],
+        "cost": [
+          "Colorless"
+        ],
         "convertedEnergyCost": 1,
         "damage": "20",
         "text": "Discard the top card of your deck. If that card is a Fighting Energy card, attach it to this Pokémon."
       },
       {
         "name": "Double Lariat",
-        "cost": ["Fighting", "Colorless", "Colorless", "Colorless"],
+        "cost": [
+          "Fighting",
+          "Colorless",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 4,
         "damage": "90×",
         "text": "Flip 2 coins. This attack does 90 damage times the number of heads."
@@ -1865,13 +2449,20 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 4,
     "number": "41",
     "artist": "Suwama Chiaki",
     "rarity": "Common",
     "flavorText": "It flies across the sky at Mach speeds. Removing the seal on its chest makes its internal energy go out of control.",
-    "nationalPokedexNumbers": [623],
+    "nationalPokedexNumbers": [
+      623
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1885,24 +2476,40 @@
     "id": "xy7-42",
     "name": "Tyranitar-EX",
     "supertype": "Pokémon",
-    "subtypes": ["Basic", "EX"],
+    "subtypes": [
+      "Basic",
+      "EX"
+    ],
     "hp": "180",
-    "types": ["Darkness"],
-    "evolvesTo": ["M Tyranitar-EX"],
+    "types": [
+      "Darkness"
+    ],
+    "evolvesTo": [
+      "M Tyranitar-EX"
+    ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
       {
         "name": "Hammer In",
-        "cost": ["Darkness", "Colorless", "Colorless"],
+        "cost": [
+          "Darkness",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 3,
         "damage": "60",
         "text": ""
       },
       {
         "name": "Break Ground",
-        "cost": ["Darkness", "Darkness", "Colorless", "Colorless"],
+        "cost": [
+          "Darkness",
+          "Darkness",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 4,
         "damage": "130",
         "text": "This attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
@@ -1920,12 +2527,19 @@
         "value": "-20"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 4,
     "number": "42",
     "artist": "Eske Yoshinob",
     "rarity": "Rare Holo EX",
-    "nationalPokedexNumbers": [248],
+    "nationalPokedexNumbers": [
+      248
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1939,9 +2553,14 @@
     "id": "xy7-43",
     "name": "M Tyranitar-EX",
     "supertype": "Pokémon",
-    "subtypes": ["MEGA", "EX"],
+    "subtypes": [
+      "MEGA",
+      "EX"
+    ],
     "hp": "240",
-    "types": ["Darkness"],
+    "types": [
+      "Darkness"
+    ],
     "evolvesFrom": "Tyranitar-EX",
     "rules": [
       "Mega Evolution rule: When 1 of your Pokémon becomes a Mega Evolution Pokémon, your turn ends.",
@@ -1954,7 +2573,12 @@
     "attacks": [
       {
         "name": "Destroyer King",
-        "cost": ["Darkness", "Darkness", "Colorless", "Colorless"],
+        "cost": [
+          "Darkness",
+          "Darkness",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 4,
         "damage": "110+",
         "text": "This attack does 60 more damage for each damage counter on your opponent's Active Pokémon."
@@ -1972,12 +2596,19 @@
         "value": "-20"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 4,
     "number": "43",
     "artist": "5ban Graphics",
     "rarity": "Rare Holo EX",
-    "nationalPokedexNumbers": [248],
+    "nationalPokedexNumbers": [
+      248
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1991,32 +2622,45 @@
     "id": "xy7-44",
     "name": "Sableye",
     "supertype": "Pokémon",
-    "subtypes": ["Basic"],
+    "subtypes": [
+      "Basic"
+    ],
     "hp": "70",
-    "types": ["Darkness"],
+    "types": [
+      "Darkness"
+    ],
     "attacks": [
       {
         "name": "Bewitching Eyes",
-        "cost": ["Darkness"],
+        "cost": [
+          "Darkness"
+        ],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Choose a Supporter card from your opponent's discard pile and use it as the effect of this attack."
       },
       {
         "name": "Furtive Drop",
-        "cost": ["Darkness", "Colorless"],
+        "cost": [
+          "Darkness",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "",
         "text": "Put 3 damage counters on your opponent's Active Pokémon."
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "44",
     "artist": "Hitoshi Ariga",
     "rarity": "Uncommon",
     "flavorText": "It dwells in the darkness of caves. It uses its sharp claws to dig up gems to nourish itself.",
-    "nationalPokedexNumbers": [302],
+    "nationalPokedexNumbers": [
+      302
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2030,14 +2674,22 @@
     "id": "xy7-45",
     "name": "Inkay",
     "supertype": "Pokémon",
-    "subtypes": ["Basic"],
+    "subtypes": [
+      "Basic"
+    ],
     "hp": "50",
-    "types": ["Darkness"],
-    "evolvesTo": ["Malamar"],
+    "types": [
+      "Darkness"
+    ],
+    "evolvesTo": [
+      "Malamar"
+    ],
     "attacks": [
       {
         "name": "Ink Spit",
-        "cost": ["Darkness"],
+        "cost": [
+          "Darkness"
+        ],
         "convertedEnergyCost": 1,
         "damage": "10",
         "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
@@ -2055,13 +2707,17 @@
         "value": "-20"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "45",
     "artist": "Tomokazu Komiya",
     "rarity": "Common",
     "flavorText": "It flashes the light-emitting spots on its body, which drains its opponent's will to fight. It takes the opportunity to scuttle away and hide.",
-    "nationalPokedexNumbers": [686],
+    "nationalPokedexNumbers": [
+      686
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2075,21 +2731,29 @@
     "id": "xy7-46",
     "name": "Malamar",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 1"],
+    "subtypes": [
+      "Stage 1"
+    ],
     "hp": "90",
-    "types": ["Darkness"],
+    "types": [
+      "Darkness"
+    ],
     "evolvesFrom": "Inkay",
     "attacks": [
       {
         "name": "Entangling Control",
-        "cost": ["Colorless"],
+        "cost": [
+          "Colorless"
+        ],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Switch 1 of your opponent's Benched Pokémon with his or her Active Pokémon. The new Active Pokémon is now Confused."
       },
       {
         "name": "Trash Tentacle",
-        "cost": ["Darkness"],
+        "cost": [
+          "Darkness"
+        ],
         "convertedEnergyCost": 1,
         "damage": "30",
         "text": "Put a card from your discard pile into your hand."
@@ -2107,13 +2771,17 @@
         "value": "-20"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "46",
     "artist": "Masakazu Fukuda",
     "rarity": "Common",
     "flavorText": "It lures prey close with hypnotic motions, then wraps its tentacles around it before finishing it off with digestive fluids.",
-    "nationalPokedexNumbers": [687],
+    "nationalPokedexNumbers": [
+      687
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2127,21 +2795,33 @@
     "id": "xy7-47",
     "name": "Beldum",
     "supertype": "Pokémon",
-    "subtypes": ["Basic"],
+    "subtypes": [
+      "Basic"
+    ],
     "hp": "60",
-    "types": ["Metal"],
-    "evolvesTo": ["Metang"],
+    "types": [
+      "Metal"
+    ],
+    "evolvesTo": [
+      "Metang"
+    ],
     "attacks": [
       {
         "name": "Ram",
-        "cost": ["Metal"],
+        "cost": [
+          "Metal"
+        ],
         "convertedEnergyCost": 1,
         "damage": "10",
         "text": ""
       },
       {
         "name": "Spinning Attack",
-        "cost": ["Metal", "Colorless", "Colorless"],
+        "cost": [
+          "Metal",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 3,
         "damage": "30",
         "text": ""
@@ -2159,13 +2839,18 @@
         "value": "-20"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 2,
     "number": "47",
     "artist": "Yuka Morii",
     "rarity": "Common",
     "flavorText": "It converses with others by magnetic pulses. In a swarm, they move in perfect unison.",
-    "nationalPokedexNumbers": [374],
+    "nationalPokedexNumbers": [
+      374
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2179,22 +2864,35 @@
     "id": "xy7-48",
     "name": "Metang",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 1"],
+    "subtypes": [
+      "Stage 1"
+    ],
     "hp": "90",
-    "types": ["Metal"],
+    "types": [
+      "Metal"
+    ],
     "evolvesFrom": "Beldum",
-    "evolvesTo": ["Metagross"],
+    "evolvesTo": [
+      "Metagross"
+    ],
     "attacks": [
       {
         "name": "Metal Claw",
-        "cost": ["Metal", "Colorless"],
+        "cost": [
+          "Metal",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "30",
         "text": ""
       },
       {
         "name": "Bullet Punch",
-        "cost": ["Metal", "Metal", "Colorless"],
+        "cost": [
+          "Metal",
+          "Metal",
+          "Colorless"
+        ],
         "convertedEnergyCost": 3,
         "damage": "50+",
         "text": "Flip 2 coins. This attack does 20 more damage for each heads."
@@ -2212,13 +2910,19 @@
         "value": "-20"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 3,
     "number": "48",
     "artist": "Shigenori Negishi",
     "rarity": "Uncommon",
     "flavorText": "It is formed by two Beldum joining together. Its two brains are linked, amplifying its psychic power.",
-    "nationalPokedexNumbers": [375],
+    "nationalPokedexNumbers": [
+      375
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2232,9 +2936,13 @@
     "id": "xy7-49",
     "name": "Metagross",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 2"],
+    "subtypes": [
+      "Stage 2"
+    ],
     "hp": "150",
-    "types": ["Metal"],
+    "types": [
+      "Metal"
+    ],
     "evolvesFrom": "Metang",
     "abilities": [
       {
@@ -2246,7 +2954,12 @@
     "attacks": [
       {
         "name": "Iron Cannon",
-        "cost": ["Metal", "Metal", "Colorless", "Colorless"],
+        "cost": [
+          "Metal",
+          "Metal",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 4,
         "damage": "80+",
         "text": "You may discard all Metal Energy attached to this Pokémon. If you do, this attack does 80 more damage."
@@ -2264,13 +2977,20 @@
         "value": "-20"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 4,
     "number": "49",
     "artist": "kirisAki",
     "rarity": "Rare",
     "flavorText": "Metang combined to form it. With four brains, it has the intelligence of a supercomputer.",
-    "nationalPokedexNumbers": [376],
+    "nationalPokedexNumbers": [
+      376
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2284,9 +3004,13 @@
     "id": "xy7-50",
     "name": "Metagross",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 2"],
+    "subtypes": [
+      "Stage 2"
+    ],
     "hp": "150",
-    "types": ["Metal"],
+    "types": [
+      "Metal"
+    ],
     "evolvesFrom": "Metang",
     "ancientTrait": {
       "name": "θ Double",
@@ -2295,14 +3019,22 @@
     "attacks": [
       {
         "name": "Machine Gun Stomp",
-        "cost": ["Colorless", "Colorless"],
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "20+",
         "text": "This attack does 10 more damage for each card in your hand."
       },
       {
         "name": "Guard Press",
-        "cost": ["Metal", "Metal", "Colorless", "Colorless"],
+        "cost": [
+          "Metal",
+          "Metal",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 4,
         "damage": "80",
         "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
@@ -2320,13 +3052,20 @@
         "value": "-20"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 4,
     "number": "50",
     "artist": "Hitoshi Ariga",
     "rarity": "Rare",
     "flavorText": "Metang combined to form it. With four brains, it has the intelligence of a supercomputer.",
-    "nationalPokedexNumbers": [376],
+    "nationalPokedexNumbers": [
+      376
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2340,20 +3079,31 @@
     "id": "xy7-51",
     "name": "Registeel",
     "supertype": "Pokémon",
-    "subtypes": ["Basic"],
+    "subtypes": [
+      "Basic"
+    ],
     "hp": "120",
-    "types": ["Metal"],
+    "types": [
+      "Metal"
+    ],
     "attacks": [
       {
         "name": "Iron Head",
-        "cost": ["Metal", "Colorless"],
+        "cost": [
+          "Metal",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "30×",
         "text": "Flip a coin until you get tails. This attack does 30 damage times the number of heads."
       },
       {
         "name": "Forbidden Iron Hammer",
-        "cost": ["Metal", "Colorless", "Colorless"],
+        "cost": [
+          "Metal",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 3,
         "damage": "70",
         "text": "If your opponent's Active Pokémon is a Pokémon-EX, discard an Energy attached to that Pokémon."
@@ -2371,13 +3121,19 @@
         "value": "-20"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 3,
     "number": "51",
     "artist": "Kouki Saitou",
     "rarity": "Rare",
     "flavorText": "Its body is said to be harder than any kind of metal. A study has revealed that its body is hollow.",
-    "nationalPokedexNumbers": [379],
+    "nationalPokedexNumbers": [
+      379
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2391,21 +3147,32 @@
     "id": "xy7-52",
     "name": "Ralts",
     "supertype": "Pokémon",
-    "subtypes": ["Basic"],
+    "subtypes": [
+      "Basic"
+    ],
     "hp": "60",
-    "types": ["Fairy"],
-    "evolvesTo": ["Kirlia"],
+    "types": [
+      "Fairy"
+    ],
+    "evolvesTo": [
+      "Kirlia"
+    ],
     "attacks": [
       {
         "name": "Mumble",
-        "cost": ["Colorless"],
+        "cost": [
+          "Colorless"
+        ],
         "convertedEnergyCost": 1,
         "damage": "10",
         "text": ""
       },
       {
         "name": "Magical Shot",
-        "cost": ["Fairy", "Colorless"],
+        "cost": [
+          "Fairy",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "20",
         "text": ""
@@ -2423,13 +3190,17 @@
         "value": "-20"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "52",
     "artist": "Aya Kusube",
     "rarity": "Common",
     "flavorText": "It is highly attuned to the emotions of people and Pokémon. It hides if it senses hostility.",
-    "nationalPokedexNumbers": [280],
+    "nationalPokedexNumbers": [
+      280
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2443,22 +3214,35 @@
     "id": "xy7-53",
     "name": "Kirlia",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 1"],
+    "subtypes": [
+      "Stage 1"
+    ],
     "hp": "80",
-    "types": ["Fairy"],
+    "types": [
+      "Fairy"
+    ],
     "evolvesFrom": "Ralts",
-    "evolvesTo": ["Gardevoir", "Gallade"],
+    "evolvesTo": [
+      "Gardevoir",
+      "Gallade"
+    ],
     "attacks": [
       {
         "name": "Calm Mind",
-        "cost": ["Colorless"],
+        "cost": [
+          "Colorless"
+        ],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Heal 30 damage from this Pokémon."
       },
       {
         "name": "Magical Shot",
-        "cost": ["Fairy", "Colorless", "Colorless"],
+        "cost": [
+          "Fairy",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 3,
         "damage": "50",
         "text": ""
@@ -2476,13 +3260,17 @@
         "value": "-20"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "53",
     "artist": "match",
     "rarity": "Uncommon",
     "flavorText": "It has a psychic power that enables it to distort the space around it and see into the future.",
-    "nationalPokedexNumbers": [281],
+    "nationalPokedexNumbers": [
+      281
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2496,9 +3284,13 @@
     "id": "xy7-54",
     "name": "Gardevoir",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 2"],
+    "subtypes": [
+      "Stage 2"
+    ],
     "hp": "130",
-    "types": ["Fairy"],
+    "types": [
+      "Fairy"
+    ],
     "evolvesFrom": "Kirlia",
     "abilities": [
       {
@@ -2510,7 +3302,11 @@
     "attacks": [
       {
         "name": "Telekinesis",
-        "cost": ["Colorless", "Colorless", "Colorless"],
+        "cost": [
+          "Colorless",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 3,
         "damage": "",
         "text": "This attack does 50 damage to 1 of your opponent's Pokémon. This attack's damage isn't affected by Weakness or Resistance."
@@ -2528,13 +3324,18 @@
         "value": "-20"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 2,
     "number": "54",
     "artist": "TOKIYA",
     "rarity": "Rare Holo",
     "flavorText": "It has the power to predict the future. Its power peaks when it is protecting its Trainer.",
-    "nationalPokedexNumbers": [282],
+    "nationalPokedexNumbers": [
+      282
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2548,14 +3349,22 @@
     "id": "xy7-55",
     "name": "Cottonee",
     "supertype": "Pokémon",
-    "subtypes": ["Basic"],
+    "subtypes": [
+      "Basic"
+    ],
     "hp": "40",
-    "types": ["Fairy"],
-    "evolvesTo": ["Whimsicott"],
+    "types": [
+      "Fairy"
+    ],
+    "evolvesTo": [
+      "Whimsicott"
+    ],
     "attacks": [
       {
         "name": "Cotton Bed",
-        "cost": ["Fairy"],
+        "cost": [
+          "Fairy"
+        ],
         "convertedEnergyCost": 1,
         "damage": "10",
         "text": "Your opponent's Active Pokémon is now Asleep."
@@ -2573,13 +3382,17 @@
         "value": "-20"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "55",
     "artist": "Kanako Eo",
     "rarity": "Common",
     "flavorText": "Perhaps because they feel more at ease in a group, they stick to others they find. They end up looking like a cloud.",
-    "nationalPokedexNumbers": [546],
+    "nationalPokedexNumbers": [
+      546
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2593,21 +3406,30 @@
     "id": "xy7-56",
     "name": "Whimsicott",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 1"],
+    "subtypes": [
+      "Stage 1"
+    ],
     "hp": "70",
-    "types": ["Fairy"],
+    "types": [
+      "Fairy"
+    ],
     "evolvesFrom": "Cottonee",
     "attacks": [
       {
         "name": "Windy Mischief",
-        "cost": ["Fairy"],
+        "cost": [
+          "Fairy"
+        ],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Move all damage counters from 1 of your Benched Pokémon to your opponent's Active Pokémon."
       },
       {
         "name": "Rolling Tackle",
-        "cost": ["Colorless", "Colorless"],
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "30",
         "text": ""
@@ -2625,13 +3447,17 @@
         "value": "-20"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "56",
     "artist": "Atsuko Nishida",
     "rarity": "Uncommon",
     "flavorText": "Like the wind, it can slip through any gap, no matter how small. It leaves balls of white fluff behind.",
-    "nationalPokedexNumbers": [547],
+    "nationalPokedexNumbers": [
+      547
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2645,9 +3471,14 @@
     "id": "xy7-57",
     "name": "Giratina-EX",
     "supertype": "Pokémon",
-    "subtypes": ["Basic", "EX"],
+    "subtypes": [
+      "Basic",
+      "EX"
+    ],
     "hp": "170",
-    "types": ["Dragon"],
+    "types": [
+      "Dragon"
+    ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -2661,7 +3492,12 @@
     "attacks": [
       {
         "name": "Chaos Wheel",
-        "cost": ["Grass", "Psychic", "Colorless", "Colorless"],
+        "cost": [
+          "Grass",
+          "Psychic",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 4,
         "damage": "100",
         "text": "Your opponent can't play any Pokémon Tool, Special Energy, or Stadium cards from his or her hand during his or her next turn."
@@ -2673,12 +3509,18 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 3,
     "number": "57",
     "artist": "PLANETA",
     "rarity": "Rare Holo EX",
-    "nationalPokedexNumbers": [487],
+    "nationalPokedexNumbers": [
+      487
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2692,10 +3534,16 @@
     "id": "xy7-58",
     "name": "Goomy",
     "supertype": "Pokémon",
-    "subtypes": ["Basic"],
+    "subtypes": [
+      "Basic"
+    ],
     "hp": "40",
-    "types": ["Dragon"],
-    "evolvesTo": ["Sliggoo"],
+    "types": [
+      "Dragon"
+    ],
+    "evolvesTo": [
+      "Sliggoo"
+    ],
     "abilities": [
       {
         "name": "Water Down",
@@ -2706,7 +3554,10 @@
     "attacks": [
       {
         "name": "Stampede",
-        "cost": ["Fairy", "Colorless"],
+        "cost": [
+          "Fairy",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "10",
         "text": ""
@@ -2718,13 +3569,18 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 2,
     "number": "58",
     "artist": "sui",
     "rarity": "Common",
     "flavorText": "It's covered in a slimy membrane that makes any punches or kicks slide off it harmlessly.",
-    "nationalPokedexNumbers": [704],
+    "nationalPokedexNumbers": [
+      704
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2738,22 +3594,33 @@
     "id": "xy7-59",
     "name": "Sliggoo",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 1"],
+    "subtypes": [
+      "Stage 1"
+    ],
     "hp": "70",
-    "types": ["Dragon"],
+    "types": [
+      "Dragon"
+    ],
     "evolvesFrom": "Goomy",
-    "evolvesTo": ["Goodra"],
+    "evolvesTo": [
+      "Goodra"
+    ],
     "attacks": [
       {
         "name": "Bubble",
-        "cost": ["Colorless"],
+        "cost": [
+          "Colorless"
+        ],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
       },
       {
         "name": "Melt",
-        "cost": ["Water", "Fairy"],
+        "cost": [
+          "Water",
+          "Fairy"
+        ],
         "convertedEnergyCost": 2,
         "damage": "20",
         "text": ""
@@ -2765,13 +3632,19 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 3,
     "number": "59",
     "artist": "Midori Harada",
     "rarity": "Uncommon",
     "flavorText": "Its four horns are a high-performance radar system. It uses them to sense sounds and smells, rather than using ears or a nose.",
-    "nationalPokedexNumbers": [705],
+    "nationalPokedexNumbers": [
+      705
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2785,21 +3658,33 @@
     "id": "xy7-60",
     "name": "Goodra",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 2"],
+    "subtypes": [
+      "Stage 2"
+    ],
     "hp": "150",
-    "types": ["Dragon"],
+    "types": [
+      "Dragon"
+    ],
     "evolvesFrom": "Sliggoo",
     "attacks": [
       {
         "name": "Liquid Blow",
-        "cost": ["Colorless", "Colorless"],
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "",
         "text": "This attack does 20 damage to 1 of your opponent's Pokémon for each Colorless in its Retreat Cost. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Shining Breath",
-        "cost": ["Water", "Fairy", "Colorless", "Colorless"],
+        "cost": [
+          "Water",
+          "Fairy",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 4,
         "damage": "110",
         "text": "During your opponent's next turn, this Pokémon can't be affected by any Special Conditions."
@@ -2811,13 +3696,19 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 3,
     "number": "60",
     "artist": "Saya Tsuruta",
     "rarity": "Rare Holo",
     "flavorText": "It attacks with retractable horns. It throws a punch that's the equivalent of the force of a hundred pro boxers.",
-    "nationalPokedexNumbers": [706],
+    "nationalPokedexNumbers": [
+      706
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2831,14 +3722,22 @@
     "id": "xy7-61",
     "name": "Meowth",
     "supertype": "Pokémon",
-    "subtypes": ["Basic"],
+    "subtypes": [
+      "Basic"
+    ],
     "hp": "60",
-    "types": ["Colorless"],
-    "evolvesTo": ["Persian"],
+    "types": [
+      "Colorless"
+    ],
+    "evolvesTo": [
+      "Persian"
+    ],
     "attacks": [
       {
         "name": "Act Tough",
-        "cost": ["Colorless"],
+        "cost": [
+          "Colorless"
+        ],
         "convertedEnergyCost": 1,
         "damage": "10+",
         "text": "If this Pokémon has any Darkness Energy attached to it, this attack does 20 more damage."
@@ -2850,13 +3749,17 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "61",
     "artist": "Kanako Eo",
     "rarity": "Common",
     "flavorText": "Adores round objects. It wanders the streets on a nightly basis to look for dropped loose change.",
-    "nationalPokedexNumbers": [52],
+    "nationalPokedexNumbers": [
+      52
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2870,21 +3773,30 @@
     "id": "xy7-62",
     "name": "Persian",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 1"],
+    "subtypes": [
+      "Stage 1"
+    ],
     "hp": "90",
-    "types": ["Colorless"],
+    "types": [
+      "Colorless"
+    ],
     "evolvesFrom": "Meowth",
     "attacks": [
       {
         "name": "Fake Out",
-        "cost": ["Colorless"],
+        "cost": [
+          "Colorless"
+        ],
         "convertedEnergyCost": 1,
         "damage": "30",
         "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
       },
       {
         "name": "Ambush",
-        "cost": ["Colorless", "Colorless"],
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "40+",
         "text": "Flip a coin. If heads, this attack does 30 more damage."
@@ -2896,13 +3808,17 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "62",
     "artist": "Mitsuhiro Arita",
     "rarity": "Common",
     "flavorText": "Its lithe muscles allow it to walk without making a sound. It attacks in an instant.",
-    "nationalPokedexNumbers": [53],
+    "nationalPokedexNumbers": [
+      53
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2916,9 +3832,13 @@
     "id": "xy7-63",
     "name": "Eevee",
     "supertype": "Pokémon",
-    "subtypes": ["Basic"],
+    "subtypes": [
+      "Basic"
+    ],
     "hp": "60",
-    "types": ["Colorless"],
+    "types": [
+      "Colorless"
+    ],
     "evolvesTo": [
       "Vaporeon",
       "Jolteon",
@@ -2932,14 +3852,19 @@
     "attacks": [
       {
         "name": "Tackle",
-        "cost": ["Colorless"],
+        "cost": [
+          "Colorless"
+        ],
         "convertedEnergyCost": 1,
         "damage": "10",
         "text": ""
       },
       {
         "name": "Lunge",
-        "cost": ["Colorless", "Colorless"],
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "30",
         "text": "Flip a coin. If tails, this attack does nothing."
@@ -2951,13 +3876,17 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "63",
     "artist": "Kouki Saitou",
     "rarity": "Common",
     "flavorText": "Thanks to its unstable genetic makeup, this special Pokémon conceals many different possible evolutions.",
-    "nationalPokedexNumbers": [133],
+    "nationalPokedexNumbers": [
+      133
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2971,21 +3900,32 @@
     "id": "xy7-64",
     "name": "Porygon",
     "supertype": "Pokémon",
-    "subtypes": ["Basic"],
+    "subtypes": [
+      "Basic"
+    ],
     "hp": "60",
-    "types": ["Colorless"],
-    "evolvesTo": ["Porygon2"],
+    "types": [
+      "Colorless"
+    ],
+    "evolvesTo": [
+      "Porygon2"
+    ],
     "attacks": [
       {
         "name": "Data Check",
-        "cost": ["Colorless"],
+        "cost": [
+          "Colorless"
+        ],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Look through your deck. Shuffle your deck afterward."
       },
       {
         "name": "Sharpen",
-        "cost": ["Colorless", "Colorless"],
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "20",
         "text": ""
@@ -2997,13 +3937,17 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "64",
     "artist": "Yukiko Baba",
     "rarity": "Common",
     "flavorText": "A Pokémon that consists entirely of programming code. It is capable of moving freely in cyberspace.",
-    "nationalPokedexNumbers": [137],
+    "nationalPokedexNumbers": [
+      137
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3017,22 +3961,34 @@
     "id": "xy7-65",
     "name": "Porygon2",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 1"],
+    "subtypes": [
+      "Stage 1"
+    ],
     "hp": "80",
-    "types": ["Colorless"],
+    "types": [
+      "Colorless"
+    ],
     "evolvesFrom": "Porygon",
-    "evolvesTo": ["Porygon-Z"],
+    "evolvesTo": [
+      "Porygon-Z"
+    ],
     "attacks": [
       {
         "name": "Sharpen",
-        "cost": ["Colorless"],
+        "cost": [
+          "Colorless"
+        ],
         "convertedEnergyCost": 1,
         "damage": "20",
         "text": ""
       },
       {
         "name": "Tri Attack",
-        "cost": ["Colorless", "Colorless", "Colorless"],
+        "cost": [
+          "Colorless",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 3,
         "damage": "30×",
         "text": "Flip 3 coins. This attack does 30 damage times the number of heads."
@@ -3044,13 +4000,18 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 2,
     "number": "65",
     "artist": "MAHOU",
     "rarity": "Uncommon",
     "flavorText": "With planetary development software installed, it became capable of working in space.",
-    "nationalPokedexNumbers": [233],
+    "nationalPokedexNumbers": [
+      233
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3064,21 +4025,31 @@
     "id": "xy7-66",
     "name": "Porygon-Z",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 2"],
+    "subtypes": [
+      "Stage 2"
+    ],
     "hp": "130",
-    "types": ["Colorless"],
+    "types": [
+      "Colorless"
+    ],
     "evolvesFrom": "Porygon2",
     "attacks": [
       {
         "name": "Cyber Crush",
-        "cost": ["Colorless"],
+        "cost": [
+          "Colorless"
+        ],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Discard all Special Energy attached to each of your opponent's Pokémon."
       },
       {
         "name": "Slowing Beam",
-        "cost": ["Colorless", "Colorless", "Colorless"],
+        "cost": [
+          "Colorless",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 3,
         "damage": "70",
         "text": "During your opponent's next turn, the Defending Pokémon's attacks cost Colorless more."
@@ -3090,13 +4061,18 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 2,
     "number": "66",
     "artist": "TOKIYA",
     "rarity": "Rare",
     "flavorText": "Its programming was modified to enable it to travel through alien dimensions. Seems there might have been an error…",
-    "nationalPokedexNumbers": [474],
+    "nationalPokedexNumbers": [
+      474
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3110,9 +4086,13 @@
     "id": "xy7-67",
     "name": "Porygon-Z",
     "supertype": "Pokémon",
-    "subtypes": ["Stage 2"],
+    "subtypes": [
+      "Stage 2"
+    ],
     "hp": "130",
-    "types": ["Colorless"],
+    "types": [
+      "Colorless"
+    ],
     "evolvesFrom": "Porygon2",
     "ancientTrait": {
       "name": "θ Stop",
@@ -3121,14 +4101,19 @@
     "attacks": [
       {
         "name": "Digital Reboot",
-        "cost": ["Colorless"],
+        "cost": [
+          "Colorless"
+        ],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Devolve as many of your Benched Pokémon as many times as you like. Put each Evolution card removed this way into your hand."
       },
       {
         "name": "Dazzle Blast",
-        "cost": ["Colorless", "Colorless"],
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "50",
         "text": "Your opponent's Active Pokémon is now Confused."
@@ -3140,13 +4125,18 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 2,
     "number": "67",
     "artist": "Naoki Saito",
     "rarity": "Rare Holo",
     "flavorText": "Its programming was modified to enable it to travel through alien dimensions. Seems there might have been an error…",
-    "nationalPokedexNumbers": [474],
+    "nationalPokedexNumbers": [
+      474
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3160,23 +4150,36 @@
     "id": "xy7-68",
     "name": "Lugia-EX",
     "supertype": "Pokémon",
-    "subtypes": ["Basic", "EX"],
+    "subtypes": [
+      "Basic",
+      "EX"
+    ],
     "hp": "170",
-    "types": ["Colorless"],
+    "types": [
+      "Colorless"
+    ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
       {
         "name": "Aero Ball",
-        "cost": ["Colorless", "Colorless"],
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "20×",
         "text": "This attack does 20 damage times the amount of Energy attached to both Active Pokémon."
       },
       {
         "name": "Deep Hurricane",
-        "cost": ["Colorless", "Colorless", "Colorless", "Colorless"],
+        "cost": [
+          "Colorless",
+          "Colorless",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 4,
         "damage": "80+",
         "text": "If there is any Stadium card in play, this attack does 70 more damage. Then, discard that Stadium card."
@@ -3194,12 +4197,17 @@
         "value": "-20"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 2,
     "number": "68",
     "artist": "Eske Yoshinob",
     "rarity": "Rare Holo EX",
-    "nationalPokedexNumbers": [249],
+    "nationalPokedexNumbers": [
+      249
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3213,7 +4221,9 @@
     "id": "xy7-69",
     "name": "Ace Trainer",
     "supertype": "Trainer",
-    "subtypes": ["Supporter"],
+    "subtypes": [
+      "Supporter"
+    ],
     "rules": [
       "You can play this card only if you have more Prize cards left than your opponent.",
       "Each player shuffles his or her hand into his or her deck. Then, draw 6 cards. Your opponent draws 3 cards.",
@@ -3235,7 +4245,9 @@
     "id": "xy7-70",
     "name": "Ampharos Spirit Link",
     "supertype": "Trainer",
-    "subtypes": ["Pokémon Tool"],
+    "subtypes": [
+      "Pokémon Tool"
+    ],
     "rules": [
       "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.",
       "Your turn does not end if the Pokémon this card is attached to becomes M Ampharos-EX.",
@@ -3257,7 +4269,9 @@
     "id": "xy7-71",
     "name": "Eco Arm",
     "supertype": "Trainer",
-    "subtypes": ["Item"],
+    "subtypes": [
+      "Item"
+    ],
     "rules": [
       "Shuffle 3 Pokémon Tool cards from your discard pile into your deck.",
       "You may play as many Item cards as you like during your turn (before your attack)."
@@ -3278,7 +4292,9 @@
     "id": "xy7-72",
     "name": "Energy Recycler",
     "supertype": "Trainer",
-    "subtypes": ["Item"],
+    "subtypes": [
+      "Item"
+    ],
     "rules": [
       "Shuffle 5 basic Energy cards from your discard pile into your deck.",
       "You may play as many Item cards as you like during your turn (before your attack)."
@@ -3299,7 +4315,9 @@
     "id": "xy7-73",
     "name": "Faded Town",
     "supertype": "Trainer",
-    "subtypes": ["Stadium"],
+    "subtypes": [
+      "Stadium"
+    ],
     "rules": [
       "At any time between turns, put 2 damage counters on each Mega Evolution Pokémon.",
       "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card."
@@ -3320,7 +4338,9 @@
     "id": "xy7-74",
     "name": "Forest of Giant Plants",
     "supertype": "Trainer",
-    "subtypes": ["Stadium"],
+    "subtypes": [
+      "Stadium"
+    ],
     "rules": [
       "Each player's Grass Pokémon can evolve during his or her first turn or the turn he or she plays those Pokémon.",
       "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card."
@@ -3341,7 +4361,9 @@
     "id": "xy7-75",
     "name": "Hex Maniac",
     "supertype": "Trainer",
-    "subtypes": ["Supporter"],
+    "subtypes": [
+      "Supporter"
+    ],
     "rules": [
       "Until the end of your opponent's next turn, each Pokémon in play, in each player's hand, and in each player's discard pile has no Abilities. (This includes cards that come into play on that turn.)",
       "You may play only 1 Supporter card during your turn (before your attack)."
@@ -3362,7 +4384,9 @@
     "id": "xy7-76",
     "name": "Level Ball",
     "supertype": "Trainer",
-    "subtypes": ["Item"],
+    "subtypes": [
+      "Item"
+    ],
     "rules": [
       "Search your deck for a Pokémon with 90 HP or less, reveal it, and put it into your hand. Shuffle your deck afterward.",
       "You may play as many Item cards as you like during your turn (before your attack)."
@@ -3383,7 +4407,9 @@
     "id": "xy7-77",
     "name": "Lucky Helmet",
     "supertype": "Trainer",
-    "subtypes": ["Pokémon Tool"],
+    "subtypes": [
+      "Pokémon Tool"
+    ],
     "rules": [
       "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.",
       "Whenever the Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent's attack (even if that Pokémon is Knocked Out), draw 2 cards.",
@@ -3405,7 +4431,9 @@
     "id": "xy7-78",
     "name": "Lysandre",
     "supertype": "Trainer",
-    "subtypes": ["Supporter"],
+    "subtypes": [
+      "Supporter"
+    ],
     "rules": [
       "Switch 1 of your opponent's Benched Pokémon with his or her Active Pokémon.",
       "You may play only 1 Supporter card during your turn (before your attack)."
@@ -3426,7 +4454,9 @@
     "id": "xy7-79",
     "name": "Paint Roller",
     "supertype": "Trainer",
-    "subtypes": ["Item"],
+    "subtypes": [
+      "Item"
+    ],
     "rules": [
       "Discard any Stadium card in play. Then, draw a card.",
       "You may play as many Item cards as you like during your turn (before your attack)."
@@ -3447,7 +4477,9 @@
     "id": "xy7-80",
     "name": "Sceptile Spirit Link",
     "supertype": "Trainer",
-    "subtypes": ["Pokémon Tool"],
+    "subtypes": [
+      "Pokémon Tool"
+    ],
     "rules": [
       "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.",
       "Your turn does not end if the Pokémon this card is attached to becomes M Sceptile-EX.",
@@ -3469,7 +4501,9 @@
     "id": "xy7-81",
     "name": "Tyranitar Spirit Link",
     "supertype": "Trainer",
-    "subtypes": ["Pokémon Tool"],
+    "subtypes": [
+      "Pokémon Tool"
+    ],
     "rules": [
       "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.",
       "Your turn does not end if the Pokémon this card is attached to becomes M Tyranitar-EX.",
@@ -3491,7 +4525,9 @@
     "id": "xy7-82",
     "name": "Dangerous Energy",
     "supertype": "Energy",
-    "subtypes": ["Special"],
+    "subtypes": [
+      "Special"
+    ],
     "rules": [
       "This card can only be attached to Darkness Pokémon. This card provides Darkness Energy only while this card is attached to a Darkness Pokémon.",
       "Whenever the Darkness Pokémon this card is attached to is your Active Pokémon and is damaged by an attack from your opponent's Pokémon-EX (even if that Pokémon is Knocked Out), put 2 damage counters on the Attacking Pokémon-EX.",
@@ -3513,7 +4549,9 @@
     "id": "xy7-83",
     "name": "Flash Energy",
     "supertype": "Energy",
-    "subtypes": ["Special"],
+    "subtypes": [
+      "Special"
+    ],
     "rules": [
       "This card can only be attached to Lightning Pokémon. This card provides Lightning Energy only while this card is attached to a Lightning Pokémon.",
       "The Lightning Pokémon this card is attached to has no Weakness.",
@@ -3535,24 +4573,36 @@
     "id": "xy7-84",
     "name": "Sceptile-EX",
     "supertype": "Pokémon",
-    "subtypes": ["Basic", "EX"],
+    "subtypes": [
+      "Basic",
+      "EX"
+    ],
     "hp": "170",
-    "types": ["Grass"],
-    "evolvesTo": ["M Sceptile-EX"],
+    "types": [
+      "Grass"
+    ],
+    "evolvesTo": [
+      "M Sceptile-EX"
+    ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
       {
         "name": "Sleep Poison",
-        "cost": ["Grass"],
+        "cost": [
+          "Grass"
+        ],
         "convertedEnergyCost": 1,
         "damage": "10",
         "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Asleep and Poisoned."
       },
       {
         "name": "Unseen Claw",
-        "cost": ["Grass", "Colorless"],
+        "cost": [
+          "Grass",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "60+",
         "text": "If your opponent's Active Pokémon is affected by a Special Condition, this attack does 70 more damage."
@@ -3564,12 +4614,16 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "84",
     "artist": "Ryo Ueda",
     "rarity": "Rare Ultra",
-    "nationalPokedexNumbers": [254],
+    "nationalPokedexNumbers": [
+      254
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3583,9 +4637,14 @@
     "id": "xy7-85",
     "name": "M Sceptile-EX",
     "supertype": "Pokémon",
-    "subtypes": ["MEGA", "EX"],
+    "subtypes": [
+      "MEGA",
+      "EX"
+    ],
     "hp": "220",
-    "types": ["Grass"],
+    "types": [
+      "Grass"
+    ],
     "evolvesFrom": "Sceptile-EX",
     "rules": [
       "Mega Evolution rule: When 1 of your Pokémon becomes a Mega Evolution Pokémon, your turn ends.",
@@ -3598,7 +4657,10 @@
     "attacks": [
       {
         "name": "Jagged Saber",
-        "cost": ["Grass", "Colorless"],
+        "cost": [
+          "Grass",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "100",
         "text": "You may attach up to 2 Grass Energy cards from your hand to your Benched Pokémon in any way you like. If you attached Energy to a Pokémon in this way, heal all damage from that Pokémon."
@@ -3610,12 +4672,17 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 2,
     "number": "85",
     "artist": "5ban Graphics",
     "rarity": "Rare Ultra",
-    "nationalPokedexNumbers": [254],
+    "nationalPokedexNumbers": [
+      254
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3629,23 +4696,37 @@
     "id": "xy7-86",
     "name": "Kyurem-EX",
     "supertype": "Pokémon",
-    "subtypes": ["Basic", "EX"],
+    "subtypes": [
+      "Basic",
+      "EX"
+    ],
     "hp": "180",
-    "types": ["Water"],
+    "types": [
+      "Water"
+    ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
       {
         "name": "Glaciate",
-        "cost": ["Water", "Water", "Colorless"],
+        "cost": [
+          "Water",
+          "Water",
+          "Colorless"
+        ],
         "convertedEnergyCost": 3,
         "damage": "",
         "text": "This attack does 30 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Icecalibur",
-        "cost": ["Water", "Water", "Water", "Colorless"],
+        "cost": [
+          "Water",
+          "Water",
+          "Water",
+          "Colorless"
+        ],
         "convertedEnergyCost": 4,
         "damage": "130",
         "text": "Discard an Energy attached to this Pokémon. The Defending Pokémon can't attack during your opponent's next turn."
@@ -3657,12 +4738,18 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 3,
     "number": "86",
     "artist": "Ryo Ueda",
     "rarity": "Rare Ultra",
-    "nationalPokedexNumbers": [646],
+    "nationalPokedexNumbers": [
+      646
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3676,24 +4763,38 @@
     "id": "xy7-87",
     "name": "Ampharos-EX",
     "supertype": "Pokémon",
-    "subtypes": ["Basic", "EX"],
+    "subtypes": [
+      "Basic",
+      "EX"
+    ],
     "hp": "170",
-    "types": ["Lightning"],
-    "evolvesTo": ["M Ampharos-EX"],
+    "types": [
+      "Lightning"
+    ],
+    "evolvesTo": [
+      "M Ampharos-EX"
+    ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
       {
         "name": "Thunder Rod",
-        "cost": ["Colorless"],
+        "cost": [
+          "Colorless"
+        ],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Look at the top 4 cards of your deck and attach as many Lightning Energy cards you find there as you like to this Pokémon. Shuffle the other cards back into your deck."
       },
       {
         "name": "Sparkling Tail",
-        "cost": ["Lightning", "Lightning", "Colorless", "Colorless"],
+        "cost": [
+          "Lightning",
+          "Lightning",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 4,
         "damage": "100",
         "text": "This attack's damage isn't affected by Weakness, Resistance, or any other effects on your opponent's Active Pokémon."
@@ -3711,12 +4812,17 @@
         "value": "-20"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 2,
     "number": "87",
     "artist": "Ryo Ueda",
     "rarity": "Rare Ultra",
-    "nationalPokedexNumbers": [181],
+    "nationalPokedexNumbers": [
+      181
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3730,9 +4836,14 @@
     "id": "xy7-88",
     "name": "M Ampharos-EX",
     "supertype": "Pokémon",
-    "subtypes": ["MEGA", "EX"],
+    "subtypes": [
+      "MEGA",
+      "EX"
+    ],
     "hp": "220",
-    "types": ["Lightning"],
+    "types": [
+      "Lightning"
+    ],
     "evolvesFrom": "Ampharos-EX",
     "rules": [
       "Mega Evolution rule: When 1 of your Pokémon becomes a Mega Evolution Pokémon, your turn ends.",
@@ -3741,7 +4852,12 @@
     "attacks": [
       {
         "name": "Exavolt",
-        "cost": ["Lightning", "Lightning", "Colorless", "Colorless"],
+        "cost": [
+          "Lightning",
+          "Lightning",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 4,
         "damage": "120+",
         "text": "You may do 50 more damage and leave your opponent's Active Pokémon Paralyzed. If you do, this Pokémon does 30 damage to itself."
@@ -3759,12 +4875,18 @@
         "value": "-20"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 3,
     "number": "88",
     "artist": "5ban Graphics",
     "rarity": "Rare Ultra",
-    "nationalPokedexNumbers": [181],
+    "nationalPokedexNumbers": [
+      181
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3778,9 +4900,14 @@
     "id": "xy7-89",
     "name": "Hoopa-EX",
     "supertype": "Pokémon",
-    "subtypes": ["Basic", "EX"],
+    "subtypes": [
+      "Basic",
+      "EX"
+    ],
     "hp": "170",
-    "types": ["Psychic"],
+    "types": [
+      "Psychic"
+    ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -3794,7 +4921,11 @@
     "attacks": [
       {
         "name": "Hyperspace Fury",
-        "cost": ["Psychic", "Psychic", "Psychic"],
+        "cost": [
+          "Psychic",
+          "Psychic",
+          "Psychic"
+        ],
         "convertedEnergyCost": 3,
         "damage": "",
         "text": "Discard 2 Energy attached to this Pokémon. This attack does 100 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
@@ -3806,12 +4937,17 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 2,
     "number": "89",
     "artist": "5ban Graphics",
     "rarity": "Rare Ultra",
-    "nationalPokedexNumbers": [720],
+    "nationalPokedexNumbers": [
+      720
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3825,23 +4961,35 @@
     "id": "xy7-90",
     "name": "Machamp-EX",
     "supertype": "Pokémon",
-    "subtypes": ["Basic", "EX"],
+    "subtypes": [
+      "Basic",
+      "EX"
+    ],
     "hp": "180",
-    "types": ["Fighting"],
+    "types": [
+      "Fighting"
+    ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
       {
         "name": "Steaming Mad",
-        "cost": ["Fighting", "Colorless"],
+        "cost": [
+          "Fighting",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "20×",
         "text": "This attack does 20 damage times the number of damage counters on this Pokémon. This Pokémon is now Confused."
       },
       {
         "name": "Crazy Hammer",
-        "cost": ["Fighting", "Fighting", "Colorless"],
+        "cost": [
+          "Fighting",
+          "Fighting",
+          "Colorless"
+        ],
         "convertedEnergyCost": 3,
         "damage": "80+",
         "text": "If this Pokémon is affected by a Special Condition, this attack does 80 more damage. Then, remove all Special Conditions from this Pokémon."
@@ -3853,12 +5001,18 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 3,
     "number": "90",
     "artist": "Ryo Ueda",
     "rarity": "Rare Ultra",
-    "nationalPokedexNumbers": [68],
+    "nationalPokedexNumbers": [
+      68
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3872,24 +5026,40 @@
     "id": "xy7-91",
     "name": "Tyranitar-EX",
     "supertype": "Pokémon",
-    "subtypes": ["Basic", "EX"],
+    "subtypes": [
+      "Basic",
+      "EX"
+    ],
     "hp": "180",
-    "types": ["Darkness"],
-    "evolvesTo": ["M Tyranitar-EX"],
+    "types": [
+      "Darkness"
+    ],
+    "evolvesTo": [
+      "M Tyranitar-EX"
+    ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
       {
         "name": "Hammer In",
-        "cost": ["Darkness", "Colorless", "Colorless"],
+        "cost": [
+          "Darkness",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 3,
         "damage": "60",
         "text": ""
       },
       {
         "name": "Break Ground",
-        "cost": ["Darkness", "Darkness", "Colorless", "Colorless"],
+        "cost": [
+          "Darkness",
+          "Darkness",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 4,
         "damage": "130",
         "text": "This attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
@@ -3907,12 +5077,19 @@
         "value": "-20"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 4,
     "number": "91",
     "artist": "Ryo Ueda",
     "rarity": "Rare Ultra",
-    "nationalPokedexNumbers": [248],
+    "nationalPokedexNumbers": [
+      248
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3926,9 +5103,14 @@
     "id": "xy7-92",
     "name": "M Tyranitar-EX",
     "supertype": "Pokémon",
-    "subtypes": ["MEGA", "EX"],
+    "subtypes": [
+      "MEGA",
+      "EX"
+    ],
     "hp": "240",
-    "types": ["Darkness"],
+    "types": [
+      "Darkness"
+    ],
     "evolvesFrom": "Tyranitar-EX",
     "rules": [
       "Mega Evolution rule: When 1 of your Pokémon becomes a Mega Evolution Pokémon, your turn ends.",
@@ -3941,7 +5123,12 @@
     "attacks": [
       {
         "name": "Destroyer King",
-        "cost": ["Darkness", "Darkness", "Colorless", "Colorless"],
+        "cost": [
+          "Darkness",
+          "Darkness",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 4,
         "damage": "110+",
         "text": "This attack does 60 more damage for each damage counter on your opponent's Active Pokémon."
@@ -3959,12 +5146,19 @@
         "value": "-20"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 4,
     "number": "92",
     "artist": "5ban Graphics",
     "rarity": "Rare Ultra",
-    "nationalPokedexNumbers": [248],
+    "nationalPokedexNumbers": [
+      248
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3978,9 +5172,14 @@
     "id": "xy7-93",
     "name": "Giratina-EX",
     "supertype": "Pokémon",
-    "subtypes": ["Basic", "EX"],
+    "subtypes": [
+      "Basic",
+      "EX"
+    ],
     "hp": "170",
-    "types": ["Dragon"],
+    "types": [
+      "Dragon"
+    ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -3994,7 +5193,12 @@
     "attacks": [
       {
         "name": "Chaos Wheel",
-        "cost": ["Grass", "Psychic", "Colorless", "Colorless"],
+        "cost": [
+          "Grass",
+          "Psychic",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 4,
         "damage": "100",
         "text": "Your opponent can't play any Pokémon Tool, Special Energy, or Stadium cards from his or her hand during his or her next turn."
@@ -4006,12 +5210,18 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 3,
     "number": "93",
     "artist": "Ryo Ueda",
     "rarity": "Rare Ultra",
-    "nationalPokedexNumbers": [487],
+    "nationalPokedexNumbers": [
+      487
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -4025,23 +5235,36 @@
     "id": "xy7-94",
     "name": "Lugia-EX",
     "supertype": "Pokémon",
-    "subtypes": ["Basic", "EX"],
+    "subtypes": [
+      "Basic",
+      "EX"
+    ],
     "hp": "170",
-    "types": ["Colorless"],
+    "types": [
+      "Colorless"
+    ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
       {
         "name": "Aero Ball",
-        "cost": ["Colorless", "Colorless"],
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 2,
         "damage": "20×",
         "text": "This attack does 20 damage times the amount of Energy attached to both Active Pokémon."
       },
       {
         "name": "Deep Hurricane",
-        "cost": ["Colorless", "Colorless", "Colorless", "Colorless"],
+        "cost": [
+          "Colorless",
+          "Colorless",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 4,
         "damage": "80+",
         "text": "If there is any Stadium card in play, this attack does 70 more damage. Then, discard that Stadium card."
@@ -4059,12 +5282,17 @@
         "value": "-20"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 2,
     "number": "94",
     "artist": "Ryo Ueda",
     "rarity": "Rare Ultra",
-    "nationalPokedexNumbers": [249],
+    "nationalPokedexNumbers": [
+      249
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -4078,7 +5306,9 @@
     "id": "xy7-95",
     "name": "Steven",
     "supertype": "Trainer",
-    "subtypes": ["Supporter"],
+    "subtypes": [
+      "Supporter"
+    ],
     "rules": [
       "Search your deck for a Supporter card and a basic Energy card, reveal them, and put them into your hand. Shuffle your deck afterward.",
       "You may play only 1 Supporter card during your turn (before your attack)."
@@ -4099,9 +5329,14 @@
     "id": "xy7-96",
     "name": "Primal Kyogre-EX",
     "supertype": "Pokémon",
-    "subtypes": ["Basic", "EX"],
+    "subtypes": [
+      "Basic",
+      "EX"
+    ],
     "hp": "240",
-    "types": ["Water"],
+    "types": [
+      "Water"
+    ],
     "evolvesFrom": "Kyogre-EX",
     "rules": [
       "Primal Reversion rule: When 1 of your Pokémon becomes Primal Kyogre-EX, your turn ends.",
@@ -4114,7 +5349,12 @@
     "attacks": [
       {
         "name": "Tidal Storm",
-        "cost": ["Water", "Water", "Water", "Colorless"],
+        "cost": [
+          "Water",
+          "Water",
+          "Water",
+          "Colorless"
+        ],
         "convertedEnergyCost": 4,
         "damage": "150",
         "text": "Move 2 Energy from this Pokémon to 1 of your Benched Pokémon. This attack does 30 damage to each of your opponent's Benched Pokémon-EX. (Don't apply Weakness and Resistance for Benched Pokémon.)"
@@ -4126,12 +5366,19 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 4,
     "number": "96",
     "artist": "5ban Graphics",
     "rarity": "Rare Secret",
-    "nationalPokedexNumbers": [382],
+    "nationalPokedexNumbers": [
+      382
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -4145,9 +5392,14 @@
     "id": "xy7-97",
     "name": "Primal Groudon-EX",
     "supertype": "Pokémon",
-    "subtypes": ["Basic", "EX"],
+    "subtypes": [
+      "Basic",
+      "EX"
+    ],
     "hp": "240",
-    "types": ["Fighting"],
+    "types": [
+      "Fighting"
+    ],
     "evolvesFrom": "Groudon-EX",
     "rules": [
       "Primal Reversion rule: When 1 of your Pokémon becomes Primal Groudon-EX, your turn ends.",
@@ -4160,7 +5412,12 @@
     "attacks": [
       {
         "name": "Gaia Volcano",
-        "cost": ["Fighting", "Fighting", "Fighting", "Colorless"],
+        "cost": [
+          "Fighting",
+          "Fighting",
+          "Fighting",
+          "Colorless"
+        ],
         "convertedEnergyCost": 4,
         "damage": "100+",
         "text": "If there is any Stadium card in play, this attack does 100 more damage. Discard that Stadium card."
@@ -4172,12 +5429,19 @@
         "value": "×2"
       }
     ],
-    "retreatCost": ["Colorless", "Colorless", "Colorless", "Colorless"],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
     "convertedRetreatCost": 4,
     "number": "97",
     "artist": "5ban Graphics",
     "rarity": "Rare Secret",
-    "nationalPokedexNumbers": [383],
+    "nationalPokedexNumbers": [
+      383
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -4191,9 +5455,14 @@
     "id": "xy7-98",
     "name": "M Rayquaza-EX",
     "supertype": "Pokémon",
-    "subtypes": ["MEGA", "EX"],
+    "subtypes": [
+      "MEGA",
+      "EX"
+    ],
     "hp": "220",
-    "types": ["Colorless"],
+    "types": [
+      "Colorless"
+    ],
     "evolvesFrom": "Rayquaza-EX",
     "rules": [
       "Mega Evolution rule: When 1 of your Pokémon becomes a Mega Evolution Pokémon, your turn ends.",
@@ -4206,7 +5475,11 @@
     "attacks": [
       {
         "name": "Emerald Break",
-        "cost": ["Colorless", "Colorless", "Colorless"],
+        "cost": [
+          "Colorless",
+          "Colorless",
+          "Colorless"
+        ],
         "convertedEnergyCost": 3,
         "damage": "30×",
         "text": "This attack does 30 damage times the number of your Benched Pokémon."
@@ -4224,12 +5497,16 @@
         "value": "-20"
       }
     ],
-    "retreatCost": ["Colorless"],
+    "retreatCost": [
+      "Colorless"
+    ],
     "convertedRetreatCost": 1,
     "number": "98",
     "artist": "5ban Graphics",
     "rarity": "Rare Secret",
-    "nationalPokedexNumbers": [384],
+    "nationalPokedexNumbers": [
+      384
+    ],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -4243,7 +5520,9 @@
     "id": "xy7-99",
     "name": "Energy Retrieval",
     "supertype": "Trainer",
-    "subtypes": ["Item"],
+    "subtypes": [
+      "Item"
+    ],
     "rules": [
       "Put 2 basic Energy cards from your discard pile into your hand.",
       "You may play as many Item cards as you like during your turn (before your attack)."
@@ -4264,7 +5543,9 @@
     "id": "xy7-100",
     "name": "Trainers' Mail",
     "supertype": "Trainer",
-    "subtypes": ["Item"],
+    "subtypes": [
+      "Item"
+    ],
     "rules": [
       "Look at the top 4 cards of your deck. You may reveal a Trainer card you find there (except Trainers' Mail) and put it into your hand. Shuffle the other cards back into your deck.",
       "You may play as many Item cards as you like during your turn (before your attack)."

--- a/cards/en/xy7.json
+++ b/cards/en/xy7.json
@@ -3,22 +3,14 @@
     "id": "xy7-1",
     "name": "Oddish",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic"
-    ],
+    "subtypes": ["Basic"],
     "hp": "50",
-    "types": [
-      "Grass"
-    ],
-    "evolvesTo": [
-      "Gloom"
-    ],
+    "types": ["Grass"],
+    "evolvesTo": ["Gloom"],
     "attacks": [
       {
         "name": "Trip Over",
-        "cost": [
-          "Grass"
-        ],
+        "cost": ["Grass"],
         "convertedEnergyCost": 1,
         "damage": "10+",
         "text": "Flip a coin. If heads, this attack does 10 more damage."
@@ -30,17 +22,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "1",
     "artist": "MAHOU",
     "rarity": "Common",
     "flavorText": "Its scientific name is \"Oddium Wanderus.\" At night, it is said to walk nearly 1,000 feet on its two roots.",
-    "nationalPokedexNumbers": [
-      43
-    ],
+    "nationalPokedexNumbers": [43],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -54,25 +42,15 @@
     "id": "xy7-2",
     "name": "Gloom",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 1"
-    ],
+    "subtypes": ["Stage 1"],
     "hp": "80",
-    "types": [
-      "Grass"
-    ],
+    "types": ["Grass"],
     "evolvesFrom": "Oddish",
-    "evolvesTo": [
-      "Vileplume",
-      "Bellossom"
-    ],
+    "evolvesTo": ["Vileplume", "Bellossom"],
     "attacks": [
       {
         "name": "Drool",
-        "cost": [
-          "Grass",
-          "Colorless"
-        ],
+        "cost": ["Grass", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "20",
         "text": ""
@@ -84,17 +62,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "2",
     "artist": "Masakazu Fukuda",
     "rarity": "Uncommon",
     "flavorText": "The honey it drools from its mouth smells so atrocious, it can curl noses more than a mile away.",
-    "nationalPokedexNumbers": [
-      44
-    ],
+    "nationalPokedexNumbers": [44],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -108,13 +82,9 @@
     "id": "xy7-3",
     "name": "Vileplume",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 2"
-    ],
+    "subtypes": ["Stage 2"],
     "hp": "130",
-    "types": [
-      "Grass"
-    ],
+    "types": ["Grass"],
     "evolvesFrom": "Gloom",
     "abilities": [
       {
@@ -126,11 +96,7 @@
     "attacks": [
       {
         "name": "Solar Beam",
-        "cost": [
-          "Grass",
-          "Grass",
-          "Colorless"
-        ],
+        "cost": ["Grass", "Grass", "Colorless"],
         "convertedEnergyCost": 3,
         "damage": "70",
         "text": ""
@@ -142,19 +108,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 3,
     "number": "3",
     "artist": "Midori Harada",
     "rarity": "Rare",
     "flavorText": "It has the world's largest petals. With every step, the petals shake out heavy clouds of toxic pollen.",
-    "nationalPokedexNumbers": [
-      45
-    ],
+    "nationalPokedexNumbers": [45],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -168,30 +128,21 @@
     "id": "xy7-4",
     "name": "Bellossom",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 2"
-    ],
+    "subtypes": ["Stage 2"],
     "hp": "120",
-    "types": [
-      "Grass"
-    ],
+    "types": ["Grass"],
     "evolvesFrom": "Gloom",
     "attacks": [
       {
-        "name": "Windwill",
-        "cost": [
-          "Grass"
-        ],
+        "name": "Windmill",
+        "cost": ["Grass"],
         "convertedEnergyCost": 1,
         "damage": "20",
         "text": "Switch this Pokémon with 1 of your Benched Pokémon."
       },
       {
         "name": "Flower Tornado",
-        "cost": [
-          "Grass",
-          "Colorless"
-        ],
+        "cost": ["Grass", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "60",
         "text": "Move as many Grass Energy attached to your Pokémon to your other Pokémon in any way you like."
@@ -203,17 +154,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "4",
     "artist": "Mizue",
     "rarity": "Uncommon",
     "flavorText": "When the heavy rainfall season ends, it is drawn out by warm sunlight to dance in the open.",
-    "nationalPokedexNumbers": [
-      182
-    ],
+    "nationalPokedexNumbers": [182],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -227,22 +174,14 @@
     "id": "xy7-5",
     "name": "Spinarak",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic"
-    ],
+    "subtypes": ["Basic"],
     "hp": "50",
-    "types": [
-      "Grass"
-    ],
-    "evolvesTo": [
-      "Ariados"
-    ],
+    "types": ["Grass"],
+    "evolvesTo": ["Ariados"],
     "attacks": [
       {
         "name": "String Shot",
-        "cost": [
-          "Colorless"
-        ],
+        "cost": ["Colorless"],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
@@ -254,17 +193,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "5",
     "artist": "Naoyo Kimura",
     "rarity": "Common",
     "flavorText": "It lies still in the same pose for days in its web, waiting for its unsuspecting prey to wander close.",
-    "nationalPokedexNumbers": [
-      167
-    ],
+    "nationalPokedexNumbers": [167],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -278,13 +213,9 @@
     "id": "xy7-6",
     "name": "Ariados",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 1"
-    ],
+    "subtypes": ["Stage 1"],
     "hp": "70",
-    "types": [
-      "Grass"
-    ],
+    "types": ["Grass"],
     "evolvesFrom": "Spinarak",
     "abilities": [
       {
@@ -296,10 +227,7 @@
     "attacks": [
       {
         "name": "Impound",
-        "cost": [
-          "Grass",
-          "Colorless"
-        ],
+        "cost": ["Grass", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "30",
         "text": "The Defending Pokémon can't retreat during your opponent's next turn."
@@ -311,17 +239,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "6",
     "artist": "Hajime Kusajima",
     "rarity": "Uncommon",
     "flavorText": "It attaches silk to its prey and sets it free. Later, it tracks the silk to the prey and its friends.",
-    "nationalPokedexNumbers": [
-      168
-    ],
+    "nationalPokedexNumbers": [168],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -335,36 +259,24 @@
     "id": "xy7-7",
     "name": "Sceptile-EX",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic",
-      "EX"
-    ],
+    "subtypes": ["Basic", "EX"],
     "hp": "170",
-    "types": [
-      "Grass"
-    ],
-    "evolvesTo": [
-      "M Sceptile-EX"
-    ],
+    "types": ["Grass"],
+    "evolvesTo": ["M Sceptile-EX"],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
       {
         "name": "Sleep Poison",
-        "cost": [
-          "Grass"
-        ],
+        "cost": ["Grass"],
         "convertedEnergyCost": 1,
         "damage": "10",
         "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Asleep and Poisoned."
       },
       {
         "name": "Unseen Claw",
-        "cost": [
-          "Grass",
-          "Colorless"
-        ],
+        "cost": ["Grass", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "60+",
         "text": "If your opponent's Active Pokémon is affected by a Special Condition, this attack does 70 more damage."
@@ -376,16 +288,12 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "7",
     "artist": "Eske Yoshinob",
     "rarity": "Rare Holo EX",
-    "nationalPokedexNumbers": [
-      254
-    ],
+    "nationalPokedexNumbers": [254],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -399,14 +307,9 @@
     "id": "xy7-8",
     "name": "M Sceptile-EX",
     "supertype": "Pokémon",
-    "subtypes": [
-      "MEGA",
-      "EX"
-    ],
+    "subtypes": ["MEGA", "EX"],
     "hp": "220",
-    "types": [
-      "Grass"
-    ],
+    "types": ["Grass"],
     "evolvesFrom": "Sceptile-EX",
     "rules": [
       "Mega Evolution rule: When 1 of your Pokémon becomes a Mega Evolution Pokémon, your turn ends.",
@@ -419,10 +322,7 @@
     "attacks": [
       {
         "name": "Jagged Saber",
-        "cost": [
-          "Grass",
-          "Colorless"
-        ],
+        "cost": ["Grass", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "100",
         "text": "You may attach up to 2 Grass Energy cards from your hand to your Benched Pokémon in any way you like. If you attached Energy to a Pokémon in this way, heal all damage from that Pokémon."
@@ -434,17 +334,12 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless"],
     "convertedRetreatCost": 2,
     "number": "8",
     "artist": "5ban Graphics",
     "rarity": "Rare Holo EX",
-    "nationalPokedexNumbers": [
-      254
-    ],
+    "nationalPokedexNumbers": [254],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -458,22 +353,14 @@
     "id": "xy7-9",
     "name": "Combee",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic"
-    ],
+    "subtypes": ["Basic"],
     "hp": "40",
-    "types": [
-      "Grass"
-    ],
-    "evolvesTo": [
-      "Vespiquen"
-    ],
+    "types": ["Grass"],
+    "evolvesTo": ["Vespiquen"],
     "attacks": [
       {
         "name": "Bug Bite",
-        "cost": [
-          "Grass"
-        ],
+        "cost": ["Grass"],
         "convertedEnergyCost": 1,
         "damage": "10",
         "text": ""
@@ -485,17 +372,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "9",
     "artist": "Sumiyoshi Kizuki",
     "rarity": "Common",
     "flavorText": "It collects and delivers honey to its colony. At night, they cluster to form a beehive and sleep.",
-    "nationalPokedexNumbers": [
-      415
-    ],
+    "nationalPokedexNumbers": [415],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -509,30 +392,21 @@
     "id": "xy7-10",
     "name": "Vespiquen",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 1"
-    ],
+    "subtypes": ["Stage 1"],
     "hp": "90",
-    "types": [
-      "Grass"
-    ],
+    "types": ["Grass"],
     "evolvesFrom": "Combee",
     "attacks": [
       {
         "name": "Intelligence Gathering",
-        "cost": [
-          "Colorless"
-        ],
+        "cost": ["Colorless"],
         "convertedEnergyCost": 1,
         "damage": "10",
         "text": "You may draw cards until you have 6 cards in your hand."
       },
       {
         "name": "Bee Revenge",
-        "cost": [
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Colorless", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "20+",
         "text": "This attack does 10 more damage for each Pokémon in your discard pile."
@@ -548,9 +422,7 @@
     "artist": "kawayoo",
     "rarity": "Uncommon",
     "flavorText": "Its abdomen is a honeycomb for grubs. It raises its grubs on honey collected by Combee.",
-    "nationalPokedexNumbers": [
-      416
-    ],
+    "nationalPokedexNumbers": [416],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -564,13 +436,9 @@
     "id": "xy7-11",
     "name": "Vespiquen",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 1"
-    ],
+    "subtypes": ["Stage 1"],
     "hp": "90",
-    "types": [
-      "Grass"
-    ],
+    "types": ["Grass"],
     "evolvesFrom": "Combee",
     "ancientTrait": {
       "name": "θ Double",
@@ -579,19 +447,14 @@
     "attacks": [
       {
         "name": "Bee Drain",
-        "cost": [
-          "Grass"
-        ],
+        "cost": ["Grass"],
         "convertedEnergyCost": 1,
         "damage": "20",
         "text": "Heal from this Pokémon the same amount of damage you did to your opponent's Active Pokémon."
       },
       {
         "name": "Fury Swipes",
-        "cost": [
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Colorless", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "30×",
         "text": "Flip 3 coins. This attack does 30 damage times the number of heads."
@@ -603,17 +466,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "11",
     "artist": "Ayaka Yoshida",
     "rarity": "Rare",
     "flavorText": "Its abdomen is a honeycomb for grubs. It raises its grubs on honey collected by Combee.",
-    "nationalPokedexNumbers": [
-      416
-    ],
+    "nationalPokedexNumbers": [416],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -627,29 +486,20 @@
     "id": "xy7-12",
     "name": "Virizion",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic"
-    ],
+    "subtypes": ["Basic"],
     "hp": "110",
-    "types": [
-      "Grass"
-    ],
+    "types": ["Grass"],
     "attacks": [
       {
         "name": "Bail Out",
-        "cost": [
-          "Grass"
-        ],
+        "cost": ["Grass"],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Put 2 Pokémon from your discard pile into your hand."
       },
       {
         "name": "Prize Count",
-        "cost": [
-          "Grass",
-          "Grass"
-        ],
+        "cost": ["Grass", "Grass"],
         "convertedEnergyCost": 2,
         "damage": "40+",
         "text": "If you have more Prize cards left than your opponent, this attack does 80 more damage."
@@ -661,17 +511,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "12",
     "artist": "match",
     "rarity": "Rare Holo",
     "flavorText": "Legends say this Pokémon confounded opponents with its swift movements.",
-    "nationalPokedexNumbers": [
-      640
-    ],
+    "nationalPokedexNumbers": [640],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -685,13 +531,9 @@
     "id": "xy7-13",
     "name": "Flareon",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 1"
-    ],
+    "subtypes": ["Stage 1"],
     "hp": "90",
-    "types": [
-      "Fire"
-    ],
+    "types": ["Fire"],
     "evolvesFrom": "Eevee",
     "abilities": [
       {
@@ -703,11 +545,7 @@
     "attacks": [
       {
         "name": "Heat Breath",
-        "cost": [
-          "Fire",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Fire", "Colorless", "Colorless"],
         "convertedEnergyCost": 3,
         "damage": "60+",
         "text": "Flip a coin. If heads, this attack does 20 more damage."
@@ -719,17 +557,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "13",
     "artist": "sui",
     "rarity": "Uncommon",
     "flavorText": "It has a flame bag inside its body. After inhaling deeply, it blows out flames of nearly 3,000 degrees Fahrenheit.",
-    "nationalPokedexNumbers": [
-      136
-    ],
+    "nationalPokedexNumbers": [136],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -743,29 +577,20 @@
     "id": "xy7-14",
     "name": "Entei",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic"
-    ],
+    "subtypes": ["Basic"],
     "hp": "120",
-    "types": [
-      "Fire"
-    ],
+    "types": ["Fire"],
     "attacks": [
       {
         "name": "Burning Roar",
-        "cost": [
-          "Colorless"
-        ],
+        "cost": ["Colorless"],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Discard the top 4 cards of your deck. If any of those cards are Fire Energy cards, attach them to your Pokémon in any way you like."
       },
       {
         "name": "Combat Blaze",
-        "cost": [
-          "Fire",
-          "Fire"
-        ],
+        "cost": ["Fire", "Fire"],
         "convertedEnergyCost": 2,
         "damage": "20+",
         "text": "This attack does 20 more damage for each of your opponent's Benched Pokémon."
@@ -777,18 +602,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless"],
     "convertedRetreatCost": 2,
     "number": "14",
     "artist": "Naoki Saito",
     "rarity": "Rare",
     "flavorText": "It is said that when it roars, a volcano erupts somewhere around the globe.",
-    "nationalPokedexNumbers": [
-      244
-    ],
+    "nationalPokedexNumbers": [244],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -802,13 +622,9 @@
     "id": "xy7-15",
     "name": "Entei",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic"
-    ],
+    "subtypes": ["Basic"],
     "hp": "130",
-    "types": [
-      "Fire"
-    ],
+    "types": ["Fire"],
     "ancientTrait": {
       "name": "θ Double",
       "text": "This Pokémon may have up to 2 Pokémon Tool cards attached to it."
@@ -816,22 +632,14 @@
     "attacks": [
       {
         "name": "Flame Screen",
-        "cost": [
-          "Fire",
-          "Colorless"
-        ],
+        "cost": ["Fire", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "30",
         "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 30 (after applying Weakness and Resistance)."
       },
       {
         "name": "Heat Tackle",
-        "cost": [
-          "Fire",
-          "Fire",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Fire", "Fire", "Colorless", "Colorless"],
         "convertedEnergyCost": 4,
         "damage": "130",
         "text": "Flip a coin. If tails, this Pokémon does 30 damage to itself."
@@ -843,18 +651,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless"],
     "convertedRetreatCost": 2,
     "number": "15",
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo",
     "flavorText": "It is said that when it roars, a volcano erupts somewhere around the globe.",
-    "nationalPokedexNumbers": [
-      244
-    ],
+    "nationalPokedexNumbers": [244],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -868,23 +671,14 @@
     "id": "xy7-16",
     "name": "Larvesta",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic"
-    ],
+    "subtypes": ["Basic"],
     "hp": "70",
-    "types": [
-      "Fire"
-    ],
-    "evolvesTo": [
-      "Volcarona"
-    ],
+    "types": ["Fire"],
+    "evolvesTo": ["Volcarona"],
     "attacks": [
       {
         "name": "Combustion",
-        "cost": [
-          "Fire",
-          "Colorless"
-        ],
+        "cost": ["Fire", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "30",
         "text": ""
@@ -896,18 +690,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless"],
     "convertedRetreatCost": 2,
     "number": "16",
     "artist": "Satoshi Shirai",
     "rarity": "Common",
     "flavorText": "The base of volcanoes is where they make their homes. They shoot fire from their five horns to repel attacking enemies.",
-    "nationalPokedexNumbers": [
-      636
-    ],
+    "nationalPokedexNumbers": [636],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -921,30 +710,21 @@
     "id": "xy7-17",
     "name": "Volcarona",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 1"
-    ],
+    "subtypes": ["Stage 1"],
     "hp": "100",
-    "types": [
-      "Fire"
-    ],
+    "types": ["Fire"],
     "evolvesFrom": "Larvesta",
     "attacks": [
       {
         "name": "Solar Birth",
-        "cost": [
-          "Colorless"
-        ],
+        "cost": ["Colorless"],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Search your deck for a Basic Pokémon and put it onto your Bench. Then, search your deck for up to 2 basic Energy cards and attach them to that Pokémon. Shuffle your deck afterward."
       },
       {
         "name": "Flamethrower",
-        "cost": [
-          "Fire",
-          "Colorless"
-        ],
+        "cost": ["Fire", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "60",
         "text": "Discard an Energy attached to this Pokémon."
@@ -956,17 +736,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "17",
     "artist": "Kyoko Umemoto",
     "rarity": "Rare Holo",
     "flavorText": "When volcanic ash darkened the atmosphere, it is said that Volcarona's fire provided a replacement for the sun.",
-    "nationalPokedexNumbers": [
-      637
-    ],
+    "nationalPokedexNumbers": [637],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -980,13 +756,9 @@
     "id": "xy7-18",
     "name": "Volcarona",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 1"
-    ],
+    "subtypes": ["Stage 1"],
     "hp": "110",
-    "types": [
-      "Fire"
-    ],
+    "types": ["Fire"],
     "evolvesFrom": "Larvesta",
     "ancientTrait": {
       "name": "θ Stop",
@@ -995,20 +767,14 @@
     "attacks": [
       {
         "name": "Burning Scales",
-        "cost": [
-          "Fire"
-        ],
+        "cost": ["Fire"],
         "convertedEnergyCost": 1,
         "damage": "20+",
         "text": "Flip 2 coins. This attack does 20 more damage for each heads."
       },
       {
         "name": "Wind Wheel",
-        "cost": [
-          "Fire",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Fire", "Colorless", "Colorless"],
         "convertedEnergyCost": 3,
         "damage": "80",
         "text": "Your opponent switches his or her Active Pokémon with 1 of his or her Benched Pokémon."
@@ -1020,18 +786,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless"],
     "convertedRetreatCost": 2,
     "number": "18",
     "artist": "Kagemaru Himeno",
     "rarity": "Rare",
     "flavorText": "When volcanic ash darkened the atmosphere, it is said that Volcarona's fire provided a replacement for the sun.",
-    "nationalPokedexNumbers": [
-      637
-    ],
+    "nationalPokedexNumbers": [637],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1045,22 +806,14 @@
     "id": "xy7-19",
     "name": "Magikarp",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic"
-    ],
+    "subtypes": ["Basic"],
     "hp": "30",
-    "types": [
-      "Water"
-    ],
-    "evolvesTo": [
-      "Gyarados"
-    ],
+    "types": ["Water"],
+    "evolvesTo": ["Gyarados"],
     "attacks": [
       {
         "name": "Epic Splash",
-        "cost": [
-          "Water"
-        ],
+        "cost": ["Water"],
         "convertedEnergyCost": 1,
         "damage": "30",
         "text": "Flip 2 coins. If either of them is tails, this attack does nothing."
@@ -1072,17 +825,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "19",
     "artist": "Akira Komayama",
     "rarity": "Common",
     "flavorText": "In the distant past, it was somewhat stronger than the horribly weak descendants that exist today.",
-    "nationalPokedexNumbers": [
-      129
-    ],
+    "nationalPokedexNumbers": [129],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1096,34 +845,21 @@
     "id": "xy7-20",
     "name": "Gyarados",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 1"
-    ],
+    "subtypes": ["Stage 1"],
     "hp": "130",
-    "types": [
-      "Water"
-    ],
+    "types": ["Water"],
     "evolvesFrom": "Magikarp",
     "attacks": [
       {
         "name": "Berserker Splash",
-        "cost": [
-          "Water",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Water", "Colorless", "Colorless"],
         "convertedEnergyCost": 3,
         "damage": "80",
         "text": "This attack does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Aqua Tail",
-        "cost": [
-          "Water",
-          "Colorless",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Water", "Colorless", "Colorless", "Colorless"],
         "convertedEnergyCost": 4,
         "damage": "90+",
         "text": "Flip a coin for each Water Energy attached to this Pokémon. This attack does 30 more damage for each heads."
@@ -1135,19 +871,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 3,
     "number": "20",
     "artist": "Shin Nagasawa",
     "rarity": "Rare",
     "flavorText": "Rarely seen in the wild. Huge and vicious, it is capable of destroying entire cities in a rage.",
-    "nationalPokedexNumbers": [
-      130
-    ],
+    "nationalPokedexNumbers": [130],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1161,13 +891,9 @@
     "id": "xy7-21",
     "name": "Gyarados",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 1"
-    ],
+    "subtypes": ["Stage 1"],
     "hp": "130",
-    "types": [
-      "Water"
-    ],
+    "types": ["Water"],
     "evolvesFrom": "Magikarp",
     "ancientTrait": {
       "name": "θ Double",
@@ -1176,22 +902,14 @@
     "attacks": [
       {
         "name": "Full Retaliation",
-        "cost": [
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Colorless", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "30+",
         "text": "This attack does 30 more damage for each damage counter on each of your Benched Magikarp."
       },
       {
         "name": "Thrash",
-        "cost": [
-          "Water",
-          "Water",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Water", "Water", "Colorless", "Colorless"],
         "convertedEnergyCost": 4,
         "damage": "100+",
         "text": "Flip a coin. If heads, this attack does 30 more damage. If tails, this Pokémon does 30 damage to itself."
@@ -1203,19 +921,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 3,
     "number": "21",
     "artist": "TOKIYA",
     "rarity": "Rare Holo",
     "flavorText": "Rarely seen in the wild. Huge and vicious, it is capable of destroying entire cities in a rage.",
-    "nationalPokedexNumbers": [
-      130
-    ],
+    "nationalPokedexNumbers": [130],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1229,13 +941,9 @@
     "id": "xy7-22",
     "name": "Vaporeon",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 1"
-    ],
+    "subtypes": ["Stage 1"],
     "hp": "90",
-    "types": [
-      "Water"
-    ],
+    "types": ["Water"],
     "evolvesFrom": "Eevee",
     "abilities": [
       {
@@ -1247,11 +955,7 @@
     "attacks": [
       {
         "name": "Hydro Splash",
-        "cost": [
-          "Water",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Water", "Colorless", "Colorless"],
         "convertedEnergyCost": 3,
         "damage": "70",
         "text": ""
@@ -1263,18 +967,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless"],
     "convertedRetreatCost": 2,
     "number": "22",
     "artist": "kirisAki",
     "rarity": "Uncommon",
     "flavorText": "It has evolved to be suitable for an aquatic life. It can invisibly melt away into water.",
-    "nationalPokedexNumbers": [
-      134
-    ],
+    "nationalPokedexNumbers": [134],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1288,29 +987,20 @@
     "id": "xy7-23",
     "name": "Relicanth",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic"
-    ],
+    "subtypes": ["Basic"],
     "hp": "90",
-    "types": [
-      "Water"
-    ],
+    "types": ["Water"],
     "attacks": [
       {
         "name": "Deep Sea Search",
-        "cost": [
-          "Colorless"
-        ],
+        "cost": ["Colorless"],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Search your deck for up to 2 Pokémon Tool cards, reveal them, and put them into your hand. Shuffle your deck afterward."
       },
       {
         "name": "Take Down",
-        "cost": [
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Colorless", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "30",
         "text": "This Pokémon does 10 damage to itself."
@@ -1322,17 +1012,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "23",
     "artist": "Kagemaru Himeno",
     "rarity": "Common",
     "flavorText": "A rare Pokémon discovered during a deep-sea exploration. It has not changed in over 100 million years.",
-    "nationalPokedexNumbers": [
-      369
-    ],
+    "nationalPokedexNumbers": [369],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1346,31 +1032,20 @@
     "id": "xy7-24",
     "name": "Regice",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic"
-    ],
+    "subtypes": ["Basic"],
     "hp": "120",
-    "types": [
-      "Water"
-    ],
+    "types": ["Water"],
     "attacks": [
       {
         "name": "Ice Beam",
-        "cost": [
-          "Water",
-          "Colorless"
-        ],
+        "cost": ["Water", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "30",
         "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
       },
       {
         "name": "Resistance Blizzard",
-        "cost": [
-          "Water",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Water", "Colorless", "Colorless"],
         "convertedEnergyCost": 3,
         "damage": "70",
         "text": "During your opponent's next turn, prevent all effects of attacks, including damage, done to this Pokémon by Pokémon-EX."
@@ -1382,19 +1057,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 3,
     "number": "24",
     "artist": "Miki Tanaka",
     "rarity": "Rare",
     "flavorText": "Its body is made of ice from the ice age. It controls frigid air of -328 degrees Fahrenheit.",
-    "nationalPokedexNumbers": [
-      378
-    ],
+    "nationalPokedexNumbers": [378],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1408,37 +1077,23 @@
     "id": "xy7-25",
     "name": "Kyurem-EX",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic",
-      "EX"
-    ],
+    "subtypes": ["Basic", "EX"],
     "hp": "180",
-    "types": [
-      "Water"
-    ],
+    "types": ["Water"],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
       {
         "name": "Glaciate",
-        "cost": [
-          "Water",
-          "Water",
-          "Colorless"
-        ],
+        "cost": ["Water", "Water", "Colorless"],
         "convertedEnergyCost": 3,
         "damage": "",
         "text": "This attack does 30 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Icecalibur",
-        "cost": [
-          "Water",
-          "Water",
-          "Water",
-          "Colorless"
-        ],
+        "cost": ["Water", "Water", "Water", "Colorless"],
         "convertedEnergyCost": 4,
         "damage": "130",
         "text": "Discard an Energy attached to this Pokémon. The Defending Pokémon can't attack during your opponent's next turn."
@@ -1450,18 +1105,12 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 3,
     "number": "25",
     "artist": "PLANETA",
     "rarity": "Rare Holo EX",
-    "nationalPokedexNumbers": [
-      646
-    ],
+    "nationalPokedexNumbers": [646],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1475,13 +1124,9 @@
     "id": "xy7-26",
     "name": "Jolteon",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 1"
-    ],
+    "subtypes": ["Stage 1"],
     "hp": "90",
-    "types": [
-      "Lightning"
-    ],
+    "types": ["Lightning"],
     "evolvesFrom": "Eevee",
     "abilities": [
       {
@@ -1493,11 +1138,7 @@
     "attacks": [
       {
         "name": "Thunder Blast",
-        "cost": [
-          "Lightning",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Lightning", "Colorless", "Colorless"],
         "convertedEnergyCost": 3,
         "damage": "80",
         "text": "Discard an Energy attached to this Pokémon."
@@ -1519,9 +1160,7 @@
     "artist": "Sanosuke Sakuma",
     "rarity": "Rare Holo",
     "flavorText": "It accumulates negative ions in the atmosphere to blast out 10,000-volt lightning bolts.",
-    "nationalPokedexNumbers": [
-      135
-    ],
+    "nationalPokedexNumbers": [135],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1535,38 +1174,24 @@
     "id": "xy7-27",
     "name": "Ampharos-EX",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic",
-      "EX"
-    ],
+    "subtypes": ["Basic", "EX"],
     "hp": "170",
-    "types": [
-      "Lightning"
-    ],
-    "evolvesTo": [
-      "M Ampharos-EX"
-    ],
+    "types": ["Lightning"],
+    "evolvesTo": ["M Ampharos-EX"],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
       {
         "name": "Thunder Rod",
-        "cost": [
-          "Colorless"
-        ],
+        "cost": ["Colorless"],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Look at the top 4 cards of your deck and attach as many Lightning Energy cards you find there as you like to this Pokémon. Shuffle the other cards back into your deck."
       },
       {
         "name": "Sparkling Tail",
-        "cost": [
-          "Lightning",
-          "Lightning",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Lightning", "Lightning", "Colorless", "Colorless"],
         "convertedEnergyCost": 4,
         "damage": "100",
         "text": "This attack's damage isn't affected by Weakness, Resistance, or any other effects on your opponent's Active Pokémon."
@@ -1584,17 +1209,12 @@
         "value": "-20"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless"],
     "convertedRetreatCost": 2,
     "number": "27",
     "artist": "Eske Yoshinob",
     "rarity": "Rare Holo EX",
-    "nationalPokedexNumbers": [
-      181
-    ],
+    "nationalPokedexNumbers": [181],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1608,14 +1228,9 @@
     "id": "xy7-28",
     "name": "M Ampharos-EX",
     "supertype": "Pokémon",
-    "subtypes": [
-      "MEGA",
-      "EX"
-    ],
+    "subtypes": ["MEGA", "EX"],
     "hp": "220",
-    "types": [
-      "Lightning"
-    ],
+    "types": ["Lightning"],
     "evolvesFrom": "Ampharos-EX",
     "rules": [
       "Mega Evolution rule: When 1 of your Pokémon becomes a Mega Evolution Pokémon, your turn ends.",
@@ -1624,12 +1239,7 @@
     "attacks": [
       {
         "name": "Exavolt",
-        "cost": [
-          "Lightning",
-          "Lightning",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Lightning", "Lightning", "Colorless", "Colorless"],
         "convertedEnergyCost": 4,
         "damage": "120+",
         "text": "You may do 50 more damage and leave your opponent's Active Pokémon Paralyzed. If you do, this Pokémon does 30 damage to itself."
@@ -1647,18 +1257,12 @@
         "value": "-20"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 3,
     "number": "28",
     "artist": "5ban Graphics",
     "rarity": "Rare Holo EX",
-    "nationalPokedexNumbers": [
-      181
-    ],
+    "nationalPokedexNumbers": [181],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1672,29 +1276,20 @@
     "id": "xy7-29",
     "name": "Rotom",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic"
-    ],
+    "subtypes": ["Basic"],
     "hp": "70",
-    "types": [
-      "Lightning"
-    ],
+    "types": ["Lightning"],
     "attacks": [
       {
         "name": "Electro Ball",
-        "cost": [
-          "Lightning"
-        ],
+        "cost": ["Lightning"],
         "convertedEnergyCost": 1,
         "damage": "20",
         "text": ""
       },
       {
         "name": "Electric Mischief",
-        "cost": [
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Colorless", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "",
         "text": "Flip 3 coins. For each heads, choose a random card from your opponent's hand. Your opponent reveals that card and shuffles it into his or her deck."
@@ -1712,17 +1307,13 @@
         "value": "-20"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "29",
     "artist": "Mizue",
     "rarity": "Uncommon",
     "flavorText": "Its body is composed of plasma. It is known to infiltrate electronic devices and wreak havoc.",
-    "nationalPokedexNumbers": [
-      479
-    ],
+    "nationalPokedexNumbers": [479],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1736,13 +1327,9 @@
     "id": "xy7-30",
     "name": "Unown",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic"
-    ],
+    "subtypes": ["Basic"],
     "hp": "60",
-    "types": [
-      "Psychic"
-    ],
+    "types": ["Psychic"],
     "abilities": [
       {
         "name": "Farewell Letter",
@@ -1753,9 +1340,7 @@
     "attacks": [
       {
         "name": "Hidden Power",
-        "cost": [
-          "Colorless"
-        ],
+        "cost": ["Colorless"],
         "convertedEnergyCost": 1,
         "damage": "10",
         "text": ""
@@ -1767,17 +1352,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "30",
     "artist": "Akira Komayama",
     "rarity": "Common",
     "flavorText": "Shaped like ancient writing, it is a huge mystery whether language or Unown came first.",
-    "nationalPokedexNumbers": [
-      201
-    ],
+    "nationalPokedexNumbers": [201],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1791,32 +1372,21 @@
     "id": "xy7-31",
     "name": "Baltoy",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic"
-    ],
+    "subtypes": ["Basic"],
     "hp": "60",
-    "types": [
-      "Psychic"
-    ],
-    "evolvesTo": [
-      "Claydol"
-    ],
+    "types": ["Psychic"],
+    "evolvesTo": ["Claydol"],
     "attacks": [
       {
         "name": "Slap",
-        "cost": [
-          "Psychic"
-        ],
+        "cost": ["Psychic"],
         "convertedEnergyCost": 1,
         "damage": "10",
         "text": ""
       },
       {
         "name": "Spinning Attack",
-        "cost": [
-          "Psychic",
-          "Colorless"
-        ],
+        "cost": ["Psychic", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "20",
         "text": ""
@@ -1828,17 +1398,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "31",
     "artist": "Kouki Saitou",
     "rarity": "Common",
     "flavorText": "It moves by spinning on its foot. It is a rare Pokémon that was discovered in ancient ruins.",
-    "nationalPokedexNumbers": [
-      343
-    ],
+    "nationalPokedexNumbers": [343],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1852,16 +1418,10 @@
     "id": "xy7-32",
     "name": "Baltoy",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic"
-    ],
+    "subtypes": ["Basic"],
     "hp": "60",
-    "types": [
-      "Psychic"
-    ],
-    "evolvesTo": [
-      "Claydol"
-    ],
+    "types": ["Psychic"],
+    "evolvesTo": ["Claydol"],
     "ancientTrait": {
       "name": "θ Stop",
       "text": "Prevent all effects of your opponent's Pokémon's Abilities done to this Pokémon."
@@ -1869,9 +1429,7 @@
     "attacks": [
       {
         "name": "Future Spin",
-        "cost": [
-          "Psychic"
-        ],
+        "cost": ["Psychic"],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Look at the top 3 cards of either player's deck and put them back on top of that player's deck in any order."
@@ -1883,17 +1441,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "32",
     "artist": "Ayaka Yoshida",
     "rarity": "Common",
     "flavorText": "It moves by spinning on its foot. It is a rare Pokémon that was discovered in ancient ruins.",
-    "nationalPokedexNumbers": [
-      343
-    ],
+    "nationalPokedexNumbers": [343],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1907,30 +1461,21 @@
     "id": "xy7-33",
     "name": "Claydol",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 1"
-    ],
+    "subtypes": ["Stage 1"],
     "hp": "100",
-    "types": [
-      "Psychic"
-    ],
+    "types": ["Psychic"],
     "evolvesFrom": "Baltoy",
     "attacks": [
       {
         "name": "Rewind",
-        "cost": [
-          "Psychic"
-        ],
+        "cost": ["Psychic"],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Devolve each of your opponent's evolved Pokémon and put the highest Stage Evolution card on it into your opponent's hand."
       },
       {
         "name": "Hyper Beam",
-        "cost": [
-          "Psychic",
-          "Colorless"
-        ],
+        "cost": ["Psychic", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "30",
         "text": "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon."
@@ -1942,18 +1487,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless"],
     "convertedRetreatCost": 2,
     "number": "33",
     "artist": "Satoshi Shirai",
     "rarity": "Rare",
     "flavorText": "It is said that it originates from clay dolls made by an ancient civilization.",
-    "nationalPokedexNumbers": [
-      344
-    ],
+    "nationalPokedexNumbers": [344],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1967,23 +1507,14 @@
     "id": "xy7-34",
     "name": "Golett",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic"
-    ],
+    "subtypes": ["Basic"],
     "hp": "90",
-    "types": [
-      "Psychic"
-    ],
-    "evolvesTo": [
-      "Golurk"
-    ],
+    "types": ["Psychic"],
+    "evolvesTo": ["Golurk"],
     "attacks": [
       {
         "name": "Smash Punch",
-        "cost": [
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Colorless", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "30",
         "text": "Flip a coin. If tails, this attack does nothing."
@@ -2001,19 +1532,13 @@
         "value": "-20"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 3,
     "number": "34",
     "artist": "Sanosuke Sakuma",
     "rarity": "Common",
     "flavorText": "Ancient science fashioned this Pokémon from clay. It's been active for thousands of years.",
-    "nationalPokedexNumbers": [
-      622
-    ],
+    "nationalPokedexNumbers": [622],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2027,13 +1552,9 @@
     "id": "xy7-35",
     "name": "Golurk",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 1"
-    ],
+    "subtypes": ["Stage 1"],
     "hp": "130",
-    "types": [
-      "Psychic"
-    ],
+    "types": ["Psychic"],
     "evolvesFrom": "Golett",
     "ancientTrait": {
       "name": "θ Stop",
@@ -2049,12 +1570,7 @@
     "attacks": [
       {
         "name": "Superpower",
-        "cost": [
-          "Colorless",
-          "Colorless",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Colorless", "Colorless", "Colorless", "Colorless"],
         "convertedEnergyCost": 4,
         "damage": "80+",
         "text": "You may do 40 more damage. If you do, this Pokémon does 20 damage to itself."
@@ -2072,20 +1588,13 @@
         "value": "-20"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 4,
     "number": "35",
     "artist": "kawayoo",
     "rarity": "Rare",
     "flavorText": "It flies across the sky at Mach speeds. Removing the seal on its chest makes its internal energy go out of control.",
-    "nationalPokedexNumbers": [
-      623
-    ],
+    "nationalPokedexNumbers": [623],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2099,14 +1608,9 @@
     "id": "xy7-36",
     "name": "Hoopa-EX",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic",
-      "EX"
-    ],
+    "subtypes": ["Basic", "EX"],
     "hp": "170",
-    "types": [
-      "Psychic"
-    ],
+    "types": ["Psychic"],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -2120,11 +1624,7 @@
     "attacks": [
       {
         "name": "Hyperspace Fury",
-        "cost": [
-          "Psychic",
-          "Psychic",
-          "Psychic"
-        ],
+        "cost": ["Psychic", "Psychic", "Psychic"],
         "convertedEnergyCost": 3,
         "damage": "",
         "text": "Discard 2 Energy attached to this Pokémon. This attack does 100 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
@@ -2136,17 +1636,12 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless"],
     "convertedRetreatCost": 2,
     "number": "36",
     "artist": "Ryota Murayama",
     "rarity": "Rare Holo EX",
-    "nationalPokedexNumbers": [
-      720
-    ],
+    "nationalPokedexNumbers": [720],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2160,35 +1655,23 @@
     "id": "xy7-37",
     "name": "Machamp-EX",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic",
-      "EX"
-    ],
+    "subtypes": ["Basic", "EX"],
     "hp": "180",
-    "types": [
-      "Fighting"
-    ],
+    "types": ["Fighting"],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
       {
         "name": "Steaming Mad",
-        "cost": [
-          "Fighting",
-          "Colorless"
-        ],
+        "cost": ["Fighting", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "20×",
         "text": "This attack does 20 damage times the number of damage counters on this Pokémon. This Pokémon is now Confused."
       },
       {
         "name": "Crazy Hammer",
-        "cost": [
-          "Fighting",
-          "Fighting",
-          "Colorless"
-        ],
+        "cost": ["Fighting", "Fighting", "Colorless"],
         "convertedEnergyCost": 3,
         "damage": "80+",
         "text": "If this Pokémon is affected by a Special Condition, this attack does 80 more damage. Then, remove all Special Conditions from this Pokémon."
@@ -2200,18 +1683,12 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 3,
     "number": "37",
     "artist": "Eske Yoshinob",
     "rarity": "Rare Holo EX",
-    "nationalPokedexNumbers": [
-      68
-    ],
+    "nationalPokedexNumbers": [68],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2225,32 +1702,21 @@
     "id": "xy7-38",
     "name": "Wooper",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic"
-    ],
+    "subtypes": ["Basic"],
     "hp": "60",
-    "types": [
-      "Fighting"
-    ],
-    "evolvesTo": [
-      "Quagsire"
-    ],
+    "types": ["Fighting"],
+    "evolvesTo": ["Quagsire"],
     "attacks": [
       {
         "name": "Nap",
-        "cost": [
-          "Colorless"
-        ],
+        "cost": ["Colorless"],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Heal 20 damage from this Pokémon."
       },
       {
         "name": "Wave Splash",
-        "cost": [
-          "Water",
-          "Colorless"
-        ],
+        "cost": ["Water", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "20",
         "text": ""
@@ -2262,18 +1728,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless"],
     "convertedRetreatCost": 2,
     "number": "38",
     "artist": "Sumiyoshi Kizuki",
     "rarity": "Common",
     "flavorText": "When the temperature cools in the evening, they emerge from water to seek food along the shore.",
-    "nationalPokedexNumbers": [
-      194
-    ],
+    "nationalPokedexNumbers": [194],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2287,32 +1748,21 @@
     "id": "xy7-39",
     "name": "Quagsire",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 1"
-    ],
+    "subtypes": ["Stage 1"],
     "hp": "110",
-    "types": [
-      "Fighting"
-    ],
+    "types": ["Fighting"],
     "evolvesFrom": "Wooper",
     "attacks": [
       {
         "name": "Wave Splash",
-        "cost": [
-          "Water",
-          "Colorless"
-        ],
+        "cost": ["Water", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "30",
         "text": ""
       },
       {
         "name": "Landslide",
-        "cost": [
-          "Water",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Water", "Colorless", "Colorless"],
         "convertedEnergyCost": 3,
         "damage": "80",
         "text": "This attack's damage isn't affected by Resistance."
@@ -2324,19 +1774,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 3,
     "number": "39",
     "artist": "Naoyo Kimura",
     "rarity": "Common",
     "flavorText": "This carefree Pokémon has an easy-going nature. While swimming, it always bumps into boat hulls.",
-    "nationalPokedexNumbers": [
-      195
-    ],
+    "nationalPokedexNumbers": [195],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2350,31 +1794,20 @@
     "id": "xy7-40",
     "name": "Regirock",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic"
-    ],
+    "subtypes": ["Basic"],
     "hp": "120",
-    "types": [
-      "Fighting"
-    ],
+    "types": ["Fighting"],
     "attacks": [
       {
         "name": "Rock Throw",
-        "cost": [
-          "Fighting",
-          "Colorless"
-        ],
+        "cost": ["Fighting", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "40",
         "text": ""
       },
       {
         "name": "Unyielding Rock",
-        "cost": [
-          "Fighting",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Fighting", "Colorless", "Colorless"],
         "convertedEnergyCost": 3,
         "damage": "60+",
         "text": "If your opponent's Active Pokémon is a Pokémon-EX, this attack does 60 more damage."
@@ -2386,19 +1819,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 3,
     "number": "40",
     "artist": "Shin Nagasawa",
     "rarity": "Rare",
     "flavorText": "The same rocks that form its body have been found in ground layers around the world.",
-    "nationalPokedexNumbers": [
-      377
-    ],
+    "nationalPokedexNumbers": [377],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2412,32 +1839,21 @@
     "id": "xy7-41",
     "name": "Golurk",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 1"
-    ],
+    "subtypes": ["Stage 1"],
     "hp": "130",
-    "types": [
-      "Fighting"
-    ],
+    "types": ["Fighting"],
     "evolvesFrom": "Golett",
     "attacks": [
       {
         "name": "Dig Out",
-        "cost": [
-          "Colorless"
-        ],
+        "cost": ["Colorless"],
         "convertedEnergyCost": 1,
         "damage": "20",
         "text": "Discard the top card of your deck. If that card is a Fighting Energy card, attach it to this Pokémon."
       },
       {
         "name": "Double Lariat",
-        "cost": [
-          "Fighting",
-          "Colorless",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Fighting", "Colorless", "Colorless", "Colorless"],
         "convertedEnergyCost": 4,
         "damage": "90×",
         "text": "Flip 2 coins. This attack does 90 damage times the number of heads."
@@ -2449,20 +1865,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 4,
     "number": "41",
     "artist": "Suwama Chiaki",
     "rarity": "Common",
     "flavorText": "It flies across the sky at Mach speeds. Removing the seal on its chest makes its internal energy go out of control.",
-    "nationalPokedexNumbers": [
-      623
-    ],
+    "nationalPokedexNumbers": [623],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2476,40 +1885,24 @@
     "id": "xy7-42",
     "name": "Tyranitar-EX",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic",
-      "EX"
-    ],
+    "subtypes": ["Basic", "EX"],
     "hp": "180",
-    "types": [
-      "Darkness"
-    ],
-    "evolvesTo": [
-      "M Tyranitar-EX"
-    ],
+    "types": ["Darkness"],
+    "evolvesTo": ["M Tyranitar-EX"],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
       {
         "name": "Hammer In",
-        "cost": [
-          "Darkness",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Darkness", "Colorless", "Colorless"],
         "convertedEnergyCost": 3,
         "damage": "60",
         "text": ""
       },
       {
         "name": "Break Ground",
-        "cost": [
-          "Darkness",
-          "Darkness",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Darkness", "Darkness", "Colorless", "Colorless"],
         "convertedEnergyCost": 4,
         "damage": "130",
         "text": "This attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
@@ -2527,19 +1920,12 @@
         "value": "-20"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 4,
     "number": "42",
     "artist": "Eske Yoshinob",
     "rarity": "Rare Holo EX",
-    "nationalPokedexNumbers": [
-      248
-    ],
+    "nationalPokedexNumbers": [248],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2553,14 +1939,9 @@
     "id": "xy7-43",
     "name": "M Tyranitar-EX",
     "supertype": "Pokémon",
-    "subtypes": [
-      "MEGA",
-      "EX"
-    ],
+    "subtypes": ["MEGA", "EX"],
     "hp": "240",
-    "types": [
-      "Darkness"
-    ],
+    "types": ["Darkness"],
     "evolvesFrom": "Tyranitar-EX",
     "rules": [
       "Mega Evolution rule: When 1 of your Pokémon becomes a Mega Evolution Pokémon, your turn ends.",
@@ -2573,12 +1954,7 @@
     "attacks": [
       {
         "name": "Destroyer King",
-        "cost": [
-          "Darkness",
-          "Darkness",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Darkness", "Darkness", "Colorless", "Colorless"],
         "convertedEnergyCost": 4,
         "damage": "110+",
         "text": "This attack does 60 more damage for each damage counter on your opponent's Active Pokémon."
@@ -2596,19 +1972,12 @@
         "value": "-20"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 4,
     "number": "43",
     "artist": "5ban Graphics",
     "rarity": "Rare Holo EX",
-    "nationalPokedexNumbers": [
-      248
-    ],
+    "nationalPokedexNumbers": [248],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2622,45 +1991,32 @@
     "id": "xy7-44",
     "name": "Sableye",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic"
-    ],
+    "subtypes": ["Basic"],
     "hp": "70",
-    "types": [
-      "Darkness"
-    ],
+    "types": ["Darkness"],
     "attacks": [
       {
         "name": "Bewitching Eyes",
-        "cost": [
-          "Darkness"
-        ],
+        "cost": ["Darkness"],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Choose a Supporter card from your opponent's discard pile and use it as the effect of this attack."
       },
       {
         "name": "Furtive Drop",
-        "cost": [
-          "Darkness",
-          "Colorless"
-        ],
+        "cost": ["Darkness", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "",
         "text": "Put 3 damage counters on your opponent's Active Pokémon."
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "44",
     "artist": "Hitoshi Ariga",
     "rarity": "Uncommon",
     "flavorText": "It dwells in the darkness of caves. It uses its sharp claws to dig up gems to nourish itself.",
-    "nationalPokedexNumbers": [
-      302
-    ],
+    "nationalPokedexNumbers": [302],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2674,22 +2030,14 @@
     "id": "xy7-45",
     "name": "Inkay",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic"
-    ],
+    "subtypes": ["Basic"],
     "hp": "50",
-    "types": [
-      "Darkness"
-    ],
-    "evolvesTo": [
-      "Malamar"
-    ],
+    "types": ["Darkness"],
+    "evolvesTo": ["Malamar"],
     "attacks": [
       {
         "name": "Ink Spit",
-        "cost": [
-          "Darkness"
-        ],
+        "cost": ["Darkness"],
         "convertedEnergyCost": 1,
         "damage": "10",
         "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
@@ -2707,17 +2055,13 @@
         "value": "-20"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "45",
     "artist": "Tomokazu Komiya",
     "rarity": "Common",
     "flavorText": "It flashes the light-emitting spots on its body, which drains its opponent's will to fight. It takes the opportunity to scuttle away and hide.",
-    "nationalPokedexNumbers": [
-      686
-    ],
+    "nationalPokedexNumbers": [686],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2731,29 +2075,21 @@
     "id": "xy7-46",
     "name": "Malamar",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 1"
-    ],
+    "subtypes": ["Stage 1"],
     "hp": "90",
-    "types": [
-      "Darkness"
-    ],
+    "types": ["Darkness"],
     "evolvesFrom": "Inkay",
     "attacks": [
       {
         "name": "Entangling Control",
-        "cost": [
-          "Colorless"
-        ],
+        "cost": ["Colorless"],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Switch 1 of your opponent's Benched Pokémon with his or her Active Pokémon. The new Active Pokémon is now Confused."
       },
       {
         "name": "Trash Tentacle",
-        "cost": [
-          "Darkness"
-        ],
+        "cost": ["Darkness"],
         "convertedEnergyCost": 1,
         "damage": "30",
         "text": "Put a card from your discard pile into your hand."
@@ -2771,17 +2107,13 @@
         "value": "-20"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "46",
     "artist": "Masakazu Fukuda",
     "rarity": "Common",
     "flavorText": "It lures prey close with hypnotic motions, then wraps its tentacles around it before finishing it off with digestive fluids.",
-    "nationalPokedexNumbers": [
-      687
-    ],
+    "nationalPokedexNumbers": [687],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2795,33 +2127,21 @@
     "id": "xy7-47",
     "name": "Beldum",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic"
-    ],
+    "subtypes": ["Basic"],
     "hp": "60",
-    "types": [
-      "Metal"
-    ],
-    "evolvesTo": [
-      "Metang"
-    ],
+    "types": ["Metal"],
+    "evolvesTo": ["Metang"],
     "attacks": [
       {
         "name": "Ram",
-        "cost": [
-          "Metal"
-        ],
+        "cost": ["Metal"],
         "convertedEnergyCost": 1,
         "damage": "10",
         "text": ""
       },
       {
         "name": "Spinning Attack",
-        "cost": [
-          "Metal",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Metal", "Colorless", "Colorless"],
         "convertedEnergyCost": 3,
         "damage": "30",
         "text": ""
@@ -2839,18 +2159,13 @@
         "value": "-20"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless"],
     "convertedRetreatCost": 2,
     "number": "47",
     "artist": "Yuka Morii",
     "rarity": "Common",
     "flavorText": "It converses with others by magnetic pulses. In a swarm, they move in perfect unison.",
-    "nationalPokedexNumbers": [
-      374
-    ],
+    "nationalPokedexNumbers": [374],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2864,35 +2179,22 @@
     "id": "xy7-48",
     "name": "Metang",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 1"
-    ],
+    "subtypes": ["Stage 1"],
     "hp": "90",
-    "types": [
-      "Metal"
-    ],
+    "types": ["Metal"],
     "evolvesFrom": "Beldum",
-    "evolvesTo": [
-      "Metagross"
-    ],
+    "evolvesTo": ["Metagross"],
     "attacks": [
       {
         "name": "Metal Claw",
-        "cost": [
-          "Metal",
-          "Colorless"
-        ],
+        "cost": ["Metal", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "30",
         "text": ""
       },
       {
         "name": "Bullet Punch",
-        "cost": [
-          "Metal",
-          "Metal",
-          "Colorless"
-        ],
+        "cost": ["Metal", "Metal", "Colorless"],
         "convertedEnergyCost": 3,
         "damage": "50+",
         "text": "Flip 2 coins. This attack does 20 more damage for each heads."
@@ -2910,19 +2212,13 @@
         "value": "-20"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 3,
     "number": "48",
     "artist": "Shigenori Negishi",
     "rarity": "Uncommon",
     "flavorText": "It is formed by two Beldum joining together. Its two brains are linked, amplifying its psychic power.",
-    "nationalPokedexNumbers": [
-      375
-    ],
+    "nationalPokedexNumbers": [375],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2936,13 +2232,9 @@
     "id": "xy7-49",
     "name": "Metagross",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 2"
-    ],
+    "subtypes": ["Stage 2"],
     "hp": "150",
-    "types": [
-      "Metal"
-    ],
+    "types": ["Metal"],
     "evolvesFrom": "Metang",
     "abilities": [
       {
@@ -2954,12 +2246,7 @@
     "attacks": [
       {
         "name": "Iron Cannon",
-        "cost": [
-          "Metal",
-          "Metal",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Metal", "Metal", "Colorless", "Colorless"],
         "convertedEnergyCost": 4,
         "damage": "80+",
         "text": "You may discard all Metal Energy attached to this Pokémon. If you do, this attack does 80 more damage."
@@ -2977,20 +2264,13 @@
         "value": "-20"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 4,
     "number": "49",
     "artist": "kirisAki",
     "rarity": "Rare",
     "flavorText": "Metang combined to form it. With four brains, it has the intelligence of a supercomputer.",
-    "nationalPokedexNumbers": [
-      376
-    ],
+    "nationalPokedexNumbers": [376],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3004,13 +2284,9 @@
     "id": "xy7-50",
     "name": "Metagross",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 2"
-    ],
+    "subtypes": ["Stage 2"],
     "hp": "150",
-    "types": [
-      "Metal"
-    ],
+    "types": ["Metal"],
     "evolvesFrom": "Metang",
     "ancientTrait": {
       "name": "θ Double",
@@ -3019,22 +2295,14 @@
     "attacks": [
       {
         "name": "Machine Gun Stomp",
-        "cost": [
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Colorless", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "20+",
         "text": "This attack does 10 more damage for each card in your hand."
       },
       {
         "name": "Guard Press",
-        "cost": [
-          "Metal",
-          "Metal",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Metal", "Metal", "Colorless", "Colorless"],
         "convertedEnergyCost": 4,
         "damage": "80",
         "text": "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
@@ -3052,20 +2320,13 @@
         "value": "-20"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 4,
     "number": "50",
     "artist": "Hitoshi Ariga",
     "rarity": "Rare",
     "flavorText": "Metang combined to form it. With four brains, it has the intelligence of a supercomputer.",
-    "nationalPokedexNumbers": [
-      376
-    ],
+    "nationalPokedexNumbers": [376],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3079,31 +2340,20 @@
     "id": "xy7-51",
     "name": "Registeel",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic"
-    ],
+    "subtypes": ["Basic"],
     "hp": "120",
-    "types": [
-      "Metal"
-    ],
+    "types": ["Metal"],
     "attacks": [
       {
         "name": "Iron Head",
-        "cost": [
-          "Metal",
-          "Colorless"
-        ],
+        "cost": ["Metal", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "30×",
         "text": "Flip a coin until you get tails. This attack does 30 damage times the number of heads."
       },
       {
         "name": "Forbidden Iron Hammer",
-        "cost": [
-          "Metal",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Metal", "Colorless", "Colorless"],
         "convertedEnergyCost": 3,
         "damage": "70",
         "text": "If your opponent's Active Pokémon is a Pokémon-EX, discard an Energy attached to that Pokémon."
@@ -3121,19 +2371,13 @@
         "value": "-20"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 3,
     "number": "51",
     "artist": "Kouki Saitou",
     "rarity": "Rare",
     "flavorText": "Its body is said to be harder than any kind of metal. A study has revealed that its body is hollow.",
-    "nationalPokedexNumbers": [
-      379
-    ],
+    "nationalPokedexNumbers": [379],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3147,32 +2391,21 @@
     "id": "xy7-52",
     "name": "Ralts",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic"
-    ],
+    "subtypes": ["Basic"],
     "hp": "60",
-    "types": [
-      "Fairy"
-    ],
-    "evolvesTo": [
-      "Kirlia"
-    ],
+    "types": ["Fairy"],
+    "evolvesTo": ["Kirlia"],
     "attacks": [
       {
         "name": "Mumble",
-        "cost": [
-          "Colorless"
-        ],
+        "cost": ["Colorless"],
         "convertedEnergyCost": 1,
         "damage": "10",
         "text": ""
       },
       {
         "name": "Magical Shot",
-        "cost": [
-          "Fairy",
-          "Colorless"
-        ],
+        "cost": ["Fairy", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "20",
         "text": ""
@@ -3190,17 +2423,13 @@
         "value": "-20"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "52",
     "artist": "Aya Kusube",
     "rarity": "Common",
     "flavorText": "It is highly attuned to the emotions of people and Pokémon. It hides if it senses hostility.",
-    "nationalPokedexNumbers": [
-      280
-    ],
+    "nationalPokedexNumbers": [280],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3214,35 +2443,22 @@
     "id": "xy7-53",
     "name": "Kirlia",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 1"
-    ],
+    "subtypes": ["Stage 1"],
     "hp": "80",
-    "types": [
-      "Fairy"
-    ],
+    "types": ["Fairy"],
     "evolvesFrom": "Ralts",
-    "evolvesTo": [
-      "Gardevoir",
-      "Gallade"
-    ],
+    "evolvesTo": ["Gardevoir", "Gallade"],
     "attacks": [
       {
         "name": "Calm Mind",
-        "cost": [
-          "Colorless"
-        ],
+        "cost": ["Colorless"],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Heal 30 damage from this Pokémon."
       },
       {
         "name": "Magical Shot",
-        "cost": [
-          "Fairy",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Fairy", "Colorless", "Colorless"],
         "convertedEnergyCost": 3,
         "damage": "50",
         "text": ""
@@ -3260,17 +2476,13 @@
         "value": "-20"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "53",
     "artist": "match",
     "rarity": "Uncommon",
     "flavorText": "It has a psychic power that enables it to distort the space around it and see into the future.",
-    "nationalPokedexNumbers": [
-      281
-    ],
+    "nationalPokedexNumbers": [281],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3284,13 +2496,9 @@
     "id": "xy7-54",
     "name": "Gardevoir",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 2"
-    ],
+    "subtypes": ["Stage 2"],
     "hp": "130",
-    "types": [
-      "Fairy"
-    ],
+    "types": ["Fairy"],
     "evolvesFrom": "Kirlia",
     "abilities": [
       {
@@ -3302,11 +2510,7 @@
     "attacks": [
       {
         "name": "Telekinesis",
-        "cost": [
-          "Colorless",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Colorless", "Colorless", "Colorless"],
         "convertedEnergyCost": 3,
         "damage": "",
         "text": "This attack does 50 damage to 1 of your opponent's Pokémon. This attack's damage isn't affected by Weakness or Resistance."
@@ -3324,18 +2528,13 @@
         "value": "-20"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless"],
     "convertedRetreatCost": 2,
     "number": "54",
     "artist": "TOKIYA",
     "rarity": "Rare Holo",
     "flavorText": "It has the power to predict the future. Its power peaks when it is protecting its Trainer.",
-    "nationalPokedexNumbers": [
-      282
-    ],
+    "nationalPokedexNumbers": [282],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3349,22 +2548,14 @@
     "id": "xy7-55",
     "name": "Cottonee",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic"
-    ],
+    "subtypes": ["Basic"],
     "hp": "40",
-    "types": [
-      "Fairy"
-    ],
-    "evolvesTo": [
-      "Whimsicott"
-    ],
+    "types": ["Fairy"],
+    "evolvesTo": ["Whimsicott"],
     "attacks": [
       {
         "name": "Cotton Bed",
-        "cost": [
-          "Fairy"
-        ],
+        "cost": ["Fairy"],
         "convertedEnergyCost": 1,
         "damage": "10",
         "text": "Your opponent's Active Pokémon is now Asleep."
@@ -3382,17 +2573,13 @@
         "value": "-20"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "55",
     "artist": "Kanako Eo",
     "rarity": "Common",
     "flavorText": "Perhaps because they feel more at ease in a group, they stick to others they find. They end up looking like a cloud.",
-    "nationalPokedexNumbers": [
-      546
-    ],
+    "nationalPokedexNumbers": [546],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3406,30 +2593,21 @@
     "id": "xy7-56",
     "name": "Whimsicott",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 1"
-    ],
+    "subtypes": ["Stage 1"],
     "hp": "70",
-    "types": [
-      "Fairy"
-    ],
+    "types": ["Fairy"],
     "evolvesFrom": "Cottonee",
     "attacks": [
       {
         "name": "Windy Mischief",
-        "cost": [
-          "Fairy"
-        ],
+        "cost": ["Fairy"],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Move all damage counters from 1 of your Benched Pokémon to your opponent's Active Pokémon."
       },
       {
         "name": "Rolling Tackle",
-        "cost": [
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Colorless", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "30",
         "text": ""
@@ -3447,17 +2625,13 @@
         "value": "-20"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "56",
     "artist": "Atsuko Nishida",
     "rarity": "Uncommon",
     "flavorText": "Like the wind, it can slip through any gap, no matter how small. It leaves balls of white fluff behind.",
-    "nationalPokedexNumbers": [
-      547
-    ],
+    "nationalPokedexNumbers": [547],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3471,14 +2645,9 @@
     "id": "xy7-57",
     "name": "Giratina-EX",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic",
-      "EX"
-    ],
+    "subtypes": ["Basic", "EX"],
     "hp": "170",
-    "types": [
-      "Dragon"
-    ],
+    "types": ["Dragon"],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -3492,12 +2661,7 @@
     "attacks": [
       {
         "name": "Chaos Wheel",
-        "cost": [
-          "Grass",
-          "Psychic",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Grass", "Psychic", "Colorless", "Colorless"],
         "convertedEnergyCost": 4,
         "damage": "100",
         "text": "Your opponent can't play any Pokémon Tool, Special Energy, or Stadium cards from his or her hand during his or her next turn."
@@ -3509,18 +2673,12 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 3,
     "number": "57",
     "artist": "PLANETA",
     "rarity": "Rare Holo EX",
-    "nationalPokedexNumbers": [
-      487
-    ],
+    "nationalPokedexNumbers": [487],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3534,16 +2692,10 @@
     "id": "xy7-58",
     "name": "Goomy",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic"
-    ],
+    "subtypes": ["Basic"],
     "hp": "40",
-    "types": [
-      "Dragon"
-    ],
-    "evolvesTo": [
-      "Sliggoo"
-    ],
+    "types": ["Dragon"],
+    "evolvesTo": ["Sliggoo"],
     "abilities": [
       {
         "name": "Water Down",
@@ -3554,10 +2706,7 @@
     "attacks": [
       {
         "name": "Stampede",
-        "cost": [
-          "Fairy",
-          "Colorless"
-        ],
+        "cost": ["Fairy", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "10",
         "text": ""
@@ -3569,18 +2718,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless"],
     "convertedRetreatCost": 2,
     "number": "58",
     "artist": "sui",
     "rarity": "Common",
     "flavorText": "It's covered in a slimy membrane that makes any punches or kicks slide off it harmlessly.",
-    "nationalPokedexNumbers": [
-      704
-    ],
+    "nationalPokedexNumbers": [704],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3594,33 +2738,22 @@
     "id": "xy7-59",
     "name": "Sliggoo",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 1"
-    ],
+    "subtypes": ["Stage 1"],
     "hp": "70",
-    "types": [
-      "Dragon"
-    ],
+    "types": ["Dragon"],
     "evolvesFrom": "Goomy",
-    "evolvesTo": [
-      "Goodra"
-    ],
+    "evolvesTo": ["Goodra"],
     "attacks": [
       {
         "name": "Bubble",
-        "cost": [
-          "Colorless"
-        ],
+        "cost": ["Colorless"],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
       },
       {
         "name": "Melt",
-        "cost": [
-          "Water",
-          "Fairy"
-        ],
+        "cost": ["Water", "Fairy"],
         "convertedEnergyCost": 2,
         "damage": "20",
         "text": ""
@@ -3632,19 +2765,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 3,
     "number": "59",
     "artist": "Midori Harada",
     "rarity": "Uncommon",
     "flavorText": "Its four horns are a high-performance radar system. It uses them to sense sounds and smells, rather than using ears or a nose.",
-    "nationalPokedexNumbers": [
-      705
-    ],
+    "nationalPokedexNumbers": [705],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3658,33 +2785,21 @@
     "id": "xy7-60",
     "name": "Goodra",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 2"
-    ],
+    "subtypes": ["Stage 2"],
     "hp": "150",
-    "types": [
-      "Dragon"
-    ],
+    "types": ["Dragon"],
     "evolvesFrom": "Sliggoo",
     "attacks": [
       {
         "name": "Liquid Blow",
-        "cost": [
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Colorless", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "",
         "text": "This attack does 20 damage to 1 of your opponent's Pokémon for each Colorless in its Retreat Cost. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Shining Breath",
-        "cost": [
-          "Water",
-          "Fairy",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Water", "Fairy", "Colorless", "Colorless"],
         "convertedEnergyCost": 4,
         "damage": "110",
         "text": "During your opponent's next turn, this Pokémon can't be affected by any Special Conditions."
@@ -3696,19 +2811,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 3,
     "number": "60",
     "artist": "Saya Tsuruta",
     "rarity": "Rare Holo",
     "flavorText": "It attacks with retractable horns. It throws a punch that's the equivalent of the force of a hundred pro boxers.",
-    "nationalPokedexNumbers": [
-      706
-    ],
+    "nationalPokedexNumbers": [706],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3722,22 +2831,14 @@
     "id": "xy7-61",
     "name": "Meowth",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic"
-    ],
+    "subtypes": ["Basic"],
     "hp": "60",
-    "types": [
-      "Colorless"
-    ],
-    "evolvesTo": [
-      "Persian"
-    ],
+    "types": ["Colorless"],
+    "evolvesTo": ["Persian"],
     "attacks": [
       {
         "name": "Act Tough",
-        "cost": [
-          "Colorless"
-        ],
+        "cost": ["Colorless"],
         "convertedEnergyCost": 1,
         "damage": "10+",
         "text": "If this Pokémon has any Darkness Energy attached to it, this attack does 20 more damage."
@@ -3749,17 +2850,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "61",
     "artist": "Kanako Eo",
     "rarity": "Common",
     "flavorText": "Adores round objects. It wanders the streets on a nightly basis to look for dropped loose change.",
-    "nationalPokedexNumbers": [
-      52
-    ],
+    "nationalPokedexNumbers": [52],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3773,30 +2870,21 @@
     "id": "xy7-62",
     "name": "Persian",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 1"
-    ],
+    "subtypes": ["Stage 1"],
     "hp": "90",
-    "types": [
-      "Colorless"
-    ],
+    "types": ["Colorless"],
     "evolvesFrom": "Meowth",
     "attacks": [
       {
         "name": "Fake Out",
-        "cost": [
-          "Colorless"
-        ],
+        "cost": ["Colorless"],
         "convertedEnergyCost": 1,
         "damage": "30",
         "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
       },
       {
         "name": "Ambush",
-        "cost": [
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Colorless", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "40+",
         "text": "Flip a coin. If heads, this attack does 30 more damage."
@@ -3808,17 +2896,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "62",
     "artist": "Mitsuhiro Arita",
     "rarity": "Common",
     "flavorText": "Its lithe muscles allow it to walk without making a sound. It attacks in an instant.",
-    "nationalPokedexNumbers": [
-      53
-    ],
+    "nationalPokedexNumbers": [53],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3832,13 +2916,9 @@
     "id": "xy7-63",
     "name": "Eevee",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic"
-    ],
+    "subtypes": ["Basic"],
     "hp": "60",
-    "types": [
-      "Colorless"
-    ],
+    "types": ["Colorless"],
     "evolvesTo": [
       "Vaporeon",
       "Jolteon",
@@ -3852,19 +2932,14 @@
     "attacks": [
       {
         "name": "Tackle",
-        "cost": [
-          "Colorless"
-        ],
+        "cost": ["Colorless"],
         "convertedEnergyCost": 1,
         "damage": "10",
         "text": ""
       },
       {
         "name": "Lunge",
-        "cost": [
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Colorless", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "30",
         "text": "Flip a coin. If tails, this attack does nothing."
@@ -3876,17 +2951,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "63",
     "artist": "Kouki Saitou",
     "rarity": "Common",
     "flavorText": "Thanks to its unstable genetic makeup, this special Pokémon conceals many different possible evolutions.",
-    "nationalPokedexNumbers": [
-      133
-    ],
+    "nationalPokedexNumbers": [133],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3900,32 +2971,21 @@
     "id": "xy7-64",
     "name": "Porygon",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic"
-    ],
+    "subtypes": ["Basic"],
     "hp": "60",
-    "types": [
-      "Colorless"
-    ],
-    "evolvesTo": [
-      "Porygon2"
-    ],
+    "types": ["Colorless"],
+    "evolvesTo": ["Porygon2"],
     "attacks": [
       {
         "name": "Data Check",
-        "cost": [
-          "Colorless"
-        ],
+        "cost": ["Colorless"],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Look through your deck. Shuffle your deck afterward."
       },
       {
         "name": "Sharpen",
-        "cost": [
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Colorless", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "20",
         "text": ""
@@ -3937,17 +2997,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "64",
     "artist": "Yukiko Baba",
     "rarity": "Common",
     "flavorText": "A Pokémon that consists entirely of programming code. It is capable of moving freely in cyberspace.",
-    "nationalPokedexNumbers": [
-      137
-    ],
+    "nationalPokedexNumbers": [137],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -3961,34 +3017,22 @@
     "id": "xy7-65",
     "name": "Porygon2",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 1"
-    ],
+    "subtypes": ["Stage 1"],
     "hp": "80",
-    "types": [
-      "Colorless"
-    ],
+    "types": ["Colorless"],
     "evolvesFrom": "Porygon",
-    "evolvesTo": [
-      "Porygon-Z"
-    ],
+    "evolvesTo": ["Porygon-Z"],
     "attacks": [
       {
         "name": "Sharpen",
-        "cost": [
-          "Colorless"
-        ],
+        "cost": ["Colorless"],
         "convertedEnergyCost": 1,
         "damage": "20",
         "text": ""
       },
       {
         "name": "Tri Attack",
-        "cost": [
-          "Colorless",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Colorless", "Colorless", "Colorless"],
         "convertedEnergyCost": 3,
         "damage": "30×",
         "text": "Flip 3 coins. This attack does 30 damage times the number of heads."
@@ -4000,18 +3044,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless"],
     "convertedRetreatCost": 2,
     "number": "65",
     "artist": "MAHOU",
     "rarity": "Uncommon",
     "flavorText": "With planetary development software installed, it became capable of working in space.",
-    "nationalPokedexNumbers": [
-      233
-    ],
+    "nationalPokedexNumbers": [233],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -4025,31 +3064,21 @@
     "id": "xy7-66",
     "name": "Porygon-Z",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 2"
-    ],
+    "subtypes": ["Stage 2"],
     "hp": "130",
-    "types": [
-      "Colorless"
-    ],
+    "types": ["Colorless"],
     "evolvesFrom": "Porygon2",
     "attacks": [
       {
         "name": "Cyber Crush",
-        "cost": [
-          "Colorless"
-        ],
+        "cost": ["Colorless"],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Discard all Special Energy attached to each of your opponent's Pokémon."
       },
       {
         "name": "Slowing Beam",
-        "cost": [
-          "Colorless",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Colorless", "Colorless", "Colorless"],
         "convertedEnergyCost": 3,
         "damage": "70",
         "text": "During your opponent's next turn, the Defending Pokémon's attacks cost Colorless more."
@@ -4061,18 +3090,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless"],
     "convertedRetreatCost": 2,
     "number": "66",
     "artist": "TOKIYA",
     "rarity": "Rare",
     "flavorText": "Its programming was modified to enable it to travel through alien dimensions. Seems there might have been an error…",
-    "nationalPokedexNumbers": [
-      474
-    ],
+    "nationalPokedexNumbers": [474],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -4086,13 +3110,9 @@
     "id": "xy7-67",
     "name": "Porygon-Z",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Stage 2"
-    ],
+    "subtypes": ["Stage 2"],
     "hp": "130",
-    "types": [
-      "Colorless"
-    ],
+    "types": ["Colorless"],
     "evolvesFrom": "Porygon2",
     "ancientTrait": {
       "name": "θ Stop",
@@ -4101,19 +3121,14 @@
     "attacks": [
       {
         "name": "Digital Reboot",
-        "cost": [
-          "Colorless"
-        ],
+        "cost": ["Colorless"],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Devolve as many of your Benched Pokémon as many times as you like. Put each Evolution card removed this way into your hand."
       },
       {
         "name": "Dazzle Blast",
-        "cost": [
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Colorless", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "50",
         "text": "Your opponent's Active Pokémon is now Confused."
@@ -4125,18 +3140,13 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless"],
     "convertedRetreatCost": 2,
     "number": "67",
     "artist": "Naoki Saito",
     "rarity": "Rare Holo",
     "flavorText": "Its programming was modified to enable it to travel through alien dimensions. Seems there might have been an error…",
-    "nationalPokedexNumbers": [
-      474
-    ],
+    "nationalPokedexNumbers": [474],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -4150,36 +3160,23 @@
     "id": "xy7-68",
     "name": "Lugia-EX",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic",
-      "EX"
-    ],
+    "subtypes": ["Basic", "EX"],
     "hp": "170",
-    "types": [
-      "Colorless"
-    ],
+    "types": ["Colorless"],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
       {
         "name": "Aero Ball",
-        "cost": [
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Colorless", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "20×",
         "text": "This attack does 20 damage times the amount of Energy attached to both Active Pokémon."
       },
       {
         "name": "Deep Hurricane",
-        "cost": [
-          "Colorless",
-          "Colorless",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Colorless", "Colorless", "Colorless", "Colorless"],
         "convertedEnergyCost": 4,
         "damage": "80+",
         "text": "If there is any Stadium card in play, this attack does 70 more damage. Then, discard that Stadium card."
@@ -4197,17 +3194,12 @@
         "value": "-20"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless"],
     "convertedRetreatCost": 2,
     "number": "68",
     "artist": "Eske Yoshinob",
     "rarity": "Rare Holo EX",
-    "nationalPokedexNumbers": [
-      249
-    ],
+    "nationalPokedexNumbers": [249],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -4221,9 +3213,7 @@
     "id": "xy7-69",
     "name": "Ace Trainer",
     "supertype": "Trainer",
-    "subtypes": [
-      "Supporter"
-    ],
+    "subtypes": ["Supporter"],
     "rules": [
       "You can play this card only if you have more Prize cards left than your opponent.",
       "Each player shuffles his or her hand into his or her deck. Then, draw 6 cards. Your opponent draws 3 cards.",
@@ -4245,9 +3235,7 @@
     "id": "xy7-70",
     "name": "Ampharos Spirit Link",
     "supertype": "Trainer",
-    "subtypes": [
-      "Pokémon Tool"
-    ],
+    "subtypes": ["Pokémon Tool"],
     "rules": [
       "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.",
       "Your turn does not end if the Pokémon this card is attached to becomes M Ampharos-EX.",
@@ -4269,9 +3257,7 @@
     "id": "xy7-71",
     "name": "Eco Arm",
     "supertype": "Trainer",
-    "subtypes": [
-      "Item"
-    ],
+    "subtypes": ["Item"],
     "rules": [
       "Shuffle 3 Pokémon Tool cards from your discard pile into your deck.",
       "You may play as many Item cards as you like during your turn (before your attack)."
@@ -4292,9 +3278,7 @@
     "id": "xy7-72",
     "name": "Energy Recycler",
     "supertype": "Trainer",
-    "subtypes": [
-      "Item"
-    ],
+    "subtypes": ["Item"],
     "rules": [
       "Shuffle 5 basic Energy cards from your discard pile into your deck.",
       "You may play as many Item cards as you like during your turn (before your attack)."
@@ -4315,9 +3299,7 @@
     "id": "xy7-73",
     "name": "Faded Town",
     "supertype": "Trainer",
-    "subtypes": [
-      "Stadium"
-    ],
+    "subtypes": ["Stadium"],
     "rules": [
       "At any time between turns, put 2 damage counters on each Mega Evolution Pokémon.",
       "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card."
@@ -4338,9 +3320,7 @@
     "id": "xy7-74",
     "name": "Forest of Giant Plants",
     "supertype": "Trainer",
-    "subtypes": [
-      "Stadium"
-    ],
+    "subtypes": ["Stadium"],
     "rules": [
       "Each player's Grass Pokémon can evolve during his or her first turn or the turn he or she plays those Pokémon.",
       "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card."
@@ -4361,9 +3341,7 @@
     "id": "xy7-75",
     "name": "Hex Maniac",
     "supertype": "Trainer",
-    "subtypes": [
-      "Supporter"
-    ],
+    "subtypes": ["Supporter"],
     "rules": [
       "Until the end of your opponent's next turn, each Pokémon in play, in each player's hand, and in each player's discard pile has no Abilities. (This includes cards that come into play on that turn.)",
       "You may play only 1 Supporter card during your turn (before your attack)."
@@ -4384,9 +3362,7 @@
     "id": "xy7-76",
     "name": "Level Ball",
     "supertype": "Trainer",
-    "subtypes": [
-      "Item"
-    ],
+    "subtypes": ["Item"],
     "rules": [
       "Search your deck for a Pokémon with 90 HP or less, reveal it, and put it into your hand. Shuffle your deck afterward.",
       "You may play as many Item cards as you like during your turn (before your attack)."
@@ -4407,9 +3383,7 @@
     "id": "xy7-77",
     "name": "Lucky Helmet",
     "supertype": "Trainer",
-    "subtypes": [
-      "Pokémon Tool"
-    ],
+    "subtypes": ["Pokémon Tool"],
     "rules": [
       "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.",
       "Whenever the Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent's attack (even if that Pokémon is Knocked Out), draw 2 cards.",
@@ -4431,9 +3405,7 @@
     "id": "xy7-78",
     "name": "Lysandre",
     "supertype": "Trainer",
-    "subtypes": [
-      "Supporter"
-    ],
+    "subtypes": ["Supporter"],
     "rules": [
       "Switch 1 of your opponent's Benched Pokémon with his or her Active Pokémon.",
       "You may play only 1 Supporter card during your turn (before your attack)."
@@ -4454,9 +3426,7 @@
     "id": "xy7-79",
     "name": "Paint Roller",
     "supertype": "Trainer",
-    "subtypes": [
-      "Item"
-    ],
+    "subtypes": ["Item"],
     "rules": [
       "Discard any Stadium card in play. Then, draw a card.",
       "You may play as many Item cards as you like during your turn (before your attack)."
@@ -4477,9 +3447,7 @@
     "id": "xy7-80",
     "name": "Sceptile Spirit Link",
     "supertype": "Trainer",
-    "subtypes": [
-      "Pokémon Tool"
-    ],
+    "subtypes": ["Pokémon Tool"],
     "rules": [
       "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.",
       "Your turn does not end if the Pokémon this card is attached to becomes M Sceptile-EX.",
@@ -4501,9 +3469,7 @@
     "id": "xy7-81",
     "name": "Tyranitar Spirit Link",
     "supertype": "Trainer",
-    "subtypes": [
-      "Pokémon Tool"
-    ],
+    "subtypes": ["Pokémon Tool"],
     "rules": [
       "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.",
       "Your turn does not end if the Pokémon this card is attached to becomes M Tyranitar-EX.",
@@ -4525,9 +3491,7 @@
     "id": "xy7-82",
     "name": "Dangerous Energy",
     "supertype": "Energy",
-    "subtypes": [
-      "Special"
-    ],
+    "subtypes": ["Special"],
     "rules": [
       "This card can only be attached to Darkness Pokémon. This card provides Darkness Energy only while this card is attached to a Darkness Pokémon.",
       "Whenever the Darkness Pokémon this card is attached to is your Active Pokémon and is damaged by an attack from your opponent's Pokémon-EX (even if that Pokémon is Knocked Out), put 2 damage counters on the Attacking Pokémon-EX.",
@@ -4549,9 +3513,7 @@
     "id": "xy7-83",
     "name": "Flash Energy",
     "supertype": "Energy",
-    "subtypes": [
-      "Special"
-    ],
+    "subtypes": ["Special"],
     "rules": [
       "This card can only be attached to Lightning Pokémon. This card provides Lightning Energy only while this card is attached to a Lightning Pokémon.",
       "The Lightning Pokémon this card is attached to has no Weakness.",
@@ -4573,36 +3535,24 @@
     "id": "xy7-84",
     "name": "Sceptile-EX",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic",
-      "EX"
-    ],
+    "subtypes": ["Basic", "EX"],
     "hp": "170",
-    "types": [
-      "Grass"
-    ],
-    "evolvesTo": [
-      "M Sceptile-EX"
-    ],
+    "types": ["Grass"],
+    "evolvesTo": ["M Sceptile-EX"],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
       {
         "name": "Sleep Poison",
-        "cost": [
-          "Grass"
-        ],
+        "cost": ["Grass"],
         "convertedEnergyCost": 1,
         "damage": "10",
         "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Asleep and Poisoned."
       },
       {
         "name": "Unseen Claw",
-        "cost": [
-          "Grass",
-          "Colorless"
-        ],
+        "cost": ["Grass", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "60+",
         "text": "If your opponent's Active Pokémon is affected by a Special Condition, this attack does 70 more damage."
@@ -4614,16 +3564,12 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "84",
     "artist": "Ryo Ueda",
     "rarity": "Rare Ultra",
-    "nationalPokedexNumbers": [
-      254
-    ],
+    "nationalPokedexNumbers": [254],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -4637,14 +3583,9 @@
     "id": "xy7-85",
     "name": "M Sceptile-EX",
     "supertype": "Pokémon",
-    "subtypes": [
-      "MEGA",
-      "EX"
-    ],
+    "subtypes": ["MEGA", "EX"],
     "hp": "220",
-    "types": [
-      "Grass"
-    ],
+    "types": ["Grass"],
     "evolvesFrom": "Sceptile-EX",
     "rules": [
       "Mega Evolution rule: When 1 of your Pokémon becomes a Mega Evolution Pokémon, your turn ends.",
@@ -4657,10 +3598,7 @@
     "attacks": [
       {
         "name": "Jagged Saber",
-        "cost": [
-          "Grass",
-          "Colorless"
-        ],
+        "cost": ["Grass", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "100",
         "text": "You may attach up to 2 Grass Energy cards from your hand to your Benched Pokémon in any way you like. If you attached Energy to a Pokémon in this way, heal all damage from that Pokémon."
@@ -4672,17 +3610,12 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless"],
     "convertedRetreatCost": 2,
     "number": "85",
     "artist": "5ban Graphics",
     "rarity": "Rare Ultra",
-    "nationalPokedexNumbers": [
-      254
-    ],
+    "nationalPokedexNumbers": [254],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -4696,37 +3629,23 @@
     "id": "xy7-86",
     "name": "Kyurem-EX",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic",
-      "EX"
-    ],
+    "subtypes": ["Basic", "EX"],
     "hp": "180",
-    "types": [
-      "Water"
-    ],
+    "types": ["Water"],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
       {
         "name": "Glaciate",
-        "cost": [
-          "Water",
-          "Water",
-          "Colorless"
-        ],
+        "cost": ["Water", "Water", "Colorless"],
         "convertedEnergyCost": 3,
         "damage": "",
         "text": "This attack does 30 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Icecalibur",
-        "cost": [
-          "Water",
-          "Water",
-          "Water",
-          "Colorless"
-        ],
+        "cost": ["Water", "Water", "Water", "Colorless"],
         "convertedEnergyCost": 4,
         "damage": "130",
         "text": "Discard an Energy attached to this Pokémon. The Defending Pokémon can't attack during your opponent's next turn."
@@ -4738,18 +3657,12 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 3,
     "number": "86",
     "artist": "Ryo Ueda",
     "rarity": "Rare Ultra",
-    "nationalPokedexNumbers": [
-      646
-    ],
+    "nationalPokedexNumbers": [646],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -4763,38 +3676,24 @@
     "id": "xy7-87",
     "name": "Ampharos-EX",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic",
-      "EX"
-    ],
+    "subtypes": ["Basic", "EX"],
     "hp": "170",
-    "types": [
-      "Lightning"
-    ],
-    "evolvesTo": [
-      "M Ampharos-EX"
-    ],
+    "types": ["Lightning"],
+    "evolvesTo": ["M Ampharos-EX"],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
       {
         "name": "Thunder Rod",
-        "cost": [
-          "Colorless"
-        ],
+        "cost": ["Colorless"],
         "convertedEnergyCost": 1,
         "damage": "",
         "text": "Look at the top 4 cards of your deck and attach as many Lightning Energy cards you find there as you like to this Pokémon. Shuffle the other cards back into your deck."
       },
       {
         "name": "Sparkling Tail",
-        "cost": [
-          "Lightning",
-          "Lightning",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Lightning", "Lightning", "Colorless", "Colorless"],
         "convertedEnergyCost": 4,
         "damage": "100",
         "text": "This attack's damage isn't affected by Weakness, Resistance, or any other effects on your opponent's Active Pokémon."
@@ -4812,17 +3711,12 @@
         "value": "-20"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless"],
     "convertedRetreatCost": 2,
     "number": "87",
     "artist": "Ryo Ueda",
     "rarity": "Rare Ultra",
-    "nationalPokedexNumbers": [
-      181
-    ],
+    "nationalPokedexNumbers": [181],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -4836,14 +3730,9 @@
     "id": "xy7-88",
     "name": "M Ampharos-EX",
     "supertype": "Pokémon",
-    "subtypes": [
-      "MEGA",
-      "EX"
-    ],
+    "subtypes": ["MEGA", "EX"],
     "hp": "220",
-    "types": [
-      "Lightning"
-    ],
+    "types": ["Lightning"],
     "evolvesFrom": "Ampharos-EX",
     "rules": [
       "Mega Evolution rule: When 1 of your Pokémon becomes a Mega Evolution Pokémon, your turn ends.",
@@ -4852,12 +3741,7 @@
     "attacks": [
       {
         "name": "Exavolt",
-        "cost": [
-          "Lightning",
-          "Lightning",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Lightning", "Lightning", "Colorless", "Colorless"],
         "convertedEnergyCost": 4,
         "damage": "120+",
         "text": "You may do 50 more damage and leave your opponent's Active Pokémon Paralyzed. If you do, this Pokémon does 30 damage to itself."
@@ -4875,18 +3759,12 @@
         "value": "-20"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 3,
     "number": "88",
     "artist": "5ban Graphics",
     "rarity": "Rare Ultra",
-    "nationalPokedexNumbers": [
-      181
-    ],
+    "nationalPokedexNumbers": [181],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -4900,14 +3778,9 @@
     "id": "xy7-89",
     "name": "Hoopa-EX",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic",
-      "EX"
-    ],
+    "subtypes": ["Basic", "EX"],
     "hp": "170",
-    "types": [
-      "Psychic"
-    ],
+    "types": ["Psychic"],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -4921,11 +3794,7 @@
     "attacks": [
       {
         "name": "Hyperspace Fury",
-        "cost": [
-          "Psychic",
-          "Psychic",
-          "Psychic"
-        ],
+        "cost": ["Psychic", "Psychic", "Psychic"],
         "convertedEnergyCost": 3,
         "damage": "",
         "text": "Discard 2 Energy attached to this Pokémon. This attack does 100 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
@@ -4937,17 +3806,12 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless"],
     "convertedRetreatCost": 2,
     "number": "89",
     "artist": "5ban Graphics",
     "rarity": "Rare Ultra",
-    "nationalPokedexNumbers": [
-      720
-    ],
+    "nationalPokedexNumbers": [720],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -4961,35 +3825,23 @@
     "id": "xy7-90",
     "name": "Machamp-EX",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic",
-      "EX"
-    ],
+    "subtypes": ["Basic", "EX"],
     "hp": "180",
-    "types": [
-      "Fighting"
-    ],
+    "types": ["Fighting"],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
       {
         "name": "Steaming Mad",
-        "cost": [
-          "Fighting",
-          "Colorless"
-        ],
+        "cost": ["Fighting", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "20×",
         "text": "This attack does 20 damage times the number of damage counters on this Pokémon. This Pokémon is now Confused."
       },
       {
         "name": "Crazy Hammer",
-        "cost": [
-          "Fighting",
-          "Fighting",
-          "Colorless"
-        ],
+        "cost": ["Fighting", "Fighting", "Colorless"],
         "convertedEnergyCost": 3,
         "damage": "80+",
         "text": "If this Pokémon is affected by a Special Condition, this attack does 80 more damage. Then, remove all Special Conditions from this Pokémon."
@@ -5001,18 +3853,12 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 3,
     "number": "90",
     "artist": "Ryo Ueda",
     "rarity": "Rare Ultra",
-    "nationalPokedexNumbers": [
-      68
-    ],
+    "nationalPokedexNumbers": [68],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -5026,40 +3872,24 @@
     "id": "xy7-91",
     "name": "Tyranitar-EX",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic",
-      "EX"
-    ],
+    "subtypes": ["Basic", "EX"],
     "hp": "180",
-    "types": [
-      "Darkness"
-    ],
-    "evolvesTo": [
-      "M Tyranitar-EX"
-    ],
+    "types": ["Darkness"],
+    "evolvesTo": ["M Tyranitar-EX"],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
       {
         "name": "Hammer In",
-        "cost": [
-          "Darkness",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Darkness", "Colorless", "Colorless"],
         "convertedEnergyCost": 3,
         "damage": "60",
         "text": ""
       },
       {
         "name": "Break Ground",
-        "cost": [
-          "Darkness",
-          "Darkness",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Darkness", "Darkness", "Colorless", "Colorless"],
         "convertedEnergyCost": 4,
         "damage": "130",
         "text": "This attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
@@ -5077,19 +3907,12 @@
         "value": "-20"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 4,
     "number": "91",
     "artist": "Ryo Ueda",
     "rarity": "Rare Ultra",
-    "nationalPokedexNumbers": [
-      248
-    ],
+    "nationalPokedexNumbers": [248],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -5103,14 +3926,9 @@
     "id": "xy7-92",
     "name": "M Tyranitar-EX",
     "supertype": "Pokémon",
-    "subtypes": [
-      "MEGA",
-      "EX"
-    ],
+    "subtypes": ["MEGA", "EX"],
     "hp": "240",
-    "types": [
-      "Darkness"
-    ],
+    "types": ["Darkness"],
     "evolvesFrom": "Tyranitar-EX",
     "rules": [
       "Mega Evolution rule: When 1 of your Pokémon becomes a Mega Evolution Pokémon, your turn ends.",
@@ -5123,12 +3941,7 @@
     "attacks": [
       {
         "name": "Destroyer King",
-        "cost": [
-          "Darkness",
-          "Darkness",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Darkness", "Darkness", "Colorless", "Colorless"],
         "convertedEnergyCost": 4,
         "damage": "110+",
         "text": "This attack does 60 more damage for each damage counter on your opponent's Active Pokémon."
@@ -5146,19 +3959,12 @@
         "value": "-20"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 4,
     "number": "92",
     "artist": "5ban Graphics",
     "rarity": "Rare Ultra",
-    "nationalPokedexNumbers": [
-      248
-    ],
+    "nationalPokedexNumbers": [248],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -5172,14 +3978,9 @@
     "id": "xy7-93",
     "name": "Giratina-EX",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic",
-      "EX"
-    ],
+    "subtypes": ["Basic", "EX"],
     "hp": "170",
-    "types": [
-      "Dragon"
-    ],
+    "types": ["Dragon"],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -5193,12 +3994,7 @@
     "attacks": [
       {
         "name": "Chaos Wheel",
-        "cost": [
-          "Grass",
-          "Psychic",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Grass", "Psychic", "Colorless", "Colorless"],
         "convertedEnergyCost": 4,
         "damage": "100",
         "text": "Your opponent can't play any Pokémon Tool, Special Energy, or Stadium cards from his or her hand during his or her next turn."
@@ -5210,18 +4006,12 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 3,
     "number": "93",
     "artist": "Ryo Ueda",
     "rarity": "Rare Ultra",
-    "nationalPokedexNumbers": [
-      487
-    ],
+    "nationalPokedexNumbers": [487],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -5235,36 +4025,23 @@
     "id": "xy7-94",
     "name": "Lugia-EX",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic",
-      "EX"
-    ],
+    "subtypes": ["Basic", "EX"],
     "hp": "170",
-    "types": [
-      "Colorless"
-    ],
+    "types": ["Colorless"],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
       {
         "name": "Aero Ball",
-        "cost": [
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Colorless", "Colorless"],
         "convertedEnergyCost": 2,
         "damage": "20×",
         "text": "This attack does 20 damage times the amount of Energy attached to both Active Pokémon."
       },
       {
         "name": "Deep Hurricane",
-        "cost": [
-          "Colorless",
-          "Colorless",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Colorless", "Colorless", "Colorless", "Colorless"],
         "convertedEnergyCost": 4,
         "damage": "80+",
         "text": "If there is any Stadium card in play, this attack does 70 more damage. Then, discard that Stadium card."
@@ -5282,17 +4059,12 @@
         "value": "-20"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless"],
     "convertedRetreatCost": 2,
     "number": "94",
     "artist": "Ryo Ueda",
     "rarity": "Rare Ultra",
-    "nationalPokedexNumbers": [
-      249
-    ],
+    "nationalPokedexNumbers": [249],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -5306,9 +4078,7 @@
     "id": "xy7-95",
     "name": "Steven",
     "supertype": "Trainer",
-    "subtypes": [
-      "Supporter"
-    ],
+    "subtypes": ["Supporter"],
     "rules": [
       "Search your deck for a Supporter card and a basic Energy card, reveal them, and put them into your hand. Shuffle your deck afterward.",
       "You may play only 1 Supporter card during your turn (before your attack)."
@@ -5329,14 +4099,9 @@
     "id": "xy7-96",
     "name": "Primal Kyogre-EX",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic",
-      "EX"
-    ],
+    "subtypes": ["Basic", "EX"],
     "hp": "240",
-    "types": [
-      "Water"
-    ],
+    "types": ["Water"],
     "evolvesFrom": "Kyogre-EX",
     "rules": [
       "Primal Reversion rule: When 1 of your Pokémon becomes Primal Kyogre-EX, your turn ends.",
@@ -5349,12 +4114,7 @@
     "attacks": [
       {
         "name": "Tidal Storm",
-        "cost": [
-          "Water",
-          "Water",
-          "Water",
-          "Colorless"
-        ],
+        "cost": ["Water", "Water", "Water", "Colorless"],
         "convertedEnergyCost": 4,
         "damage": "150",
         "text": "Move 2 Energy from this Pokémon to 1 of your Benched Pokémon. This attack does 30 damage to each of your opponent's Benched Pokémon-EX. (Don't apply Weakness and Resistance for Benched Pokémon.)"
@@ -5366,19 +4126,12 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 4,
     "number": "96",
     "artist": "5ban Graphics",
     "rarity": "Rare Secret",
-    "nationalPokedexNumbers": [
-      382
-    ],
+    "nationalPokedexNumbers": [382],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -5392,14 +4145,9 @@
     "id": "xy7-97",
     "name": "Primal Groudon-EX",
     "supertype": "Pokémon",
-    "subtypes": [
-      "Basic",
-      "EX"
-    ],
+    "subtypes": ["Basic", "EX"],
     "hp": "240",
-    "types": [
-      "Fighting"
-    ],
+    "types": ["Fighting"],
     "evolvesFrom": "Groudon-EX",
     "rules": [
       "Primal Reversion rule: When 1 of your Pokémon becomes Primal Groudon-EX, your turn ends.",
@@ -5412,12 +4160,7 @@
     "attacks": [
       {
         "name": "Gaia Volcano",
-        "cost": [
-          "Fighting",
-          "Fighting",
-          "Fighting",
-          "Colorless"
-        ],
+        "cost": ["Fighting", "Fighting", "Fighting", "Colorless"],
         "convertedEnergyCost": 4,
         "damage": "100+",
         "text": "If there is any Stadium card in play, this attack does 100 more damage. Discard that Stadium card."
@@ -5429,19 +4172,12 @@
         "value": "×2"
       }
     ],
-    "retreatCost": [
-      "Colorless",
-      "Colorless",
-      "Colorless",
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless", "Colorless", "Colorless", "Colorless"],
     "convertedRetreatCost": 4,
     "number": "97",
     "artist": "5ban Graphics",
     "rarity": "Rare Secret",
-    "nationalPokedexNumbers": [
-      383
-    ],
+    "nationalPokedexNumbers": [383],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -5455,14 +4191,9 @@
     "id": "xy7-98",
     "name": "M Rayquaza-EX",
     "supertype": "Pokémon",
-    "subtypes": [
-      "MEGA",
-      "EX"
-    ],
+    "subtypes": ["MEGA", "EX"],
     "hp": "220",
-    "types": [
-      "Colorless"
-    ],
+    "types": ["Colorless"],
     "evolvesFrom": "Rayquaza-EX",
     "rules": [
       "Mega Evolution rule: When 1 of your Pokémon becomes a Mega Evolution Pokémon, your turn ends.",
@@ -5475,11 +4206,7 @@
     "attacks": [
       {
         "name": "Emerald Break",
-        "cost": [
-          "Colorless",
-          "Colorless",
-          "Colorless"
-        ],
+        "cost": ["Colorless", "Colorless", "Colorless"],
         "convertedEnergyCost": 3,
         "damage": "30×",
         "text": "This attack does 30 damage times the number of your Benched Pokémon."
@@ -5497,16 +4224,12 @@
         "value": "-20"
       }
     ],
-    "retreatCost": [
-      "Colorless"
-    ],
+    "retreatCost": ["Colorless"],
     "convertedRetreatCost": 1,
     "number": "98",
     "artist": "5ban Graphics",
     "rarity": "Rare Secret",
-    "nationalPokedexNumbers": [
-      384
-    ],
+    "nationalPokedexNumbers": [384],
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -5520,9 +4243,7 @@
     "id": "xy7-99",
     "name": "Energy Retrieval",
     "supertype": "Trainer",
-    "subtypes": [
-      "Item"
-    ],
+    "subtypes": ["Item"],
     "rules": [
       "Put 2 basic Energy cards from your discard pile into your hand.",
       "You may play as many Item cards as you like during your turn (before your attack)."
@@ -5543,9 +4264,7 @@
     "id": "xy7-100",
     "name": "Trainers' Mail",
     "supertype": "Trainer",
-    "subtypes": [
-      "Item"
-    ],
+    "subtypes": ["Item"],
     "rules": [
       "Look at the top 4 cards of your deck. You may reveal a Trainer card you find there (except Trainers' Mail) and put it into your hand. Shuffle the other cards back into your deck.",
       "You may play as many Item cards as you like during your turn (before your attack)."


### PR DESCRIPTION
There was a typo on xy7-4 incorrectly referring to the first attack name as 'Windwill' instead of 'Windmill'