### PR TITLE
Various weakness and SP fixes

### DIFF
--- a/cards/en/dp1.json
+++ b/cards/en/dp1.json
@@ -4034,7 +4034,7 @@
     "weaknesses": [
       {
         "type": "Lightning",
-        "value": "×2"
+        "value": "+20"
       }
     ],
     "resistances": [

--- a/cards/en/dpp.json
+++ b/cards/en/dpp.json
@@ -2450,7 +2450,8 @@
     "name": "Carnivine G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "hp": "80",
     "types": [

--- a/cards/en/pl1.json
+++ b/cards/en/pl1.json
@@ -3227,7 +3227,7 @@
     "weaknesses": [
       {
         "type": "Fighting",
-        "value": "+20"
+        "value": "×2"
       }
     ],
     "resistances": [

--- a/cards/en/pl3.json
+++ b/cards/en/pl3.json
@@ -1189,7 +1189,8 @@
     "name": "Camerupt G",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "57",
     "hp": "100",
@@ -1885,7 +1886,8 @@
     "name": "Lickilicky C",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "SP"
     ],
     "level": "57",
     "hp": "90",


### PR DESCRIPTION
* dp1-64 had a weakness of ×2 instead of +20
* pl1-50 had a weakness of +20 instead of ×2
* dpp-DP42, pl3-19, pl3-30 were missing the "SP" subtype