### PR TITLE
Updated legalities of sets/en.json after 2023 standard rotation

### DIFF
--- a/sets/en.json
+++ b/sets/en.json
@@ -2131,7 +2131,6 @@
     "total": 216,
     "legalities": {
       "unlimited": "Legal",
-      "standard": "Legal",
       "expanded": "Legal"
     },
     "ptcgoCode": "SSH",
@@ -2150,7 +2149,6 @@
     "total": 209,
     "legalities": {
       "unlimited": "Legal",
-      "standard": "Legal",
       "expanded": "Legal"
     },
     "ptcgoCode": "RCL",
@@ -2169,7 +2167,6 @@
     "total": 201,
     "legalities": {
       "unlimited": "Legal",
-      "standard": "Legal",
       "expanded": "Legal"
     },
     "ptcgoCode": "DAA",
@@ -2207,7 +2204,6 @@
     "total": 80,
     "legalities": {
       "unlimited": "Legal",
-      "standard": "Legal",
       "expanded": "Legal"
     },
     "ptcgoCode": "CPA",
@@ -2226,7 +2222,6 @@
     "total": 203,
     "legalities": {
       "unlimited": "Legal",
-      "standard": "Legal",
       "expanded": "Legal"
     },
     "ptcgoCode": "VIV",
@@ -2264,7 +2259,6 @@
     "total": 122,
     "legalities": {
       "unlimited": "Legal",
-      "standard": "Legal",
       "expanded": "Legal"
     },
     "ptcgoCode": "SHF",


### PR DESCRIPTION
I removed the standard legality from sets in the swsh block that do not contain cards with the E or F regulation block. These are:

* swsh1
* swsh2
* swsh3
* swsh35
* swsh4
* swsh45sv