### PR TITLE
Fixed damage of Greninja V-Union's Twister Shuriken

### DIFF
--- a/cards/en/swshp.json
+++ b/cards/en/swshp.json
@@ -9764,7 +9764,7 @@
           "Colorless"
         ],
         "convertedEnergyCost": 3,
-        "damage": "130",
+        "damage": "",
         "text": "This attack does 100 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
@@ -9866,7 +9866,7 @@
           "Colorless"
         ],
         "convertedEnergyCost": 3,
-        "damage": "130",
+        "damage": "",
         "text": "This attack does 100 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
@@ -9968,7 +9968,7 @@
           "Colorless"
         ],
         "convertedEnergyCost": 3,
-        "damage": "130",
+        "damage": "",
         "text": "This attack does 100 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
@@ -10070,7 +10070,7 @@
           "Colorless"
         ],
         "convertedEnergyCost": 3,
-        "damage": "130",
+        "damage": "",
         "text": "This attack does 100 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       },
       {


### PR DESCRIPTION
The damage was incorrectly set to "130" instead of ""