### PR TITLE
Replace instances of double quotes (”) with standard straight quotes (")

### DIFF
--- a/cards/en/base2.json
+++ b/cards/en/base2.json
@@ -3313,7 +3313,7 @@
     "number": "53",
     "artist": "Kagemaru Himeno",
     "rarity": "Common",
-    "flavorText": "Its tail fin billows like an elegant ballroom dress, giving it the nickname “Water Queen.”",
+    "flavorText": "Its tail fin billows like an elegant ballroom dress, giving it the nickname \"Water Queen.\"",
     "nationalPokedexNumbers": [
       118
     ],

--- a/cards/en/base4.json
+++ b/cards/en/base4.json
@@ -4739,7 +4739,7 @@
     "number": "76",
     "artist": "Kagemaru Himeno",
     "rarity": "Common",
-    "flavorText": "Its tail fin billows like an elegant ballroom dress, giving it the nickname “Water Queen.”",
+    "flavorText": "Its tail fin billows like an elegant ballroom dress, giving it the nickname \"Water Queen.\"",
     "nationalPokedexNumbers": [
       118
     ],

--- a/cards/en/base5.json
+++ b/cards/en/base5.json
@@ -302,7 +302,7 @@
     "number": "5",
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo",
-    "flavorText": "Sometimes called “The God of Destruction.” Its wings are able to support it in spite of its massive weight.",
+    "flavorText": "Sometimes called \"The God of Destruction.\" Its wings are able to support it in spite of its massive weight.",
     "nationalPokedexNumbers": [
       149
     ],
@@ -1232,7 +1232,7 @@
     "number": "22",
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare",
-    "flavorText": "Sometimes called “The God of Destruction.” Its wings are able to support it in spite of its massive weight.",
+    "flavorText": "Sometimes called \"The God of Destruction.\" Its wings are able to support it in spite of its massive weight.",
     "nationalPokedexNumbers": [
       149
     ],
@@ -3683,7 +3683,7 @@
     "number": "62",
     "artist": "Atsuko Nishida",
     "rarity": "Common",
-    "flavorText": "A popular Pokémon that earns money for its owner with its “Pay Day” ability.",
+    "flavorText": "A popular Pokémon that earns money for its owner with its \"Pay Day\" ability.",
     "nationalPokedexNumbers": [
       52
     ],

--- a/cards/en/basep.json
+++ b/cards/en/basep.json
@@ -2225,7 +2225,7 @@
       "Remove all damage counters from all of your own Pokémon with damage counters on them, then discard all Energy cards attached to those Pokémon."
     ],
     "number": "40",
-    "artist": "“Big Mama” Tagawa",
+    "artist": "\"Big Mama\" Tagawa",
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal"
@@ -2247,7 +2247,7 @@
       "Once during each player's turn (before attacking), that player may flip a coin. If heads, that player draws a card."
     ],
     "number": "41",
-    "artist": "“Big Mama” Tagawa",
+    "artist": "\"Big Mama\" Tagawa",
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal"

--- a/cards/en/neo2.json
+++ b/cards/en/neo2.json
@@ -4297,7 +4297,7 @@
       "Search your deck for a card with Unown in its name and put it onto your Bench. Shuffle your deck afterward. (You can't play this card if your Bench is full.)"
     ],
     "number": "74",
-    "artist": "“Big Mama” Tagawa, CR CG gangs",
+    "artist": "\"Big Mama\" Tagawa, CR CG gangs",
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal"
@@ -4315,7 +4315,7 @@
       "Flip 2 coins. For each heads, search your deck for a Basic Energy card. Show that card to your opponent, then put it into your hand. Shuffle your deck afterward."
     ],
     "number": "75",
-    "artist": "“Big Mama” Tagawa & Benimaru Itoh",
+    "artist": "\"Big Mama\" Tagawa & Benimaru Itoh",
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal"


### PR DESCRIPTION
Replaced rare instances where double quotes were used instead of straight quotes, causing equality issues in artist names

Example “Big Mama” != "Big Mama", creating two distinct artists