### PR TITLE
Added rules to cel25-20_A and cel25-66_A

### DIFF
--- a/cards/en/cel25c.json
+++ b/cards/en/cel25c.json
@@ -466,6 +466,9 @@
     "evolvesTo": [
       "Clefairy"
     ],
+    "rules": [
+      "If this Baby Pokémon is your Active Pokémon and your opponent tries to attack, your opponent flips a coin (before doing anything required in order to use that attack). If tails, your opponent's turn ends without an attack."
+    ],
     "attacks": [
       {
         "cost": [
@@ -504,6 +507,9 @@
     ],
     "evolvesTo": [
       "Gyarados"
+    ],
+    "rules": [
+      "You can't have more than 1 Shining Magikarp in your deck."
     ],
     "attacks": [
       {

--- a/cards/en/cel25c.json
+++ b/cards/en/cel25c.json
@@ -567,6 +567,9 @@
       "Fighting",
       "Darkness"
     ],
+    "rules": [
+      "This Pokémon is both Fighting Darkness type."
+    ],
     "abilities": [
       {
         "type": "Poké-Body",


### PR DESCRIPTION
Cleffa was missing the Baby Pokémon rule, and Shining Magikarp was missing the Shining Pokémon rule

EDIT: I also noticed that Team Magma's Groudon from the same set was missing the dual type rules, so I added that as well.