### PR TITLE
include ptcgoCode for sv1, sv2, sv3

### DIFF
--- a/sets/en.json
+++ b/sets/en.json
@@ -2673,6 +2673,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "ptcgoCode": "SVI",
     "releaseDate": "2023/03/31",
     "updatedAt": "2023/03/31 15:45:00",
     "images": {
@@ -2691,6 +2692,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "ptcgoCode": "PAL",
     "releaseDate": "2023/06/09",
     "updatedAt": "2023/06/09 15:00:00",
     "images": {
@@ -2709,6 +2711,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "ptcgoCode": "OBF",
     "releaseDate": "2023/08/11",
     "updatedAt": "2023/08/11 15:00:00",
     "images": {


### PR DESCRIPTION
I noticed that the `ptcgoCode` is missing from some of the latest sets:

| Set `id` | Set `ptcgoCode` |
|--|--|
| `sv1` | `SVI` |
| `sv2` | `PAL` |
| `sv3` | `OBF` |

