### PR TITLE
Fix Tauros (id:base6-65)

### DIFF
--- a/cards/en/base6.json
+++ b/cards/en/base6.json
@@ -4025,7 +4025,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20+",
-        "text": "Does 20 damage plus 10 more damage for each counter on Tauros. Flip a coin. If tails, Tauros is now Confused (after doing damage)."
+        "text": "Does 20 damage plus 10 more damage for each damage counter on Tauros. Flip a coin. If tails, Tauros is now Confused (after doing damage)."
       }
     ],
     "weaknesses": [


### PR DESCRIPTION
I noticed that the text of Tauros's "Rampage" attack at one point said "counter" instead of "damage counter". I think I've fixed it.