### PR TITLE
Add Victory Medal and World Collection Pikachu

### DIFF
--- a/cards/en/vc.json
+++ b/cards/en/vc.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "vc-s07",
+    "name": "Victory Medal",
+    "supertype": "Trainer",
+    "rules": "Flip 2 coins. If one of them is heads, draw a card. If both are heads, search your deck for any 1 card, put it into your hand, and shuffle your deck afterward.",
+    "artist": "Takumi Akabane",
+    "rarity": "Promo",
+    "legalities": {
+      "unlimited": "Legal",
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/vc/s07.png",
+      "large": "https://images.pokemontcg.io/vc/s07_hires.png"
+    }
+  },
+]

--- a/cards/en/wc.json
+++ b/cards/en/wc.json
@@ -1,0 +1,65 @@
+[
+  {
+    "id": "wc-en",
+    "name": "Pikachu",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Basic"
+    ],
+    "hp": "50",
+    "types": [
+      "Lightning"
+    ],
+    "attacks": [
+      {
+        "name": "Hello!",
+        "cost": [
+          "Colorless"
+        ],
+        "convertedEnergyCost": 1,
+        "damage": "",
+        "text": "Greet your opponent. Then, each player draws a card."
+      },
+      {
+        "name": "Thunderbolt",
+        "cost": [
+          "Lightning",
+          "Lightning",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 3,
+        "damage": "60",
+        "text": "Discard all Energy attached to Pikachu."
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Fighting",
+        "value": "×2"
+      }
+    ],
+    "resistances": [
+      {
+        "type": "Metal",
+        "value": "-20"
+      }
+    ],
+    "retreatCost": [
+      "Colorless"
+    ],
+    "convertedRetreatCost": 1,
+    "artist": "Kouki Saitou",
+    "rarity": "Promo",
+    "flavorText": "It raises its tail to check its surroundings. The tail is sometimes struck by lightning in this pose.",
+    "nationalPokedexNumbers": [
+      25
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/wc/en.png",
+      "large": "https://images.pokemontcg.io/wc/en_hires.png"
+    }
+  },
+]

--- a/sets/en.json
+++ b/sets/en.json
@@ -772,6 +772,17 @@
     }
   },
   {
+    "id": "vm",
+    "name": "Victory Medal",
+    "series": "Other",
+    "total": 1,
+    "legalities": {
+      "unlimited": "Legal"
+    },
+    "releaseDate": "2007/05/26",
+    "updatedAt": "2022/05/20 15:37:00",
+  },
+  {
     "id": "dp2",
     "name": "Mysterious Treasures",
     "series": "Diamond & Pearl",
@@ -1071,6 +1082,17 @@
       "symbol": "https://images.pokemontcg.io/hgss2/symbol.png",
       "logo": "https://images.pokemontcg.io/hgss2/logo.png"
     }
+  },
+  {
+    "id": "wc",
+    "name": "World Collection",
+    "series": "Other",
+    "total": 1,
+    "legalities": {
+      "unlimited": "Legal"
+    },
+    "releaseDate": "2010/07/08",
+    "updatedAt": "2022/05/20 15:37:00",
   },
   {
     "id": "hgss3",


### PR DESCRIPTION
Adds 1 of the cards from each as the others will probably want to be added as variants when they release. No card numbers as they have no card number. Not sure exactly how these sets want to be structured but that can be discussed and the PR edited if needs be.

Images: https://i0.wp.com/pkmncards.com/wp-content/uploads/victory-medal-spring-battle-road-2006-2007.jpg
https://i0.wp.com/pkmncards.com/wp-content/uploads/pikachu-world-collection-english.jpg
