### PR TITLE
Add "Special" subtype to Special energy cards

### DIFF
--- a/cards/en/swsh10.json
+++ b/cards/en/swsh10.json
@@ -11625,6 +11625,9 @@
     "id": "swsh10-216",
     "name": "Double Turbo Energy",
     "supertype": "Energy",
+    "subtypes": [
+      "Special"
+    ],
     "rules": [
       "As long as this card is attached to a Pokémon, it provides ColorlessColorless Energy. The attacks of the Pokémon this card is attached to do 20 less damage to your opponent's Pokémon (before applying Weakness and Resistance)."
     ],

--- a/cards/en/swsh7.json
+++ b/cards/en/swsh7.json
@@ -9127,6 +9127,9 @@
     "id": "swsh7-165",
     "name": "Treasure Energy",
     "supertype": "Energy",
+    "subtypes": [
+      "Special"
+    ],
     "rules": [
       "As long as this card is attached to a Pokémon, it provides Colorless Energy. If you took this card as a face-down Prize card during your turn, before you put it into your hand, you may attach this card to 1 of your Pokémon."
     ],

--- a/cards/en/swsh8.json
+++ b/cards/en/swsh8.json
@@ -14149,7 +14149,8 @@
     "name": "Fusion Strike Energy",
     "supertype": "Energy",
     "subtypes": [
-      "Fusion Strike"
+      "Fusion Strike",
+      "Special"
     ],
     "rules": [
       "This card can only be attached to a Fusion Strike Pokémon. If this card is attached to anything other than a Fusion Strike Pokémon, discard this card. As long as this card is attached to a Pokémon, it provides every type of Energy but provides only 1 Energy at a time. Prevent all effects of your opponent's Pokémon's Abilities done to the Pokémon this card is attached to."

--- a/cards/en/swsh9.json
+++ b/cards/en/swsh9.json
@@ -8435,6 +8435,9 @@
     "id": "swsh9-151",
     "name": "Double Turbo Energy",
     "supertype": "Energy",
+    "subtypes": [
+      "Special"
+    ],
     "rules": [
       "As long as this card is attached to a Pokémon, it provides ColorlessColorless Energy. The attacks of the Pokémon this card is attached to do 20 less damage to your opponent's Pokémon (before applying Weakness and Resistance)."
     ],


### PR DESCRIPTION
This PR adds the "Special" subtype to special energy cards that were added in newer sets but were missing the necessary subtype, fixing an issue with incorrect metadata returned from the API regarding these cards.

This PR fixes the issue outlined in #294 and results in PR #290 being OBE (overcome by events).