### PR TITLE
fix: sv3 - add artists & flavorText, fix rules & attacks

### DIFF
--- a/cards/en/sv3.json
+++ b/cards/en/sv3.json
@@ -11371,7 +11371,8 @@
       "Item"
     ],
     "rules": [
-      "You can use this card only if any of your Pokémon were Knocked Out during your opponent's last turn.\nSearch your deck for up to 3 Basic Energy cards, reveal them, and put them into your hand. Then, shuffle your deck.",
+      "You can use this card only if any of your Pokémon were Knocked Out during your opponent's last turn.",
+      "Search your deck for up to 3 Basic Energy cards, reveal them, and put them into your hand. Then, shuffle your deck.",
       "You may play any number of Item cards during your turn."
     ],
     "number": "189",

--- a/cards/en/sv3.json
+++ b/cards/en/sv3.json
@@ -3561,9 +3561,10 @@
       {
         "name": "Tail Smack",
         "cost": [
+          "Water",
           "Water"
         ],
-        "convertedEnergyCost": 1,
+        "convertedEnergyCost": 2,
         "damage": "30",
         "text": ""
       }

--- a/cards/en/sv3.json
+++ b/cards/en/sv3.json
@@ -44,7 +44,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "1",
+    "artist": "Midori Harada",
     "rarity": "Common",
+    "flavorText": "During the day, it stays in the cold underground to avoid the sun. It grows by bathing in moonlight.",
     "nationalPokedexNumbers": [
       43
     ],
@@ -107,7 +109,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "2",
+    "artist": "Haru Akasaka",
     "rarity": "Common",
+    "flavorText": "What appears to be drool is actually sweet honey. It is very sticky and clings stubbornly if touched.",
     "nationalPokedexNumbers": [
       44
     ],
@@ -165,7 +169,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "3",
+    "artist": "sui",
     "rarity": "Uncommon",
+    "flavorText": "Bellossom gather at times and appear to dance. They say that the dance is a ritual to summon the sun.",
     "nationalPokedexNumbers": [
       182
     ],
@@ -192,7 +198,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor",
+      "Kleavor"
     ],
     "attacks": [
       {
@@ -226,7 +233,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "4",
+    "artist": "Shin Nagasawa",
     "rarity": "Common",
+    "flavorText": "It slashes through grass with its sharp scythes, moving too fast for the human eye to track.",
     "nationalPokedexNumbers": [
       123
     ],
@@ -284,7 +293,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "5",
+    "artist": "Kurata So",
     "rarity": "Common",
+    "flavorText": "The berries stored in its vaselike shell eventually become a thick, pulpy juice.",
     "nationalPokedexNumbers": [
       213
     ],
@@ -335,7 +346,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "6",
+    "artist": "Saya Tsuruta",
     "rarity": "Common",
+    "flavorText": "They usually live on ponds, but after an evening shower, they may appear on puddles in towns.",
     "nationalPokedexNumbers": [
       283
     ],
@@ -394,7 +407,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "7",
+    "artist": "Haru Akasaka",
     "rarity": "Uncommon",
+    "flavorText": "It flaps its four wings to hover and fly freely in any direction—to and fro and sideways.",
     "nationalPokedexNumbers": [
       284
     ],
@@ -455,7 +470,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "8",
+    "artist": "HYOGONOSUKE",
     "rarity": "Common",
+    "flavorText": "At night, Combee sleep in a group of about a hundred, packed closely together in a lump.",
     "nationalPokedexNumbers": [
       415
     ],
@@ -516,7 +533,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "9",
+    "artist": "You Iribi",
     "rarity": "Common",
+    "flavorText": "There is a theory that the developer of the modern-day Poké Ball really liked Foongus, but this has not been confirmed.",
     "nationalPokedexNumbers": [
       590
     ],
@@ -567,7 +586,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "10",
+    "artist": "Nobuhiro Imagawa",
     "rarity": "Uncommon",
+    "flavorText": "Be wary of the poisonous spores it releases. Mushrooms resembling Amoonguss's caps will grow out of anywhere the spores touch.",
     "nationalPokedexNumbers": [
       591
     ],
@@ -619,7 +640,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "11",
+    "artist": "Narumi Sato",
     "rarity": "Common",
+    "flavorText": "With a voice like a human child's, it cries out to lure adults deep into the forest, getting them lost among the trees.",
     "nationalPokedexNumbers": [
       708
     ],
@@ -679,7 +702,9 @@
     ],
     "convertedRetreatCost": 3,
     "number": "12",
+    "artist": "Anesaki Dynamic",
     "rarity": "Uncommon",
+    "flavorText": "Small roots that extend from the tips of this Pokémon's feet can tie into the trees of the forest and give Trevenant control over them.",
     "nationalPokedexNumbers": [
       709
     ],
@@ -730,7 +755,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "13",
+    "artist": "Tomokazu Komiya",
     "rarity": "Common",
+    "flavorText": "It feels relaxed in tight, dark places and has been known to use its Trainer's pocket or bag as a nest.",
     "nationalPokedexNumbers": [
       722
     ],
@@ -783,7 +810,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "14",
+    "artist": "sui",
     "rarity": "Uncommon",
+    "flavorText": "Supremely sensitive to the presence of others, it can detect opponents standing behind it, flinging its sharp feathers to take them out.",
     "nationalPokedexNumbers": [
       723
     ],
@@ -845,6 +874,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "15",
+    "artist": "PLANETA Mochizuki",
     "rarity": "Double Rare",
     "nationalPokedexNumbers": [
       724
@@ -906,7 +936,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "16",
+    "artist": "Kurata So",
     "rarity": "Common",
+    "flavorText": "Its sweat is sweet, like syrup made from boiled-down fruit. Because of this, Bounsweet was highly valued in the past, when sweeteners were scarce.",
     "nationalPokedexNumbers": [
       761
     ],
@@ -968,7 +1000,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "17",
+    "artist": "nagimiso",
     "rarity": "Common",
+    "flavorText": "Steenee spreads a sweet scent that makes others feel invigorated. This same scent is popular for antiperspirants.",
     "nationalPokedexNumbers": [
       762
     ],
@@ -1028,7 +1062,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "18",
+    "artist": "Atsushi Furusawa",
     "rarity": "Uncommon",
+    "flavorText": "This Pokémon is proud and aggressive. However, it is said that a Tsareena will instantly become calm if someone touches the crown on its calyx.",
     "nationalPokedexNumbers": [
       763
     ],
@@ -1054,6 +1090,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Dolliv"
+    ],
     "attacks": [
       {
         "name": "Absorb",
@@ -1076,7 +1115,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "19",
+    "artist": "Masako Tomii",
     "rarity": "Common",
+    "flavorText": "It protects itself from enemies by emitting oil from the fruit on its head. This oil is bitter and astringent enough to make someone flinch.",
     "nationalPokedexNumbers": [
       928
     ],
@@ -1103,6 +1144,9 @@
       "Grass"
     ],
     "evolvesFrom": "Smoliv",
+    "evolvesTo": [
+      "Arboliva"
+    ],
     "attacks": [
       {
         "name": "Sunny Wind",
@@ -1125,7 +1169,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "20",
+    "artist": "Mizue",
     "rarity": "Common",
+    "flavorText": "Dolliv shares its tasty, fresh-scented oil with others. This species has coexisted with humans since times long gone.",
     "nationalPokedexNumbers": [
       929
     ],
@@ -1184,7 +1230,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "21",
+    "artist": "KEIICHIRO ITO",
     "rarity": "Uncommon",
+    "flavorText": "This calm Pokémon is very compassionate. It will share its delicious, nutrient-rich oil with weakened Pokémon.",
     "nationalPokedexNumbers": [
       930
     ],
@@ -1246,6 +1294,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "22",
+    "artist": "5ban Graphics",
     "rarity": "Double Rare",
     "nationalPokedexNumbers": [
       949
@@ -1272,6 +1321,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Scovillain"
+    ],
     "attacks": [
       {
         "name": "Reckless Charge",
@@ -1294,7 +1346,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "23",
+    "artist": "Shin Nagasawa",
     "rarity": "Common",
+    "flavorText": "The more sunlight this Pokémon bathes in, the more spicy chemicals are produced by its body, and thus the spicier its moves become.",
     "nationalPokedexNumbers": [
       951
     ],
@@ -1319,6 +1373,9 @@
     "hp": "70",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Scovillain"
     ],
     "attacks": [
       {
@@ -1345,7 +1402,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "24",
+    "artist": "Pani Kobayashi",
     "rarity": "Common",
+    "flavorText": "The more sunlight this Pokémon bathes in, the more spicy chemicals are produced by its body, and thus the spicier its moves become.",
     "nationalPokedexNumbers": [
       951
     ],
@@ -1404,7 +1463,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "25",
+    "artist": "kodama",
     "rarity": "Rare",
+    "flavorText": "The red head converts spicy chemicals into fire energy and blasts the surrounding area with a super spicy stream of flame.",
     "nationalPokedexNumbers": [
       952
     ],
@@ -1455,7 +1516,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "26",
+    "artist": "DOM",
     "rarity": "Common",
+    "flavorText": "From the time it is born, a flame burns at the tip of its tail. Its life would end if the flame were to go out.",
     "nationalPokedexNumbers": [
       4
     ],
@@ -1509,7 +1572,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "27",
+    "artist": "Ryota Murayama",
     "rarity": "Uncommon",
+    "flavorText": "If it becomes agitated during battle, it spouts intense flames, incinerating its surroundings.",
     "nationalPokedexNumbers": [
       5
     ],
@@ -1570,7 +1635,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "28",
+    "artist": "0313",
     "rarity": "Common",
+    "flavorText": "As each tail grows, its fur becomes more lustrous. When held, it feels slightly warm.",
     "nationalPokedexNumbers": [
       37
     ],
@@ -1629,7 +1696,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "29",
+    "artist": "Yoshioka",
     "rarity": "Uncommon",
+    "flavorText": "Very smart and very vengeful. Grabbing one of its many tails could result in a 1,000-year curse.",
     "nationalPokedexNumbers": [
       38
     ],
@@ -1687,7 +1756,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "30",
+    "artist": "toriyufu",
     "rarity": "Rare",
+    "flavorText": "It is said that when it roars, a volcano erupts somewhere around the globe.",
     "nationalPokedexNumbers": [
       244
     ],
@@ -1741,7 +1812,9 @@
     ],
     "convertedRetreatCost": 3,
     "number": "31",
+    "artist": "Mizue",
     "rarity": "Common",
+    "flavorText": "Magma of almost 2,200 degrees Fahrenheit courses through its body. When it grows cold, the magma hardens and slows it.",
     "nationalPokedexNumbers": [
       322
     ],
@@ -1804,7 +1877,9 @@
     ],
     "convertedRetreatCost": 3,
     "number": "32",
+    "artist": "Shiburingaru",
     "rarity": "Uncommon",
+    "flavorText": "It lives in the crater of a volcano. It is well known that the humps on its back erupt every 10 years.",
     "nationalPokedexNumbers": [
       323
     ],
@@ -1867,6 +1942,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "33",
+    "artist": "Saki Hayashiro",
     "rarity": "Double Rare",
     "nationalPokedexNumbers": [
       494
@@ -1931,7 +2007,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "34",
+    "artist": "Miki Tanaka",
     "rarity": "Common",
+    "flavorText": "This popular symbol of good fortune will never fall over in its sleep, no matter how it's pushed or pulled.",
     "nationalPokedexNumbers": [
       554
     ],
@@ -1996,7 +2074,9 @@
     ],
     "convertedRetreatCost": 3,
     "number": "35",
+    "artist": "Yuya Oka",
     "rarity": "Uncommon",
+    "flavorText": "This Pokémon's power level rises along with the temperature of its fire, which can reach 2,500 degrees Fahrenheit.",
     "nationalPokedexNumbers": [
       555
     ],
@@ -2047,7 +2127,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "36",
+    "artist": "Nagomi Nijo",
     "rarity": "Common",
+    "flavorText": "The younger the life this Pokémon absorbs, the brighter and eerier the flame on its head burns.",
     "nationalPokedexNumbers": [
       607
     ],
@@ -2109,7 +2191,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "37",
+    "artist": "Aya Kusube",
     "rarity": "Common",
+    "flavorText": "It lurks in cities, pretending to be a lamp. Once it finds someone whose death is near, it will trail quietly after them.",
     "nationalPokedexNumbers": [
       608
     ],
@@ -2170,7 +2254,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "38",
+    "artist": "Haru Akasaka",
     "rarity": "Uncommon",
+    "flavorText": "In homes illuminated by Chandelure instead of lights, funerals were a constant occurrence—or so it's said.",
     "nationalPokedexNumbers": [
       609
     ],
@@ -2219,7 +2305,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "39",
+    "artist": "otumami",
     "rarity": "Common",
+    "flavorText": "A flame serves as its tongue, melting through the hard shell of Durant so that Heatmor can devour their insides.",
     "nationalPokedexNumbers": [
       631
     ],
@@ -2281,7 +2369,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "40",
+    "artist": "Yuka Morii",
     "rarity": "Common",
+    "flavorText": "This Pokémon was called the Larva That Stole the Sun. The fire Larvesta spouts from its horns can cut right through a sheet of iron.",
     "nationalPokedexNumbers": [
       636
     ],
@@ -2342,7 +2432,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "41",
+    "artist": "Yukiko Baba",
     "rarity": "Uncommon",
+    "flavorText": "Its burning body causes it to be unpopular in hot parts of the world, but in cold ones, Volcarona is revered as an embodiment of the sun.",
     "nationalPokedexNumbers": [
       637
     ],
@@ -2372,7 +2464,7 @@
     ],
     "rules": [
       "Pokémon ex rule: When your Pokémon ex is Knocked Out, your opponent takes 2 Prize cards.",
-      "As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's)."
+      "Tera: As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's)."
     ],
     "attacks": [
       {
@@ -2399,6 +2491,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "42",
+    "artist": "5ban Graphics",
     "rarity": "Double Rare",
     "nationalPokedexNumbers": [
       875
@@ -2424,6 +2517,10 @@
     "hp": "70",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Armarouge",
+      "Ceruledge"
     ],
     "attacks": [
       {
@@ -2457,7 +2554,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "43",
+    "artist": "Saya Tsuruta",
     "rarity": "Common",
+    "flavorText": "Burnt charcoal came to life and became a Pokémon. Possessing a fiery fighting spirit, Charcadet will battle even tough opponents.",
     "nationalPokedexNumbers": [
       935
     ],
@@ -2514,7 +2613,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "44",
+    "artist": "Souichirou Gunjima",
     "rarity": "Uncommon",
+    "flavorText": "Armarouge evolved through the use of a set of armor that belonged to a distinguished warrior. This Pokémon is incredibly loyal.",
     "nationalPokedexNumbers": [
       936
     ],
@@ -2574,7 +2675,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "45",
+    "artist": "matazo",
     "rarity": "Uncommon",
+    "flavorText": "Crossing icy seas is no issue for this cold-resistant Pokémon. Its smooth skin is a little cool to the touch.",
     "nationalPokedexNumbers": [
       131
     ],
@@ -2625,7 +2728,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "46",
+    "artist": "Jerky",
     "rarity": "Common",
+    "flavorText": "These Pokémon have sharp fangs and powerful jaws. Sailors avoid Carvanha dens at all costs.",
     "nationalPokedexNumbers": [
       318
     ],
@@ -2684,7 +2789,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "47",
+    "artist": "Tonji Matsuno",
     "rarity": "Uncommon",
+    "flavorText": "This Pokémon is known as the Bully of the Sea. Any ship entering the waters Sharpedo calls home will be attacked—no exceptions.",
     "nationalPokedexNumbers": [
       319
     ],
@@ -2735,7 +2842,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "48",
+    "artist": "Jerky",
     "rarity": "Common",
+    "flavorText": "It spins its two tails like a screw to propel itself through water. The tails also slice clinging seaweed.",
     "nationalPokedexNumbers": [
       418
     ],
@@ -2794,7 +2903,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "49",
+    "artist": "Kouki Saitou",
     "rarity": "Uncommon",
+    "flavorText": "With its flotation sac inflated, it can carry people on its back. It deflates the sac before it dives.",
     "nationalPokedexNumbers": [
       419
     ],
@@ -2845,7 +2956,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "50",
+    "artist": "OKUBO",
     "rarity": "Common",
+    "flavorText": "It uses sound waves to communicate with others of its kind. People and other Pokémon species can't hear its cries of warning.",
     "nationalPokedexNumbers": [
       535
     ],
@@ -2899,7 +3012,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "51",
+    "artist": "sowsow",
     "rarity": "Common",
+    "flavorText": "On occasion, their cries are sublimely pleasing to the ear. Palpitoad with larger lumps on their bodies can sing with a wider range of sounds.",
     "nationalPokedexNumbers": [
       536
     ],
@@ -2958,7 +3073,9 @@
     ],
     "convertedRetreatCost": 3,
     "number": "52",
+    "artist": "Misa Tsutsui",
     "rarity": "Uncommon",
+    "flavorText": "This Pokémon is popular among the elderly, who say the vibrations of its lumps are great for massages.",
     "nationalPokedexNumbers": [
       537
     ],
@@ -3020,7 +3137,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "53",
+    "artist": "Mizue",
     "rarity": "Common",
+    "flavorText": "Many of this species can be found along the shorelines of cold regions. If a Cubchoo lacks dangling snot, there's a chance it is sick.",
     "nationalPokedexNumbers": [
       613
     ],
@@ -3082,7 +3201,9 @@
     ],
     "convertedRetreatCost": 3,
     "number": "54",
+    "artist": "Misa Tsutsui",
     "rarity": "Uncommon",
+    "flavorText": "It is a ferocious, carnivorous Pokémon. Once it captures its prey, it will breathe cold air onto the prey to freeze and preserve it.",
     "nationalPokedexNumbers": [
       614
     ],
@@ -3130,7 +3251,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "55",
+    "artist": "kirisAki",
     "rarity": "Common",
+    "flavorText": "Cryogonal appear during cold seasons. It is said that people and Pokémon who die on snowy mountains are reborn into these Pokémon.",
     "nationalPokedexNumbers": [
       615
     ],
@@ -3181,7 +3304,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "56",
+    "artist": "Atsuya Uki",
     "rarity": "Common",
+    "flavorText": "It protects its skin by covering its body in delicate bubbles. Beneath its happy-go-lucky air, it keeps a watchful eye on its surroundings.",
     "nationalPokedexNumbers": [
       656
     ],
@@ -3234,7 +3359,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "57",
+    "artist": "Tonji Matsuno",
     "rarity": "Uncommon",
+    "flavorText": "Its swiftness is unparalleled. It can scale a tower of more than 600 metres in a minute's time.",
     "nationalPokedexNumbers": [
       657
     ],
@@ -3260,6 +3387,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Wugtrio"
+    ],
     "attacks": [
       {
         "name": "Rain Splash",
@@ -3282,7 +3412,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "58",
+    "artist": "Pani Kobayashi",
     "rarity": "Common",
+    "flavorText": "This Pokémon can pick up the scent of a Veluza just over 65 feet away and will hide itself in the sand.",
     "nationalPokedexNumbers": [
       960
     ],
@@ -3331,7 +3463,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "59",
+    "artist": "Akira Komayama",
     "rarity": "Uncommon",
+    "flavorText": "It has a vicious temperament, contrary to what its appearance may suggest. It wraps its long bodies around prey, then drags the prey into its den.",
     "nationalPokedexNumbers": [
       961
     ],
@@ -3356,6 +3490,9 @@
     "hp": "50",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Palafin"
     ],
     "attacks": [
       {
@@ -3389,7 +3526,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "60",
+    "artist": "kodama",
     "rarity": "Common",
+    "flavorText": "It likes playing with others of its kind using the water ring on its tail. It uses ultrasonic waves to sense the emotions of other living creatures.",
     "nationalPokedexNumbers": [
       963
     ],
@@ -3415,14 +3554,16 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Palafin"
+    ],
     "attacks": [
       {
         "name": "Tail Smack",
         "cost": [
-          "Water",
           "Water"
         ],
-        "convertedEnergyCost": 2,
+        "convertedEnergyCost": 1,
         "damage": "30",
         "text": ""
       }
@@ -3439,7 +3580,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "61",
+    "artist": "Kouki Saitou",
     "rarity": "Common",
+    "flavorText": "It likes playing with others of its kind using the water ring on its tail. It uses ultrasonic waves to sense the emotions of other living creatures.",
     "nationalPokedexNumbers": [
       963
     ],
@@ -3499,7 +3642,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "62",
+    "artist": "Souichirou Gunjima",
     "rarity": "Rare",
+    "flavorText": "This Pokémon's ancient genes have awakened. It is now so extraordinarily strong that it can easily lift a cruise ship with one fin.",
     "nationalPokedexNumbers": [
       964
     ],
@@ -3560,7 +3705,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "63",
+    "artist": "Masakazu Fukuda",
     "rarity": "Common",
+    "flavorText": "The electromagnetic waves emitted by the units at the sides of its head expel antigravity, which allows it to float.",
     "nationalPokedexNumbers": [
       81
     ],
@@ -3624,7 +3771,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "64",
+    "artist": "kurumitsu",
     "rarity": "Common",
+    "flavorText": "Three Magnemite are linked by a strong magnetic force. Earaches will occur if you get too close.",
     "nationalPokedexNumbers": [
       82
     ],
@@ -3685,7 +3834,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "65",
+    "artist": "Anesaki Dynamic",
     "rarity": "Uncommon",
+    "flavorText": "As it zooms through the sky, this Pokémon seems to be receiving signals of unknown origin while transmitting signals of unknown purpose.",
     "nationalPokedexNumbers": [
       462
     ],
@@ -3716,7 +3867,7 @@
     "evolvesFrom": "Pupitar",
     "rules": [
       "Pokémon ex rule: When your Pokémon ex is Knocked Out, your opponent takes 2 Prize cards.",
-      "As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's)."
+      "Tera: As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's)."
     ],
     "attacks": [
       {
@@ -3753,6 +3904,7 @@
     ],
     "convertedRetreatCost": 4,
     "number": "66",
+    "artist": "5ban Graphics",
     "rarity": "Double Rare",
     "nationalPokedexNumbers": [
       248
@@ -3814,7 +3966,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "67",
+    "artist": "Kagemaru Himeno",
     "rarity": "Common",
+    "flavorText": "While one alone doesn't have much power, a chain of many Tynamo can be as powerful as lightning.",
     "nationalPokedexNumbers": [
       602
     ],
@@ -3878,7 +4032,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "68",
+    "artist": "Souichirou Gunjima",
     "rarity": "Common",
+    "flavorText": "They coil around foes and shock them with electricity-generating organs that seem simply to be circular patterns.",
     "nationalPokedexNumbers": [
       603
     ],
@@ -3940,7 +4096,9 @@
     ],
     "convertedRetreatCost": 3,
     "number": "69",
+    "artist": "Masakazu Fukuda",
     "rarity": "Uncommon",
+    "flavorText": "They crawl out of the ocean using their arms. They will attack prey on shore and immediately drag it into the ocean.",
     "nationalPokedexNumbers": [
       604
     ],
@@ -3997,7 +4155,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "70",
+    "artist": "GOSSAN",
     "rarity": "Rare",
+    "flavorText": "As it flies around, it shoots lightning all over the place and causes forest fires. It is therefore disliked.",
     "nationalPokedexNumbers": [
       642
     ],
@@ -4048,7 +4208,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "71",
+    "artist": "AKIRA EGAWA",
     "rarity": "Common",
+    "flavorText": "It has no problem drinking dirty water. An organ inside Toxel's body filters such water into a poisonous liquid that is harmless to Toxel.",
     "nationalPokedexNumbers": [
       848
     ],
@@ -4108,7 +4270,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "72",
+    "artist": "Anesaki Dynamic",
     "rarity": "Rare",
+    "flavorText": "Many youths admire the way this Pokémon listlessly picks fights and keeps its cool no matter what opponent it faces.",
     "nationalPokedexNumbers": [
       849
     ],
@@ -4167,9 +4331,10 @@
       }
     ],
     "number": "73",
+    "artist": "aky CG Works",
     "rarity": "Double Rare",
     "nationalPokedexNumbers": [
-      922
+      923
     ],
     "legalities": {
       "unlimited": "Legal",
@@ -4192,6 +4357,9 @@
     "hp": "50",
     "types": [
       "Lightning"
+    ],
+    "evolvesTo": [
+      "Bellibolt"
     ],
     "attacks": [
       {
@@ -4226,7 +4394,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "74",
+    "artist": "kirisAki",
     "rarity": "Common",
+    "flavorText": "Tadbulb shakes its tail to generate electricity. If it senses danger, it will make its head blink on and off to alert its allies.",
     "nationalPokedexNumbers": [
       938
     ],
@@ -4252,6 +4422,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Bellibolt"
+    ],
     "attacks": [
       {
         "name": "Thunder Jolt",
@@ -4275,7 +4448,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "75",
+    "artist": "Saya Tsuruta",
     "rarity": "Common",
+    "flavorText": "Tadbulb shakes its tail to generate electricity. If it senses danger, it will make its head blink on and off to alert its allies.",
     "nationalPokedexNumbers": [
       938
     ],
@@ -4301,6 +4476,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Bellibolt"
+    ],
     "attacks": [
       {
         "name": "Shake and Discharge",
@@ -4325,7 +4503,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "76",
+    "artist": "Shin Nagasawa",
     "rarity": "Common",
+    "flavorText": "Tadbulb shakes its tail to generate electricity. If it senses danger, it will make its head blink on and off to alert its allies.",
     "nationalPokedexNumbers": [
       938
     ],
@@ -4376,7 +4556,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "77",
+    "artist": "Kouki Saitou",
     "rarity": "Uncommon",
+    "flavorText": "When this Pokémon expands and contracts its wobbly body, the belly-button dynamo in its stomach produces a huge amount of electricity.",
     "nationalPokedexNumbers": [
       939
     ],
@@ -4436,7 +4618,9 @@
     ],
     "convertedRetreatCost": 3,
     "number": "78",
+    "artist": "Toshinao Aoki",
     "rarity": "Uncommon",
+    "flavorText": "When this Pokémon expands and contracts its wobbly body, the belly-button dynamo in its stomach produces a huge amount of electricity.",
     "nationalPokedexNumbers": [
       939
     ],
@@ -4495,6 +4679,7 @@
       }
     ],
     "number": "79",
+    "artist": "5ban Graphics",
     "rarity": "Double Rare",
     "nationalPokedexNumbers": [
       1008
@@ -4524,8 +4709,14 @@
     "evolvesTo": [
       "Clefairy"
     ],
-    "rules": [
-      "Grasping Draw: Draw cards until you have 7 cards in your hand."
+    "attacks": [
+      {
+        "name": "Grasping Draw",
+        "cost": [],
+        "convertedEnergyCost": 0,
+        "damage": "",
+        "text": "Draw cards until you have 7 cards in your hand."
+      }
     ],
     "weaknesses": [
       {
@@ -4534,7 +4725,9 @@
       }
     ],
     "number": "80",
+    "artist": "kurumitsu",
     "rarity": "Common",
+    "flavorText": "Because of its unusual, starlike silhouette, people believe that it came here on a meteor.",
     "nationalPokedexNumbers": [
       173
     ],
@@ -4586,7 +4779,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "81",
+    "artist": "Yuka Morii",
     "rarity": "Common",
+    "flavorText": "Its adorable behavior and cry make it highly popular. However, this cute Pokémon is rarely found.",
     "nationalPokedexNumbers": [
       35
     ],
@@ -4649,6 +4844,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "82",
+    "artist": "Satoshi Shirai",
     "rarity": "Double Rare",
     "nationalPokedexNumbers": [
       36
@@ -4710,7 +4906,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "83",
+    "artist": "Natsumi Yoshida",
     "rarity": "Common",
+    "flavorText": "It is considered to be a symbol of good luck. Its shell is said to be filled with happiness.",
     "nationalPokedexNumbers": [
       175
     ],
@@ -4772,7 +4970,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "84",
+    "artist": "Kyoko Umemoto",
     "rarity": "Uncommon",
+    "flavorText": "It grows dispirited if it is not with kind people. It can float in midair without moving its wings.",
     "nationalPokedexNumbers": [
       176
     ],
@@ -4825,7 +5025,9 @@
       }
     ],
     "number": "85",
+    "artist": "Cona Nitanda",
     "rarity": "Rare",
+    "flavorText": "Known as a bringer of blessings, it's been depicted on good-luck charms since ancient times.",
     "nationalPokedexNumbers": [
       468
     ],
@@ -4890,7 +5092,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "86",
+    "artist": "Cona Nitanda",
     "rarity": "Uncommon",
+    "flavorText": "The tip of its forked tail quivers when it is predicting its opponent's next move.",
     "nationalPokedexNumbers": [
       196
     ],
@@ -4952,7 +5156,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "87",
+    "artist": "Sekio",
     "rarity": "Common",
+    "flavorText": "In contrast to its appearance, it's quite timid. When playing with other puppy Pokémon, it sometimes gets bullied.",
     "nationalPokedexNumbers": [
       209
     ],
@@ -5014,7 +5220,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "88",
+    "artist": "Lee HyunJung",
     "rarity": "Uncommon",
+    "flavorText": "Although it's popular with young people, Granbull is timid and sensitive, so it's totally incompetent as a watchdog.",
     "nationalPokedexNumbers": [
       210
     ],
@@ -5063,7 +5271,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "89",
+    "artist": "0313",
     "rarity": "Common",
+    "flavorText": "It chomps with its gaping mouth. Its huge jaws are actually steel horns that have been transformed.",
     "nationalPokedexNumbers": [
       303
     ],
@@ -5130,7 +5340,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "90",
+    "artist": "GOSSAN",
     "rarity": "Common",
+    "flavorText": "Spoink will die if it stops bouncing. The pearl on its head amplifies its psychic powers.",
     "nationalPokedexNumbers": [
       325
     ],
@@ -5196,7 +5408,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "91",
+    "artist": "Scav",
     "rarity": "Uncommon",
+    "flavorText": "It can perform odd dance steps to influence foes. Its style of dancing became hugely popular overseas.",
     "nationalPokedexNumbers": [
       326
     ],
@@ -5259,7 +5473,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "92",
+    "artist": "Tetsu Kayama",
     "rarity": "Uncommon",
+    "flavorText": "It was discovered at the site of a meteor strike 40 years ago. Its stare can lull its foes to sleep.",
     "nationalPokedexNumbers": [
       337
     ],
@@ -5323,7 +5539,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "93",
+    "artist": "Tetsu Kayama",
     "rarity": "Uncommon",
+    "flavorText": "Solar energy is the source of its power, so it is strong during the daytime. When it spins, its body shines.",
     "nationalPokedexNumbers": [
       338
     ],
@@ -5381,7 +5599,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "94",
+    "artist": "Scav",
     "rarity": "Common",
+    "flavorText": "It was discovered in ancient ruins. While moving, it constantly spins. It stands on one foot even when asleep.",
     "nationalPokedexNumbers": [
       343
     ],
@@ -5446,7 +5666,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "95",
+    "artist": "Shigenori Negishi",
     "rarity": "Rare",
+    "flavorText": "It appears to have been born from clay dolls made by ancient people. It uses telekinesis to float and move.",
     "nationalPokedexNumbers": [
       344
     ],
@@ -5477,7 +5699,7 @@
     "evolvesFrom": "Combee",
     "rules": [
       "Pokémon ex rule: When your Pokémon ex is Knocked Out, your opponent takes 2 Prize cards.",
-      "As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's)."
+      "Tera: As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's)."
     ],
     "attacks": [
       {
@@ -5519,6 +5741,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "96",
+    "artist": "5ban Graphics",
     "rarity": "Double Rare",
     "nationalPokedexNumbers": [
       416
@@ -5576,7 +5799,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "97",
+    "artist": "Yuka Morii",
     "rarity": "Common",
+    "flavorText": "The soul of someone who died alone possessed some leftover tea. This Pokémon appears in hotels and houses.",
     "nationalPokedexNumbers": [
       854
     ],
@@ -5641,7 +5866,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "98",
+    "artist": "Megumi Mizutani",
     "rarity": "Uncommon",
+    "flavorText": "The tea that composes Polteageist's body has a distinct and enjoyable flavor. Drinking too much, however, can be fatal.",
     "nationalPokedexNumbers": [
       855
     ],
@@ -5666,6 +5893,9 @@
     "hp": "70",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Houndstone"
     ],
     "attacks": [
       {
@@ -5706,7 +5936,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "99",
+    "artist": "Shibuzoh.",
     "rarity": "Common",
+    "flavorText": "It is said that a dog Pokémon that died in the wild without ever interacting with a human was reborn as this Pokémon.",
     "nationalPokedexNumbers": [
       971
     ],
@@ -5731,6 +5963,9 @@
     "hp": "80",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Houndstone"
     ],
     "attacks": [
       {
@@ -5764,7 +5999,9 @@
     ],
     "convertedRetreatCost": 3,
     "number": "100",
+    "artist": "Pani Kobayashi",
     "rarity": "Common",
+    "flavorText": "It is said that a dog Pokémon that died in the wild without ever interacting with a human was reborn as this Pokémon.",
     "nationalPokedexNumbers": [
       971
     ],
@@ -5833,7 +6070,9 @@
     ],
     "convertedRetreatCost": 3,
     "number": "101",
+    "artist": "Saya Tsuruta",
     "rarity": "Uncommon",
+    "flavorText": "Houndstone spends most of its time sleeping in graveyards. Among all the dog Pokémon, this one is most loyal to its master.",
     "nationalPokedexNumbers": [
       972
     ],
@@ -5905,6 +6144,7 @@
     ],
     "convertedRetreatCost": 3,
     "number": "102",
+    "artist": "5ban Graphics",
     "rarity": "Double Rare",
     "nationalPokedexNumbers": [
       972
@@ -5956,7 +6196,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "103",
+    "artist": "OKACHEKE",
     "rarity": "Common",
+    "flavorText": "It lives about one yard underground, where it feeds on plant roots. It sometimes appears aboveground.",
     "nationalPokedexNumbers": [
       50
     ],
@@ -6005,7 +6247,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "104",
+    "artist": "Nelnal",
     "rarity": "Uncommon",
+    "flavorText": "Its three heads bob separately up and down to loosen the soil nearby, making it easier for it to burrow.",
     "nationalPokedexNumbers": [
       51
     ],
@@ -6066,7 +6310,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "105",
+    "artist": "KYUPIYAMA",
     "rarity": "Common",
+    "flavorText": "Born deep underground, this Pokémon becomes a pupa after eating enough dirt to make a mountain.",
     "nationalPokedexNumbers": [
       246
     ],
@@ -6128,7 +6374,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "106",
+    "artist": "Souichirou Gunjima",
     "rarity": "Uncommon",
+    "flavorText": "This pupa flies around wildly by venting with great force the gas pressurized inside its body.",
     "nationalPokedexNumbers": [
       247
     ],
@@ -6191,7 +6439,9 @@
     ],
     "convertedRetreatCost": 3,
     "number": "107",
+    "artist": "Nobuhiro Imagawa",
     "rarity": "Common",
+    "flavorText": "It hunts without twitching a muscle by pulling in its prey with powerful magnetism. But sometimes it pulls natural enemies in close.",
     "nationalPokedexNumbers": [
       299
     ],
@@ -6253,7 +6503,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "108",
+    "artist": "Scav",
     "rarity": "Common",
+    "flavorText": "Its two whiskers provide a sensitive radar. Even in muddy waters, it can detect its prey's location.",
     "nationalPokedexNumbers": [
       339
     ],
@@ -6316,7 +6568,9 @@
     ],
     "convertedRetreatCost": 3,
     "number": "109",
+    "artist": "0313",
     "rarity": "Uncommon",
+    "flavorText": "It is extremely protective of its territory. If any foe approaches, it attacks using vicious tremors.",
     "nationalPokedexNumbers": [
       340
     ],
@@ -6345,8 +6599,14 @@
     "evolvesTo": [
       "Sudowoodo"
     ],
-    "rules": [
-      "Blubbering: 10 damage. Your opponent's Active Pokémon is now Confused."
+    "attacks": [
+      {
+        "name": "Blubbering",
+        "cost": [],
+        "convertedEnergyCost": 0,
+        "damage": "10",
+        "text": "Your opponent's Active Pokémon is now Confused."
+      }
     ],
     "weaknesses": [
       {
@@ -6355,7 +6615,9 @@
       }
     ],
     "number": "110",
+    "artist": "Mizue",
     "rarity": "Common",
+    "flavorText": "In order to adjust the level of fluids in its body, it exudes water from its eyes. This makes it appear to be crying.",
     "nationalPokedexNumbers": [
       438
     ],
@@ -6407,7 +6669,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "111",
+    "artist": "sowsow",
     "rarity": "Common",
+    "flavorText": "It's a digger, using its claws to burrow through the ground. It causes damage to vegetable crops, so many farmers have little love for it.",
     "nationalPokedexNumbers": [
       529
     ],
@@ -6464,7 +6728,9 @@
     ],
     "convertedRetreatCost": 3,
     "number": "112",
+    "artist": "Sumiyoshi Kizuki",
     "rarity": "Uncommon",
+    "flavorText": "For some reason, this Pokémon smiles slightly when it emits a strong electric current from the yellow markings on its body.",
     "nationalPokedexNumbers": [
       618
     ],
@@ -6528,7 +6794,9 @@
     ],
     "convertedRetreatCost": 4,
     "number": "113",
+    "artist": "SATOSHI NAKAI",
     "rarity": "Uncommon",
+    "flavorText": "The fur on its belly retains heat exceptionally well. People used to make heavy winter clothing from fur shed by this Pokémon.",
     "nationalPokedexNumbers": [
       660
     ],
@@ -6593,7 +6861,9 @@
     ],
     "convertedRetreatCost": 3,
     "number": "114",
+    "artist": "Nagomi Nijo",
     "rarity": "Common",
+    "flavorText": "This Pokémon punches trees and eats the berries that drop down, training itself and getting food at the same time.",
     "nationalPokedexNumbers": [
       739
     ],
@@ -6657,7 +6927,9 @@
     ],
     "convertedRetreatCost": 4,
     "number": "115",
+    "artist": "Misa Tsutsui",
     "rarity": "Uncommon",
+    "flavorText": "The detached pincers of these Pokémon are delicious. Some Trainers bring Lechonk into the mountains just to search for them.",
     "nationalPokedexNumbers": [
       740
     ],
@@ -6708,7 +6980,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "116",
+    "artist": "Jerky",
     "rarity": "Common",
+    "flavorText": "This Pokémon is very friendly when it's young. Its disposition becomes vicious once it matures, but it never forgets the kindness of its master.",
     "nationalPokedexNumbers": [
       744
     ],
@@ -6769,7 +7043,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "117",
+    "artist": "Mitsuhiro Arita",
     "rarity": "Uncommon",
+    "flavorText": "This Pokémon uses its rocky mane to slash any who approach. It will even disobey its Trainer if it dislikes the orders it was given.",
     "nationalPokedexNumbers": [
       745
     ],
@@ -6794,6 +7070,9 @@
     "hp": "60",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Toedscruel"
     ],
     "attacks": [
       {
@@ -6827,7 +7106,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "118",
+    "artist": "Oswaldo KATO",
     "rarity": "Common",
+    "flavorText": "Toedscool lives in muggy forests. The flaps that fall from its body are chewy and very delicious.",
     "nationalPokedexNumbers": [
       948
     ],
@@ -6889,7 +7170,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "119",
+    "artist": "Kouki Saitou",
     "rarity": "Uncommon",
+    "flavorText": "These Pokémon gather into groups and form colonies deep within forests. They absolutely hate it when strangers approach.",
     "nationalPokedexNumbers": [
       949
     ],
@@ -6952,6 +7235,7 @@
     ],
     "convertedRetreatCost": 3,
     "number": "120",
+    "artist": "aky CG Works",
     "rarity": "Double Rare",
     "nationalPokedexNumbers": [
       950
@@ -6977,6 +7261,9 @@
     "hp": "60",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Glimmora"
     ],
     "attacks": [
       {
@@ -7009,7 +7296,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "121",
+    "artist": "Sanosuke Sakuma",
     "rarity": "Common",
+    "flavorText": "It absorbs nutrients from cave walls. The petals it wears are made of crystallized poison.",
     "nationalPokedexNumbers": [
       969
     ],
@@ -7035,6 +7324,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Glimmora"
+    ],
     "attacks": [
       {
         "name": "Poison Shard",
@@ -7059,7 +7351,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "122",
+    "artist": "GIDORA",
     "rarity": "Common",
+    "flavorText": "It absorbs nutrients from cave walls. The petals it wears are made of crystallized poison.",
     "nationalPokedexNumbers": [
       969
     ],
@@ -7122,6 +7416,7 @@
     ],
     "convertedRetreatCost": 3,
     "number": "123",
+    "artist": "5ban Graphics",
     "rarity": "Double Rare",
     "nationalPokedexNumbers": [
       970
@@ -7186,6 +7481,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "124",
+    "artist": "aky CG Works",
     "rarity": "Double Rare",
     "nationalPokedexNumbers": [
       1007
@@ -7217,7 +7513,7 @@
     "evolvesFrom": "Charmeleon",
     "rules": [
       "Pokémon ex rule: When your Pokémon ex is Knocked Out, your opponent takes 2 Prize cards.",
-      "As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's)."
+      "Tera: As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's)."
     ],
     "abilities": [
       {
@@ -7250,6 +7546,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "125",
+    "artist": "5ban Graphics",
     "rarity": "Double Rare",
     "nationalPokedexNumbers": [
       6
@@ -7277,7 +7574,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Quagsire"
+      "Quagsire",
+      "Clodsire"
     ],
     "attacks": [
       {
@@ -7301,7 +7599,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "126",
+    "artist": "Shibuzoh.",
     "rarity": "Common",
+    "flavorText": "After losing a territorial struggle, Wooper began living on land. The Pokémon changed over time, developing a poisonous film to protect its body.",
     "nationalPokedexNumbers": [
       194
     ],
@@ -7328,7 +7628,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Quagsire"
+      "Quagsire",
+      "Clodsire"
     ],
     "attacks": [
       {
@@ -7354,7 +7655,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "127",
+    "artist": "Pani Kobayashi",
     "rarity": "Common",
+    "flavorText": "After losing a territorial struggle, Wooper began living on land. The Pokémon changed over time, developing a poisonous film to protect its body.",
     "nationalPokedexNumbers": [
       194
     ],
@@ -7416,7 +7719,9 @@
     ],
     "convertedRetreatCost": 3,
     "number": "128",
+    "artist": "Kouki Saitou",
     "rarity": "Uncommon",
+    "flavorText": "When attacked, this Pokémon will retaliate by sticking thick spines out from its body. It's a risky move that puts everything on the line.",
     "nationalPokedexNumbers": [
       980
     ],
@@ -7478,7 +7783,9 @@
     ],
     "convertedRetreatCost": 3,
     "number": "129",
+    "artist": "Shin Nagasawa",
     "rarity": "Uncommon",
+    "flavorText": "When attacked, this Pokémon will retaliate by sticking thick spines out from its body. It's a risky move that puts everything on the line.",
     "nationalPokedexNumbers": [
       980
     ],
@@ -7538,7 +7845,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "130",
+    "artist": "rika",
     "rarity": "Uncommon",
+    "flavorText": "When exposed to the moon's aura, the rings on its body glow faintly and it gains a mysterious power.",
     "nationalPokedexNumbers": [
       197
     ],
@@ -7599,7 +7908,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "131",
+    "artist": "Scav",
     "rarity": "Common",
+    "flavorText": "It is smart enough to hunt in packs. It uses a variety of cries for communicating with others.",
     "nationalPokedexNumbers": [
       228
     ],
@@ -7661,7 +7972,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "132",
+    "artist": "Kurata So",
     "rarity": "Common",
+    "flavorText": "It is smart enough to hunt in packs. It uses a variety of cries for communicating with others.",
     "nationalPokedexNumbers": [
       228
     ],
@@ -7723,7 +8036,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "133",
+    "artist": "Haru Akasaka",
     "rarity": "Uncommon",
+    "flavorText": "If you are burned by the flames it shoots from its mouth, the pain will never go away.",
     "nationalPokedexNumbers": [
       229
     ],
@@ -7789,6 +8104,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "134",
+    "artist": "PLANETA Tsuji",
     "rarity": "Double Rare",
     "nationalPokedexNumbers": [
       229
@@ -7852,6 +8168,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "135",
+    "artist": "Nisota Niso",
     "rarity": "Double Rare",
     "nationalPokedexNumbers": [
       359
@@ -7912,7 +8229,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "136",
+    "artist": "Bun Toujo",
     "rarity": "Rare",
+    "flavorText": "It can lull people to sleep and make them dream. It is active during nights of the new moon.",
     "nationalPokedexNumbers": [
       491
     ],
@@ -7964,7 +8283,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "137",
+    "artist": "Kedamahadaitai Yawarakai",
     "rarity": "Common",
+    "flavorText": "By exposing foes to the blinking of its luminescent spots, Inkay demoralizes them, and then it seizes the chance to flee.",
     "nationalPokedexNumbers": [
       686
     ],
@@ -8023,7 +8344,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "138",
+    "artist": "Nelnal",
     "rarity": "Uncommon",
+    "flavorText": "It's said that Malamar's hypnotic powers played a role in certain history-changing events.",
     "nationalPokedexNumbers": [
       687
     ],
@@ -8084,7 +8407,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "139",
+    "artist": "Shiburingaru",
     "rarity": "Common",
+    "flavorText": "It taunts its prey and lures them into narrow, rocky areas where it then sprays them with toxic gas to make them dizzy and take them down.",
     "nationalPokedexNumbers": [
       757
     ],
@@ -8143,7 +8468,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "140",
+    "artist": "Shigenori Negishi",
     "rarity": "Uncommon",
+    "flavorText": "Salazzle makes its opponents light-headed with poisonous gas, then captivates them with alluring movements to turn them into loyal servants.",
     "nationalPokedexNumbers": [
       758
     ],
@@ -8209,7 +8536,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "141",
+    "artist": "otumami",
     "rarity": "Rare",
+    "flavorText": "This Pokémon's pincers, which contain steel, can crush any hard object they get ahold of into bits.",
     "nationalPokedexNumbers": [
       212
     ],
@@ -8274,7 +8603,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "142",
+    "artist": "Takeshi Nakamura",
     "rarity": "Uncommon",
+    "flavorText": "People fashion swords from Skarmory's shed feathers, so this Pokémon is a popular element in heraldic designs.",
     "nationalPokedexNumbers": [
       227
     ],
@@ -8337,7 +8668,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "143",
+    "artist": "sowsow",
     "rarity": "Uncommon",
+    "flavorText": "It chomps with its gaping mouth. Its huge jaws are actually steel horns that have been transformed.",
     "nationalPokedexNumbers": [
       303
     ],
@@ -8405,7 +8738,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "144",
+    "artist": "Shinji Kanda",
     "rarity": "Common",
+    "flavorText": "Ancient people believed that the pattern on Bronzor's back contained a mysterious power.",
     "nationalPokedexNumbers": [
       436
     ],
@@ -8472,7 +8807,9 @@
     ],
     "convertedRetreatCost": 3,
     "number": "145",
+    "artist": "Nobuhiro Imagawa",
     "rarity": "Uncommon",
+    "flavorText": "In ages past, this Pokémon was revered as a bringer of rain. It was found buried in the ground.",
     "nationalPokedexNumbers": [
       437
     ],
@@ -8542,7 +8879,9 @@
     ],
     "convertedRetreatCost": 4,
     "number": "146",
+    "artist": "takuyoa",
     "rarity": "Uncommon",
+    "flavorText": "It uses three small units to catch prey and battle enemies. The main body mostly just gives orders.",
     "nationalPokedexNumbers": [
       476
     ],
@@ -8598,7 +8937,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "147",
+    "artist": "kawayoo",
     "rarity": "Uncommon",
+    "flavorText": "Known as the Drill King, this Pokémon can tunnel through the terrain at speeds of over 90 mph.",
     "nationalPokedexNumbers": [
       530
     ],
@@ -8655,7 +8996,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "148",
+    "artist": "Hitoshi Ariga",
     "rarity": "Common",
+    "flavorText": "Pawniard will fearlessly challenge even powerful foes. In a pinch, it will cling to opponents and pierce them with the blades all over its body.",
     "nationalPokedexNumbers": [
       624
     ],
@@ -8682,6 +9025,9 @@
       "Metal"
     ],
     "evolvesFrom": "Pawniard",
+    "evolvesTo": [
+      "Kingambit"
+    ],
     "attacks": [
       {
         "name": "Metal Claw",
@@ -8699,8 +9045,8 @@
           "Colorless"
         ],
         "convertedEnergyCost": 2,
-        "damage": "50+ damage. Flip 3 coins. If 1 of them is heads, this attack does 20 more damage. If 2 of them are heads, this attack does 60 more",
-        "text": "If all of them are heads, this attack does 120 more damage."
+        "damage": "50+",
+        "text": "Flip 3 coins. If 1 of them is heads, this attack does 20 more damage. If 2 of them are heads, this attack does 60 more damage. If all of them are heads, this attack does 120 more damage."
       }
     ],
     "weaknesses": [
@@ -8721,7 +9067,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "149",
+    "artist": "GIDORA",
     "rarity": "Common",
+    "flavorText": "This Pokémon commands a group of several Pawniard. Groups that are defeated in territorial disputes are absorbed by the winning side.",
     "nationalPokedexNumbers": [
       625
     ],
@@ -8790,7 +9138,9 @@
     ],
     "convertedRetreatCost": 4,
     "number": "150",
+    "artist": "Ryota Murayama",
     "rarity": "Uncommon",
+    "flavorText": "Only a Bisharp that stands above all others in its vast army can evolve into Kingambit.",
     "nationalPokedexNumbers": [
       983
     ],
@@ -8854,7 +9204,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "151",
+    "artist": "Sekio",
     "rarity": "Common",
+    "flavorText": "When it's in trouble, it curls up into a ball, makes its fur spikes stand on end, and then discharges electricity indiscriminately.",
     "nationalPokedexNumbers": [
       777
     ],
@@ -8911,7 +9263,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "152",
+    "artist": "Nobuhiro Imagawa",
     "rarity": "Common",
+    "flavorText": "They live as a group, but when the time comes, one strong Meltan will absorb all the others and evolve.",
     "nationalPokedexNumbers": [
       808
     ],
@@ -8985,6 +9339,7 @@
     ],
     "convertedRetreatCost": 4,
     "number": "153",
+    "artist": "PLANETA Igarashi",
     "rarity": "Double Rare",
     "nationalPokedexNumbers": [
       809
@@ -9010,6 +9365,9 @@
     "hp": "60",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Revavroom"
     ],
     "attacks": [
       {
@@ -9039,7 +9397,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "154",
+    "artist": "Kouki Saitou",
     "rarity": "Common",
+    "flavorText": "It is said that this Pokémon was born when an unknown poison Pokémon entered and inspirited an engine left at a scrap-processing factory.",
     "nationalPokedexNumbers": [
       965
     ],
@@ -9064,6 +9424,9 @@
     "hp": "70",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Revavroom"
     ],
     "attacks": [
       {
@@ -9095,7 +9458,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "155",
+    "artist": "Saya Tsuruta",
     "rarity": "Common",
+    "flavorText": "It is said that this Pokémon was born when an unknown poison Pokémon entered and inspirited an engine left at a scrap-processing factory.",
     "nationalPokedexNumbers": [
       965
     ],
@@ -9163,6 +9528,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "156",
+    "artist": "takuyoa",
     "rarity": "Double Rare",
     "nationalPokedexNumbers": [
       966
@@ -9208,7 +9574,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "157",
+    "artist": "satoma",
     "rarity": "Common",
+    "flavorText": "It sheds many layers of skin as it grows larger. During this process, it is protected by a rapid waterfall.",
     "nationalPokedexNumbers": [
       147
     ],
@@ -9265,7 +9633,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "158",
+    "artist": "Misa Tsutsui",
     "rarity": "Uncommon",
+    "flavorText": "They say that if it emits an aura from its whole body, the weather will begin to change instantly.",
     "nationalPokedexNumbers": [
       148
     ],
@@ -9296,7 +9666,7 @@
     "evolvesFrom": "Dragonair",
     "rules": [
       "Pokémon ex rule: When your Pokémon ex is Knocked Out, your opponent takes 2 Prize cards.",
-      "As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's)."
+      "Tera: As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's)."
     ],
     "attacks": [
       {
@@ -9315,8 +9685,8 @@
           "Lightning"
         ],
         "convertedEnergyCost": 2,
-        "damage": "140+ damage. Flip a coin. If heads, this attack does 140 more",
-        "text": "If tails, during your next turn, this Pokémon can't attack."
+        "damage": "140+",
+        "text": "Flip a coin. If heads, this attack does 140 more damage. If tails, during your next turn, this Pokémon can't attack."
       }
     ],
     "retreatCost": [
@@ -9325,6 +9695,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "159",
+    "artist": "5ban Graphics",
     "rarity": "Double Rare",
     "nationalPokedexNumbers": [
       149
@@ -9378,7 +9749,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "160",
+    "artist": "kurumitsu",
     "rarity": "Uncommon",
+    "flavorText": "If it bonds with a person, it will gently envelop the friend with its soft wings, then hum.",
     "nationalPokedexNumbers": [
       334
     ],
@@ -9422,7 +9795,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "161",
+    "artist": "hatachu",
     "rarity": "Uncommon",
+    "flavorText": "Drampa is a kind and friendly Pokémon—up until it's angered. When that happens, it stirs up a gale and flattens everything around.",
     "nationalPokedexNumbers": [
       780
     ],
@@ -9479,7 +9854,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "162",
+    "artist": "Naoyo Kimura",
     "rarity": "Common",
+    "flavorText": "It is docile and prefers to avoid conflict. If disturbed, however, it can ferociously strike back.",
     "nationalPokedexNumbers": [
       16
     ],
@@ -9538,7 +9915,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "163",
+    "artist": "Kariya",
     "rarity": "Uncommon",
+    "flavorText": "Very protective of its sprawling territorial area, this Pokémon will fiercely peck at any intruder.",
     "nationalPokedexNumbers": [
       17
     ],
@@ -9601,6 +9980,7 @@
       }
     ],
     "number": "164",
+    "artist": "takuyoa",
     "rarity": "Double Rare",
     "nationalPokedexNumbers": [
       18
@@ -9660,7 +10040,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "165",
+    "artist": "Yuya Oka",
     "rarity": "Uncommon",
+    "flavorText": "There are records of a lost human child being raised by a childless Kangaskhan.",
     "nationalPokedexNumbers": [
       115
     ],
@@ -9690,11 +10072,11 @@
       "Vaporeon",
       "Jolteon",
       "Flareon",
-      "Sylveon",
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Sylveon"
     ],
     "attacks": [
       {
@@ -9728,7 +10110,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "166",
+    "artist": "ryoma uratsuka",
     "rarity": "Common",
+    "flavorText": "Its ability to evolve into many forms allows it to adapt smoothly and perfectly to any environment.",
     "nationalPokedexNumbers": [
       133
     ],
@@ -9789,7 +10173,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "167",
+    "artist": "Kagemaru Himeno",
     "rarity": "Common",
+    "flavorText": "A Pokémon with abundant curiosity. It shows an interest in everything, so it always zigzags.",
     "nationalPokedexNumbers": [
       263
     ],
@@ -9816,6 +10202,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Zigzagoon",
+    "evolvesTo": [
+      "Obstagoon"
+    ],
     "attacks": [
       {
         "name": "Jet Headbutt",
@@ -9845,7 +10234,9 @@
       }
     ],
     "number": "168",
+    "artist": "Nagomi Nijo",
     "rarity": "Uncommon",
+    "flavorText": "It uses its explosive speed and razor-sharp claws to bring down prey. Running along winding paths is not its strong suit.",
     "nationalPokedexNumbers": [
       264
     ],
@@ -9912,7 +10303,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "169",
+    "artist": "Oswaldo KATO",
     "rarity": "Common",
+    "flavorText": "It constantly grooms its cotton-like wings. It takes a shower to clean itself if it becomes dirty.",
     "nationalPokedexNumbers": [
       333
     ],
@@ -9963,7 +10356,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "170",
+    "artist": "Yuka Morii",
     "rarity": "Common",
+    "flavorText": "This Pokémon is far brighter than the average child, and Lillipup won't forget the love it receives or any abuse it suffers.",
     "nationalPokedexNumbers": [
       506
     ],
@@ -10026,7 +10421,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "171",
+    "artist": "Kariya",
     "rarity": "Common",
+    "flavorText": "The black fur that covers this Pokémon's body is dense and springy. Even sharp fangs bounce right off.",
     "nationalPokedexNumbers": [
       507
     ],
@@ -10088,7 +10485,9 @@
     ],
     "convertedRetreatCost": 3,
     "number": "172",
+    "artist": "Keisin",
     "rarity": "Uncommon",
+    "flavorText": "Stoutland is immensely proud of its impressive moustache. It's said that moustache length is what determines social standing among this species.",
     "nationalPokedexNumbers": [
       508
     ],
@@ -10147,7 +10546,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "173",
+    "artist": "Tika Matsuno",
     "rarity": "Common",
+    "flavorText": "This Pokémon has a kind heart. By touching with its feelers, Audino can gauge other creatures' feelings and physical conditions.",
     "nationalPokedexNumbers": [
       531
     ],
@@ -10204,7 +10605,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "174",
+    "artist": "Yuya Oka",
     "rarity": "Uncommon",
+    "flavorText": "These Pokémon live in herds of about 20 individuals. Bouffalant that betray the herd will lose the hair on their heads for some reason.",
     "nationalPokedexNumbers": [
       626
     ],
@@ -10255,7 +10658,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "175",
+    "artist": "Lee HyunJung",
     "rarity": "Common",
+    "flavorText": "It's very sensitive to danger. The sound of Corviknight's flapping will have Bunnelby digging a hole to hide underground in moments.",
     "nationalPokedexNumbers": [
       659
     ],
@@ -10306,7 +10711,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "176",
+    "artist": "saino misaki",
     "rarity": "Common",
+    "flavorText": "Its stomach fills most of its torso. It wanders the same path every day, searching for fresh food.",
     "nationalPokedexNumbers": [
       734
     ],
@@ -10366,7 +10773,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "177",
+    "artist": "Eri Yamaki",
     "rarity": "Uncommon",
+    "flavorText": "Once it finds signs of prey, it will patiently stake out the location, waiting until the sun goes down.",
     "nationalPokedexNumbers": [
       735
     ],
@@ -10426,7 +10835,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "178",
+    "artist": "Taiga Kayama",
     "rarity": "Common",
+    "flavorText": "It stores berries in its cheeks. When there are no berries to be found, Skwovet will stuff pebbles into its cheeks to stave off its cravings.",
     "nationalPokedexNumbers": [
       819
     ],
@@ -10457,7 +10868,7 @@
     "evolvesFrom": "Skwovet",
     "rules": [
       "Pokémon ex rule: When your Pokémon ex is Knocked Out, your opponent takes 2 Prize cards.",
-      "As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's)."
+      "Tera: As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's)."
     ],
     "attacks": [
       {
@@ -10493,6 +10904,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "179",
+    "artist": "5ban Graphics",
     "rarity": "Double Rare",
     "nationalPokedexNumbers": [
       820
@@ -10519,6 +10931,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Oinkologne"
+    ],
     "attacks": [
       {
         "name": "Tackle",
@@ -10541,7 +10956,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "180",
+    "artist": "HYOGONOSUKE",
     "rarity": "Common",
+    "flavorText": "It searches for food all day. It possesses a keen sense of smell but doesn't use it for anything other than foraging.",
     "nationalPokedexNumbers": [
       915
     ],
@@ -10567,6 +10984,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Oinkologne"
+    ],
     "attacks": [
       {
         "name": "Disarming Voice",
@@ -10591,7 +11011,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "181",
+    "artist": "Tomokazu Komiya",
     "rarity": "Common",
+    "flavorText": "It searches for food all day. It possesses a keen sense of smell but doesn't use it for anything other than foraging.",
     "nationalPokedexNumbers": [
       915
     ],
@@ -10616,6 +11038,9 @@
     "hp": "70",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Oinkologne"
     ],
     "attacks": [
       {
@@ -10650,7 +11075,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "182",
+    "artist": "Atsuko Nishida",
     "rarity": "Common",
+    "flavorText": "It searches for food all day. It possesses a keen sense of smell but doesn't use it for anything other than foraging.",
     "nationalPokedexNumbers": [
       915
     ],
@@ -10712,7 +11139,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "183",
+    "artist": "Pani Kobayashi",
     "rarity": "Uncommon",
+    "flavorText": "Oinkologne is proud of its fine, glossy skin. It emits a concentrated scent from the tip of its tail.",
     "nationalPokedexNumbers": [
       916
     ],
@@ -10774,7 +11203,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "184",
+    "artist": "Akira Komayama",
     "rarity": "Uncommon",
+    "flavorText": "This Pokémon sends a flowerlike scent wafting about. Well-developed muscles in its legs allow it to leap more than 16 feet with no trouble at all.",
     "nationalPokedexNumbers": [
       916
     ],
@@ -10839,7 +11270,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "185",
+    "artist": "Hiroki Asanuma",
     "rarity": "Uncommon",
+    "flavorText": "This Pokémon apparently ties the base of its neck into a knot so that the energy stored in its belly does not escape from its beak.",
     "nationalPokedexNumbers": [
       973
     ],
@@ -10866,6 +11299,7 @@
       "You may play only 1 Supporter card during your turn."
     ],
     "number": "186",
+    "artist": "GIDORA",
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
@@ -10890,6 +11324,7 @@
       "You may play only 1 Supporter card during your turn."
     ],
     "number": "187",
+    "artist": "GIDORA",
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
@@ -10914,6 +11349,7 @@
       "You may play only 1 Supporter card during your turn."
     ],
     "number": "188",
+    "artist": "kirisAki",
     "rarity": "Rare",
     "legalities": {
       "unlimited": "Legal",
@@ -10934,11 +11370,11 @@
       "Item"
     ],
     "rules": [
-      "You can use this card only if any of your Pokémon were Knocked Out during your opponent's last turn.",
-      "Search your deck for up to 3 Basic Energy cards, reveal them, and put them into your hand. Then, shuffle your deck.",
+      "You can use this card only if any of your Pokémon were Knocked Out during your opponent's last turn.\nSearch your deck for up to 3 Basic Energy cards, reveal them, and put them into your hand. Then, shuffle your deck.",
       "You may play any number of Item cards during your turn."
     ],
     "number": "189",
+    "artist": "Toyste Beach",
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
@@ -10963,6 +11399,7 @@
       "You may play only 1 Supporter card during your turn."
     ],
     "number": "190",
+    "artist": "Naoki Saito",
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
@@ -10984,9 +11421,10 @@
     ],
     "rules": [
       "As long as the Pokémon this card is attached to is in the Active Spot, cards in your deck can't be discarded by effects of your opponent's attacks, Abilities, Item cards, Pokémon Tool cards, or Supporter cards.",
-      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "You may attach any number of Pokémon Tools to your Pokémon during your turn. You may attach only 1 Pokémon Tool to each Pokémon, and it stays attached."
     ],
     "number": "191",
+    "artist": "Toyste Beach",
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
@@ -11008,9 +11446,10 @@
     ],
     "rules": [
       "Attacks used by each Basic Pokémon in play (both yours and your opponent's) cost Colorless more.",
-      "You may play only 1 Stadium card during your turn. Put it into the Active Spot, and discard it if another Stadium comes into play. A Stadium with the same name can't be played."
+      "You may play only 1 Stadium card during your turn. Put it next to the Active Spot, and discard it if another Stadium comes into play. A Stadium with the same name can't be played."
     ],
     "number": "192",
+    "artist": "Oswaldo KATO",
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
@@ -11035,6 +11474,7 @@
       "You may play only 1 Supporter card during your turn."
     ],
     "number": "193",
+    "artist": "yuu",
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
@@ -11059,6 +11499,7 @@
       "You may play only 1 Supporter card during your turn."
     ],
     "number": "194",
+    "artist": "nagimiso",
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
@@ -11083,6 +11524,7 @@
       "You may play only 1 Supporter card during your turn."
     ],
     "number": "195",
+    "artist": "nagimiso",
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
@@ -11104,9 +11546,10 @@
     ],
     "rules": [
       "Once during each player's turn, that player may search their deck for a Pokémon Tool card, reveal it, and put it into their hand. Then, that player shuffles their deck.",
-      "You may play only 1 Stadium card during your turn. Put it into the Active Spot, and discard it if another Stadium comes into play. A Stadium with the same name can't be played."
+      "You may play only 1 Stadium card during your turn. Put it next to the Active Spot, and discard it if another Stadium comes into play. A Stadium with the same name can't be played."
     ],
     "number": "196",
+    "artist": "Oswaldo KATO",
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
@@ -11128,9 +11571,10 @@
     ],
     "rules": [
       "If the Pokémon this card is attached to is Knocked Out by damage from an attack from your opponent's Pokémon, put 4 damage counters on the Attacking Pokémon.",
-      "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached."
+      "You may attach any number of Pokémon Tools to your Pokémon during your turn. You may attach only 1 Pokémon Tool to each Pokémon, and it stays attached."
     ],
     "number": "197",
+    "artist": "Ayaka Yoshida",
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
@@ -11191,7 +11635,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "198",
+    "artist": "Masako Tomii",
     "rarity": "Illustration Rare",
+    "flavorText": "What appears to be drool is actually sweet honey. It is very sticky and clings stubbornly if touched.",
     "nationalPokedexNumbers": [
       44
     ],
@@ -11250,7 +11696,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "199",
+    "artist": "SIE NANAHARA",
     "rarity": "Illustration Rare",
+    "flavorText": "Very smart and very vengeful. Grabbing one of its many tails could result in a 1,000-year curse.",
     "nationalPokedexNumbers": [
       38
     ],
@@ -11310,7 +11758,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "200",
+    "artist": "Akira Komayama",
     "rarity": "Illustration Rare",
+    "flavorText": "This Pokémon's ancient genes have awakened. It is now so extraordinarily strong that it can easily lift a cruise ship with one fin.",
     "nationalPokedexNumbers": [
       964
     ],
@@ -11370,7 +11820,9 @@
     ],
     "convertedRetreatCost": 3,
     "number": "201",
+    "artist": "KEIICHIRO ITO",
     "rarity": "Illustration Rare",
+    "flavorText": "When this Pokémon expands and contracts its wobbly body, the belly-button dynamo in its stomach produces a huge amount of electricity.",
     "nationalPokedexNumbers": [
       939
     ],
@@ -11399,8 +11851,14 @@
     "evolvesTo": [
       "Clefairy"
     ],
-    "rules": [
-      "Grasping Draw: Draw cards until you have 7 cards in your hand."
+    "attacks": [
+      {
+        "name": "Grasping Draw",
+        "cost": [],
+        "convertedEnergyCost": 0,
+        "damage": "",
+        "text": "Draw cards until you have 7 cards in your hand."
+      }
     ],
     "weaknesses": [
       {
@@ -11409,7 +11867,9 @@
       }
     ],
     "number": "202",
+    "artist": "HYOGONOSUKE",
     "rarity": "Illustration Rare",
+    "flavorText": "Because of its unusual, starlike silhouette, people believe that it came here on a meteor.",
     "nationalPokedexNumbers": [
       173
     ],
@@ -11470,7 +11930,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "203",
+    "artist": "Miki Tanaka",
     "rarity": "Illustration Rare",
+    "flavorText": "Born deep underground, this Pokémon becomes a pupa after eating enough dirt to make a mountain.",
     "nationalPokedexNumbers": [
       246
     ],
@@ -11531,7 +11993,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "204",
+    "artist": "KYUPIYAMA",
     "rarity": "Illustration Rare",
+    "flavorText": "It is smart enough to hunt in packs. It uses a variety of cries for communicating with others.",
     "nationalPokedexNumbers": [
       228
     ],
@@ -11597,7 +12061,9 @@
     ],
     "convertedRetreatCost": 2,
     "number": "205",
+    "artist": "Oku",
     "rarity": "Illustration Rare",
+    "flavorText": "This Pokémon's pincers, which contain steel, can crush any hard object they get ahold of into bits.",
     "nationalPokedexNumbers": [
       212
     ],
@@ -11622,6 +12088,9 @@
     "hp": "60",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Revavroom"
     ],
     "attacks": [
       {
@@ -11651,7 +12120,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "206",
+    "artist": "Souichirou Gunjima",
     "rarity": "Illustration Rare",
+    "flavorText": "It is said that this Pokémon was born when an unknown poison Pokémon entered and inspirited an engine left at a scrap-processing factory.",
     "nationalPokedexNumbers": [
       965
     ],
@@ -11708,7 +12179,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "207",
+    "artist": "Jerky",
     "rarity": "Illustration Rare",
+    "flavorText": "It is docile and prefers to avoid conflict. If disturbed, however, it can ferociously strike back.",
     "nationalPokedexNumbers": [
       16
     ],
@@ -11767,7 +12240,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "208",
+    "artist": "Jerky",
     "rarity": "Illustration Rare",
+    "flavorText": "Very protective of its sprawling territorial area, this Pokémon will fiercely peck at any intruder.",
     "nationalPokedexNumbers": [
       17
     ],
@@ -11793,6 +12268,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Oinkologne"
+    ],
     "attacks": [
       {
         "name": "Tackle",
@@ -11815,7 +12293,9 @@
     ],
     "convertedRetreatCost": 1,
     "number": "209",
+    "artist": "Narumi Sato",
     "rarity": "Illustration Rare",
+    "flavorText": "It searches for food all day. It possesses a keen sense of smell but doesn't use it for anything other than foraging.",
     "nationalPokedexNumbers": [
       915
     ],
@@ -11845,7 +12325,7 @@
     ],
     "rules": [
       "Pokémon ex rule: When your Pokémon ex is Knocked Out, your opponent takes 2 Prize cards.",
-      "As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's)."
+      "Tera: As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's)."
     ],
     "attacks": [
       {
@@ -11872,6 +12352,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "210",
+    "artist": "5ban Graphics",
     "rarity": "Ultra Rare",
     "nationalPokedexNumbers": [
       875
@@ -11903,7 +12384,7 @@
     "evolvesFrom": "Pupitar",
     "rules": [
       "Pokémon ex rule: When your Pokémon ex is Knocked Out, your opponent takes 2 Prize cards.",
-      "As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's)."
+      "Tera: As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's)."
     ],
     "attacks": [
       {
@@ -11940,6 +12421,7 @@
     ],
     "convertedRetreatCost": 4,
     "number": "211",
+    "artist": "5ban Graphics",
     "rarity": "Ultra Rare",
     "nationalPokedexNumbers": [
       248
@@ -11971,7 +12453,7 @@
     "evolvesFrom": "Combee",
     "rules": [
       "Pokémon ex rule: When your Pokémon ex is Knocked Out, your opponent takes 2 Prize cards.",
-      "As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's)."
+      "Tera: As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's)."
     ],
     "attacks": [
       {
@@ -12013,6 +12495,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "212",
+    "artist": "5ban Graphics",
     "rarity": "Ultra Rare",
     "nationalPokedexNumbers": [
       416
@@ -12076,6 +12559,7 @@
     ],
     "convertedRetreatCost": 3,
     "number": "213",
+    "artist": "5ban Graphics",
     "rarity": "Ultra Rare",
     "nationalPokedexNumbers": [
       970
@@ -12139,6 +12623,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "214",
+    "artist": "PLANETA Mochizuki",
     "rarity": "Ultra Rare",
     "nationalPokedexNumbers": [
       359
@@ -12170,7 +12655,7 @@
     "evolvesFrom": "Charmeleon",
     "rules": [
       "Pokémon ex rule: When your Pokémon ex is Knocked Out, your opponent takes 2 Prize cards.",
-      "As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's)."
+      "Tera: As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's)."
     ],
     "abilities": [
       {
@@ -12203,6 +12688,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "215",
+    "artist": "5ban Graphics",
     "rarity": "Ultra Rare",
     "nationalPokedexNumbers": [
       6
@@ -12271,6 +12757,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "216",
+    "artist": "takuyoa",
     "rarity": "Ultra Rare",
     "nationalPokedexNumbers": [
       966
@@ -12334,6 +12821,7 @@
       }
     ],
     "number": "217",
+    "artist": "takuyoa",
     "rarity": "Ultra Rare",
     "nationalPokedexNumbers": [
       18
@@ -12361,6 +12849,7 @@
       "You may play only 1 Supporter card during your turn."
     ],
     "number": "218",
+    "artist": "kirisAki",
     "rarity": "Ultra Rare",
     "legalities": {
       "unlimited": "Legal",
@@ -12385,6 +12874,7 @@
       "You may play only 1 Supporter card during your turn."
     ],
     "number": "219",
+    "artist": "Naoki Saito",
     "rarity": "Ultra Rare",
     "legalities": {
       "unlimited": "Legal",
@@ -12409,6 +12899,7 @@
       "You may play only 1 Supporter card during your turn."
     ],
     "number": "220",
+    "artist": "yuu",
     "rarity": "Ultra Rare",
     "legalities": {
       "unlimited": "Legal",
@@ -12433,6 +12924,7 @@
       "You may play only 1 Supporter card during your turn."
     ],
     "number": "221",
+    "artist": "nagimiso",
     "rarity": "Ultra Rare",
     "legalities": {
       "unlimited": "Legal",
@@ -12460,7 +12952,7 @@
     ],
     "rules": [
       "Pokémon ex rule: When your Pokémon ex is Knocked Out, your opponent takes 2 Prize cards.",
-      "As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's)."
+      "Tera: As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's)."
     ],
     "attacks": [
       {
@@ -12487,6 +12979,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "222",
+    "artist": "Toshinao Aoki",
     "rarity": "Special Illustration Rare",
     "nationalPokedexNumbers": [
       875
@@ -12518,7 +13011,7 @@
     "evolvesFrom": "Charmeleon",
     "rules": [
       "Pokémon ex rule: When your Pokémon ex is Knocked Out, your opponent takes 2 Prize cards.",
-      "As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's)."
+      "Tera: As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's)."
     ],
     "abilities": [
       {
@@ -12551,6 +13044,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "223",
+    "artist": "AKIRA EGAWA",
     "rarity": "Special Illustration Rare",
     "nationalPokedexNumbers": [
       6
@@ -12619,6 +13113,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "224",
+    "artist": "Souichirou Gunjima",
     "rarity": "Special Illustration Rare",
     "nationalPokedexNumbers": [
       966
@@ -12682,6 +13177,7 @@
       }
     ],
     "number": "225",
+    "artist": "Jerky",
     "rarity": "Special Illustration Rare",
     "nationalPokedexNumbers": [
       18
@@ -12709,6 +13205,7 @@
       "You may play only 1 Supporter card during your turn."
     ],
     "number": "226",
+    "artist": "DOM",
     "rarity": "Special Illustration Rare",
     "legalities": {
       "unlimited": "Legal",
@@ -12733,6 +13230,7 @@
       "You may play only 1 Supporter card during your turn."
     ],
     "number": "227",
+    "artist": "Ryota Murayama",
     "rarity": "Special Illustration Rare",
     "legalities": {
       "unlimited": "Legal",
@@ -12761,7 +13259,7 @@
     "evolvesFrom": "Charmeleon",
     "rules": [
       "Pokémon ex rule: When your Pokémon ex is Knocked Out, your opponent takes 2 Prize cards.",
-      "As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's)."
+      "Tera: As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's)."
     ],
     "abilities": [
       {
@@ -12794,6 +13292,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "228",
+    "artist": "5ban Graphics",
     "rarity": "Hyper Rare",
     "nationalPokedexNumbers": [
       6
@@ -12818,9 +13317,10 @@
     ],
     "rules": [
       "Once during each player's turn, that player may search their deck for a Basic Pokémon that doesn't have a Rule Box and put it onto their Bench. Then, that player shuffles their deck. (Pokémon ex, Pokémon V, etc. have Rule Boxes.)",
-      "You may play only 1 Stadium card during your turn. Put it into the Active Spot, and discard it if another Stadium comes into play. A Stadium with the same name can't be played."
+      "You may play only 1 Stadium card during your turn. Put it next to the Active Spot, and discard it if another Stadium comes into play. A Stadium with the same name can't be played."
     ],
     "number": "229",
+    "artist": "Oswaldo KATO",
     "rarity": "Hyper Rare",
     "legalities": {
       "unlimited": "Legal",


### PR DESCRIPTION
This PR contains the following improvements:
-  adds the missing artists and flavorTexts
- prefixes Tera rules fix "Tera: " like in sv1 and sv2. 
- fix some rule texts
- sv3-80 attack
- sv3-110 attack
- sv3-149 attack
- sv3-159 attack
- added missing evolutions to evolvesTo 

This contains fixes for #465