### PR TITLE
Changed xy4-98's subtype from "Pokémon Tool" to "Pokémon Tool F"

### DIFF
--- a/cards/en/xy4.json
+++ b/cards/en/xy4.json
@@ -5898,7 +5898,7 @@
     "name": "Jamming Net Team Flare Hyper Gear",
     "supertype": "Trainer",
     "subtypes": [
-      "Pokémon Tool"
+      "Pokémon Tool F"
     ],
     "rules": [
       "Attach this Pokemon Tool to 1 of your opponent's Pokemon-EX that doesn't already have a Pokemon Tool attached to it.",


### PR DESCRIPTION
This is for consistency with xy4-97