### PR TITLE
Removed standard legality from xy12-35

### DIFF
--- a/cards/en/xy12.json
+++ b/cards/en/xy12.json
@@ -2101,7 +2101,6 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {


### PR DESCRIPTION
That card was mistakenly left standard legal after #429. I believe this happened because, if I'm not mistaken, [this page](https://pokegym.net/current-standard-legal-card-list/) on the pokegym website mistakenly listed that card as standard legal. I guess this is because it is almost identical to cel25-5, but they do have different resistances. That card has since been removed from that page. 