### PR TITLE
Added Best of Game and fixed MCD21 rarities

### DIFF
--- a/cards/en/basep.json
+++ b/cards/en/basep.json
@@ -1372,6 +1372,7 @@
       25
     ],
     "legalities": {
+      "unlimited": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/basep/24.png",

--- a/cards/en/bp.json
+++ b/cards/en/bp.json
@@ -1,0 +1,505 @@
+[
+  {
+    "id": "bp-1",
+    "name": "Electabuzz",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Basic"
+    ],
+    "level": "35",
+    "hp": "70",
+    "types": [
+      "Lightning"
+    ],
+    "evolvesTo": [
+      "Electivire"
+    ],
+    "attacks": [
+      {
+        "name": "Thundershock",
+        "cost": [
+          "Lightning"
+        ],
+        "convertedEnergyCost": 1,
+        "damage": "10",
+        "text": "Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
+      },
+      {
+        "name": "Thunderpunch",
+        "cost": [
+          "Lightning",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 2,
+        "damage": "30+",
+        "text": "Flip a coin. If heads, this attack does 30 damage plus 10 more damage; if tails, this attack does 30 damage plus Electabuzz does 10 damage to itself."
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Fighting",
+        "value": "×2"
+      }
+    ],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
+    "convertedRetreatCost": 2,
+    "number": "1",
+    "artist": "Ken Sugimori",
+    "rarity": "Promo",
+    "flavorText": "Normally found near power plants, it can wander away and cause major blackouts in cities.",
+    "nationalPokedexNumbers": [
+      125
+    ],
+    "legalities": {
+      "unlimited": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/bp/1.png",
+      "large": "https://images.pokemontcg.io/bp/1_hires.png"
+    }
+  },
+  {
+    "id": "bp-2",
+    "name": "Hitmonchan",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Basic"
+    ],
+    "level": "33",
+    "hp": "70",
+    "types": [
+      "Fighting"
+    ],
+    "attacks": [
+      {
+        "name": "Jab",
+        "cost": [
+          "Fighting"
+        ],
+        "convertedEnergyCost": 1,
+        "damage": "20",
+        "text": ""
+      },
+      {
+        "name": "Special Punch",
+        "cost": [
+          "Fighting",
+          "Fighting",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 3,
+        "damage": "40",
+        "text": ""
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Psychic",
+        "value": "×2"
+      }
+    ],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
+    "convertedRetreatCost": 2,
+    "number": "7",
+    "artist": "Ken Sugimori",
+    "rarity": "Promo",
+    "flavorText": "While seeming to do nothing, it fires punches in lightning-fast volleys that are impossible to see.",
+    "nationalPokedexNumbers": [
+      107
+    ],
+    "legalities": {
+      "unlimited": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/bp/2.png",
+      "large": "https://images.pokemontcg.io/bp/2_hires.png"
+    }
+  },
+  {
+    "id": "bp-3",
+    "name": "Professor Elm",
+    "supertype": "Trainer",
+    "rules": [
+      "Shuffle your hand into your deck. Then, draw 7 cards. You can't play any more Trainer cards this turn."
+    ],
+    "number": "3",
+    "artist": "Ken Sugimori",
+    "rarity": "Promo",
+    "legalities": {
+      "unlimited": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/bp/3.png",
+      "large": "https://images.pokemontcg.io/bp/3_hires.png"
+    }
+  },
+  {
+    "id": "bp-4",
+    "name": "Rocket's Scizor",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Basic"
+    ],
+    "hp": "60",
+    "types": [
+      "Metal"
+    ],
+    "attacks": [
+      {
+        "name": "Focus",
+        "cost": [
+          "Colorless"
+        ],
+        "convertedEnergyCost": 1,
+        "damage": "",
+        "text": "During your next turn, Rocket's Scizor's Agility attack's damage is doubled."
+      },
+      {
+        "name": "Agility",
+        "cost": [
+          "Metal",
+          "Colorless",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 3,
+        "damage": "20",
+        "text": "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Rocket's Scizor."
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Fire",
+        "value": "×2"
+      }
+    ],
+    "resistances": [
+      {
+        "type": "Grass",
+        "value": "-30"
+      }
+    ],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
+    "convertedRetreatCost": 2,
+    "number": "4",
+    "artist": "K Hoshiba",
+    "rarity": "Promo",
+    "nationalPokedexNumbers": [
+      212
+    ],
+    "legalities": {
+      "unlimited": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/bp/4.png",
+      "large": "https://images.pokemontcg.io/bp/4_hires.png"
+    }
+  },
+  {
+    "id": "bp-5",
+    "name": "Rocket's Sneasel",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Basic"
+    ],
+    "hp": "60",
+    "types": [
+      "Darkness"
+    ],
+    "attacks": [
+      {
+        "name": "Entrap",
+        "cost": [
+          "Darkness"
+        ],
+        "convertedEnergyCost": 1,
+        "damage": "",
+        "text": "The Defending Pokémon can't retreat during your opponent's next turn."
+      },
+      {
+        "name": "Continuous Scratch",
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 2,
+        "damage": "10×",
+        "text": "Flip 4 coins. This attack does 10 damage times the number of heads."
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Fighting",
+        "value": "×2"
+      }
+    ],
+    "resistances": [
+      {
+        "type": "Psychic",
+        "value": "-30"
+      }
+    ],
+    "retreatCost": [
+      "Colorless"
+    ],
+    "convertedRetreatCost": 1,
+    "number": "5",
+    "artist": "Katsura Tabata",
+    "rarity": "Promo",
+    "nationalPokedexNumbers": [
+      215
+    ],
+    "legalities": {
+      "unlimited": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/bp/5.png",
+      "large": "https://images.pokemontcg.io/bp/5_hires.png"
+    }
+  },
+  {
+    "id": "bp-6",
+    "name": "Dark Ivysaur",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Stage 1"
+    ],
+    "hp": "50",
+    "types": [
+      "Grass"
+    ],
+    "evolvesFrom": "Bulbasaur",
+    "evolvesTo": [
+      "Dark Venusaur"
+    ],
+    "abilities": [
+      {
+        "name": "Vine Pull",
+        "text": "Once during your turn when Dark Ivysaur retreats, choose 1 of your opponent's Benched Pokémon and switch it with his or her Active Pokémon.",
+        "type": "Poké-Body"
+      }
+    ],
+    "attacks": [
+      {
+        "name": "Fury Strikes",
+        "cost": [
+          "Grass",
+          "Grass"
+        ],
+        "convertedEnergyCost": 2,
+        "damage": "",
+        "text": "Your opponent puts 3 markers onto his or her Pokémon (divided as he or she chooses). (More than 1 marker can be put on the same Pokémon.) Then, this attack does 10 damage to each Pokémon for each marker on it. Don't apply Weakness and Resistance. Remove the markers at the end of the turn."
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Fire",
+        "value": "×2"
+      }
+    ],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
+    "convertedRetreatCost": 2,
+    "number": "6",
+    "artist": "Shin-ichi Yoshida",
+    "rarity": "Promo",
+    "nationalPokedexNumbers": [
+      2
+    ],
+    "legalities": {
+      "unlimited": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/bp/6.png",
+      "large": "https://images.pokemontcg.io/bp/6_hires.png"
+    }
+  },
+  {
+    "id": "bp-7",
+    "name": "Dark Venusaur",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Stage 2"
+    ],
+    "hp": "70",
+    "types": [
+      "Grass"
+    ],
+    "evolvesFrom": "Dark Ivysaur",
+    "attacks": [
+      {
+        "name": "Horrid Pollen",
+        "cost": [
+          "Grass",
+          "Grass",
+          "Grass"
+        ],
+        "convertedEnergyCost": 3,
+        "damage": "30",
+        "text": "Flip 2 coins. If 1 is heads, the Defending Pokémon is now Asleep and Poisoned. If both are heads, the Defending Pokémon is now Confused and Poisoned. If both are tails, the Defending Pokémon is now Paralyzed and Poisoned."
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Fire",
+        "value": "×2"
+      }
+    ],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
+    "convertedRetreatCost": 2,
+    "number": "7",
+    "artist": "Shin-ichi Yoshida",
+    "rarity": "Promo",
+    "nationalPokedexNumbers": [
+      3
+    ],
+    "legalities": {
+      "unlimited": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/bp/7.png",
+      "large": "https://images.pokemontcg.io/bp/7_hires.png"
+    }
+  },
+  {
+    "id": "bp-8",
+    "name": "Rocket's Mewtwo",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Basic"
+    ],
+    "level": "35",
+    "hp": "70",
+    "types": [
+      "Psychic"
+    ],
+    "attacks": [
+      {
+        "name": "Juxtapose",
+        "cost": [
+          "Psychic"
+        ],
+        "convertedEnergyCost": 1,
+        "damage": "",
+        "text": "Flip a coin. If heads, switch the number of damage counters on Rocket's Mewtwo with the number of damage counters on the Defending Pokémon (even if it would Knock Out either Pokémon). (It's okay if 1 of the Pokémon has no damage counters on it.)"
+      },
+      {
+        "name": "Hypnoblast",
+        "cost": [
+          "Psychic",
+          "Psychic"
+        ],
+        "convertedEnergyCost": 2,
+        "damage": "20",
+        "text": "Flip a coin. If heads, the Defending Pokémon is now Asleep."
+      },
+      {
+        "name": "Psyburn",
+        "cost": [
+          "Psychic",
+          "Psychic",
+          "Psychic",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 4,
+        "damage": "60",
+        "text": ""
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Psychic",
+        "value": "×2"
+      }
+    ],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
+    "convertedRetreatCost": 2,
+    "number": "8",
+    "artist": "Shin-ichi Yoshida",
+    "rarity": "Promo",
+    "nationalPokedexNumbers": [
+      150
+    ],
+    "legalities": {
+      "unlimited": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/bp/8.png",
+      "large": "https://images.pokemontcg.io/bp/8_hires.png"
+    }
+  },
+  {
+    "id": "bp-9",
+    "name": "Rocket's Hitmonchan",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Basic"
+    ],
+    "level": "29",
+    "hp": "60",
+    "types": [
+      "Fighting"
+    ],
+    "attacks": [
+      {
+        "name": "Crosscounter",
+        "cost": [
+          "Fighting"
+        ],
+        "convertedEnergyCost": 1,
+        "damage": "",
+        "text": "If an attack does damage to Rocket's Hitmonchan during your opponent's next turn (even if Rocket's Hitmonchan is Knocked Out), flip a coin. If heads, Rocket's Hitmonchan attacks your opponent's Active Pokémon for double that amount of damage. (If Rocket's Hitmonchan takes 20 damage, it does 40 damage to that Pokémon.)"
+      },
+      {
+        "name": "Magnum Punch",
+        "cost": [
+          "Fighting",
+          "Fighting",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 3,
+        "damage": "50",
+        "text": ""
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Psychic",
+        "value": "×2"
+      }
+    ],
+    "retreatCost": [
+      "Colorless"
+    ],
+    "convertedRetreatCost": 1,
+    "number": "9",
+    "artist": "Ken Sugimori",
+    "rarity": "Promo",
+    "nationalPokedexNumbers": [
+      107
+    ],
+    "legalities": {
+      "unlimited": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/bp/9.png",
+      "large": "https://images.pokemontcg.io/bp/+_hires.png"
+    }
+  }
+]

--- a/cards/en/bp.json
+++ b/cards/en/bp.json
@@ -499,7 +499,7 @@
     },
     "images": {
       "small": "https://images.pokemontcg.io/bp/9.png",
-      "large": "https://images.pokemontcg.io/bp/+_hires.png"
+      "large": "https://images.pokemontcg.io/bp/9_hires.png"
     }
   }
 ]

--- a/cards/en/cel25c.json
+++ b/cards/en/cel25c.json
@@ -448,6 +448,7 @@
       25
     ],
     "legalities": {
+      "unlimited": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/cel25c/24_A.png",

--- a/cards/en/mcd21.json
+++ b/cards/en/mcd21.json
@@ -38,7 +38,7 @@
     "convertedRetreatCost": 2,
     "number": "1",
     "artist": "Mizue",
-    "rarity": "Common",
+    "rarity": "Promo",
     "flavorText": "A strange seed was planted on its back at birth. The plant sprouts and grows with this Pokémon.",
     "nationalPokedexNumbers": [
       1
@@ -89,7 +89,7 @@
     "convertedRetreatCost": 1,
     "number": "2",
     "artist": "sowsow",
-    "rarity": "Common",
+    "rarity": "Promo",
     "flavorText": "It uses the leaf on its head to determine the temperature and humidity. It loves to sunbathe.",
     "nationalPokedexNumbers": [
       152
@@ -141,7 +141,7 @@
     "convertedRetreatCost": 1,
     "number": "3",
     "artist": "Akira Komayama",
-    "rarity": "Common",
+    "rarity": "Promo",
     "flavorText": "Small hooks on the bottom of its feet catch on walls and ceilings. That is how it can hang from above.",
     "nationalPokedexNumbers": [
       252
@@ -206,7 +206,7 @@
     "convertedRetreatCost": 2,
     "number": "4",
     "artist": "OOYAMA",
-    "rarity": "Common",
+    "rarity": "Promo",
     "flavorText": "It undertakes photosynthesis with its body, making oxygen. The leaf on its head wilts if it is thirsty.",
     "nationalPokedexNumbers": [
       387
@@ -265,7 +265,7 @@
     "convertedRetreatCost": 1,
     "number": "5",
     "artist": "Ken Sugimori",
-    "rarity": "Common",
+    "rarity": "Promo",
     "flavorText": "It is very intelligent and calm. Being exposed to lots of sunlight makes its movements swifter.",
     "nationalPokedexNumbers": [
       495
@@ -386,7 +386,7 @@
     "convertedRetreatCost": 1,
     "number": "7",
     "artist": "Megumi Mizutani",
-    "rarity": "Common",
+    "rarity": "Promo",
     "flavorText": "This wary Pokémon uses photosynthesis to store up energy during the day, while becoming active at night.",
     "nationalPokedexNumbers": [
       722
@@ -438,7 +438,7 @@
     "convertedRetreatCost": 1,
     "number": "8",
     "artist": "kirisAki",
-    "rarity": "Common",
+    "rarity": "Promo",
     "flavorText": "When it uses its special stick to strike up a beat, the sound waves produced carry revitalizing energy to the plants and flowers in the area.",
     "nationalPokedexNumbers": [
       810
@@ -500,7 +500,7 @@
     "convertedRetreatCost": 1,
     "number": "9",
     "artist": "Kagemaru Himeno",
-    "rarity": "Common",
+    "rarity": "Promo",
     "flavorText": "The flame on its tail indicates Charmander's life force. If it is healthy, the flame burns brightly.",
     "nationalPokedexNumbers": [
       4
@@ -552,7 +552,7 @@
     "convertedRetreatCost": 1,
     "number": "10",
     "artist": "kirisAki",
-    "rarity": "Common",
+    "rarity": "Promo",
     "flavorText": "It has a timid nature. If it is startled, the flames on its back burn more vigorously.",
     "nationalPokedexNumbers": [
       155
@@ -603,7 +603,7 @@
     "convertedRetreatCost": 1,
     "number": "11",
     "artist": "sui",
-    "rarity": "Common",
+    "rarity": "Promo",
     "flavorText": "A fire burns inside, so it feels very warm to hug. It launches fireballs of 1,800 degrees Fahrenheit.",
     "nationalPokedexNumbers": [
       255
@@ -654,7 +654,7 @@
     "convertedRetreatCost": 1,
     "number": "12",
     "artist": "Kouki Saitou",
-    "rarity": "Common",
+    "rarity": "Promo",
     "flavorText": "The gas made in its belly burns from its rear end. The fire burns weakly when it feels sick.",
     "nationalPokedexNumbers": [
       390
@@ -707,7 +707,7 @@
     "convertedRetreatCost": 2,
     "number": "13",
     "artist": "Ken Sugimori",
-    "rarity": "Common",
+    "rarity": "Promo",
     "flavorText": "It blows fire through its nose. When it catches a cold, the fire becomes pitch-black smoke instead.",
     "nationalPokedexNumbers": [
       498
@@ -828,7 +828,7 @@
     "convertedRetreatCost": 1,
     "number": "15",
     "artist": "Akira Komayama",
-    "rarity": "Common",
+    "rarity": "Promo",
     "flavorText": "While grooming itself, it builds up fur inside its stomach. It sets the fur alight and spews fiery attacks, which change based on how it coughs.",
     "nationalPokedexNumbers": [
       725
@@ -879,7 +879,7 @@
     "convertedRetreatCost": 1,
     "number": "16",
     "artist": "Hitoshi Ariga",
-    "rarity": "Common",
+    "rarity": "Promo",
     "flavorText": "A warm-up of running around gets fire energy coursing through this Pokémon's body. Once that happens, it's ready to fight at full power.",
     "nationalPokedexNumbers": [
       813
@@ -931,7 +931,7 @@
     "convertedRetreatCost": 1,
     "number": "17",
     "artist": "tetsuya koizumi",
-    "rarity": "Common",
+    "rarity": "Promo",
     "flavorText": "It shelters itself in its shell, then strikes back with spouts of water at every opportunity.",
     "nationalPokedexNumbers": [
       7
@@ -982,7 +982,7 @@
     "convertedRetreatCost": 1,
     "number": "18",
     "artist": "Kagemaru Himeno",
-    "rarity": "Common",
+    "rarity": "Promo",
     "flavorText": "It is small but rough and tough. It won't hesitate to take a bite out of anything that moves.",
     "nationalPokedexNumbers": [
       158
@@ -1043,7 +1043,7 @@
     "convertedRetreatCost": 1,
     "number": "19",
     "artist": "Aya Kusube",
-    "rarity": "Common",
+    "rarity": "Promo",
     "flavorText": "To alert it, the fin on its head senses the flow of water. It has the strength to heft boulders.",
     "nationalPokedexNumbers": [
       258
@@ -1104,7 +1104,7 @@
     "convertedRetreatCost": 1,
     "number": "20",
     "artist": "Shibuzoh.",
-    "rarity": "Common",
+    "rarity": "Promo",
     "flavorText": "Because it is very proud, it hates accepting food from people. Its thick down guards it from cold.",
     "nationalPokedexNumbers": [
       393
@@ -1156,7 +1156,7 @@
     "convertedRetreatCost": 1,
     "number": "21",
     "artist": "Ken Sugimori",
-    "rarity": "Common",
+    "rarity": "Promo",
     "flavorText": "It fights using the scalchop on its stomach. In response to an attack, it retaliates immediately by slashing.",
     "nationalPokedexNumbers": [
       501
@@ -1277,7 +1277,7 @@
     "convertedRetreatCost": 1,
     "number": "23",
     "artist": "Kouki Saitou",
-    "rarity": "Common",
+    "rarity": "Promo",
     "flavorText": "This Pokémon snorts body fluids from its nose, blowing balloons to smash into its foes. It's famous for being a hard worker.",
     "nationalPokedexNumbers": [
       728
@@ -1329,7 +1329,7 @@
     "convertedRetreatCost": 1,
     "number": "24",
     "artist": "Mizue",
-    "rarity": "Common",
+    "rarity": "Promo",
     "flavorText": "When scared, this Pokémon cries. Its tears pack the chemical punch of 100 onions, and attackers won't be able to resist weeping.",
     "nationalPokedexNumbers": [
       816
@@ -1397,7 +1397,7 @@
     "convertedRetreatCost": 1,
     "number": "25",
     "artist": "Sanosuke Sakuma",
-    "rarity": "Common",
+    "rarity": "Promo",
     "flavorText": "Its nature is to store up electricity. Forests where nests of Pikachu live are dangerous, since the trees are so often struck by lightning.",
     "nationalPokedexNumbers": [
       25

--- a/cards/en/sm10.json
+++ b/cards/en/sm10.json
@@ -4772,7 +4772,6 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "standard": "Banned",
       "expanded": "Banned"
     },
     "images": {

--- a/cards/en/sm12.json
+++ b/cards/en/sm12.json
@@ -11538,7 +11538,6 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "standard": "Banned",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/smp.json
+++ b/cards/en/smp.json
@@ -16312,5 +16312,169 @@
       "small": "https://images.pokemontcg.io/smp/SM244.png",
       "large": "https://images.pokemontcg.io/smp/SM244_hires.png"
     }
+  },
+  {
+    "id": "smp-SM245",
+    "name": "Mismagius",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Stage 1"
+    ],
+    "hp": "90",
+    "types": [
+      "Psychic"
+    ],
+    "evolvesFrom": "Misdreavus",
+    "attacks": [
+      {
+        "name": "Psybeam",
+        "cost": [
+          "Psychic"
+        ],
+        "convertedEnergyCost": 1,
+        "damage": "20",
+        "text": "Your opponent's Active Pokémon is now Confused."
+      },
+      {
+        "name": "Nonahex",
+        "cost": [
+          "Psychic",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 2,
+        "damage": "",
+        "text": "If your opponent's Active Pokémon has exactly 9 damage counters on it, that Pokémon is Knocked Out."
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Darkness",
+        "value": "×2"
+      }
+    ],
+    "resistances": [
+      {
+        "type": "Fighting",
+        "value": "-20"
+      }
+    ],
+    "retreatCost": [
+      "Colorless"
+    ],
+    "convertedRetreatCost": 1,
+    "number": "SM245",
+    "artist": "NC Empire",
+    "rarity": "Promo",
+    "flavorText": "Feared for its wrath and the curses it spreads, this Pokémon will also, on a whim, cast spells that help people.",
+    "nationalPokedexNumbers": [
+      429
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/smp/SM245.png",
+      "large": "https://images.pokemontcg.io/smp/SM245_hires.png"
+    }
+  },
+  {
+    "id": "smp-SM246",
+    "name": "Sabrina & Brycen",
+    "supertype": "Trainer",
+    "subtypes": [
+      "Supporter"
+    ],
+    "rules": [
+      "Search your deck for up to 2 basic Energy cards, reveal them, and put them into your hand. Then, shuffle your deck.",
+      "When you play this card, you may discard 5 other cards from your hand. If you do, you may also search for up to 3 Pokémon of different types in this way.",
+      "You may play only 1 Supporter card during your turn (before your attack)."
+    ],
+    "number": "SM246",
+    "artist": "Ryuta Fuse",
+    "rarity": "Promo",
+    "legalities": {
+      "unlimited": "Legal",
+      "expanded": "Legal"
+    }
+  },
+  {
+    "id": "smp-SM247",
+    "name": "Reshiram & Charizard-GX",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Basic",
+      "TAG TEAM",
+      "GX"
+    ],
+    "hp": "270",
+    "types": [
+      "Fire"
+    ],
+    "rules": [
+      "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
+    ],
+    "attacks": [
+      {
+        "name": "Outrage",
+        "cost": [
+          "Fire",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 2,
+        "damage": "30+",
+        "text": "This attack does 10 more damage for each damage counter on this Pokémon."
+      },
+      {
+        "name": "Flare Strike",
+        "cost": [
+          "Fire",
+          "Fire",
+          "Fire",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 4,
+        "damage": "230",
+        "text": "This Pokémon can't use Flare Strike during your next turn."
+      },
+      {
+        "name": "Double Blaze-GX",
+        "cost": [
+          "Fire",
+          "Fire",
+          "Fire"
+        ],
+        "convertedEnergyCost": 3,
+        "damage": "200+",
+        "text": "If this Pokémon has at least 3 extra Fire Energy attached to it (in addition to this attack's cost), this attack does 100 more damage, and this attack's damage isn't affected by any effects on your opponent's Active Pokémon. (You can't use more than 1 GX attack in a game.)"
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Water",
+        "value": "×2"
+      }
+    ],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
+    "convertedRetreatCost": 3,
+    "number": "SM247",
+    "artist": "aky CG Works",
+    "rarity": "Promo",
+    "nationalPokedexNumbers": [
+      6,
+      643
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/smp/SM247.png",
+      "large": "https://images.pokemontcg.io/smp/SM247_hires.png"
+    }
   }
 ]

--- a/sets/en.json
+++ b/sets/en.json
@@ -1313,8 +1313,8 @@
     "id": "xyp",
     "name": "XY Black Star Promos",
     "series": "XY",
-    "printedTotal": 183,
-    "total": 183,
+    "printedTotal": 211,
+    "total": 211,
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -1688,8 +1688,8 @@
     "id": "smp",
     "name": "SM Black Star Promos",
     "series": "Sun & Moon",
-    "printedTotal": 156,
-    "total": 156,
+    "printedTotal": 247,
+    "total": 247,
     "legalities": {
       "unlimited": "Legal",
       "expanded": "Legal"
@@ -2044,8 +2044,8 @@
     "id": "swshp",
     "name": "SWSH Black Star Promos",
     "series": "Sword & Shield",
-    "printedTotal": 103,
-    "total": 103,
+    "printedTotal": 178,
+    "total": 178,
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",

--- a/sets/en.json
+++ b/sets/en.json
@@ -1692,7 +1692,6 @@
     "total": 156,
     "legalities": {
       "unlimited": "Legal",
-      "standard": "Legal",
       "expanded": "Legal"
     },
     "ptcgoCode": "PR-SM",

--- a/sets/en.json
+++ b/sets/en.json
@@ -254,6 +254,23 @@
     }
   },
   {
+    "id": "bp",
+    "name": "Best of Game",
+    "series": "Other",
+    "printedTotal": 9,
+    "total": 9,
+    "legalities": {
+      "unlimited": "Legal"
+    },
+    "ptcgoCode": "BP",
+    "releaseDate": "2002/12/01",
+    "updatedAt": "2021/10/16 09:52:00",
+    "images": {
+      "symbol": "https://images.pokemontcg.io/bp/symbol.png",
+      "logo": "https://images.pokemontcg.io/bp/logo.png"
+    }
+  },
+  {
     "id": "ecard2",
     "name": "Aquapolis",
     "series": "E-Card",


### PR DESCRIPTION
I used the set id "bp". Data can be vetted from here: https://pokegym.net/towerdb/index.php?/category/102, but I don't have watermark-less images. I set the release date to 2002-12-01, but I only know it's 2002-12, not any more accurately. I set the printed total to be the same as total, as this seems to be the way with promo sets, although, IMHO, the sets with no printed total on the cards should not have printed totals in the data either.

I also changed the MCD21 card rarities to "Promo".