### PR TITLE
Fixing card legalities

### DIFF
--- a/cards/en/base1.json
+++ b/cards/en/base1.json
@@ -2810,7 +2810,8 @@
       10
     ],
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/45.png",
@@ -4180,7 +4181,8 @@
       13
     ],
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/69.png",
@@ -4397,7 +4399,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/81.png",
@@ -4433,7 +4437,8 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/83.png",
@@ -4451,7 +4456,8 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/84.png",
@@ -4505,7 +4511,8 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/87.png",
@@ -4631,7 +4638,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/94.png",
@@ -4649,7 +4658,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/95.png",
@@ -4670,7 +4681,8 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/96.png",
@@ -4688,7 +4700,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/97.png",
@@ -4706,7 +4720,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/98.png",
@@ -4724,7 +4740,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/99.png",
@@ -4742,7 +4760,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/100.png",
@@ -4760,7 +4780,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/101.png",
@@ -4778,7 +4800,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/102.png",

--- a/cards/en/base2.json
+++ b/cards/en/base2.json
@@ -3947,7 +3947,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base2/64.png",

--- a/cards/en/base3.json
+++ b/cards/en/base3.json
@@ -3419,7 +3419,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base3/59.png",
@@ -3455,7 +3457,8 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base3/61.png",

--- a/cards/en/base4.json
+++ b/cards/en/base4.json
@@ -4273,7 +4273,8 @@
       10
     ],
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/68.png",
@@ -6147,7 +6148,8 @@
       13
     ],
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/100.png",
@@ -6327,7 +6329,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/110.png",
@@ -6363,7 +6367,8 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/112.png",
@@ -6381,7 +6386,8 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/113.png",
@@ -6417,7 +6423,8 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/115.png",
@@ -6525,7 +6532,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/121.png",
@@ -6543,7 +6552,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/122.png",
@@ -6561,7 +6572,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/123.png",
@@ -6582,7 +6595,8 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/124.png",
@@ -6600,7 +6614,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/125.png",
@@ -6618,7 +6634,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/126.png",
@@ -6636,7 +6654,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/127.png",
@@ -6654,7 +6674,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/128.png",
@@ -6672,7 +6694,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/129.png",
@@ -6690,7 +6714,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/130.png",

--- a/cards/en/base6.json
+++ b/cards/en/base6.json
@@ -4258,7 +4258,8 @@
       10
     ],
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base6/69.png",
@@ -6001,7 +6002,8 @@
       13
     ],
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base6/99.png",
@@ -6151,7 +6153,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base6/107.png",
@@ -6206,7 +6210,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base6/110.png",

--- a/cards/en/basep.json
+++ b/cards/en/basep.json
@@ -1604,7 +1604,8 @@
       25
     ],
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/basep/28.png",

--- a/cards/en/bw1.json
+++ b/cards/en/bw1.json
@@ -5577,6 +5577,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5600,6 +5601,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5623,6 +5625,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5646,6 +5649,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5692,6 +5696,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5738,6 +5743,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5761,6 +5767,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5853,6 +5860,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5871,6 +5879,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5889,6 +5898,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5908,6 +5918,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5926,6 +5937,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5944,6 +5956,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5962,6 +5975,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5980,6 +5994,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5998,6 +6013,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/bw10.json
+++ b/cards/en/bw10.json
@@ -4757,6 +4757,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -4826,6 +4827,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -4872,6 +4874,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5695,6 +5698,7 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/bw11.json
+++ b/cards/en/bw11.json
@@ -6564,6 +6564,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -6587,6 +6588,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/bw2.json
+++ b/cards/en/bw2.json
@@ -5587,6 +5587,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5610,6 +5611,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5656,6 +5658,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/bw3.json
+++ b/cards/en/bw3.json
@@ -5402,6 +5402,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/bw4.json
+++ b/cards/en/bw4.json
@@ -5217,6 +5217,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5263,6 +5264,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/bw5.json
+++ b/cards/en/bw5.json
@@ -5795,6 +5795,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -6385,6 +6386,7 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/bw6.json
+++ b/cards/en/bw6.json
@@ -6900,6 +6900,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/bw7.json
+++ b/cards/en/bw7.json
@@ -7631,6 +7631,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7654,6 +7655,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7700,6 +7702,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7723,6 +7726,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7747,6 +7751,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7770,6 +7775,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7793,6 +7799,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -8375,6 +8382,7 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -8586,6 +8594,7 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/bw8.json
+++ b/cards/en/bw8.json
@@ -7127,6 +7127,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/col1.json
+++ b/cards/en/col1.json
@@ -3634,7 +3634,9 @@
       129
     ],
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/col1/61.png",
@@ -4517,7 +4519,8 @@
     "artist": "Kanako Eo",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/col1/77.png",
@@ -4749,7 +4752,9 @@
     "number": "88",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/col1/88.png",
@@ -4766,7 +4771,9 @@
     "number": "89",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/col1/89.png",
@@ -4783,7 +4790,9 @@
     "number": "90",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/col1/90.png",
@@ -4800,7 +4809,9 @@
     "number": "91",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/col1/91.png",
@@ -4817,7 +4828,9 @@
     "number": "92",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/col1/92.png",
@@ -4834,7 +4847,9 @@
     "number": "93",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/col1/93.png",
@@ -4851,7 +4866,9 @@
     "number": "94",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/col1/94.png",
@@ -4868,7 +4885,9 @@
     "number": "95",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/col1/95.png",

--- a/cards/en/dp1.json
+++ b/cards/en/dp1.json
@@ -6570,7 +6570,9 @@
     "artist": "Ryo Ueda",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/107.png",
@@ -6613,7 +6615,8 @@
     "artist": "Ryo Ueda",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/109.png",
@@ -6634,7 +6637,9 @@
     "artist": "Shin-ichi Yoshikawa",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/110.png",
@@ -6742,7 +6747,8 @@
     "artist": "Shizurow",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/115.png",
@@ -6784,7 +6790,9 @@
     "artist": "Kai Ishikawa",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/117.png",
@@ -6805,7 +6813,9 @@
     "artist": "Shin-ichi Yoshikawa",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/118.png",
@@ -6826,7 +6836,9 @@
     "artist": "Ryo Ueda",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/119.png",
@@ -7023,7 +7035,9 @@
     "number": "123",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/123.png",
@@ -7040,7 +7054,9 @@
     "number": "124",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/124.png",
@@ -7057,7 +7073,9 @@
     "number": "125",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/125.png",
@@ -7074,7 +7092,9 @@
     "number": "126",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/126.png",
@@ -7091,7 +7111,9 @@
     "number": "127",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/127.png",
@@ -7108,7 +7130,9 @@
     "number": "128",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/128.png",
@@ -7125,7 +7149,9 @@
     "number": "129",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/129.png",
@@ -7142,7 +7168,9 @@
     "number": "130",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/130.png",

--- a/cards/en/dp2.json
+++ b/cards/en/dp2.json
@@ -6659,7 +6659,9 @@
     "artist": "Ryo Ueda",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp2/114.png",

--- a/cards/en/dp3.json
+++ b/cards/en/dp3.json
@@ -7360,14 +7360,15 @@
       "Item"
     ],
     "rules": [
-      "Attach Plus Power to 1 of your Pokémon. Discard this card at the end of your turn.",
+      "Attach PlusPower to 1 of your Pokémon. Discard this card at the end of your turn.",
       "If the Pokémon PlusPower is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance)."
     ],
     "number": "121",
     "artist": "Ryo Ueda",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp3/121.png",
@@ -7498,7 +7499,9 @@
     "artist": "Shin-ichi Yoshikawa",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp3/127.png",
@@ -7519,7 +7522,9 @@
     "artist": "Ryo Ueda",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp3/128.png",

--- a/cards/en/dp4.json
+++ b/cards/en/dp4.json
@@ -6004,7 +6004,9 @@
     "artist": "Ryo Ueda",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp4/102.png",

--- a/cards/en/dp5.json
+++ b/cards/en/dp5.json
@@ -5037,7 +5037,9 @@
     "artist": "Ryo Ueda",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp5/85.png",
@@ -5058,7 +5060,9 @@
     "artist": "Ryo Ueda",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp5/86.png",
@@ -5079,7 +5083,8 @@
     "artist": "Shizurow",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp5/87.png",
@@ -5150,7 +5155,9 @@
     "artist": "Ryo Ueda",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp5/90.png",

--- a/cards/en/dp7.json
+++ b/cards/en/dp7.json
@@ -5504,7 +5504,9 @@
     "artist": "Ryo Ueda",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp7/84.png",
@@ -5525,7 +5527,9 @@
     "artist": "Kent Kanetsuna",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp7/85.png",
@@ -5673,7 +5677,9 @@
     "artist": "Shin-ichi Yoshikawa",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp7/92.png",
@@ -5694,7 +5700,9 @@
     "artist": "Ryo Ueda",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp7/93.png",
@@ -5736,7 +5744,8 @@
     "artist": "Takumi Akabane",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp7/95.png",

--- a/cards/en/dv1.json
+++ b/cards/en/dv1.json
@@ -1047,6 +1047,7 @@
     "artist": "Ryo Ueda",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/ecard1.json
+++ b/cards/en/ecard1.json
@@ -7884,7 +7884,8 @@
     "artist": "Ken Sugimori",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard1/137.png",
@@ -7906,7 +7907,8 @@
     "artist": "Ken Sugimori",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard1/138.png",
@@ -8174,7 +8176,8 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard1/151.png",
@@ -8210,7 +8213,9 @@
     "artist": "Kai Ishikawa",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard1/153.png",
@@ -8228,7 +8233,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard1/154.png",
@@ -8264,7 +8271,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard1/156.png",
@@ -8282,7 +8291,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard1/157.png",
@@ -8341,7 +8352,9 @@
     "number": "160",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard1/160.png",
@@ -8358,7 +8371,9 @@
     "number": "161",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard1/161.png",
@@ -8375,7 +8390,9 @@
     "number": "162",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard1/162.png",
@@ -8392,7 +8409,9 @@
     "number": "163",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard1/163.png",
@@ -8409,7 +8428,9 @@
     "number": "164",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard1/164.png",
@@ -8426,7 +8447,9 @@
     "number": "165",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard1/165.png",

--- a/cards/en/ecard2.json
+++ b/cards/en/ecard2.json
@@ -8778,7 +8778,9 @@
     "artist": "Mikio Menjo",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard2/120.png",
@@ -9366,7 +9368,8 @@
     "artist": "Takumi Akabane",
     "rarity": "Rare",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard2/144.png",
@@ -9429,7 +9432,8 @@
     "artist": "Shin-ichi Yoshikawa",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard2/147.png",

--- a/cards/en/ecard3.json
+++ b/cards/en/ecard3.json
@@ -9143,7 +9143,8 @@
     "artist": "Kagemaru Himeno",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard3/125.png",
@@ -9179,7 +9180,9 @@
     "artist": "Katsura Tabata",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard3/127.png",
@@ -9197,7 +9200,8 @@
     "artist": "Katsura Tabata",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard3/128.png",
@@ -9537,7 +9541,8 @@
     "artist": "Kagemaru Himeno",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard3/140.png",

--- a/cards/en/ex1.json
+++ b/cards/en/ex1.json
@@ -4777,7 +4777,9 @@
     "artist": "Ken Ikuji",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex1/82.png",
@@ -4821,7 +4823,9 @@
     "artist": "Kazuo Yazawa",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex1/84.png",
@@ -4864,7 +4868,9 @@
     "artist": "K. Hoshiba",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex1/86.png",
@@ -4949,7 +4955,9 @@
     "artist": "Kai Ishikawa",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex1/90.png",
@@ -4970,7 +4978,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex1/91.png",
@@ -4991,7 +5001,9 @@
     "artist": "Hiromichi Sugiyama",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex1/92.png",
@@ -5054,7 +5066,8 @@
     "artist": "Takumi Akabane",
     "rarity": "Rare",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex1/95.png",
@@ -5610,7 +5623,9 @@
     "number": "104",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex1/104.png",
@@ -5627,7 +5642,9 @@
     "number": "105",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex1/105.png",
@@ -5644,7 +5661,9 @@
     "number": "106",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex1/106.png",
@@ -5661,7 +5680,9 @@
     "number": "107",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex1/107.png",
@@ -5678,7 +5699,9 @@
     "number": "108",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex1/108.png",
@@ -5695,7 +5718,9 @@
     "number": "109",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex1/109.png",

--- a/cards/en/ex10.json
+++ b/cards/en/ex10.json
@@ -4752,7 +4752,8 @@
     "artist": "Zu-Ka",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex10/81.png",
@@ -4816,7 +4817,9 @@
     "artist": "Ken Ikuji",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex10/84.png",
@@ -4881,7 +4884,9 @@
     "artist": "Shin-ichi Yoshikawa",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex10/87.png",
@@ -4968,7 +4973,9 @@
     "artist": "Ryo Ueda",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex10/91.png",
@@ -5032,7 +5039,9 @@
     "artist": "Kai Ishikawa",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex10/94.png",
@@ -5053,7 +5062,9 @@
     "artist": "Shin-ichi Yoshikawa",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex10/95.png",
@@ -5158,7 +5169,8 @@
     "artist": "Shin-ichi Yoshikawa",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex10/100.png",

--- a/cards/en/ex11.json
+++ b/cards/en/ex11.json
@@ -5366,7 +5366,9 @@
     "artist": "Nakaoka",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex11/90.png",
@@ -5585,7 +5587,8 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex11/100.png",
@@ -5606,7 +5609,9 @@
     "artist": "Shin-ichi Yoshikawa",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex11/101.png",
@@ -5627,7 +5632,9 @@
     "artist": "Hiromichi Sugiyama",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex11/102.png",

--- a/cards/en/ex12.json
+++ b/cards/en/ex12.json
@@ -4607,7 +4607,8 @@
     "artist": "Takumi Akabane",
     "rarity": "Rare",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex12/81.png",

--- a/cards/en/ex13.json
+++ b/cards/en/ex13.json
@@ -5166,7 +5166,9 @@
     "artist": "Ryo Ueda",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex13/90.png",
@@ -5757,7 +5759,9 @@
     "number": "105",
     "rarity": "Rare Holo",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex13/105.png",
@@ -5774,7 +5778,9 @@
     "number": "106",
     "rarity": "Rare Holo",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex13/106.png",
@@ -5791,7 +5797,9 @@
     "number": "107",
     "rarity": "Rare Holo",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex13/107.png",
@@ -5808,7 +5816,9 @@
     "number": "108",
     "rarity": "Rare Holo",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex13/108.png",
@@ -5825,7 +5835,9 @@
     "number": "109",
     "rarity": "Rare Holo",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex13/109.png",
@@ -5842,7 +5854,9 @@
     "number": "110",
     "rarity": "Rare Holo",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex13/110.png",

--- a/cards/en/ex14.json
+++ b/cards/en/ex14.json
@@ -4250,7 +4250,8 @@
     "artist": "Ken Sugimori",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex14/71.png",
@@ -4489,7 +4490,9 @@
     "artist": "Shin-ichi Yoshikawa",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex14/82.png",
@@ -4573,7 +4576,9 @@
     "artist": "Kai Ishikawa",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex14/86.png",
@@ -4594,7 +4599,9 @@
     "artist": "Shin-ichi Yoshikawa",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex14/87.png",

--- a/cards/en/ex15.json
+++ b/cards/en/ex15.json
@@ -4070,7 +4070,8 @@
     "artist": "Ken Sugimori",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex15/73.png",
@@ -4268,7 +4269,8 @@
     "artist": "Ken Sugimori",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex15/82.png",
@@ -4289,7 +4291,9 @@
     "artist": "Hiromichi Sugiyama",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex15/83.png",

--- a/cards/en/ex16.json
+++ b/cards/en/ex16.json
@@ -4284,7 +4284,8 @@
     "artist": "Zu-Ka",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex16/73.png",
@@ -4326,7 +4327,9 @@
     "artist": "Ken Ikuji",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex16/75.png",
@@ -4369,7 +4372,9 @@
     "artist": "Nakaoka",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex16/77.png",
@@ -4686,7 +4691,8 @@
     "artist": "Shin-ichi Yoshikawa",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex16/91.png",
@@ -5443,7 +5449,9 @@
     "number": "103",
     "rarity": "Rare Holo",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex16/103.png",
@@ -5460,7 +5468,9 @@
     "number": "104",
     "rarity": "Rare Holo",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex16/104.png",
@@ -5477,7 +5487,9 @@
     "number": "105",
     "rarity": "Rare Holo",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex16/105.png",
@@ -5494,7 +5506,9 @@
     "number": "106",
     "rarity": "Rare Holo",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex16/106.png",
@@ -5511,7 +5525,9 @@
     "number": "107",
     "rarity": "Rare Holo",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex16/107.png",
@@ -5528,7 +5544,9 @@
     "number": "108",
     "rarity": "Rare Holo",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex16/108.png",

--- a/cards/en/ex2.json
+++ b/cards/en/ex2.json
@@ -5050,7 +5050,9 @@
     "artist": "Ryo Ueda",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex2/88.png",

--- a/cards/en/ex3.json
+++ b/cards/en/ex3.json
@@ -4858,7 +4858,8 @@
     "artist": "Zu-Ka",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex3/84.png",
@@ -4946,7 +4947,8 @@
     "artist": "Ken Sugimori",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex3/88.png",

--- a/cards/en/ex6.json
+++ b/cards/en/ex6.json
@@ -5119,7 +5119,8 @@
     "artist": "Ken Sugimori",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex6/87.png",
@@ -5183,7 +5184,9 @@
     "artist": "Ken Ikuji",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex6/90.png",
@@ -5226,7 +5229,9 @@
     "artist": "Nakaoka",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex6/92.png",
@@ -5290,7 +5295,9 @@
     "artist": "K. Hoshiba",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex6/95.png",
@@ -5375,7 +5382,8 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex6/99.png",
@@ -5396,7 +5404,8 @@
     "artist": "K. Utsunomiya",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex6/100.png",
@@ -5417,7 +5426,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex6/101.png",
@@ -5438,7 +5449,9 @@
     "artist": "Hiromichi Sugiyama",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex6/102.png",

--- a/cards/en/ex7.json
+++ b/cards/en/ex7.json
@@ -4982,7 +4982,8 @@
     "artist": "Ken Sugimori",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex7/83.png",
@@ -6304,7 +6305,8 @@
     "artist": "Ken Sugimori",
     "rarity": "Rare Secret",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex7/111.png",

--- a/cards/en/ex9.json
+++ b/cards/en/ex9.json
@@ -4403,7 +4403,9 @@
     "artist": "Kazuo Yazawa",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex9/78.png",
@@ -4511,7 +4513,9 @@
     "artist": "Ryo Ueda",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex9/83.png",
@@ -5396,7 +5400,9 @@
     "number": "101",
     "rarity": "Rare Holo",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex9/101.png",
@@ -5413,7 +5419,9 @@
     "number": "102",
     "rarity": "Rare Holo",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex9/102.png",
@@ -5430,7 +5438,9 @@
     "number": "103",
     "rarity": "Rare Holo",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex9/103.png",
@@ -5447,7 +5457,9 @@
     "number": "104",
     "rarity": "Rare Holo",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex9/104.png",
@@ -5464,7 +5476,9 @@
     "number": "105",
     "rarity": "Rare Holo",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex9/105.png",
@@ -5481,7 +5495,9 @@
     "number": "106",
     "rarity": "Rare Holo",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex9/106.png",

--- a/cards/en/g1.json
+++ b/cards/en/g1.json
@@ -3650,6 +3650,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -3673,6 +3674,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -3810,6 +3812,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -3833,6 +3836,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -4011,6 +4015,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -4029,6 +4034,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -4047,6 +4053,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -4065,6 +4072,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -4083,6 +4091,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -4101,6 +4110,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -4119,6 +4129,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -4137,6 +4148,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -4155,6 +4167,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/gym1.json
+++ b/cards/en/gym1.json
@@ -6063,7 +6063,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/gym1/127.png",
@@ -6081,7 +6083,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/gym1/128.png",
@@ -6099,7 +6103,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/gym1/129.png",
@@ -6117,7 +6123,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/gym1/130.png",
@@ -6135,7 +6143,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/gym1/131.png",
@@ -6153,7 +6163,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/gym1/132.png",

--- a/cards/en/gym2.json
+++ b/cards/en/gym2.json
@@ -6275,7 +6275,9 @@
     "number": "127",
     "artist": "Keiji Kinebuchi",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/gym2/127.png",
@@ -6293,7 +6295,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/gym2/128.png",
@@ -6311,7 +6315,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/gym2/129.png",
@@ -6329,7 +6335,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/gym2/130.png",
@@ -6347,7 +6355,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/gym2/131.png",
@@ -6365,7 +6375,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/gym2/132.png",

--- a/cards/en/hgss1.json
+++ b/cards/en/hgss1.json
@@ -4232,7 +4232,9 @@
       129
     ],
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/72.png",
@@ -5243,7 +5245,8 @@
     "artist": "Kanako Eo",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/90.png",
@@ -5261,7 +5264,9 @@
     "artist": "Wataru Kawahara",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/91.png",
@@ -5283,7 +5288,8 @@
     "artist": "Kanako Eo",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/92.png",
@@ -5304,7 +5310,9 @@
     "artist": "Takashi Yamaguchi",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/93.png",
@@ -5325,7 +5333,8 @@
     "artist": "Noriko Hotta",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/94.png",
@@ -5346,7 +5355,9 @@
     "artist": "Hideaki Hakozaki",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/95.png",
@@ -5367,7 +5378,9 @@
     "artist": "Noriko Hotta",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/96.png",
@@ -5410,7 +5423,9 @@
     "artist": "Takashi Yamaguchi",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/98.png",
@@ -5496,7 +5511,9 @@
     "artist": "Hideaki Hakozaki",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/102.png",
@@ -5517,7 +5534,8 @@
     "artist": "Kent Kanetsuna",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/103.png",
@@ -5538,7 +5556,8 @@
     "artist": "Kent Kanetsuna",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/104.png",
@@ -6197,7 +6216,9 @@
     "number": "115",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/115.png",
@@ -6214,7 +6235,9 @@
     "number": "116",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/116.png",
@@ -6231,7 +6254,9 @@
     "number": "117",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/117.png",
@@ -6248,7 +6273,9 @@
     "number": "118",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/118.png",
@@ -6265,7 +6292,9 @@
     "number": "119",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/119.png",
@@ -6282,7 +6311,9 @@
     "number": "120",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/120.png",
@@ -6299,7 +6330,9 @@
     "number": "121",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/121.png",
@@ -6316,7 +6349,9 @@
     "number": "122",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/122.png",

--- a/cards/en/hgss2.json
+++ b/cards/en/hgss2.json
@@ -4371,7 +4371,8 @@
     "artist": "Kouki Saitou",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss2/78.png",
@@ -4392,7 +4393,8 @@
     "artist": "Hideaki Hakozaki",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss2/79.png",
@@ -4414,7 +4416,8 @@
     "artist": "Takashi Yamaguchi",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss2/80.png",
@@ -4456,7 +4459,9 @@
     "artist": "Noriko Hotta",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss2/82.png",

--- a/cards/en/neo1.json
+++ b/cards/en/neo1.json
@@ -5231,7 +5231,8 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/neo1/98.png",
@@ -5386,7 +5387,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/neo1/106.png",
@@ -5404,7 +5407,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/neo1/107.png",
@@ -5422,7 +5427,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/neo1/108.png",
@@ -5440,7 +5447,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/neo1/109.png",
@@ -5458,7 +5467,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/neo1/110.png",
@@ -5476,7 +5487,9 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/neo1/111.png",

--- a/cards/en/pl1.json
+++ b/cards/en/pl1.json
@@ -6660,7 +6660,8 @@
     "artist": "Ryo Ueda",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/pl1/108.png",
@@ -6748,7 +6749,8 @@
     "artist": "Ryo Ueda",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/pl1/112.png",
@@ -6769,7 +6771,9 @@
     "artist": "Ryo Ueda",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/pl1/113.png",
@@ -6954,7 +6958,8 @@
     "artist": "Takumi Akabane",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/pl1/121.png",

--- a/cards/en/pl2.json
+++ b/cards/en/pl2.json
@@ -6643,7 +6643,8 @@
       25
     ],
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/pl2/114.png",

--- a/cards/en/pl3.json
+++ b/cards/en/pl3.json
@@ -8394,7 +8394,8 @@
     "artist": "Wataru Kawahara",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/pl3/140.png",

--- a/cards/en/pl4.json
+++ b/cards/en/pl4.json
@@ -5303,7 +5303,9 @@
     "artist": "Nobuyuki Fujimoto",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/pl4/88.png",

--- a/cards/en/pop2.json
+++ b/cards/en/pop2.json
@@ -499,7 +499,8 @@
     "artist": "Ken Sugimori",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/pop2/11.png",

--- a/cards/en/pop5.json
+++ b/cards/en/pop5.json
@@ -271,7 +271,8 @@
     "artist": "Ken Sugimori",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/pop5/6.png",
@@ -289,7 +290,9 @@
     "artist": "Ryo Ueda",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/pop5/7.png",

--- a/cards/en/pop8.json
+++ b/cards/en/pop8.json
@@ -544,7 +544,9 @@
     "artist": "Ryo Ueda",
     "rarity": "Uncommon",
     "legalities": {
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/pop8/10.png",

--- a/cards/en/sm1.json
+++ b/cards/en/sm1.json
@@ -7145,6 +7145,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7168,6 +7169,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7191,6 +7193,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7215,6 +7218,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7238,6 +7242,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7377,6 +7382,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7400,6 +7406,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7423,6 +7430,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7469,6 +7477,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7538,6 +7547,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -9018,6 +9028,7 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -9059,6 +9070,7 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -9077,6 +9089,7 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -9095,6 +9108,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -9113,6 +9127,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -9131,6 +9146,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -9149,6 +9165,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -9167,6 +9184,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -9185,6 +9203,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -9203,6 +9222,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -9221,6 +9241,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -9239,6 +9260,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/sm2.json
+++ b/cards/en/sm2.json
@@ -7647,6 +7647,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -10159,6 +10160,7 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -10198,6 +10200,7 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -10216,6 +10219,7 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -10234,6 +10238,7 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/sm3.json
+++ b/cards/en/sm3.json
@@ -7329,6 +7329,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -9915,6 +9916,7 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -9933,6 +9935,7 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -9951,6 +9954,7 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/sm35.json
+++ b/cards/en/sm35.json
@@ -3608,6 +3608,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -3631,6 +3632,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -3723,6 +3725,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -3792,6 +3795,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/sm4.json
+++ b/cards/en/sm4.json
@@ -7371,6 +7371,7 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/sm5.json
+++ b/cards/en/sm5.json
@@ -7584,6 +7584,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7632,6 +7633,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -9384,6 +9386,7 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/sm6.json
+++ b/cards/en/sm6.json
@@ -6604,6 +6604,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -8173,6 +8174,7 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/sm7.json
+++ b/cards/en/sm7.json
@@ -7636,6 +7636,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7936,6 +7937,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -8051,6 +8053,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/sm75.json
+++ b/cards/en/sm75.json
@@ -3485,6 +3485,7 @@
     "rarity": "Rare Holo",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/swsh6.json
+++ b/cards/en/swsh6.json
@@ -11794,7 +11794,6 @@
     "supertype": "Trainer",
     "subtypes": [
       "Item",
-      "V",
       "Single Strike"
     ],
     "rules": [

--- a/cards/en/xy0.json
+++ b/cards/en/xy0.json
@@ -1963,6 +1963,7 @@
     "artist": "5ban Graphics",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -1985,6 +1986,7 @@
     "artist": "5ban Graphics",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -2007,6 +2009,7 @@
     "artist": "5ban Graphics",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -2029,6 +2032,7 @@
     "artist": "5ban Graphics",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/xy1.json
+++ b/cards/en/xy1.json
@@ -7078,6 +7078,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7395,6 +7396,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7413,6 +7415,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7431,6 +7434,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7449,6 +7453,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7467,6 +7472,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7485,6 +7491,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7503,6 +7510,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7521,6 +7529,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7539,6 +7548,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/xy12.json
+++ b/cards/en/xy12.json
@@ -4377,6 +4377,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -4447,6 +4448,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -4470,6 +4472,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -4516,6 +4519,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -4586,6 +4590,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -4702,6 +4707,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -4766,6 +4772,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -4784,6 +4791,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -4802,6 +4810,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -4820,6 +4829,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -4838,6 +4848,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -4856,6 +4867,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -4874,6 +4886,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -4892,6 +4905,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -4910,6 +4924,7 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5379,6 +5394,7 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5402,6 +5418,7 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5629,8 +5646,6 @@
       84
     ],
     "legalities": {
-      "unlimited": "Legal",
-      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/112.png",

--- a/cards/en/xy2.json
+++ b/cards/en/xy2.json
@@ -5507,6 +5507,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5530,6 +5531,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/xy3.json
+++ b/cards/en/xy3.json
@@ -5476,6 +5476,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5569,6 +5570,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/xy5.json
+++ b/cards/en/xy5.json
@@ -7525,6 +7525,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7548,6 +7549,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7572,6 +7574,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7737,6 +7740,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -8913,6 +8917,7 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/xy6.json
+++ b/cards/en/xy6.json
@@ -5346,6 +5346,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -6152,6 +6153,7 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/xy7.json
+++ b/cards/en/xy7.json
@@ -4304,6 +4304,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -4396,6 +4397,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5532,6 +5534,7 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/xy8.json
+++ b/cards/en/xy8.json
@@ -8304,6 +8304,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/xy9.json
+++ b/cards/en/xy9.json
@@ -5747,6 +5747,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5840,6 +5841,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5863,6 +5865,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5886,6 +5889,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -6614,6 +6618,7 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {


### PR DESCRIPTION
This is a general fix for card legalities, mostly for legacy set cards that have been reprinted. Fixes issues #208 and #210 (unrelated small fix) but makes issue #130 perhaps more urgent, as there are legal cards that work completely differently than what the API shows.

PokéGym's lists have been used as a source for legality, but I found a couple of errors there, which I have reported to their admin.