### PR TITLE
Fixed nationalPokedexNumbers of Legend cards

### DIFF
--- a/cards/en/hgss2.json
+++ b/cards/en/hgss2.json
@@ -4937,7 +4937,8 @@
     "artist": "Shinji Higuchi + Sachiko Eba",
     "rarity": "LEGEND",
     "nationalPokedexNumbers": [
-      243
+      243,
+      244
     ],
     "legalities": {
       "unlimited": "Legal"
@@ -4999,7 +5000,8 @@
     "artist": "Shinji Higuchi + Sachiko Eba",
     "rarity": "LEGEND",
     "nationalPokedexNumbers": [
-      243
+      243,
+      244
     ],
     "legalities": {
       "unlimited": "Legal"
@@ -5067,7 +5069,8 @@
     "artist": "Shinji Higuchi + Noriko Takaya",
     "rarity": "LEGEND",
     "nationalPokedexNumbers": [
-      243
+      243,
+      245
     ],
     "legalities": {
       "unlimited": "Legal"
@@ -5135,7 +5138,8 @@
     "artist": "Shinji Higuchi + Noriko Takaya",
     "rarity": "LEGEND",
     "nationalPokedexNumbers": [
-      243
+      243,
+      245
     ],
     "legalities": {
       "unlimited": "Legal"
@@ -5204,7 +5208,8 @@
     "artist": "Shinji Higuchi + Sachiko Eba",
     "rarity": "LEGEND",
     "nationalPokedexNumbers": [
-      244
+      244,
+      245
     ],
     "legalities": {
       "unlimited": "Legal"
@@ -5273,7 +5278,8 @@
     "artist": "Shinji Higuchi + Sachiko Eba",
     "rarity": "LEGEND",
     "nationalPokedexNumbers": [
-      244
+      244,
+      245
     ],
     "legalities": {
       "unlimited": "Legal"

--- a/cards/en/hgss3.json
+++ b/cards/en/hgss3.json
@@ -4917,7 +4917,8 @@
     "artist": "Shinji Higuchi + Sachiko Eba",
     "rarity": "LEGEND",
     "nationalPokedexNumbers": [
-      382
+      382,
+      383
     ],
     "legalities": {
       "unlimited": "Legal"
@@ -4989,7 +4990,8 @@
     "artist": "Shinji Higuchi + Sachiko Eba",
     "rarity": "LEGEND",
     "nationalPokedexNumbers": [
-      382
+      382,
+      383
     ],
     "legalities": {
       "unlimited": "Legal"
@@ -5056,7 +5058,8 @@
     "artist": "Shinji Higuchi + Sachiko Eba",
     "rarity": "LEGEND",
     "nationalPokedexNumbers": [
-      384
+      384,
+      386
     ],
     "legalities": {
       "unlimited": "Legal"
@@ -5123,7 +5126,8 @@
     "artist": "Shinji Higuchi + Sachiko Eba",
     "rarity": "LEGEND",
     "nationalPokedexNumbers": [
-      384
+      384,
+      386
     ],
     "legalities": {
       "unlimited": "Legal"

--- a/cards/en/hgss4.json
+++ b/cards/en/hgss4.json
@@ -5778,7 +5778,8 @@
     "artist": "Shinji Higuchi + Noriko Takaya",
     "rarity": "LEGEND",
     "nationalPokedexNumbers": [
-      488
+      488,
+      491
     ],
     "legalities": {
       "unlimited": "Legal"
@@ -5846,7 +5847,8 @@
     "artist": "Shinji Higuchi + Noriko Takaya",
     "rarity": "LEGEND",
     "nationalPokedexNumbers": [
-      488
+      488,
+      491
     ],
     "legalities": {
       "unlimited": "Legal"
@@ -5916,7 +5918,8 @@
     "artist": "Shinji Higuchi + Sachiko Eba",
     "rarity": "LEGEND",
     "nationalPokedexNumbers": [
-      483
+      483,
+      484
     ],
     "legalities": {
       "unlimited": "Legal"
@@ -5986,7 +5989,8 @@
     "artist": "Shinji Higuchi + Sachiko Eba",
     "rarity": "LEGEND",
     "nationalPokedexNumbers": [
-      483
+      483,
+      484
     ],
     "legalities": {
       "unlimited": "Legal"


### PR DESCRIPTION
All legend cards with two Pokémon only had the lowest national Pokédex number.