### PR TITLE
Various fixes to SWSH promos

### DIFF
--- a/cards/en/swshp.json
+++ b/cards/en/swshp.json
@@ -8129,6 +8129,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Drakloak",
+    "rules": [
+      "(This card cannot be used at official tournaments.)"
+    ],
     "attacks": [
       {
         "name": "Mach Turn",
@@ -8308,6 +8311,10 @@
     "types": [
       "Metal"
     ],
+    "rules": [
+      "(This card cannot be used at official tournaments.)",
+      "Put this card onto your Active Zacian. Zacian LV.X can use any attack, Poké-Power, or Poké-Body from its previous Level."
+    ],
     "abilities": [
       {
         "name": "Bladed Armament",
@@ -8369,6 +8376,9 @@
     "types": [
       "Water"
     ],
+    "rules": [
+      "(This card cannot be used at official tournaments.)"
+    ],
     "attacks": [
       {
         "name": "Filch",
@@ -8426,6 +8436,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Toxel",
+    "rules": [
+      "(This card cannot be used at official tournaments.)"
+    ],
     "attacks": [
       {
         "name": "Slow Ballad",
@@ -8484,6 +8497,9 @@
     "hp": "110",
     "types": [
       "Darkness"
+    ],
+    "rules": [
+      "(This card cannot be used at official tournaments.)"
     ],
     "attacks": [
       {
@@ -8953,7 +8969,8 @@
       "Darkness"
     ],
     "rules": [
-      "You can't have more than 1 Pokémon Star in your deck."
+      "You can't have more than 1 Pokémon Star in your deck.",
+      "(This card cannot be used at official tournaments.)"
     ],
     "abilities": [
       {

--- a/cards/en/swshp.json
+++ b/cards/en/swshp.json
@@ -8170,9 +8170,6 @@
       887
     ],
     "legalities": {
-      "unlimited": "Legal",
-      "standard": "Legal",
-      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH132.png",
@@ -8301,11 +8298,12 @@
   },
   {
     "id": "swshp-SWSH135",
-    "name": "Zacian",
+    "name": "Zacian LV.X",
     "supertype": "Pokémon",
     "subtypes": [
-      "BREAK"
+      "Level-Up"
     ],
+    "level": "X",
     "hp": "160",
     "types": [
       "Metal"
@@ -8348,15 +8346,12 @@
     ],
     "convertedRetreatCost": 2,
     "number": "SWSH135",
-    "artist": "5ban GraphicsLV.X",
+    "artist": "5ban Graphics",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       888
     ],
     "legalities": {
-      "unlimited": "Legal",
-      "standard": "Legal",
-      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH135.png",
@@ -8365,7 +8360,7 @@
   },
   {
     "id": "swshp-SWSH136",
-    "name": "Mimikyu",
+    "name": "Mimikyu δ",
     "supertype": "Pokémon",
     "subtypes": [
       "Basic"
@@ -8412,9 +8407,6 @@
       778
     ],
     "legalities": {
-      "unlimited": "Legal",
-      "standard": "Legal",
-      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH136.png",
@@ -8428,6 +8420,7 @@
     "subtypes": [
       "Stage 1"
     ],
+    "level": "65",
     "hp": "120",
     "types": [
       "Lightning"
@@ -8467,16 +8460,13 @@
     ],
     "convertedRetreatCost": 2,
     "number": "SWSH137",
-    "artist": "Naoyo KimuraLV.65",
+    "artist": "Naoyo Kimura",
     "rarity": "Promo",
     "flavorText": "When this Pokémon sounds as if it's strumming a guitar, it's actually clawing at the protrusions on its chest to generate electricity.",
     "nationalPokedexNumbers": [
       849
     ],
     "legalities": {
-      "unlimited": "Legal",
-      "standard": "Legal",
-      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH137.png",
@@ -8490,6 +8480,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "61",
     "hp": "110",
     "types": [
       "Darkness"
@@ -8529,15 +8520,12 @@
     ],
     "convertedRetreatCost": 2,
     "number": "SWSH138",
-    "artist": "kawayooLV.61",
+    "artist": "kawayoo",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       635
     ],
     "legalities": {
-      "unlimited": "Legal",
-      "standard": "Legal",
-      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH138.png",
@@ -8964,6 +8952,9 @@
     "types": [
       "Darkness"
     ],
+    "rules": [
+      "You can't have more than 1 Pokémon Star in your deck."
+    ],
     "abilities": [
       {
         "name": "Shadow Knife",
@@ -9001,9 +8992,6 @@
       658
     ],
     "legalities": {
-      "unlimited": "Legal",
-      "standard": "Legal",
-      "expanded": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH144.png",


### PR DESCRIPTION
This fixes:

- legalities of non-tournament-legal cards
- Lv.X subtype in Zacian
- added Lv.X and δ to card names based on what was done at cards from those periods
- moved some rogue level numbers from the illustrator field
- added Star rule

EDIT: Additional fixes:

- added Lv.X rule
- added "(This card cannot be used at official tournaments.)" to rules of relevant cards