### PR TITLE
Removed "\\n" from several flavor texts

### DIFF
--- a/cards/en/swsh12pt5.json
+++ b/cards/en/swsh12pt5.json
@@ -1806,7 +1806,7 @@
     "number": "30",
     "artist": "Shigenori Negishi",
     "rarity": "Common",
-    "flavorText": "It can radiate chilliness from the bottoms of its\\nfeet. It'll spend the whole day tap-dancing on a\\nfrozen floor.",
+    "flavorText": "It can radiate chilliness from the bottoms of its feet. It'll spend the whole day tap-dancing on a frozen floor.",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -4110,7 +4110,7 @@
     "number": "67",
     "artist": "Jiro Sasumo",
     "rarity": "Rare",
-    "flavorText": "When it flies to this land from across the sea, the bitter winter\\ncomes to an end. According to legend, this Pokémon's love\\ngives rise to the budding of fresh life across Hisui.",
+    "flavorText": "When it flies to this land from across the sea, the bitter winter comes to an end. According to legend, this Pokémon's love gives rise to the budding of fresh life across Hisui.",
     "nationalPokedexNumbers": [
       905
     ],
@@ -4514,7 +4514,7 @@
     "number": "74",
     "artist": "kodama",
     "rarity": "Rare",
-    "flavorText": "This form of Lycanroc is reckless. It charges\\nheadlong at its opponents, attacking without any\\ncare about what injuries it might receive.",
+    "flavorText": "This form of Lycanroc is reckless. It charges headlong at its opponents, attacking without any care about what injuries it might receive.",
     "nationalPokedexNumbers": [
       745
     ],
@@ -5110,7 +5110,7 @@
     "number": "84",
     "artist": "miki kudo",
     "rarity": "Common",
-    "flavorText": "Living with a savage, seafaring people has\\ntoughened this Pokémon's body so much that\\nparts of it have turned to iron.",
+    "flavorText": "Living with a savage, seafaring people has toughened this Pokémon's body so much that parts of it have turned to iron.",
     "nationalPokedexNumbers": [
       52
     ],
@@ -5783,7 +5783,7 @@
     "number": "94",
     "artist": "nagimiso",
     "rarity": "Rare Holo",
-    "flavorText": "Now armed with a weapon it used in ancient\\ntimes, this Pokémon needs only a single strike\\nto fell even Gigantamax Pokémon.",
+    "flavorText": "Now armed with a weapon it used in ancient times, this Pokémon needs only a single strike to fell even Gigantamax Pokémon.",
     "nationalPokedexNumbers": [
       888
     ],
@@ -5994,7 +5994,7 @@
     "number": "97",
     "artist": "GIDORA",
     "rarity": "Rare Holo",
-    "flavorText": "Its ability to deflect any attack led to it being\\nknown as the Fighting Master's Shield.\\nIt was feared and respected by all.",
+    "flavorText": "Its ability to deflect any attack led to it being known as the Fighting Master's Shield. It was feared and respected by all.",
     "nationalPokedexNumbers": [
       889
     ],

--- a/cards/en/swsh12pt5gg.json
+++ b/cards/en/swsh12pt5gg.json
@@ -46,7 +46,7 @@
     "number": "GG01",
     "artist": "HYOGONOSUKE",
     "rarity": "Trainer Gallery Rare Holo",
-    "flavorText": "An enigmatic Pokémon that happens to bear a resemblance to a\\nPoké Ball. When excited, it discharges the electric current it has\\nstored in its belly, then lets out a great, uproarious laugh.",
+    "flavorText": "An enigmatic Pokémon that happens to bear a resemblance to a Poké Ball. When excited, it discharges the electric current it has stored in its belly, then lets out a great, uproarious laugh.",
     "nationalPokedexNumbers": [
       100
     ],

--- a/cards/en/swsh8.json
+++ b/cards/en/swsh8.json
@@ -10472,7 +10472,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": "During your opponent's next turn, Pokémon can't be played from your opponent's hand to evolve the Defending Pokémon.\\n "
+        "text": "During your opponent's next turn, Pokémon can't be played from your opponent's hand to evolve the Defending Pokémon."
       },
       {
         "name": "Dark Cutter",


### PR DESCRIPTION
Some flavor texts sometimes had the string "\\\\n" instead of a space.
EDIT: I noticed this also affected an attack text, so I fixed that as well.