### PR TITLE
Supporter fixes

### DIFF
--- a/cards/en/cel25.json
+++ b/cards/en/cel25.json
@@ -1406,7 +1406,8 @@
       "Supporter"
     ],
     "rules": [
-      "Discard your hand and draw 7 cards."
+      "Discard your hand and draw 7 cards.",
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "23",
     "artist": "KIYOTAKA OSHIYAMA",
@@ -1430,7 +1431,8 @@
       "Supporter"
     ],
     "rules": [
-      "Discard your hand and draw 7 cards."
+      "Discard your hand and draw 7 cards.",
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "24",
     "artist": "Ken Sugimori",

--- a/cards/en/cel25c.json
+++ b/cards/en/cel25c.json
@@ -187,9 +187,6 @@
     "id": "cel25c-15_A2",
     "name": "Here Comes Team Rocket!",
     "supertype": "Trainer",
-    "subtypes": [
-      "Supporter"
-    ],
     "rules": [
       "Each player plays with his or her Prize cards face up for the rest of the game."
     ],
@@ -324,9 +321,6 @@
     "id": "cel25c-73_A",
     "name": "Imposter Professor Oak",
     "supertype": "Trainer",
-    "subtypes": [
-      "Supporter"
-    ],
     "rules": [
       "Your opponent shuffles his or her hand into his or her deck, then draws 7 cards."
     ],

--- a/cards/en/sm7.json
+++ b/cards/en/sm7.json
@@ -8076,7 +8076,8 @@
       "Supporter"
     ],
     "rules": [
-      "Choose 1: Shuffle your hand into your deck then draw 5 cards, or switch your Active Pokémon with 1 of your Benched Pokémon."
+      "Choose 1: Shuffle your hand into your deck then draw 5 cards, or switch your Active Pokémon with 1 of your Benched Pokémon.",
+      "You may play only 1 Supporter card during your turn (before your attack)."
     ],
     "number": "148",
     "artist": "Megumi Mizutani",
@@ -8098,7 +8099,8 @@
       "Supporter"
     ],
     "rules": [
-      "Choose 1: Shuffle your hand into your deck then draw 5 cards, or switch your Active Pokémon with 1 of your Benched Pokémon."
+      "Choose 1: Shuffle your hand into your deck then draw 5 cards, or switch your Active Pokémon with 1 of your Benched Pokémon.",
+      "You may play only 1 Supporter card during your turn (before your attack)."
     ],
     "number": "148a",
     "artist": "You Iribi",

--- a/cards/en/xy8.json
+++ b/cards/en/xy8.json
@@ -8042,7 +8042,8 @@
       "Supporter"
     ],
     "rules": [
-      "Choose 1: Draw cards until you have 5 cards in your hand, or during this turn, your Pokémon's attacks do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance)."
+      "Choose 1: Draw cards until you have 5 cards in your hand, or during this turn, your Pokémon's attacks do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
+      "You may play only 1 Supporter card during your turn (before your attack)."
     ],
     "number": "138",
     "artist": "Ken Sugimori",
@@ -8931,7 +8932,8 @@
       "Supporter"
     ],
     "rules": [
-      "Choose 1: Draw cards until you have 5 cards in your hand, or during this turn, your Pokémon's attacks do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance)."
+      "Choose 1: Draw cards until you have 5 cards in your hand, or during this turn, your Pokémon's attacks do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
+      "You may play only 1 Supporter card during your turn (before your attack)."
     ],
     "number": "162",
     "artist": "Ken Sugimori",


### PR DESCRIPTION
* Added "You may play only 1 Supporter card during your turn (before your attack)." to the rules of xy8-138, xy8-162, sm7-148, sm7-148a
* Added "You may play only 1 Supporter card during your turn." to the rules of cel25-23, cel25-24
* Removed "Supporter" subtype (and, in fact, all subtypes) from cel25c-15_A2 and cel25c-73_A (yay more cel25c fixes)