### PR TITLE
Added item subtype for consistency

### DIFF
--- a/cards/en/dpp.json
+++ b/cards/en/dpp.json
@@ -251,6 +251,9 @@
     "id": "dpp-DP05",
     "name": "Tropical Wind",
     "supertype": "Trainer",
+    "subtypes": [
+      "Item"
+    ],
     "rules": [
       "Flip a coin. If heads, remove 2 damage counters from each Active Pokémon (remove 1 damage counter if a Pokémon has only 1). If tails, each Active Pokémon is now Asleep."
     ],
@@ -1427,6 +1430,9 @@
     "id": "dpp-DP25",
     "name": "Tropical Wind",
     "supertype": "Trainer",
+    "subtypes": [
+      "Item"
+    ],
     "rules": [
       "Flip a coin. If heads, remove 2 damage counters from each Active Pokémon (remove 1 damage counter if a Pokémon has only 1). If tails, each Active Pokémon is now Asleep."
     ],
@@ -2835,6 +2841,9 @@
     "id": "dpp-DP48",
     "name": "Tropical Wind",
     "supertype": "Trainer",
+    "subtypes": [
+      "Item"
+    ],
     "rules": [
       "Flip a coin. If heads, remove 2 damage counters from each Active Pokémon (remove 1 damage counter if a Pokémon has only 1). If tails, each Active Pokémon is now Asleep."
     ],
@@ -3138,6 +3147,9 @@
     "id": "dpp-DP54",
     "name": "Beginning Door",
     "supertype": "Trainer",
+    "subtypes": [
+      "Item"
+    ],
     "rules": [
       "Search your deck for Arceus, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
     ],

--- a/cards/en/ex11.json
+++ b/cards/en/ex11.json
@@ -5538,6 +5538,9 @@
     "id": "ex11-98",
     "name": "Holon Transceiver",
     "supertype": "Trainer",
+    "subtypes": [
+      "Item"
+    ],
     "rules": [
       "Search your deck for a Supporter card that has Holon in its name, show it to your opponent, and put it into your hand. Shuffle your deck afterward. Or, search your discard pile for a Supporter card that has Holon in its name, show it to your opponent, and put it into your hand."
     ],

--- a/cards/en/ex8.json
+++ b/cards/en/ex8.json
@@ -4990,6 +4990,9 @@
     "id": "ex8-86",
     "name": "Energy Charge",
     "supertype": "Trainer",
+    "subtypes": [
+      "Item"
+    ],
     "rules": [
       "Flip a coin. If heads, search your discard pile for 2 Energy cards (1 if there is only 1), show them to your opponent, and shuffle them into your deck."
     ],

--- a/cards/en/hgss1.json
+++ b/cards/en/hgss1.json
@@ -5257,6 +5257,9 @@
     "id": "hgss1-91",
     "name": "Energy Switch",
     "supertype": "Trainer",
+    "subtypes": [
+      "Item"
+    ],
     "rules": [
       "Move a basic Energy card attached 1 of your Pokémon to another of your Pokémon."
     ],

--- a/cards/en/hsp.json
+++ b/cards/en/hsp.json
@@ -1018,6 +1018,9 @@
     "id": "hsp-HGSS18",
     "name": "Tropical Tidal Wave",
     "supertype": "Trainer",
+    "subtypes": [
+      "Item"
+    ],
     "rules": [
       "Flip a coin. If heads, discard all Trainer and Stadium cards your opponent has in play. If tails, discard all Trainer and Stadium cards you have in play."
     ],

--- a/cards/en/np.json
+++ b/cards/en/np.json
@@ -1500,6 +1500,9 @@
     "id": "np-26",
     "name": "Tropical Wind",
     "supertype": "Trainer",
+    "subtypes": [
+      "Item"
+    ],
     "rules": [
       "Flip a coin. If heads, remove 2 damage counters from each Active Pokémon (remove 1 damage counter if a Pokémon has only 1). If tails, each Active Pokémon is now Asleep."
     ],
@@ -1518,6 +1521,9 @@
     "id": "np-27",
     "name": "Tropical Tidal Wave",
     "supertype": "Trainer",
+    "subtypes": [
+      "Item"
+    ],
     "rules": [
       "Flip a coin. If heads, discard all Trainer cards your opponent has in play. If tails, discard all Trainer (excluding Supporter cards) you have in play."
     ],
@@ -1991,6 +1997,9 @@
     "id": "np-36",
     "name": "Tropical Tidal Wave",
     "supertype": "Trainer",
+    "subtypes": [
+      "Item"
+    ],
     "rules": [
       "Flip a coin. If heads, discard all Trainer cards your opponent has in play. If tails, discard all Trainer cards (excluding Supporter cards) you have in play."
     ],

--- a/cards/en/pop5.json
+++ b/cards/en/pop5.json
@@ -283,6 +283,9 @@
     "id": "pop5-7",
     "name": "Rare Candy",
     "supertype": "Trainer",
+    "subtypes": [
+      "Item"
+    ],
     "rules": [
       "Choose 1 of your Basic Pokémon in play. If you have a Stage 1 or Stage 2 card that evolves from that Pokémon in your hand, put that card on the Basic Pokémon. (This counts as evolving that Pokémon.)"
     ],

--- a/cards/en/pop8.json
+++ b/cards/en/pop8.json
@@ -519,6 +519,9 @@
     "id": "pop8-9",
     "name": "Night Maintenance",
     "supertype": "Trainer",
+    "subtypes": [
+      "Item"
+    ],
     "rules": [
       "Search your discard pile for up to 3 in any combination of Pokémon and basic Energy cards. Show them to your opponent and shuffle them into your deck."
     ],
@@ -537,6 +540,9 @@
     "id": "pop8-10",
     "name": "Rare Candy",
     "supertype": "Trainer",
+    "subtypes": [
+      "Item"
+    ],
     "rules": [
       "Choose 1 of your Basic Pokémon in play. If you have a Stage 1 or Stage 2 card that evolves from that Pokémon in your hand, put that card on the Basic Pokémon. (This counts as evolving that Pokémon.)"
     ],


### PR DESCRIPTION
I noticed that most trainer cards from ex to hgss that were only labeled "trainer" had the "item" subtype. I added the subtype to the few of them that did not have it, i.e. to all of the cards that matched this query: `supertype:trainer -subtypes:"*" -set.id:"base*" -set.id:"neo*" -set.id:"gym*" -set.id:"ecard*" -set.id:"bp"`