### PR TITLE
fix rules for swsh9tg-TG27 and swsh9tg-TG28

### DIFF
--- a/cards/en/swsh9tg.json
+++ b/cards/en/swsh9tg.json
@@ -1544,7 +1544,8 @@
       "Supporter"
     ],
     "rules": [
-      "$$$CARD.RULES.MISSING.TOKEN$$$",
+      "You can play this card only when it is the last card in your hand.",
+      "Put a Rapid Strike Pokémon from your discard pile onto your Bench. If you do, draw 5 cards.",
       "Supporter rule: You may play only 1 Supporter card during your turn."
     ],
     "number": "TG27",
@@ -1570,7 +1571,8 @@
       "Supporter"
     ],
     "rules": [
-      "$$$CARD.RULES.MISSING.TOKEN$$$",
+      "You can play this card only when it is the last card in your hand.",
+      "Search your deck for a Single Strike Pokémon and put it onto your Bench. Then, shuffle your deck. If you searched your deck in this way, draw 5 cards.",
       "Supporter rule: You may play only 1 Supporter card during your turn."
     ],
     "number": "TG28",


### PR DESCRIPTION
I fixed the rules for TG27 and TG28 which contained weird `$$$CARD.RULES.MISSING.TOKEN$$$` string