### PR TITLE
Fix EX Dragon release date

### DIFF
--- a/sets/en.json
+++ b/sets/en.json
@@ -348,8 +348,8 @@
       "unlimited": "Legal"
     },
     "ptcgoCode": "DR",
-    "releaseDate": "2003/09/18",
-    "updatedAt": "2019/01/28 16:44:00",
+    "releaseDate": "2003/11/24",
+    "updatedAt": "2023/02/16 05:47:00",
     "images": {
       "symbol": "https://images.pokemontcg.io/ex3/symbol.png",
       "logo": "https://images.pokemontcg.io/ex3/logo.png"


### PR DESCRIPTION
EX Dragon set had the wrong release date. It was set to the same as the previous set (EX Sandstorm).

Reference: https://bulbapedia.bulbagarden.net/wiki/EX_Dragon_(TCG)
