### PR TITLE
Fixed attacks with no cost

### DIFF
--- a/cards/en/swsh11.json
+++ b/cards/en/swsh11.json
@@ -2594,7 +2594,7 @@
       {
         "name": "Surprise Attack",
         "cost": [
-          "[-]"
+
         ],
         "convertedEnergyCost": 1,
         "damage": "40",
@@ -2645,7 +2645,7 @@
       {
         "name": "Upstream Spirits",
         "cost": [
-          "[-]"
+
         ],
         "convertedEnergyCost": 1,
         "damage": "20×",
@@ -4536,7 +4536,7 @@
       {
         "name": "Collect",
         "cost": [
-          "[-]"
+
         ],
         "convertedEnergyCost": 1,
         "damage": "",
@@ -4602,7 +4602,7 @@
       {
         "name": "Doom Curse",
         "cost": [
-          "[-]"
+
         ],
         "convertedEnergyCost": 1,
         "damage": "",
@@ -5053,7 +5053,7 @@
       {
         "name": "Singe",
         "cost": [
-          "[-]"
+
         ],
         "convertedEnergyCost": 1,
         "damage": "",
@@ -5105,7 +5105,7 @@
       {
         "name": "Very Vulnerable",
         "cost": [
-          "[-]"
+
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
@@ -8141,7 +8141,7 @@
       {
         "name": "Rigidify",
         "cost": [
-          "[-]"
+
         ],
         "convertedEnergyCost": 1,
         "damage": "",
@@ -8933,7 +8933,7 @@
       {
         "name": "Void Return",
         "cost": [
-          "[-]"
+
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
@@ -9780,7 +9780,7 @@
       {
         "name": "Tantrum Blast",
         "cost": [
-          "[-]"
+
         ],
         "convertedEnergyCost": 1,
         "damage": "100×",

--- a/cards/en/swsh11.json
+++ b/cards/en/swsh11.json
@@ -2596,7 +2596,7 @@
         "cost": [
 
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "40",
         "text": "Flip a coin. If tails, this attack does nothing."
       }
@@ -2647,7 +2647,7 @@
         "cost": [
 
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "20×",
         "text": "This attack does 20 damage for each basic Energy card in your discard pile. Then, shuffle those cards into your deck."
       },
@@ -4538,7 +4538,7 @@
         "cost": [
 
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Draw a card."
       },
@@ -4604,7 +4604,7 @@
         "cost": [
 
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "At the end of your opponent's next turn, the Defending Pokémon will be Knocked Out."
       },
@@ -5055,7 +5055,7 @@
         "cost": [
 
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Your opponent's Active Pokémon is now Burned."
       }
@@ -5107,7 +5107,7 @@
         "cost": [
 
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10+",
         "text": "If you have no cards in your hand, this attack does 150 more damage."
       },
@@ -8143,7 +8143,7 @@
         "cost": [
 
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "During your opponent's next turn, this Pokémon takes 50 less damage from attacks (after applying Weakness and Resistance)."
       },
@@ -8935,7 +8935,7 @@
         "cost": [
 
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "30",
         "text": "You may switch this Pokémon with 1 of your Benched Pokémon."
       },
@@ -9782,7 +9782,7 @@
         "cost": [
 
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "100×",
         "text": "This attack does 100 damage for each Special Condition affecting this Pokémon."
       },

--- a/cards/en/swsh11tg.json
+++ b/cards/en/swsh11tg.json
@@ -452,7 +452,7 @@
       {
         "name": "Very Vulnerable",
         "cost": [
-          "[-]"
+
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",

--- a/cards/en/swsh11tg.json
+++ b/cards/en/swsh11tg.json
@@ -454,7 +454,7 @@
         "cost": [
 
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10+",
         "text": "If you have no cards in your hand, this attack does 150 more damage."
       },

--- a/cards/en/swsh12.json
+++ b/cards/en/swsh12.json
@@ -534,7 +534,7 @@
         "cost": [
 
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Search your deck for up to 2 Grass Energy cards and attach them to your Benched Pokémon in any way you like. Then, shuffle your deck."
       },
@@ -1942,7 +1942,7 @@
         "cost": [
 
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10+",
         "text": "If your opponent's Active Pokémon is a Pokémon V, this attack does 50 more damage."
       },
@@ -2020,7 +2020,7 @@
         "cost": [
 
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "70×",
         "text": "This attack does 70 damage for each of your opponent's Pokémon V in play. This damage isn't affected by Weakness or Resistance. (You can't use more than 1 VSTAR Power in a game.)"
       }
@@ -9146,7 +9146,7 @@
         "cost": [
 
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Put 3 damage counters on each of your opponent's Pokémon that has any damage counters on it."
       },
@@ -9941,7 +9941,7 @@
         "cost": [
 
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "10+",
         "text": "If your opponent's Active Pokémon is a Pokémon V, this attack does 50 more damage."
       },
@@ -11212,7 +11212,7 @@
         "cost": [
 
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "70×",
         "text": "This attack does 70 damage for each of your opponent's Pokémon V in play. This damage isn't affected by Weakness or Resistance. (You can't use more than 1 VSTAR Power in a game.)"
       }

--- a/cards/en/swsh12.json
+++ b/cards/en/swsh12.json
@@ -532,7 +532,7 @@
       {
         "name": "Swelling Scent",
         "cost": [
-          "[-]"
+
         ],
         "convertedEnergyCost": 1,
         "damage": "",
@@ -1940,7 +1940,7 @@
       {
         "name": "White Drop",
         "cost": [
-          "[-]"
+
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
@@ -2018,7 +2018,7 @@
       {
         "name": "Silvery Snow Star",
         "cost": [
-          "[-]"
+
         ],
         "convertedEnergyCost": 1,
         "damage": "70×",
@@ -9144,7 +9144,7 @@
       {
         "name": "Eerie Cry",
         "cost": [
-          "[-]"
+
         ],
         "convertedEnergyCost": 1,
         "damage": "",
@@ -9939,7 +9939,7 @@
       {
         "name": "White Drop",
         "cost": [
-          "[-]"
+
         ],
         "convertedEnergyCost": 1,
         "damage": "10+",
@@ -11210,7 +11210,7 @@
       {
         "name": "Silvery Snow Star",
         "cost": [
-          "[-]"
+
         ],
         "convertedEnergyCost": 1,
         "damage": "70×",

--- a/cards/en/swsh12pt5gg.json
+++ b/cards/en/swsh12pt5gg.json
@@ -17,7 +17,7 @@
       {
         "name": "Cheerful Charge",
         "cost": [
-          "[-]"
+
         ],
         "convertedEnergyCost": 1,
         "damage": "",

--- a/cards/en/swsh12pt5gg.json
+++ b/cards/en/swsh12pt5gg.json
@@ -19,7 +19,7 @@
         "cost": [
 
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "You can use this attack only if you go second, and only during your first turn. Choose up to 2 of your Benched Pokémon. For each of those Pokémon, search your deck for a basic Energy card and attach it to that Pokémon. Then, shuffle your deck."
       },

--- a/cards/en/swshp.json
+++ b/cards/en/swshp.json
@@ -15204,7 +15204,7 @@
         "cost": [
 
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "",
         "text": "Your opponent's Active Pokémon is now Burned."
       },
@@ -17658,7 +17658,7 @@
         "cost": [
 
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "100×",
         "text": "This attack does 100 damage for each Special Condition affecting this Pokémon."
       },
@@ -17805,7 +17805,7 @@
         "cost": [
 
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "30",
         "text": "You may switch this Pokémon with 1 of your Benched Pokémon."
       },
@@ -18297,7 +18297,7 @@
         "cost": [
 
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "100×",
         "text": "This attack does 100 damage for each Special Condition affecting this Pokémon."
       },
@@ -18446,7 +18446,7 @@
         "cost": [
 
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 0,
         "damage": "30",
         "text": "You may switch this Pokémon with 1 of your Benched Pokémon."
       },

--- a/cards/en/swshp.json
+++ b/cards/en/swshp.json
@@ -15202,7 +15202,7 @@
       {
         "name": "Singe",
         "cost": [
-          "[-]"
+
         ],
         "convertedEnergyCost": 1,
         "damage": "",
@@ -17656,7 +17656,7 @@
       {
         "name": "Tantrum Blast",
         "cost": [
-          "[-]"
+
         ],
         "convertedEnergyCost": 1,
         "damage": "100×",
@@ -17803,7 +17803,7 @@
       {
         "name": "Void Return",
         "cost": [
-          "[-]"
+
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
@@ -18295,7 +18295,7 @@
       {
         "name": "Tantrum Blast",
         "cost": [
-          "[-]"
+
         ],
         "convertedEnergyCost": 1,
         "damage": "100×",
@@ -18444,7 +18444,7 @@
       {
         "name": "Void Return",
         "cost": [
-          "[-]"
+
         ],
         "convertedEnergyCost": 1,
         "damage": "30",


### PR DESCRIPTION
There were some cards which had an attack with a cost of "[-]" and a convertedEnergyCost of 1, instead of an attack with no cost and a convertedEnergyCost of 0. This was also causing problems with pokemontcg.guru, which displays the "Hmmmmm...something went wrong on our end." message while trying to display the info about these cards.

One thing I should note is that I also fixed the "duplicate" copies that are removed in #338. I did this because I saw that that PR already had conflicts, so I figured adding one more would not be a big deal.