### PR TITLE
Remove presumed rarities from iconless basic energy, mcdonalds cards and futsal cards.

### DIFF
--- a/cards/en/base1.json
+++ b/cards/en/base1.json
@@ -4698,7 +4698,6 @@
     ],
     "number": "97",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -4718,7 +4717,6 @@
     ],
     "number": "98",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -4738,7 +4736,6 @@
     ],
     "number": "99",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -4758,7 +4755,6 @@
     ],
     "number": "100",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -4778,7 +4774,6 @@
     ],
     "number": "101",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -4798,7 +4793,6 @@
     ],
     "number": "102",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",

--- a/cards/en/base4.json
+++ b/cards/en/base4.json
@@ -6612,7 +6612,6 @@
     ],
     "number": "125",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -6632,7 +6631,6 @@
     ],
     "number": "126",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -6652,7 +6650,6 @@
     ],
     "number": "127",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -6672,7 +6669,6 @@
     ],
     "number": "128",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -6692,7 +6688,6 @@
     ],
     "number": "129",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -6712,7 +6707,6 @@
     ],
     "number": "130",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",

--- a/cards/en/ecard1.json
+++ b/cards/en/ecard1.json
@@ -8351,7 +8351,6 @@
       "Basic"
     ],
     "number": "160",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -8370,7 +8369,6 @@
       "Basic"
     ],
     "number": "161",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -8389,7 +8387,6 @@
       "Basic"
     ],
     "number": "162",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -8408,7 +8405,6 @@
       "Basic"
     ],
     "number": "163",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -8427,7 +8423,6 @@
       "Basic"
     ],
     "number": "164",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -8446,7 +8441,6 @@
       "Basic"
     ],
     "number": "165",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",

--- a/cards/en/fut20.json
+++ b/cards/en/fut20.json
@@ -44,7 +44,6 @@
     "convertedRetreatCost": 1,
     "number": "1",
     "artist": "The Pokémon Company Art Team",
-    "rarity": "Promo",
     "flavorText": "Pikachu that can generate powerful electricity have cheek sacs that are extra soft and super stretchy.",
     "nationalPokedexNumbers": [
       25
@@ -103,7 +102,6 @@
     "convertedRetreatCost": 1,
     "number": "2",
     "artist": "The Pokémon Company Art Team",
-    "rarity": "Promo",
     "flavorText": "It has the ability to alter the composition of its body to suit its surrounding environment.",
     "nationalPokedexNumbers": [
       133
@@ -163,7 +161,6 @@
     "convertedRetreatCost": 1,
     "number": "3",
     "artist": "The Pokémon Company Art Team",
-    "rarity": "Promo",
     "flavorText": "When it uses its special stick to strike up a beat, the sound waves produced carry revitalizing energy to the plants and flowers in the area.",
     "nationalPokedexNumbers": [
       810
@@ -222,7 +219,6 @@
     "convertedRetreatCost": 1,
     "number": "4",
     "artist": "The Pokémon Company Art Team",
-    "rarity": "Promo",
     "flavorText": "A warm-up of running around gets fire energy coursing through this Pokémon's body. Once that happens, it's ready to fight at full power.",
     "nationalPokedexNumbers": [
       813
@@ -281,7 +277,6 @@
     "convertedRetreatCost": 1,
     "number": "5",
     "artist": "The Pokémon Company Art Team",
-    "rarity": "Promo",
     "flavorText": "When scared, this Pokémon cries. Its tears pack the chemical punch of 100 onions, and attackers won't be able to resist weeping.",
     "nationalPokedexNumbers": [
       816

--- a/cards/en/gym1.json
+++ b/cards/en/gym1.json
@@ -6061,7 +6061,6 @@
     ],
     "number": "127",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -6081,7 +6080,6 @@
     ],
     "number": "128",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -6101,7 +6099,6 @@
     ],
     "number": "129",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -6121,7 +6118,6 @@
     ],
     "number": "130",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -6141,7 +6137,6 @@
     ],
     "number": "131",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -6161,7 +6156,6 @@
     ],
     "number": "132",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",

--- a/cards/en/gym2.json
+++ b/cards/en/gym2.json
@@ -6274,7 +6274,6 @@
     ],
     "number": "127",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -6294,7 +6293,6 @@
     ],
     "number": "128",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -6314,7 +6312,6 @@
     ],
     "number": "129",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -6334,7 +6331,6 @@
     ],
     "number": "130",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -6354,7 +6350,6 @@
     ],
     "number": "131",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -6374,7 +6369,6 @@
     ],
     "number": "132",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",

--- a/cards/en/mcd11.json
+++ b/cards/en/mcd11.json
@@ -43,7 +43,6 @@
     "convertedRetreatCost": 1,
     "number": "1",
     "artist": "Ken Sugimori",
-    "rarity": "Promo",
     "flavorText": "It is very intelligent and calm. Being exposed to lots of sunlight makes its movements swifter.",
     "nationalPokedexNumbers": [
       495
@@ -109,7 +108,6 @@
     "convertedRetreatCost": 2,
     "number": "2",
     "artist": "Kagemaru Himeno",
-    "rarity": "Promo",
     "flavorText": "It uses an up-tempo song and dance to drive away the bird Pokémon that prey on its flower seeds.",
     "nationalPokedexNumbers": [
       556
@@ -162,7 +160,6 @@
     "convertedRetreatCost": 2,
     "number": "3",
     "artist": "Ken Sugimori",
-    "rarity": "Promo",
     "flavorText": "It blows fire through its nose. When it catches a cold, the fire becomes pitch-black smoke instead.",
     "nationalPokedexNumbers": [
       498
@@ -214,7 +211,6 @@
     "convertedRetreatCost": 1,
     "number": "4",
     "artist": "Ken Sugimori",
-    "rarity": "Promo",
     "flavorText": "It fights using the scalchop on its stomach. In response to an attack, it retaliates immediately by slashing.",
     "nationalPokedexNumbers": [
       501
@@ -276,7 +272,6 @@
     "convertedRetreatCost": 2,
     "number": "5",
     "artist": "sui",
-    "rarity": "Promo",
     "flavorText": "Floating in the open sea is how they live. When they find a wounded Pokémon, they embrace it and bring it to shore.",
     "nationalPokedexNumbers": [
       594
@@ -328,7 +323,6 @@
     "convertedRetreatCost": 1,
     "number": "6",
     "artist": "Ken Sugimori",
-    "rarity": "Promo",
     "flavorText": "Its mane shines when it discharges electricity. They use their flashing manes to communicate with one another.",
     "nationalPokedexNumbers": [
       522
@@ -379,7 +373,6 @@
     "convertedRetreatCost": 1,
     "number": "7",
     "artist": "Ken Sugimori",
-    "rarity": "Promo",
     "flavorText": "It eats the dreams of people and Pokémon. When it eats a pleasant dream, it expels pink-colored mist.",
     "nationalPokedexNumbers": [
       517
@@ -433,7 +426,6 @@
     "convertedRetreatCost": 2,
     "number": "8",
     "artist": "Ken Sugimori",
-    "rarity": "Promo",
     "flavorText": "It moves along below the sand's surface, except for its nose and eyes. A dark membrane shields its eyes from the sun.",
     "nationalPokedexNumbers": [
       551
@@ -500,7 +492,6 @@
     "convertedRetreatCost": 1,
     "number": "9",
     "artist": "Ken Sugimori",
-    "rarity": "Promo",
     "flavorText": "It changes into the forms of others to surprise them. Apparently, it often transforms into a silent child.",
     "nationalPokedexNumbers": [
       570
@@ -567,7 +558,6 @@
     "convertedRetreatCost": 1,
     "number": "10",
     "artist": "Ken Sugimori",
-    "rarity": "Promo",
     "flavorText": "The two minigears that mesh together are predetermined. Each will rebound from other minigears without meshing.",
     "nationalPokedexNumbers": [
       599
@@ -633,7 +623,6 @@
     "convertedRetreatCost": 1,
     "number": "11",
     "artist": "Ken Sugimori",
-    "rarity": "Promo",
     "flavorText": "These Pokémon live in cities. They are accustomed to people. Flocks often gather in parks and plazas.",
     "nationalPokedexNumbers": [
       519
@@ -683,7 +672,6 @@
     "convertedRetreatCost": 2,
     "number": "12",
     "artist": "MAHOU",
-    "rarity": "Promo",
     "flavorText": "It touches others with the feelers on its ears, using the sound of their heartbeats to tell how they are feeling.",
     "nationalPokedexNumbers": [
       531

--- a/cards/en/mcd12.json
+++ b/cards/en/mcd12.json
@@ -53,7 +53,6 @@
     "convertedRetreatCost": 1,
     "number": "1",
     "artist": "Kagemaru Himeno",
-    "rarity": "Promo",
     "flavorText": "They avoid attacks by sinking into the shadows of thick foliage. They retaliate with masterful whipping techniques.",
     "nationalPokedexNumbers": [
       496
@@ -120,7 +119,6 @@
     "convertedRetreatCost": 1,
     "number": "2",
     "artist": "Kouki Saitou",
-    "rarity": "Promo",
     "flavorText": "This Pokémon dwells deep in the forest. Eating a leaf from its head whisks weariness away as if by magic.",
     "nationalPokedexNumbers": [
       511
@@ -182,7 +180,6 @@
     "convertedRetreatCost": 2,
     "number": "3",
     "artist": "MAHOU",
-    "rarity": "Promo",
     "flavorText": "The Pokémon can easily melt holes in hard rocks with a liquid secreted from its mouth.",
     "nationalPokedexNumbers": [
       557
@@ -247,7 +244,6 @@
     "convertedRetreatCost": 3,
     "number": "4",
     "artist": "Kouki Saitou",
-    "rarity": "Promo",
     "flavorText": "When its internal fire flares up, its movements grow sharper and faster. When in trouble, it emits smoke.",
     "nationalPokedexNumbers": [
       499
@@ -311,7 +307,6 @@
     "convertedRetreatCost": 1,
     "number": "5",
     "artist": "Masakazu Fukuda",
-    "rarity": "Promo",
     "flavorText": "Scalchop techniques differ from one Dewott to another. It never neglects maintaining its scalchops.",
     "nationalPokedexNumbers": [
       502
@@ -365,7 +360,6 @@
     ],
     "number": "6",
     "artist": "Kouki Saitou",
-    "rarity": "Promo",
     "flavorText": "The energy made in its cheeks' electric pouches is stored inside its membranes and released while it is gliding.",
     "nationalPokedexNumbers": [
       587
@@ -417,7 +411,6 @@
     "convertedRetreatCost": 1,
     "number": "7",
     "artist": "Masakazu Fukuda",
-    "rarity": "Promo",
     "flavorText": "Its habitat is dark forests and caves. It emits ultrasonic waves from its nose to learn about its surroundings.",
     "nationalPokedexNumbers": [
       527
@@ -476,7 +469,6 @@
     "convertedRetreatCost": 2,
     "number": "8",
     "artist": "match",
-    "rarity": "Promo",
     "flavorText": "It can dig through the ground at a speed of 30 mph. It could give a car running aboveground a good race.",
     "nationalPokedexNumbers": [
       529
@@ -534,7 +526,6 @@
     "convertedRetreatCost": 1,
     "number": "9",
     "artist": "Atsuko Nishida",
-    "rarity": "Promo",
     "flavorText": "They steal from people for fun, but their victims can't help but forgive them. Their deceptively cute act is perfect.",
     "nationalPokedexNumbers": [
       509
@@ -591,7 +582,6 @@
     "convertedRetreatCost": 1,
     "number": "10",
     "artist": "Masakazu Fukuda",
-    "rarity": "Promo",
     "flavorText": "Its skin has a rubbery elasticity, so it can reduce damage by defensively pulling its skin up to its neck.",
     "nationalPokedexNumbers": [
       559
@@ -660,7 +650,6 @@
     "convertedRetreatCost": 1,
     "number": "11",
     "artist": "Kouki Saitou",
-    "rarity": "Promo",
     "flavorText": "Spinning minigears are rotated at high speed and repeatedly fired away. It is dangerous if the gears don't return.",
     "nationalPokedexNumbers": [
       600
@@ -705,7 +694,6 @@
     "convertedRetreatCost": 1,
     "number": "12",
     "artist": "Atsuko Nishida",
-    "rarity": "Promo",
     "flavorText": "They use their tusks to crush the berries they eat. Repeated regrowth makes their tusks strong and sharp.",
     "nationalPokedexNumbers": [
       610

--- a/cards/en/mcd14.json
+++ b/cards/en/mcd14.json
@@ -36,7 +36,6 @@
     "convertedRetreatCost": 1,
     "number": "1",
     "artist": "Akira Komayama",
-    "rarity": "Promo",
     "flavorText": "Often found in forests and grasslands. It has a sharp, toxic barb of around two inches on top of its head.",
     "nationalPokedexNumbers": [
       13
@@ -97,7 +96,6 @@
     "convertedRetreatCost": 1,
     "number": "2",
     "artist": "5ban Graphics",
-    "rarity": "Promo",
     "flavorText": "The quills on its head are usually soft. When it flexes them, the points become so hard and sharp that they can pierce rock.",
     "nationalPokedexNumbers": [
       650
@@ -158,7 +156,6 @@
     "convertedRetreatCost": 1,
     "number": "3",
     "artist": "5ban Graphics",
-    "rarity": "Promo",
     "flavorText": "Eating a twig fills it with energy, and its roomy ears give vent to air hotter than 390 degrees Fahrenheit.",
     "nationalPokedexNumbers": [
       653
@@ -219,7 +216,6 @@
     "convertedRetreatCost": 1,
     "number": "4",
     "artist": "5ban Graphics",
-    "rarity": "Promo",
     "flavorText": "It secretes flexible bubbles from its chest and back. The bubbles reduce the damage it would otherwise take when attacked.",
     "nationalPokedexNumbers": [
       656
@@ -286,7 +282,6 @@
     "convertedRetreatCost": 1,
     "number": "5",
     "artist": "MAHOU",
-    "rarity": "Promo",
     "flavorText": "It raises its tail to check its surroundings. The tail is sometimes struck by lightning in this pose.",
     "nationalPokedexNumbers": [
       25
@@ -343,7 +338,6 @@
     "convertedRetreatCost": 1,
     "number": "6",
     "artist": "5ban Graphics",
-    "rarity": "Promo",
     "flavorText": "Opponents who stare at the flashing of the light-emitting spots on its body become dazed and lose their will to fight.",
     "nationalPokedexNumbers": [
       686
@@ -402,7 +396,6 @@
     "convertedRetreatCost": 2,
     "number": "7",
     "artist": "5ban Graphics",
-    "rarity": "Promo",
     "flavorText": "Apparently this Pokémon is born when a departed spirit inhabits a sword. It attaches itself to people and drinks their life force.",
     "nationalPokedexNumbers": [
       679
@@ -461,7 +454,6 @@
     "convertedRetreatCost": 2,
     "number": "8",
     "artist": "Naoki Saito",
-    "rarity": "Promo",
     "flavorText": "It has an active, playful nature. Many women like to frolic with it because of its affectionate ways.",
     "nationalPokedexNumbers": [
       209
@@ -518,7 +510,6 @@
     "convertedRetreatCost": 1,
     "number": "9",
     "artist": "5ban Graphics",
-    "rarity": "Promo",
     "flavorText": "To entangle its opponents in battle, it extrudes white threads as sweet and sticky as cotton candy.",
     "nationalPokedexNumbers": [
       684
@@ -570,7 +561,6 @@
     "convertedRetreatCost": 1,
     "number": "10",
     "artist": "5ban Graphics",
-    "rarity": "Promo",
     "flavorText": "They use their large ears to dig burrows. They will dig the whole night through.",
     "nationalPokedexNumbers": [
       659
@@ -627,7 +617,6 @@
     "convertedRetreatCost": 1,
     "number": "11",
     "artist": "5ban Graphics",
-    "rarity": "Promo",
     "flavorText": "These friendly Pokémon send signals to one another with beautiful chirps and tail-feather movements.",
     "nationalPokedexNumbers": [
       661
@@ -687,7 +676,6 @@
     "convertedRetreatCost": 1,
     "number": "12",
     "artist": "5ban Graphics",
-    "rarity": "Promo",
     "flavorText": "Trimming its fluffy fur not only makes it more elegant but also increases the swiftness of its movements.",
     "nationalPokedexNumbers": [
       676

--- a/cards/en/mcd15.json
+++ b/cards/en/mcd15.json
@@ -36,7 +36,6 @@
     "convertedRetreatCost": 1,
     "number": "1",
     "artist": "Akira Komayama",
-    "rarity": "Promo",
     "flavorText": "Small hooks on the bottom of its feet catch on walls and ceilings. That is how it can hang from above.",
     "nationalPokedexNumbers": [
       252
@@ -88,7 +87,6 @@
     "convertedRetreatCost": 1,
     "number": "2",
     "artist": "Kanako Eo",
-    "rarity": "Promo",
     "flavorText": "It searches about for clean water. If it does not drink water for too long, the leaf on its head wilts.",
     "nationalPokedexNumbers": [
       270
@@ -139,7 +137,6 @@
     "convertedRetreatCost": 1,
     "number": "3",
     "artist": "sui",
-    "rarity": "Promo",
     "flavorText": "A fire burns inside, so it feels very warm to hug. It launches fireballs of 1,800 degrees Fahrenheit.",
     "nationalPokedexNumbers": [
       255
@@ -190,7 +187,6 @@
     "convertedRetreatCost": 1,
     "number": "4",
     "artist": "Tomokazu Komiya",
-    "rarity": "Promo",
     "flavorText": "It appears in large numbers by seashores. At night, its central core flashes with a red light.",
     "nationalPokedexNumbers": [
       120
@@ -251,7 +247,6 @@
     "convertedRetreatCost": 1,
     "number": "5",
     "artist": "Aya Kusube",
-    "rarity": "Promo",
     "flavorText": "To alert it, the fin on its head senses the flow of water. It has the strength to heft boulders.",
     "nationalPokedexNumbers": [
       258
@@ -318,7 +313,6 @@
     "convertedRetreatCost": 1,
     "number": "6",
     "artist": "Naoki Saito",
-    "rarity": "Promo",
     "flavorText": "It raises its tail to check its surroundings. The tail is sometimes struck by lightning in this pose.",
     "nationalPokedexNumbers": [
       25
@@ -385,7 +379,6 @@
     "convertedRetreatCost": 1,
     "number": "7",
     "artist": "Sumiyoshi Kizuki",
-    "rarity": "Promo",
     "flavorText": "It stores static electricity in its fur for discharging. It gives off sparks if a storm approaches.",
     "nationalPokedexNumbers": [
       309
@@ -490,7 +483,6 @@
     "convertedRetreatCost": 1,
     "number": "9",
     "artist": "sui",
-    "rarity": "Promo",
     "flavorText": "It eats just one berry a day. By enduring hunger, its spirit is tempered and made sharper.",
     "nationalPokedexNumbers": [
       307
@@ -558,7 +550,6 @@
     "convertedRetreatCost": 2,
     "number": "10",
     "artist": "Shigenori Negishi",
-    "rarity": "Promo",
     "flavorText": "The tip of its tail is filled with oil that is lighter than water, so it acts as a float.",
     "nationalPokedexNumbers": [
       183
@@ -619,7 +610,6 @@
     "convertedRetreatCost": 1,
     "number": "11",
     "artist": "Sumiyoshi Kizuki",
-    "rarity": "Promo",
     "flavorText": "A Pokémon with abundant curiosity. It shows an interest in everything, so it always zigzags.",
     "nationalPokedexNumbers": [
       263
@@ -680,7 +670,6 @@
     "convertedRetreatCost": 1,
     "number": "12",
     "artist": "Yuka Morii",
-    "rarity": "Promo",
     "flavorText": "It shows its cute side by chasing its own tail until it gets dizzy.",
     "nationalPokedexNumbers": [
       300

--- a/cards/en/mcd16.json
+++ b/cards/en/mcd16.json
@@ -45,7 +45,6 @@
     "convertedRetreatCost": 1,
     "number": "1",
     "artist": "kirisAki",
-    "rarity": "Promo",
     "flavorText": "While young, it has six gorgeous tails. When it grows, several new tails are sprouted.",
     "nationalPokedexNumbers": [
       37
@@ -96,7 +95,6 @@
     "convertedRetreatCost": 1,
     "number": "2",
     "artist": "sui",
-    "rarity": "Promo",
     "flavorText": "A fire burns inside, so it feels very warm to hug. It launches fireballs of 1,800 degrees Fahrenheit.",
     "nationalPokedexNumbers": [
       255
@@ -147,7 +145,6 @@
     "convertedRetreatCost": 1,
     "number": "3",
     "artist": "5ban Graphics",
-    "rarity": "Promo",
     "flavorText": "Eating a twig fills it with energy, and its roomy ears give vent to air hotter than 390 degrees Fahrenheit.",
     "nationalPokedexNumbers": [
       653
@@ -198,7 +195,6 @@
     "convertedRetreatCost": 1,
     "number": "4",
     "artist": "Akira Komayama",
-    "rarity": "Promo",
     "flavorText": "In the distant past, it was somewhat stronger than the horribly weak descendants that exist today.",
     "nationalPokedexNumbers": [
       129
@@ -249,7 +245,6 @@
     "convertedRetreatCost": 1,
     "number": "5",
     "artist": "Kagemaru Himeno",
-    "rarity": "Promo",
     "flavorText": "It is small but rough and tough. It won't hesitate to take a bite out of anything that moves.",
     "nationalPokedexNumbers": [
       158
@@ -316,7 +311,6 @@
     "convertedRetreatCost": 1,
     "number": "6",
     "artist": "Naoki Saito",
-    "rarity": "Promo",
     "flavorText": "It raises its tail to check its surroundings. The tail is sometimes struck by lightning in this pose.",
     "nationalPokedexNumbers": [
       25
@@ -375,7 +369,6 @@
     "convertedRetreatCost": 2,
     "number": "7",
     "artist": "Tomokazu Komiya",
-    "rarity": "Promo",
     "flavorText": "Its skin has a rubbery elasticity, so it can reduce damage by defensively pulling it skin up to its neck.",
     "nationalPokedexNumbers": [
       559
@@ -441,7 +434,6 @@
     "convertedRetreatCost": 1,
     "number": "8",
     "artist": "Kanako Eo",
-    "rarity": "Promo",
     "flavorText": "It captivates foes with its huge, round eyes, then lulls them to sleep by singing a soothing melody.",
     "nationalPokedexNumbers": [
       39
@@ -498,7 +490,6 @@
     "convertedRetreatCost": 1,
     "number": "9",
     "artist": "HiRON",
-    "rarity": "Promo",
     "flavorText": "A proverb claims that happiness will come to anyone who can make a sleeping Togepi stand up.",
     "nationalPokedexNumbers": [
       175
@@ -563,7 +554,6 @@
     "convertedRetreatCost": 1,
     "number": "10",
     "artist": "5ban Graphics",
-    "rarity": "Promo",
     "flavorText": "Its whiskers serve as antennas. By sending and receiving electrical waves, it can communicate with others over vast distances.",
     "nationalPokedexNumbers": [
       702
@@ -614,7 +604,6 @@
     "convertedRetreatCost": 1,
     "number": "11",
     "artist": "Kanako Eo",
-    "rarity": "Promo",
     "flavorText": "Adores round objects. It wanders the streets on a nightly basis to look for dropped loose change.",
     "nationalPokedexNumbers": [
       52
@@ -682,7 +671,6 @@
     "convertedRetreatCost": 1,
     "number": "12",
     "artist": "Kouki Saitou",
-    "rarity": "Promo",
     "flavorText": "Thanks to its unstable genetic makeup, this special Pokémon conceals many different possible evolutions.",
     "nationalPokedexNumbers": [
       133

--- a/cards/en/mcd17.json
+++ b/cards/en/mcd17.json
@@ -46,7 +46,6 @@
     "convertedRetreatCost": 1,
     "number": "1",
     "artist": "Megumi Mizutani",
-    "rarity": "Promo",
     "flavorText": "This wary Pokémon uses photosynthesis to store up energy during the day, while becoming active at night.",
     "nationalPokedexNumbers": [
       722
@@ -99,7 +98,6 @@
     "convertedRetreatCost": 2,
     "number": "2",
     "artist": "Akira Komayama",
-    "rarity": "Promo",
     "flavorText": "They often gather near places frequented by electric Pokémon in order to avoid being attacked by bird Pokémon.",
     "nationalPokedexNumbers": [
       736
@@ -160,7 +158,6 @@
     "convertedRetreatCost": 1,
     "number": "3",
     "artist": "Akira Komayama",
-    "rarity": "Promo",
     "flavorText": "While grooming itself, it builds up fur inside its stomach. It sets the fur alight and spews fiery attacks, which change based on how it coughs.",
     "nationalPokedexNumbers": [
       725
@@ -221,7 +218,6 @@
     "convertedRetreatCost": 1,
     "number": "4",
     "artist": "Kouki Saitou",
-    "rarity": "Promo",
     "flavorText": "This Pokémon snorts body fluids from its nose, blowing balloons to smash into its foes. It's famous for being a hard worker.",
     "nationalPokedexNumbers": [
       728
@@ -289,7 +285,6 @@
     "convertedRetreatCost": 1,
     "number": "5",
     "artist": "kirisAki",
-    "rarity": "Promo",
     "flavorText": "A plan was recently announced to gather many Pikachu and make an electric power plant.",
     "nationalPokedexNumbers": [
       25
@@ -340,7 +335,6 @@
     "convertedRetreatCost": 1,
     "number": "6",
     "artist": "Megumi Mizutani",
-    "rarity": "Promo",
     "flavorText": "Its body is gaseous and frail. It slowly grows as it collects dust from the atmosphere.",
     "nationalPokedexNumbers": [
       789
@@ -404,7 +398,6 @@
     "convertedRetreatCost": 2,
     "number": "7",
     "artist": "Shin Nagasawa",
-    "rarity": "Promo",
     "flavorText": "It punches so much, its pincers often come off from overuse, but they grow back quickly. What little meat they contain is rich and delicious.",
     "nationalPokedexNumbers": [
       739
@@ -461,7 +454,6 @@
     "convertedRetreatCost": 1,
     "number": "8",
     "artist": "Kagemaru Himeno",
-    "rarity": "Promo",
     "flavorText": "This Pokémon was not originally found in Alola. Human actions caused a surge in their numbers, and they went feral. They're prideful and crafty.",
     "nationalPokedexNumbers": [
       52
@@ -527,7 +519,6 @@
     "convertedRetreatCost": 1,
     "number": "9",
     "artist": "Megumi Mizutani",
-    "rarity": "Promo",
     "flavorText": "Its head sports an altered form of whiskers made of metal. When in communication with its comrades, its whiskers wobble to and fro.",
     "nationalPokedexNumbers": [
       50
@@ -584,7 +575,6 @@
     "convertedRetreatCost": 1,
     "number": "10",
     "artist": "Hitoshi Ariga",
-    "rarity": "Promo",
     "flavorText": "It feeds on the nectar and pollen of flowers. Because it's able to sense auras, it can identify which flowers are about to bloom.",
     "nationalPokedexNumbers": [
       742
@@ -641,7 +631,6 @@
     "convertedRetreatCost": 1,
     "number": "11",
     "artist": "Shin Nagasawa",
-    "rarity": "Promo",
     "flavorText": "This Pokémon feeds on berries, whose leftover seeds become the ammunition for the attacks it fires off from its mouth.",
     "nationalPokedexNumbers": [
       731
@@ -702,7 +691,6 @@
     "convertedRetreatCost": 1,
     "number": "12",
     "artist": "match",
-    "rarity": "Promo",
     "flavorText": "With its sharp fangs, it will bite anything. It did not originally live in Alola but was imported from another region.",
     "nationalPokedexNumbers": [
       734

--- a/cards/en/mcd18.json
+++ b/cards/en/mcd18.json
@@ -39,7 +39,6 @@
     "convertedRetreatCost": 2,
     "number": "1",
     "artist": "MAHOU",
-    "rarity": "Promo",
     "flavorText": "It's both clever and loyal, but if a stranger tries to invade its territory, it barks threateningly.",
     "nationalPokedexNumbers": [
       58
@@ -91,7 +90,6 @@
     "convertedRetreatCost": 2,
     "number": "2",
     "artist": "Shibuzoh.",
-    "rarity": "Promo",
     "flavorText": "As a result of headaches so fierce they cause it to cry, it sometimes uses psychokinesis without meaning to.",
     "nationalPokedexNumbers": [
       54
@@ -142,7 +140,6 @@
     "convertedRetreatCost": 1,
     "number": "3",
     "artist": "Saya Tsuruta",
-    "rarity": "Promo",
     "flavorText": "Known to shoot down flying bugs with precision blasts of ink from the surface of the water.",
     "nationalPokedexNumbers": [
       116
@@ -209,7 +206,6 @@
     "convertedRetreatCost": 1,
     "number": "4",
     "artist": "Shibuzoh.",
-    "rarity": "Promo",
     "flavorText": "A plan was recently announced to gather many Pikachu and make an electric power plant.",
     "nationalPokedexNumbers": [
       25
@@ -274,7 +270,6 @@
     "convertedRetreatCost": 3,
     "number": "5",
     "artist": "Mina Nakai",
-    "rarity": "Promo",
     "flavorText": "Its long tail often breaks off. It doesn't really feel any pain, though, and the tail grows back, so Slowpoke isn't particularly bothered.",
     "nationalPokedexNumbers": [
       79
@@ -327,7 +322,6 @@
     "convertedRetreatCost": 2,
     "number": "6",
     "artist": "Masakazu Fukuda",
-    "rarity": "Promo",
     "flavorText": "It loves working out. As it gazes at its muscles, which continue to swell day by day, it becomes more and more dedicated to its training.",
     "nationalPokedexNumbers": [
       66
@@ -389,7 +383,6 @@
     "convertedRetreatCost": 2,
     "number": "7",
     "artist": "sui",
-    "rarity": "Promo",
     "flavorText": "When it thinks of its deceased mother, it weeps loudly. Mandibuzz that hear its cries will attack it from the air.",
     "nationalPokedexNumbers": [
       104
@@ -455,7 +448,6 @@
     "convertedRetreatCost": 1,
     "number": "8",
     "artist": "MAHOU",
-    "rarity": "Promo",
     "flavorText": "It sends out electromagnetic waves, which let it float through the air. Touching it while it's eating electricity will give you a full-body shock.",
     "nationalPokedexNumbers": [
       81
@@ -516,7 +508,6 @@
     "convertedRetreatCost": 2,
     "number": "9",
     "artist": "Naoyo Kimura",
-    "rarity": "Promo",
     "flavorText": "After a 10-hour struggle, a fisherman was able to pull one up and confirm its existence.",
     "nationalPokedexNumbers": [
       147
@@ -581,7 +572,6 @@
     "convertedRetreatCost": 2,
     "number": "10",
     "artist": "Megumi Mizutani",
-    "rarity": "Promo",
     "flavorText": "The eggs laid by Chansey are rich in nutrients and a favorite food of many Pokémon.",
     "nationalPokedexNumbers": [
       113
@@ -647,7 +637,6 @@
     "convertedRetreatCost": 2,
     "number": "11",
     "artist": "Shibuzoh.",
-    "rarity": "Promo",
     "flavorText": "Possessing an unbalanced and unstable genetic makeup, it conceals many possible evolutions.",
     "nationalPokedexNumbers": [
       133
@@ -707,7 +696,6 @@
     "convertedRetreatCost": 1,
     "number": "12",
     "artist": "Shin Nagasawa",
-    "rarity": "Promo",
     "flavorText": "Roughly 20 years ago, it was artificially created, utilizing the latest technology of the time.",
     "nationalPokedexNumbers": [
       137

--- a/cards/en/mcd19.json
+++ b/cards/en/mcd19.json
@@ -30,7 +30,6 @@
     "convertedRetreatCost": 1,
     "number": "1",
     "artist": "Sekio",
-    "rarity": "Promo",
     "nationalPokedexNumbers": [
       10
     ],
@@ -74,7 +73,6 @@
     "convertedRetreatCost": 3,
     "number": "2",
     "artist": "Satoshi Shirai",
-    "rarity": "Promo",
     "nationalPokedexNumbers": [
       103
     ],
@@ -130,7 +128,6 @@
     "convertedRetreatCost": 2,
     "number": "3",
     "artist": "Yumi",
-    "rarity": "Promo",
     "nationalPokedexNumbers": [
       126
     ],
@@ -174,7 +171,6 @@
     "convertedRetreatCost": 1,
     "number": "4",
     "artist": "Shin Nagasawa",
-    "rarity": "Promo",
     "nationalPokedexNumbers": [
       27
     ],
@@ -228,7 +224,6 @@
     "convertedRetreatCost": 2,
     "number": "5",
     "artist": "Saya Tsuruta",
-    "rarity": "Promo",
     "nationalPokedexNumbers": [
       131
     ],
@@ -272,7 +267,6 @@
     "convertedRetreatCost": 1,
     "number": "6",
     "artist": "Kagemaru Himeno",
-    "rarity": "Promo",
     "nationalPokedexNumbers": [
       25
     ],
@@ -316,7 +310,6 @@
     "convertedRetreatCost": 1,
     "number": "7",
     "artist": "Shibuzoh.",
-    "rarity": "Promo",
     "nationalPokedexNumbers": [
       92
     ],
@@ -360,7 +353,6 @@
     "convertedRetreatCost": 1,
     "number": "8",
     "artist": "Miki Tanaka",
-    "rarity": "Promo",
     "nationalPokedexNumbers": [
       56
     ],
@@ -415,7 +407,6 @@
     "convertedRetreatCost": 2,
     "number": "9",
     "artist": "Mitsuhiro Arita",
-    "rarity": "Promo",
     "nationalPokedexNumbers": [
       95
     ],
@@ -459,7 +450,6 @@
     "convertedRetreatCost": 1,
     "number": "10",
     "artist": "Akira Komayama",
-    "rarity": "Promo",
     "nationalPokedexNumbers": [
       52
     ],
@@ -501,7 +491,6 @@
     "convertedRetreatCost": 1,
     "number": "11",
     "artist": "Megumi Mizutani",
-    "rarity": "Promo",
     "nationalPokedexNumbers": [
       51
     ],
@@ -552,7 +541,6 @@
     "convertedRetreatCost": 1,
     "number": "12",
     "artist": "Atsuko Nishida",
-    "rarity": "Promo",
     "nationalPokedexNumbers": [
       133
     ],

--- a/cards/en/mcd21.json
+++ b/cards/en/mcd21.json
@@ -38,7 +38,6 @@
     "convertedRetreatCost": 2,
     "number": "1",
     "artist": "Mizue",
-    "rarity": "Promo",
     "flavorText": "A strange seed was planted on its back at birth. The plant sprouts and grows with this Pokémon.",
     "nationalPokedexNumbers": [
       1
@@ -89,7 +88,6 @@
     "convertedRetreatCost": 1,
     "number": "2",
     "artist": "sowsow",
-    "rarity": "Promo",
     "flavorText": "It uses the leaf on its head to determine the temperature and humidity. It loves to sunbathe.",
     "nationalPokedexNumbers": [
       152
@@ -140,7 +138,6 @@
     "convertedRetreatCost": 1,
     "number": "3",
     "artist": "Akira Komayama",
-    "rarity": "Promo",
     "flavorText": "Small hooks on the bottom of its feet catch on walls and ceilings. That is how it can hang from above.",
     "nationalPokedexNumbers": [
       252
@@ -204,7 +201,6 @@
     "convertedRetreatCost": 2,
     "number": "4",
     "artist": "OOYAMA",
-    "rarity": "Promo",
     "flavorText": "It undertakes photosynthesis with its body, making oxygen. The leaf on its head wilts if it is thirsty.",
     "nationalPokedexNumbers": [
       387
@@ -262,7 +258,6 @@
     "convertedRetreatCost": 1,
     "number": "5",
     "artist": "Ken Sugimori",
-    "rarity": "Promo",
     "flavorText": "It is very intelligent and calm. Being exposed to lots of sunlight makes its movements swifter.",
     "nationalPokedexNumbers": [
       495
@@ -383,7 +378,6 @@
     "convertedRetreatCost": 1,
     "number": "7",
     "artist": "Megumi Mizutani",
-    "rarity": "Promo",
     "flavorText": "This wary Pokémon uses photosynthesis to store up energy during the day, while becoming active at night.",
     "nationalPokedexNumbers": [
       722
@@ -435,7 +429,6 @@
     "convertedRetreatCost": 1,
     "number": "8",
     "artist": "kirisAki",
-    "rarity": "Promo",
     "flavorText": "When it uses its special stick to strike up a beat, the sound waves produced carry revitalizing energy to the plants and flowers in the area.",
     "nationalPokedexNumbers": [
       810
@@ -497,7 +490,6 @@
     "convertedRetreatCost": 1,
     "number": "9",
     "artist": "Kagemaru Himeno",
-    "rarity": "Promo",
     "flavorText": "The flame on its tail indicates Charmander's life force. If it is healthy, the flame burns brightly.",
     "nationalPokedexNumbers": [
       4
@@ -549,7 +541,6 @@
     "convertedRetreatCost": 1,
     "number": "10",
     "artist": "kirisAki",
-    "rarity": "Promo",
     "flavorText": "It has a timid nature. If it is startled, the flames on its back burn more vigorously.",
     "nationalPokedexNumbers": [
       155
@@ -600,7 +591,6 @@
     "convertedRetreatCost": 1,
     "number": "11",
     "artist": "sui",
-    "rarity": "Promo",
     "flavorText": "A fire burns inside, so it feels very warm to hug. It launches fireballs of 1,800 degrees Fahrenheit.",
     "nationalPokedexNumbers": [
       255
@@ -651,7 +641,6 @@
     "convertedRetreatCost": 1,
     "number": "12",
     "artist": "Kouki Saitou",
-    "rarity": "Promo",
     "flavorText": "The gas made in its belly burns from its rear end. The fire burns weakly when it feels sick.",
     "nationalPokedexNumbers": [
       390
@@ -704,7 +693,6 @@
     "convertedRetreatCost": 2,
     "number": "13",
     "artist": "Ken Sugimori",
-    "rarity": "Promo",
     "flavorText": "It blows fire through its nose. When it catches a cold, the fire becomes pitch-black smoke instead.",
     "nationalPokedexNumbers": [
       498
@@ -825,7 +813,6 @@
     "convertedRetreatCost": 1,
     "number": "15",
     "artist": "Akira Komayama",
-    "rarity": "Promo",
     "flavorText": "While grooming itself, it builds up fur inside its stomach. It sets the fur alight and spews fiery attacks, which change based on how it coughs.",
     "nationalPokedexNumbers": [
       725
@@ -876,7 +863,6 @@
     "convertedRetreatCost": 1,
     "number": "16",
     "artist": "Hitoshi Ariga",
-    "rarity": "Promo",
     "flavorText": "A warm-up of running around gets fire energy coursing through this Pokémon's body. Once that happens, it's ready to fight at full power.",
     "nationalPokedexNumbers": [
       813
@@ -928,7 +914,6 @@
     "convertedRetreatCost": 1,
     "number": "17",
     "artist": "tetsuya koizumi",
-    "rarity": "Promo",
     "flavorText": "It shelters itself in its shell, then strikes back with spouts of water at every opportunity.",
     "nationalPokedexNumbers": [
       7
@@ -979,7 +964,6 @@
     "convertedRetreatCost": 1,
     "number": "18",
     "artist": "Kagemaru Himeno",
-    "rarity": "Promo",
     "flavorText": "It is small but rough and tough. It won't hesitate to take a bite out of anything that moves.",
     "nationalPokedexNumbers": [
       158
@@ -1040,7 +1024,6 @@
     "convertedRetreatCost": 1,
     "number": "19",
     "artist": "Aya Kusube",
-    "rarity": "Promo",
     "flavorText": "To alert it, the fin on its head senses the flow of water. It has the strength to heft boulders.",
     "nationalPokedexNumbers": [
       258
@@ -1101,7 +1084,6 @@
     "convertedRetreatCost": 1,
     "number": "20",
     "artist": "Shibuzoh.",
-    "rarity": "Promo",
     "flavorText": "Because it is very proud, it hates accepting food from people. Its thick down guards it from cold.",
     "nationalPokedexNumbers": [
       393
@@ -1153,7 +1135,6 @@
     "convertedRetreatCost": 1,
     "number": "21",
     "artist": "Ken Sugimori",
-    "rarity": "Promo",
     "flavorText": "It fights using the scalchop on its stomach. In response to an attack, it retaliates immediately by slashing.",
     "nationalPokedexNumbers": [
       501
@@ -1274,7 +1255,6 @@
     "convertedRetreatCost": 1,
     "number": "23",
     "artist": "Kouki Saitou",
-    "rarity": "Promo",
     "flavorText": "This Pokémon snorts body fluids from its nose, blowing balloons to smash into its foes. It's famous for being a hard worker.",
     "nationalPokedexNumbers": [
       728
@@ -1326,7 +1306,6 @@
     "convertedRetreatCost": 1,
     "number": "24",
     "artist": "Mizue",
-    "rarity": "Promo",
     "flavorText": "When scared, this Pokémon cries. Its tears pack the chemical punch of 100 onions, and attackers won't be able to resist weeping.",
     "nationalPokedexNumbers": [
       816
@@ -1394,7 +1373,6 @@
     "convertedRetreatCost": 1,
     "number": "25",
     "artist": "Sanosuke Sakuma",
-    "rarity": "Promo",
     "flavorText": "Its nature is to store up electricity. Forests where nests of Pikachu live are dangerous, since the trees are so often struck by lightning.",
     "nationalPokedexNumbers": [
       25

--- a/cards/en/neo1.json
+++ b/cards/en/neo1.json
@@ -5385,7 +5385,6 @@
     ],
     "number": "106",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -5405,7 +5404,6 @@
     ],
     "number": "107",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -5425,7 +5423,6 @@
     ],
     "number": "108",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -5445,7 +5442,6 @@
     ],
     "number": "109",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -5465,7 +5461,6 @@
     ],
     "number": "110",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -5485,7 +5480,6 @@
     ],
     "number": "111",
     "artist": "Keiji Kinebuchi",
-    "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",

--- a/sets/en.json
+++ b/sets/en.json
@@ -10,7 +10,7 @@
     },
     "ptcgoCode": "BS",
     "releaseDate": "1999/01/09",
-    "updatedAt": "2020/08/14 09:35:00",
+    "updatedAt": "2022/10/10 15:12:00",
     "images": {
       "symbol": "https://images.pokemontcg.io/base1/symbol.png",
       "logo": "https://images.pokemontcg.io/base1/logo.png"
@@ -78,7 +78,7 @@
     },
     "ptcgoCode": "B2",
     "releaseDate": "2000/02/24",
-    "updatedAt": "2020/08/14 09:35:00",
+    "updatedAt": "2022/10/10 15:12:00",
     "images": {
       "symbol": "https://images.pokemontcg.io/base4/symbol.png",
       "logo": "https://images.pokemontcg.io/base4/logo.png"
@@ -112,7 +112,7 @@
     },
     "ptcgoCode": "G1",
     "releaseDate": "2000/08/14",
-    "updatedAt": "2020/08/14 09:35:00",
+    "updatedAt": "2022/10/10 15:12:00",
     "images": {
       "symbol": "https://images.pokemontcg.io/gym1/symbol.png",
       "logo": "https://images.pokemontcg.io/gym1/logo.png"
@@ -129,7 +129,7 @@
     },
     "ptcgoCode": "G2",
     "releaseDate": "2000/10/16",
-    "updatedAt": "2020/08/14 09:35:00",
+    "updatedAt": "2022/10/10 15:12:00",
     "images": {
       "symbol": "https://images.pokemontcg.io/gym2/symbol.png",
       "logo": "https://images.pokemontcg.io/gym2/logo.png"
@@ -146,7 +146,7 @@
     },
     "ptcgoCode": "N1",
     "releaseDate": "2000/12/16",
-    "updatedAt": "2020/08/14 09:35:00",
+    "updatedAt": "2022/10/10 15:12:00",
     "images": {
       "symbol": "https://images.pokemontcg.io/neo1/symbol.png",
       "logo": "https://images.pokemontcg.io/neo1/logo.png"
@@ -247,7 +247,7 @@
     },
     "ptcgoCode": "EX",
     "releaseDate": "2002/09/15",
-    "updatedAt": "2020/08/14 09:35:00",
+    "updatedAt": "2022/10/10 15:12:00",
     "images": {
       "symbol": "https://images.pokemontcg.io/ecard1/symbol.png",
       "logo": "https://images.pokemontcg.io/ecard1/logo.png"
@@ -1170,7 +1170,7 @@
       "expanded": "Legal"
     },
     "releaseDate": "2011/06/17",
-    "updatedAt": "2021/09/01 05:37:00",
+    "updatedAt": "2022/10/10 15:12:00",
     "images": {
       "symbol": "https://images.pokemontcg.io/mcd11/symbol.png",
       "logo": "https://images.pokemontcg.io/mcd11/logo.png"
@@ -1259,7 +1259,7 @@
       "expanded": "Legal"
     },
     "releaseDate": "2012/06/15",
-    "updatedAt": "2021/09/01 05:37:00",
+    "updatedAt": "2022/10/10 15:12:00",
     "images": {
       "symbol": "https://images.pokemontcg.io/mcd12/symbol.png",
       "logo": "https://images.pokemontcg.io/mcd12/logo.png"
@@ -1474,7 +1474,7 @@
       "expanded": "Legal"
     },
     "releaseDate": "2014/05/23",
-    "updatedAt": "2021/03/21 12:30:00",
+    "updatedAt": "2022/10/10 15:12:00",
     "images": {
       "symbol": "https://images.pokemontcg.io/mcd14/symbol.png",
       "logo": "https://images.pokemontcg.io/mcd14/logo.png"
@@ -1617,7 +1617,7 @@
       "expanded": "Legal"
     },
     "releaseDate": "2015/11/27",
-    "updatedAt": "2021/09/21 06:10:00",
+    "updatedAt": "2022/10/10 15:12:00",
     "images": {
       "symbol": "https://images.pokemontcg.io/mcd15/symbol.png",
       "logo": "https://images.pokemontcg.io/mcd15/logo.png"
@@ -1706,7 +1706,7 @@
       "expanded": "Legal"
     },
     "releaseDate": "2016/08/19",
-    "updatedAt": "2021/09/01 05:37:00",
+    "updatedAt": "2022/10/10 15:12:00",
     "images": {
       "symbol": "https://images.pokemontcg.io/mcd16/symbol.png",
       "logo": "https://images.pokemontcg.io/mcd16/logo.png"
@@ -1849,7 +1849,7 @@
       "expanded": "Legal"
     },
     "releaseDate": "2017/11/07",
-    "updatedAt": "2021/09/21 06:34:00",
+    "updatedAt": "2022/10/10 15:12:00",
     "images": {
       "symbol": "https://images.pokemontcg.io/mcd17/symbol.png",
       "logo": "https://images.pokemontcg.io/mcd17/logo.png"
@@ -1938,7 +1938,7 @@
       "expanded": "Legal"
     },
     "releaseDate": "2018/10/16",
-    "updatedAt": "2021/09/21 06:52:00",
+    "updatedAt": "2022/10/10 15:12:00",
     "images": {
       "symbol": "https://images.pokemontcg.io/mcd18/symbol.png",
       "logo": "https://images.pokemontcg.io/mcd18/logo.png"
@@ -2080,7 +2080,7 @@
       "expanded": "Legal"
     },
     "releaseDate": "2019/10/15",
-    "updatedAt": "2021/09/01 05:37:00",
+    "updatedAt": "2022/10/10 15:12:00",
     "images": {
       "symbol": "https://images.pokemontcg.io/mcd19/symbol.png",
       "logo": "https://images.pokemontcg.io/mcd19/logo.png"
@@ -2193,7 +2193,7 @@
     },
     "ptcgoCode": "FUT20",
     "releaseDate": "2020/09/11",
-    "updatedAt": "2021/11/12 06:03:00",
+    "updatedAt": "2022/10/10 15:12:00",
     "images": {
       "symbol": "https://images.pokemontcg.io/fut20/symbol.png",
       "logo": "https://images.pokemontcg.io/fut20/logo.png"
@@ -2343,7 +2343,7 @@
       "expanded": "Legal"
     },
     "releaseDate": "2021/02/09",
-    "updatedAt": "2021/09/07 13:00:00",
+    "updatedAt": "2022/10/10 15:12:00",
     "images": {
       "symbol": "https://images.pokemontcg.io/mcd21/symbol.png",
       "logo": "https://images.pokemontcg.io/mcd21/logo.png"


### PR DESCRIPTION
Following discussion with pkmncards.com we came to the conclusion that the promo rarity has a specific layout, and that iconless basic energy should not be counted as common. This change is mostly applying this to the database with the exception of Dragon Vault, as I see this as enough of a potential edge case to be worth discussing due to them having a rarity specified on pokemon.com (see #320 ). I also have not changed SM1 energy as that is rolled into my numberless energy PR #260 .