### PR TITLE
Added SWSH285, SWSH286 to swshp.json

### DIFF
--- a/cards/en/swshp.json
+++ b/cards/en/swshp.json
@@ -18158,6 +18158,130 @@
     }
   },
   {
+    "id": "swshp-SWSH285",
+    "name": "Pikachu V",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Basic",
+      "V"
+    ],
+    "hp": "200",
+    "types": [
+      "Lightning"
+    ],
+    "evolvesTo": [
+      "Pikachu VMAX"
+    ],
+    "rules": [
+      "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
+    ],
+    "attacks": [
+      {
+        "name": "Pika Drive",
+        "cost": [
+          "Lightning",
+          "Lightning",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 3,
+        "damage": "200",
+        "text": "During your next turn, this Pokémon can't attack."
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Fighting",
+        "value": "×2"
+      }
+    ],
+    "retreatCost": [
+      "Colorless"
+    ],
+    "convertedRetreatCost": 1,
+    "number": "SWSH285",
+    "artist": "You Iribi",
+    "rarity": "Promo",
+    "nationalPokedexNumbers": [
+      25
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "regulationMark": "F",
+    "images": {
+      "small": "https://images.pokemontcg.io/swshp/SWSH285.png",
+      "large": "https://images.pokemontcg.io/swshp/SWSH285_hires.png"
+    }
+  },
+  {
+    "id": "swshp-SWSH286",
+    "name": "Pikachu VMAX",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "VMAX"
+    ],
+    "hp": "310",
+    "types": [
+      "Lightning"
+    ],
+    "evolvesFrom": "Pikachu V",
+    "rules": [
+      "VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize cards."
+    ],
+    "attacks": [
+      {
+        "name": "Tail Charge",
+        "cost": [
+          "Lightning"
+        ],
+        "convertedEnergyCost": 1,
+        "damage": "30",
+        "text": "Attach up to 3 Lightning Energy cards from your discard pile to 1 of your Pokémon."
+      },
+      {
+        "name": "G-Max Thunder",
+        "cost": [
+          "Lightning",
+          "Lightning",
+          "Lightning",
+          "Colorless"
+        ],
+        "convertedEnergyCost": 4,
+        "damage": "250",
+        "text": ""
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Fighting",
+        "value": "×2"
+      }
+    ],
+    "retreatCost": [
+      "Colorless",
+      "Colorless"
+    ],
+    "convertedRetreatCost": 2,
+    "number": "SWSH286",
+    "artist": "AKIRA EGAWA",
+    "rarity": "Promo",
+    "nationalPokedexNumbers": [
+      25
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "regulationMark": "F",
+    "images": {
+      "small": "https://images.pokemontcg.io/swshp/SWSH286.png",
+      "large": "https://images.pokemontcg.io/swshp/SWSH286_hires.png"
+    }
+  },
+  {
     "id": "swshp-SWSH287",
     "name": "Morpeko V-UNION",
     "supertype": "Pokémon",


### PR DESCRIPTION
Those cards are already in the api but not on GitHub. I added them as they are returned by the api, with the following differences:

* I added the artists
* Pikachu V evolves to Pikachu VMAX instead of Raichu
* Pikachu VMAX does not evolve instead of evolving to Raichu