### PR TITLE
Various fixes

### DIFF
--- a/cards/en/ex7.json
+++ b/cards/en/ex7.json
@@ -2009,6 +2009,10 @@
       {
         "type": "Grass",
         "value": "-30"
+      },
+      {
+        "type": "Fighting",
+        "value": "-30"
       }
     ],
     "retreatCost": [

--- a/cards/en/pl4.json
+++ b/cards/en/pl4.json
@@ -5706,6 +5706,12 @@
     ],
     "weaknesses": [
       {
+        "type": "Colorless",
+        "value": "×2"
+      }
+    ],
+    "resistances": [
+      {
         "type": "Fighting",
         "value": "-20"
       }

--- a/cards/en/swsh7.json
+++ b/cards/en/swsh7.json
@@ -3641,7 +3641,7 @@
           ],
           "convertedEnergyCost": 1,
           "damage": "30+",
-          "text": "If your opponent's Active Pokémon is affected by a Special Condition, this attack does 90 more. Then, that Pokémon recovers from all Special Conditions."
+          "text": "If your opponent's Active Pokémon is affected by a Special Condition, this attack does 90 more damage. Then, that Pokémon recovers from all Special Conditions."
         }
       ],
       "weaknesses": [


### PR DESCRIPTION
* [Hypno (Evolving Skies)](https://pokemontcg.guru/card/hypno-sword-and-shield/swsh7-62): fixes #235 (still missing the word `damage`)
* [Salamence LV.X (Arceus)](https://pokemontcg.guru/card/salamence-lv-x-platinum/pl4-98): wrong weakness, missing resistance
* [Dark Dragonair (Team Rocket Returns)](https://pokemontcg.guru/card/dark-dragonair-ex/ex7-32): missing weakness