### PR TITLE
Fixed numbers of tk2a-11 and tk2b-11

### DIFF
--- a/cards/en/tk2a.json
+++ b/cards/en/tk2a.json
@@ -471,7 +471,7 @@
     "subtypes": [
       "Basic"
     ],
-    "number": "10",
+    "number": "11",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",

--- a/cards/en/tk2b.json
+++ b/cards/en/tk2b.json
@@ -487,7 +487,7 @@
     "subtypes": [
       "Basic"
     ],
-    "number": "10",
+    "number": "11",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",


### PR DESCRIPTION
As it was pointed out in #386, both of those cards had the number set to 10 instead of 11.