### PR TITLE
Replaced instances of \xa0 with a regular space due to uniqueness issues

### DIFF
--- a/cards/en/hgss2.json
+++ b/cards/en/hgss2.json
@@ -4990,7 +4990,7 @@
       }
     ],
     "number": "91",
-    "artist": "Shinji Higuchi + Sachiko Eba",
+    "artist": "Shinji Higuchi + Sachiko Eba",
     "rarity": "LEGEND",
     "nationalPokedexNumbers": [
       243
@@ -5195,7 +5195,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "94",
-    "artist": "Shinji Higuchi + Sachiko Eba",
+    "artist": "Shinji Higuchi + Sachiko Eba",
     "rarity": "LEGEND",
     "nationalPokedexNumbers": [
       244
@@ -5264,7 +5264,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "95",
-    "artist": "Shinji Higuchi + Sachiko Eba",
+    "artist": "Shinji Higuchi + Sachiko Eba",
     "rarity": "LEGEND",
     "nationalPokedexNumbers": [
       244

--- a/cards/en/hgss3.json
+++ b/cards/en/hgss3.json
@@ -2216,7 +2216,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "36",
-    "artist": "Wataru Kawahara/Direc. Shinji Higuchi",
+    "artist": "Wataru Kawahara/Direc. Shinji Higuchi",
     "rarity": "Uncommon",
     "flavorText": "When it moves, it leaves only a blur. If it hides in grass, its protective colors make it invisible.",
     "nationalPokedexNumbers": [
@@ -4908,7 +4908,7 @@
     ],
     "convertedRetreatCost": 3,
     "number": "87",
-    "artist": "Shinji Higuchi + Sachiko Eba",
+    "artist": "Shinji Higuchi + Sachiko Eba",
     "rarity": "LEGEND",
     "nationalPokedexNumbers": [
       382
@@ -4980,7 +4980,7 @@
     ],
     "convertedRetreatCost": 3,
     "number": "88",
-    "artist": "Shinji Higuchi + Sachiko Eba",
+    "artist": "Shinji Higuchi + Sachiko Eba",
     "rarity": "LEGEND",
     "nationalPokedexNumbers": [
       382
@@ -5047,7 +5047,7 @@
     ],
     "convertedRetreatCost": 3,
     "number": "89",
-    "artist": "Shinji Higuchi + Sachiko Eba",
+    "artist": "Shinji Higuchi + Sachiko Eba",
     "rarity": "LEGEND",
     "nationalPokedexNumbers": [
       384
@@ -5114,7 +5114,7 @@
     ],
     "convertedRetreatCost": 3,
     "number": "90",
-    "artist": "Shinji Higuchi + Sachiko Eba",
+    "artist": "Shinji Higuchi + Sachiko Eba",
     "rarity": "LEGEND",
     "nationalPokedexNumbers": [
       384

--- a/cards/en/hgss4.json
+++ b/cards/en/hgss4.json
@@ -5905,7 +5905,7 @@
     ],
     "convertedRetreatCost": 3,
     "number": "101",
-    "artist": "Shinji Higuchi + Sachiko Eba",
+    "artist": "Shinji Higuchi + Sachiko Eba",
     "rarity": "LEGEND",
     "nationalPokedexNumbers": [
       483
@@ -5975,7 +5975,7 @@
     ],
     "convertedRetreatCost": 3,
     "number": "102",
-    "artist": "Shinji Higuchi + Sachiko Eba",
+    "artist": "Shinji Higuchi + Sachiko Eba",
     "rarity": "LEGEND",
     "nationalPokedexNumbers": [
       483

--- a/cards/en/swsh7.json
+++ b/cards/en/swsh7.json
@@ -1951,7 +1951,7 @@
       "abilities": [
         {
           "name": "Enthusiastic Dance",
-          "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may use this Ability. During this turn, your Basic Pokémon's attacks do 100 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
+          "text": "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may use this Ability. During this turn, your Basic Pokémon's attacks do 100 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
           "type": "Ability"
         }
       ],
@@ -4940,7 +4940,7 @@
           ],
           "convertedEnergyCost": 2,
           "damage": "",
-          "text": "Put 2 damage counters on 1 of your opponent's Pokémon. If your opponent's Pokémon is Knocked Out by this attack, take another turn after this one. (Skip Pokémon Checkup.) If 1 of your Pokémon used Yoga Loop during your last turn, this attack can't be used."
+          "text": "Put 2 damage counters on 1 of your opponent's Pokémon. If your opponent's Pokémon is Knocked Out by this attack, take another turn after this one. (Skip Pokémon Checkup.) If 1 of your Pokémon used Yoga Loop during your last turn, this attack can't be used."
         },
         {
           "name": "Smash Uppercut",
@@ -7021,7 +7021,7 @@
           ],
           "convertedEnergyCost": 3,
           "damage": "",
-          "text": "This attack does 40 damage to 1 of your opponent's Pokémon for each Prize card your opponent has taken. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+          "text": "This attack does 40 damage to 1 of your opponent's Pokémon for each Prize card your opponent has taken. (Don't apply Weakness and Resistance for Benched Pokémon.)"
         }
       ],
       "retreatCost": [
@@ -8463,7 +8463,7 @@
         "Pokémon Tool"
       ],
       "rules": [
-        "The attacks of the Pokémon this card is attached to do 30 more damage to your opponent's Active Fighting Pokémon (before applying Weakness and Resistance).",
+        "The attacks of the Pokémon this card is attached to do 30 more damage to your opponent's Active Fighting Pokémon (before applying Weakness and Resistance).",
         "Item rule: You may play any number of Item cards during your turn.",
         "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached."
       ],
@@ -8539,7 +8539,7 @@
         "Pokémon Tool"
       ],
       "rules": [
-        "If the Pokémon this card is attached to has no Abilities, it takes 20 less damage from attacks from your opponent's Pokémon (after applying Weakness and Resistance).",
+        "If the Pokémon this card is attached to has no Abilities, it takes 20 less damage from attacks from your opponent's Pokémon (after applying Weakness and Resistance).",
         "Item rule: You may play any number of Item cards during your turn.",
         "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached."
       ],
@@ -8740,7 +8740,7 @@
         "Pokémon Tool"
       ],
       "rules": [
-        "The attacks of the Pokémon this card is attached to do 30 more damage to your opponent's Active Lightning Pokémon (before applying Weakness and Resistance).",
+        "The attacks of the Pokémon this card is attached to do 30 more damage to your opponent's Active Lightning Pokémon (before applying Weakness and Resistance).",
         "Item rule: You may play any number of Item cards during your turn.",
         "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached."
       ],
@@ -8842,7 +8842,7 @@
         "Pokémon Tool"
       ],
       "rules": [
-        "If the Pokémon this card is attached to is in the Active Spot and is damaged by an attack from your opponent's Pokémon (even if it is Knocked Out), your opponent discards a card from their hand.",
+        "If the Pokémon this card is attached to is in the Active Spot and is damaged by an attack from your opponent's Pokémon (even if it is Knocked Out), your opponent discards a card from their hand.",
         "Item rule: You may play any number of Item cards during your turn.",
         "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached."
       ],
@@ -10238,7 +10238,7 @@
           ],
           "convertedEnergyCost": 2,
           "damage": "",
-          "text": "Put 2 damage counters on 1 of your opponent's Pokémon. If your opponent's Pokémon is Knocked Out by this attack, take another turn after this one. (Skip Pokémon Checkup.) If 1 of your Pokémon used Yoga Loop during your last turn, this attack can't be used."
+          "text": "Put 2 damage counters on 1 of your opponent's Pokémon. If your opponent's Pokémon is Knocked Out by this attack, take another turn after this one. (Skip Pokémon Checkup.) If 1 of your Pokémon used Yoga Loop during your last turn, this attack can't be used."
         },
         {
           "name": "Smash Uppercut",
@@ -10304,7 +10304,7 @@
           ],
           "convertedEnergyCost": 2,
           "damage": "",
-          "text": "Put 2 damage counters on 1 of your opponent's Pokémon. If your opponent's Pokémon is Knocked Out by this attack, take another turn after this one. (Skip Pokémon Checkup.) If 1 of your Pokémon used Yoga Loop during your last turn, this attack can't be used."
+          "text": "Put 2 damage counters on 1 of your opponent's Pokémon. If your opponent's Pokémon is Knocked Out by this attack, take another turn after this one. (Skip Pokémon Checkup.) If 1 of your Pokémon used Yoga Loop during your last turn, this attack can't be used."
         },
         {
           "name": "Smash Uppercut",
@@ -12603,7 +12603,7 @@
         "Pokémon Tool"
       ],
       "rules": [
-        "If the Pokémon this card is attached to has no Abilities, it takes 20 less damage from attacks from your opponent's Pokémon (after applying Weakness and Resistance).",
+        "If the Pokémon this card is attached to has no Abilities, it takes 20 less damage from attacks from your opponent's Pokémon (after applying Weakness and Resistance).",
         "Item rule: You may play any number of Item cards during your turn.",
         "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached."
       ],

--- a/cards/en/swshp.json
+++ b/cards/en/swshp.json
@@ -5412,7 +5412,7 @@
     "abilities": [
       {
         "name": "Rapid Strike Search",
-        "text": "Once during your turn, you may search your deck for a Rapid Strike card, reveal it, and put it into your hand. Then, shuffle your deck. You can't use more than 1 Rapid Strike Search Ability each turn.",
+        "text": "Once during your turn, you may search your deck for a Rapid Strike card, reveal it, and put it into your hand. Then, shuffle your deck. You can't use more than 1 Rapid Strike Search Ability each turn.",
         "type": "Ability"
       }
     ],


### PR DESCRIPTION
 \xa0 and <space> are considered the same by some systems and so any artists that use <space> and \xa0 are considered distinct in UTF8, but not others (such as mysql)

This was found by the json having both 'Shinji Higuchi + Sachiko Eba' and 'Shinji Higuchi\xa0+\xa0Sachiko Eba', to which mysql considers the same

More info on \xa0 here:
https://stackoverflow.com/questions/10993612/how-to-remove-xa0-from-string-in-python

Thanks!