### PR TITLE
fix nat dex numbers in astral radiance, EX box topper rarity, Evolves into Field, Promos, Typos, add new subtypes and more.

### DIFF
--- a/cards/en/cel25c.json
+++ b/cards/en/cel25c.json
@@ -416,9 +416,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesTo": [
-      "Raichu"
-    ],
     "attacks": [
       {
         "cost": [
@@ -705,7 +702,8 @@
     "name": "Gardevoir ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "EX"
     ],
     "level": "ex",
     "hp": "150",
@@ -766,7 +764,8 @@
     "name": "Umbreon ★",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "70",
     "types": [
@@ -829,7 +828,8 @@
     "name": "Luxray GL LV.X",
     "supertype": "Pokémon",
     "subtypes": [
-      "Level-Up"
+      "Level-Up",
+      "SP"
     ],
     "level": "X",
     "hp": "110",
@@ -889,7 +889,8 @@
     "name": "Garchomp C LV.X",
     "supertype": "Pokémon",
     "subtypes": [
-      "Level-Up"
+      "Level-Up",
+      "SP"
     ],
     "level": "X",
     "hp": "110",
@@ -944,7 +945,8 @@
     "name": "Donphan",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "Prime"
     ],
     "hp": "120",
     "types": [

--- a/cards/en/dp3.json
+++ b/cards/en/dp3.json
@@ -1494,7 +1494,7 @@
     ],
     "number": "24",
     "artist": "Ken Sugimori",
-    "rarity": "Common",
+    "rarity": "Rare",
     "flavorText": "Its three heads moves alternately, driving it through tough soil to depths of over 60 miles.",
     "nationalPokedexNumbers": [
       51

--- a/cards/en/dp6.json
+++ b/cards/en/dp6.json
@@ -2339,7 +2339,7 @@
     "abilities": [
       {
         "name": "Regi Heal",
-        "text": "Once during your turn (before your attack), you may discard 2 cards from your hand. Then, remove 3 damage counters from Registeel. This power can't be used if Registeel is affected by a Special Conition.",
+        "text": "Once during your turn (before your attack), you may discard 2 cards from your hand. Then, remove 3 damage counters from Registeel. This power can't be used if Registeel is affected by a Special Condition.",
         "type": "Poké-Power"
       }
     ],

--- a/cards/en/dpp.json
+++ b/cards/en/dpp.json
@@ -2394,7 +2394,8 @@
     "name": "Toxicroak G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "hp": "90",
     "types": [
@@ -2511,7 +2512,8 @@
     "name": "Probopass G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "hp": "90",
     "types": [
@@ -2639,7 +2641,8 @@
     "name": "Charizard G LV.X",
     "supertype": "Pokémon",
     "subtypes": [
-      "Level-Up"
+      "Level-Up",
+      "SP"
     ],
     "hp": "120",
     "types": [
@@ -2708,7 +2711,8 @@
     "name": "Garchomp C LV.X",
     "supertype": "Pokémon",
     "subtypes": [
-      "Level-Up"
+      "Level-Up",
+      "SP"
     ],
     "hp": "110",
     "types": [
@@ -2763,7 +2767,8 @@
     "name": "Rayquaza C LV.X",
     "supertype": "Pokémon",
     "subtypes": [
-      "Level-Up"
+      "Level-Up",
+      "SP"
     ],
     "hp": "120",
     "types": [

--- a/cards/en/ex10.json
+++ b/cards/en/ex10.json
@@ -5182,7 +5182,7 @@
     "name": "Blissey ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",
@@ -5253,7 +5253,7 @@
     "name": "Espeon ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",
@@ -5320,7 +5320,7 @@
     "name": "Feraligatr ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -5521,7 +5521,7 @@
     "name": "Meganium ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -5606,7 +5606,7 @@
     "name": "Politoed ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -5684,7 +5684,7 @@
     "name": "Scizor ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",
@@ -5761,7 +5761,7 @@
     "name": "Steelix ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",
@@ -5852,7 +5852,7 @@
     "name": "Typhlosion ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -5918,7 +5918,7 @@
     "name": "Tyranitar ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -6014,7 +6014,7 @@
     "name": "Umbreon ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",
@@ -6276,7 +6276,7 @@
     "name": "Rocket's Persian ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",

--- a/cards/en/ex10.json
+++ b/cards/en/ex10.json
@@ -6317,7 +6317,7 @@
     "convertedRetreatCost": 1,
     "number": "116",
     "artist": "Mitsuhiro Arita",
-    "rarity": "Rare Secret",
+    "rarity": "Rare Holo EX",
     "nationalPokedexNumbers": [
       53
     ],
@@ -6378,7 +6378,7 @@
     "convertedRetreatCost": 1,
     "number": "117",
     "artist": "Ryo Ueda",
-    "rarity": "Rare Secret",
+    "rarity": "Rare Holo EX",
     "nationalPokedexNumbers": [
       251
     ],

--- a/cards/en/ex10.json
+++ b/cards/en/ex10.json
@@ -6090,7 +6090,8 @@
     "name": "Entei Star",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "80",
     "types": [
@@ -6151,7 +6152,8 @@
     "name": "Raikou Star",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "80",
     "types": [
@@ -6212,7 +6214,8 @@
     "name": "Suicune Star",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "80",
     "types": [

--- a/cards/en/ex11.json
+++ b/cards/en/ex11.json
@@ -6206,7 +6206,7 @@
     "convertedRetreatCost": 1,
     "number": "114",
     "artist": "Kagemaru Himeno",
-    "rarity": "Rare Secret",
+    "rarity": "Rare Holo",
     "nationalPokedexNumbers": [
       184
     ],

--- a/cards/en/ex11.json
+++ b/cards/en/ex11.json
@@ -5969,7 +5969,8 @@
     "name": "Groudon Star",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "90",
     "types": [
@@ -6033,7 +6034,8 @@
     "name": "Kyogre Star",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "90",
     "types": [
@@ -6097,7 +6099,8 @@
     "name": "Metagross Star",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "90",
     "types": [

--- a/cards/en/ex11.json
+++ b/cards/en/ex11.json
@@ -5754,7 +5754,7 @@
     "name": "Flareon ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",
@@ -5825,7 +5825,7 @@
     "name": "Jolteon ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",
@@ -5898,7 +5898,7 @@
     "name": "Vaporeon ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",

--- a/cards/en/ex12.json
+++ b/cards/en/ex12.json
@@ -5374,7 +5374,7 @@
     "convertedRetreatCost": 1,
     "number": "93",
     "artist": "Ryo Ueda",
-    "rarity": "Rare Secret",
+    "rarity": "Rare Holo",
     "nationalPokedexNumbers": [
       25
     ],

--- a/cards/en/ex12.json
+++ b/cards/en/ex12.json
@@ -4641,7 +4641,7 @@
     "name": "Arcanine ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",
@@ -4713,7 +4713,7 @@
     "name": "Armaldo ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -4786,7 +4786,7 @@
     "name": "Banette ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",
@@ -4852,7 +4852,7 @@
     "name": "Dustox ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -4923,7 +4923,7 @@
     "name": "Flygon ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -5062,7 +5062,7 @@
     "name": "Walrein ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",

--- a/cards/en/ex12.json
+++ b/cards/en/ex12.json
@@ -5140,7 +5140,8 @@
     "name": "Regice Star",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "90",
     "types": [
@@ -5202,7 +5203,8 @@
     "name": "Regirock Star",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "90",
     "types": [
@@ -5264,7 +5266,8 @@
     "name": "Registeel Star",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "90",
     "types": [

--- a/cards/en/ex13.json
+++ b/cards/en/ex13.json
@@ -5365,7 +5365,7 @@
     "name": "Crawdaunt ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",
@@ -5496,7 +5496,7 @@
     "name": "Mightyena ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",

--- a/cards/en/ex13.json
+++ b/cards/en/ex13.json
@@ -5569,7 +5569,8 @@
     "name": "Gyarados Star δ",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "80",
     "types": [
@@ -5632,7 +5633,8 @@
     "name": "Mewtwo Star",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "80",
     "types": [
@@ -5692,14 +5694,12 @@
     "name": "Pikachu Star",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "60",
     "types": [
       "Lightning"
-    ],
-    "evolvesTo": [
-      "Raichu"
     ],
     "rules": [
       "You can't have more than 1 Pokémon Star in your deck."

--- a/cards/en/ex13.json
+++ b/cards/en/ex13.json
@@ -5898,7 +5898,7 @@
     "convertedRetreatCost": 1,
     "number": "111",
     "artist": "Ken Sugimori",
-    "rarity": "Rare Secret",
+    "rarity": "Rare Holo",
     "nationalPokedexNumbers": [
       151
     ],

--- a/cards/en/ex14.json
+++ b/cards/en/ex14.json
@@ -4634,7 +4634,7 @@
     "name": "Aggron ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -4716,7 +4716,7 @@
     "name": "Blaziken ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -4782,7 +4782,7 @@
     "name": "Delcatty ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",
@@ -4848,7 +4848,7 @@
     "name": "Exploud ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -5107,7 +5107,7 @@
     "name": "Sceptile ex δ",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -5173,7 +5173,7 @@
     "name": "Shiftry ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -5246,7 +5246,7 @@
     "name": "Swampert ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",

--- a/cards/en/ex14.json
+++ b/cards/en/ex14.json
@@ -5370,12 +5370,12 @@
     "name": "Celebi Star",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "60",
     "types": [
-      "Grass",
-      "Star"
+      "Grass"
     ],
     "rules": [
       "You can't have more than 1 Pokémon Star in your deck."

--- a/cards/en/ex14.json
+++ b/cards/en/ex14.json
@@ -5309,7 +5309,8 @@
     "name": "Alakazam Star",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "80",
     "types": [
@@ -5373,7 +5374,8 @@
     ],
     "hp": "60",
     "types": [
-      "Grass"
+      "Grass",
+      "Star"
     ],
     "rules": [
       "You can't have more than 1 Pokémon Star in your deck."

--- a/cards/en/ex15.json
+++ b/cards/en/ex15.json
@@ -4435,7 +4435,8 @@
     "name": "Altaria ex δ",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "EX"
     ],
     "level": "ex",
     "hp": "100",
@@ -4505,7 +4506,8 @@
     "name": "Dragonite ex δ",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "EX"
     ],
     "level": "ex",
     "hp": "150",
@@ -4564,7 +4566,8 @@
     "name": "Flygon ex δ",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "EX"
     ],
     "level": "ex",
     "hp": "150",
@@ -4619,7 +4622,8 @@
     "name": "Gardevoir ex δ",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "EX"
     ],
     "level": "ex",
     "hp": "150",
@@ -4680,7 +4684,8 @@
     "name": "Kingdra ex δ",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "EX"
     ],
     "level": "ex",
     "hp": "140",
@@ -4750,7 +4755,8 @@
     "name": "Latias ex δ",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "EX"
     ],
     "level": "ex",
     "hp": "100",
@@ -4810,7 +4816,8 @@
     "name": "Latios ex δ",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "EX"
     ],
     "level": "ex",
     "hp": "100",
@@ -4880,7 +4887,8 @@
     "name": "Rayquaza ex δ",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "EX"
     ],
     "level": "ex",
     "hp": "110",
@@ -4950,7 +4958,8 @@
     "level": "ex",
     "hp": "160",
     "types": [
-      "Water"
+      "Water",
+      "EX"
     ],
     "evolvesFrom": "Shelgon",
     "rules": [
@@ -5028,7 +5037,8 @@
     "name": "Tyranitar ex δ",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "EX"
     ],
     "level": "ex",
     "hp": "150",
@@ -5104,7 +5114,8 @@
     "name": "Charizard Star δ",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "90",
     "types": [
@@ -5169,7 +5180,8 @@
     "name": "Mew Star δ",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "70",
     "types": [

--- a/cards/en/ex15.json
+++ b/cards/en/ex15.json
@@ -4953,13 +4953,13 @@
     "name": "Salamence ex δ",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "EX"
     ],
     "level": "ex",
     "hp": "160",
     "types": [
-      "Water",
-      "EX"
+      "Water"
     ],
     "evolvesFrom": "Shelgon",
     "rules": [

--- a/cards/en/ex16.json
+++ b/cards/en/ex16.json
@@ -4769,7 +4769,7 @@
     "name": "Claydol ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",
@@ -4841,7 +4841,7 @@
     "name": "Flygon ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -4908,7 +4908,7 @@
     "name": "Metagross ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -4978,7 +4978,7 @@
     "name": "Salamence ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -5056,7 +5056,7 @@
     "name": "Shiftry ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -5201,7 +5201,7 @@
     "name": "Walrein ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",

--- a/cards/en/ex16.json
+++ b/cards/en/ex16.json
@@ -5388,12 +5388,12 @@
     "name": "Vaporeon Star",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "70",
     "types": [
-      "Water",
-      "Star"
+      "Water"
     ],
     "rules": [
       "You can't have more than 1 Pokémon Star in your deck."

--- a/cards/en/ex16.json
+++ b/cards/en/ex16.json
@@ -5264,7 +5264,8 @@
     "name": "Flareon Star",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "70",
     "types": [
@@ -5322,7 +5323,8 @@
     "name": "Jolteon Star",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "70",
     "types": [
@@ -5390,7 +5392,8 @@
     ],
     "hp": "70",
     "types": [
-      "Water"
+      "Water",
+      "Star"
     ],
     "rules": [
       "You can't have more than 1 Pokémon Star in your deck."

--- a/cards/en/ex2.json
+++ b/cards/en/ex2.json
@@ -5187,7 +5187,7 @@
     "name": "Aerodactyl ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",
@@ -5263,7 +5263,7 @@
     "name": "Aggron ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -5343,7 +5343,7 @@
     "name": "Gardevoir ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -5413,7 +5413,7 @@
     "name": "Kabutops ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -5482,7 +5482,7 @@
     "name": "Raichu ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",
@@ -5545,7 +5545,7 @@
     "name": "Typhlosion ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -5617,7 +5617,7 @@
     "name": "Wailord ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",

--- a/cards/en/ex4.json
+++ b/cards/en/ex4.json
@@ -4571,7 +4571,7 @@
     "name": "Blaziken ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -4641,7 +4641,7 @@
     "name": "Cradily ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -4844,7 +4844,7 @@
     "name": "Sceptile ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -4994,7 +4994,7 @@
     "name": "Swampert ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",

--- a/cards/en/ex5.json
+++ b/cards/en/ex5.json
@@ -5308,7 +5308,7 @@
     "name": "Metagross ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -5386,7 +5386,7 @@
     "name": "Ninetales ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",
@@ -5640,7 +5640,7 @@
     "name": "Vileplume ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -5702,7 +5702,7 @@
     "name": "Wigglytuff ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",

--- a/cards/en/ex6.json
+++ b/cards/en/ex6.json
@@ -5484,7 +5484,7 @@
     "name": "Blastoise ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -5548,7 +5548,7 @@
     "name": "Charizard ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -5627,7 +5627,7 @@
     "name": "Clefable ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -5691,7 +5691,7 @@
     "name": "Electrode ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",
@@ -5751,7 +5751,7 @@
     "name": "Gengar ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -5830,7 +5830,7 @@
     "name": "Gyarados ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",
@@ -6004,7 +6004,7 @@
     "name": "Venusaur ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",

--- a/cards/en/ex7.json
+++ b/cards/en/ex7.json
@@ -5605,7 +5605,7 @@
     "name": "Rocket's Scizor ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",

--- a/cards/en/ex7.json
+++ b/cards/en/ex7.json
@@ -6032,14 +6032,12 @@
     "name": "Mudkip Star",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "70",
     "types": [
       "Water"
-    ],
-    "evolvesTo": [
-      "Marshtomp"
     ],
     "rules": [
       "You can't have more than 1 Pokémon Star in your deck."
@@ -6094,14 +6092,12 @@
     "name": "Torchic Star",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "70",
     "types": [
       "Fire"
-    ],
-    "evolvesTo": [
-      "Combusken"
     ],
     "rules": [
       "You can't have more than 1 Pokémon Star in your deck."
@@ -6156,14 +6152,12 @@
     "name": "Treecko Star",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "70",
     "types": [
       "Grass"
-    ],
-    "evolvesTo": [
-      "Grovyle"
     ],
     "rules": [
       "You can't have more than 1 Pokémon Star in your deck."

--- a/cards/en/ex8.json
+++ b/cards/en/ex8.json
@@ -5203,7 +5203,7 @@
     "name": "Crobat ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -5457,7 +5457,7 @@
     "name": "Hariyama ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",
@@ -5529,7 +5529,7 @@
     "name": "Manectric ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",
@@ -5669,7 +5669,7 @@
     "name": "Salamence ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 2",
       "EX"
     ],
     "level": "ex",
@@ -5752,7 +5752,7 @@
     "name": "Sharpedo ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",

--- a/cards/en/ex8.json
+++ b/cards/en/ex8.json
@@ -5818,7 +5818,8 @@
     "name": "Latias Star",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "80",
     "types": [
@@ -5888,7 +5889,8 @@
     "name": "Latios Star",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "80",
     "types": [
@@ -5954,7 +5956,8 @@
     "name": "Rayquaza Star",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "90",
     "types": [

--- a/cards/en/ex9.json
+++ b/cards/en/ex9.json
@@ -5557,7 +5557,7 @@
     "convertedRetreatCost": 1,
     "number": "107",
     "artist": "Masakazu Fukuda",
-    "rarity": "Rare Secret",
+    "rarity": "Rare Holo",
     "nationalPokedexNumbers": [
       83
     ],

--- a/cards/en/ex9.json
+++ b/cards/en/ex9.json
@@ -4655,7 +4655,7 @@
     "name": "Altaria ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",
@@ -4719,7 +4719,7 @@
     "name": "Cacturne ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",
@@ -4789,7 +4789,7 @@
     "name": "Camerupt ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",
@@ -4921,7 +4921,7 @@
     "name": "Dusclops ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",
@@ -4994,7 +4994,7 @@
     "name": "Medicham ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",
@@ -5065,7 +5065,7 @@
     "name": "Milotic ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",
@@ -5136,7 +5136,7 @@
     "name": "Raichu ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "Stage 1",
       "EX"
     ],
     "level": "ex",

--- a/cards/en/hgss1.json
+++ b/cards/en/hgss1.json
@@ -688,7 +688,7 @@
     "abilities": [
       {
         "name": "Second Sight",
-        "text": "Once during your turn (before your attack), you may look at the top 3 cards of that player's deck and put them back on top of that player's deck in any order. This power can't be uesd if Slowking is affected by a Special Condition.",
+        "text": "Once during your turn (before your attack), you may look at the top 3 cards of that player's deck and put them back on top of that player's deck in any order. This power can't be used if Slowking is affected by a Special Condition.",
         "type": "Poké-Power"
       }
     ],
@@ -5568,7 +5568,8 @@
     "name": "Ampharos",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "Prime"
     ],
     "hp": "140",
     "types": [
@@ -5631,7 +5632,8 @@
     "name": "Blissey",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "Prime"
     ],
     "hp": "130",
     "types": [
@@ -5688,7 +5690,8 @@
     "name": "Donphan",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "Prime"
     ],
     "hp": "120",
     "types": [
@@ -5762,7 +5765,8 @@
     "name": "Feraligatr",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "Prime"
     ],
     "hp": "140",
     "types": [
@@ -5821,7 +5825,8 @@
     "name": "Meganium",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "Prime"
     ],
     "hp": "150",
     "types": [
@@ -5885,7 +5890,8 @@
     "name": "Typhlosion",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "Prime"
     ],
     "hp": "140",
     "types": [

--- a/cards/en/hgss2.json
+++ b/cards/en/hgss2.json
@@ -4494,7 +4494,8 @@
     "name": "Crobat",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "Prime"
     ],
     "hp": "130",
     "types": [
@@ -4552,7 +4553,8 @@
     "name": "Kingdra",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "Prime"
     ],
     "hp": "130",
     "types": [
@@ -4606,7 +4608,8 @@
     "name": "Lanturn",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "Prime"
     ],
     "hp": "110",
     "types": [
@@ -4663,7 +4666,8 @@
     "name": "Steelix",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "Prime"
     ],
     "hp": "140",
     "types": [
@@ -4740,7 +4744,8 @@
     "name": "Tyranitar",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "Prime"
     ],
     "hp": "160",
     "types": [
@@ -4818,7 +4823,8 @@
     "name": "Ursaring",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "Prime"
     ],
     "hp": "110",
     "types": [

--- a/cards/en/hgss3.json
+++ b/cards/en/hgss3.json
@@ -4494,7 +4494,8 @@
     "name": "Espeon",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "Prime"
     ],
     "hp": "100",
     "types": [
@@ -4611,7 +4612,8 @@
     "name": "Raichu",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "Prime"
     ],
     "hp": "100",
     "types": [
@@ -4673,7 +4675,8 @@
     "name": "Scizor",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "Prime"
     ],
     "hp": "100",
     "types": [
@@ -4735,7 +4738,8 @@
     "name": "Slowking",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "Prime"
     ],
     "hp": "100",
     "types": [
@@ -4792,7 +4796,8 @@
     "name": "Umbreon",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "Prime"
     ],
     "hp": "100",
     "types": [

--- a/cards/en/hgss4.json
+++ b/cards/en/hgss4.json
@@ -5225,7 +5225,8 @@
     "name": "Absol",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Prime"
     ],
     "hp": "80",
     "types": [
@@ -5285,7 +5286,8 @@
     "name": "Celebi",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Prime"
     ],
     "hp": "60",
     "types": [
@@ -5340,7 +5342,8 @@
     "name": "Electrode",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "Prime"
     ],
     "hp": "90",
     "types": [
@@ -5401,7 +5404,8 @@
     "name": "Gengar",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "Prime"
     ],
     "hp": "130",
     "types": [
@@ -5467,7 +5471,8 @@
     "name": "Machamp",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "Prime"
     ],
     "hp": "150",
     "types": [
@@ -5537,7 +5542,8 @@
     "name": "Magnezone",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "Prime"
     ],
     "hp": "140",
     "types": [
@@ -5600,7 +5606,8 @@
     "name": "Mew",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Prime"
     ],
     "hp": "60",
     "types": [
@@ -5649,7 +5656,8 @@
     "name": "Yanmega",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "Prime"
     ],
     "hp": "110",
     "types": [

--- a/cards/en/hsp.json
+++ b/cards/en/hsp.json
@@ -388,7 +388,8 @@
     "name": "Feraligatr",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "Prime"
     ],
     "hp": "140",
     "types": [
@@ -447,7 +448,8 @@
     "name": "Meganium",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "Prime"
     ],
     "hp": "150",
     "types": [
@@ -511,7 +513,8 @@
     "name": "Typhlosion",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "Prime"
     ],
     "hp": "140",
     "types": [

--- a/cards/en/np.json
+++ b/cards/en/np.json
@@ -1812,7 +1812,7 @@
     "abilities": [
       {
         "name": "Synchronized Lift",
-        "text": "As long as you have Articuno ex and Moltres ex in play, the Retreat Cost for Zapdox ex is 0.",
+        "text": "As long as you have Articuno ex and Moltres ex in play, the Retreat Cost for Zapdos ex is 0.",
         "type": "Poké-Body"
       }
     ],

--- a/cards/en/pl1.json
+++ b/cards/en/pl1.json
@@ -410,7 +410,8 @@
     "name": "Dialga G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "79",
     "hp": "100",
@@ -750,7 +751,8 @@
     "name": "Palkia G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "78",
     "hp": "100",
@@ -1065,7 +1067,8 @@
     "name": "Weavile G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "48",
     "hp": "80",
@@ -1929,7 +1932,8 @@
     "name": "Gyarados G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "46",
     "hp": "110",
@@ -2545,7 +2549,8 @@
     "name": "Toxicroak G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "40",
     "hp": "90",
@@ -2601,7 +2606,8 @@
     "name": "Bronzong G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "58",
     "hp": "90",
@@ -2989,7 +2995,8 @@
     "name": "Crobat G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "44",
     "hp": "80",
@@ -3186,7 +3193,8 @@
     "name": "Houndoom G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "45",
     "hp": "90",
@@ -4898,7 +4906,8 @@
     "name": "Honchkrow G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "47",
     "hp": "80",
@@ -5587,7 +5596,8 @@
     "name": "Purugly G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "40",
     "hp": "90",
@@ -5956,7 +5966,8 @@
     "name": "Skuntank G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "46",
     "hp": "80",
@@ -6971,7 +6982,8 @@
     "name": "Dialga G LV.X",
     "supertype": "Pokémon",
     "subtypes": [
-      "Level-Up"
+      "Level-Up",
+      "SP"
     ],
     "level": "X",
     "hp": "120",
@@ -7171,7 +7183,8 @@
     "name": "Palkia G LV.X",
     "supertype": "Pokémon",
     "subtypes": [
-      "Level-Up"
+      "Level-Up",
+      "SP"
     ],
     "level": "X",
     "hp": "120",

--- a/cards/en/pl2.json
+++ b/cards/en/pl2.json
@@ -6394,13 +6394,13 @@
     "name": "Mismagius GL LV.X",
     "supertype": "Pokémon",
     "subtypes": [
-      "Level-Up"
+      "Level-Up",
+      "SP"
     ],
     "level": "X",
     "hp": "100",
     "types": [
-      "Psychic",
-      "SP"
+      "Psychic"
     ],
     "evolvesFrom": "Mismagius GL",
     "rules": [

--- a/cards/en/pl2.json
+++ b/cards/en/pl2.json
@@ -72,7 +72,8 @@
     "name": "Bastiodon GL",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "41",
     "hp": "90",
@@ -141,7 +142,8 @@
     "name": "Darkrai G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "58",
     "hp": "90",
@@ -204,7 +206,8 @@
     "name": "Floatzel GL",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "37",
     "hp": "80",
@@ -330,7 +333,8 @@
     "name": "Froslass GL",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "44",
     "hp": "70",
@@ -452,7 +456,8 @@
     "name": "Lucario GL",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "32",
     "hp": "80",
@@ -508,7 +513,8 @@
     "name": "Luxray GL",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "48",
     "hp": "80",
@@ -573,7 +579,8 @@
     "name": "Mismagius GL",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "26",
     "hp": "80",
@@ -636,7 +643,8 @@
     "name": "Rampardos GL",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "63",
     "hp": "90",
@@ -695,7 +703,8 @@
     "name": "Roserade GL",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "22",
     "hp": "80",
@@ -963,7 +972,8 @@
     "name": "Bronzong E4",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "54",
     "hp": "90",
@@ -1028,7 +1038,8 @@
     "name": "Drapion E4",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "53",
     "hp": "100",
@@ -1096,7 +1107,8 @@
     "name": "Espeon E4",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "55",
     "hp": "80",
@@ -1218,7 +1230,8 @@
     "name": "Gallade E4",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "59",
     "hp": "80",
@@ -1429,7 +1442,8 @@
     "name": "Golem E4",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "52",
     "hp": "110",
@@ -1499,7 +1513,8 @@
     "name": "Heracross E4",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "51",
     "hp": "90",
@@ -1700,7 +1715,8 @@
     "name": "Mamoswine GL",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "61",
     "hp": "100",
@@ -1766,7 +1782,8 @@
     "name": "Mr. Mime E4",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "53",
     "hp": "70",
@@ -1973,7 +1990,8 @@
     "name": "Raichu GL",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "46",
     "hp": "80",
@@ -2032,7 +2050,8 @@
     "name": "Rhyperior E4",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "55",
     "hp": "100",
@@ -2229,7 +2248,8 @@
     "name": "Vespiquen E4",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "50",
     "hp": "80",
@@ -2353,7 +2373,8 @@
     "name": "Yanmega E4",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "49",
     "hp": "90",
@@ -2417,7 +2438,8 @@
     "name": "Alakazam E4",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "56",
     "hp": "80",
@@ -2475,7 +2497,8 @@
     "name": "Electrode G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "38",
     "hp": "70",
@@ -2538,7 +2561,8 @@
     "name": "Gengar GL",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "65",
     "hp": "70",
@@ -2669,7 +2693,8 @@
     "name": "Hippowdon E4",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "52",
     "hp": "90",
@@ -2732,7 +2757,8 @@
     "name": "Infernape E4",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "55",
     "hp": "90",
@@ -2936,7 +2962,8 @@
     "name": "Machamp GL",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "64",
     "hp": "100",
@@ -2999,7 +3026,8 @@
     "name": "Rapidash E4",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "53",
     "hp": "70",
@@ -3051,7 +3079,8 @@
     "name": "Scizor E4",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "49",
     "hp": "80",
@@ -3238,7 +3267,8 @@
     "name": "Steelix GL",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "38",
     "hp": "110",
@@ -3451,7 +3481,8 @@
     "name": "Whiscash E4",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "50",
     "hp": "80",
@@ -3515,7 +3546,8 @@
     "name": "Aerodactyl GL",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "62",
     "hp": "80",
@@ -3574,7 +3606,8 @@
     "name": "Ambipom G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "40",
     "hp": "80",
@@ -3831,7 +3864,8 @@
     "name": "Flareon E4",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "55",
     "hp": "70",
@@ -3888,7 +3922,8 @@
     "name": "Forretress G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "35",
     "hp": "80",
@@ -3953,7 +3988,8 @@
     "name": "Gliscor E4",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "53",
     "hp": "80",
@@ -4148,7 +4184,8 @@
     "name": "Houndoom E4",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "52",
     "hp": "80",
@@ -4829,7 +4866,8 @@
     "name": "Quagsire GL",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "34",
     "hp": "90",
@@ -5399,15 +5437,13 @@
     "name": "Turtwig GL",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "20",
     "hp": "90",
     "types": [
       "Grass"
-    ],
-    "evolvesTo": [
-      "Grotle"
     ],
     "abilities": [
       {
@@ -5928,7 +5964,8 @@
     "name": "Alakazam E4 LV.X",
     "supertype": "Pokémon",
     "subtypes": [
-      "Level-Up"
+      "Level-Up",
+      "SP"
     ],
     "level": "X",
     "hp": "100",
@@ -5989,7 +6026,8 @@
     "name": "Floatzel GL LV.X",
     "supertype": "Pokémon",
     "subtypes": [
-      "Level-Up"
+      "Level-Up",
+      "SP"
     ],
     "level": "X",
     "hp": "100",
@@ -6106,7 +6144,8 @@
     "name": "Gallade E4 LV.X",
     "supertype": "Pokémon",
     "subtypes": [
-      "Level-Up"
+      "Level-Up",
+      "SP"
     ],
     "level": "X",
     "hp": "100",
@@ -6236,7 +6275,8 @@
     "name": "Infernape E4 LV.X",
     "supertype": "Pokémon",
     "subtypes": [
-      "Level-Up"
+      "Level-Up",
+      "SP"
     ],
     "level": "X",
     "hp": "110",
@@ -6292,7 +6332,8 @@
     "name": "Luxray GL LV.X",
     "supertype": "Pokémon",
     "subtypes": [
-      "Level-Up"
+      "Level-Up",
+      "SP"
     ],
     "level": "X",
     "hp": "110",
@@ -6358,7 +6399,8 @@
     "level": "X",
     "hp": "100",
     "types": [
-      "Psychic"
+      "Psychic",
+      "SP"
     ],
     "evolvesFrom": "Mismagius GL",
     "rules": [

--- a/cards/en/pl3.json
+++ b/cards/en/pl3.json
@@ -4,7 +4,8 @@
     "name": "Absol G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "59",
     "hp": "70",
@@ -68,7 +69,8 @@
     "name": "Blaziken FB",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "50",
     "hp": "80",
@@ -125,7 +127,8 @@
     "name": "Drifblim FB",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "50",
     "hp": "80",
@@ -188,7 +191,8 @@
     "name": "Electivire FB",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "50",
     "hp": "90",
@@ -451,7 +455,8 @@
     "name": "Rayquaza C",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "73",
     "hp": "100",
@@ -518,7 +523,8 @@
     "name": "Regigigas FB",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "50",
     "hp": "100",
@@ -653,7 +659,8 @@
     "name": "Staraptor FB",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "50",
     "hp": "80",
@@ -927,7 +934,8 @@
     "name": "Arcanine G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "60",
     "hp": "90",
@@ -1053,7 +1061,8 @@
     "name": "Butterfree FB",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "50",
     "hp": "90",
@@ -1242,7 +1251,8 @@
     "name": "Charizard G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "65",
     "hp": "100",
@@ -1426,7 +1436,8 @@
     "name": "Crawdaunt G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "61",
     "hp": "80",
@@ -1614,7 +1625,8 @@
     "name": "Dusknoir FB",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "50",
     "hp": "90",
@@ -1680,7 +1692,8 @@
     "name": "Empoleon FB",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "50",
     "hp": "90",
@@ -1931,7 +1944,8 @@
     "name": "Lucario C",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "60",
     "hp": "90",
@@ -2176,7 +2190,8 @@
     "name": "Milotic C",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "58",
     "hp": "90",
@@ -2472,7 +2487,8 @@
     "name": "Roserade C",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "58",
     "hp": "90",
@@ -2529,7 +2545,8 @@
     "name": "Sableye G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "58",
     "hp": "70",
@@ -3012,7 +3029,8 @@
     "name": "Altaria C",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "59",
     "hp": "80",
@@ -3329,7 +3347,8 @@
     "name": "Chatot G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "49",
     "hp": "60",
@@ -3453,7 +3472,8 @@
     "name": "Dragonite FB",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "50",
     "hp": "100",
@@ -3712,7 +3732,8 @@
     "name": "Garchomp C",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "62",
     "hp": "80",
@@ -4083,7 +4104,8 @@
     "name": "Manectric G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "58",
     "hp": "80",
@@ -4836,7 +4858,8 @@
     "name": "Raticate G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "57",
     "hp": "70",
@@ -5142,7 +5165,8 @@
     "name": "Skarmory FB",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "50",
     "hp": "80",
@@ -5205,7 +5229,8 @@
     "name": "Spiritomb C",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "58",
     "hp": "70",
@@ -5332,7 +5357,8 @@
     "name": "Togekiss C",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "60",
     "hp": "70",
@@ -8413,7 +8439,8 @@
     "name": "Absol G LV.X",
     "supertype": "Pokémon",
     "subtypes": [
-      "Level-Up"
+      "Level-Up",
+      "SP"
     ],
     "level": "X",
     "hp": "100",
@@ -8478,7 +8505,8 @@
     "name": "Blaziken FB LV.X",
     "supertype": "Pokémon",
     "subtypes": [
-      "Level-Up"
+      "Level-Up",
+      "SP"
     ],
     "level": "X",
     "hp": "110",
@@ -8537,7 +8565,8 @@
     "name": "Charizard G LV.X",
     "supertype": "Pokémon",
     "subtypes": [
-      "Level-Up"
+      "Level-Up",
+      "SP"
     ],
     "level": "X",
     "hp": "120",
@@ -8607,7 +8636,8 @@
     "name": "Electivire FB LV.X",
     "supertype": "Pokémon",
     "subtypes": [
-      "Level-Up"
+      "Level-Up",
+      "SP"
     ],
     "level": "X",
     "hp": "120",
@@ -8675,7 +8705,8 @@
     "name": "Garchomp C LV.X",
     "supertype": "Pokémon",
     "subtypes": [
-      "Level-Up"
+      "Level-Up",
+      "SP"
     ],
     "level": "X",
     "hp": "110",
@@ -8731,7 +8762,8 @@
     "name": "Rayquaza C LV.X",
     "supertype": "Pokémon",
     "subtypes": [
-      "Level-Up"
+      "Level-Up",
+      "SP"
     ],
     "level": "X",
     "hp": "120",
@@ -8800,7 +8832,8 @@
     "name": "Staraptor FB LV.X",
     "supertype": "Pokémon",
     "subtypes": [
-      "Level-Up"
+      "Level-Up",
+      "SP"
     ],
     "level": "X",
     "hp": "100",

--- a/cards/en/pl4.json
+++ b/cards/en/pl4.json
@@ -723,7 +723,8 @@
     "name": "Zapdos G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "60",
     "hp": "90",
@@ -1627,7 +1628,8 @@
     "name": "Porygon-Z G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "56",
     "hp": "80",
@@ -3370,7 +3372,8 @@
     "name": "Beedrill G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "56",
     "hp": "80",

--- a/cards/en/pop5.json
+++ b/cards/en/pop5.json
@@ -688,7 +688,8 @@
     "name": "Espeon Star",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "70",
     "types": [
@@ -746,7 +747,8 @@
     "name": "Umbreon Star",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "70",
     "types": [

--- a/cards/en/sm5.json
+++ b/cards/en/sm5.json
@@ -3379,7 +3379,8 @@
     "name": "Giratina ◇",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Prism Star"
     ],
     "hp": "160",
     "types": [
@@ -3612,7 +3613,8 @@
     "name": "Lunala ◇",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Prism Star"
     ],
     "hp": "160",
     "types": [
@@ -4558,7 +4560,8 @@
     "name": "Darkrai ◇",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Prism Star"
     ],
     "hp": "160",
     "types": [
@@ -5346,7 +5349,8 @@
     "name": "Solgaleo ◇",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Prism Star"
     ],
     "hp": "160",
     "types": [
@@ -7251,7 +7255,8 @@
     "name": "Cyrus ◇",
     "supertype": "Trainer",
     "subtypes": [
-      "Supporter"
+      "Supporter",
+      "Prism Star"
     ],
     "rules": [
       "You can play this card only if your Active Pokémon is a Water or Metal Pokémon.",
@@ -7697,7 +7702,8 @@
     "name": "Super Boost Energy ◇",
     "supertype": "Energy",
     "subtypes": [
-      "Special"
+      "Special",
+      "Prism Star"
     ],
     "rules": [
       "This card provides Colorless Energy.",

--- a/cards/en/sm6.json
+++ b/cards/en/sm6.json
@@ -1828,7 +1828,8 @@
     "name": "Volcanion ◇",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Prism Star"
     ],
     "hp": "160",
     "types": [
@@ -4411,7 +4412,8 @@
     "name": "Diancie ◇",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Prism Star"
     ],
     "hp": "120",
     "types": [
@@ -5828,7 +5830,8 @@
     "name": "Arceus ◇",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Prism Star"
     ],
     "hp": "160",
     "types": [
@@ -6404,7 +6407,8 @@
     "name": "Lysandre ◇",
     "supertype": "Trainer",
     "subtypes": [
-      "Supporter"
+      "Supporter",
+      "Prism Star"
     ],
     "rules": [
       "For each of your Fire Pokémon in play, put a card from your opponent's discard pile in the Lost Zone.",
@@ -6616,7 +6620,8 @@
     "name": "Beast Energy ◇",
     "supertype": "Energy",
     "subtypes": [
-      "Special"
+      "Special",
+      "Prism Star"
     ],
     "rules": [
       "This card provides Colorless Energy.",

--- a/cards/en/sm7.json
+++ b/cards/en/sm7.json
@@ -5907,7 +5907,8 @@
     "name": "Jirachi ◇",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Prism Star"
     ],
     "hp": "80",
     "types": [
@@ -6522,7 +6523,8 @@
     "name": "Latias ◇",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Prism Star"
     ],
     "hp": "130",
     "types": [
@@ -6573,7 +6575,8 @@
     "name": "Latios ◇",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Prism Star"
     ],
     "hp": "140",
     "types": [

--- a/cards/en/sm75.json
+++ b/cards/en/sm75.json
@@ -348,7 +348,8 @@
     "name": "Victini ◇",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Prism Star"
     ],
     "hp": "90",
     "types": [
@@ -3569,7 +3570,8 @@
     "name": "Lance ◇",
     "supertype": "Trainer",
     "subtypes": [
-      "Supporter"
+      "Supporter",
+      "Prism Star"
     ],
     "rules": [
       "You can play this card only if 1 of your Pokémon was Knocked Out during your opponent's last turn.",

--- a/cards/en/sm8.json
+++ b/cards/en/sm8.json
@@ -1061,7 +1061,8 @@
     "name": "Celebi ◇",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Prism Star"
     ],
     "hp": "90",
     "types": [
@@ -8661,7 +8662,8 @@
     "name": "Xerneas ◇",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Prism Star"
     ],
     "hp": "160",
     "types": [
@@ -9276,7 +9278,8 @@
     "name": "Ditto ◇",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Prism Star"
     ],
     "hp": "40",
     "types": [
@@ -10339,7 +10342,8 @@
     "name": "Heat Factory ◇",
     "supertype": "Trainer",
     "subtypes": [
-      "Stadium"
+      "Stadium",
+      "Prism Star"
     ],
     "rules": [
       "Once during each player's turn, that player may discard a Fire Energy card from their hand. If they do, they draw 3 cards.",
@@ -10387,7 +10391,8 @@
     "name": "Life Forest ◇",
     "supertype": "Trainer",
     "subtypes": [
-      "Stadium"
+      "Stadium",
+      "Prism Star"
     ],
     "rules": [
       "Once during each player's turn, that player may heal 60 damage and remove all Special Conditions from 1 of their Grass Pokémon.",
@@ -10435,7 +10440,8 @@
     "name": "Lusamine ◇",
     "supertype": "Trainer",
     "subtypes": [
-      "Supporter"
+      "Supporter",
+      "Prism Star"
     ],
     "rules": [
       "You can play this card only if your opponent has exactly 3 Prize cards remaining.",
@@ -10715,7 +10721,8 @@
     "name": "Thunder Mountain ◇",
     "supertype": "Trainer",
     "subtypes": [
-      "Stadium"
+      "Stadium",
+      "Prism Star"
     ],
     "rules": [
       "The attacks of Lightning Pokémon (both yours and your opponent's) cost Lightning less.",

--- a/cards/en/sm9.json
+++ b/cards/en/sm9.json
@@ -550,7 +550,8 @@
     "name": "Shaymin ◇",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Prism Star"
     ],
     "hp": "80",
     "types": [
@@ -3051,7 +3052,8 @@
     "name": "Tapu Koko ◇",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Prism Star"
     ],
     "hp": "130",
     "types": [
@@ -8136,7 +8138,8 @@
     "name": "Black Market ◇",
     "supertype": "Trainer",
     "subtypes": [
-      "Stadium"
+      "Stadium",
+      "Prism Star"
     ],
     "rules": [
       "When a Darkness Pokémon (yours or your opponent's) that has any Darkness Energy attached to it is Knocked Out by damage from an opponent's attack, that player takes 1 fewer Prize card.",
@@ -8748,7 +8751,8 @@
     "name": "Wondrous Labyrinth ◇",
     "supertype": "Trainer",
     "subtypes": [
-      "Stadium"
+      "Stadium",
+      "Prism Star"
     ],
     "rules": [
       "The attacks of non-Fairy Pokémon (both yours and your opponent's) cost Colorless more.",

--- a/cards/en/swsh1.json
+++ b/cards/en/swsh1.json
@@ -9937,7 +9937,7 @@
       "Item"
     ],
     "rules": [
-      "Choose 1 or both:",
+      "Choose 1 or both: • Shuffle up to 2 Pokémon from your discard pile into your deck. • Shuffle up to 2 basic Energy cards from your discard pile into your deck.",
       "You may play any number of Item cards during your turn."
     ],
     "number": "171",
@@ -11779,7 +11779,7 @@
       "Item"
     ],
     "rules": [
-      "Choose 1 or both:",
+      "Choose 1 or both: • Shuffle up to 2 Pokémon from your discard pile into your deck. • Shuffle up to 2 basic Energy cards from your discard pile into your deck.",
       "You may play any number of Item cards during your turn."
     ],
     "number": "215",

--- a/cards/en/swsh10.json
+++ b/cards/en/swsh10.json
@@ -2648,6 +2648,9 @@
     "artist": "Akira Komayama",
     "rarity": "Rare",
     "flavorText": "Clads itself in the souls of comrades that perished before fulfilling their goals of journeying upstream. No other species throughout all Hisui's rivers is Basculegion's equal.",
+    "nationalPokedexNumbers": [
+      902
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -2952,6 +2955,9 @@
     "number": "49",
     "artist": "5ban Graphics",
     "rarity": "Rare Holo V",
+    "nationalPokedexNumbers": [
+      866
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -3077,6 +3083,9 @@
     "artist": "Shiburingaru",
     "rarity": "Rare",
     "flavorText": "This Pokémon is a cluster of electrical energy. It's said that removing the rings on Regieleki's body will unleash the Pokémon's latent power.",
+    "nationalPokedexNumbers": [
+      894
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -4200,6 +4209,9 @@
     "artist": "Mizue",
     "rarity": "Rare Holo",
     "flavorText": "The black orbs shine with an uncanny light when the Pokémon is erecting invisible barriers. The fur shed from its beard retains heat well and is a highly useful material for winter clothing.",
+    "nationalPokedexNumbers": [
+      899
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -5227,6 +5239,9 @@
     "artist": "Shin Nagasawa",
     "rarity": "Rare",
     "flavorText": "A violent creature that fells towering trees with its crude axes and shields itself with hard stone. If one should chance upon this Pokémon in the wilds, one's only recourse is to flee.",
+    "nationalPokedexNumbers": [
+      900
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -5287,6 +5302,9 @@
     "artist": "Anesaki Dynamic",
     "rarity": "Rare Holo",
     "flavorText": "A violent creature that fells towering trees with its crude axes and shields itself with hard stone. If one should chance upon this Pokémon in the wilds, one's only recourse is to flee.",
+    "nationalPokedexNumbers": [
+      900
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -5349,6 +5367,9 @@
     "number": "87",
     "artist": "5ban Graphics",
     "rarity": "Rare Holo V",
+    "nationalPokedexNumbers": [
+      900
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -5519,6 +5540,9 @@
     "artist": "AKIRA EGAWA",
     "rarity": "Uncommon",
     "flavorText": "Its lancelike spikes and savage temperament have earned it the nickname “sea fiend.” It slurps up poison to nourish itself.",
+    "nationalPokedexNumbers": [
+      904
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -5578,6 +5602,9 @@
     "artist": "Anesaki Dynamic",
     "rarity": "Rare",
     "flavorText": "Its lancelike spikes and savage temperament have earned it the nickname “sea fiend.” It slurps up poison to nourish itself.",
+    "nationalPokedexNumbers": [
+      904
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -5697,6 +5724,9 @@
     "artist": "Kouki Saitou",
     "rarity": "Rare Holo",
     "flavorText": "Because of Sneasler's virulent poison and daunting physical prowess, no other species could hope to best it on the frozen highlands. Preferring solitude, this species does not form packs.",
+    "nationalPokedexNumbers": [
+      904
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -5753,6 +5783,9 @@
     "number": "94",
     "artist": "5ban Graphics",
     "rarity": "Rare Holo V",
+    "nationalPokedexNumbers": [
+      904
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -7286,6 +7319,9 @@
     "artist": "DOM",
     "rarity": "Rare",
     "flavorText": "An academic theory proposes that Regidrago's arms were once the head of an ancient dragon Pokémon. The theory remains unproven.",
+    "nationalPokedexNumbers": [
+      895
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -7680,6 +7716,9 @@
     "artist": "nagimiso",
     "rarity": "Rare",
     "flavorText": "I believe it was Hisui's swampy terrain that gave Ursaluna its burly physique and newfound capacity to manipulate peat at will.",
+    "nationalPokedexNumbers": [
+      901
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -8287,6 +8326,9 @@
     "number": "134",
     "artist": "aky CG Works",
     "rarity": "Rare Holo V",
+    "nationalPokedexNumbers": [
+      899
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -9878,6 +9920,9 @@
     "number": "174",
     "artist": "5ban Graphics",
     "rarity": "Rare Ultra",
+    "nationalPokedexNumbers": [
+      904
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -9934,6 +9979,9 @@
     "number": "175",
     "artist": "OKACHEKE",
     "rarity": "Rare Ultra",
+    "nationalPokedexNumbers": [
+      904
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -10251,6 +10299,9 @@
     "number": "180",
     "artist": "aky CG Works",
     "rarity": "Rare Ultra",
+    "nationalPokedexNumbers": [
+      899
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -10927,6 +10978,9 @@
     "number": "196",
     "artist": "5ban Graphics",
     "rarity": "Rare Rainbow",
+    "nationalPokedexNumbers": [
+      900
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",

--- a/cards/en/swsh10tg.json
+++ b/cards/en/swsh10tg.json
@@ -843,6 +843,9 @@
     "number": "TG14",
     "artist": "Mitsuhiro Arita",
     "rarity": "Rare Holo V",
+    "nationalPokedexNumbers": [
+      898
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -905,6 +908,9 @@
     "number": "TG15",
     "artist": "Hitoshi Ariga",
     "rarity": "Rare Holo V",
+    "nationalPokedexNumbers": [
+      898
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -1042,6 +1048,9 @@
     "number": "TG17",
     "artist": "Oswaldo KATO",
     "rarity": "Rare Holo V",
+    "nationalPokedexNumbers": [
+      898
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -1108,6 +1117,9 @@
     "number": "TG18",
     "artist": "chibi",
     "rarity": "Rare Holo V",
+    "nationalPokedexNumbers": [
+      898
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -1616,6 +1628,9 @@
     "number": "TG29",
     "artist": "5ban Graphics",
     "rarity": "Rare Secret",
+    "nationalPokedexNumbers": [
+      898
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -1682,6 +1697,9 @@
     "number": "TG30",
     "artist": "5ban Graphics",
     "rarity": "Rare Secret",
+    "nationalPokedexNumbers": [
+      898
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",

--- a/cards/en/swshp.json
+++ b/cards/en/swshp.json
@@ -11535,6 +11535,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "SWSH179",
+    "artist": "Souichirou Gunjima",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       136
@@ -11591,6 +11592,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "SWSH180",
+    "artist": "OKACHEKE",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       136
@@ -11656,6 +11658,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "SWSH181",
+    "artist": "Tika Matsuno",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       134
@@ -11721,6 +11724,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "SWSH182",
+    "artist": "Atsushi Furusawa",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       134
@@ -11780,6 +11784,7 @@
       }
     ],
     "number": "SWSH183",
+    "artist": "nagimiso",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       135
@@ -11829,6 +11834,7 @@
       }
     ],
     "number": "SWSH184",
+    "artist": "Hasuno",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       135
@@ -11877,6 +11883,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "SWSH185",
+    "artist": "Shinji Kanda",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       146
@@ -11935,6 +11942,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "SWSH186",
+    "artist": "NC Empire",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       448
@@ -11992,6 +12000,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "SWSH187",
+    "artist": "saino misaki",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       510
@@ -12051,6 +12060,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "SWSH188",
+    "artist": "Misa Tsutsui",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       400
@@ -12104,6 +12114,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "SWSH189",
+    "artist": "nagimiso",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       841
@@ -12233,6 +12244,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "SWSH191",
+    "artist": "OKACHEKE",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       470
@@ -12293,6 +12305,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "SWSH192",
+    "artist": "OKACHEKE",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       471
@@ -12344,6 +12357,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "SWSH193",
+    "artist": "Megumi Higuchi",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       862
@@ -12408,6 +12422,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "SWSH194",
+    "artist": "PLANETA Yamashita",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       470
@@ -12470,6 +12485,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "SWSH195",
+    "artist": "5ban Graphics",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       470
@@ -12534,6 +12550,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "SWSH196",
+    "artist": "PLANETA Yamashita",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       471
@@ -12600,6 +12617,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "SWSH197",
+    "artist": "5ban Graphics",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       471
@@ -12657,6 +12675,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "SWSH198",
+    "artist": "5ban Graphics",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       25
@@ -12720,6 +12739,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "SWSH199",
+    "artist": "PLANETA Mochizuki",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       745
@@ -12789,6 +12809,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "SWSH200",
+    "artist": "PLANETA Mochizuki",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       823
@@ -12858,6 +12879,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "SWSH201",
+    "artist": "5ban Graphics",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       196
@@ -12919,6 +12941,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "SWSH202",
+    "artist": "aky CG Works",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       700
@@ -12984,6 +13007,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "SWSH203",
+    "artist": "5ban Graphics",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       197
@@ -13049,6 +13073,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "SWSH204",
+    "artist": "Atsushi Furusawa",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       493
@@ -13633,6 +13658,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "SWSH213",
+    "artist": "takuyoa",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       448
@@ -13698,6 +13724,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "SWSH214",
+    "artist": "aky CG Works",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       448
@@ -14105,6 +14132,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "SWSH219",
+    "artist": "Ayaka Yoshida"
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       836
@@ -14156,6 +14184,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "SWSH220",
+    "artist": "sowsow",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       722
@@ -14216,6 +14245,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "SWSH221",
+    "artist": "Teeziro",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       155
@@ -14267,6 +14297,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "SWSH222",
+    "artist": "kurumitsu",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       501

--- a/cards/en/swshp.json
+++ b/cards/en/swshp.json
@@ -8238,7 +8238,8 @@
     "name": "Dragapult",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "Prime"
     ],
     "hp": "150",
     "types": [
@@ -8621,7 +8622,8 @@
     "name": "Hydreigon C",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "61",
     "hp": "110",
@@ -9100,7 +9102,8 @@
     "name": "Greninja Star",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "Star"
     ],
     "hp": "130",
     "types": [
@@ -11398,6 +11401,67 @@
     }
   },
   {
+    "id": "swshp-SWSH177",
+    "name": "Special Delivery Bidoof",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Basic"
+    ],
+    "hp": "70",
+    "types": [
+      "Colorless"
+    ],
+    "attacks": [
+      {
+        "name": "Happy Delivery",
+        "cost": [
+          "Colorless"
+        ],
+        "convertedEnergyCost": 1,
+        "damage": "",
+        "text": "Search your deck for an Item card, reveal it, and put it into your hand. Then, shuffle your deck."
+      },
+      {
+        "name": "Rock Smash",
+        "cost": [
+          "Colorless",
+          "Colorless",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 3,
+        "damage": "30+",
+        "text": "Flip a coin. If heads, this attack does 30 more damage."
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Fighting",
+        "value": "×2"
+      }
+    ],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
+    "convertedRetreatCost": 2,
+    "number": "SWSH177",
+    "artist": "The Pokemon Company Art Team",
+    "rarity": "Promo",
+    "nationalPokedexNumbers": [
+      399
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "regulationMark": "E",
+    "images": {
+      "small": "https://images.pokemontcg.io/swshp/SWSH177.png",
+      "large": "https://images.pokemontcg.io/swshp/SWSH177_hires.png"
+    }
+  }
+  {
     "id": "swshp-SWSH178",
     "name": "Professor's Research",
     "supertype": "Trainer",
@@ -12109,6 +12173,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "SWSH190",
+    "artist": "OKACHEKE",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       133
@@ -13000,6 +13065,525 @@
     }
   },
   {
+    "id": "swshp-SWSH205",
+    "name": "Hisuian Basculegion",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Stage 1"
+    ],
+    "hp": "120",
+    "types": [
+      "Water"
+    ],
+    "evolvesFrom": "Hisuian Basculin",
+    "attacks": [
+      {
+        "name": "Grudge Dive",
+        "cost": [
+          "Water"
+        ],
+        "convertedEnergyCost": 1,
+        "damage": "30+",
+        "text": "If any of your Pokémon were Knocked Out by damage from an attack from your opponent's Pokémon during their last turn, this attack does 90 more damage, and your opponent's Active Pokémon is now Confused."
+      },
+      {
+        "name": "Jet Headbutt",
+        "cost": [
+          "Water",
+          "Colorless",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 3,
+        "damage": "80",
+        "text": ""
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Lightning",
+        "value": "×2"
+      }
+    ],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
+    "convertedRetreatCost": 2,
+    "number": "SWSH205",
+    "artist": "Pani Kobayashi",
+    "rarity": "Promo",
+    "flavorText": "Clads itself in the souls of comrades that perished before fulfilling their goals of journeying upstream. No other species throughout all Hisui's rivers is Basculegion's equal.",
+    "nationalPokedexNumbers": [
+      902
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "regulationMark": "F",
+    "images": {
+      "small": "https://images.pokemontcg.io/swshp/SWSH205.png",
+      "large": "https://images.pokemontcg.io/swshp/SWSH205_hires.png"
+    }
+  },
+  {
+    "id": "swshp-SWSH206",
+    "name": "Wyrdeer",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Stage 1"
+    ],
+    "hp": "140",
+    "types": [
+      "Psychic"
+    ],
+    "evolvesFrom": "Stantler",
+    "abilities": [
+      {
+        "name": "Hurried Gait",
+        "text": "Once during your turn, you may draw a card.",
+        "type": "Ability"
+      }
+    ],
+    "attacks": [
+      {
+        "name": "Extrasensory",
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 2,
+        "damage": "40+",
+        "text": "If you have the same number of cards in your hand as your opponent, this attack does 80 more damage."
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Darkness",
+        "value": "×2"
+      }
+    ],
+    "resistances": [
+      {
+        "type": "Fighting",
+        "value": "-30"
+      }
+    ],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
+    "convertedRetreatCost": 2,
+    "number": "SWSH206",
+    "artist": "Eri Yamaki",
+    "rarity": "Promo",
+    "flavorText": "The black orbs shine with an uncanny light when the Pokémon is erecting invisible barriers. The fur shed from its beard retains heat well and is a highly useful material for winter clothing.",
+    "nationalPokedexNumbers": [
+      899
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "regulationMark": "F",
+    "images": {
+      "small": "https://images.pokemontcg.io/swshp/SWSH206.png",
+      "large": "https://images.pokemontcg.io/swshp/SWSH206_hires.png"
+    }
+  },
+  {
+    "id": "swshp-SWSH207",
+    "name": "Hisuian Samurott",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Stage 2"
+    ],
+    "hp": "170",
+    "types": [
+      "Darkness"
+    ],
+    "evolvesFrom": "Dewott",
+    "abilities": [
+      {
+        "name": "Wily Stance",
+        "text": "You must discard a card from your hand in order to use this Ability. Once during your turn, you may draw 3 cards.",
+        "type": "Ability"
+      }
+    ],
+    "attacks": [
+      {
+        "name": "Dark Mastery",
+        "cost": [
+          "Darkness",
+          "Colorless",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 3,
+        "damage": "60+",
+        "text": "This attack does 20 more damage for each Energy attached to all of your Pokémon."
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Grass",
+        "value": "×2"
+      }
+    ],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
+    "convertedRetreatCost": 2,
+    "number": "SWSH207",
+    "artist": "Oswaldo KATO",
+    "rarity": "Promo",
+    "flavorText": "Hard of heart and deft of blade, this rare form of Samurott is a product of the Pokémon's evolution in the region of Hisui. Its turbulent blows crash into foes like ceaseless pounding waves.",
+    "nationalPokedexNumbers": [
+      503
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "regulationMark": "F",
+    "images": {
+      "small": "https://images.pokemontcg.io/swshp/SWSH207.png",
+      "large": "https://images.pokemontcg.io/swshp/SWSH207_hires.png"
+    }
+  },
+  {
+    "id": "swshp-SWSH208",
+    "name": "Magnezone",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Stage 2"
+    ],
+    "hp": "150",
+    "types": [
+      "Metal"
+    ],
+    "evolvesFrom": "Magneton",
+    "abilities": [
+      {
+        "name": "Giga Magnet",
+        "text": "Once during your turn, you may look at the top 6 cards of your deck and attach any number of Metal Energy cards you find there to your Pokémon in any way you like. Shuffle the other cards back into your deck.",
+        "type": "Ability"
+      }
+    ],
+    "attacks": [
+      {
+        "name": "Power Beam",
+        "cost": [
+          "Metal",
+          "Colorless",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 3,
+        "damage": "120",
+        "text": ""
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Fire",
+        "value": "×2"
+      }
+    ],
+    "resistances": [
+      {
+        "type": "Grass",
+        "value": "-30"
+      }
+    ],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
+    "convertedRetreatCost": 2,
+    "number": "SWSH208",
+    "artist": "zig",
+    "rarity": "Promo",
+    "flavorText": "Some say that Magnezone receives signals from space via the antenna on its head and that it's being controlled by some mysterious being.",
+    "nationalPokedexNumbers": [
+      462
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "regulationMark": "F",
+    "images": {
+      "small": "https://images.pokemontcg.io/swshp/SWSH208.png",
+      "large": "https://images.pokemontcg.io/swshp/SWSH208_hires.png"
+    }
+  },
+  {
+    "id": "swshp-SWSH209",
+    "name": "Toxel",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Basic",
+      "Fusion Strike"
+    ],
+    "hp": "60",
+    "types": [
+      "Lightning"
+    ],
+    "evolvesTo": [
+      "Toxtricity"
+    ],
+    "attacks": [
+      {
+        "name": "Growl",
+        "cost": [
+          "Colorless"
+        ],
+        "convertedEnergyCost": 1,
+        "damage": "",
+        "text": "During your opponent's next turn, the Defending Pokémon's attacks do 30 less damage (before applying Weakness and Resistance)."
+      },
+      {
+        "name": "Tiny Bolt",
+        "cost": [
+          "Lightning"
+        ],
+        "convertedEnergyCost": 1,
+        "damage": "10",
+        "text": ""
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Fighting",
+        "value": "×2"
+      }
+    ],
+    "retreatCost": [
+      "Colorless"
+    ],
+    "convertedRetreatCost": 1,
+    "number": "SWSH209",
+    "artist": "Souichirou Gunjima",
+    "rarity": "Promo",
+    "flavorText": "It manipulates the chemical makeup of its poison to produce electricity. The voltage is weak, but it can cause a tingling paralysis.",
+    "nationalPokedexNumbers": [
+      848
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "regulationMark": "E",
+    "images": {
+      "small": "https://images.pokemontcg.io/swshp/SWSH209.png",
+      "large": "https://images.pokemontcg.io/swshp/SWSH209_hires.png"
+    }
+  },
+  {
+    "id": "swshp-SWSH210",
+    "name": "Oricorio",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Basic",
+      "Fusion Strike"
+    ],
+    "hp": "90",
+    "types": [
+      "Psychic"
+    ],
+    "attacks": [
+      {
+        "name": "Mixed Call",
+        "cost": [
+          "Colorless"
+        ],
+        "convertedEnergyCost": 1,
+        "damage": "",
+        "text": "Search your deck for a Pokémon and a Supporter card, reveal them, and put them into your hand. Then, shuffle your deck."
+      },
+      {
+        "name": "Razor Wing",
+        "cost": [
+          "Psychic",
+          "Colorless",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 3,
+        "damage": "80",
+        "text": ""
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Darkness",
+        "value": "×2"
+      }
+    ],
+    "resistances": [
+      {
+        "type": "Fighting",
+        "value": "-30"
+      }
+    ],
+    "retreatCost": [
+      "Colorless"
+    ],
+    "convertedRetreatCost": 1,
+    "number": "SWSH210",
+    "artist": "Ryuta Fuse",
+    "rarity": "Promo",
+    "flavorText": "This Oricorio has sipped purple nectar. Some dancers use its graceful, elegant dancing as inspiration.",
+    "nationalPokedexNumbers": [
+      741
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "regulationMark": "E",
+    "images": {
+      "small": "https://images.pokemontcg.io/swshp/SWSH210.png",
+      "large": "https://images.pokemontcg.io/swshp/SWSH210_hires.png"
+    }
+  },
+  {
+    "id": "swshp-SWSH211",
+    "name": "Sylveon",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Stage 1"
+    ],
+    "hp": "110",
+    "types": [
+      "Psychic"
+    ],
+    "evolvesFrom": "Eevee",
+    "attacks": [
+      {
+        "name": "Time Out Kick",
+        "cost": [
+          "Psychic"
+        ],
+        "convertedEnergyCost": 1,
+        "damage": "30",
+        "text": "You may put an Energy attached to your opponent’s Active Pokémon into their hand."
+      },
+      {
+        "name": "Symphony Whip",
+        "cost": [
+          "Psychic",
+          "Colorless",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 3,
+        "damage": "70+",
+        "text": "If you played a Supporter card from your hand during this turn, this attack does 70 more damage."
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Metal",
+        "value": "×2"
+      }
+    ],
+    "retreatCost": [
+      "Colorless"
+    ],
+    "convertedRetreatCost": 1,
+    "number": "SWSH211",
+    "artist": "Mizue",
+    "rarity": "Promo",
+    "flavorText": "There’s a Galarian fairy tale that describes a beautiful Sylveon vanquishing a dreadful dragon Pokémon.",
+    "nationalPokedexNumbers": [
+      700
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "expanded": "Legal"
+    },
+    "regulationMark": "E",
+    "images": {
+      "small": "https://images.pokemontcg.io/swshp/SWSH211.png",
+      "large": "https://images.pokemontcg.io/swshp/SWSH211_hires.png"
+    }
+  },
+  {
+    "id": "swshp-SWSH212",
+    "name": "Eevee",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Basic"
+    ],
+    "hp": "60",
+    "types": [
+      "Colorless"
+    ],
+    "evolvesTo": [
+      "Vaporeon",
+      "Jolteon",
+      "Flareon",
+      "Sylveon",
+      "Espeon",
+      "Umbreon",
+      "Leafeon",
+      "Glaceon"
+    ],
+    "attacks": [
+      {
+        "name": "Be Prepared",
+        "cost": [
+          "Colorless"
+        ],
+        "convertedEnergyCost": 1,
+        "damage": "",
+        "text": "Attach a basic Energy card from your hand to this Pokémon."
+      },
+      {
+        "name": "Bite",
+        "cost": [
+          "Colorless",
+          "Colorless",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 3,
+        "damage": "30",
+        "text": ""
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Fighting",
+        "value": "×2"
+      }
+    ],
+    "retreatCost": [
+      "Colorless"
+    ],
+    "convertedRetreatCost": 1,
+    "number": "SWSH212",
+    "artist": "Mizue"
+    "rarity": "Promo",
+    "nationalPokedexNumbers": [
+      133
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "regulationMark": "E",
+    "images": {
+      "small": "https://images.pokemontcg.io/swshp/SWSH212.png",
+      "large": "https://images.pokemontcg.io/swshp/SWSH212_hires.png"
+    }
+  },
+  {
     "id": "swshp-SWSH213",
     "name": "Lucario V",
     "supertype": "Pokémon",
@@ -13696,6 +14280,135 @@
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH222.png",
       "large": "https://images.pokemontcg.io/swshp/SWSH222_hires.png"
+    }
+  },
+{
+    "id": "swshp-SWSH248",
+    "name": "Kleavor V",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Basic",
+      "V"
+    ],
+    "hp": "210",
+    "types": [
+      "Fighting"
+    ],
+    "rules": [
+      "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
+    ],
+    "attacks": [
+      {
+        "name": "Cut",
+        "cost": [
+          "Fighting"
+        ],
+        "convertedEnergyCost": 1,
+        "damage": "40",
+        "text": ""
+      },
+      {
+        "name": "Axe Slash",
+        "cost": [
+          "Fighting",
+          "Fighting",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 3,
+        "damage": "150",
+        "text": "Discard an Energy from this Pokémon. If you do, discard an Energy from your opponent's Active Pokémon."
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Grass",
+        "value": "×2"
+      }
+    ],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
+    "convertedRetreatCost": 2,
+    "number": "SWSH248",
+    "artist": "5ban Graphics",
+    "rarity": "Promo",
+    "nationalPokedexNumbers": [
+      900
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "regulationMark": "F",
+    "images": {
+      "small": "https://images.pokemontcg.io/swshp/SWSH248.png",
+      "large": "https://images.pokemontcg.io/swshp/SWSH248_hires.png"
+    }
+  },
+  {
+    "id": "swshp-SWSH249",
+    "name": "Kleavor VSTAR",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "VSTAR"
+    ],
+    "hp": "270",
+    "types": [
+      "Fighting"
+    ],
+    "evolvesFrom": "Kleavor V",
+    "rules": [
+      "VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize cards."
+    ],
+    "attacks": [
+      {
+        "name": "Axe Break",
+        "cost": [
+          "Fighting",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 2,
+        "damage": "120",
+        "text": "This attack also does 60 damage to 1 of your opponent's Benched Pokémon V. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+      },
+      {
+        "name": "Rampaging Star",
+        "cost": [
+          "Fighting"
+        ],
+        "convertedEnergyCost": 1,
+        "damage": "30×",
+        "text": "This attack does 30 damage for each Pokémon in your discard pile. (You can't use more than 1 VSTAR Power in a game.)"
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Grass",
+        "value": "×2"
+      }
+    ],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
+    "convertedRetreatCost": 2,
+    "number": "SWSH248",
+    "artist": "5ban Graphics",
+    "rarity": "Rare Rainbow",
+    "nationalPokedexNumbers": [
+      900
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "regulationMark": "F",
+    "images": {
+      "small": "https://images.pokemontcg.io/swshp/SWSH249.png",
+      "large": "https://images.pokemontcg.io/swshp/SWSH249_hires.png"
     }
   }
 ]

--- a/cards/en/xy12.json
+++ b/cards/en/xy12.json
@@ -5597,9 +5597,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesTo": [
-      "Dodrio"
-    ],
     "rules": [
       "(This card cannot be used at official tournaments.)"
     ],


### PR DESCRIPTION
Add NationalDexNumbers to the pokemon missing them in astral radiance. Also fixes the box toppers in later ex sets to match the official rarities on the official database (and celebi ex).