### PR TITLE
Fixed stadium rules in sv1, sv2 and svp-45

### DIFF
--- a/cards/en/sv1.json
+++ b/cards/en/sv1.json
@@ -9931,7 +9931,7 @@
     ],
     "rules": [
       "The Retreat Cost of each Basic Pokémon in play (both yours and your opponent's) is Colorless less.",
-      "You may play only 1 Stadium card during your turn. Put it into the Active Spot, and discard it if another Stadium comes into play. A Stadium with the same name can't be played."
+      "You may play only 1 Stadium card during your turn. Put it next to the Active Spot, and discard it if another Stadium comes into play. A Stadium with the same name can't be played."
     ],
     "number": "167",
     "artist": "Oswaldo KATO",
@@ -10206,7 +10206,7 @@
     ],
     "rules": [
       "Once during each player's turn, that player may flip a coin. If heads, that player searches their deck for a Pokémon, reveals it, and puts it into their hand. Then, that player shuffles their deck.",
-      "You may play only 1 Stadium card during your turn. Put it into the Active Spot, and discard it if another Stadium comes into play. A Stadium with the same name can't be played."
+      "You may play only 1 Stadium card during your turn. Put it next to the Active Spot, and discard it if another Stadium comes into play. A Stadium with the same name can't be played."
     ],
     "number": "178",
     "artist": "Oswaldo KATO",

--- a/cards/en/sv2.json
+++ b/cards/en/sv2.json
@@ -10191,7 +10191,7 @@
     ],
     "rules": [
       "Once during each player's turn, that player may search their deck for a Basic Pokémon that doesn't have a Rule Box and put it onto their Bench. Then, that player shuffles their deck. (Pokémon ex, Pokémon V, etc. have Rule Boxes.)",
-      "You may play only 1 Stadium card during your turn. Put it into the Active Spot, and discard it if another Stadium comes into play. A Stadium with the same name can't be played."
+      "You may play only 1 Stadium card during your turn. Put it next to the Active Spot, and discard it if another Stadium comes into play. A Stadium with the same name can't be played."
     ],
     "number": "171",
     "artist": "Oswaldo KATO",
@@ -10266,7 +10266,7 @@
     ],
     "rules": [
       "Whenever any player attaches an Energy card from their hand to 1 of their Basic non-Water Pokémon, put 2 damage counters on that Pokémon.",
-      "You may play only 1 Stadium card during your turn. Put it into the Active Spot, and discard it if another Stadium comes into play. A Stadium with the same name can't be played."
+      "You may play only 1 Stadium card during your turn. Put it next to the Active Spot, and discard it if another Stadium comes into play. A Stadium with the same name can't be played."
     ],
     "number": "174",
     "artist": "AYUMI ODASHIMA",
@@ -10291,7 +10291,7 @@
     ],
     "rules": [
       "The Retreat Cost of each Basic non-Fighting Pokémon in play (both yours and your opponent's) is Colorless more.",
-      "You may play only 1 Stadium card during your turn. Put it into the Active Spot, and discard it if another Stadium comes into play. A Stadium with the same name can't be played."
+      "You may play only 1 Stadium card during your turn. Put it next to the Active Spot, and discard it if another Stadium comes into play. A Stadium with the same name can't be played."
     ],
     "number": "175",
     "artist": "AYUMI ODASHIMA",
@@ -10566,7 +10566,7 @@
     ],
     "rules": [
       "The attacks of Stage 1 Pokémon (both yours and your opponent's) do 10 more damage to the opponent's Active Pokémon (before applying Weakness and Resistance).",
-      "You may play only 1 Stadium card during your turn. Put it into the Active Spot, and discard it if another Stadium comes into play. A Stadium with the same name can't be played."
+      "You may play only 1 Stadium card during your turn. Put it next to the Active Spot, and discard it if another Stadium comes into play. A Stadium with the same name can't be played."
     ],
     "number": "186",
     "artist": "AYUMI ODASHIMA",

--- a/cards/en/svp.json
+++ b/cards/en/svp.json
@@ -2487,7 +2487,7 @@
     ],
     "rules": [
       "The Retreat Cost of each Psyduck in play (both yours and your opponent's) is Colorless less.",
-      "You may play only 1 Stadium card during your turn. Put it into the Active Spot, and discard it if another Stadium comes into play. A Stadium with the same name can't be played."
+      "You may play only 1 Stadium card during your turn. Put it next to the Active Spot, and discard it if another Stadium comes into play. A Stadium with the same name can't be played."
     ],
     "number": "45",
     "rarity": "Promo",


### PR DESCRIPTION
All of those stadium cards had a rule that said "Put it into the Active Spot" instead of "Put it next to the Active Spot". The stadiums in sv3 were fine.