### PR TITLE
Changed legalities to "unlimited": "Banned" for illegal cards in swshp

### DIFF
--- a/cards/en/swshp.json
+++ b/cards/en/swshp.json
@@ -8313,9 +8313,7 @@
       887
     ],
     "legalities": {
-      "unlimited": "Legal",
-      "standard": "Legal",
-      "expanded": "Legal"
+      "unlimited": "Banned"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH132.png",
@@ -8505,9 +8503,7 @@
       888
     ],
     "legalities": {
-      "unlimited": "Legal",
-      "standard": "Legal",
-      "expanded": "Legal"
+      "unlimited": "Banned"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH135.png",
@@ -8566,9 +8562,7 @@
       778
     ],
     "legalities": {
-      "unlimited": "Legal",
-      "standard": "Legal",
-      "expanded": "Legal"
+      "unlimited": "Banned"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH136.png",
@@ -8632,9 +8626,7 @@
       849
     ],
     "legalities": {
-      "unlimited": "Legal",
-      "standard": "Legal",
-      "expanded": "Legal"
+      "unlimited": "Banned"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH137.png",
@@ -8698,9 +8690,7 @@
       635
     ],
     "legalities": {
-      "unlimited": "Legal",
-      "standard": "Legal",
-      "expanded": "Legal"
+      "unlimited": "Banned"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH138.png",
@@ -9170,9 +9160,7 @@
       658
     ],
     "legalities": {
-      "unlimited": "Legal",
-      "standard": "Legal",
-      "expanded": "Legal"
+      "unlimited": "Banned"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swshp/SWSH144.png",


### PR DESCRIPTION
The cards in question are the ones with the "(This card cannot be used at official tournaments.)" rule. I chose `"unlimited": "Banned"` to be consistent with #377 