### PR TITLE
Add Gold Pikachu & Zekrom Tag Team GX

### DIFF
--- a/cards/en/smp.json
+++ b/cards/en/smp.json
@@ -16393,5 +16393,79 @@
       "small": "https://images.pokemontcg.io/smp/SM247.png",
       "large": "https://images.pokemontcg.io/smp/SM247_hires.png"
     }
+  },
+  {
+      "id": "smp-SM248",
+      "name": "Pikachu & Zekrom-GX",
+      "supertype": "Pokémon",
+      "subtypes": [
+          "Basic",
+          "TAG TEAM",
+          "GX"
+      ],
+      "hp": "240",
+      "types": [
+          "Lightning"
+      ],
+      "rules": [
+          "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
+      ],
+      "attacks": [
+          {
+              "name": "Full Blitz",
+              "cost": [
+                  "Lightning",
+                  "Lightning",
+                  "Lightning"
+              ],
+              "convertedEnergyCost": 3,
+              "damage": "150",
+              "text": "Search your deck for up to 3 Lightning Energy cards and attach them to 1 of your Pokemon. Then, shuffle your deck."
+          },
+          {
+              "name": "Tag Bolt-GX",
+              "cost": [
+                  "Lightning",
+                  "Lightning",
+                  "Lightning"
+              ],
+              "convertedEnergyCost": 3,
+              "damage": "200",
+              "text": "If this Pokemon has at least 3 extra Lightning Energy attached to it (in addition to this attack's cost), this attack does 170 damage to 1 of your opponent's Benched Pokemon. (Don't apply Weakness and Resistance for Benched Pokemon.) (You can't use more than 1 GX attack in a game.)"
+          }
+      ],
+      "weaknesses": [
+      {
+          "type": "Fighting",
+          "value": "×2"
+      }
+      ],
+      "resistances": [
+          {
+              "type": "Metal",
+              "value": "-20"
+          }
+      ],
+      "retreatCost": [
+          "Colorless",
+          "Colorless",
+          "Colorless"
+      ],
+      "convertedRetreatCost": 3,
+      "number": "SM248",
+      "artist": "5ban Graphics",
+      "rarity": "Promo",
+      "nationalPokedexNumbers": [
+          25,
+          644
+      ],
+      "legalities": {
+          "unlimited": "Legal",
+          "expanded": "Legal"
+      },
+      "images": {
+          "small": "https://images.pokemontcg.io/smp/SM248.png",
+          "large": "https://images.pokemontcg.io/smp/SM248_hires.png"
+      }
   }
 ]


### PR DESCRIPTION
Reference: https://www.tcgplayer.com/product/253397/pokemon-sm-promos-pikachu-and-zekrom-gx-sm248