### PR TITLE
Updated legalities of Black & White block post 2023 rotation

### DIFF
--- a/cards/en/bw1.json
+++ b/cards/en/bw1.json
@@ -5649,7 +5649,6 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/bw10.json
+++ b/cards/en/bw10.json
@@ -4726,6 +4726,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5009,6 +5010,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/bw5.json
+++ b/cards/en/bw5.json
@@ -5634,6 +5634,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5842,6 +5843,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/bw6.json
+++ b/cards/en/bw6.json
@@ -6900,7 +6900,6 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/bw7.json
+++ b/cards/en/bw7.json
@@ -7775,7 +7775,6 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -8386,7 +8385,6 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/bw9.json
+++ b/cards/en/bw9.json
@@ -6973,6 +6973,7 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {


### PR DESCRIPTION
See issue #417. This PR does not include the updates to Super Rod and Superior Energy Retrieval, that will become legal with Paldea Evolved.