### PR TITLE
Various fixes

### DIFF
--- a/cards/en/base2.json
+++ b/cards/en/base2.json
@@ -329,7 +329,6 @@
     "types": [
       "Psychic"
     ],
-    "evolvesFrom": "Mime Jr.",
     "abilities": [
       {
         "name": "Invisible Wall",
@@ -638,7 +637,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesFrom": "Munchlax",
     "abilities": [
       {
         "name": "Thick Skinned",
@@ -1330,7 +1328,6 @@
     "types": [
       "Psychic"
     ],
-    "evolvesFrom": "Mime Jr.",
     "abilities": [
       {
         "name": "Invisible Wall",
@@ -1639,7 +1636,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesFrom": "Munchlax",
     "abilities": [
       {
         "name": "Thick Skinned",
@@ -3700,7 +3696,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesFrom": "Pichu",
     "evolvesTo": [
       "Raichu"
     ],

--- a/cards/en/base3.json
+++ b/cards/en/base3.json
@@ -2277,7 +2277,6 @@
     "types": [
       "Fire"
     ],
-    "evolvesFrom": "Magby",
     "evolvesTo": [
       "Magmortar"
     ],

--- a/cards/en/base4.json
+++ b/cards/en/base4.json
@@ -1686,7 +1686,6 @@
     "types": [
       "Psychic"
     ],
-    "evolvesFrom": "Mime Jr.",
     "abilities": [
       {
         "name": "Invisible Wall",
@@ -1874,7 +1873,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesFrom": "Munchlax",
     "abilities": [
       {
         "name": "Thick Skinned",

--- a/cards/en/base6.json
+++ b/cards/en/base6.json
@@ -3062,7 +3062,7 @@
     "types": [
       "Grass"
     ],
-    "evolvesFrom": "Kakuna",
+    "evolvesFrom": "Weedle",
     "evolvesTo": [
       "Beedrill"
     ],

--- a/cards/en/basep.json
+++ b/cards/en/basep.json
@@ -1737,7 +1737,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesFrom": "Clefairy",
     "evolvesTo": [
       "Clefairy"
     ],

--- a/cards/en/basep.json
+++ b/cards/en/basep.json
@@ -1960,7 +1960,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesFrom": "Pikachu",
     "evolvesTo": [
       "Pikachu"
     ],
@@ -2005,7 +2004,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesFrom": "Jigglypuff",
     "evolvesTo": [
       "Jigglypuff"
     ],

--- a/cards/en/bw11.json
+++ b/cards/en/bw11.json
@@ -7245,7 +7245,7 @@
     "types": [
       "Psychic"
     ],
-    "evolvesFrom": "Kirlia",
+    "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
       "Gallade"

--- a/cards/en/ecard1.json
+++ b/cards/en/ecard1.json
@@ -2957,7 +2957,6 @@
     "types": [
       "Fire"
     ],
-    "evolvesFrom": "Magmar",
     "evolvesTo": [
       "Magmar"
     ],

--- a/cards/en/ecard1.json
+++ b/cards/en/ecard1.json
@@ -1213,7 +1213,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesFrom": "Pikachu",
     "evolvesTo": [
       "Pikachu"
     ],

--- a/cards/en/ecard2.json
+++ b/cards/en/ecard2.json
@@ -474,7 +474,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesFrom": "Electabuzz",
     "evolvesTo": [
       "Electabuzz"
     ],
@@ -3545,7 +3544,6 @@
     "types": [
       "Psychic"
     ],
-    "evolvesFrom": "Jynx",
     "evolvesTo": [
       "Jynx"
     ],

--- a/cards/en/ecard3.json
+++ b/cards/en/ecard3.json
@@ -2865,7 +2865,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesFrom": "Clefairy",
     "evolvesTo": [
       "Clefairy"
     ],

--- a/cards/en/ecard3.json
+++ b/cards/en/ecard3.json
@@ -3990,7 +3990,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesFrom": "Jigglypuff",
     "evolvesTo": [
       "Jigglypuff"
     ],

--- a/cards/en/ex3.json
+++ b/cards/en/ex3.json
@@ -4960,8 +4960,8 @@
     "name": "Ampharos ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
-      "EX"
+      "Stage 2",
+      "ex"
     ],
     "hp": "150",
     "types": [
@@ -5028,8 +5028,8 @@
     "name": "Dragonite ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
-      "EX"
+      "Stage 2",
+      "ex"
     ],
     "hp": "150",
     "types": [
@@ -5110,8 +5110,8 @@
     "name": "Golem ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
-      "EX"
+      "Stage 2",
+      "ex"
     ],
     "hp": "160",
     "types": [
@@ -5184,8 +5184,8 @@
     "name": "Kingdra ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
-      "EX"
+      "Stage 2",
+      "ex"
     ],
     "hp": "150",
     "types": [
@@ -5253,7 +5253,7 @@
     "supertype": "Pokémon",
     "subtypes": [
       "Basic",
-      "EX"
+      "ex"
     ],
     "hp": "90",
     "types": [
@@ -5325,7 +5325,7 @@
     "supertype": "Pokémon",
     "subtypes": [
       "Basic",
-      "EX"
+      "ex"
     ],
     "hp": "100",
     "types": [
@@ -5396,8 +5396,8 @@
     "name": "Magcargo ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
-      "EX"
+      "Stage 1",
+      "ex"
     ],
     "hp": "100",
     "types": [
@@ -5460,8 +5460,8 @@
     "name": "Muk ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
-      "EX"
+      "Stage 1",
+      "ex"
     ],
     "hp": "100",
     "types": [
@@ -5531,7 +5531,7 @@
     "supertype": "Pokémon",
     "subtypes": [
       "Basic",
-      "EX"
+      "ex"
     ],
     "hp": "100",
     "types": [

--- a/cards/en/neo1.json
+++ b/cards/en/neo1.json
@@ -661,7 +661,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesFrom": "Pikachu",
     "evolvesTo": [
       "Pikachu"
     ],

--- a/cards/en/neo2.json
+++ b/cards/en/neo2.json
@@ -3926,7 +3926,6 @@
     "types": [
       "Fighting"
     ],
-    "evolvesFrom": "HitmonchanHitmonleeHitmontop",
     "evolvesTo": [
       "Hitmonlee",
       "Hitmonchan",

--- a/cards/en/neo2.json
+++ b/cards/en/neo2.json
@@ -2423,7 +2423,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesFrom": "Jigglypuff",
     "evolvesTo": [
       "Jigglypuff"
     ],

--- a/cards/en/neo3.json
+++ b/cards/en/neo3.json
@@ -3190,7 +3190,6 @@
     "types": [
       "Psychic"
     ],
-    "evolvesFrom": "Jynx",
     "evolvesTo": [
       "Jynx"
     ],

--- a/cards/en/pl1.json
+++ b/cards/en/pl1.json
@@ -3060,7 +3060,7 @@
     "types": [
       "Lightning"
     ],
-    "evolvesFrom": "Flaaffy",
+    "evolvesFrom": "Mareep",
     "evolvesTo": [
       "Ampharos"
     ],

--- a/cards/en/pop1.json
+++ b/cards/en/pop1.json
@@ -883,8 +883,8 @@
     "name": "Armaldo ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
-      "EX"
+      "Stage 2",
+      "ex"
     ],
     "hp": "160",
     "types": [
@@ -954,8 +954,8 @@
     "name": "Tyranitar ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
-      "EX"
+      "Stage 2",
+      "ex"
     ],
     "hp": "150",
     "types": [

--- a/cards/en/smp.json
+++ b/cards/en/smp.json
@@ -8579,7 +8579,7 @@
     "types": [
       "Fairy"
     ],
-    "evolvesFrom": "Vulpix",
+    "evolvesFrom": "Alolan Vulpix",
     "attacks": [
       {
         "name": "Smash Kick",

--- a/cards/en/sv3pt5.json
+++ b/cards/en/sv3pt5.json
@@ -1736,7 +1736,7 @@
   },
   {
     "id": "sv3pt5-29",
-    "name": "Nidoran♀",
+    "name": "Nidoran ♀",
     "supertype": "Pokémon",
     "subtypes": [
       "Basic"
@@ -1799,7 +1799,7 @@
     "types": [
       "Darkness"
     ],
-    "evolvesFrom": "Nidoran♀",
+    "evolvesFrom": "Nidoran ♀",
     "evolvesTo": [
       "Nidoqueen"
     ],
@@ -1920,7 +1920,7 @@
   },
   {
     "id": "sv3pt5-32",
-    "name": "Nidoran♂",
+    "name": "Nidoran ♂",
     "supertype": "Pokémon",
     "subtypes": [
       "Basic"
@@ -1982,7 +1982,7 @@
     "types": [
       "Darkness"
     ],
-    "evolvesFrom": "Nidoran♂",
+    "evolvesFrom": "Nidoran ♂",
     "evolvesTo": [
       "Nidoking"
     ],

--- a/cards/en/xyp.json
+++ b/cards/en/xyp.json
@@ -8643,7 +8643,7 @@
     "types": [
       "Fairy"
     ],
-    "evolvesFrom": "Flabebe",
+    "evolvesFrom": "Flabébé",
     "evolvesTo": [
       "Florges"
     ],


### PR DESCRIPTION
Originally this PR was named "Fixed Pokémon-ex subtypes, removed evolvesFrom from Basic Pokémon", but then I added a bunch more fixes. I left the original comment below, but see the commit descriptions as well.

* Pokémon-ex in ex3 and pop1 had the "EX" subtype instead of "ex", and "Basic" instead of their normal evolution stage
* Some Basic Pokémon in the base series had evolvesFrom set to their babies (for example Snorlax had "Munchlax")