### PR TITLE
Adding missing rules, flavorText and artists to svp

### DIFF
--- a/cards/en/svp.json
+++ b/cards/en/svp.json
@@ -165,6 +165,9 @@
     "types": [
       "Psychic"
     ],
+    "rules": [
+      "Pokémon ex rule: When your Pokémon ex is Knocked Out, your opponent takes 2 Prize cards."
+    ],
     "attacks": [
       {
         "name": "Void Return",
@@ -918,6 +921,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Flaaffy",
+    "rules": [
+      "Pokémon ex rule: When your Pokémon ex is Knocked Out, your opponent takes 2 Prize cards."
+    ],
     "attacks": [
       {
         "name": "Electro Ball",
@@ -980,6 +986,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Riolu",
+    "rules": [
+      "Pokémon ex rule: When your Pokémon ex is Knocked Out, your opponent takes 2 Prize cards."
+    ],
     "attacks": [
       {
         "name": "Low Sweep",
@@ -1041,6 +1050,9 @@
     "hp": "210",
     "types": [
       "Colorless"
+    ],
+    "rules": [
+      "Pokémon ex rule: When your Pokémon ex is Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
       {
@@ -1614,6 +1626,9 @@
     "types": [
       "Lightning"
     ],
+    "rules": [
+      "Pokémon ex rule: When your Pokémon ex is Knocked Out, your opponent takes 2 Prize cards."
+    ],
     "abilities": [
       {
         "name": "Tandem Unit",
@@ -1668,6 +1683,9 @@
     "hp": "230",
     "types": [
       "Fighting"
+    ],
+    "rules": [
+      "Pokémon ex rule: When your Pokémon ex is Knocked Out, your opponent takes 2 Prize cards."
     ],
     "abilities": [
       {

--- a/cards/en/svp.json
+++ b/cards/en/svp.json
@@ -1147,6 +1147,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "19",
+    "artist": "Oswaldo KATO",
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
@@ -1203,6 +1204,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "20",
+    "artist": "Anesaki Dynamic",
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
@@ -1267,6 +1269,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "21",
+    "artist": "Shiburingaru",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       198
@@ -1333,6 +1336,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "22",
+    "artist": "Nisota Niso",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       279
@@ -1392,6 +1396,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "23",
+    "artist": "Misa Tsutsui",
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
@@ -1447,6 +1452,7 @@
         "value": "×2"
       }
     ],
+    "artist": "Misa Tsutsui",
     "retreatCost": [
       "Colorless",
       "Colorless",
@@ -1454,6 +1460,7 @@
     ],
     "convertedRetreatCost": 3,
     "number": "24",
+    "artist": "Uta",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       58
@@ -1504,6 +1511,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "25",
+    "artist": "Kouki Saitou",
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
@@ -1556,6 +1564,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "26",
+    "artist": "Mina Nakai",
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
@@ -1607,6 +1616,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "27",
+    "artist": "Atsushi Furusawa",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       25
@@ -1669,6 +1679,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "28",
+    "artist": "5ban Graphics",
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
@@ -1728,6 +1739,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "29",
+    "artist": "aky CG Works",
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",

--- a/cards/en/svp.json
+++ b/cards/en/svp.json
@@ -1157,7 +1157,8 @@
     "images": {
       "small": "https://images.pokemontcg.io/svp/19.png",
       "large": "https://images.pokemontcg.io/svp/19_hires.png"
-    }
+    },
+    "flavorText": "This Pokémon blasts cryogenic air out from its mouth. This air can instantly freeze even liquid-hot lava."
   },
   {
     "id": "svp-20",
@@ -1212,7 +1213,8 @@
     "images": {
       "small": "https://images.pokemontcg.io/svp/20.png",
       "large": "https://images.pokemontcg.io/svp/20_hires.png"
-    }
+    },
+    "flavorText": "This intelligent Pokémon has a very daring disposition. It knocks rocks into the sky with its hammer, aiming for flying Corviknight."
   },
   {
     "id": "svp-21",
@@ -1278,7 +1280,8 @@
     "images": {
       "small": "https://images.pokemontcg.io/svp/21.png",
       "large": "https://images.pokemontcg.io/svp/21_hires.png"
-    }
+    },
+    "flavorText": "Feared and loathed by many, it is believed to bring misfortune to all those who see it at night."
   },
   {
     "id": "svp-22",
@@ -1343,7 +1346,8 @@
     "images": {
       "small": "https://images.pokemontcg.io/svp/22.png",
       "large": "https://images.pokemontcg.io/svp/22_hires.png"
-    }
+    },
+    "flavorText": "It is a flying transporter that carries small Pokémon in its beak. It bobs on the waves to rest its wings."
   },
   {
     "id": "svp-23",
@@ -1398,7 +1402,8 @@
     "images": {
       "small": "https://images.pokemontcg.io/svp/23.png",
       "large": "https://images.pokemontcg.io/svp/23_hires.png"
-    }
+    },
+    "flavorText": "It protects itself from enemies by emitting oil from the fruit on its head. This oil is bitter and astringent enough to make someone flinch."
   },
   {
     "id": "svp-24",
@@ -1462,7 +1467,8 @@
     "images": {
       "small": "https://images.pokemontcg.io/svp/24.png",
       "large": "https://images.pokemontcg.io/svp/24_hires.png"
-    }
+    },
+    "flavorText": "It’s very friendly and faithful to people. It will try to repel enemies by barking and biting."
   },
   {
     "id": "svp-25",
@@ -1508,7 +1514,8 @@
     "images": {
       "small": "https://images.pokemontcg.io/svp/25.png",
       "large": "https://images.pokemontcg.io/svp/25_hires.png"
-    }
+    },
+    "flavorText": "It swings its handmade hammer around to protect itself, but the hammer is often stolen by Pokémon that eat metal."
   },
   {
     "id": "svp-26",
@@ -1559,7 +1566,8 @@
     "images": {
       "small": "https://images.pokemontcg.io/svp/26.png",
       "large": "https://images.pokemontcg.io/svp/26_hires.png"
-    }
+    },
+    "flavorText": "It is said that this Pokémon was born when an unknown poison Pokémon entered and inspirited an engine left at a scrap-processing factory."
   },
   {
     "id": "svp-27",
@@ -1612,7 +1620,8 @@
     "images": {
       "small": "https://images.pokemontcg.io/svp/27.png",
       "large": "https://images.pokemontcg.io/svp/27_hires.png"
-    }
+    },
+    "flavorText": "Pikachu seems excited to be going on an adventure, and so do its new pals, from attention-seeking Sprigatito to laid-back Fuecoco and tidy Quaxly."
   },
   {
     "id": "svp-28",


### PR DESCRIPTION
This closes #454. Moreover, I noticed that all ex cards in svp were missing the Pokémon ex rule, so I added it.