### PR TITLE
Add missing regulation marks

### DIFF
--- a/cards/en/cel25.json
+++ b/cards/en/cel25.json
@@ -61,6 +61,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/cel25/1.png",
       "large": "https://images.pokemontcg.io/cel25/1_hires.png"
@@ -123,6 +124,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/cel25/2.png",
       "large": "https://images.pokemontcg.io/cel25/2_hires.png"
@@ -187,6 +189,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/cel25/3.png",
       "large": "https://images.pokemontcg.io/cel25/3_hires.png"
@@ -245,6 +248,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/cel25/4.png",
       "large": "https://images.pokemontcg.io/cel25/4_hires.png"
@@ -306,6 +310,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/cel25/5.png",
       "large": "https://images.pokemontcg.io/cel25/5_hires.png"
@@ -374,6 +379,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/cel25/6.png",
       "large": "https://images.pokemontcg.io/cel25/6_hires.png"
@@ -433,6 +439,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/cel25/7.png",
       "large": "https://images.pokemontcg.io/cel25/7_hires.png"
@@ -490,6 +497,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/cel25/8.png",
       "large": "https://images.pokemontcg.io/cel25/8_hires.png"
@@ -547,6 +555,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/cel25/9.png",
       "large": "https://images.pokemontcg.io/cel25/9_hires.png"
@@ -609,6 +618,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/cel25/10.png",
       "large": "https://images.pokemontcg.io/cel25/10_hires.png"
@@ -671,6 +681,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/cel25/11.png",
       "large": "https://images.pokemontcg.io/cel25/11_hires.png"
@@ -732,6 +743,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/cel25/12.png",
       "large": "https://images.pokemontcg.io/cel25/12_hires.png"
@@ -789,6 +801,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/cel25/13.png",
       "large": "https://images.pokemontcg.io/cel25/13_hires.png"
@@ -850,6 +863,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/cel25/14.png",
       "large": "https://images.pokemontcg.io/cel25/14_hires.png"
@@ -918,6 +932,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/cel25/15.png",
       "large": "https://images.pokemontcg.io/cel25/15_hires.png"
@@ -980,6 +995,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/cel25/16.png",
       "large": "https://images.pokemontcg.io/cel25/16_hires.png"
@@ -1044,6 +1060,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/cel25/17.png",
       "large": "https://images.pokemontcg.io/cel25/17_hires.png"
@@ -1106,6 +1123,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/cel25/18.png",
       "large": "https://images.pokemontcg.io/cel25/18_hires.png"
@@ -1173,6 +1191,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/cel25/19.png",
       "large": "https://images.pokemontcg.io/cel25/19_hires.png"
@@ -1239,6 +1258,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/cel25/20.png",
       "large": "https://images.pokemontcg.io/cel25/20_hires.png"
@@ -1303,6 +1323,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/cel25/21.png",
       "large": "https://images.pokemontcg.io/cel25/21_hires.png"
@@ -1371,6 +1392,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/cel25/22.png",
       "large": "https://images.pokemontcg.io/cel25/22_hires.png"
@@ -1394,6 +1416,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/cel25/23.png",
       "large": "https://images.pokemontcg.io/cel25/23_hires.png"
@@ -1417,6 +1440,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/cel25/24.png",
       "large": "https://images.pokemontcg.io/cel25/24_hires.png"
@@ -1479,6 +1503,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/cel25/25.png",
       "large": "https://images.pokemontcg.io/cel25/25_hires.png"

--- a/cards/en/fut20.json
+++ b/cards/en/fut20.json
@@ -53,6 +53,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/fut20/1.png",
       "large": "https://images.pokemontcg.io/fut20/1_hires.png"
@@ -111,6 +112,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/fut20/2.png",
       "large": "https://images.pokemontcg.io/fut20/2_hires.png"
@@ -170,6 +172,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/fut20/3.png",
       "large": "https://images.pokemontcg.io/fut20/3_hires.png"
@@ -228,6 +231,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/fut20/4.png",
       "large": "https://images.pokemontcg.io/fut20/4_hires.png"
@@ -286,6 +290,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/fut20/5.png",
       "large": "https://images.pokemontcg.io/fut20/5_hires.png"

--- a/cards/en/pgo.json
+++ b/cards/en/pgo.json
@@ -4127,6 +4127,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "F",
     "images": {
       "small": "https://images.pokemontcg.io/pgo/69.png",
       "large": "https://images.pokemontcg.io/pgo/69_hires.png"

--- a/cards/en/swsh10.json
+++ b/cards/en/swsh10.json
@@ -8462,6 +8462,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "F",
     "images": {
       "small": "https://images.pokemontcg.io/swsh10/139.png",
       "large": "https://images.pokemontcg.io/swsh10/139_hires.png"
@@ -8486,6 +8487,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "F",
     "images": {
       "small": "https://images.pokemontcg.io/swsh10/140.png",
       "large": "https://images.pokemontcg.io/swsh10/140_hires.png"
@@ -8909,6 +8911,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "F",
     "images": {
       "small": "https://images.pokemontcg.io/swsh10/157.png",
       "large": "https://images.pokemontcg.io/swsh10/157_hires.png"

--- a/cards/en/swsh11.json
+++ b/cards/en/swsh11.json
@@ -9469,6 +9469,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "F",
     "images": {
       "small": "https://images.pokemontcg.io/swsh11/159.png",
       "large": "https://images.pokemontcg.io/swsh11/159_hires.png"
@@ -10949,6 +10950,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "F",
     "images": {
       "small": "https://images.pokemontcg.io/swsh11/193.png",
       "large": "https://images.pokemontcg.io/swsh11/193_hires.png"
@@ -11572,6 +11574,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "F",
     "images": {
       "small": "https://images.pokemontcg.io/swsh11/208.png",
       "large": "https://images.pokemontcg.io/swsh11/208_hires.png"
@@ -11836,6 +11839,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "F",
     "images": {
       "small": "https://images.pokemontcg.io/swsh11/216.png",
       "large": "https://images.pokemontcg.io/swsh11/216_hires.png"

--- a/cards/en/swsh12.json
+++ b/cards/en/swsh12.json
@@ -9627,6 +9627,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "F",
     "images": {
       "small": "https://images.pokemontcg.io/swsh12/165.png",
       "large": "https://images.pokemontcg.io/swsh12/165_hires.png"
@@ -11884,6 +11885,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "F",
     "images": {
       "small": "https://images.pokemontcg.io/swsh12/212.png",
       "large": "https://images.pokemontcg.io/swsh12/212_hires.png"

--- a/cards/en/swsh12tg.json
+++ b/cards/en/swsh12tg.json
@@ -1435,6 +1435,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/swsh12tg/TG25.png",
       "large": "https://images.pokemontcg.io/swsh12tg/TG25_hires.png"

--- a/cards/en/swsh35.json
+++ b/cards/en/swsh35.json
@@ -3312,6 +3312,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/swsh35/60.png",
       "large": "https://images.pokemontcg.io/swsh35/60_hires.png"

--- a/cards/en/swsh45.json
+++ b/cards/en/swsh45.json
@@ -2046,6 +2046,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/swsh45/35.png",
       "large": "https://images.pokemontcg.io/swsh45/35_hires.png"
@@ -2105,6 +2106,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/swsh45/36.png",
       "large": "https://images.pokemontcg.io/swsh45/36_hires.png"

--- a/cards/en/swsh5.json
+++ b/cards/en/swsh5.json
@@ -7593,6 +7593,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/swsh5/124.png",
       "large": "https://images.pokemontcg.io/swsh5/124_hires.png"
@@ -7617,6 +7618,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/swsh5/125.png",
       "large": "https://images.pokemontcg.io/swsh5/125_hires.png"
@@ -7642,6 +7644,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/swsh5/126.png",
       "large": "https://images.pokemontcg.io/swsh5/126_hires.png"
@@ -7718,6 +7721,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/swsh5/129.png",
       "large": "https://images.pokemontcg.io/swsh5/129_hires.png"
@@ -10089,6 +10093,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/swsh5/180.png",
       "large": "https://images.pokemontcg.io/swsh5/180_hires.png"
@@ -10113,6 +10118,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/swsh5/181.png",
       "large": "https://images.pokemontcg.io/swsh5/181_hires.png"

--- a/cards/en/swsh6.json
+++ b/cards/en/swsh6.json
@@ -7966,6 +7966,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/swsh6/132.png",
       "large": "https://images.pokemontcg.io/swsh6/132_hires.png"
@@ -10496,6 +10497,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/swsh6/189.png",
       "large": "https://images.pokemontcg.io/swsh6/189_hires.png"
@@ -11552,6 +11554,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/swsh6/213.png",
       "large": "https://images.pokemontcg.io/swsh6/213_hires.png"

--- a/cards/en/swsh7.json
+++ b/cards/en/swsh7.json
@@ -8574,6 +8574,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/swsh7/143.png",
       "large": "https://images.pokemontcg.io/swsh7/143_hires.png"
@@ -11314,6 +11315,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/swsh7/200.png",
       "large": "https://images.pokemontcg.io/swsh7/200_hires.png"
@@ -12519,6 +12521,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/swsh7/222.png",
       "large": "https://images.pokemontcg.io/swsh7/222_hires.png"

--- a/cards/en/swsh8.json
+++ b/cards/en/swsh8.json
@@ -13704,6 +13704,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/swsh8/226.png",
       "large": "https://images.pokemontcg.io/swsh8/226_hires.png"
@@ -13936,6 +13937,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/swsh8/235.png",
       "large": "https://images.pokemontcg.io/swsh8/235_hires.png"
@@ -14061,6 +14063,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/swsh8/240.png",
       "large": "https://images.pokemontcg.io/swsh8/240_hires.png"
@@ -15157,6 +15160,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/swsh8/263.png",
       "large": "https://images.pokemontcg.io/swsh8/263_hires.png"
@@ -15862,6 +15866,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "E",
     "images": {
       "small": "https://images.pokemontcg.io/swsh8/278.png",
       "large": "https://images.pokemontcg.io/swsh8/278_hires.png"

--- a/cards/en/swsh9.json
+++ b/cards/en/swsh9.json
@@ -8149,6 +8149,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "F",
     "images": {
       "small": "https://images.pokemontcg.io/swsh9/139.png",
       "large": "https://images.pokemontcg.io/swsh9/139_hires.png"
@@ -8426,6 +8427,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "F",
     "images": {
       "small": "https://images.pokemontcg.io/swsh9/150.png",
       "large": "https://images.pokemontcg.io/swsh9/150_hires.png"
@@ -10233,6 +10235,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "F",
     "images": {
       "small": "https://images.pokemontcg.io/swsh9/186.png",
       "large": "https://images.pokemontcg.io/swsh9/186_hires.png"

--- a/cards/en/swshp.json
+++ b/cards/en/swshp.json
@@ -47,6 +47,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH001.png",
       "large": "https://images.pokemontcg.io/swshp/SWSH001_hires.png"
@@ -99,6 +100,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH002.png",
       "large": "https://images.pokemontcg.io/swshp/SWSH002_hires.png"
@@ -152,6 +154,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH003.png",
       "large": "https://images.pokemontcg.io/swshp/SWSH003_hires.png"
@@ -219,6 +222,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH004.png",
       "large": "https://images.pokemontcg.io/swshp/SWSH004_hires.png"
@@ -278,6 +282,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH005.png",
       "large": "https://images.pokemontcg.io/swshp/SWSH005_hires.png"
@@ -578,6 +583,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH010.png",
       "large": "https://images.pokemontcg.io/swshp/SWSH010_hires.png"
@@ -640,6 +646,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH011.png",
       "large": "https://images.pokemontcg.io/swshp/SWSH011_hires.png"
@@ -691,6 +698,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH012.png",
       "large": "https://images.pokemontcg.io/swshp/SWSH012_hires.png"
@@ -759,6 +767,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH013.png",
       "large": "https://images.pokemontcg.io/swshp/SWSH013_hires.png"
@@ -825,6 +834,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH014.png",
       "large": "https://images.pokemontcg.io/swshp/SWSH014_hires.png"
@@ -887,6 +897,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH015.png",
       "large": "https://images.pokemontcg.io/swshp/SWSH015_hires.png"
@@ -951,6 +962,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH016.png",
       "large": "https://images.pokemontcg.io/swshp/SWSH016_hires.png"
@@ -1015,6 +1027,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH017.png",
       "large": "https://images.pokemontcg.io/swshp/SWSH017_hires.png"
@@ -1217,6 +1230,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH020.png",
       "large": "https://images.pokemontcg.io/swshp/SWSH020_hires.png"
@@ -1934,6 +1948,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH031.png",
       "large": "https://images.pokemontcg.io/swshp/SWSH031_hires.png"
@@ -4699,6 +4714,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH074.png",
       "large": "https://images.pokemontcg.io/swshp/SWSH074_hires.png"
@@ -7335,6 +7351,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH116.png",
       "large": "https://images.pokemontcg.io/swshp/SWSH116_hires.png"
@@ -9243,6 +9260,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "D",
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH146.png",
       "large": "https://images.pokemontcg.io/swshp/SWSH146_hires.png"
@@ -17760,6 +17778,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "regulationMark": "F",
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH296.png",
       "large": "https://images.pokemontcg.io/swshp/SWSH296_hires.png"


### PR DESCRIPTION
This PR adds the `regulationMark` field to all cards that were missing this data.

After this change, the only cards in standard-format-legal sets that are missing regulation marks are the basic energy cards and cards whose `rules` include `("This card cannot be used at official tournaments")`. That should make it easy to keep the `legalities` accurate when D cards rotate out of standard later this year.