### PR TITLE
Removed level ex

### DIFF
--- a/cards/en/bwp.json
+++ b/cards/en/bwp.json
@@ -1921,7 +1921,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "180",
     "types": [
       "Fire"
@@ -1989,7 +1988,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "180",
     "types": [
       "Water"
@@ -2057,7 +2055,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "180",
     "types": [
       "Lightning"
@@ -2458,7 +2455,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "170",
     "types": [
       "Psychic"
@@ -2526,7 +2522,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "180",
     "types": [
       "Darkness"
@@ -2594,7 +2589,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "170",
     "types": [
       "Dragon"
@@ -3405,7 +3399,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "170",
     "types": [
       "Water"
@@ -3467,7 +3460,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "180",
     "types": [
       "Dragon"
@@ -3535,7 +3527,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "180",
     "types": [
       "Dragon"
@@ -4643,7 +4634,6 @@
       "EX",
       "Team Plasma"
     ],
-    "level": "ex",
     "hp": "170",
     "types": [
       "Lightning"
@@ -4708,7 +4698,6 @@
       "EX",
       "Team Plasma"
     ],
-    "level": "ex",
     "hp": "170",
     "types": [
       "Psychic"
@@ -4770,7 +4759,6 @@
       "EX",
       "Team Plasma"
     ],
-    "level": "ex",
     "hp": "180",
     "types": [
       "Colorless"
@@ -5538,7 +5526,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "170",
     "types": [
       "Colorless"

--- a/cards/en/cel25c.json
+++ b/cards/en/cel25c.json
@@ -656,7 +656,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "90",
     "types": [
       "Psychic"
@@ -715,7 +714,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Fire"

--- a/cards/en/dc1.json
+++ b/cards/en/dc1.json
@@ -302,7 +302,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "190",
     "types": [
       "Water"
@@ -842,7 +841,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "190",
     "types": [
       "Fighting"

--- a/cards/en/ex1.json
+++ b/cards/en/ex1.json
@@ -5082,7 +5082,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "120",
     "types": [
       "Colorless"
@@ -5150,7 +5149,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "90",
     "types": [
       "Lightning"
@@ -5222,7 +5220,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "90",
     "types": [
       "Fighting"
@@ -5285,7 +5282,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "110",
     "types": [
       "Water"
@@ -5349,7 +5345,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "90",
     "types": [
       "Fire"
@@ -5415,7 +5410,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Psychic"
@@ -5479,7 +5473,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "80",
     "types": [
       "Grass"
@@ -5550,7 +5543,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "80",
     "types": [
       "Darkness"

--- a/cards/en/ex10.json
+++ b/cards/en/ex10.json
@@ -5185,7 +5185,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "160",
     "types": [
       "Colorless"
@@ -5256,7 +5255,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "110",
     "types": [
       "Psychic"
@@ -5323,7 +5321,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Water"
@@ -5397,7 +5394,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "110",
     "types": [
       "Fire"
@@ -5458,7 +5454,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Colorless"
@@ -5524,7 +5519,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Grass"
@@ -5609,7 +5603,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Water"
@@ -5687,7 +5680,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "120",
     "types": [
       "Metal"
@@ -5764,7 +5756,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Metal"
@@ -5855,7 +5846,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Fire"
@@ -5921,7 +5911,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "160",
     "types": [
       "Darkness"
@@ -6017,7 +6006,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "110",
     "types": [
       "Darkness"
@@ -6279,7 +6267,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Darkness"
@@ -6340,7 +6327,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "70",
     "types": [
       "Grass"

--- a/cards/en/ex11.json
+++ b/cards/en/ex11.json
@@ -5757,7 +5757,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "110",
     "types": [
       "Fire"
@@ -5828,7 +5827,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Lightning"
@@ -5901,7 +5899,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "120",
     "types": [
       "Water"

--- a/cards/en/ex12.json
+++ b/cards/en/ex12.json
@@ -4644,7 +4644,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "120",
     "types": [
       "Fire"
@@ -4716,7 +4715,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "160",
     "types": [
       "Fighting"
@@ -4789,7 +4787,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "90",
     "types": [
       "Psychic"
@@ -4855,7 +4852,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "140",
     "types": [
       "Grass"
@@ -4926,7 +4922,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Colorless"
@@ -5006,7 +5001,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "90",
     "types": [
       "Psychic"
@@ -5065,7 +5059,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Water"

--- a/cards/en/ex13.json
+++ b/cards/en/ex13.json
@@ -5368,7 +5368,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "110",
     "types": [
       "Water"
@@ -5429,7 +5428,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "90",
     "types": [
       "Psychic"
@@ -5499,7 +5497,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Darkness"

--- a/cards/en/ex14.json
+++ b/cards/en/ex14.json
@@ -4637,7 +4637,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Metal"
@@ -4719,7 +4718,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Fighting"
@@ -4785,7 +4783,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "90",
     "types": [
       "Colorless"
@@ -4851,7 +4848,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Colorless"
@@ -4924,7 +4920,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Fighting"
@@ -4985,7 +4980,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "90",
     "types": [
       "Psychic"
@@ -5049,7 +5043,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Water"
@@ -5110,7 +5103,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "140",
     "types": [
       "Psychic"
@@ -5176,7 +5168,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "140",
     "types": [
       "Darkness"
@@ -5249,7 +5240,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Water"

--- a/cards/en/ex15.json
+++ b/cards/en/ex15.json
@@ -4438,7 +4438,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Water"
@@ -4509,7 +4508,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Grass"
@@ -4569,7 +4567,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Psychic"
@@ -4625,7 +4622,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Fire"
@@ -4687,7 +4683,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "140",
     "types": [
       "Fighting"
@@ -4758,7 +4753,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Fire"
@@ -4819,7 +4813,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Water"
@@ -4890,7 +4883,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "110",
     "types": [
       "Lightning"
@@ -4956,7 +4948,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "160",
     "types": [
       "Water"
@@ -5040,7 +5031,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Lightning"

--- a/cards/en/ex16.json
+++ b/cards/en/ex16.json
@@ -4707,7 +4707,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Darkness"
@@ -4772,7 +4771,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "120",
     "types": [
       "Psychic"
@@ -4844,7 +4842,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Colorless"
@@ -4911,7 +4908,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Metal"
@@ -4981,7 +4977,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "160",
     "types": [
       "Colorless"
@@ -5059,7 +5054,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "140",
     "types": [
       "Darkness"
@@ -5128,7 +5122,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Metal"
@@ -5204,7 +5197,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Water"

--- a/cards/en/ex2.json
+++ b/cards/en/ex2.json
@@ -5190,7 +5190,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Colorless"
@@ -5266,7 +5265,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Metal"
@@ -5346,7 +5344,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Psychic"
@@ -5416,7 +5413,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Water"
@@ -5485,7 +5481,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Lightning"
@@ -5548,7 +5543,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "160",
     "types": [
       "Fire"
@@ -5620,7 +5614,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "200",
     "types": [
       "Water"

--- a/cards/en/ex3.json
+++ b/cards/en/ex3.json
@@ -4963,7 +4963,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Lightning"
@@ -5032,7 +5031,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Colorless"
@@ -5115,7 +5113,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "160",
     "types": [
       "Fighting"
@@ -5190,7 +5187,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Water"
@@ -5259,7 +5255,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "90",
     "types": [
       "Colorless"
@@ -5332,7 +5327,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Colorless"
@@ -5405,7 +5399,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Fire"
@@ -5470,7 +5463,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Grass"
@@ -5541,7 +5533,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Colorless"

--- a/cards/en/ex4.json
+++ b/cards/en/ex4.json
@@ -4574,7 +4574,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Fire"
@@ -4644,7 +4643,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Grass"
@@ -4721,7 +4719,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Fire"
@@ -4784,7 +4781,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Lightning"
@@ -4847,7 +4843,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Grass"
@@ -4934,7 +4929,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Water"
@@ -4997,7 +4991,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Fighting"

--- a/cards/en/ex5.json
+++ b/cards/en/ex5.json
@@ -5167,7 +5167,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Fighting"
@@ -5239,7 +5238,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Water"
@@ -5311,7 +5309,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Metal"
@@ -5389,7 +5386,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "90",
     "types": [
       "Fire"
@@ -5453,7 +5449,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "90",
     "types": [
       "Water"
@@ -5514,7 +5509,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Fighting"
@@ -5576,7 +5570,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "90",
     "types": [
       "Metal"
@@ -5643,7 +5636,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "140",
     "types": [
       "Grass"
@@ -5705,7 +5697,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Colorless"

--- a/cards/en/ex6.json
+++ b/cards/en/ex6.json
@@ -5487,7 +5487,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Water"
@@ -5551,7 +5550,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "160",
     "types": [
       "Fire"
@@ -5630,7 +5628,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Colorless"
@@ -5694,7 +5691,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "90",
     "types": [
       "Lightning"
@@ -5754,7 +5750,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Psychic"
@@ -5833,7 +5828,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "130",
     "types": [
       "Water"
@@ -5901,7 +5895,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "80",
     "types": [
       "Psychic"
@@ -5954,7 +5947,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "80",
     "types": [
       "Psychic"
@@ -6007,7 +5999,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "150",
     "types": [
       "Grass"

--- a/cards/en/ex7.json
+++ b/cards/en/ex7.json
@@ -5255,7 +5255,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Darkness"
@@ -5324,7 +5323,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Darkness"
@@ -5393,7 +5391,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Darkness"
@@ -5462,7 +5459,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Darkness"
@@ -5537,7 +5533,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Darkness"
@@ -5608,7 +5603,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "120",
     "types": [
       "Darkness"
@@ -5675,7 +5669,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "80",
     "types": [
       "Darkness"
@@ -5753,7 +5746,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "90",
     "types": [
       "Darkness"
@@ -5824,7 +5816,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Darkness"
@@ -5897,7 +5888,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Darkness"
@@ -5966,7 +5956,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Darkness"

--- a/cards/en/ex8.json
+++ b/cards/en/ex8.json
@@ -5206,7 +5206,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "130",
     "types": [
       "Grass"
@@ -5279,7 +5278,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Psychic"
@@ -5338,7 +5336,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "110",
     "types": [
       "Psychic"
@@ -5399,7 +5396,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "90",
     "types": [
       "Psychic"
@@ -5460,7 +5456,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "110",
     "types": [
       "Fighting"
@@ -5532,7 +5527,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Lightning"
@@ -5602,7 +5596,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Colorless"
@@ -5672,7 +5665,6 @@
       "Stage 2",
       "EX"
     ],
-    "level": "ex",
     "hp": "160",
     "types": [
       "Colorless"
@@ -5755,7 +5747,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Darkness"

--- a/cards/en/ex9.json
+++ b/cards/en/ex9.json
@@ -4658,7 +4658,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Colorless"
@@ -4722,7 +4721,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "110",
     "types": [
       "Grass"
@@ -4792,7 +4790,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "120",
     "types": [
       "Fire"
@@ -4864,7 +4861,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "110",
     "types": [
       "Psychic"
@@ -4924,7 +4920,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Psychic"
@@ -4997,7 +4992,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "110",
     "types": [
       "Fighting"
@@ -5068,7 +5062,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "130",
     "types": [
       "Water"
@@ -5139,7 +5132,6 @@
       "Stage 1",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Lightning"
@@ -5207,7 +5199,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "100",
     "types": [
       "Water"
@@ -5271,7 +5262,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "110",
     "types": [
       "Fighting"
@@ -5335,7 +5325,6 @@
       "Basic",
       "EX"
     ],
-    "level": "ex",
     "hp": "90",
     "types": [
       "Metal"


### PR DESCRIPTION
I removed the level from all the cards that had it set to "ex", i.e. from most of the Pokémon-ex (from the ex era) and from a few Pokémon-EX (from bw/xy).
This closes #349 