### PR TITLE
Fixes to cards in svp (30-32, 36-45)

### DIFF
--- a/cards/en/svp.json
+++ b/cards/en/svp.json
@@ -1818,6 +1818,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "30",
+    "artist": "aky CG Works",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       1002
@@ -1884,6 +1885,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "31",
+    "artist": "takuyoa",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       959
@@ -1948,6 +1950,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "32",
+    "artist": "PLANETA Hiiragi",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       979
@@ -2008,6 +2011,7 @@
     ],
     "convertedRetreatCost": 2,
     "number": "36",
+    "artist": "nagimiso",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       964
@@ -2047,6 +2051,7 @@
       }
     ],
     "number": "37",
+    "artist": "Mina Nakai",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       173
@@ -2100,6 +2105,7 @@
       }
     ],
     "number": "38",
+    "artist": "OKACHEKE",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       468
@@ -2163,6 +2169,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "39",
+    "artist": "Souichirou Gunjima",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       303
@@ -2212,6 +2219,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "40",
+    "artist": "Ryuta Fuse",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       921
@@ -2274,6 +2282,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "41",
+    "artist": "kirisAki",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       194
@@ -2343,6 +2352,7 @@
     ],
     "convertedRetreatCost": 3,
     "number": "42",
+    "artist": "Pani Kobayashi",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       972
@@ -2412,6 +2422,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "43",
+    "artist": "saino misaki",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       133
@@ -2463,6 +2474,7 @@
     ],
     "convertedRetreatCost": 1,
     "number": "44",
+    "artist": "MINAMINAMI Take",
     "rarity": "Promo",
     "nationalPokedexNumbers": [
       4
@@ -2490,6 +2502,7 @@
       "You may play only 1 Stadium card during your turn. Put it into the Active Spot, and discard it if another Stadium comes into play. A Stadium with the same name can't be played."
     ],
     "number": "45",
+    "artist": "Naoki Saito",
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",

--- a/cards/en/svp.json
+++ b/cards/en/svp.json
@@ -2013,6 +2013,7 @@
     "number": "36",
     "artist": "nagimiso",
     "rarity": "Promo",
+    "flavorText": "This Pokémon's ancient genes have awakened. It is now so extraordinarily strong that it can easily lift a cruise ship with one fin.",
     "nationalPokedexNumbers": [
       964
     ],
@@ -2053,6 +2054,7 @@
     "number": "37",
     "artist": "Mina Nakai",
     "rarity": "Promo",
+    "flavorText": "Because of its unusual, starlike silhouette, people believe that it came here on a meteor.",
     "nationalPokedexNumbers": [
       173
     ],
@@ -2107,6 +2109,7 @@
     "number": "38",
     "artist": "OKACHEKE",
     "rarity": "Promo",
+    "flavorText": "Known as a bringer of blessings, it's been depicted on good-luck charms since ancient times.",
     "nationalPokedexNumbers": [
       468
     ],
@@ -2171,6 +2174,7 @@
     "number": "39",
     "artist": "Souichirou Gunjima",
     "rarity": "Promo",
+    "flavorText": "It chomps with its gaping mouth. Its huge jaws are actually steel horns that have been transformed.",
     "nationalPokedexNumbers": [
       303
     ],
@@ -2221,6 +2225,7 @@
     "number": "40",
     "artist": "Ryuta Fuse",
     "rarity": "Promo",
+    "flavorText": "It has underdeveloped electric sacs on its cheeks. These sacs can produce electricity only if Pawmi rubs them furiously with the pads on its forepaws.",
     "nationalPokedexNumbers": [
       921
     ],
@@ -2284,6 +2289,7 @@
     "number": "41",
     "artist": "kirisAki",
     "rarity": "Promo",
+    "flavorText": "After losing a territorial struggle, Wooper began living on land. The Pokémon changed over time, developing a poisonous film to protect its body.",
     "nationalPokedexNumbers": [
       194
     ],
@@ -2354,6 +2360,7 @@
     "number": "42",
     "artist": "Pani Kobayashi",
     "rarity": "Promo",
+    "flavorText": "Houndstone spends most of its time sleeping in graveyards. Among all the dog Pokémon, this one is most loyal to its master.",
     "nationalPokedexNumbers": [
       972
     ],
@@ -2424,6 +2431,7 @@
     "number": "43",
     "artist": "saino misaki",
     "rarity": "Promo",
+    "flavorText": "Its ability to evolve into many forms allows it to adapt smoothly and perfectly to any environment.",
     "nationalPokedexNumbers": [
       133
     ],
@@ -2476,6 +2484,7 @@
     "number": "44",
     "artist": "MINAMINAMI Take",
     "rarity": "Promo",
+    "flavorText": "From the time it is born, a flame burns at the tip of its tail. Its life would end if the flame were to go out.",
     "nationalPokedexNumbers": [
       4
     ],

--- a/cards/en/svp.json
+++ b/cards/en/svp.json
@@ -2042,8 +2042,14 @@
     "evolvesTo": [
       "Clefairy"
     ],
-    "rules": [
-      "Grasping Draw: Draw cards until you have 7 cards in your hand."
+    "attacks": [
+      {
+        "name": "Grasping Draw",
+        "cost": [],
+        "convertedEnergyCost": 0,
+        "damage": "",
+        "text": "Draw cards until you have 7 cards in your hand."
+      }
     ],
     "weaknesses": [
       {


### PR DESCRIPTION
* All cards were missing the artist
* All non-ex Pokémon were missing the flavor text
* Cleffa had its attack listed as a rule