### PR TITLE
Fixed structure of sets/en.json

### DIFF
--- a/sets/en.json
+++ b/sets/en.json
@@ -2660,7 +2660,7 @@
     "images": {
       "symbol": "https://images.pokemontcg.io/sve/symbol.png",
       "logo": "https://images.pokemontcg.io/sve/logo.png"
-    },
+    }
   },
   {
     "id": "sv1",


### PR DESCRIPTION
There was an extra comma after the images for `sve`. Thanks to julien on Discord for pointing this out

Edit: this closes #463 