### PR TITLE
Removed extra rule from Suicune & Entei Legend

### DIFF
--- a/cards/en/hgss2.json
+++ b/cards/en/hgss2.json
@@ -5164,7 +5164,6 @@
     ],
     "rules": [
       "Put this card from your hand onto your Bench only with the other half of Suicune & Entei LEGEND.",
-      "Put this card from your hand onto your Bench only with the other half of Suicune & Entei LEGEND. When this Pokémon has been Knocked Out, your opponent takes 2 Prize cards",
       "When this Pokémon has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [
@@ -5234,7 +5233,6 @@
     ],
     "rules": [
       "Put this card from your hand onto your Bench only with the other half of Suicune & Entei LEGEND.",
-      "Put this card from your hand onto your Bench only with the other half of Suicune & Entei LEGEND. When this Pokémon has been Knocked Out, your opponent takes 2 Prize cards",
       "When this Pokémon has been Knocked Out, your opponent takes 2 Prize cards."
     ],
     "attacks": [


### PR DESCRIPTION
Both halves of that Pokémon correctly had the rule about how to play them and the rule about prize cards, but they also had a third rule which was just the other two combined. The other Legend Pokémon do not seem to have the same issue.