### PR TITLE
Fixed primal Pokémon

### DIFF
--- a/cards/en/xy5.json
+++ b/cards/en/xy5.json
@@ -3222,7 +3222,7 @@
     "name": "Primal Kyogre-EX",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "MEGA",
       "EX"
     ],
     "hp": "240",
@@ -5134,7 +5134,7 @@
     "name": "Primal Groudon-EX",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "MEGA",
       "EX"
     ],
     "hp": "240",
@@ -5147,8 +5147,8 @@
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "ancientTrait": {
-      "name": "Ω Barrage",
-      "text": "This Pokémon may attack twice a turn. (If the first attack Knocks Out your opponent's Active Pokémon, you may attack again after your opponent chooses a new Active Pokémon.)"
+      "name": "Ω Barrier",
+      "text": "Whenever your opponent plays a Trainer card (excluding Pokémon Tools and Stadium cards), prevent all effects of that card done to this Pokémon."
     },
     "attacks": [
       {
@@ -8233,7 +8233,7 @@
     "name": "Primal Kyogre-EX",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "MEGA",
       "EX"
     ],
     "hp": "240",
@@ -8363,7 +8363,7 @@
     "name": "Primal Groudon-EX",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "MEGA",
       "EX"
     ],
     "hp": "240",

--- a/cards/en/xy7.json
+++ b/cards/en/xy7.json
@@ -5355,7 +5355,7 @@
     "name": "Primal Kyogre-EX",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "MEGA",
       "EX"
     ],
     "hp": "240",
@@ -5418,7 +5418,7 @@
     "name": "Primal Groudon-EX",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
+      "MEGA",
       "EX"
     ],
     "hp": "240",


### PR DESCRIPTION
Fixed primal Pokémon subtypes ("Basic" to "MEGA") and fixed the ancient trait of xy5-85, which was Ω Barrage instead of Ω Barrier. One could argue the subtype "Primal Reversion" should be added to these Pokémon, I personally think that's not necessary.