### PR TITLE
Fixed attack text of xy3-112

### DIFF
--- a/cards/en/xy3.json
+++ b/cards/en/xy3.json
@@ -6199,7 +6199,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "180-",
-        "text": "This attack does 10 less damage for each damage counter on this Pokémon."
+        "text": "This attack does 180 damage minus 10 damage for each damage counter on this Pokémon."
       }
     ],
     "weaknesses": [


### PR DESCRIPTION
The attack said "This attack does 10 less damage for each damage counter on this Pokémon." instead of "This attack does 180 damage minus 10 damage for each damage counter on this Pokémon."