### PR TITLE
Updated legalities of XY block post 2023 rotation

### DIFF
--- a/cards/en/g1.json
+++ b/cards/en/g1.json
@@ -3840,7 +3840,6 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -3933,6 +3932,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/xy0.json
+++ b/cards/en/xy0.json
@@ -1941,6 +1941,7 @@
     "artist": "5ban Graphics",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/xy1.json
+++ b/cards/en/xy1.json
@@ -7291,6 +7291,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/xy10.json
+++ b/cards/en/xy10.json
@@ -5884,6 +5884,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5953,6 +5954,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/xy12.json
+++ b/cards/en/xy12.json
@@ -2101,6 +2101,7 @@
     ],
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -4527,7 +4528,6 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/xy2.json
+++ b/cards/en/xy2.json
@@ -5532,7 +5532,6 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5672,6 +5671,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/xy3.json
+++ b/cards/en/xy3.json
@@ -5570,7 +5570,6 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/xy4.json
+++ b/cards/en/xy4.json
@@ -6051,6 +6051,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/xy6.json
+++ b/cards/en/xy6.json
@@ -5416,6 +5416,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/xy8.json
+++ b/cards/en/xy8.json
@@ -8168,6 +8168,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -8308,7 +8309,6 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/xy9.json
+++ b/cards/en/xy9.json
@@ -6617,7 +6617,6 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {


### PR DESCRIPTION
See issue #417. This PR does not include the update to Super Rod, that will become legal with Paldea Evolved.