### PR TITLE
Brilliant Stars Trainer Gallery Rarity Fixes

### DIFF
--- a/cards/en/swsh9tg.json
+++ b/cards/en/swsh9tg.json
@@ -44,7 +44,7 @@
     "convertedRetreatCost": 2,
     "number": "TG01",
     "artist": "You Iribi",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "Once it has stored up enough heat, this Pokémon's body temperature can reach up to 1,700 degrees Fahrenheit.",
     "nationalPokedexNumbers": [
       136
@@ -104,7 +104,7 @@
     "convertedRetreatCost": 2,
     "number": "TG02",
     "artist": "Jiro Sasumo",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "When Vaporeon's fins begin to vibrate, it is a sign that rain will come within a few hours.",
     "nationalPokedexNumbers": [
       134
@@ -166,7 +166,7 @@
     "convertedRetreatCost": 2,
     "number": "TG03",
     "artist": "Shinya Komatsu",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "It traps enemies with its suction-cupped tentacles, then smashes them with its rock-hard head.",
     "nationalPokedexNumbers": [
       224
@@ -226,7 +226,7 @@
     "convertedRetreatCost": 1,
     "number": "TG04",
     "artist": "DOM",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "If it is angered or startled, the fur all over its body bristles like sharp needles that pierce foes.",
     "nationalPokedexNumbers": [
       135
@@ -290,7 +290,7 @@
     "convertedRetreatCost": 3,
     "number": "TG05",
     "artist": "AKIRA EGAWA",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "When the interior part of its tail spins like a motor, Zekrom can generate many bolts of lightning to blast its surroundings.",
     "nationalPokedexNumbers": [
       644
@@ -357,7 +357,7 @@
     "convertedRetreatCost": 2,
     "number": "TG06",
     "artist": "Megumi Higuchi",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "At the bidding of transmissions from the spirit world, it steals people and Pokémon away. No one knows whether it has a will of its own.",
     "nationalPokedexNumbers": [
       477
@@ -407,7 +407,7 @@
     "convertedRetreatCost": 1,
     "number": "TG07",
     "artist": "kurumitsu",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "Since Dedenne can't generate as much electricity on its own, it steals electricity from outlets or other electric Pokémon.",
     "nationalPokedexNumbers": [
       702
@@ -466,7 +466,7 @@
     "convertedRetreatCost": 1,
     "number": "TG08",
     "artist": "OKACHEKE",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "When Alcremie is content, the cream it secretes from its hands becomes sweeter and richer.",
     "nationalPokedexNumbers": [
       869
@@ -526,7 +526,7 @@
     "convertedRetreatCost": 2,
     "number": "TG09",
     "artist": "Shiburingaru",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "It spews threads from its mouth to catch its prey. When night falls, it leaves its web to go hunt aggressively.",
     "nationalPokedexNumbers": [
       168
@@ -587,7 +587,7 @@
     "convertedRetreatCost": 2,
     "number": "TG10",
     "artist": "NC Empire",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "Identifiable by its eerie howls, people a long time ago thought it was the grim reaper and feared it.",
     "nationalPokedexNumbers": [
       229
@@ -657,7 +657,7 @@
     "convertedRetreatCost": 1,
     "number": "TG11",
     "artist": "Souichirou Gunjima",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "Thanks to its unstable genetic makeup, this special Pokémon conceals many different possible evolutions.",
     "nationalPokedexNumbers": [
       133
@@ -717,7 +717,7 @@
     "convertedRetreatCost": 2,
     "number": "TG12",
     "artist": "Akira Komayama",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "It knows the forest inside and out. If it comes across a wounded Pokémon, Oranguru will gather medicinal herbs to treat it.",
     "nationalPokedexNumbers": [
       765
@@ -910,7 +910,7 @@
     "convertedRetreatCost": 2,
     "number": "TG15",
     "artist": "sui",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Holo VMAX",
     "nationalPokedexNumbers": [
       700
     ],
@@ -1047,7 +1047,7 @@
     "convertedRetreatCost": 1,
     "number": "TG17",
     "artist": "Naoki Saito",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Holo VMAX",
     "nationalPokedexNumbers": [
       778
     ],
@@ -1183,7 +1183,7 @@
     "convertedRetreatCost": 3,
     "number": "TG19",
     "artist": "kodama",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Holo VMAX",
     "nationalPokedexNumbers": [
       892
     ],
@@ -1315,7 +1315,7 @@
     "convertedRetreatCost": 2,
     "number": "TG21",
     "artist": "Scav",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Holo VMAX",
     "nationalPokedexNumbers": [
       892
     ],
@@ -1445,7 +1445,7 @@
     "convertedRetreatCost": 2,
     "number": "TG23",
     "artist": "kawayoo",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Holo VMAX",
     "nationalPokedexNumbers": [
       197
     ],


### PR DESCRIPTION
Brought consistency to the rarities of this trainer gallery. All Rare Holo cards have been changed to Trainer Gallery Rare Holo. All Rare Holo V have been changed to Rare Holo VMAX where the card is of a VMAX Variety.