### PR TITLE
Celebrations Main Rarity Fixes

### DIFF
--- a/cards/en/cel25.json
+++ b/cards/en/cel25.json
@@ -370,7 +370,7 @@
     ],
     "number": "6",
     "artist": "aky CG Works",
-    "rarity": "V",
+    "rarity": "Rare Holo V",
     "nationalPokedexNumbers": [
       25
     ],
@@ -430,7 +430,7 @@
     ],
     "number": "7",
     "artist": "aky CG Works",
-    "rarity": "VM",
+    "rarity": "Rare Holo VMAX",
     "nationalPokedexNumbers": [
       25
     ],
@@ -488,7 +488,7 @@
     "convertedRetreatCost": 1,
     "number": "8",
     "artist": "aky CG Works",
-    "rarity": "V",
+    "rarity": "Rare Holo V",
     "nationalPokedexNumbers": [
       25
     ],
@@ -546,7 +546,7 @@
     "convertedRetreatCost": 1,
     "number": "9",
     "artist": "aky CG Works",
-    "rarity": "VM",
+    "rarity": "Rare Holo VMAX",
     "nationalPokedexNumbers": [
       25
     ],
@@ -986,7 +986,7 @@
     "convertedRetreatCost": 2,
     "number": "16",
     "artist": "Mitsuhiro Arita",
-    "rarity": "V",
+    "rarity": "Rare Holo V",
     "nationalPokedexNumbers": [
       888
     ],
@@ -1114,7 +1114,7 @@
     "convertedRetreatCost": 2,
     "number": "18",
     "artist": "Mitsuhiro Arita",
-    "rarity": "V",
+    "rarity": "Rare Holo V",
     "nationalPokedexNumbers": [
       889
     ],


### PR DESCRIPTION
V has become Rare Holo V, and VM has become Rare Holo VMAX for consistency. A total of 6 cards from celebrations main set were affected.