### PR TITLE
Crown Zenith Gallarian Gallery Rarity Fixes

### DIFF
--- a/cards/en/swsh12pt5gg.json
+++ b/cards/en/swsh12pt5gg.json
@@ -2062,7 +2062,7 @@
     "convertedRetreatCost": 2,
     "number": "GG35",
     "artist": "Jiro Sasumo",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo VSTAR",
     "nationalPokedexNumbers": [
       470
     ],
@@ -2125,7 +2125,7 @@
     "convertedRetreatCost": 3,
     "number": "GG36",
     "artist": "Shigenori Negishi",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo V",
     "nationalPokedexNumbers": [
       244
     ],
@@ -2190,7 +2190,7 @@
     "convertedRetreatCost": 2,
     "number": "GG37",
     "artist": "nagano",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo VSTAR",
     "nationalPokedexNumbers": [
       514
     ],
@@ -2252,7 +2252,7 @@
     "convertedRetreatCost": 2,
     "number": "GG38",
     "artist": "Atsushi Furusawa",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo V",
     "nationalPokedexNumbers": [
       245
     ],
@@ -2314,7 +2314,7 @@
     "convertedRetreatCost": 1,
     "number": "GG39",
     "artist": "Jerky",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo V",
     "nationalPokedexNumbers": [
       457
     ],
@@ -2381,7 +2381,7 @@
     "convertedRetreatCost": 2,
     "number": "GG40",
     "artist": "Gemi",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo VSTAR",
     "nationalPokedexNumbers": [
       471
     ],
@@ -2442,7 +2442,7 @@
     "convertedRetreatCost": 1,
     "number": "GG41",
     "artist": "nagimiso",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo V",
     "nationalPokedexNumbers": [
       243
     ],
@@ -2508,7 +2508,7 @@
     "convertedRetreatCost": 2,
     "number": "GG42",
     "artist": "aoki",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo VMAX",
     "nationalPokedexNumbers": [
       807
     ],
@@ -2571,7 +2571,7 @@
     ],
     "number": "GG43",
     "artist": "Ligton",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo VSTAR",
     "nationalPokedexNumbers": [
       807
     ],
@@ -2642,7 +2642,7 @@
     "convertedRetreatCost": 2,
     "number": "GG44",
     "artist": "GOSSAN",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo VSTAR",
     "nationalPokedexNumbers": [
       150
     ],
@@ -2712,7 +2712,7 @@
     "convertedRetreatCost": 3,
     "number": "GG45",
     "artist": "Akira Komayama",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo VMAX",
     "nationalPokedexNumbers": [
       386
     ],
@@ -2783,7 +2783,7 @@
     "convertedRetreatCost": 2,
     "number": "GG46",
     "artist": "DOM",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo VSTAR",
     "nationalPokedexNumbers": [
       386
     ],
@@ -2852,7 +2852,7 @@
     "convertedRetreatCost": 2,
     "number": "GG47",
     "artist": "sui",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo VMAX",
     "nationalPokedexNumbers": [
       858
     ],
@@ -2915,7 +2915,7 @@
     "convertedRetreatCost": 2,
     "number": "GG48",
     "artist": "Hataya",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo V",
     "nationalPokedexNumbers": [
       888
     ],
@@ -2979,7 +2979,7 @@
     "convertedRetreatCost": 2,
     "number": "GG49",
     "artist": "Yuka Morii",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo V",
     "nationalPokedexNumbers": [
       452
     ],
@@ -3041,7 +3041,7 @@
     "convertedRetreatCost": 2,
     "number": "GG50",
     "artist": "Pani Kobayashi",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo VSTAR",
     "nationalPokedexNumbers": [
       491
     ],
@@ -3106,7 +3106,7 @@
     "convertedRetreatCost": 2,
     "number": "GG51",
     "artist": "kodama",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo V",
     "nationalPokedexNumbers": [
       503
     ],
@@ -3168,7 +3168,7 @@
     "convertedRetreatCost": 2,
     "number": "GG52",
     "artist": "Shibuzoh.",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo VSTAR",
     "nationalPokedexNumbers": [
       503
     ],
@@ -3232,7 +3232,7 @@
     "convertedRetreatCost": 2,
     "number": "GG53",
     "artist": "OKACHEKE",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo V",
     "nationalPokedexNumbers": [
       720
     ],
@@ -3301,7 +3301,7 @@
     "convertedRetreatCost": 2,
     "number": "GG54",
     "artist": "Haru Akasaka",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo V",
     "nationalPokedexNumbers": [
       889
     ],
@@ -3366,7 +3366,7 @@
     "convertedRetreatCost": 4,
     "number": "GG55",
     "artist": "Aya Kusube",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo VSTAR",
     "nationalPokedexNumbers": [
       486
     ],
@@ -3428,7 +3428,7 @@
     "convertedRetreatCost": 2,
     "number": "GG56",
     "artist": "SIE NANAHARA",
-    "rarity": "Trainer Gallery Rare Holo V",
+    "rarity": "Rare Holo VSTAR",
     "nationalPokedexNumbers": [
       571
     ],
@@ -3456,7 +3456,7 @@
     ],
     "number": "GG57",
     "artist": "Naoki Saito",
-    "rarity": "Trainer Gallery Rare Ultra",
+    "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -3481,7 +3481,7 @@
     ],
     "number": "GG58",
     "artist": "chibi",
-    "rarity": "Trainer Gallery Rare Ultra",
+    "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -3506,7 +3506,7 @@
     ],
     "number": "GG59",
     "artist": "kantaro",
-    "rarity": "Trainer Gallery Rare Ultra",
+    "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -3531,7 +3531,7 @@
     ],
     "number": "GG60",
     "artist": "Atsuya Uki",
-    "rarity": "Trainer Gallery Rare Ultra",
+    "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -3556,7 +3556,7 @@
     ],
     "number": "GG61",
     "artist": "Yoriyuki Ikegami",
-    "rarity": "Trainer Gallery Rare Ultra",
+    "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -3581,7 +3581,7 @@
     ],
     "number": "GG62",
     "artist": "Oswaldo KATO",
-    "rarity": "Trainer Gallery Rare Ultra",
+    "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -3606,7 +3606,7 @@
     ],
     "number": "GG63",
     "artist": "Naoki Saito",
-    "rarity": "Trainer Gallery Rare Ultra",
+    "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -3631,7 +3631,7 @@
     ],
     "number": "GG64",
     "artist": "saino misaki",
-    "rarity": "Trainer Gallery Rare Ultra",
+    "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -3656,7 +3656,7 @@
     ],
     "number": "GG65",
     "artist": "GIDORA",
-    "rarity": "Trainer Gallery Rare Ultra",
+    "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -3681,7 +3681,7 @@
     ],
     "number": "GG66",
     "artist": "Toshinao Aoki",
-    "rarity": "Trainer Gallery Rare Ultra",
+    "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -3740,7 +3740,7 @@
     "convertedRetreatCost": 2,
     "number": "GG67",
     "artist": "AKIRA EGAWA",
-    "rarity": "Trainer Gallery Rare Secret",
+    "rarity": "Rare Secret",
     "nationalPokedexNumbers": [
       484
     ],
@@ -3814,7 +3814,7 @@
     "convertedRetreatCost": 3,
     "number": "GG68",
     "artist": "AKIRA EGAWA",
-    "rarity": "Trainer Gallery Rare Secret",
+    "rarity": "Rare Secret",
     "nationalPokedexNumbers": [
       483
     ],
@@ -3874,7 +3874,7 @@
     "convertedRetreatCost": 2,
     "number": "GG69",
     "artist": "AKIRA EGAWA",
-    "rarity": "Trainer Gallery Rare Secret",
+    "rarity": "Rare Secret",
     "nationalPokedexNumbers": [
       487
     ],
@@ -3937,7 +3937,7 @@
     "convertedRetreatCost": 2,
     "number": "GG70",
     "artist": "AKIRA EGAWA",
-    "rarity": "Trainer Gallery Rare Secret",
+    "rarity": "Rare Secret",
     "nationalPokedexNumbers": [
       493
     ],


### PR DESCRIPTION
Brought consistency to the rarities of this trainer gallery. All Trainer Gallery Rare Holo V have been changed to Rare Holo V. All Rare Holo V have been changed to Rare Holo VMAX where the card is of a VMAX Variety. All Rare Holo V have been changed to Rare Holo VSTAR where the card is of a VSTAR Variety. All Trainer Gallery Rare Ultra have been changed to Rare Ultra. All Trainer Gallery Rare Secret have been changed to Rare Secret.