### PR TITLE
Lost Origin Trainer Gallery Rarity Fixes

### DIFF
--- a/cards/en/swsh11tg.json
+++ b/cards/en/swsh11tg.json
@@ -43,7 +43,7 @@
     "convertedRetreatCost": 2,
     "number": "TG01",
     "artist": "Oswaldo KATO",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "Mushroom-lacking specimens of this Pokémon lie unmoving in the forest, lending credence to the hypothesis that the large mushroom is in control of Parasect's actions.",
     "nationalPokedexNumbers": [
       47
@@ -104,7 +104,7 @@
     "convertedRetreatCost": 1,
     "number": "TG02",
     "artist": "saino misaki",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "After captivating opponents with its sweet scent, it lashes them with its thorny whips.",
     "nationalPokedexNumbers": [
       407
@@ -165,7 +165,7 @@
     "convertedRetreatCost": 3,
     "number": "TG03",
     "artist": "GIDORA",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "It spits fire that is hot enough to melt boulders. It may cause forest fires by blowing flames.",
     "nationalPokedexNumbers": [
       6
@@ -225,7 +225,7 @@
     "convertedRetreatCost": 2,
     "number": "TG04",
     "artist": "chibi",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "This Pokémon haunts dilapidated mansions. It sways its arms to hypnotize opponents with the ominous dancing of its flames.",
     "nationalPokedexNumbers": [
       609
@@ -287,7 +287,7 @@
     "convertedRetreatCost": 1,
     "number": "TG05",
     "artist": "Atsushi Furusawa",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "Possesses cheek sacs in which it stores electricity. This clever forest-dweller roasts tough berries with an electric shock before consuming them.",
     "nationalPokedexNumbers": [
       25
@@ -352,7 +352,7 @@
     "convertedRetreatCost": 2,
     "number": "TG06",
     "artist": "Akira Komayama",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "Possesses potential victims' shadows in an effort to steal away the victims' lives. If your shadow begins to laugh, you must take hold of a protective charm posthaste!",
     "nationalPokedexNumbers": [
       94
@@ -420,7 +420,7 @@
     "convertedRetreatCost": 1,
     "number": "TG07",
     "artist": "Tomomi Kaneko",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "Resentment at being cast off made it spring into being. Some say that treating it well will satisfy it, and it will once more become a stuffed toy.",
     "nationalPokedexNumbers": [
       354
@@ -483,7 +483,7 @@
     "convertedRetreatCost": 2,
     "number": "TG08",
     "artist": "You Iribi",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "Snaps at its foes with fangs cloaked in blazing flame. Despite its bulk, it deftly feints every which way, leading opponents on a deceptively merry chase as it all but dances around them.",
     "nationalPokedexNumbers": [
       59
@@ -542,7 +542,7 @@
     "convertedRetreatCost": 2,
     "number": "TG09",
     "artist": "Hitoshi Ariga",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "It lays curses by thinking wicked thoughts. Writings tell that this Pokémon was born out of the assembly of five score and eight malevolent spirits.",
     "nationalPokedexNumbers": [
       442
@@ -604,7 +604,7 @@
     "convertedRetreatCost": 4,
     "number": "TG10",
     "artist": "Kouki Saitou",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "This glutton appears in villages without warning and devours the entirety of their rice granaries—such occurrences have long been counted among the gravest of disasters.",
     "nationalPokedexNumbers": [
       143
@@ -659,7 +659,7 @@
     ],
     "number": "TG11",
     "artist": "Atsushi Furusawa",
-    "rarity": "Rare Holo",
+    "rarity": "Trainer Gallery Rare Holo",
     "flavorText": "Its form changes depending on the weather. The rougher conditions get, the rougher Castform's disposition!",
     "nationalPokedexNumbers": [
       351
@@ -784,7 +784,7 @@
     "convertedRetreatCost": 1,
     "number": "TG13",
     "artist": "Teeziro",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Holo VMAX",
     "nationalPokedexNumbers": [
       826
     ],
@@ -907,7 +907,7 @@
     "convertedRetreatCost": 3,
     "number": "TG15",
     "artist": "Oswaldo KATO",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Holo VMAX",
     "nationalPokedexNumbers": [
       851
     ],
@@ -1033,7 +1033,7 @@
     "convertedRetreatCost": 2,
     "number": "TG17",
     "artist": "Souichirou Gunjima",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Holo VMAX",
     "nationalPokedexNumbers": [
       25
     ],
@@ -1353,7 +1353,7 @@
     "convertedRetreatCost": 3,
     "number": "TG22",
     "artist": "Mitsuhiro Arita",
-    "rarity": "Rare Holo V",
+    "rarity": "Rare Holo VMAX",
     "nationalPokedexNumbers": [
       890
     ],


### PR DESCRIPTION
Brought consistency to the rarities of this trainer gallery. All Rare Holo cards have been changed to Trainer Gallery Rare Holo. All Rare Holo V have been changed to Rare Holo VMAX where the card is of a VMAX Variety.