### PR TITLE
Updated standard legalities of Super Rod and Superior Energy Retrieval

### DIFF
--- a/cards/en/bw3.json
+++ b/cards/en/bw3.json
@@ -5425,6 +5425,7 @@
     "artist": "5ban Graphics",
     "rarity": "Uncommon",
     "legalities": {
+      "standard": "Legal",
       "unlimited": "Legal",
       "expanded": "Legal"
     },

--- a/cards/en/bw9.json
+++ b/cards/en/bw9.json
@@ -6131,6 +6131,7 @@
     "artist": "5ban Graphics",
     "rarity": "Uncommon",
     "legalities": {
+      "standard": "Legal",
       "unlimited": "Legal",
       "expanded": "Legal"
     },

--- a/cards/en/dv1.json
+++ b/cards/en/dv1.json
@@ -1092,6 +1092,7 @@
     "artist": "5ban Graphics",
     "rarity": "Rare Holo",
     "legalities": {
+      "standard": "Legal",
       "unlimited": "Legal",
       "expanded": "Legal"
     },

--- a/cards/en/neo1.json
+++ b/cards/en/neo1.json
@@ -5326,6 +5326,7 @@
     "artist": "Keiji Kinebuchi",
     "rarity": "Common",
     "legalities": {
+      "standard": "Legal",
       "unlimited": "Legal"
     },
     "images": {

--- a/cards/en/xy8.json
+++ b/cards/en/xy8.json
@@ -8331,6 +8331,7 @@
     "artist": "Toyste Beach",
     "rarity": "Uncommon",
     "legalities": {
+      "standard": "Legal",
       "unlimited": "Legal",
       "expanded": "Legal"
     },


### PR DESCRIPTION
After the release of Paldea Evolved, these cards are legal again in the standard format. This includes neo1-103, that recieved an errata according to https://pokegym.net/current-standard-legal-card-list/