### PR TITLE
Silver Tempest Trainer Gallery Rarity Fixes

### DIFF
--- a/cards/en/swsh12tg.json
+++ b/cards/en/swsh12tg.json
@@ -720,7 +720,7 @@
     "convertedRetreatCost": 1,
     "number": "TG12",
     "artist": "HYOGONOSUKE",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo V",
     "nationalPokedexNumbers": [
       402
     ],
@@ -784,7 +784,7 @@
     "convertedRetreatCost": 1,
     "number": "TG13",
     "artist": "Teeziro",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo V",
     "nationalPokedexNumbers": [
       497
     ],
@@ -852,7 +852,7 @@
     "convertedRetreatCost": 2,
     "number": "TG14",
     "artist": "nagimiso",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo V",
     "nationalPokedexNumbers": [
       257
     ],
@@ -917,7 +917,7 @@
     "convertedRetreatCost": 2,
     "number": "TG15",
     "artist": "KIYOTAKA OSHIYAMA",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo VMAX",
     "nationalPokedexNumbers": [
       257
     ],
@@ -974,7 +974,7 @@
     "convertedRetreatCost": 2,
     "number": "TG16",
     "artist": "yuu",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo V",
     "nationalPokedexNumbers": [
       807
     ],
@@ -1038,7 +1038,7 @@
     "convertedRetreatCost": 1,
     "number": "TG17",
     "artist": "saino misaki",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo V",
     "nationalPokedexNumbers": [
       303
     ],
@@ -1108,7 +1108,7 @@
     "convertedRetreatCost": 1,
     "number": "TG18",
     "artist": "KIYOTAKA OSHIYAMA",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo V",
     "nationalPokedexNumbers": [
       823
     ],
@@ -1172,7 +1172,7 @@
     ],
     "number": "TG19",
     "artist": "Shigenori Negishi",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo VMAX",
     "nationalPokedexNumbers": [
       823
     ],
@@ -1229,7 +1229,7 @@
     "convertedRetreatCost": 2,
     "number": "TG20",
     "artist": "Hideki Ishikawa",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo VMAX",
     "nationalPokedexNumbers": [
       384
     ],
@@ -1288,7 +1288,7 @@
     "convertedRetreatCost": 3,
     "number": "TG21",
     "artist": "AKIRA EGAWA",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo VMAX",
     "nationalPokedexNumbers": [
       884
     ],
@@ -1351,7 +1351,7 @@
     "convertedRetreatCost": 4,
     "number": "TG22",
     "artist": "You Iribi",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo V",
     "nationalPokedexNumbers": [
       242
     ],
@@ -1379,7 +1379,7 @@
     ],
     "number": "TG23",
     "artist": "Sanosuke Sakuma",
-    "rarity": "Trainer Gallery Rare Ultra",
+    "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -1404,7 +1404,7 @@
     ],
     "number": "TG24",
     "artist": "Ryuta Fuse",
-    "rarity": "Trainer Gallery Rare Ultra",
+    "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -1429,7 +1429,7 @@
     ],
     "number": "TG25",
     "artist": "Ryuta Fuse",
-    "rarity": "Trainer Gallery Rare Ultra",
+    "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -1454,7 +1454,7 @@
     ],
     "number": "TG26",
     "artist": "kirisAki",
-    "rarity": "Trainer Gallery Rare Ultra",
+    "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -1479,7 +1479,7 @@
     ],
     "number": "TG27",
     "artist": "take",
-    "rarity": "Trainer Gallery Rare Ultra",
+    "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -1504,7 +1504,7 @@
     ],
     "number": "TG28",
     "artist": "nagimiso",
-    "rarity": "Trainer Gallery Rare Ultra",
+    "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -1558,7 +1558,7 @@
     "convertedRetreatCost": 2,
     "number": "TG29",
     "artist": "PLANETA Mochizuki",
-    "rarity": "Trainer Gallery Rare Secret",
+    "rarity": "Rare Secret",
     "nationalPokedexNumbers": [
       384
     ],
@@ -1617,7 +1617,7 @@
     "convertedRetreatCost": 3,
     "number": "TG30",
     "artist": "PLANETA Mochizuki",
-    "rarity": "Trainer Gallery Rare Secret",
+    "rarity": "Rare Secret",
     "nationalPokedexNumbers": [
       884
     ],


### PR DESCRIPTION
Brought consistency to the rarities of this trainer gallery. All Trainer Gallery Rare Holo V have been changed to Rare Holo V. All Rare Holo V have been changed to Rare Holo VMAX where the card is of a VMAX Variety. All Trainer Gallery Rare Ultra have been changed to Rare Ultra. All Trainer Gallery Rare Secret have been changed to Rare Secret.