### PR TITLE
Correct Rarity Discrepancy in swsh Sets

### DIFF
--- a/cards/en/swsh1.json
+++ b/cards/en/swsh1.json
@@ -10192,7 +10192,7 @@
     "convertedRetreatCost": 2,
     "number": "187",
     "artist": "Eske Yoshinob",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       781
     ],
@@ -10261,7 +10261,7 @@
     "convertedRetreatCost": 4,
     "number": "188",
     "artist": "Ayaka Yoshida",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       324
     ],
@@ -10326,7 +10326,7 @@
     "convertedRetreatCost": 2,
     "number": "189",
     "artist": "5ban Graphics",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       131
     ],
@@ -10390,7 +10390,7 @@
     "convertedRetreatCost": 2,
     "number": "190",
     "artist": "5ban Graphics",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       877
     ],
@@ -10461,7 +10461,7 @@
     "convertedRetreatCost": 3,
     "number": "191",
     "artist": "Ayaka Yoshida",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       202
     ],
@@ -10529,7 +10529,7 @@
     "convertedRetreatCost": 2,
     "number": "192",
     "artist": "5ban Graphics",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       876
     ],
@@ -10594,7 +10594,7 @@
     "convertedRetreatCost": 3,
     "number": "193",
     "artist": "5ban Graphics",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       874
     ],
@@ -10657,7 +10657,7 @@
     "convertedRetreatCost": 2,
     "number": "194",
     "artist": "Eske Yoshinob",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       302
     ],
@@ -10725,7 +10725,7 @@
     "convertedRetreatCost": 2,
     "number": "195",
     "artist": "5ban Graphics",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       888
     ],
@@ -10793,7 +10793,7 @@
     "convertedRetreatCost": 2,
     "number": "196",
     "artist": "aky CG Works",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       889
     ],
@@ -10862,7 +10862,7 @@
     "convertedRetreatCost": 4,
     "number": "197",
     "artist": "aky CG Works",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       143
     ],
@@ -10931,7 +10931,7 @@
     "convertedRetreatCost": 1,
     "number": "198",
     "artist": "aky CG Works",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       845
     ],

--- a/cards/en/swsh2.json
+++ b/cards/en/swsh2.json
@@ -10025,7 +10025,7 @@
     "convertedRetreatCost": 3,
     "number": "175",
     "artist": "5ban Graphics",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       812
     ],
@@ -10085,7 +10085,7 @@
     "convertedRetreatCost": 1,
     "number": "176",
     "artist": "5ban Graphics",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       830
     ],
@@ -10152,7 +10152,7 @@
     "convertedRetreatCost": 2,
     "number": "177",
     "artist": "Saki Hayashiro",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       38
     ],
@@ -10214,7 +10214,7 @@
     "convertedRetreatCost": 2,
     "number": "178",
     "artist": "5ban Graphics",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       815
     ],
@@ -10281,7 +10281,7 @@
     "convertedRetreatCost": 2,
     "number": "179",
     "artist": "Ayaka Yoshida",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       350
     ],
@@ -10345,7 +10345,7 @@
     "convertedRetreatCost": 2,
     "number": "180",
     "artist": "5ban Graphics",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       818
     ],
@@ -10408,7 +10408,7 @@
     "convertedRetreatCost": 2,
     "number": "181",
     "artist": "aky CG Works",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       836
     ],
@@ -10472,7 +10472,7 @@
     "convertedRetreatCost": 2,
     "number": "182",
     "artist": "5ban Graphics",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       849
     ],
@@ -10540,7 +10540,7 @@
     "convertedRetreatCost": 1,
     "number": "183",
     "artist": "aky CG Works",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       887
     ],
@@ -10605,7 +10605,7 @@
     "convertedRetreatCost": 3,
     "number": "184",
     "artist": "aky CG Works",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       844
     ],
@@ -10667,7 +10667,7 @@
     "convertedRetreatCost": 2,
     "number": "185",
     "artist": "aky CG Works",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       870
     ],
@@ -10732,7 +10732,7 @@
     "convertedRetreatCost": 2,
     "number": "186",
     "artist": "Eske Yoshinob",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       687
     ],
@@ -10807,7 +10807,7 @@
     "convertedRetreatCost": 4,
     "number": "187",
     "artist": "5ban Graphics",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       879
     ],
@@ -10869,7 +10869,7 @@
     "convertedRetreatCost": 2,
     "number": "188",
     "artist": "5ban Graphics",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       832
     ],

--- a/cards/en/swsh3.json
+++ b/cards/en/swsh3.json
@@ -48,7 +48,7 @@
     "convertedRetreatCost": 1,
     "number": "1",
     "artist": "Saki Hayashiro",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       12
     ],
@@ -10106,7 +10106,7 @@
     "convertedRetreatCost": 1,
     "number": "177",
     "artist": "Saki Hayashiro",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       12
     ],
@@ -10169,7 +10169,7 @@
     "convertedRetreatCost": 1,
     "number": "178",
     "artist": "Ayaka Yoshida",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       229
     ],
@@ -10235,7 +10235,7 @@
     "convertedRetreatCost": 3,
     "number": "179",
     "artist": "5ban Graphics",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       851
     ],
@@ -10301,7 +10301,7 @@
     "convertedRetreatCost": 3,
     "number": "180",
     "artist": "Ayaka Yoshida",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       738
     ],
@@ -10370,7 +10370,7 @@
     "convertedRetreatCost": 4,
     "number": "181",
     "artist": "Eske Yoshinob",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       464
     ],
@@ -10430,7 +10430,7 @@
     "convertedRetreatCost": 1,
     "number": "182",
     "artist": "PLANETA Mochizuki",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       169
     ],
@@ -10500,7 +10500,7 @@
     "convertedRetreatCost": 2,
     "number": "183",
     "artist": "Satoshi Shirai",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       212
     ],
@@ -10569,7 +10569,7 @@
     "convertedRetreatCost": 4,
     "number": "184",
     "artist": "PLANETA Tsuji",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       618
     ],
@@ -10642,7 +10642,7 @@
     "convertedRetreatCost": 2,
     "number": "185",
     "artist": "Saki Hayashiro",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       373
     ],

--- a/cards/en/swsh35.json
+++ b/cards/en/swsh35.json
@@ -3500,7 +3500,7 @@
     "convertedRetreatCost": 4,
     "number": "69",
     "artist": "aky CG Works",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       834
     ],
@@ -3564,7 +3564,7 @@
     "convertedRetreatCost": 2,
     "number": "70",
     "artist": "PLANETA Mochizuki",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       282
     ],
@@ -3631,7 +3631,7 @@
     "convertedRetreatCost": 2,
     "number": "71",
     "artist": "5ban Graphics",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       864
     ],
@@ -3695,7 +3695,7 @@
     "convertedRetreatCost": 2,
     "number": "72",
     "artist": "PLANETA Igarashi",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       853
     ],

--- a/cards/en/swsh4.json
+++ b/cards/en/swsh4.json
@@ -9459,7 +9459,7 @@
     "convertedRetreatCost": 1,
     "number": "166",
     "artist": "5ban Graphics",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       826
     ],
@@ -9522,7 +9522,7 @@
     "convertedRetreatCost": 1,
     "number": "167",
     "artist": "PLANETA Igarashi",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       893
     ],
@@ -9587,7 +9587,7 @@
     ],
     "number": "168",
     "artist": "Eske Yoshinob",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       663
     ],
@@ -9652,7 +9652,7 @@
     "convertedRetreatCost": 2,
     "number": "169",
     "artist": "5ban Graphics",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       555
     ],
@@ -9718,7 +9718,7 @@
     "convertedRetreatCost": 1,
     "number": "170",
     "artist": "Saki Hayashiro",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       25
     ],
@@ -9784,7 +9784,7 @@
     "convertedRetreatCost": 3,
     "number": "171",
     "artist": "PLANETA Mochizuki",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       181
     ],
@@ -9852,7 +9852,7 @@
     "convertedRetreatCost": 1,
     "number": "172",
     "artist": "Ayaka Yoshida",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       65
     ],
@@ -9921,7 +9921,7 @@
     "convertedRetreatCost": 4,
     "number": "173",
     "artist": "5ban Graphics",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       839
     ],
@@ -9983,7 +9983,7 @@
     "convertedRetreatCost": 2,
     "number": "174",
     "artist": "PLANETA Tsuji",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       865
     ],
@@ -10051,7 +10051,7 @@
     "convertedRetreatCost": 3,
     "number": "175",
     "artist": "Eske Yoshinob",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       452
     ],
@@ -10126,7 +10126,7 @@
     "convertedRetreatCost": 4,
     "number": "176",
     "artist": "Satoshi Shirai",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       208
     ],
@@ -10198,7 +10198,7 @@
     "convertedRetreatCost": 3,
     "number": "177",
     "artist": "aky CG Works",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       681
     ],
@@ -10267,7 +10267,7 @@
     "convertedRetreatCost": 1,
     "number": "178",
     "artist": "PLANETA Mochizuki",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       468
     ],

--- a/cards/en/swsh5.json
+++ b/cards/en/swsh5.json
@@ -7954,7 +7954,7 @@
     "convertedRetreatCost": 1,
     "number": "142",
     "artist": "Satoshi Shirai",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       402
     ],
@@ -8017,7 +8017,7 @@
     "convertedRetreatCost": 1,
     "number": "143",
     "artist": "PLANETA Mochizuki",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       841
     ],
@@ -8079,7 +8079,7 @@
     "convertedRetreatCost": 1,
     "number": "144",
     "artist": "Saki Hayashiro",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       494
     ],
@@ -8142,7 +8142,7 @@
     "convertedRetreatCost": 2,
     "number": "145",
     "artist": "Ayaka Yoshida",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       395
     ],
@@ -8205,7 +8205,7 @@
     "convertedRetreatCost": 2,
     "number": "146",
     "artist": "chibi",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       395
     ],
@@ -8268,7 +8268,7 @@
     "convertedRetreatCost": 1,
     "number": "147",
     "artist": "Eske Yoshinob",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -8331,7 +8331,7 @@
     "convertedRetreatCost": 2,
     "number": "148",
     "artist": "Eske Yoshinob",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       778
     ],
@@ -8402,7 +8402,7 @@
     "convertedRetreatCost": 3,
     "number": "149",
     "artist": "PLANETA Tsuji",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       800
     ],
@@ -8467,7 +8467,7 @@
     "convertedRetreatCost": 2,
     "number": "150",
     "artist": "PLANETA Mochizuki",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       892
     ],
@@ -8532,7 +8532,7 @@
     "convertedRetreatCost": 2,
     "number": "151",
     "artist": "kawayoo",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       892
     ],
@@ -8597,7 +8597,7 @@
     "convertedRetreatCost": 2,
     "number": "152",
     "artist": "PLANETA Mochizuki",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       892
     ],
@@ -8662,7 +8662,7 @@
     "convertedRetreatCost": 2,
     "number": "153",
     "artist": "Ryota Murayama",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       892
     ],
@@ -8731,7 +8731,7 @@
     "convertedRetreatCost": 3,
     "number": "154",
     "artist": "Ayaka Yoshida",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       248
     ],
@@ -8800,7 +8800,7 @@
     "convertedRetreatCost": 3,
     "number": "155",
     "artist": "HYOGONOSUKE",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       248
     ],
@@ -8869,7 +8869,7 @@
     "convertedRetreatCost": 1,
     "number": "156",
     "artist": "PLANETA Mochizuki",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       823
     ],
@@ -8937,7 +8937,7 @@
     "convertedRetreatCost": 3,
     "number": "157",
     "artist": "Eske Yoshinob",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       508
     ],

--- a/cards/en/swsh6.json
+++ b/cards/en/swsh6.json
@@ -8560,7 +8560,7 @@
     "convertedRetreatCost": 1,
     "number": "160",
     "artist": "PLANETA Tsuji",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       251
     ],
@@ -8627,7 +8627,7 @@
     "convertedRetreatCost": 2,
     "number": "161",
     "artist": "Ayaka Yoshida",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       257
     ],
@@ -8694,7 +8694,7 @@
     "convertedRetreatCost": 3,
     "number": "162",
     "artist": "Eske Yoshinob",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       721
     ],
@@ -8758,7 +8758,7 @@
     "convertedRetreatCost": 2,
     "number": "163",
     "artist": "5ban Graphics",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -8819,7 +8819,7 @@
     "convertedRetreatCost": 2,
     "number": "164",
     "artist": "OKACHEKE",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -8872,7 +8872,7 @@
     "convertedRetreatCost": 2,
     "number": "165",
     "artist": "PLANETA Tsuji",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       807
     ],
@@ -8928,7 +8928,7 @@
     "convertedRetreatCost": 2,
     "number": "166",
     "artist": "Atsushi Furusawa",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       807
     ],
@@ -8997,7 +8997,7 @@
     "convertedRetreatCost": 1,
     "number": "167",
     "artist": "Saki Hayashiro",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       78
     ],
@@ -9066,7 +9066,7 @@
     "convertedRetreatCost": 1,
     "number": "168",
     "artist": "sui",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       78
     ],
@@ -9134,7 +9134,7 @@
     "convertedRetreatCost": 2,
     "number": "169",
     "artist": "5ban Graphics",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       144
     ],
@@ -9202,7 +9202,7 @@
     "convertedRetreatCost": 2,
     "number": "170",
     "artist": "Uta",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       144
     ],
@@ -9272,7 +9272,7 @@
     "convertedRetreatCost": 2,
     "number": "171",
     "artist": "5ban Graphics",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -9339,7 +9339,7 @@
     "convertedRetreatCost": 2,
     "number": "172",
     "artist": "kodama",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -9398,7 +9398,7 @@
     "convertedRetreatCost": 1,
     "number": "173",
     "artist": "5ban Graphics",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       145
     ],
@@ -9460,7 +9460,7 @@
     "convertedRetreatCost": 1,
     "number": "174",
     "artist": "Akira Komayama",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       145
     ],
@@ -9522,7 +9522,7 @@
     "convertedRetreatCost": 2,
     "number": "175",
     "artist": "PLANETA Tsuji",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       844
     ],
@@ -9584,7 +9584,7 @@
     "convertedRetreatCost": 2,
     "number": "176",
     "artist": "aky CG Works",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       146
     ],
@@ -9646,7 +9646,7 @@
     "convertedRetreatCost": 2,
     "number": "177",
     "artist": "Shibuzoh.",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       146
     ],
@@ -9711,7 +9711,7 @@
     "convertedRetreatCost": 3,
     "number": "178",
     "artist": "5ban Graphics",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       199
     ],
@@ -9776,7 +9776,7 @@
     "convertedRetreatCost": 3,
     "number": "179",
     "artist": "Tomokazu Komiya",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       199
     ],
@@ -9837,7 +9837,7 @@
     "convertedRetreatCost": 1,
     "number": "180",
     "artist": "Ayaka Yoshida",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       510
     ],
@@ -9908,7 +9908,7 @@
     "convertedRetreatCost": 3,
     "number": "181",
     "artist": "PLANETA Mochizuki",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       376
     ],
@@ -9970,7 +9970,7 @@
     "convertedRetreatCost": 4,
     "number": "182",
     "artist": "Saki Hayashiro",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       242
     ],
@@ -10032,7 +10032,7 @@
     "convertedRetreatCost": 4,
     "number": "183",
     "artist": "Saya Tsuruta",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       242
     ],
@@ -10104,7 +10104,7 @@
     "convertedRetreatCost": 2,
     "number": "184",
     "artist": "PLANETA Mochizuki",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       641
     ],
@@ -10176,7 +10176,7 @@
     "convertedRetreatCost": 2,
     "number": "185",
     "artist": "tetsuya koizumi",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Ultra",
     "nationalPokedexNumbers": [
       641
     ],


### PR DESCRIPTION
In most of the sword and shield series sets, the rarity for Ultra Rare Pokemon V (The "Textured" ones after the trainer cards) is listed as "Rare Holo V". This is inconsistent with the players guides for these sets, and was likely a result of copying the card objects from earlier in the set. 

In the data for Evolving Skies and Shining Fates, this set of cards do reflect their correct rarity.

I have altered the rarity of this group of cards in each swsh set that were listed incorrectly, from "Rare Holo V" to "Rare Ultra" to bring in line with API naming standards and proper rarity classification.