### PR TITLE
fix(sv1): bad nationalPokedexNumbers for Pawmot

### DIFF
--- a/cards/en/sv1.json
+++ b/cards/en/sv1.json
@@ -4477,7 +4477,7 @@
     "artist": "Mizue",
     "rarity": "Rare",
     "nationalPokedexNumbers": [
-      922
+      923
     ],
     "legalities": {
       "unlimited": "Legal",


### PR DESCRIPTION
Fix the national pokedex number on SV1 for pokémon Pawmot.