### PR TITLE
Added missing levels from xy12 and xyp

### DIFF
--- a/cards/en/xy12.json
+++ b/cards/en/xy12.json
@@ -136,6 +136,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "13",
     "hp": "40",
     "types": [
       "Grass"
@@ -187,6 +188,7 @@
     "subtypes": [
       "Stage 1"
     ],
+    "level": "21",
     "hp": "70",
     "types": [
       "Grass"
@@ -251,6 +253,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "12",
     "hp": "40",
     "types": [
       "Grass"
@@ -302,6 +305,7 @@
     "subtypes": [
       "Stage 1"
     ],
+    "level": "23",
     "hp": "80",
     "types": [
       "Grass"
@@ -366,6 +370,7 @@
     "subtypes": [
       "Stage 2"
     ],
+    "level": "32",
     "hp": "120",
     "types": [
       "Grass"
@@ -422,6 +427,7 @@
       "Basic"
     ],
     "hp": "80",
+    "level": "8",
     "types": [
       "Grass"
     ],
@@ -485,6 +491,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "10",
     "hp": "60",
     "types": [
       "Fire"
@@ -546,6 +553,7 @@
     "subtypes": [
       "Stage 1"
     ],
+    "level": "32",
     "hp": "80",
     "types": [
       "Fire"
@@ -611,6 +619,7 @@
     "subtypes": [
       "Stage 2"
     ],
+    "level": "76",
     "hp": "150",
     "types": [
       "Fire"
@@ -804,6 +813,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "11",
     "hp": "60",
     "types": [
       "Fire"
@@ -856,6 +866,7 @@
     "subtypes": [
       "Stage 1"
     ],
+    "level": "32",
     "hp": "100",
     "types": [
       "Fire"
@@ -958,6 +969,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "18",
     "hp": "70",
     "types": [
       "Fire"
@@ -1020,6 +1032,7 @@
     "subtypes": [
       "Stage 1"
     ],
+    "level": "45",
     "hp": "130",
     "types": [
       "Fire"
@@ -1080,6 +1093,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "10",
     "hp": "60",
     "types": [
       "Fire"
@@ -1142,6 +1156,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "24",
     "hp": "80",
     "types": [
       "Fire"
@@ -1331,6 +1346,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "13",
     "hp": "60",
     "types": [
       "Water"
@@ -1383,6 +1399,7 @@
     "subtypes": [
       "Stage 1"
     ],
+    "level": "28",
     "hp": "80",
     "types": [
       "Water"
@@ -1448,6 +1465,7 @@
     "subtypes": [
       "Stage 2"
     ],
+    "level": "48",
     "hp": "140",
     "types": [
       "Water"
@@ -1634,6 +1652,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "12",
     "hp": "80",
     "types": [
       "Water"
@@ -1696,6 +1715,7 @@
     "subtypes": [
       "Stage 1"
     ],
+    "level": "42",
     "hp": "120",
     "types": [
       "Water"
@@ -1758,6 +1778,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "15",
     "hp": "60",
     "types": [
       "Water"
@@ -1809,6 +1830,7 @@
     "subtypes": [
       "Stage 1"
     ],
+    "level": "28",
     "hp": "90",
     "types": [
       "Water"
@@ -1907,6 +1929,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "8",
     "hp": "30",
     "types": [
       "Water"
@@ -1958,6 +1981,7 @@
     "subtypes": [
       "Stage 1"
     ],
+    "level": "41",
     "hp": "130",
     "types": [
       "Water"
@@ -2023,6 +2047,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "12",
     "hp": "60",
     "types": [
       "Lightning"
@@ -2090,6 +2115,7 @@
     "subtypes": [
       "Stage 1"
     ],
+    "level": "40",
     "hp": "100",
     "types": [
       "Lightning"
@@ -2156,6 +2182,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "13",
     "hp": "50",
     "types": [
       "Lightning"
@@ -2223,6 +2250,7 @@
     "subtypes": [
       "Stage 1"
     ],
+    "level": "30",
     "hp": "80",
     "types": [
       "Lightning"
@@ -2293,6 +2321,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "10",
     "hp": "60",
     "types": [
       "Lightning"
@@ -2350,6 +2379,7 @@
     "subtypes": [
       "Stage 1"
     ],
+    "level": "40",
     "hp": "80",
     "types": [
       "Lightning"
@@ -2414,6 +2444,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "35",
     "hp": "70",
     "types": [
       "Lightning"
@@ -2482,6 +2513,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "64",
     "hp": "110",
     "types": [
       "Lightning"
@@ -2546,6 +2578,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "20",
     "hp": "60",
     "types": [
       "Psychic"
@@ -2597,6 +2630,7 @@
     "subtypes": [
       "Stage 1"
     ],
+    "level": "25",
     "hp": "90",
     "types": [
       "Psychic"
@@ -2661,6 +2695,7 @@
     "subtypes": [
       "Stage 2"
     ],
+    "level": "48",
     "hp": "150",
     "types": [
       "Psychic"
@@ -2767,6 +2802,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "8",
     "hp": "40",
     "types": [
       "Psychic"
@@ -2834,6 +2870,7 @@
     "subtypes": [
       "Stage 1"
     ],
+    "level": "22",
     "hp": "70",
     "types": [
       "Psychic"
@@ -2902,6 +2939,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "12",
     "hp": "60",
     "types": [
       "Psychic"
@@ -2963,6 +3001,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "13",
     "hp": "60",
     "types": [
       "Psychic"
@@ -3015,6 +3054,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "53",
     "hp": "130",
     "types": [
       "Psychic"
@@ -3151,6 +3191,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "8",
     "hp": "40",
     "types": [
       "Psychic"
@@ -3207,6 +3248,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "12",
     "hp": "60",
     "types": [
       "Fighting"
@@ -3258,6 +3300,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "8",
     "hp": "40",
     "types": [
       "Fighting"
@@ -3317,6 +3360,7 @@
     "subtypes": [
       "Stage 1"
     ],
+    "level": "36",
     "hp": "90",
     "types": [
       "Fighting"
@@ -3378,6 +3422,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "20",
     "hp": "70",
     "types": [
       "Fighting"
@@ -3431,6 +3476,7 @@
     "subtypes": [
       "Stage 1"
     ],
+    "level": "40",
     "hp": "90",
     "types": [
       "Fighting"
@@ -3496,6 +3542,7 @@
     "subtypes": [
       "Stage 2"
     ],
+    "level": "67",
     "hp": "160",
     "types": [
       "Fighting"
@@ -3598,6 +3645,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "12",
     "hp": "100",
     "types": [
       "Fighting"
@@ -3661,6 +3709,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "33",
     "hp": "90",
     "types": [
       "Fighting"
@@ -3721,6 +3770,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "14",
     "hp": "40",
     "types": [
       "Fairy"
@@ -3917,6 +3967,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "9",
     "hp": "40",
     "types": [
       "Colorless"
@@ -3975,6 +4026,7 @@
     "subtypes": [
       "Stage 1"
     ],
+    "level": "41",
     "hp": "60",
     "types": [
       "Colorless"
@@ -4033,6 +4085,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "20",
     "hp": "70",
     "types": [
       "Colorless"
@@ -4101,6 +4154,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "10",
     "hp": "60",
     "types": [
       "Colorless"
@@ -4158,6 +4212,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "55",
     "hp": "120",
     "types": [
       "Colorless"
@@ -4224,6 +4279,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "12",
     "hp": "60",
     "types": [
       "Colorless"
@@ -5479,6 +5535,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "12",
     "hp": "40",
     "types": [
       "Lightning"
@@ -5541,6 +5598,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "13",
     "hp": "50",
     "types": [
       "Lightning"
@@ -5593,6 +5651,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "15",
     "hp": "50",
     "types": [
       "Colorless"

--- a/cards/en/xyp.json
+++ b/cards/en/xyp.json
@@ -11006,6 +11006,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "20",
     "hp": "130",
     "types": [
       "Colorless"
@@ -12388,6 +12389,7 @@
     "subtypes": [
       "Basic"
     ],
+    "level": "13",
     "hp": "50",
     "types": [
       "Lightning"


### PR DESCRIPTION
Most Pokémon from xy12 and two from xyp have a level printed on the card, but they were missing it in the database.