### PR TITLE
Fixed typos in attack texts, ability texts, rules

### DIFF
--- a/cards/en/base3.json
+++ b/cards/en/base3.json
@@ -2929,7 +2929,7 @@
     "abilities": [
       {
         "name": "Kabuto Armor",
-        "text": "Whenever an attack (even your own) does damage to Kabuto (after applying Weakness and Resistance), that attack does half the damage to Kabuto (rounded down to the nearest 10). (Any other effects of attacks still happen.) This power stops working while Kabuto is Asleep, Confused, or Paralzyed.",
+        "text": "Whenever an attack (even your own) does damage to Kabuto (after applying Weakness and Resistance), that attack does half the damage to Kabuto (rounded down to the nearest 10). (Any other effects of attacks still happen.) This power stops working while Kabuto is Asleep, Confused, or Paralyzed.",
         "type": "Pokémon Power"
       }
     ],

--- a/cards/en/bw5.json
+++ b/cards/en/bw5.json
@@ -664,7 +664,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": "The Defending Pokémon is now Paralyzed and Poisined. Shuffle this Pokémon and all cards attached to it into your deck."
+        "text": "The Defending Pokémon is now Paralyzed and Poisoned. Shuffle this Pokémon and all cards attached to it into your deck."
       }
     ],
     "weaknesses": [

--- a/cards/en/dp3.json
+++ b/cards/en/dp3.json
@@ -450,7 +450,7 @@
     "abilities": [
       {
         "name": "Osmotic Pressure",
-        "text": "Once during your turn (before your attack), if you have Gastrodon West Sea in play, you may move up to 3 damage counters from Gastodon East Sea to 1 of your Gastrodon West Sea.",
+        "text": "Once during your turn (before your attack), if you have Gastrodon West Sea in play, you may move up to 3 damage counters from Gastrodon East Sea to 1 of your Gastrodon West Sea.",
         "type": "Poké-Power"
       }
     ],

--- a/cards/en/dpp.json
+++ b/cards/en/dpp.json
@@ -2587,7 +2587,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "70",
-        "text": "Probopass G‘s Retreat Cost is 0 until the end of your next turn."
+        "text": "Probopass G's Retreat Cost is 0 until the end of your next turn."
       }
     ],
     "weaknesses": [
@@ -3250,7 +3250,7 @@
     "abilities": [
       {
         "name": "Multitype",
-        "text": "Arceus LV.X‘s type is the same as its previous Level.",
+        "text": "Arceus LV.X's type is the same as its previous Level.",
         "type": "Poké-Body"
       }
     ],

--- a/cards/en/ecard2.json
+++ b/cards/en/ecard2.json
@@ -4503,7 +4503,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, search your deck for a Psychic Energy card and attach it to 1 of your Benched Pokémon. Shuffe your deck afterward."
+        "text": "Flip a coin. If heads, search your deck for a Psychic Energy card and attach it to 1 of your Benched Pokémon. Shuffle your deck afterward."
       }
     ],
     "weaknesses": [
@@ -6823,7 +6823,7 @@
     ],
     "rules": [
       "This card stays in play when you play it. Discard this card if another Stadium card comes into play.",
-      "Once during each player's turn (before attacking), if that player's Bench isn't full, that player flips a coin. If heads, that player shows his or her opponent a basic Energy card from his or her hand. Then, that player searches his or her deck for a Basic Pokémon card of the same type (color) as the revealed Energy card and puts it onto his or her Bench. The player shuffes his or her deck afterward."
+      "Once during each player's turn (before attacking), if that player's Bench isn't full, that player flips a coin. If heads, that player shows his or her opponent a basic Energy card from his or her hand. Then, that player searches his or her deck for a Basic Pokémon card of the same type (color) as the revealed Energy card and puts it onto his or her Bench. The player shuffles his or her deck afterward."
     ],
     "number": "118",
     "artist": "Midori Harada",
@@ -7570,7 +7570,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Kindra does 10 damage to itself. (Don't apply Weakness or Resistance when Kingdra damages itself with this attack.)"
+        "text": "Kingdra does 10 damage to itself. (Don't apply Weakness or Resistance when Kingdra damages itself with this attack.)"
       },
       {
         "name": "Dual Burn",

--- a/cards/en/ecard3.json
+++ b/cards/en/ecard3.json
@@ -3144,7 +3144,7 @@
     "abilities": [
       {
         "name": "Slippery Skin",
-        "text": "As long as the Defending Pokémon is an Evolved Pokémon, Dusparce's Retreat Cost is 0.",
+        "text": "As long as the Defending Pokémon is an Evolved Pokémon, Dunsparce's Retreat Cost is 0.",
         "type": "Poké-Body"
       }
     ],

--- a/cards/en/ex12.json
+++ b/cards/en/ex12.json
@@ -2440,7 +2440,7 @@
     "abilities": [
       {
         "name": "Paranoid",
-        "text": "As long as Machoke is Confused, Machok's attacks do 50 more damage to the Defending Pokémon (before applying Weakness and Resistance).",
+        "text": "As long as Machoke is Confused, Machoke's attacks do 50 more damage to the Defending Pokémon (before applying Weakness and Resistance).",
         "type": "Poké-Body"
       }
     ],

--- a/cards/en/ex16.json
+++ b/cards/en/ex16.json
@@ -1140,7 +1140,7 @@
     "abilities": [
       {
         "name": "Safeguard",
-        "text": "Prevent all effects of attacks, including damage, done to Ninetails by your opponent's Pokémon-ex.",
+        "text": "Prevent all effects of attacks, including damage, done to Ninetales by your opponent's Pokémon-ex.",
         "type": "Poké-Body"
       }
     ],

--- a/cards/en/ex4.json
+++ b/cards/en/ex4.json
@@ -4274,7 +4274,7 @@
     ],
     "rules": [
       "Attach Team Aqua Belt to 1 of your Pokémon with Team Aqua in its name that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.",
-      "At any time between turns, if the Pokémon Team Aqua Belt is attached to is your Active Pokémon, search your deck for a card that evolves from that Pokémon and put it on that Pokémon. (This counts as evolving that Pokémon.) Shuffle your deck aftrerward, then discard Team Aqua Belt."
+      "At any time between turns, if the Pokémon Team Aqua Belt is attached to is your Active Pokémon, search your deck for a card that evolves from that Pokémon and put it on that Pokémon. (This counts as evolving that Pokémon.) Shuffle your deck afterward, then discard Team Aqua Belt."
     ],
     "number": "76",
     "artist": "Mitsuhiro Arita",

--- a/cards/en/ex8.json
+++ b/cards/en/ex8.json
@@ -2263,7 +2263,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40+",
-        "text": "You may do 40 damage plus 10 more damage for each Lightning Energy attached to Manetric. If you do, Manetric does 10 damage to itself."
+        "text": "You may do 40 damage plus 10 more damage for each Lightning Energy attached to Manectric. If you do, Manectric does 10 damage to itself."
       }
     ],
     "weaknesses": [
@@ -5555,7 +5555,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "",
-        "text": "Discard all Lightning Energy attached to Manetric ex and then choose 1 of your opponent's Pokémon. This attack does 80 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Discard all Lightning Energy attached to Manectric ex and then choose 1 of your opponent's Pokémon. This attack does 80 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       }
     ],
     "weaknesses": [

--- a/cards/en/gym1.json
+++ b/cards/en/gym1.json
@@ -965,7 +965,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "If your opponent has any Benched Pokémon, choose up to 3 of them. This attack does 10 damgae to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "If your opponent has any Benched Pokémon, choose up to 3 of them. This attack does 10 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Fissure",

--- a/cards/en/hgss1.json
+++ b/cards/en/hgss1.json
@@ -510,7 +510,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": "Does 20 damage to 1 of your opponetn's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Mud Shot",

--- a/cards/en/neo1.json
+++ b/cards/en/neo1.json
@@ -3910,7 +3910,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": "Flip a coin. If heads, the Defending Pokémon is now Paralyzed. If tails, Marril does 10 damage to itself."
+        "text": "Flip a coin. If heads, the Defending Pokémon is now Paralyzed. If tails, Marill does 10 damage to itself."
       }
     ],
     "weaknesses": [

--- a/cards/en/pl2.json
+++ b/cards/en/pl2.json
@@ -5448,7 +5448,7 @@
     "abilities": [
       {
         "name": "Overgrow",
-        "text": "As long as Turtwig GL‘s remaining HP is 60 or less, each of Turtwig GL‘s attacks does 30 more damage to the Defending Pokémon (before applying Weakness and Resistance).",
+        "text": "As long as Turtwig GL's remaining HP is 60 or less, each of Turtwig GL's attacks does 30 more damage to the Defending Pokémon (before applying Weakness and Resistance).",
         "type": "Poké-Body"
       }
     ],

--- a/cards/en/pl3.json
+++ b/cards/en/pl3.json
@@ -945,7 +945,7 @@
     "abilities": [
       {
         "name": "Extreme Speed",
-        "text": "Arcanine G‘s Retreat Cost is Colorless less for each Fire Energy attached to Arcanine G.",
+        "text": "Arcanine G's Retreat Cost is Colorless less for each Fire Energy attached to Arcanine G.",
         "type": "Poké-Body"
       }
     ],
@@ -1072,7 +1072,7 @@
     "abilities": [
       {
         "name": "Compound Eyes",
-        "text": "If your opponent's Active Pokémon has any Poké-Bodies, each of Butterfree FB‘s attacks does 30 more damage to the Active Pokémon (before applying Weakness and Resistance).",
+        "text": "If your opponent's Active Pokémon has any Poké-Bodies, each of Butterfree FB's attacks does 30 more damage to the Active Pokémon (before applying Weakness and Resistance).",
         "type": "Poké-Body"
       }
     ],

--- a/cards/en/pl4.json
+++ b/cards/en/pl4.json
@@ -346,7 +346,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "Seach your discard pile for a basic Energy card and attach it to 1 of your Benched Pokémon."
+        "text": "Search your discard pile for a basic Energy card and attach it to 1 of your Benched Pokémon."
       }
     ],
     "weaknesses": [
@@ -5513,7 +5513,7 @@
     "abilities": [
       {
         "name": "Multitype",
-        "text": "Arceus LV.X‘s type is the same as its previous Level.",
+        "text": "Arceus LV.X's type is the same as its previous Level.",
         "type": "Poké-Body"
       }
     ],
@@ -5568,7 +5568,7 @@
     "abilities": [
       {
         "name": "Multitype",
-        "text": "Arceus LV.X‘s type is the same type as its previous Level.",
+        "text": "Arceus LV.X's type is the same type as its previous Level.",
         "type": "Poké-Body"
       }
     ],

--- a/cards/en/sm11.json
+++ b/cards/en/sm11.json
@@ -7323,7 +7323,7 @@
     "abilities": [
       {
         "name": "Cellular Companions",
-        "text": "As long as this Pokémon is on your Bench, your Zygarde's and Zygarde-GX‘s attacks do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
+        "text": "As long as this Pokémon is on your Bench, your Zygarde's and Zygarde-GX's attacks do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
         "type": "Ability"
       }
     ],

--- a/cards/en/smp.json
+++ b/cards/en/smp.json
@@ -10903,7 +10903,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": "During your next turn, this Pokémon's Psycho Boost's base damage is 50."
+        "text": "During your next turn, this Pokémon's Psycho Boost attack's base damage is 50."
       }
     ],
     "weaknesses": [

--- a/cards/en/xyp.json
+++ b/cards/en/xyp.json
@@ -8356,7 +8356,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Flip 3 coins. This attack does 20 damage imtes the number of heads to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+        "text": "Flip 3 coins. This attack does 20 damage times the number of heads to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
       },
       {
         "name": "Ninja Blade",


### PR DESCRIPTION
A few things to note:

* I did not fix a typo on ex4-19 because it's a misprint on the card
* Most attack texts say "10 HP" instead of "10HP". dpp-DP36 is the only one that has 10HP. Comparing it with dp1-27 I concluded that the missing space is a misprint, so I did not add it
* I was not sure whether I should change "ColorlessColorlessColorless" to "Colorless Colorless Colorless" (and similar), so I did not do it
* Some "typos" were non-standard apostrophes. The cards that had this sort of typo are 
  * dpp-DP43
  * dpp-DP56
  * pl2-85
  * pl3-15
  * pl3-17
  * pl4-95
  * pl4-96
  * sm11-124