### PR TITLE
Astral Radiance Trainer Gallery Rarity Fixes

### DIFF
--- a/cards/en/swsh10tg.json
+++ b/cards/en/swsh10tg.json
@@ -46,7 +46,7 @@
     "convertedRetreatCost": 3,
     "number": "TG01",
     "artist": "Mitsuhiro Arita",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "The Pokémon is known to bring blizzards. A shake of its massive body is enough to cause whiteout conditions.",
     "nationalPokedexNumbers": [
       460
@@ -105,7 +105,7 @@
     "convertedRetreatCost": 1,
     "number": "TG02",
     "artist": "Misaki Hashimoto",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "It ate a sour apple, and that induced its evolution. In its cheeks, it stores an acid capable of causing chemical burns.",
     "nationalPokedexNumbers": [
       841
@@ -163,7 +163,7 @@
     "convertedRetreatCost": 1,
     "number": "TG03",
     "artist": "Taira Akitsu",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "It stores energy by sleeping at underwater depths at which no other life forms can survive.",
     "nationalPokedexNumbers": [
       230
@@ -223,7 +223,7 @@
     "convertedRetreatCost": 2,
     "number": "TG04",
     "artist": "aoki",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "It shows no mercy to any who desecrate fields and mountains. It will fly around on its icy wings, causing a blizzard to chase offenders away.",
     "nationalPokedexNumbers": [
       873
@@ -284,7 +284,7 @@
     "convertedRetreatCost": 2,
     "number": "TG05",
     "artist": "Sanosuke Sakuma",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "To protect its Trainer, it will expend all its psychic power to create a small black hole.",
     "nationalPokedexNumbers": [
       282
@@ -350,7 +350,7 @@
     "convertedRetreatCost": 2,
     "number": "TG06",
     "artist": "kirisAki",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "The black orbs shine with an uncanny light when the Pokémon is erecting invisible barriers. The fur shed from its beard retains heat well and is a highly useful material for winter clothing.",
     "nationalPokedexNumbers": [
       899
@@ -403,7 +403,7 @@
     "convertedRetreatCost": 2,
     "number": "TG07",
     "artist": "Kinu Nishimura",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "The six of them work together as one Pokémon. Teamwork is also their battle strategy, and they constantly change their formation as they fight.",
     "nationalPokedexNumbers": [
       870
@@ -466,7 +466,7 @@
     "convertedRetreatCost": 2,
     "number": "TG08",
     "artist": "Souichirou Gunjima",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "A violent creature that fells towering trees with its crude axes and shields itself with hard stone. If one should chance upon this Pokémon in the wilds, one's only recourse is to flee.",
     "nationalPokedexNumbers": [
       900
@@ -527,7 +527,7 @@
     "convertedRetreatCost": 2,
     "number": "TG09",
     "artist": "GOSSAN",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "It chases down prey in a pack of around ten. They defeat foes with perfectly coordinated teamwork.",
     "nationalPokedexNumbers": [
       262
@@ -587,7 +587,7 @@
     "convertedRetreatCost": 2,
     "number": "TG10",
     "artist": "GOSSAN",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "It evolved after experiencing numerous fights. While crossing its arms, it lets out a shout that would make any opponent flinch.",
     "nationalPokedexNumbers": [
       862
@@ -655,7 +655,7 @@
     "convertedRetreatCost": 3,
     "number": "TG11",
     "artist": "Hataya",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "Many scientists suspect that this Pokémon originated outside the Galar region, based on the patterns on its body.",
     "nationalPokedexNumbers": [
       437
@@ -722,7 +722,7 @@
     "convertedRetreatCost": 1,
     "number": "TG12",
     "artist": "HYOGONOSUKE",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "It always stands on one foot. It changes feet so fast, the movement can rarely be seen.",
     "nationalPokedexNumbers": [
       163
@@ -913,7 +913,7 @@
     "convertedRetreatCost": 2,
     "number": "TG15",
     "artist": "Hitoshi Ariga",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Holo VMAX",
     "nationalPokedexNumbers": [
       898
     ],
@@ -1122,7 +1122,7 @@
     "convertedRetreatCost": 2,
     "number": "TG18",
     "artist": "chibi",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Holo VMAX",
     "nationalPokedexNumbers": [
       898
     ],


### PR DESCRIPTION
Brought consistency to the rarities of this trainer gallery. All Rare Holo cards have been changed to Trainer Gallery Rare Holo. All Rare Holo V have been changed to Rare Holo VMAX where the card is of a VMAX Variety.