### PR TITLE
Various fixes to cel25c

### DIFF
--- a/cards/en/cel25c.json
+++ b/cards/en/cel25c.json
@@ -653,7 +653,7 @@
       "Psychic"
     ],
     "rules": [
-      "When a Pokémon-ex has been knocked out, your opponent takes 2 Prize cards."
+      "When Pokémon-ex has been knocked out, your opponent takes 2 Prize cards."
     ],
     "abilities": [
       {
@@ -713,7 +713,7 @@
     ],
     "evolvesFrom": "Kirlia",
     "rules": [
-      "When a Pokémon-ex has been knocked out, your opponent takes 2 Prize cards."
+      "When Pokémon-ex has been knocked out, your opponent takes 2 Prize cards."
     ],
     "abilities": [
       {

--- a/cards/en/cel25c.json
+++ b/cards/en/cel25c.json
@@ -773,13 +773,13 @@
       "Darkness"
     ],
     "rules": [
-      "You can't have more than 1 Pokémon★ in your deck."
+      "You can't have more than 1 Pokémon Star in your deck."
     ],
     "abilities": [
       {
         "type": "Poké-Power",
         "name": "Dark Ray",
-        "text": "Once during your turn, when you put Umbreon from your hand onto your Bench, you may choose 1 card from your opponent's hand without looking and discard it."
+        "text": "Once during your turn, when you put Umbreon Star from your hand onto your Bench, you may choose 1 card from your opponent's hand without looking and discard it."
       }
     ],
     "attacks": [

--- a/cards/en/cel25c.json
+++ b/cards/en/cel25c.json
@@ -6,6 +6,7 @@
     "subtypes": [
       "Stage 2"
     ],
+    "level": "52",
     "hp": "100",
     "types": [
       "Water"
@@ -65,6 +66,7 @@
     "subtypes": [
       "Stage 2"
     ],
+    "level": "76",
     "hp": "120",
     "types": [
       "Fire"
@@ -131,6 +133,7 @@
     "subtypes": [
       "Stage 2"
     ],
+    "level": "67",
     "hp": "100",
     "types": [
       "Grass"
@@ -211,6 +214,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "34",
     "hp": "70",
     "types": [
       "Lightning"
@@ -348,6 +352,7 @@
     "subtypes": [
       "Stage 1"
     ],
+    "level": "31",
     "hp": "70",
     "types": [
       "Water"
@@ -412,6 +417,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "17",
     "hp": "50",
     "types": [
       "Lightning"
@@ -459,6 +465,7 @@
     "subtypes": [
       "Baby"
     ],
+    "level": "6",
     "hp": "30",
     "types": [
       "Colorless"
@@ -498,6 +505,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "45",
     "hp": "30",
     "types": [
       "Water"

--- a/cards/en/cel25c.json
+++ b/cards/en/cel25c.json
@@ -839,13 +839,13 @@
     ],
     "evolvesFrom": "Luxray GL",
     "rules": [
-      "Put this card onto your Active Luxray [GL]. Luxray [GL] LV. X can use any attack, Poké-Power, or Poké-Body from its previous Level."
+      "Put this card onto your Active Luxray GL. Luxray GL LV. X can use any attack, Poké-Power, or Poké-Body from its previous Level."
     ],
     "abilities": [
       {
         "type": "Poké-Power",
         "name": "Bright Look",
-        "text": "Once during your turn (before your attack), when you put Luxray LV.X from your hand onto your Active Luxray , you may switch the Defending Pokémon with 1 of your opponent's Benched Pokémon."
+        "text": "Once during your turn (before your attack), when you put Luxray GL LV.X from your hand onto your Active Luxray GL, you may switch the Defending Pokémon with 1 of your opponent's Benched Pokémon."
       }
     ],
     "attacks": [
@@ -901,13 +901,13 @@
     ],
     "evolvesFrom": "Garchomp C",
     "rules": [
-      "Put this card onto your Active Garchomp [C]. Garchomp [C] LV. X can use any attack, Poké-Power, or Poké-Body from its previous Level."
+      "Put this card onto your Active Garchomp C. Garchomp C LV. X can use any attack, Poké-Power, or Poké-Body from its previous Level."
     ],
     "abilities": [
       {
         "type": "Poké-Power",
         "name": "Healing Breath",
-        "text": "Once during your turn (before your attack), when you put Garchomp LV.X from your hand onto your Active Garchomp , you may remove all damage counters from each of your Pokémon SP."
+        "text": "Once during your turn (before your attack), when you put Garchomp C LV.X from your hand onto your Active Garchomp C, you may remove all damage counters from each of your Pokémon SP."
       }
     ],
     "attacks": [
@@ -919,7 +919,7 @@
         ],
         "name": "Dragon Rush",
         "damage": "",
-        "text": "Discard 2 Energy attached to Garchomp [C]. Choose 1 of your opponent's Pokémon. This attack does 80 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Garchomp [C] can't use Dragon Rush during your next turn.",
+        "text": "Discard 2 Energy attached to Garchomp C. Choose 1 of your opponent's Pokémon. This attack does 80 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Garchomp C can't use Dragon Rush during your next turn.",
         "convertedEnergyCost": 3
       }
     ],

--- a/cards/en/cel25c.json
+++ b/cards/en/cel25c.json
@@ -1352,7 +1352,7 @@
       "Psychic"
     ],
     "rules": [
-      "When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
+      "Pokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
     ],
     "abilities": [
       {

--- a/cards/en/cel25c.json
+++ b/cards/en/cel25c.json
@@ -447,6 +447,7 @@
     "number": "24",
     "artist": "Kagemaru Himeno",
     "rarity": "Classic Collection",
+    "flavorText": "Your Birthdate: ______________________________",
     "nationalPokedexNumbers": [
       25
     ],
@@ -487,6 +488,7 @@
     "number": "20",
     "artist": "Kagemaru Himeno",
     "rarity": "Classic Collection",
+    "flavorText": "Because of its unusual, star-like silhouette, people believe that it came here on a meteor.",
     "nationalPokedexNumbers": [
       173
     ],
@@ -546,6 +548,7 @@
     "number": "66",
     "artist": "Ken Sugimori",
     "rarity": "Classic Collection",
+    "flavorText": "An underpowered, pathetic Pokémon. It may jump high on rare occasions, but never more than seven feet.",
     "nationalPokedexNumbers": [
       129
     ],
@@ -1074,6 +1077,7 @@
     "number": "113",
     "artist": "5ban Graphics",
     "rarity": "Classic Collection",
+    "flavorText": "This Pokémon appears in legends. It sends flames into the air from its tail, burning up everything around it.",
     "nationalPokedexNumbers": [
       643
     ],
@@ -1134,6 +1138,7 @@
     "number": "114",
     "artist": "5ban Graphics",
     "rarity": "Classic Collection",
+    "flavorText": "This Pokémon appears in legends. In its tail, it has a giant generator that creates electricity.",
     "nationalPokedexNumbers": [
       644
     ],

--- a/cards/en/cel25c.json
+++ b/cards/en/cel25c.json
@@ -901,7 +901,7 @@
     ],
     "evolvesFrom": "Garchomp C",
     "rules": [
-      "Put this card onto your Active Garchomp C. Garchomp C LV. X can use any attack, Poké-Power, or Poké-Body from its previous Level."
+      "Put this card onto your Active Garchomp C. Garchomp C LV.X can use any attack, Poké-Power, or Poké-Body from its previous Level."
     ],
     "abilities": [
       {
@@ -1151,7 +1151,7 @@
       "Psychic"
     ],
     "rules": [
-      "When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
+      "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
       {
@@ -1215,7 +1215,7 @@
       "Fairy"
     ],
     "rules": [
-      "When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
+      "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
       {
@@ -1288,7 +1288,7 @@
     ],
     "evolvesFrom": "Rayquaza-EX",
     "rules": [
-      "When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards.",
+      "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards.",
       "Mega Evolution rule: When 1 of your Pokémon becomes a Mega Evolution Pokémon, your turn ends."
     ],
     "ancientTrait": {


### PR DESCRIPTION
I added "Pokémon-GX rule: " to cel25c-60_A's rules. It was the only (non-tag team) Pokémon-GX that did not have that at the beginning of the rules.