### PR TITLE
Standardized spaces

### DIFF
--- a/cards/en/cel25.json
+++ b/cards/en/cel25.json
@@ -150,7 +150,7 @@
         ],
         "name": "Aqua Storm",
         "damage": "",
-        "text": "Discard the top 5 cards of your deck, and then choose 2 of your opponent's Benched Pokémon. This attack does 50 damage for each Energy card you discarded in this way to each of those Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
+        "text": "Discard the top 5 cards of your deck, and then choose 2 of your opponent's Benched Pokémon. This attack does 50 damage for each Energy card you discarded in this way to each of those Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
         "convertedEnergyCost": 3
       },
       {

--- a/cards/en/swsh8.json
+++ b/cards/en/swsh8.json
@@ -4489,7 +4489,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 50 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 50 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Crabhammer",
@@ -6340,7 +6340,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "During your opponent's next turn, the Defending Pokémon's attacks do 30 less damage (before applying Weakness and Resistance)."
+        "text": "During your opponent's next turn, the Defending Pokémon's attacks do 30 less damage (before applying Weakness and Resistance)."
       },
       {
         "name": "Tiny Bolt",
@@ -10472,7 +10472,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "During your opponent's next turn, Pokémon can't be played from your opponent's hand to evolve the Defending Pokémon.\\n "
+        "text": "During your opponent's next turn, Pokémon can't be played from your opponent's hand to evolve the Defending Pokémon.\\n "
       },
       {
         "name": "Dark Cutter",
@@ -13822,7 +13822,7 @@
       "Fusion Strike"
     ],
     "rules": [
-      "You must play 2 Crossceiver cards at once. (This effect works one time for 2 cards.)",
+      "You must play 2 Crossceiver cards at once. (This effect works one time for 2 cards.)",
       "Put a Pokémon or a Supporter card from your discard pile into your hand.",
       "Item rule: You may play any number of Item cards during your turn."
     ],

--- a/cards/en/swsh9.json
+++ b/cards/en/swsh9.json
@@ -2640,7 +2640,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "This attack does 40 damage to 1 of your opponent's Pokémon for each Fusion Strike Energy attached to all of your Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 40 damage to 1 of your opponent's Pokémon for each Fusion Strike Energy attached to all of your Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Icicle Missile",
@@ -3951,7 +3951,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 60 damage to 1 of your opponent's Pokémon for each Energy attached to this Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can't use more than 1 VSTAR Power in a game.)"
+        "text": "This attack does 60 damage to 1 of your opponent's Pokémon for each Energy attached to this Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can't use more than 1 VSTAR Power in a game.)"
       }
     ],
     "weaknesses": [
@@ -5393,7 +5393,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Until the end of your next turn, the Defending Pokémon's Weakness is now Darkness. (The amount of Weakness doesn't change.)"
+        "text": "Until the end of your next turn, the Defending Pokémon's Weakness is now Darkness. (The amount of Weakness doesn't change.)"
       },
       {
         "name": "Cursed Drop",
@@ -5693,7 +5693,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 30 damage to 1 of your opponent's Pokémon for each Darkness Energy attached to this Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "This attack does 30 damage to 1 of your opponent's Pokémon for each Darkness Energy attached to this Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Darkness Fang",
@@ -6182,7 +6182,7 @@
     "abilities": [
       {
         "name": "Miraculous Armor",
-        "text": "This Pokémon takes 100 less damage from attacks from your opponent's Pokémon V (after applying Weakness and Resistance).",
+        "text": "This Pokémon takes 100 less damage from attacks from your opponent's Pokémon V (after applying Weakness and Resistance).",
         "type": "Ability"
       }
     ],
@@ -8036,7 +8036,7 @@
       "Pokémon Tool"
     ],
     "rules": [
-      "The attacks of the Pokémon this card is attached to do 30 more damage to your opponent's Active Pokémon V (before applying Weakness and Resistance).",
+      "The attacks of the Pokémon this card is attached to do 30 more damage to your opponent's Active Pokémon V (before applying Weakness and Resistance).",
       "Item rule: You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
@@ -8315,7 +8315,7 @@
       "Pokémon Tool"
     ],
     "rules": [
-      "If the Pokémon this card is attached to doesn't have a Rule Box, it takes 30 less damage from attacks from your opponent's Pokémon(after applying Weakness and Resistance). (Pokémon V, Pokémon-GX, etc. have Rule Boxes.)",
+      "If the Pokémon this card is attached to doesn't have a Rule Box, it takes 30 less damage from attacks from your opponent's Pokémon(after applying Weakness and Resistance). (Pokémon V, Pokémon-GX, etc. have Rule Boxes.)",
       "Item rule: You may play any number of Item cards during your turn.",
       "Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
     ],
@@ -8391,7 +8391,7 @@
       "Supporter"
     ],
     "rules": [
-      "Shuffle up to 3 in any combination of Pokémon and Supporter cards, except for Team Yell's Cheer, from your discard pile into your deck.",
+      "Shuffle up to 3 in any combination of Pokémon and Supporter cards, except for Team Yell's Cheer, from your discard pile into your deck.",
       "Supporter rule: You may play only 1 Supporter card during your turn."
     ],
     "number": "149",
@@ -9741,7 +9741,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "This attack does 60 damage to 1 of your opponent's Pokémon for each Energy attached to this Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can't use more than 1 VSTAR Power in a game.)"
+        "text": "This attack does 60 damage to 1 of your opponent's Pokémon for each Energy attached to this Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can't use more than 1 VSTAR Power in a game.)"
       }
     ],
     "weaknesses": [

--- a/cards/en/swsh9tg.json
+++ b/cards/en/swsh9tg.json
@@ -136,7 +136,7 @@
     "abilities": [
       {
         "name": "Rapid Strike Search",
-        "text": "Once during your turn, you may search your deck for a Rapid Strike card, reveal it, and put it into your hand. Then, shuffle your deck. You can't use more than 1 Rapid Strike Search Ability each turn.",
+        "text": "Once during your turn, you may search your deck for a Rapid Strike card, reveal it, and put it into your hand. Then, shuffle your deck. You can't use more than 1 Rapid Strike Search Ability each turn.",
         "type": "Ability"
       }
     ],
@@ -321,7 +321,7 @@
     "abilities": [
       {
         "name": "Spectral Breach",
-        "text": "All Special Energy attached to Pokémon (both yours and your opponent's) provide Colorless Energy and have no other effect.",
+        "text": "All Special Energy attached to Pokémon (both yours and your opponent's) provide Colorless Energy and have no other effect.",
         "type": "Ability"
       }
     ],
@@ -1299,7 +1299,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Discard all Energy from this Pokémon. This attack does 120 damage to 2 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard all Energy from this Pokémon. This attack does 120 damage to 2 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [
@@ -1694,7 +1694,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Discard all Energy from this Pokémon. This attack does 120 damage to 2 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard all Energy from this Pokémon. This attack does 120 damage to 2 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [


### PR DESCRIPTION
julien on Discord pointed out that some cards were occasionally using U+00A0 (non-breaking space) instead of U+0020 (regular space). I changed all of those non-breaking spaces (in the files under /cards/en) to regular spaces.