### PR TITLE
Removed prize cards rule from Ho-Oh Legend and Lugia Legend

### DIFF
--- a/cards/en/hgss1.json
+++ b/cards/en/hgss1.json
@@ -5957,8 +5957,7 @@
       "Fire"
     ],
     "rules": [
-      "Put this card from your hand onto your Bench only with the other half of Ho-Oh LEGEND.",
-      "When this Pokémon has been Knocked Out, your opponent takes 2 Prize cards."
+      "Put this card from your hand onto your Bench only with the other half of Ho-Oh LEGEND."
     ],
     "abilities": [
       {
@@ -6025,8 +6024,7 @@
       "Fire"
     ],
     "rules": [
-      "Put this card from your hand onto your Bench only with the other half of Ho-Oh LEGEND.",
-      "When this Pokémon has been Knocked Out, your opponent takes 2 Prize cards."
+      "Put this card from your hand onto your Bench only with the other half of Ho-Oh LEGEND."
     ],
     "abilities": [
       {
@@ -6093,8 +6091,7 @@
       "Water"
     ],
     "rules": [
-      "Put this card from your hand onto your Bench only with the other half of Lugia LEGEND.",
-      "When this Pokémon has been Knocked Out, your opponent takes 2 Prize cards."
+      "Put this card from your hand onto your Bench only with the other half of Lugia LEGEND."
     ],
     "abilities": [
       {
@@ -6159,8 +6156,7 @@
       "Water"
     ],
     "rules": [
-      "Put this card from your hand onto your Bench only with the other half of Lugia LEGEND.",
-      "When this Pokémon has been Knocked Out, your opponent takes 2 Prize cards."
+      "Put this card from your hand onto your Bench only with the other half of Lugia LEGEND."
     ],
     "abilities": [
       {


### PR DESCRIPTION
Unlike all other Legend Pokémon, these two do not give up two prizes when knocked out. They have flavor text instead of that rule, which I did not add because it was already there.