### PR TITLE
Fixed numbers in bwp

### DIFF
--- a/cards/en/bwp.json
+++ b/cards/en/bwp.json
@@ -163,7 +163,7 @@
     }
   },
   {
-    "id": "bwp-BW004",
+    "id": "bwp-BW04",
     "name": "Reshiram",
     "supertype": "Pokémon",
     "subtypes": [
@@ -207,7 +207,7 @@
       "Colorless"
     ],
     "convertedRetreatCost": 2,
-    "number": "BW004",
+    "number": "BW04",
     "artist": "5ban Graphics",
     "rarity": "Promo",
     "flavorText": "This Pokémon appears in legends. It sends flames into the air from its tail, burning up everything around it.",
@@ -219,12 +219,12 @@
       "expanded": "Legal"
     },
     "images": {
-      "small": "https://images.pokemontcg.io/bwp/BW004.png",
-      "large": "https://images.pokemontcg.io/bwp/BW004_hires.png"
+      "small": "https://images.pokemontcg.io/bwp/BW04.png",
+      "large": "https://images.pokemontcg.io/bwp/BW04_hires.png"
     }
   },
   {
-    "id": "bwp-BW005",
+    "id": "bwp-BW05",
     "name": "Zekrom",
     "supertype": "Pokémon",
     "subtypes": [
@@ -268,7 +268,7 @@
       "Colorless"
     ],
     "convertedRetreatCost": 2,
-    "number": "BW005",
+    "number": "BW05",
     "artist": "5ban Graphics",
     "rarity": "Promo",
     "flavorText": "This Pokémon appears in legends. In its tail, it has a giant generator that creates electricity.",
@@ -280,8 +280,8 @@
       "expanded": "Legal"
     },
     "images": {
-      "small": "https://images.pokemontcg.io/bwp/BW005.png",
-      "large": "https://images.pokemontcg.io/bwp/BW005_hires.png"
+      "small": "https://images.pokemontcg.io/bwp/BW05.png",
+      "large": "https://images.pokemontcg.io/bwp/BW05_hires.png"
     }
   },
   {

--- a/cards/en/bwp.json
+++ b/cards/en/bwp.json
@@ -163,7 +163,7 @@
     }
   },
   {
-    "id": "bwp-BW04",
+    "id": "bwp-BW004",
     "name": "Reshiram",
     "supertype": "Pokémon",
     "subtypes": [
@@ -219,12 +219,12 @@
       "expanded": "Legal"
     },
     "images": {
-      "small": "https://images.pokemontcg.io/bwp/BW04.png",
-      "large": "https://images.pokemontcg.io/bwp/BW04_hires.png"
+      "small": "https://images.pokemontcg.io/bwp/BW004.png",
+      "large": "https://images.pokemontcg.io/bwp/BW004_hires.png"
     }
   },
   {
-    "id": "bwp-BW05",
+    "id": "bwp-BW005",
     "name": "Zekrom",
     "supertype": "Pokémon",
     "subtypes": [
@@ -280,8 +280,8 @@
       "expanded": "Legal"
     },
     "images": {
-      "small": "https://images.pokemontcg.io/bwp/BW05.png",
-      "large": "https://images.pokemontcg.io/bwp/BW05_hires.png"
+      "small": "https://images.pokemontcg.io/bwp/BW005.png",
+      "large": "https://images.pokemontcg.io/bwp/BW005_hires.png"
     }
   },
   {


### PR DESCRIPTION
As it was pointed out in #386, there are two cards in bwp with wrong numbers. Namely, Reshiram has BW004 instead of BW04, and Zekrom has BW005 instead of BW05. This PR fixes this.

~~It should be noted that I did not only change the numbers, but also the ids and the images. If there are problems with changing those as well, I'm happy to revert some of my changes and just fix the numbers.~~ EDIT: I reverted these changes