### PR TITLE
feat: add Paldea Evolved ptgoCode

### DIFF
--- a/sets/en.json
+++ b/sets/en.json
@@ -2660,6 +2660,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "ptcgoCode": "PAL",
     "releaseDate": "2023/06/09",
     "updatedAt": "2023/06/09 15:00:00",
     "images": {


### PR DESCRIPTION
Paldea Evolved was missing ptgoCode in the set data.
The code is `PAL` and I have added it!