### PR TITLE
Removed "Supporter rule: ", "Item rule: " and "Pokémon Tool rule: "

### DIFF
--- a/cards/en/pgo.json
+++ b/cards/en/pgo.json
@@ -3993,7 +3993,7 @@
     ],
     "rules": [
       "Draw 2 cards. If you drew any cards in this way, flip a coin. If heads, attach a Water Energy card from your discard pile to 1 of your Benched Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "64",
     "artist": "Anesaki Dynamic",
@@ -4018,7 +4018,7 @@
     ],
     "rules": [
       "Draw 2 cards. If you drew any cards in this way, flip a coin. If heads, attach a Fire Energy card from your discard pile to 1 of your Benched Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "65",
     "artist": "Ryuta Fuse",
@@ -4142,7 +4142,7 @@
     ],
     "rules": [
       "Draw 2 cards. If you drew any cards in this way, flip a coin. If heads, attach a Lightning Energy card from your discard pile to 1 of your Benched Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "70",
     "artist": "Naoki Saito",
@@ -4635,7 +4635,7 @@
     ],
     "rules": [
       "Discard your hand and draw 7 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "78",
     "artist": "Yusuke Kozaki",
@@ -4856,7 +4856,7 @@
     ],
     "rules": [
       "Draw 2 cards. If you drew any cards in this way, flip a coin. If heads, attach a Water Energy card from your discard pile to 1 of your Benched Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "82",
     "artist": "Anesaki Dynamic",
@@ -4881,7 +4881,7 @@
     ],
     "rules": [
       "Draw 2 cards. If you drew any cards in this way, flip a coin. If heads, attach a Fire Energy card from your discard pile to 1 of your Benched Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "83",
     "artist": "Ryuta Fuse",
@@ -4906,7 +4906,7 @@
     ],
     "rules": [
       "Discard your hand and draw 7 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "84",
     "artist": "Yusuke Kozaki",
@@ -4932,7 +4932,7 @@
     ],
     "rules": [
       "Draw 2 cards. If you drew any cards in this way, flip a coin. If heads, attach a Lightning Energy card from your discard pile to 1 of your Benched Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "85",
     "artist": "Naoki Saito",

--- a/cards/en/pgo.json
+++ b/cards/en/pgo.json
@@ -4043,7 +4043,7 @@
     ],
     "rules": [
       "Flip a coin. If heads, search your deck for a Basic Pokémon, put it onto your Bench, and shuffle your deck. If tails, put this Egg Incubator on the bottom of your deck instead of in the discard pile.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "66",
     "artist": "sadaji",
@@ -4068,7 +4068,7 @@
     ],
     "rules": [
       "Each player reveals the top 3 cards of their deck and puts all Pokémon they find there into their hand. Then, each player shuffles the other cards back into their deck.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "67",
     "artist": "ORBITALLINK Inc.",
@@ -4117,7 +4117,7 @@
     ],
     "rules": [
       "Choose 1 of your Basic Pokémon in play. If you have a Stage 2 card in your hand that evolves from that Pokémon, put that card onto the Basic Pokémon to evolve it, skipping the Stage 1. You can't use this card during your first turn or on a Basic Pokémon that was put into play this turn.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "69",
     "artist": "Ayaka Yoshida",
@@ -5028,7 +5028,7 @@
     ],
     "rules": [
       "Flip a coin. If heads, search your deck for a Basic Pokémon, put it onto your Bench, and shuffle your deck. If tails, put this Egg Incubator on the bottom of your deck instead of in the discard pile.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "87",
     "artist": "sadaji",
@@ -5053,7 +5053,7 @@
     ],
     "rules": [
       "Each player reveals the top 3 cards of their deck and puts all Pokémon they find there into their hand. Then, each player shuffles the other cards back into their deck.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "88",
     "artist": "ORBITALLINK Inc.",

--- a/cards/en/swsh10.json
+++ b/cards/en/swsh10.json
@@ -8777,7 +8777,7 @@
     "rules": [
       "When applying Weakness to damage from the attacks of the Pokémon this card is attached to done to your opponent's Active Pokémon, apply it as ×3.",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "152",
     "artist": "Ryo Ueda",
@@ -11568,7 +11568,7 @@
     "rules": [
       "The attacks of the Pokémon this card is attached to do 30 more damage to your opponent's Active Pokémon V (before applying Weakness and Resistance).",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "211",
     "artist": "Studio Bora Inc.",

--- a/cards/en/swsh10.json
+++ b/cards/en/swsh10.json
@@ -8377,7 +8377,7 @@
     ],
     "rules": [
       "Until the end of your turn, your opponent's Active Pokémon has no Abilities. (This includes Pokémon that come into play during that turn.)",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "136",
     "artist": "Studio Bora Inc.",
@@ -8452,7 +8452,7 @@
     ],
     "rules": [
       "Attach a basic Darkness Energy card from your discard pile to 1 of your Benched Darkness Pokémon.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "139",
     "artist": "Ryo Ueda",
@@ -8477,7 +8477,7 @@
     ],
     "rules": [
       "Look at the top 7 cards of your deck. You may reveal an Energy card you find there and put it into your hand. Shuffle the other cards back into your deck.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "140",
     "artist": "ORBITALLINK Inc.",
@@ -8502,7 +8502,7 @@
     ],
     "rules": [
       "Search your deck for a Pokémon that has no Retreat Cost, reveal it, and put it into your hand. Then, shuffle your deck.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "141",
     "artist": "Studio Bora Inc.",
@@ -8601,7 +8601,7 @@
     ],
     "rules": [
       "Reveal the top card of your deck. If that card is a Fighting Energy card, attach it to 1 of your Benched Pokémon. If it is not a Fighting Energy card, put it into your hand.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "145",
     "artist": "Eske Yoshinob",
@@ -8626,7 +8626,7 @@
     ],
     "rules": [
       "Look at your face-down Prize cards. You may reveal a Basic Pokémon you find there, put it into your hand, and put this Hisuian Heavy Ball in its place as a face-down Prize card. (If you don't reveal a Basic Pokémon, put this card in the discard pile.) Then, shuffle your face-down Prize cards.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "146",
     "artist": "Studio Bora Inc.",
@@ -8750,7 +8750,7 @@
     ],
     "rules": [
       "Your Active Pokémon is now Burned. Heal 40 damage from it.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "151",
     "artist": "AYUMI ODASHIMA",
@@ -8776,7 +8776,7 @@
     ],
     "rules": [
       "When applying Weakness to damage from the attacks of the Pokémon this card is attached to done to your opponent's Active Pokémon, apply it as ×3.",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "152",
@@ -8802,7 +8802,7 @@
     ],
     "rules": [
       "Choose 1 of your Pokémon, and then flip a coin until you get tails. For each heads, heal 40 damage from that Pokémon.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "153",
     "artist": "ORBITALLINK Inc.",
@@ -8827,7 +8827,7 @@
     ],
     "rules": [
       "Switch your Active Basic Pokémon with 1 of your Benched Pokémon. If you do, heal 30 damage from the Pokémon you moved to your Bench.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "154",
     "artist": "Toyste Beach",
@@ -8876,7 +8876,7 @@
     ],
     "rules": [
       "Look at the top card of your deck. You may put that card into your hand. If you don't, discard that card and draw a card.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "156",
     "artist": "Toyste Beach",
@@ -8901,7 +8901,7 @@
     ],
     "rules": [
       "Play this card as if it were a 60-HP Basic Colorless Pokémon. At any time during your turn, you may discard this card from play. This card can't retreat.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "157",
     "artist": "AYUMI ODASHIMA",
@@ -8926,7 +8926,7 @@
     ],
     "rules": [
       "You can use this card only if you go second, and only during your first turn. Search your deck for a basic Energy card and attach it to 1 of your Pokémon. Then, shuffle your deck. Your turn ends.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "158",
     "artist": "sadaji",
@@ -11567,7 +11567,7 @@
     ],
     "rules": [
       "The attacks of the Pokémon this card is attached to do 30 more damage to your opponent's Active Pokémon V (before applying Weakness and Resistance).",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "211",
@@ -11665,7 +11665,7 @@
     ],
     "rules": [
       "Look at the top card of your deck. You may put that card into your hand. If you don't, discard that card and draw a card.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "215",
     "artist": "Toyste Beach",

--- a/cards/en/swsh10.json
+++ b/cards/en/swsh10.json
@@ -8352,7 +8352,7 @@
     ],
     "rules": [
       "You can use this card only if you discard 2 Metal Energy cards from your hand. Search your deck for up to 2 cards and put them into your hand. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "135",
     "artist": "Souichirou Gunjima",
@@ -8402,7 +8402,7 @@
     ],
     "rules": [
       "Each player reveals their hand. Draw 3 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "137",
     "artist": "Hitoshi Ariga",
@@ -8427,7 +8427,7 @@
     ],
     "rules": [
       "Flip 2 coins. Put a number of cards up to the number of heads from your discard pile on top of your deck in any order.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "138",
     "artist": "nagimiso",
@@ -8551,7 +8551,7 @@
     ],
     "rules": [
       "Draw 2 cards. If you drew any cards in this way, attach up to 2 Grass Energy cards from your hand to 1 of your Benched Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "143",
     "artist": "Yuu Nishida",
@@ -8576,7 +8576,7 @@
     ],
     "rules": [
       "During this turn, your Fighting Pokémon's attacks do 30 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance). During your turn, if this Grant is in your discard pile, you may discard 2 cards, except any Grant, from your hand. If you do, put this Grant into your hand. (This effect doesn't use up your Supporter card for the turn.)",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "144",
     "artist": "Hideki Ishikawa",
@@ -8651,7 +8651,7 @@
     ],
     "rules": [
       "Search your deck for a Water Pokémon and an Item card, reveal them, and put them into your hand. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "147",
     "artist": "kirisAki",
@@ -8700,7 +8700,7 @@
     ],
     "rules": [
       "Choose a card in your hand, and discard the other cards. If you do, draw 4 cards. (If you have no other cards in your hand, you can't use this card.)",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "149",
     "artist": "Hitoshi Ariga",
@@ -8725,7 +8725,7 @@
     ],
     "rules": [
       "You can use this card only if your opponent has 3 or fewer Prize cards remaining. Each player shuffles their hand into their deck. Then, you draw 6 cards, and your opponent draws 2 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "150",
     "artist": "Megumi Mizutani",
@@ -8951,7 +8951,7 @@
     ],
     "rules": [
       "Draw cards until you have 1 more card in your hand than your opponent.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "159",
     "artist": "kirisAki",
@@ -10328,7 +10328,7 @@
     ],
     "rules": [
       "You can use this card only if you discard 2 Metal Energy cards from your hand. Search your deck for up to 2 cards and put them into your hand. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "181",
     "artist": "Souichirou Gunjima",
@@ -10353,7 +10353,7 @@
     ],
     "rules": [
       "Each player reveals their hand. Draw 3 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "182",
     "artist": "Hitoshi Ariga",
@@ -10378,7 +10378,7 @@
     ],
     "rules": [
       "Flip 2 coins. Put a number of cards up to the number of heads from your discard pile on top of your deck in any order.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "183",
     "artist": "nagimiso",
@@ -10403,7 +10403,7 @@
     ],
     "rules": [
       "Draw 2 cards. If you drew any cards in this way, attach up to 2 Grass Energy cards from your hand to 1 of your Benched Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "184",
     "artist": "En Morikura",
@@ -10428,7 +10428,7 @@
     ],
     "rules": [
       "During this turn, your Fighting Pokémon's attacks do 30 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance). During your turn, if this Grant is in your discard pile, you may discard 2 cards, except any Grant, from your hand. If you do, put this Grant into your hand. (This effect doesn't use up your Supporter card for the turn.)",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "185",
     "artist": "Hideki Ishikawa",
@@ -10453,7 +10453,7 @@
     ],
     "rules": [
       "Search your deck for a Water Pokémon and an Item card, reveal them, and put them into your hand. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "186",
     "artist": "kirisAki",
@@ -10478,7 +10478,7 @@
     ],
     "rules": [
       "Choose a card in your hand, and discard the other cards. If you do, draw 4 cards. (If you have no other cards in your hand, you can't use this card.)",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "187",
     "artist": "Hitoshi Ariga",
@@ -10503,7 +10503,7 @@
     ],
     "rules": [
       "You can use this card only if your opponent has 3 or fewer Prize cards remaining. Each player shuffles their hand into their deck. Then, you draw 6 cards, and your opponent draws 2 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "188",
     "artist": "Sanosuke Sakuma",
@@ -10528,7 +10528,7 @@
     ],
     "rules": [
       "Draw cards until you have 1 more card in your hand than your opponent.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "189",
     "artist": "kirisAki",
@@ -11143,7 +11143,7 @@
     ],
     "rules": [
       "You can use this card only if you discard 2 Metal Energy cards from your hand. Search your deck for up to 2 cards and put them into your hand. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "199",
     "artist": "Souichirou Gunjima",
@@ -11168,7 +11168,7 @@
     ],
     "rules": [
       "Each player reveals their hand. Draw 3 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "200",
     "artist": "Hitoshi Ariga",
@@ -11193,7 +11193,7 @@
     ],
     "rules": [
       "Flip 2 coins. Put a number of cards up to the number of heads from your discard pile on top of your deck in any order.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "201",
     "artist": "nagimiso",
@@ -11218,7 +11218,7 @@
     ],
     "rules": [
       "Draw 2 cards. If you drew any cards in this way, attach up to 2 Grass Energy cards from your hand to 1 of your Benched Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "202",
     "artist": "En Morikura",
@@ -11243,7 +11243,7 @@
     ],
     "rules": [
       "During this turn, your Fighting Pokémon's attacks do 30 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance). During your turn, if this Grant is in your discard pile, you may discard 2 cards, except any Grant, from your hand. If you do, put this Grant into your hand. (This effect doesn't use up your Supporter card for the turn.)",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "203",
     "artist": "Hideki Ishikawa",
@@ -11268,7 +11268,7 @@
     ],
     "rules": [
       "Search your deck for a Water Pokémon and an Item card, reveal them, and put them into your hand. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "204",
     "artist": "kirisAki",
@@ -11293,7 +11293,7 @@
     ],
     "rules": [
       "Choose a card in your hand, and discard the other cards. If you do, draw 4 cards. (If you have no other cards in your hand, you can't use this card.)",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "205",
     "artist": "Hitoshi Ariga",
@@ -11318,7 +11318,7 @@
     ],
     "rules": [
       "You can use this card only if your opponent has 3 or fewer Prize cards remaining. Each player shuffles their hand into their deck. Then, you draw 6 cards, and your opponent draws 2 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "206",
     "artist": "Sanosuke Sakuma",
@@ -11343,7 +11343,7 @@
     ],
     "rules": [
       "Draw cards until you have 1 more card in your hand than your opponent.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "207",
     "artist": "kirisAki",

--- a/cards/en/swsh10tg.json
+++ b/cards/en/swsh10tg.json
@@ -1461,7 +1461,7 @@
     ],
     "rules": [
       "Draw 3 cards. If you drew any cards in this way, discard up to 3 cards from your hand. (You must discard at least 1 card.)",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "TG24",
     "artist": "Jiro Sasumo",
@@ -1486,7 +1486,7 @@
     ],
     "rules": [
       "Discard the top 5 cards of your deck, and attach any Energy cards you discarded in this way to your Benched Fighting Pokémon in any way you like.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "TG25",
     "artist": "Souichirou Gunjima",
@@ -1511,7 +1511,7 @@
     ],
     "rules": [
       "Attach a Water Energy card from your discard pile to 1 of your Pokémon V. If you do, draw 3 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "TG26",
     "artist": "nagimiso",
@@ -1536,7 +1536,7 @@
     ],
     "rules": [
       "Discard up to 2 cards from your hand, and draw 2 cards for each card you discarded in this way.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "TG27",
     "artist": "Sanosuke Sakuma",
@@ -1561,7 +1561,7 @@
     ],
     "rules": [
       "Search your deck for an Energy card and a Darkness Pokémon, reveal them, and put them into your hand. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "TG28",
     "artist": "GOSSAN",

--- a/cards/en/swsh11.json
+++ b/cards/en/swsh11.json
@@ -9340,7 +9340,7 @@
     "rules": [
       "If the Pokémon V this card is attached to has full HP and is Knocked Out by damage from an attack from your opponent's Pokémon, put 8 damage counters on the Attacking Pokémon.",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "154",
     "rarity": "Uncommon",
@@ -9604,7 +9604,7 @@
     "rules": [
       "Prevent all damage done to the Pokémon this card is attached to by attacks from your opponent's Pokémon that have 40 HP or less remaining.",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "165",
     "rarity": "Uncommon",
@@ -9726,7 +9726,7 @@
     "rules": [
       "The Pokémon this card is attached to can attack even if it's Asleep or Paralyzed.",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "170",
     "rarity": "Uncommon",
@@ -11783,7 +11783,7 @@
     "rules": [
       "If the Pokémon V this card is attached to has full HP and is Knocked Out by damage from an attack from your opponent's Pokémon, put 8 damage counters on the Attacking Pokémon.",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "214",
     "rarity": "Rare Secret",

--- a/cards/en/swsh11.json
+++ b/cards/en/swsh11.json
@@ -9290,7 +9290,7 @@
     ],
     "rules": [
       "Look at the top card of your deck. You may switch that card with 1 of your face-down Prize cards. (The cards stay face down.)",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "152",
     "rarity": "Uncommon",
@@ -9339,7 +9339,7 @@
     ],
     "rules": [
       "If the Pokémon V this card is attached to has full HP and is Knocked Out by damage from an attack from your opponent's Pokémon, put 8 damage counters on the Attacking Pokémon.",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "154",
@@ -9388,7 +9388,7 @@
     ],
     "rules": [
       "Move up to 2 damage counters from 1 of your Pokémon to your other Pokémon in any way you like.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "156",
     "rarity": "Uncommon",
@@ -9530,7 +9530,7 @@
     ],
     "rules": [
       "You can use this card only if you put another card from your hand in the Lost Zone. Choose a Pokémon Tool attached to any Pokémon, or any Stadium in play, and put it in the Lost Zone.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "162",
     "rarity": "Uncommon",
@@ -9554,7 +9554,7 @@
     ],
     "rules": [
       "You can use this card only if you have 7 or more cards in the Lost Zone. Search your deck for up to 2 basic Energy cards of different types and attach them to your Pokémon in any way you like. Then, shuffle your deck.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "163",
     "rarity": "Uncommon",
@@ -9603,7 +9603,7 @@
     ],
     "rules": [
       "Prevent all damage done to the Pokémon this card is attached to by attacks from your opponent's Pokémon that have 40 HP or less remaining.",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "165",
@@ -9676,7 +9676,7 @@
     ],
     "rules": [
       "Look at the top 7 cards of your deck. You may reveal any number of Pokémon Tool cards you find there and put them into your hand. Shuffle the other cards back into your deck.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "168",
     "rarity": "Uncommon",
@@ -9725,7 +9725,7 @@
     ],
     "rules": [
       "The Pokémon this card is attached to can attack even if it's Asleep or Paralyzed.",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "170",
@@ -11782,7 +11782,7 @@
     ],
     "rules": [
       "If the Pokémon V this card is attached to has full HP and is Knocked Out by damage from an attack from your opponent's Pokémon, put 8 damage counters on the Attacking Pokémon.",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "214",
@@ -11830,7 +11830,7 @@
     ],
     "rules": [
       "Attach a basic Darkness Energy card from your discard pile to 1 of your Benched Darkness Pokémon.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "216",
     "rarity": "Rare Secret",
@@ -11854,7 +11854,7 @@
     ],
     "rules": [
       "You can use this card only if you put another card from your hand in the Lost Zone. Choose a Pokémon Tool attached to any Pokémon, or any Stadium in play, and put it in the Lost Zone.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "217",
     "rarity": "Rare Secret",

--- a/cards/en/swsh11.json
+++ b/cards/en/swsh11.json
@@ -9314,7 +9314,7 @@
     ],
     "rules": [
       "Search your deck for up to 3 Evolution Pokémon that don't have a Rule Box, reveal them, and put them into your hand. Then, shuffle your deck. (Pokémon V, Pokémon-GX, etc. have Rule Boxes.)",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "153",
     "rarity": "Uncommon",
@@ -9364,7 +9364,7 @@
     ],
     "rules": [
       "Look at the top 5 cards of your deck and put 3 of them into your hand. Put the other cards in the Lost Zone.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "155",
     "rarity": "Uncommon",
@@ -9412,7 +9412,7 @@
     ],
     "rules": [
       "You can use this card only if you have 10 or more cards in the Lost Zone. During your opponent's next turn, all of your Pokémon take 120 less damage from attacks from your opponent's Pokémon V (after applying Weakness and Resistance). (This includes Pokémon that come into play during that turn.)",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "157",
     "rarity": "Uncommon",
@@ -9436,7 +9436,7 @@
     ],
     "rules": [
       "Draw 2 cards. If your Active Pokémon has \"Hisuian\" in its name, draw 2 more cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "158",
     "rarity": "Uncommon",
@@ -9460,7 +9460,7 @@
     ],
     "rules": [
       "Search your deck for up to 4 basic Energy cards, reveal them, and put them into your hand. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "159",
     "rarity": "Uncommon",
@@ -9578,7 +9578,7 @@
     ],
     "rules": [
       "Look at the top 5 cards of your opponent's deck and discard any number of Item cards you find there. Your opponent shuffles the other cards back into their deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "164",
     "rarity": "Uncommon",
@@ -9628,7 +9628,7 @@
     ],
     "rules": [
       "Reveal the top 5 cards of your deck and have your opponent choose 2 of them. Discard the chosen cards and put the remaining cards into your hand.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "166",
     "rarity": "Uncommon",
@@ -9652,7 +9652,7 @@
     ],
     "rules": [
       "Choose a Basic Pokémon in your discard pile and switch it with 1 of your Basic Pokémon in play. Any attached cards, damage counters, Special Conditions, turns in play, and any other effects remain on the new Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "167",
     "rarity": "Uncommon",
@@ -9700,7 +9700,7 @@
     ],
     "rules": [
       "Discard 1 of your Benched Pokémon V and all attached cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "169",
     "rarity": "Rare Holo",
@@ -10845,7 +10845,7 @@
     ],
     "rules": [
       "Search your deck for up to 3 Evolution Pokémon that don't have a Rule Box, reveal them, and put them into your hand. Then, shuffle your deck. (Pokémon V, Pokémon-GX, etc. have Rule Boxes.)",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "189",
     "rarity": "Rare Ultra",
@@ -10869,7 +10869,7 @@
     ],
     "rules": [
       "Look at the top 5 cards of your deck and put 3 of them into your hand. Put the other cards in the Lost Zone.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "190",
     "rarity": "Rare Ultra",
@@ -10893,7 +10893,7 @@
     ],
     "rules": [
       "You can use this card only if you have 10 or more cards in the Lost Zone. During your opponent's next turn, all of your Pokémon take 120 less damage from attacks from your opponent's Pokémon V (after applying Weakness and Resistance). (This includes Pokémon that come into play during that turn.)",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "191",
     "rarity": "Rare Ultra",
@@ -10917,7 +10917,7 @@
     ],
     "rules": [
       "Draw 2 cards. If your Active Pokémon has \"Hisuian\" in its name, draw 2 more cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "192",
     "rarity": "Rare Ultra",
@@ -10941,7 +10941,7 @@
     ],
     "rules": [
       "Search your deck for up to 4 basic Energy cards, reveal them, and put them into your hand. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "193",
     "rarity": "Rare Ultra",
@@ -10965,7 +10965,7 @@
     ],
     "rules": [
       "Look at the top 5 cards of your opponent's deck and discard any number of Item cards you find there. Your opponent shuffles the other cards back into their deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "194",
     "rarity": "Rare Ultra",
@@ -10989,7 +10989,7 @@
     ],
     "rules": [
       "Choose a Basic Pokémon in your discard pile and switch it with 1 of your Basic Pokémon in play. Any attached cards, damage counters, Special Conditions, turns in play, and any other effects remain on the new Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "195",
     "rarity": "Rare Ultra",
@@ -11013,7 +11013,7 @@
     ],
     "rules": [
       "Discard 1 of your Benched Pokémon V and all attached cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "196",
     "rarity": "Rare Ultra",
@@ -11469,7 +11469,7 @@
     ],
     "rules": [
       "Search your deck for up to 3 Evolution Pokémon that don't have a Rule Box, reveal them, and put them into your hand. Then, shuffle your deck. (Pokémon V, Pokémon-GX, etc. have Rule Boxes.)",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "204",
     "rarity": "Rare Rainbow",
@@ -11493,7 +11493,7 @@
     ],
     "rules": [
       "Look at the top 5 cards of your deck and put 3 of them into your hand. Put the other cards in the Lost Zone.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "205",
     "rarity": "Rare Rainbow",
@@ -11517,7 +11517,7 @@
     ],
     "rules": [
       "You can use this card only if you have 10 or more cards in the Lost Zone. During your opponent's next turn, all of your Pokémon take 120 less damage from attacks from your opponent's Pokémon V (after applying Weakness and Resistance). (This includes Pokémon that come into play during that turn.)",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "206",
     "rarity": "Rare Rainbow",
@@ -11541,7 +11541,7 @@
     ],
     "rules": [
       "Draw 2 cards. If your Active Pokémon has \"Hisuian\" in its name, draw 2 more cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "207",
     "rarity": "Rare Rainbow",
@@ -11565,7 +11565,7 @@
     ],
     "rules": [
       "Search your deck for up to 4 basic Energy cards, reveal them, and put them into your hand. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "208",
     "rarity": "Rare Rainbow",
@@ -11589,7 +11589,7 @@
     ],
     "rules": [
       "Look at the top 5 cards of your opponent's deck and discard any number of Item cards you find there. Your opponent shuffles the other cards back into their deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "209",
     "rarity": "Rare Rainbow",
@@ -11613,7 +11613,7 @@
     ],
     "rules": [
       "Choose a Basic Pokémon in your discard pile and switch it with 1 of your Basic Pokémon in play. Any attached cards, damage counters, Special Conditions, turns in play, and any other effects remain on the new Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "210",
     "rarity": "Rare Rainbow",
@@ -11637,7 +11637,7 @@
     ],
     "rules": [
       "Discard 1 of your Benched Pokémon V and all attached cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "211",
     "rarity": "Rare Rainbow",

--- a/cards/en/swsh11tg.json
+++ b/cards/en/swsh11tg.json
@@ -1377,7 +1377,7 @@
     ],
     "rules": [
       "Search your deck for up to 3 Pokémon V, reveal them, and put them into your hand. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "TG23",
     "artist": "Taira Akitsu",
@@ -1402,7 +1402,7 @@
     ],
     "rules": [
       "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "TG24",
     "artist": "NC Empire",
@@ -1428,7 +1428,7 @@
     ],
     "rules": [
       "Heal 70 damage from your Active Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "TG25",
     "artist": "Sanosuke Sakuma",
@@ -1453,7 +1453,7 @@
     ],
     "rules": [
       "Shuffle your hand into your deck. Then, draw 4 cards. If your Active Pokémon is your only Pokémon in play, draw 8 cards instead.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "TG26",
     "artist": "Hideki Ishikawa",
@@ -1478,7 +1478,7 @@
     ],
     "rules": [
       "Put up to 4 in any combination of Water Pokémon and Water Energy cards from your discard pile into your hand.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "TG27",
     "artist": "saino misaki",
@@ -1503,7 +1503,7 @@
     ],
     "rules": [
       "Flip 2 coins. Search your deck for a number of cards up to the number of heads, put them into your hand, and shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "TG28",
     "artist": "Taira Akitsu",

--- a/cards/en/swsh12.json
+++ b/cards/en/swsh12.json
@@ -9260,7 +9260,7 @@
     ],
     "rules": [
       "You can use this card only when it is the last card in your hand. Draw a card for each Benched Pokémon (both yours and your opponent's).",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "151",
     "artist": "Ken Sugimori",
@@ -9285,7 +9285,7 @@
     ],
     "rules": [
       "Look at the top 7 cards of your deck. You may reveal any number of Water Pokémon and Water Energy cards you find there and put them into your hand. Shuffle the other cards back into your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "152",
     "artist": "Ken Sugimori",
@@ -9416,7 +9416,7 @@
     ],
     "rules": [
       "Search your deck for a Basic Pokémon and put it onto your Bench. Then, shuffle your deck. You may switch that Pokémon with your Active Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "157",
     "artist": "Yusuke Ohmura",
@@ -9441,7 +9441,7 @@
     ],
     "rules": [
       "Draw 2 cards. If any of your Pokémon were Knocked Out during your opponent's last turn, draw 2 more cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "158",
     "artist": "Hideki Ishikawa",
@@ -9466,7 +9466,7 @@
     ],
     "rules": [
       "Search your deck for up to 3 Dragon Pokémon, reveal them, and put them into your hand. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "159",
     "artist": "Ken Sugimori",
@@ -9542,7 +9542,7 @@
     ],
     "rules": [
       "Put up to 3 Pokémon that have \"Hisuian\" in their names from your discard pile into your hand.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "162",
     "artist": "Ken Sugimori",
@@ -9592,7 +9592,7 @@
     ],
     "rules": [
       "Choose 1: • Discard up to 3 cards from your hand. (You must discard at least 1 card.) If you do, draw cards until you have 5 cards in your hand. • Switch 1 of your opponent's Benched Pokémon V with their Active Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "164",
     "artist": "Ken Sugimori",
@@ -9642,7 +9642,7 @@
     ],
     "rules": [
       "Draw 3 cards. Your opponent may draw a card. If they do, draw 1 more card.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "166",
     "artist": "Megumi Mizutani",
@@ -9667,7 +9667,7 @@
     ],
     "rules": [
       "Draw 3 cards. Discard a Stadium in play.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "167",
     "artist": "Sanosuke Sakuma",
@@ -10926,7 +10926,7 @@
     ],
     "rules": [
       "You can use this card only when it is the last card in your hand. Draw a card for each Benched Pokémon (both yours and your opponent's).",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "188",
     "artist": "Hideki Ishikawa",
@@ -10951,7 +10951,7 @@
     ],
     "rules": [
       "Look at the top 7 cards of your deck. You may reveal any number of Water Pokémon and Water Energy cards you find there and put them into your hand. Shuffle the other cards back into your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "189",
     "artist": "Naoki Saito",
@@ -10976,7 +10976,7 @@
     ],
     "rules": [
       "Search your deck for a Basic Pokémon and put it onto your Bench. Then, shuffle your deck. You may switch that Pokémon with your Active Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "190",
     "artist": "saino misaki",
@@ -11001,7 +11001,7 @@
     ],
     "rules": [
       "Draw 2 cards. If any of your Pokémon were Knocked Out during your opponent's last turn, draw 2 more cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "191",
     "artist": "Hideki Ishikawa",
@@ -11026,7 +11026,7 @@
     ],
     "rules": [
       "Search your deck for up to 3 Dragon Pokémon, reveal them, and put them into your hand. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "192",
     "artist": "Ryuta Fuse",
@@ -11051,7 +11051,7 @@
     ],
     "rules": [
       "Choose 1: • Discard up to 3 cards from your hand. (You must discard at least 1 card.) If you do, draw cards until you have 5 cards in your hand. • Switch 1 of your opponent's Benched Pokémon V with their Active Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "193",
     "artist": "Megumi Mizutani",
@@ -11076,7 +11076,7 @@
     ],
     "rules": [
       "Draw 3 cards. Your opponent may draw a card. If they do, draw 1 more card.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "194",
     "artist": "Ryuta Fuse",
@@ -11101,7 +11101,7 @@
     ],
     "rules": [
       "Draw 3 cards. Discard a Stadium in play.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "195",
     "artist": "Yuu Nishida",
@@ -11570,7 +11570,7 @@
     ],
     "rules": [
       "You can use this card only when it is the last card in your hand. Draw a card for each Benched Pokémon (both yours and your opponent's).",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "203",
     "artist": "Hideki Ishikawa",
@@ -11595,7 +11595,7 @@
     ],
     "rules": [
       "Look at the top 7 cards of your deck. You may reveal any number of Water Pokémon and Water Energy cards you find there and put them into your hand. Shuffle the other cards back into your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "204",
     "artist": "Naoki Saito",
@@ -11620,7 +11620,7 @@
     ],
     "rules": [
       "Search your deck for a Basic Pokémon and put it onto your Bench. Then, shuffle your deck. You may switch that Pokémon with your Active Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "205",
     "artist": "saino misaki",
@@ -11645,7 +11645,7 @@
     ],
     "rules": [
       "Search your deck for up to 3 Dragon Pokémon, reveal them, and put them into your hand. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "206",
     "artist": "Ryuta Fuse",
@@ -11670,7 +11670,7 @@
     ],
     "rules": [
       "Choose 1: • Discard up to 3 cards from your hand. (You must discard at least 1 card.) If you do, draw cards until you have 5 cards in your hand. • Switch 1 of your opponent's Benched Pokémon V with their Active Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "207",
     "artist": "Megumi Mizutani",
@@ -11695,7 +11695,7 @@
     ],
     "rules": [
       "Draw 3 cards. Your opponent may draw a card. If they do, draw 1 more card.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "208",
     "artist": "Ryuta Fuse",
@@ -11720,7 +11720,7 @@
     ],
     "rules": [
       "Draw 3 cards. Discard a Stadium in play.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "209",
     "artist": "Yuu Nishida",

--- a/cards/en/swsh12.json
+++ b/cards/en/swsh12.json
@@ -9337,7 +9337,7 @@
     "rules": [
       "The Pokémon V this card is attached to can use the VSTAR Power on this card. (You still need the necessary Energy to use this attack.) ColorlessColorlessColorless Star Gravity Put damage counters on each of your opponent's Pokémon V until its remaining HP is 100. (You can't use more than 1 VSTAR Power in a game.)",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "154",
     "artist": "AYUMI ODASHIMA",
@@ -9364,7 +9364,7 @@
     "rules": [
       "At the end of each turn, if the Pokémon this card is attached to has 30 HP or less remaining and has any damage counters on it, heal 120 damage from it. If you healed any damage in this way, discard this card.",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "155",
     "artist": "AYUMI ODASHIMA",
@@ -9391,7 +9391,7 @@
     "rules": [
       "The Pokémon V this card is attached to can use the VSTAR Power on this card. Star Alchemy During your turn, you may search your deck for a card and put it into your hand. Then, shuffle your deck. (You can't use more than 1 VSTAR Power in a game.)",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "156",
     "artist": "AYUMI ODASHIMA",
@@ -9493,7 +9493,7 @@
     "rules": [
       "Whenever your opponent plays a Supporter card from their hand, prevent all effects of that card done to the Pokémon VSTAR or Pokémon VMAX this card is attached to.",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "160",
     "artist": "Studio Bora Inc.",
@@ -11926,7 +11926,7 @@
     "rules": [
       "Whenever your opponent plays a Supporter card from their hand, prevent all effects of that card done to the Pokémon VSTAR or Pokémon VMAX this card is attached to.",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "214",
     "artist": "Studio Bora Inc.",

--- a/cards/en/swsh12.json
+++ b/cards/en/swsh12.json
@@ -9310,7 +9310,7 @@
     ],
     "rules": [
       "Flip a coin. If heads, search your deck for an Evolution Pokémon, reveal it, and put it into your hand. If tails, search your deck for a Basic Pokémon, reveal it, and put it into your hand. Then, shuffle your deck.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "153",
     "artist": "sadaji",
@@ -9336,7 +9336,7 @@
     ],
     "rules": [
       "The Pokémon V this card is attached to can use the VSTAR Power on this card. (You still need the necessary Energy to use this attack.) ColorlessColorlessColorless Star Gravity Put damage counters on each of your opponent's Pokémon V until its remaining HP is 100. (You can't use more than 1 VSTAR Power in a game.)",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "154",
@@ -9363,7 +9363,7 @@
     ],
     "rules": [
       "At the end of each turn, if the Pokémon this card is attached to has 30 HP or less remaining and has any damage counters on it, heal 120 damage from it. If you healed any damage in this way, discard this card.",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "155",
@@ -9390,7 +9390,7 @@
     ],
     "rules": [
       "The Pokémon V this card is attached to can use the VSTAR Power on this card. Star Alchemy During your turn, you may search your deck for a card and put it into your hand. Then, shuffle your deck. (You can't use more than 1 VSTAR Power in a game.)",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "156",
@@ -9492,7 +9492,7 @@
     ],
     "rules": [
       "Whenever your opponent plays a Supporter card from their hand, prevent all effects of that card done to the Pokémon VSTAR or Pokémon VMAX this card is attached to.",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "160",
@@ -9567,7 +9567,7 @@
     ],
     "rules": [
       "You may use 4 Quad Stone cards at once. • If you used 1 card, heal 10 damage from your Active Pokémon. • If you used 4 cards, heal all damage from each of your Pokémon. (This effect works one time for 4 cards.)",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "163",
     "artist": "sadaji",
@@ -9617,7 +9617,7 @@
     ],
     "rules": [
       "Play this card as if it were a 60-HP Basic Colorless Pokémon. At any time during your turn, you may discard this card from play. This card can't retreat.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "165",
     "artist": "AYUMI ODASHIMA",
@@ -11875,7 +11875,7 @@
     ],
     "rules": [
       "Move a basic Energy from 1 of your Pokémon to another of your Pokémon.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "212",
     "artist": "Toyste Beach",
@@ -11925,7 +11925,7 @@
     ],
     "rules": [
       "Whenever your opponent plays a Supporter card from their hand, prevent all effects of that card done to the Pokémon VSTAR or Pokémon VMAX this card is attached to.",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "214",

--- a/cards/en/swsh12pt5.json
+++ b/cards/en/swsh12pt5.json
@@ -7600,7 +7600,7 @@
     ],
     "rules": [
       "Flip a coin. If heads, discard an Energy from 1 of your opponent's Pokémon.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "125",
     "artist": "sadaji",
@@ -7649,7 +7649,7 @@
     ],
     "rules": [
       "Put up to 2 basic Energy cards from your discard pile into your hand.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "127",
     "artist": "Ryo Ueda",
@@ -7673,7 +7673,7 @@
     ],
     "rules": [
       "Search your deck for a basic Energy card, reveal it, and put it into your hand. Then, shuffle your deck.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "128",
     "artist": "Studio Bora Inc.",
@@ -7697,7 +7697,7 @@
     ],
     "rules": [
       "Move a basic Energy from 1 of your Pokémon to another of your Pokémon.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "129",
     "artist": "Toyste Beach",
@@ -7771,7 +7771,7 @@
     ],
     "rules": [
       "Look at the top 7 cards of your deck. You may reveal a Pokémon you find there and put it into your hand. Shuffle the other cards back into your deck.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "132",
     "artist": "Toyste Beach",
@@ -7845,7 +7845,7 @@
     ],
     "rules": [
       "You can use this card only if you put another card from your hand in the Lost Zone. Choose a Pokémon Tool attached to any Pokémon, or any Stadium in play, and put it in the Lost Zone.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "135",
     "artist": "Amelicart",
@@ -7895,7 +7895,7 @@
     ],
     "rules": [
       "Flip a coin. If heads, search your deck for a Pokémon, reveal it, and put it into your hand. Then, shuffle your deck.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "137",
     "artist": "Studio Bora Inc.",
@@ -7919,7 +7919,7 @@
     ],
     "rules": [
       "Flip a coin. If heads, switch 1 of your opponent's Benched Pokémon with their Active Pokémon.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "138",
     "artist": "Ryo Ueda",
@@ -7943,7 +7943,7 @@
     ],
     "rules": [
       "Heal 30 damage from 1 of your Pokémon.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "139",
     "artist": "Ryo Ueda",
@@ -7992,7 +7992,7 @@
     ],
     "rules": [
       "Choose 1 of your Basic Pokémon in play. If you have a Stage 2 card in your hand that evolves from that Pokémon, put that card onto the Basic Pokémon to evolve it, skipping the Stage 1. You can't use this card during your first turn or on a Basic Pokémon that was put into play this turn.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "141",
     "artist": "Yoshinobu Saito",
@@ -8016,7 +8016,7 @@
     ],
     "rules": [
       "Put up to 2 Pokémon, each with 90 HP or less, from your discard pile into your hand.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "142",
     "artist": "Amelicart",
@@ -8042,7 +8042,7 @@
     ],
     "rules": [
       "The Pokémon V this card is attached to can use the VSTAR Power on this card. Star Order During your turn, you may use this Ability. During this turn, if your opponent's Active Pokémon VSTAR or Active Pokémon VMAX is Knocked Out by damage from an attack from your Basic Pokémon V, take 1 more Prize card. (You can't use more than 1 VSTAR Power in a game.)",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "143",
@@ -8068,7 +8068,7 @@
     ],
     "rules": [
       "Switch your Active Pokémon with 1 of your Benched Pokémon.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "144",
     "artist": "Studio Bora Inc.",
@@ -8092,7 +8092,7 @@
     ],
     "rules": [
       "Look at the top card of your deck. You may put that card into your hand. If you don't, discard that card and draw a card.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "145",
     "artist": "Amelicart",
@@ -8117,7 +8117,7 @@
     ],
     "rules": [
       "You can use this card only if you discard 2 other cards from your hand. Search your deck for a Pokémon, reveal it, and put it into your hand. Then, shuffle your deck.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "146",
     "artist": "Amelicart",

--- a/cards/en/swsh12pt5.json
+++ b/cards/en/swsh12pt5.json
@@ -8043,7 +8043,7 @@
     "rules": [
       "The Pokémon V this card is attached to can use the VSTAR Power on this card. Star Order During your turn, you may use this Ability. During this turn, if your opponent's Active Pokémon VSTAR or Active Pokémon VMAX is Knocked Out by damage from an attack from your Basic Pokémon V, take 1 more Prize card. (You can't use more than 1 VSTAR Power in a game.)",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "143",
     "artist": "AYUMI ODASHIMA",

--- a/cards/en/swsh12pt5.json
+++ b/cards/en/swsh12pt5.json
@@ -7550,7 +7550,7 @@
     ],
     "rules": [
       "Discard the top 5 cards of your deck, and attach any Energy cards you discarded in this way to your Benched Fighting Pokémon in any way you like.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "123",
     "artist": "Atsushi Furusawa",
@@ -7575,7 +7575,7 @@
     ],
     "rules": [
       "Attach a basic Energy card from your hand to 1 of your Benched Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "124",
     "artist": "You Iribi",
@@ -7624,7 +7624,7 @@
     ],
     "rules": [
       "Flip a coin. If heads, look at the bottom 8 cards of your deck and put 1 of them into your hand. If tails, look at the bottom 3 cards of your deck and put 1 of them into your hand. Shuffle the other cards back into your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "126",
     "artist": "Yuu Nishida",
@@ -7721,7 +7721,7 @@
     ],
     "rules": [
       "Draw 3 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "130",
     "artist": "kirisAki",
@@ -7746,7 +7746,7 @@
     ],
     "rules": [
       "Draw 3 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "131",
     "artist": "Ryuta Fuse",
@@ -7795,7 +7795,7 @@
     ],
     "rules": [
       "Draw 3 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "133",
     "artist": "Taira Akitsu",
@@ -7820,7 +7820,7 @@
     ],
     "rules": [
       "During this turn, your Pokémon's attacks do 30 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "134",
     "artist": "Naoki Saito",
@@ -7870,7 +7870,7 @@
     ],
     "rules": [
       "Put up to 4 in any combination of Water Pokémon and Water Energy cards from your discard pile into your hand.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "136",
     "artist": "Souichirou Gunjima",
@@ -7967,7 +7967,7 @@
     ],
     "rules": [
       "You can play this card only if any of your Pokémon were Knocked Out during your opponent's last turn. Attach a basic Energy card from your discard pile to 1 of your Pokémon. If you do, search your deck for a card and put it into your hand. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "140",
     "artist": "Hideki Ishikawa",
@@ -8142,7 +8142,7 @@
     ],
     "rules": [
       "Choose up to 2 of your Fusion Strike Pokémon. For each of those Pokémon, search your deck for a Fusion Strike Energy card and attach it to that Pokémon. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "147",
     "artist": "Megumi Mizutani",
@@ -8167,7 +8167,7 @@
     ],
     "rules": [
       "Draw 3 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "148",
     "artist": "Kinu Nishimura",
@@ -8192,7 +8192,7 @@
     ],
     "rules": [
       "Draw 3 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "149",
     "artist": "Hideki Ishikawa",
@@ -8217,7 +8217,7 @@
     ],
     "rules": [
       "Discard your hand and draw 7 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "150",
     "artist": "Sanosuke Sakuma",
@@ -8243,7 +8243,7 @@
     ],
     "rules": [
       "Discard 1 of your Benched Pokémon V and all attached cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "151",
     "artist": "Souichirou Gunjima",

--- a/cards/en/swsh12pt5gg.json
+++ b/cards/en/swsh12pt5gg.json
@@ -3452,7 +3452,7 @@
     ],
     "rules": [
       "You can use this card only if you discard 2 Metal Energy cards from your hand. Search your deck for up to 2 cards and put them into your hand. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "GG57",
     "artist": "Naoki Saito",
@@ -3477,7 +3477,7 @@
     ],
     "rules": [
       "Put 1 of your Colorless Pokémon that has any damage counters on it and all attached cards into your hand.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "GG58",
     "artist": "chibi",
@@ -3502,7 +3502,7 @@
     ],
     "rules": [
       "Look at the top 5 cards of your deck and put 3 of them into your hand. Put the other cards in the Lost Zone.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "GG59",
     "artist": "kantaro",
@@ -3527,7 +3527,7 @@
     ],
     "rules": [
       "Draw cards until you have 5 cards in your hand. If any of your Pokémon were Knocked Out during your opponent's last turn, draw cards until you have 8 cards in your hand instead.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "GG60",
     "artist": "Atsuya Uki",
@@ -3552,7 +3552,7 @@
     ],
     "rules": [
       "Draw 2 cards. If you drew any cards in this way, attach up to 2 Grass Energy cards from your hand to 1 of your Benched Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "GG61",
     "artist": "Yoriyuki Ikegami",
@@ -3577,7 +3577,7 @@
     ],
     "rules": [
       "During this turn, your Fighting Pokémon's attacks do 30 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance). During your turn, if this Grant is in your discard pile, you may discard 2 cards, except any Grant, from your hand. If you do, put this Grant into your hand. (This effect doesn't use up your Supporter card for the turn.)",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "GG62",
     "artist": "Oswaldo KATO",
@@ -3602,7 +3602,7 @@
     ],
     "rules": [
       "Search your deck for a Water Pokémon and an Item card, reveal them, and put them into your hand. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "GG63",
     "artist": "Naoki Saito",
@@ -3627,7 +3627,7 @@
     ],
     "rules": [
       "Attach a Water Energy card from your discard pile to 1 of your Pokémon V. If you do, draw 3 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "GG64",
     "artist": "saino misaki",
@@ -3652,7 +3652,7 @@
     ],
     "rules": [
       "You can play this card only if any of your Pokémon were Knocked Out during your opponent's last turn. Attach a basic Energy card from your discard pile to 1 of your Pokémon. If you do, search your deck for a card and put it into your hand. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "GG65",
     "artist": "GIDORA",
@@ -3677,7 +3677,7 @@
     ],
     "rules": [
       "You can use this card only if your opponent has 3 or fewer Prize cards remaining. Each player shuffles their hand into their deck. Then, you draw 6 cards, and your opponent draws 2 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "GG66",
     "artist": "Toshinao Aoki",

--- a/cards/en/swsh12tg.json
+++ b/cards/en/swsh12tg.json
@@ -1375,7 +1375,7 @@
     ],
     "rules": [
       "Draw 3 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "TG23",
     "artist": "Sanosuke Sakuma",
@@ -1400,7 +1400,7 @@
     ],
     "rules": [
       "Look at the top 7 cards of your deck. You may reveal any number of Energy cards you find there and put them into your hand. Shuffle the other cards back into your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "TG24",
     "artist": "Ryuta Fuse",
@@ -1425,7 +1425,7 @@
     ],
     "rules": [
       "Each player shuffles their hand into their deck and draws 4 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "TG25",
     "artist": "Ryuta Fuse",
@@ -1450,7 +1450,7 @@
     ],
     "rules": [
       "Search your deck for up to 2 cards and discard them. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "TG26",
     "artist": "kirisAki",
@@ -1475,7 +1475,7 @@
     ],
     "rules": [
       "You can play this card only if any of your Pokémon were Knocked Out during your opponent's last turn. Attach a basic Energy card from your discard pile to 1 of your Pokémon. If you do, search your deck for a card and put it into your hand. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "TG27",
     "artist": "take",
@@ -1500,7 +1500,7 @@
     ],
     "rules": [
       "Choose a Trainer card from your discard pile. Then, ask your opponent if you may put it into your hand. If yes, put that card into your hand. If no, draw 3 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "TG28",
     "artist": "nagimiso",

--- a/cards/en/swsh7.json
+++ b/cards/en/swsh7.json
@@ -8539,7 +8539,7 @@
     ],
     "rules": [
       "Search your deck for a card that evolves from 1 of your Pokémon and put it onto that Pokémon to evolve it. Then, shuffle your deck. You can use this card during your first turn or on a Pokémon that was put into play this turn. Your turn ends.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "142",
     "artist": "sadaji",
@@ -8614,7 +8614,7 @@
     ],
     "rules": [
       "The attacks of the Pokémon this card is attached to do 30 more damage to your opponent's Active Fighting Pokémon (before applying Weakness and Resistance).",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "145",
@@ -8640,7 +8640,7 @@
     ],
     "rules": [
       "You can play this card only if you took it as a face-down Prize card, before you put it into your hand. Search your deck for a Pokémon and put it onto your Bench. Then, shuffle your deck.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "146",
     "artist": "Ryo Ueda",
@@ -8666,7 +8666,7 @@
     ],
     "rules": [
       "If the Pokémon V this card is attached to has \"Vaporeon,\" \"Jolteon,\" or \"Flareon\" in its name, its attacks cost Colorless less.",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "147",
@@ -8693,7 +8693,7 @@
     ],
     "rules": [
       "If the Pokémon this card is attached to has no Abilities, it takes 20 less damage from attacks from your opponent's Pokémon (after applying Weakness and Resistance).",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "148",
@@ -8744,7 +8744,7 @@
     ],
     "rules": [
       "Heal 20 damage from your Active Pokémon. If you healed any damage in this way, flip a coin. If heads, put this Lucky Ice Pop into your hand instead of the discard pile.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "150",
     "artist": "inose yukie",
@@ -8770,7 +8770,7 @@
     ],
     "rules": [
       "If the Pokémon V this card is attached to has \"Espeon\" or \"Umbreon\" in its name, whenever your opponent plays a Supporter card from their hand, prevent all effects of that card done to that Pokémon.",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "151",
@@ -8823,7 +8823,7 @@
     ],
     "rules": [
       "The Rapid Strike Pokémon this card is attached to can use the attack on this card. (You still need the necessary Energy to use this attack.) FireLightning Meteor Discard 2 Energy from this Pokémon. This attack does 90 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "153",
@@ -8849,7 +8849,7 @@
     ],
     "rules": [
       "Put up to 2 Pokémon, each with 90 HP or less, from your discard pile into your hand.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "154",
     "artist": "Ryo Ueda",
@@ -8875,7 +8875,7 @@
     ],
     "rules": [
       "If the Pokémon V this card is attached to has \"Sylveon\" in its name and is Knocked Out by damage from an attack from your opponent's Pokémon, that player takes 1 fewer Prize card.",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "155",
@@ -8902,7 +8902,7 @@
     ],
     "rules": [
       "The attacks of the Pokémon this card is attached to do 30 more damage to your opponent's Active Lightning Pokémon (before applying Weakness and Resistance).",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "156",
@@ -8954,7 +8954,7 @@
     ],
     "rules": [
       "The Single Strike Pokémon this card is attached to can use the attack on this card. (You still need the necessary Energy to use this attack.) FightingMetalMetalColorlessColorless Superstrong Slash 300 Discard all Energy from this Pokémon.",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "158",
@@ -8981,7 +8981,7 @@
     ],
     "rules": [
       "If the Pokémon V this card is attached to has \"Leafeon\" or \"Glaceon\" in its name, it has no Retreat Cost and no Weakness.",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "159",
@@ -9008,7 +9008,7 @@
     ],
     "rules": [
       "If the Pokémon this card is attached to is in the Active Spot and is damaged by an attack from your opponent's Pokémon (even if it is Knocked Out), your opponent discards a card from their hand.",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "160",
@@ -9058,7 +9058,7 @@
     ],
     "rules": [
       "Switch a card from your hand with the top card of your deck.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "162",
     "artist": "Ryo Ueda",
@@ -9083,7 +9083,7 @@
     ],
     "rules": [
       "Switch 1 of your opponent's Benched Pokémon that has 50 HP or less remaining with your opponent's Active Pokémon.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "163",
     "artist": "sadaji",
@@ -12793,7 +12793,7 @@
     ],
     "rules": [
       "Search your deck for a card that evolves from 1 of your Pokémon and put it onto that Pokémon to evolve it. Then, shuffle your deck. You can use this card during your first turn or on a Pokémon that was put into play this turn. Your turn ends.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "229",
     "artist": "sadaji",
@@ -12843,7 +12843,7 @@
     ],
     "rules": [
       "If the Pokémon this card is attached to has no Abilities, it takes 20 less damage from attacks from your opponent's Pokémon (after applying Weakness and Resistance).",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "231",
@@ -12893,7 +12893,7 @@
     ],
     "rules": [
       "Switch 1 of your opponent's Benched Pokémon that has 50 HP or less remaining with your opponent's Active Pokémon.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "233",
     "artist": "sadaji",

--- a/cards/en/swsh7.json
+++ b/cards/en/swsh7.json
@@ -8615,7 +8615,7 @@
     "rules": [
       "The attacks of the Pokémon this card is attached to do 30 more damage to your opponent's Active Fighting Pokémon (before applying Weakness and Resistance).",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "145",
     "artist": "Toyste Beach",
@@ -8667,7 +8667,7 @@
     "rules": [
       "If the Pokémon V this card is attached to has \"Vaporeon,\" \"Jolteon,\" or \"Flareon\" in its name, its attacks cost Colorless less.",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "147",
     "artist": "Studio Bora Inc.",
@@ -8694,7 +8694,7 @@
     "rules": [
       "If the Pokémon this card is attached to has no Abilities, it takes 20 less damage from attacks from your opponent's Pokémon (after applying Weakness and Resistance).",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "148",
     "artist": "AYUMI ODASHIMA",
@@ -8771,7 +8771,7 @@
     "rules": [
       "If the Pokémon V this card is attached to has \"Espeon\" or \"Umbreon\" in its name, whenever your opponent plays a Supporter card from their hand, prevent all effects of that card done to that Pokémon.",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "151",
     "artist": "Studio Bora Inc.",
@@ -8824,7 +8824,7 @@
     "rules": [
       "The Rapid Strike Pokémon this card is attached to can use the attack on this card. (You still need the necessary Energy to use this attack.) FireLightning Meteor Discard 2 Energy from this Pokémon. This attack does 90 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "153",
     "artist": "5ban Graphics",
@@ -8876,7 +8876,7 @@
     "rules": [
       "If the Pokémon V this card is attached to has \"Sylveon\" in its name and is Knocked Out by damage from an attack from your opponent's Pokémon, that player takes 1 fewer Prize card.",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "155",
     "artist": "Studio Bora Inc.",
@@ -8903,7 +8903,7 @@
     "rules": [
       "The attacks of the Pokémon this card is attached to do 30 more damage to your opponent's Active Lightning Pokémon (before applying Weakness and Resistance).",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "156",
     "artist": "Toyste Beach",
@@ -8955,7 +8955,7 @@
     "rules": [
       "The Single Strike Pokémon this card is attached to can use the attack on this card. (You still need the necessary Energy to use this attack.) FightingMetalMetalColorlessColorless Superstrong Slash 300 Discard all Energy from this Pokémon.",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "158",
     "artist": "5ban Graphics",
@@ -8982,7 +8982,7 @@
     "rules": [
       "If the Pokémon V this card is attached to has \"Leafeon\" or \"Glaceon\" in its name, it has no Retreat Cost and no Weakness.",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "159",
     "artist": "Studio Bora Inc.",
@@ -9009,7 +9009,7 @@
     "rules": [
       "If the Pokémon this card is attached to is in the Active Spot and is damaged by an attack from your opponent's Pokémon (even if it is Knocked Out), your opponent discards a card from their hand.",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "160",
     "artist": "AYUMI ODASHIMA",
@@ -12844,7 +12844,7 @@
     "rules": [
       "If the Pokémon this card is attached to has no Abilities, it takes 20 less damage from attacks from your opponent's Pokémon (after applying Weakness and Resistance).",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "231",
     "artist": "AYUMI ODASHIMA",

--- a/cards/en/swsh7.json
+++ b/cards/en/swsh7.json
@@ -8514,7 +8514,7 @@
     ],
     "rules": [
       "Draw 2 cards. If you do, your Active Pokémon recovers from all Special Conditions.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "141",
     "artist": "Megumi Mizutani",
@@ -8564,7 +8564,7 @@
     ],
     "rules": [
       "Shuffle your hand into your deck. Then, draw a card for each card in your opponent's hand.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "143",
     "artist": "Sanosuke Sakuma",
@@ -8719,7 +8719,7 @@
     ],
     "rules": [
       "Look at the top 7 cards of your deck. You may reveal any number of Energy cards you find there and put them into your hand. Shuffle the other cards back into your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "149",
     "artist": "take",
@@ -8796,7 +8796,7 @@
     ],
     "rules": [
       "You can play this card only if any of your Pokémon were Knocked Out during your opponent's last turn. Attach a basic Energy card from your discard pile to 1 of your Pokémon. If you do, search your deck for a card and put it into your hand. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "152",
     "artist": "take",
@@ -9108,7 +9108,7 @@
     ],
     "rules": [
       "You can play this card only if you discard 2 other cards from your hand. Draw a card for each of your opponent's Pokémon in play.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "164",
     "artist": "Taira Akitsu",
@@ -11280,7 +11280,7 @@
     ],
     "rules": [
       "Draw 2 cards. If you do, your Active Pokémon recovers from all Special Conditions.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "199",
     "artist": "En Morikura",
@@ -11305,7 +11305,7 @@
     ],
     "rules": [
       "Shuffle your hand into your deck. Then, draw a card for each card in your opponent's hand.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "200",
     "artist": "Sanosuke Sakuma",
@@ -11330,7 +11330,7 @@
     ],
     "rules": [
       "Look at the top 7 cards of your deck. You may reveal any number of Energy cards you find there and put them into your hand. Shuffle the other cards back into your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "201",
     "artist": "Hitoshi Ariga",
@@ -11355,7 +11355,7 @@
     ],
     "rules": [
       "You can play this card only if any of your Pokémon were Knocked Out during your opponent's last turn. Attach a basic Energy card from your discard pile to 1 of your Pokémon. If you do, search your deck for a card and put it into your hand. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "202",
     "artist": "kirisAki",
@@ -11380,7 +11380,7 @@
     ],
     "rules": [
       "You can play this card only if you discard 2 other cards from your hand. Draw a card for each of your opponent's Pokémon in play.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "203",
     "artist": "Taira Akitsu",
@@ -12486,7 +12486,7 @@
     ],
     "rules": [
       "Draw 2 cards. If you do, your Active Pokémon recovers from all Special Conditions.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "221",
     "artist": "En Morikura",
@@ -12511,7 +12511,7 @@
     ],
     "rules": [
       "Shuffle your hand into your deck. Then, draw a card for each card in your opponent's hand.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "222",
     "artist": "Sanosuke Sakuma",
@@ -12536,7 +12536,7 @@
     ],
     "rules": [
       "Look at the top 7 cards of your deck. You may reveal any number of Energy cards you find there and put them into your hand. Shuffle the other cards back into your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "223",
     "artist": "Hitoshi Ariga",
@@ -12561,7 +12561,7 @@
     ],
     "rules": [
       "You can play this card only if any of your Pokémon were Knocked Out during your opponent's last turn. Attach a basic Energy card from your discard pile to 1 of your Pokémon. If you do, search your deck for a card and put it into your hand. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "224",
     "artist": "kirisAki",
@@ -12586,7 +12586,7 @@
     ],
     "rules": [
       "You can play this card only if you discard 2 other cards from your hand. Draw a card for each of your opponent's Pokémon in play.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "225",
     "artist": "Taira Akitsu",

--- a/cards/en/swsh8.json
+++ b/cards/en/swsh8.json
@@ -13902,7 +13902,7 @@
     "rules": [
       "If the Pokémon VMAX this card is attached to is Knocked Out by damage from an attack from your opponent's Pokémon, search your deck for a card and put it into your hand. Then, shuffle your deck.",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "234",
     "artist": "AYUMI ODASHIMA",
@@ -14129,7 +14129,7 @@
     "rules": [
       "The attacks of the Pokémon this card is attached to do 30 more damage to your opponent's Active Water Pokémon (before applying Weakness and Resistance).",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "243",
     "artist": "Toyste Beach",

--- a/cards/en/swsh8.json
+++ b/cards/en/swsh8.json
@@ -13669,7 +13669,7 @@
     "rules": [
       "You can use this card only during your first turn.",
       "Search your deck for up to 2 Basic Pokémon and put them onto your Bench. Then, shuffle your deck.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "225",
     "artist": "Ryo Ueda",
@@ -13770,7 +13770,7 @@
     ],
     "rules": [
       "You can use this card only if you discard another Item card from your hand. Flip a coin. If heads, search your deck for a card and put it into your hand. Then, shuffle your deck.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "229",
     "artist": "Ryo Ueda",
@@ -13797,7 +13797,7 @@
     "rules": [
       "You must play 2 Cross Switcher cards at once. (This effect works one time for 2 cards.)",
       "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. If you do, switch your Active Pokémon with 1 of your Benched Pokémon.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "230",
     "artist": "inose yukie",
@@ -13824,7 +13824,7 @@
     "rules": [
       "You must play 2 Crossceiver cards at once. (This effect works one time for 2 cards.)",
       "Put a Pokémon or a Supporter card from your discard pile into your hand.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "231",
     "artist": "Studio Bora Inc.",
@@ -13901,7 +13901,7 @@
     ],
     "rules": [
       "If the Pokémon VMAX this card is attached to is Knocked Out by damage from an attack from your opponent's Pokémon, search your deck for a card and put it into your hand. Then, shuffle your deck.",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "234",
@@ -13953,7 +13953,7 @@
     ],
     "rules": [
       "During this turn, your Fusion Strike Pokémon's attacks do 30 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "236",
     "artist": "Toyste Beach",
@@ -13978,7 +13978,7 @@
     ],
     "rules": [
       "You can play this card only if you discard another card from your hand. Search your deck for a Basic Pokémon, reveal it, and put it into your hand. Then, shuffle your deck.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "237",
     "artist": "Ryo Ueda",
@@ -14128,7 +14128,7 @@
     ],
     "rules": [
       "The attacks of the Pokémon this card is attached to do 30 more damage to your opponent's Active Water Pokémon (before applying Weakness and Resistance).",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "243",
@@ -15971,7 +15971,7 @@
     ],
     "rules": [
       "During this turn, your Fusion Strike Pokémon's attacks do 30 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "281",
     "artist": "Toyste Beach",

--- a/cards/en/swsh8.json
+++ b/cards/en/swsh8.json
@@ -13643,7 +13643,7 @@
     ],
     "rules": [
       "Search your deck for up to 3 Pokémon V, reveal them, and put them into your hand. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "224",
     "artist": "Taira Akitsu",
@@ -13694,7 +13694,7 @@
     ],
     "rules": [
       "Draw 2 cards. Flip a coin. If heads, draw 2 more cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "226",
     "artist": "Yuu Nishida",
@@ -13720,7 +13720,7 @@
     ],
     "rules": [
       "Search your deck for up to 3 Fusion Strike Pokémon, reveal them, and put them into your hand. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "227",
     "artist": "Yusuke Ohmura",
@@ -13745,7 +13745,7 @@
     ],
     "rules": [
       "Heal 70 damage from your Active Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "228",
     "artist": "Sanosuke Sakuma",
@@ -13849,7 +13849,7 @@
     ],
     "rules": [
       "Draw 2 cards. If you go second and it's your first turn, draw 3 more cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "232",
     "artist": "Sanosuke Sakuma",
@@ -13875,7 +13875,7 @@
     ],
     "rules": [
       "Choose up to 2 of your Fusion Strike Pokémon. For each of those Pokémon, search your deck for a Fusion Strike Energy card and attach it to that Pokémon. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "233",
     "artist": "Yusuke Ohmura",
@@ -13927,7 +13927,7 @@
     ],
     "rules": [
       "Each player shuffles their hand into their deck and draws 4 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "235",
     "artist": "Ryuta Fuse",
@@ -14003,7 +14003,7 @@
     ],
     "rules": [
       "Draw 2 cards. If your opponent has exactly 1, 3, or 5 Prize cards remaining, draw 2 more cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "238",
     "artist": "kirisAki",
@@ -14028,7 +14028,7 @@
     ],
     "rules": [
       "Draw 2 cards. If your opponent has exactly 2, 4, or 6 Prize cards remaining, draw 2 more cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "239",
     "artist": "kirisAki",
@@ -14053,7 +14053,7 @@
     ],
     "rules": [
       "Shuffle your hand into your deck. Then, draw 5 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "240",
     "artist": "Yuu Nishida",
@@ -14078,7 +14078,7 @@
     ],
     "rules": [
       "Your opponent reveals their hand. Discard up to 2 in any combination of Pokémon Tool cards, Special Energy cards, and Stadium cards from it.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "241",
     "artist": "Hideki Ishikawa",
@@ -15024,7 +15024,7 @@
     ],
     "rules": [
       "Search your deck for up to 3 Fusion Strike Pokémon, reveal them, and put them into your hand. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "258",
     "artist": "Sanosuke Sakuma",
@@ -15049,7 +15049,7 @@
     ],
     "rules": [
       "Draw 2 cards. If you go second and it's your first turn, draw 3 more cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "259",
     "artist": "Yuu Nishida",
@@ -15075,7 +15075,7 @@
     ],
     "rules": [
       "Choose up to 2 of your Fusion Strike Pokémon. For each of those Pokémon, search your deck for a Fusion Strike Energy card and attach it to that Pokémon. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "260",
     "artist": "Ryuta Fuse",
@@ -15100,7 +15100,7 @@
     ],
     "rules": [
       "Draw 2 cards. If your opponent has exactly 1, 3, or 5 Prize cards remaining, draw 2 more cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "261",
     "artist": "Hideki Ishikawa",
@@ -15125,7 +15125,7 @@
     ],
     "rules": [
       "Draw 2 cards. If your opponent has exactly 2, 4, or 6 Prize cards remaining, draw 2 more cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "262",
     "artist": "Hideki Ishikawa",
@@ -15150,7 +15150,7 @@
     ],
     "rules": [
       "Shuffle your hand into your deck. Then, draw 5 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "263",
     "artist": "Yuu Nishida",
@@ -15175,7 +15175,7 @@
     ],
     "rules": [
       "Your opponent reveals their hand. Discard up to 2 in any combination of Pokémon Tool cards, Special Energy cards, and Stadium cards from it.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "264",
     "artist": "Hideki Ishikawa",
@@ -15730,7 +15730,7 @@
     ],
     "rules": [
       "Search your deck for up to 3 Fusion Strike Pokémon, reveal them, and put them into your hand. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "273",
     "artist": "Sanosuke Sakuma",
@@ -15755,7 +15755,7 @@
     ],
     "rules": [
       "Draw 2 cards. If you go second and it's your first turn, draw 3 more cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "274",
     "artist": "Yuu Nishida",
@@ -15781,7 +15781,7 @@
     ],
     "rules": [
       "Choose up to 2 of your Fusion Strike Pokémon. For each of those Pokémon, search your deck for a Fusion Strike Energy card and attach it to that Pokémon. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "275",
     "artist": "Ryuta Fuse",
@@ -15806,7 +15806,7 @@
     ],
     "rules": [
       "Draw 2 cards. If your opponent has exactly 1, 3, or 5 Prize cards remaining, draw 2 more cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "276",
     "artist": "Hideki Ishikawa",
@@ -15831,7 +15831,7 @@
     ],
     "rules": [
       "Draw 2 cards. If your opponent has exactly 2, 4, or 6 Prize cards remaining, draw 2 more cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "277",
     "artist": "Hideki Ishikawa",
@@ -15856,7 +15856,7 @@
     ],
     "rules": [
       "Shuffle your hand into your deck. Then, draw 5 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "278",
     "artist": "Yuu Nishida",
@@ -15881,7 +15881,7 @@
     ],
     "rules": [
       "Your opponent reveals their hand. Discard up to 2 in any combination of Pokémon Tool cards, Special Energy cards, and Stadium cards from it.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "279",
     "artist": "Hideki Ishikawa",

--- a/cards/en/swsh9.json
+++ b/cards/en/swsh9.json
@@ -7935,7 +7935,7 @@
     ],
     "rules": [
       "If the Pokémon this card is attached to uses an attack, if you flip any coins for the damage or effect of that attack, and if any of them are tails, draw 3 cards at the end of your turn.",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "131",
@@ -8037,7 +8037,7 @@
     ],
     "rules": [
       "The attacks of the Pokémon this card is attached to do 30 more damage to your opponent's Active Pokémon V (before applying Weakness and Resistance).",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "135",
@@ -8064,7 +8064,7 @@
     ],
     "rules": [
       "The attacks of the Pokémon this card is attached to do 30 more damage to your opponent's Active Psychic Pokémon (before applying Weakness and Resistance).",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "136",
@@ -8139,7 +8139,7 @@
     ],
     "rules": [
       "Heal 20 damage from each of your Pokémon.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "139",
     "artist": "AYUMI ODASHIMA",
@@ -8215,7 +8215,7 @@
     ],
     "rules": [
       "The attacks of the Pokémon this card is attached to do 30 more damage to your opponent's Active Dragon Pokémon (before applying Weakness and Resistance).",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "142",
@@ -8316,7 +8316,7 @@
     ],
     "rules": [
       "If the Pokémon this card is attached to doesn't have a Rule Box, it takes 30 less damage from attacks from your opponent's Pokémon(after applying Weakness and Resistance). (Pokémon V, Pokémon-GX, etc. have Rule Boxes.)",
-      "Item rule: You may play any number of Item cards during your turn.",
+      "You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "146",
@@ -8417,7 +8417,7 @@
     ],
     "rules": [
       "You can use this card only if you discard 2 other cards from your hand. Search your deck for a Pokémon, reveal it, and put it into your hand. Then, shuffle your deck.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "150",
     "artist": "sadaji",
@@ -10225,7 +10225,7 @@
     ],
     "rules": [
       "You can use this card only if you discard 2 other cards from your hand. Search your deck for a Pokémon, reveal it, and put it into your hand. Then, shuffle your deck.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "186",
     "artist": "sadaji",

--- a/cards/en/swsh9.json
+++ b/cards/en/swsh9.json
@@ -7884,7 +7884,7 @@
     ],
     "rules": [
       "Your opponent reveals their hand, and you draw a card for each Trainer card you find there.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "129",
     "artist": "Shiburingaru",
@@ -7909,7 +7909,7 @@
     ],
     "rules": [
       "Draw 3 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "130",
     "artist": "Ken Sugimori",
@@ -7961,7 +7961,7 @@
     ],
     "rules": [
       "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "132",
     "artist": "GIDORA",
@@ -7986,7 +7986,7 @@
     ],
     "rules": [
       "Choose up to 3 of your Benched Pokémon. For each of those Pokémon, search your deck for a different type of basic Energy card and attach it to that Pokémon. Then, shuffle your deck. Your turn ends.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "133",
     "artist": "Hasegawa Saki",
@@ -8011,7 +8011,7 @@
     ],
     "rules": [
       "Put 1 of your Colorless Pokémon that has any damage counters on it and all attached cards into your hand.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "134",
     "artist": "Yusuke Ohmura",
@@ -8114,7 +8114,7 @@
     ],
     "rules": [
       "Draw cards until you have 5 cards in your hand. If any of your Pokémon were Knocked Out during your opponent's last turn, draw cards until you have 8 cards in your hand instead.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "138",
     "artist": "Megumi Mizutani",
@@ -8164,7 +8164,7 @@
     ],
     "rules": [
       "Draw 3 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "140",
     "artist": "Yuu Nishida",
@@ -8189,7 +8189,7 @@
     ],
     "rules": [
       "Search your deck for up to 3 Basic Pokémon that don't have a Rule Box and put them onto your Bench. Then, shuffle your deck. (Pokémon V, Pokémon-GX, etc. have Rule Boxes.)",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "141",
     "artist": "Ken Sugimori",
@@ -8241,7 +8241,7 @@
     ],
     "rules": [
       "You can use this card only if you discard a Fire Energy card from your hand. Look at the top 7 cards of your deck and put up to 2 of them into your hand. Shuffle the other cards back into your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "143",
     "artist": "Hitoshi Ariga",
@@ -8290,7 +8290,7 @@
     ],
     "rules": [
       "Attach a basic Energy card from your discard pile to 1 of your Benched Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "145",
     "artist": "saino misaki",
@@ -8342,7 +8342,7 @@
     ],
     "rules": [
       "Discard your hand and draw 7 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "147",
     "artist": "Sanosuke Sakuma",
@@ -8367,7 +8367,7 @@
     ],
     "rules": [
       "Choose 1 or more: Shuffle a Pokémon from your discard pile into your deck.Shuffle a Pokémon Tool card from your discard pile into your deck.Shuffle a Stadium card from your discard pile into your deck.Shuffle an Energy card from your discard pile into your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "148",
     "artist": "Nagomi Nijo",
@@ -8392,7 +8392,7 @@
     ],
     "rules": [
       "Shuffle up to 3 in any combination of Pokémon and Supporter cards, except for Team Yell's Cheer, from your discard pile into your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "149",
     "artist": "GOSSAN",
@@ -9437,7 +9437,7 @@
     ],
     "rules": [
       "Draw 3 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "167",
     "artist": "Yuu Nishida",
@@ -9462,7 +9462,7 @@
     ],
     "rules": [
       "Put 1 of your Colorless Pokémon that has any damage counters on it and all attached cards into your hand.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "168",
     "artist": "Ryuta Fuse",
@@ -9487,7 +9487,7 @@
     ],
     "rules": [
       "Draw cards until you have 5 cards in your hand. If any of your Pokémon were Knocked Out during your opponent's last turn, draw cards until you have 8 cards in your hand instead.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "169",
     "artist": "Megumi Mizutani",
@@ -9512,7 +9512,7 @@
     ],
     "rules": [
       "You can use this card only if you discard a Fire Energy card from your hand. Look at the top 7 cards of your deck and put up to 2 of them into your hand. Shuffle the other cards back into your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "170",
     "artist": "Hitoshi Ariga",
@@ -9537,7 +9537,7 @@
     ],
     "rules": [
       "Attach a basic Energy card from your discard pile to 1 of your Benched Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "171",
     "artist": "Souichirou Gunjima",
@@ -9562,7 +9562,7 @@
     ],
     "rules": [
       "Choose 1 or more: Shuffle a Pokémon from your discard pile into your deck.Shuffle a Pokémon Tool card from your discard pile into your deck.Shuffle a Stadium card from your discard pile into your deck.Shuffle an Energy card from your discard pile into your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "172",
     "artist": "kirisAki",
@@ -9843,7 +9843,7 @@
     ],
     "rules": [
       "Put 1 of your Colorless Pokémon that has any damage counters on it and all attached cards into your hand.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "177",
     "artist": "Ryuta Fuse",
@@ -9868,7 +9868,7 @@
     ],
     "rules": [
       "Draw cards until you have 5 cards in your hand. If any of your Pokémon were Knocked Out during your opponent's last turn, draw cards until you have 8 cards in your hand instead.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "178",
     "artist": "Megumi Mizutani",
@@ -9893,7 +9893,7 @@
     ],
     "rules": [
       "You can use this card only if you discard a Fire Energy card from your hand. Look at the top 7 cards of your deck and put up to 2 of them into your hand. Shuffle the other cards back into your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "179",
     "artist": "Hitoshi Ariga",
@@ -9918,7 +9918,7 @@
     ],
     "rules": [
       "Choose 1 or more: Shuffle a Pokémon from your discard pile into your deck.Shuffle a Pokémon Tool card from your discard pile into your deck.Shuffle a Stadium card from your discard pile into your deck.Shuffle an Energy card from your discard pile into your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "180",
     "artist": "kirisAki",

--- a/cards/en/swsh9.json
+++ b/cards/en/swsh9.json
@@ -7936,7 +7936,7 @@
     "rules": [
       "If the Pokémon this card is attached to uses an attack, if you flip any coins for the damage or effect of that attack, and if any of them are tails, draw 3 cards at the end of your turn.",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "131",
     "artist": "Ayaka Yoshida",
@@ -8038,7 +8038,7 @@
     "rules": [
       "The attacks of the Pokémon this card is attached to do 30 more damage to your opponent's Active Pokémon V (before applying Weakness and Resistance).",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "135",
     "artist": "Studio Bora Inc.",
@@ -8065,7 +8065,7 @@
     "rules": [
       "The attacks of the Pokémon this card is attached to do 30 more damage to your opponent's Active Psychic Pokémon (before applying Weakness and Resistance).",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "136",
     "artist": "Toyste Beach",
@@ -8216,7 +8216,7 @@
     "rules": [
       "The attacks of the Pokémon this card is attached to do 30 more damage to your opponent's Active Dragon Pokémon (before applying Weakness and Resistance).",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "142",
     "artist": "Toyste Beach",
@@ -8317,7 +8317,7 @@
     "rules": [
       "If the Pokémon this card is attached to doesn't have a Rule Box, it takes 30 less damage from attacks from your opponent's Pokémon(after applying Weakness and Resistance). (Pokémon V, Pokémon-GX, etc. have Rule Boxes.)",
       "You may play any number of Item cards during your turn.",
-      "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
     "number": "146",
     "artist": "Toyste Beach",

--- a/cards/en/swsh9tg.json
+++ b/cards/en/swsh9tg.json
@@ -1469,7 +1469,7 @@
     ],
     "rules": [
       "Your opponent reveals their hand, and you draw a card for each Trainer card you find there.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "TG24",
     "artist": "yuu",
@@ -1494,7 +1494,7 @@
     ],
     "rules": [
       "Choose up to 3 of your Benched Pokémon. For each of those Pokémon, search your deck for a different type of basic Energy card and attach it to that Pokémon. Then, shuffle your deck. Your turn ends.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "TG25",
     "artist": "Sanosuke Sakuma",
@@ -1519,7 +1519,7 @@
     ],
     "rules": [
       "Search your deck for up to 3 Basic Pokémon that don't have a Rule Box and put them onto your Bench. Then, shuffle your deck. (Pokémon V, Pokémon-GX, etc. have Rule Boxes.)",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "TG26",
     "artist": "Naoki Saito",
@@ -1546,7 +1546,7 @@
     "rules": [
       "You can play this card only when it is the last card in your hand.",
       "Put a Rapid Strike Pokémon from your discard pile onto your Bench. If you do, draw 5 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "TG27",
     "artist": "KIYOTAKA OSHIYAMA",
@@ -1573,7 +1573,7 @@
     "rules": [
       "You can play this card only when it is the last card in your hand.",
       "Search your deck for a Single Strike Pokémon and put it onto your Bench. Then, shuffle your deck. If you searched your deck in this way, draw 5 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "TG28",
     "artist": "Souichirou Gunjima",

--- a/cards/en/swshp.json
+++ b/cards/en/swshp.json
@@ -7566,7 +7566,7 @@
     ],
     "rules": [
       "Each player shuffles their hand and puts it on the bottom of their deck. If either player put any cards on the bottom of their deck in this way, you draw 5 cards, and your opponent draws 4 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "SWSH120",
     "artist": "Sanosuke Sakuma",
@@ -7591,7 +7591,7 @@
     ],
     "rules": [
       "Each player shuffles their hand and puts it on the bottom of their deck. If either player put any cards on the bottom of their deck in this way, you draw 5 cards, and your opponent draws 4 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "SWSH121",
     "artist": "Naoki Saito",
@@ -9579,7 +9579,7 @@
     ],
     "rules": [
       "Discard your hand and draw 7 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "SWSH152",
     "artist": "Yuu Nishida",
@@ -10905,7 +10905,7 @@
     ],
     "rules": [
       "Search your deck for up to 2 cards and discard them. Then, shuffle your deck.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "SWSH167",
     "artist": "Ryuta Fuse",
@@ -11548,7 +11548,7 @@
     ],
     "rules": [
       "Discard your hand and draw 7 cards.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "SWSH178",
     "artist": "Yusuke Kozaki",
@@ -14626,7 +14626,7 @@
     ],
     "rules": [
       "Draw 2 cards. If you drew any cards in this way, flip a coin. If heads, attach a Lightning Energy card from your discard pile to 1 of your Benched Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "SWSH226",
     "artist": "Naoki Saito",
@@ -14651,7 +14651,7 @@
     ],
     "rules": [
       "Draw 2 cards. If you drew any cards in this way, flip a coin. If heads, attach a Water Energy card from your discard pile to 1 of your Benched Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "SWSH227",
     "artist": "Anesaki Dynamic",
@@ -14676,7 +14676,7 @@
     ],
     "rules": [
       "Draw 2 cards. If you drew any cards in this way, flip a coin. If heads, attach a Fire Energy card from your discard pile to 1 of your Benched Pokémon.",
-      "Supporter rule: You may play only 1 Supporter card during your turn."
+      "You may play only 1 Supporter card during your turn."
     ],
     "number": "SWSH228",
     "artist": "Ryuta Fuse",

--- a/cards/en/swshp.json
+++ b/cards/en/swshp.json
@@ -9250,7 +9250,7 @@
     ],
     "rules": [
       "Flip a coin. If heads, search your deck for a Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
-      "Item rule: You may play any number of Item cards during your turn."
+      "You may play any number of Item cards during your turn."
     ],
     "number": "SWSH146",
     "artist": "5ban Graphics",


### PR DESCRIPTION
Most Supporter cards from the swsh sets (including pgo) had "Supporter rule: " at the beginning of a rule. Since this did not reflect what was written in the card, I removed it. Thanks to julien on Discord who made me notice this.