### PR TITLE
Added Poké Card Creator Pack

### DIFF
--- a/cards/en/pccp.json
+++ b/cards/en/pccp.json
@@ -1,0 +1,317 @@
+[
+  {
+    "id": "pccp-1",
+    "name": "Treecko",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Basic"
+    ],
+    "hp": "60",
+    "types": [
+      "Grass"
+    ],
+    "evolvesTo": [
+      "Grovyle"
+    ],
+    "rules": [
+      "NOT TOURNAMENT LEGAL"
+    ],
+    "attacks": [
+      {
+        "name": "Tackle",
+        "cost": [
+          "Colorless"
+        ],
+        "convertedEnergyCost": 1,
+        "damage": "10"
+      },
+      {
+        "name": "Poison Claws",
+        "cost": [
+          "Grass",
+          "Colorless",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 3,
+        "damage": "30",
+        "text": "The Defending Pokémon is now Poisoned."
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Fire",
+        "value": "×2"
+      }
+    ],
+    "resistances": [
+      {
+        "type": "Water",
+        "value": "-30"
+      }
+    ],
+    "retreatCost": [
+      "Colorless"
+    ],
+    "convertedRetreatCost": 1,
+    "number": "1",
+    "artist": "Mark Kraus",
+    "nationalPokedexNumbers": [
+      252
+    ],
+    "legalities": {
+      "unlimited": "Banned"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/pccp/1.png",
+      "large": "https://images.pokemontcg.io/pccp/1_hires.png"
+    }
+  },
+  {
+    "id": "pccp-2",
+    "name": "Wurmple",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Basic"
+    ],
+    "hp": "50",
+    "types": [
+      "Grass"
+    ],
+    "evolvesTo": [
+      "Silcoon",
+      "Cascoon"
+    ],
+    "rules": [
+      "NOT TOURNAMENT LEGAL"
+    ],
+    "attacks": [
+      {
+        "name": "Gooey Thread",
+        "cost": [
+          "Colorless"
+        ],
+        "convertedEnergyCost": 1,
+        "damage": "10",
+        "text": "The Defending Pokémon can't retreat until the end of your opponent's next turn."
+      },
+      {
+        "name": "Lunge",
+        "cost": [
+          "Grass",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 2,
+        "damage": "40",
+        "text": "Flip a coin. If tails, this attack does nothing."
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Fire",
+        "value": "×2"
+      }
+    ],
+    "retreatCost": [
+      "Colorless"
+    ],
+    "convertedRetreatCost": 1,
+    "number": "2",
+    "artist": "Katie Gross",
+    "nationalPokedexNumbers": [
+      265
+    ],
+    "legalities": {
+      "unlimited": "Banned"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/pccp/2.png",
+      "large": "https://images.pokemontcg.io/pccp/2_hires.png"
+    }
+  },
+  {
+    "id": "pccp-3",
+    "name": "Torchic",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Basic"
+    ],
+    "hp": "60",
+    "types": [
+      "Fire"
+    ],
+    "evolvesTo": [
+      "Combusken"
+    ],
+    "rules": [
+      "NOT TOURNAMENT LEGAL"
+    ],
+    "attacks": [
+      {
+        "name": "Super Singe",
+        "cost": [
+          "Fire"
+        ],
+        "convertedEnergyCost": 1,
+        "damage": "10",
+        "text": "The Defending Pokémon is now Burned."
+      },
+      {
+        "name": "Flamethrower",
+        "cost": [
+          "Fire",
+          "Colorless",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 3,
+        "damage": "40",
+        "text": "Discard a Fire Energy card attached to Torchic."
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Water",
+        "value": "×2"
+      }
+    ],
+    "retreatCost": [
+      "Colorless"
+    ],
+    "convertedRetreatCost": 1,
+    "number": "3",
+    "artist": "May Do",
+    "nationalPokedexNumbers": [
+      255
+    ],
+    "legalities": {
+      "unlimited": "Banned"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/pccp/3.png",
+      "large": "https://images.pokemontcg.io/pccp/3_hires.png"
+    }
+  },
+  {
+    "id": "pccp-4",
+    "name": "Mudkip",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Basic"
+    ],
+    "hp": "60",
+    "types": [
+      "Water"
+    ],
+    "evolvesTo": [
+      "Marshtomp"
+    ],
+    "rules": [
+      "NOT TOURNAMENT LEGAL"
+    ],
+    "attacks": [
+      {
+        "name": "Tail Rap",
+        "cost": [
+          "Colorless"
+        ],
+        "convertedEnergyCost": 1,
+        "damage": "10×",
+        "text": "Flip 2 coins. This attack does 10 damage times the number of heads."
+      },
+      {
+        "name": "Hypno Splash",
+        "cost": [
+          "Water",
+          "Colorless",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 3,
+        "damage": "40",
+        "text": "The defending Pokémon is now Asleep."
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Lightning",
+        "value": "×2"
+      }
+    ],
+    "retreatCost": [
+      "Colorless"
+    ],
+    "convertedRetreatCost": 1,
+    "number": "4",
+    "artist": "Rowan Laidlaw",
+    "nationalPokedexNumbers": [
+      258
+    ],
+    "legalities": {
+      "unlimited": "Banned"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/pccp/4.png",
+      "large": "https://images.pokemontcg.io/pccp/4_hires.png"
+    }
+  },
+  {
+    "id": "pccp-5",
+    "name": "Pikachu",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Basic"
+    ],
+    "hp": "60",
+    "types": [
+      "Lightning"
+    ],
+    "evolvesTo": [
+      "Raichu"
+    ],
+    "rules": [
+      "NOT TOURNAMENT LEGAL"
+    ],
+    "attacks": [
+      {
+        "name": "Thundershock",
+        "cost": [
+          "Colorless"
+        ],
+        "convertedEnergyCost": 1,
+        "damage": "10",
+        "text": "Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
+      },
+      {
+        "name": "Shock Bolt",
+        "cost": [
+          "Lightning",
+          "Lightning",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 3,
+        "damage": "60",
+        "text": "Discard all Lightning Energy cards attached to Pikachu or this attack does nothing."
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Fighting",
+        "value": "×2"
+      }
+    ],
+    "retreatCost": [
+      "Colorless"
+    ],
+    "convertedRetreatCost": 1,
+    "number": "5",
+    "artist": "Sylvia Forrest",
+    "nationalPokedexNumbers": [
+      25
+    ],
+    "legalities": {
+      "unlimited": "Banned"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/pccp/5.png",
+      "large": "https://images.pokemontcg.io/pccp/5_hires.png"
+    }
+  }
+]

--- a/sets/en.json
+++ b/sets/en.json
@@ -422,6 +422,22 @@
     }
   },
   {
+    "id": "pccp",
+    "name": "Poké Card Creator Pack",
+    "series": "Other",
+    "printedTotal": 5,
+    "total": 5,
+    "legalities": {
+      "unlimited": "Banned"
+    },
+    "releaseDate": "2004/07/01",
+    "updatedAt": "2023/02/28 00:00:00",
+    "images": {
+      "symbol": "https://images.pokemontcg.io/pccp/symbol.png",
+      "logo": "https://images.pokemontcg.io/pccp/logo.png"
+    }
+  },
+  {
     "id": "ex5",
     "name": "Hidden Legends",
     "series": "EX",


### PR DESCRIPTION
Basically, I noticed from Bulbapedia that [this set](https://bulbapedia.bulbagarden.net/wiki/Pok%C3%A9_Card_Creator_Pack_(TCG)) was missing. I did my best to try to add it. Here's a list of things I'm not sure I did right:

* I chose "pccp" as the id for this set
* I omitted the ptcgoCode
* I chose "Other" for the series, arguably one should choose "EX"
* I put "2004/07/01" as the release date. Bulbapedia only says the month of release, not the day.
* I put "2023/02/28 00:00:00" for updatedAt
* I put the rule "NOT TOURNAMENT LEGAL" on each card, since it is on the cards themselves and it's in all caps on the cards
* I put "unlimited": "Banned" for the legalities (both for the set and for the cards). See issue #247 

I hope the images can be found using the link to Bulbapedia I provided above, and that they're good enough.