### PR TITLE
Fixed nonstandard apostrophes in sv1, sv2 and svp-24

### DIFF
--- a/cards/en/sv1.json
+++ b/cards/en/sv1.json
@@ -511,7 +511,7 @@
       "small": "https://images.pokemontcg.io/sv1/9.png",
       "large": "https://images.pokemontcg.io/sv1/9_hires.png"
     },
-    "flavorText": "Spewpa doesn’t live in a fixed location. It roams where it pleases across the fields and mountains, building up the energy it needs to evolve."
+    "flavorText": "Spewpa doesn't live in a fixed location. It roams where it pleases across the fields and mountains, building up the energy it needs to evolve."
   },
   {
     "id": "sv1-10",
@@ -937,7 +937,7 @@
       "small": "https://images.pokemontcg.io/sv1/16.png",
       "large": "https://images.pokemontcg.io/sv1/16_hires.png"
     },
-    "flavorText": "The ball of threads wrapped around its body is elastic enough to deflect the scythes of Scyther, this Pokémon’s natural enemy."
+    "flavorText": "The ball of threads wrapped around its body is elastic enough to deflect the scythes of Scyther, this Pokémon's natural enemy."
   },
   {
     "id": "sv1-17",
@@ -988,7 +988,7 @@
       "small": "https://images.pokemontcg.io/sv1/17.png",
       "large": "https://images.pokemontcg.io/sv1/17_hires.png"
     },
-    "flavorText": "The thread it secretes from its rear is as strong as wire. The secret behind the thread’s strength is the topic of ongoing research."
+    "flavorText": "The thread it secretes from its rear is as strong as wire. The secret behind the thread's strength is the topic of ongoing research."
   },
   {
     "id": "sv1-18",
@@ -1039,7 +1039,7 @@
       "small": "https://images.pokemontcg.io/sv1/18.png",
       "large": "https://images.pokemontcg.io/sv1/18_hires.png"
     },
-    "flavorText": "The thread it secretes from its rear is as strong as wire. The secret behind the thread’s strength is the topic of ongoing research."
+    "flavorText": "The thread it secretes from its rear is as strong as wire. The secret behind the thread's strength is the topic of ongoing research."
   },
   {
     "id": "sv1-19",
@@ -1103,7 +1103,7 @@
       "small": "https://images.pokemontcg.io/sv1/19.png",
       "large": "https://images.pokemontcg.io/sv1/19_hires.png"
     },
-    "flavorText": "The thread it secretes from its rear is as strong as wire. The secret behind the thread’s strength is the topic of ongoing research."
+    "flavorText": "The thread it secretes from its rear is as strong as wire. The secret behind the thread's strength is the topic of ongoing research."
   },
   {
     "id": "sv1-20",
@@ -1734,7 +1734,7 @@
       "small": "https://images.pokemontcg.io/sv1/30.png",
       "large": "https://images.pokemontcg.io/sv1/30_hires.png"
     },
-    "flavorText": "It’s very friendly and faithful to people. It will try to repel enemies by barking and biting."
+    "flavorText": "It's very friendly and faithful to people. It will try to repel enemies by barking and biting."
   },
   {
     "id": "sv1-31",
@@ -1797,7 +1797,7 @@
       "small": "https://images.pokemontcg.io/sv1/31.png",
       "large": "https://images.pokemontcg.io/sv1/31_hires.png"
     },
-    "flavorText": "It’s very friendly and faithful to people. It will try to repel enemies by barking and biting."
+    "flavorText": "It's very friendly and faithful to people. It will try to repel enemies by barking and biting."
   },
   {
     "id": "sv1-32",
@@ -1868,7 +1868,7 @@
       "small": "https://images.pokemontcg.io/sv1/32.png",
       "large": "https://images.pokemontcg.io/sv1/32_hires.png"
     },
-    "flavorText": "It’s very friendly and faithful to people. It will try to repel enemies by barking and biting."
+    "flavorText": "It's very friendly and faithful to people. It will try to repel enemies by barking and biting."
   },
   {
     "id": "sv1-33",
@@ -2117,7 +2117,7 @@
       "small": "https://images.pokemontcg.io/sv1/36.png",
       "large": "https://images.pokemontcg.io/sv1/36_hires.png"
     },
-    "flavorText": "Its flame sac is small, so energy is always leaking out. This energy is released from the dent atop Fuecoco’s head and flickers to and fro."
+    "flavorText": "Its flame sac is small, so energy is always leaking out. This energy is released from the dent atop Fuecoco's head and flickers to and fro."
   },
   {
     "id": "sv1-37",
@@ -2182,7 +2182,7 @@
       "small": "https://images.pokemontcg.io/sv1/37.png",
       "large": "https://images.pokemontcg.io/sv1/37_hires.png"
     },
-    "flavorText": "The valve in Crocalor’s flame sac is closely connected to its vocal cords. This Pokémon utters a guttural cry as it spews flames every which way."
+    "flavorText": "The valve in Crocalor's flame sac is closely connected to its vocal cords. This Pokémon utters a guttural cry as it spews flames every which way."
   },
   {
     "id": "sv1-38",
@@ -2246,7 +2246,7 @@
       "small": "https://images.pokemontcg.io/sv1/38.png",
       "large": "https://images.pokemontcg.io/sv1/38_hires.png"
     },
-    "flavorText": "Skeledirge’s gentle singing soothes the souls of all that hear it. It burns its enemies to a crisp with flames of over 5,400 degrees Fahrenheit."
+    "flavorText": "Skeledirge's gentle singing soothes the souls of all that hear it. It burns its enemies to a crisp with flames of over 5,400 degrees Fahrenheit."
   },
   {
     "id": "sv1-39",
@@ -2881,7 +2881,7 @@
       "small": "https://images.pokemontcg.io/sv1/49.png",
       "large": "https://images.pokemontcg.io/sv1/49_hires.png"
     },
-    "flavorText": "Clauncher’s claws will regrow if they fall off. The meat inside the claws is edible, but it has a distinct flavor that doesn’t appeal to all tastes."
+    "flavorText": "Clauncher's claws will regrow if they fall off. The meat inside the claws is edible, but it has a distinct flavor that doesn't appeal to all tastes."
   },
   {
     "id": "sv1-50",
@@ -3607,7 +3607,7 @@
       "small": "https://images.pokemontcg.io/sv1/61.png",
       "large": "https://images.pokemontcg.io/sv1/61_hires.png"
     },
-    "flavorText": "This Pokémon is a glutton, but it’s bad at getting food. It teams up with a Tatsugiri to catch prey."
+    "flavorText": "This Pokémon is a glutton, but it's bad at getting food. It teams up with a Tatsugiri to catch prey."
   },
   {
     "id": "sv1-62",
@@ -3787,7 +3787,7 @@
       "small": "https://images.pokemontcg.io/sv1/64.png",
       "large": "https://images.pokemontcg.io/sv1/64_hires.png"
     },
-    "flavorText": "They’re formed by several Magnemite linked together. They frequently appear when sunspots flare up."
+    "flavorText": "They're formed by several Magnemite linked together. They frequently appear when sunspots flare up."
   },
   {
     "id": "sv1-65",
@@ -3854,7 +3854,7 @@
       "small": "https://images.pokemontcg.io/sv1/65.png",
       "large": "https://images.pokemontcg.io/sv1/65_hires.png"
     },
-    "flavorText": "They’re formed by several Magnemite linked together. They frequently appear when sunspots flare up."
+    "flavorText": "They're formed by several Magnemite linked together. They frequently appear when sunspots flare up."
   },
   {
     "id": "sv1-66",
@@ -4489,7 +4489,7 @@
       "small": "https://images.pokemontcg.io/sv1/76.png",
       "large": "https://images.pokemontcg.io/sv1/76_hires.png"
     },
-    "flavorText": "Pawmot’s fluffy fur acts as a battery. It can store the same amount of electricity as an electric car."
+    "flavorText": "Pawmot's fluffy fur acts as a battery. It can store the same amount of electricity as an electric car."
   },
   {
     "id": "sv1-77",
@@ -4998,7 +4998,7 @@
       "small": "https://images.pokemontcg.io/sv1/84.png",
       "large": "https://images.pokemontcg.io/sv1/84_hires.png"
     },
-    "flavorText": "The horns on its head provide a strong power that enables it to sense people’s emotions."
+    "flavorText": "The horns on its head provide a strong power that enables it to sense people's emotions."
   },
   {
     "id": "sv1-85",
@@ -5402,7 +5402,7 @@
       "small": "https://images.pokemontcg.io/sv1/90.png",
       "large": "https://images.pokemontcg.io/sv1/90_hires.png"
     },
-    "flavorText": "It can generate and release gas within its body. That’s how it can control the altitude of its drift."
+    "flavorText": "It can generate and release gas within its body. That's how it can control the altitude of its drift."
   },
   {
     "id": "sv1-91",
@@ -5615,7 +5615,7 @@
       "small": "https://images.pokemontcg.io/sv1/94.png",
       "large": "https://images.pokemontcg.io/sv1/94_hires.png"
     },
-    "flavorText": "It’s small and its electricity-generating organ is not fully developed, so it uses its tail to absorb electricity from people’s homes and charge itself."
+    "flavorText": "It's small and its electricity-generating organ is not fully developed, so it uses its tail to absorb electricity from people's homes and charge itself."
   },
   {
     "id": "sv1-95",
@@ -5666,7 +5666,7 @@
       "small": "https://images.pokemontcg.io/sv1/95.png",
       "large": "https://images.pokemontcg.io/sv1/95_hires.png"
     },
-    "flavorText": "It’s small and its electricity-generating organ is not fully developed, so it uses its tail to absorb electricity from people’s homes and charge itself."
+    "flavorText": "It's small and its electricity-generating organ is not fully developed, so it uses its tail to absorb electricity from people's homes and charge itself."
   },
   {
     "id": "sv1-96",
@@ -5774,7 +5774,7 @@
       "small": "https://images.pokemontcg.io/sv1/97.png",
       "large": "https://images.pokemontcg.io/sv1/97_hires.png"
     },
-    "flavorText": "This Pokémon is smooth and moist to the touch. Yeast in Fidough’s breath induces fermentation in the Pokémon’s vicinity."
+    "flavorText": "This Pokémon is smooth and moist to the touch. Yeast in Fidough's breath induces fermentation in the Pokémon's vicinity."
   },
   {
     "id": "sv1-98",
@@ -5836,7 +5836,7 @@
       "small": "https://images.pokemontcg.io/sv1/98.png",
       "large": "https://images.pokemontcg.io/sv1/98_hires.png"
     },
-    "flavorText": "This Pokémon is smooth and moist to the touch. Yeast in Fidough’s breath induces fermentation in the Pokémon’s vicinity."
+    "flavorText": "This Pokémon is smooth and moist to the touch. Yeast in Fidough's breath induces fermentation in the Pokémon's vicinity."
   },
   {
     "id": "sv1-99",
@@ -5896,7 +5896,7 @@
       "small": "https://images.pokemontcg.io/sv1/99.png",
       "large": "https://images.pokemontcg.io/sv1/99_hires.png"
     },
-    "flavorText": "The pleasant aroma that emanates from this Pokémon’s body helps wheat grow, so Dachsbun has been treasured by farming villages."
+    "flavorText": "The pleasant aroma that emanates from this Pokémon's body helps wheat grow, so Dachsbun has been treasured by farming villages."
   },
   {
     "id": "sv1-100",
@@ -5948,7 +5948,7 @@
       "small": "https://images.pokemontcg.io/sv1/100.png",
       "large": "https://images.pokemontcg.io/sv1/100_hires.png"
     },
-    "flavorText": "Flittle’s toes levitate about half an inch above the ground because of the psychic power emitted from the frills on the Pokémon’s belly."
+    "flavorText": "Flittle's toes levitate about half an inch above the ground because of the psychic power emitted from the frills on the Pokémon's belly."
   },
   {
     "id": "sv1-101",
@@ -6004,7 +6004,7 @@
       "small": "https://images.pokemontcg.io/sv1/101.png",
       "large": "https://images.pokemontcg.io/sv1/101_hires.png"
     },
-    "flavorText": "Flittle’s toes levitate about half an inch above the ground because of the psychic power emitted from the frills on the Pokémon’s belly."
+    "flavorText": "Flittle's toes levitate about half an inch above the ground because of the psychic power emitted from the frills on the Pokémon's belly."
   },
   {
     "id": "sv1-102",
@@ -6060,7 +6060,7 @@
       "small": "https://images.pokemontcg.io/sv1/102.png",
       "large": "https://images.pokemontcg.io/sv1/102_hires.png"
     },
-    "flavorText": "Flittle’s toes levitate about half an inch above the ground because of the psychic power emitted from the frills on the Pokémon’s belly."
+    "flavorText": "Flittle's toes levitate about half an inch above the ground because of the psychic power emitted from the frills on the Pokémon's belly."
   },
   {
     "id": "sv1-103",
@@ -6181,7 +6181,7 @@
       "small": "https://images.pokemontcg.io/sv1/104.png",
       "large": "https://images.pokemontcg.io/sv1/104_hires.png"
     },
-    "flavorText": "This friendly Pokémon doesn’t like being alone. Pay it even the slightest bit of attention, and it will follow you forever."
+    "flavorText": "This friendly Pokémon doesn't like being alone. Pay it even the slightest bit of attention, and it will follow you forever."
   },
   {
     "id": "sv1-105",
@@ -6251,7 +6251,7 @@
       "small": "https://images.pokemontcg.io/sv1/105.png",
       "large": "https://images.pokemontcg.io/sv1/105_hires.png"
     },
-    "flavorText": "This friendly Pokémon doesn’t like being alone. Pay it even the slightest bit of attention, and it will follow you forever."
+    "flavorText": "This friendly Pokémon doesn't like being alone. Pay it even the slightest bit of attention, and it will follow you forever."
   },
   {
     "id": "sv1-106",
@@ -6311,7 +6311,7 @@
       "small": "https://images.pokemontcg.io/sv1/106.png",
       "large": "https://images.pokemontcg.io/sv1/106_hires.png"
     },
-    "flavorText": "A lovingly mourned Pokémon was reborn as Houndstone. It doesn’t like anyone touching the protuberance atop its head."
+    "flavorText": "A lovingly mourned Pokémon was reborn as Houndstone. It doesn't like anyone touching the protuberance atop its head."
   },
   {
     "id": "sv1-107",
@@ -6584,7 +6584,7 @@
       "small": "https://images.pokemontcg.io/sv1/111.png",
       "large": "https://images.pokemontcg.io/sv1/111_hires.png"
     },
-    "flavorText": "Through yoga training, it gained the psychic power to predict its foe’s next move."
+    "flavorText": "Through yoga training, it gained the psychic power to predict its foe's next move."
   },
   {
     "id": "sv1-112",
@@ -6767,7 +6767,7 @@
       "small": "https://images.pokemontcg.io/sv1/114.png",
       "large": "https://images.pokemontcg.io/sv1/114_hires.png"
     },
-    "flavorText": "It’s said that no foe can remain invisible to Lucario, since it can detect auras—even those of foes it could not otherwise see."
+    "flavorText": "It's said that no foe can remain invisible to Lucario, since it can detect auras—even those of foes it could not otherwise see."
   },
   {
     "id": "sv1-115",
@@ -7064,7 +7064,7 @@
       "small": "https://images.pokemontcg.io/sv1/119.png",
       "large": "https://images.pokemontcg.io/sv1/119_hires.png"
     },
-    "flavorText": "Silicobra’s neck pouch, which can inflate and deflate like a balloon, gets more elastic each time Silicobra sheds its skin."
+    "flavorText": "Silicobra's neck pouch, which can inflate and deflate like a balloon, gets more elastic each time Silicobra sheds its skin."
   },
   {
     "id": "sv1-120",
@@ -7191,7 +7191,7 @@
       "small": "https://images.pokemontcg.io/sv1/121.png",
       "large": "https://images.pokemontcg.io/sv1/121_hires.png"
     },
-    "flavorText": "The elemental composition of the rocks that form its body were found to match the bedrock of a land far away from this Pokémon’s habitat."
+    "flavorText": "The elemental composition of the rocks that form its body were found to match the bedrock of a land far away from this Pokémon's habitat."
   },
   {
     "id": "sv1-122",
@@ -7255,7 +7255,7 @@
       "small": "https://images.pokemontcg.io/sv1/122.png",
       "large": "https://images.pokemontcg.io/sv1/122_hires.png"
     },
-    "flavorText": "Klawf hangs upside-down from cliffs, waiting for prey. But Klawf can’t remain in this position for long because its blood rushes to its head."
+    "flavorText": "Klawf hangs upside-down from cliffs, waiting for prey. But Klawf can't remain in this position for long because its blood rushes to its head."
   },
   {
     "id": "sv1-123",
@@ -7323,7 +7323,7 @@
       "small": "https://images.pokemontcg.io/sv1/123.png",
       "large": "https://images.pokemontcg.io/sv1/123_hires.png"
     },
-    "flavorText": "Klawf hangs upside-down from cliffs, waiting for prey. But Klawf can’t remain in this position for long because its blood rushes to its head."
+    "flavorText": "Klawf hangs upside-down from cliffs, waiting for prey. But Klawf can't remain in this position for long because its blood rushes to its head."
   },
   {
     "id": "sv1-124",
@@ -7570,7 +7570,7 @@
       "small": "https://images.pokemontcg.io/sv1/127.png",
       "large": "https://images.pokemontcg.io/sv1/127_hires.png"
     },
-    "flavorText": "It’s thickly covered with a filthy, vile sludge. It is so toxic, even its footprints contain poison."
+    "flavorText": "It's thickly covered with a filthy, vile sludge. It is so toxic, even its footprints contain poison."
   },
   {
     "id": "sv1-128",
@@ -8811,7 +8811,7 @@
       "small": "https://images.pokemontcg.io/sv1/147.png",
       "large": "https://images.pokemontcg.io/sv1/147_hires.png"
     },
-    "flavorText": "It’s Seviper’s archrival. To threaten those it encounters, it fans out the claws on its front paws."
+    "flavorText": "It's Seviper's archrival. To threaten those it encounters, it fans out the claws on its front paws."
   },
   {
     "id": "sv1-148",
@@ -9247,7 +9247,7 @@
       "small": "https://images.pokemontcg.io/sv1/154.png",
       "large": "https://images.pokemontcg.io/sv1/154_hires.png"
     },
-    "flavorText": "It searches for food all day. It possesses a keen sense of smell but doesn’t use it for anything other than foraging."
+    "flavorText": "It searches for food all day. It possesses a keen sense of smell but doesn't use it for anything other than foraging."
   },
   {
     "id": "sv1-155",
@@ -9308,7 +9308,7 @@
       "small": "https://images.pokemontcg.io/sv1/155.png",
       "large": "https://images.pokemontcg.io/sv1/155_hires.png"
     },
-    "flavorText": "It searches for food all day. It possesses a keen sense of smell but doesn’t use it for anything other than foraging."
+    "flavorText": "It searches for food all day. It possesses a keen sense of smell but doesn't use it for anything other than foraging."
   },
   {
     "id": "sv1-156",
@@ -9360,7 +9360,7 @@
       "small": "https://images.pokemontcg.io/sv1/156.png",
       "large": "https://images.pokemontcg.io/sv1/156_hires.png"
     },
-    "flavorText": "It searches for food all day. It possesses a keen sense of smell but doesn’t use it for anything other than foraging."
+    "flavorText": "It searches for food all day. It possesses a keen sense of smell but doesn't use it for anything other than foraging."
   },
   {
     "id": "sv1-157",
@@ -9719,7 +9719,7 @@
       "small": "https://images.pokemontcg.io/sv1/162.png",
       "large": "https://images.pokemontcg.io/sv1/162_hires.png"
     },
-    "flavorText": "Green-feathered flocks hold the most sway. When they’re out searching for food in the mornings and evenings, it gets very noisy."
+    "flavorText": "Green-feathered flocks hold the most sway. When they're out searching for food in the mornings and evenings, it gets very noisy."
   },
   {
     "id": "sv1-163",
@@ -9827,7 +9827,7 @@
       "small": "https://images.pokemontcg.io/sv1/164.png",
       "large": "https://images.pokemontcg.io/sv1/164_hires.png"
     },
-    "flavorText": "It can sprint at over 70 mph while carrying a human. The rider’s body heat warms Cyclizar’s back and lifts the Pokémon’s spirit."
+    "flavorText": "It can sprint at over 70 mph while carrying a human. The rider's body heat warms Cyclizar's back and lifts the Pokémon's spirit."
   },
   {
     "id": "sv1-165",
@@ -10771,7 +10771,7 @@
       "small": "https://images.pokemontcg.io/sv1/199.png",
       "large": "https://images.pokemontcg.io/sv1/199_hires.png"
     },
-    "flavorText": "The thread it secretes from its rear is as strong as wire. The secret behind the thread’s strength is the topic of ongoing research."
+    "flavorText": "The thread it secretes from its rear is as strong as wire. The secret behind the thread's strength is the topic of ongoing research."
   },
   {
     "id": "sv1-200",
@@ -11116,7 +11116,7 @@
       "small": "https://images.pokemontcg.io/sv1/205.png",
       "large": "https://images.pokemontcg.io/sv1/205_hires.png"
     },
-    "flavorText": "Clauncher’s claws will regrow if they fall off. The meat inside the claws is edible, but it has a distinct flavor that doesn’t appeal to all tastes."
+    "flavorText": "Clauncher's claws will regrow if they fall off. The meat inside the claws is edible, but it has a distinct flavor that doesn't appeal to all tastes."
   },
   {
     "id": "sv1-206",
@@ -11232,7 +11232,7 @@
       "small": "https://images.pokemontcg.io/sv1/207.png",
       "large": "https://images.pokemontcg.io/sv1/207_hires.png"
     },
-    "flavorText": "This Pokémon is a glutton, but it’s bad at getting food. It teams up with a Tatsugiri to catch prey."
+    "flavorText": "This Pokémon is a glutton, but it's bad at getting food. It teams up with a Tatsugiri to catch prey."
   },
   {
     "id": "sv1-208",
@@ -11346,7 +11346,7 @@
       "small": "https://images.pokemontcg.io/sv1/209.png",
       "large": "https://images.pokemontcg.io/sv1/209_hires.png"
     },
-    "flavorText": "Pawmot’s fluffy fur acts as a battery. It can store the same amount of electricity as an electric car."
+    "flavorText": "Pawmot's fluffy fur acts as a battery. It can store the same amount of electricity as an electric car."
   },
   {
     "id": "sv1-210",
@@ -11470,7 +11470,7 @@
       "small": "https://images.pokemontcg.io/sv1/211.png",
       "large": "https://images.pokemontcg.io/sv1/211_hires.png"
     },
-    "flavorText": "The horns on its head provide a strong power that enables it to sense people’s emotions."
+    "flavorText": "The horns on its head provide a strong power that enables it to sense people's emotions."
   },
   {
     "id": "sv1-212",
@@ -11601,7 +11601,7 @@
       "small": "https://images.pokemontcg.io/sv1/213.png",
       "large": "https://images.pokemontcg.io/sv1/213_hires.png"
     },
-    "flavorText": "This Pokémon is smooth and moist to the touch. Yeast in Fidough’s breath induces fermentation in the Pokémon’s vicinity."
+    "flavorText": "This Pokémon is smooth and moist to the touch. Yeast in Fidough's breath induces fermentation in the Pokémon's vicinity."
   },
   {
     "id": "sv1-214",
@@ -11658,7 +11658,7 @@
       "small": "https://images.pokemontcg.io/sv1/214.png",
       "large": "https://images.pokemontcg.io/sv1/214_hires.png"
     },
-    "flavorText": "This friendly Pokémon doesn’t like being alone. Pay it even the slightest bit of attention, and it will follow you forever."
+    "flavorText": "This friendly Pokémon doesn't like being alone. Pay it even the slightest bit of attention, and it will follow you forever."
   },
   {
     "id": "sv1-215",
@@ -11843,7 +11843,7 @@
       "small": "https://images.pokemontcg.io/sv1/217.png",
       "large": "https://images.pokemontcg.io/sv1/217_hires.png"
     },
-    "flavorText": "Klawf hangs upside-down from cliffs, waiting for prey. But Klawf can’t remain in this position for long because its blood rushes to its head."
+    "flavorText": "Klawf hangs upside-down from cliffs, waiting for prey. But Klawf can't remain in this position for long because its blood rushes to its head."
   },
   {
     "id": "sv1-218",

--- a/cards/en/sv2.json
+++ b/cards/en/sv2.json
@@ -105,7 +105,7 @@
       "small": "https://images.pokemontcg.io/sv2/2.png",
       "large": "https://images.pokemontcg.io/sv2/2_hires.png"
     },
-    "flavorText": "Skiploom enthusiasts can apparently tell where a Skiploom was born by the scent drifting from the flower on the Pokémon’s head."
+    "flavorText": "Skiploom enthusiasts can apparently tell where a Skiploom was born by the scent drifting from the flower on the Pokémon's head."
   },
   {
     "id": "sv2-3",
@@ -215,7 +215,7 @@
       "small": "https://images.pokemontcg.io/sv2/4.png",
       "large": "https://images.pokemontcg.io/sv2/4_hires.png"
     },
-    "flavorText": "It likes to make its shell thicker by adding layers of tree bark. The additional weight doesn’t bother it."
+    "flavorText": "It likes to make its shell thicker by adding layers of tree bark. The additional weight doesn't bother it."
   },
   {
     "id": "sv2-5",
@@ -570,7 +570,7 @@
       "small": "https://images.pokemontcg.io/sv2/10.png",
       "large": "https://images.pokemontcg.io/sv2/10_hires.png"
     },
-    "flavorText": "During cold seasons, it migrates to the mountain’s lower reaches. It returns to the snow-covered summit in the spring."
+    "flavorText": "During cold seasons, it migrates to the mountain's lower reaches. It returns to the snow-covered summit in the spring."
   },
   {
     "id": "sv2-11",
@@ -916,7 +916,7 @@
       "small": "https://images.pokemontcg.io/sv2/16.png",
       "large": "https://images.pokemontcg.io/sv2/16_hires.png"
     },
-    "flavorText": "The ball of threads wrapped around its body is elastic enough to deflect the scythes of Scyther, this Pokémon’s natural enemy."
+    "flavorText": "The ball of threads wrapped around its body is elastic enough to deflect the scythes of Scyther, this Pokémon's natural enemy."
   },
   {
     "id": "sv2-17",
@@ -968,7 +968,7 @@
       "small": "https://images.pokemontcg.io/sv2/17.png",
       "large": "https://images.pokemontcg.io/sv2/17_hires.png"
     },
-    "flavorText": "The ball of threads wrapped around its body is elastic enough to deflect the scythes of Scyther, this Pokémon’s natural enemy."
+    "flavorText": "The ball of threads wrapped around its body is elastic enough to deflect the scythes of Scyther, this Pokémon's natural enemy."
   },
   {
     "id": "sv2-18",
@@ -1091,7 +1091,7 @@
       "small": "https://images.pokemontcg.io/sv2/19.png",
       "large": "https://images.pokemontcg.io/sv2/19_hires.png"
     },
-    "flavorText": "It has its third set of legs folded up. When it’s in a tough spot, this Pokémon jumps over 30 feet using the strength of its legs."
+    "flavorText": "It has its third set of legs folded up. When it's in a tough spot, this Pokémon jumps over 30 feet using the strength of its legs."
   },
   {
     "id": "sv2-20",
@@ -1141,7 +1141,7 @@
       "small": "https://images.pokemontcg.io/sv2/20.png",
       "large": "https://images.pokemontcg.io/sv2/20_hires.png"
     },
-    "flavorText": "It has its third set of legs folded up. When it’s in a tough spot, this Pokémon jumps over 30 feet using the strength of its legs."
+    "flavorText": "It has its third set of legs folded up. When it's in a tough spot, this Pokémon jumps over 30 feet using the strength of its legs."
   },
   {
     "id": "sv2-21",
@@ -1844,7 +1844,7 @@
       "small": "https://images.pokemontcg.io/sv2/32.png",
       "large": "https://images.pokemontcg.io/sv2/32_hires.png"
     },
-    "flavorText": "The females of a pride work together to bring down prey. It’s thanks to them that their pride doesn’t starve."
+    "flavorText": "The females of a pride work together to bring down prey. It's thanks to them that their pride doesn't starve."
   },
   {
     "id": "sv2-33",
@@ -2078,7 +2078,7 @@
       "small": "https://images.pokemontcg.io/sv2/36.png",
       "large": "https://images.pokemontcg.io/sv2/36_hires.png"
     },
-    "flavorText": "The combination of Crocalor’s fire energy and overflowing vitality has caused an egg-shaped fireball to appear on the Pokémon’s head."
+    "flavorText": "The combination of Crocalor's fire energy and overflowing vitality has caused an egg-shaped fireball to appear on the Pokémon's head."
   },
   {
     "id": "sv2-37",
@@ -5466,7 +5466,7 @@
       "small": "https://images.pokemontcg.io/sv2/92.png",
       "large": "https://images.pokemontcg.io/sv2/92_hires.png"
     },
-    "flavorText": "Gothitelle unleashes psychic energy and shows opponents dreams of the universe’s end. These dreams are apparently ethereal and beautiful."
+    "flavorText": "Gothitelle unleashes psychic energy and shows opponents dreams of the universe's end. These dreams are apparently ethereal and beautiful."
   },
   {
     "id": "sv2-93",
@@ -5552,7 +5552,7 @@
           "Psychic",
           "Colorless"
         ],
-        "name": "Plotter’s Command",
+        "name": "Plotter's Command",
         "damage": "30",
         "text": "Choose 1 of your opponent's Active Pokémon's attacks. During your opponent's next turn, that Pokémon can't use that attack.",
         "convertedEnergyCost": 2
@@ -6932,7 +6932,7 @@
       "small": "https://images.pokemontcg.io/sv2/116.png",
       "large": "https://images.pokemontcg.io/sv2/116_hires.png"
     },
-    "flavorText": "This Pokémon is very friendly when it’s young. Its disposition becomes vicious once it matures, but it never forgets the kindness of its master."
+    "flavorText": "This Pokémon is very friendly when it's young. Its disposition becomes vicious once it matures, but it never forgets the kindness of its master."
   },
   {
     "id": "sv2-117",
@@ -7049,7 +7049,7 @@
       "small": "https://images.pokemontcg.io/sv2/118.png",
       "large": "https://images.pokemontcg.io/sv2/118_hires.png"
     },
-    "flavorText": "This Pokémon battles by throwing hard berries. It won’t obey a Trainer who throws Poké Balls without skill."
+    "flavorText": "This Pokémon battles by throwing hard berries. It won't obey a Trainer who throws Poké Balls without skill."
   },
   {
     "id": "sv2-119",
@@ -7278,7 +7278,7 @@
       "small": "https://images.pokemontcg.io/sv2/122.png",
       "large": "https://images.pokemontcg.io/sv2/122_hires.png"
     },
-    "flavorText": "This Pokémon dry cures its prey by spraying salt over them. The curing process steals away the water in the prey’s body."
+    "flavorText": "This Pokémon dry cures its prey by spraying salt over them. The curing process steals away the water in the prey's body."
   },
   {
     "id": "sv2-123",
@@ -8055,7 +8055,7 @@
       "small": "https://images.pokemontcg.io/sv2/135.png",
       "large": "https://images.pokemontcg.io/sv2/135_hires.png"
     },
-    "flavorText": "Extremely strong, it can change the landscape. It is so insolent that it doesn’t care about others."
+    "flavorText": "Extremely strong, it can change the landscape. It is so insolent that it doesn't care about others."
   },
   {
     "id": "sv2-136",
@@ -8225,7 +8225,7 @@
       "small": "https://images.pokemontcg.io/sv2/138.png",
       "large": "https://images.pokemontcg.io/sv2/138_hires.png"
     },
-    "flavorText": "It can’t see, so its first approach to examining things is to bite them. You will be covered in wounds until a Deino warms up to you."
+    "flavorText": "It can't see, so its first approach to examining things is to bite them. You will be covered in wounds until a Deino warms up to you."
   },
   {
     "id": "sv2-139",
@@ -8288,7 +8288,7 @@
       "small": "https://images.pokemontcg.io/sv2/139.png",
       "large": "https://images.pokemontcg.io/sv2/139_hires.png"
     },
-    "flavorText": "The two heads do not get along at all. If you don’t give each head the same amount of attention, they’ll begin fighting out of jealousy."
+    "flavorText": "The two heads do not get along at all. If you don't give each head the same amount of attention, they'll begin fighting out of jealousy."
   },
   {
     "id": "sv2-140",
@@ -8400,7 +8400,7 @@
       "small": "https://images.pokemontcg.io/sv2/141.png",
       "large": "https://images.pokemontcg.io/sv2/141_hires.png"
     },
-    "flavorText": "It always scowls in an attempt to make opponents take it seriously, but even crying children will burst into laughter when they see Maschiff’s face."
+    "flavorText": "It always scowls in an attempt to make opponents take it seriously, but even crying children will burst into laughter when they see Maschiff's face."
   },
   {
     "id": "sv2-142",
@@ -8463,7 +8463,7 @@
       "small": "https://images.pokemontcg.io/sv2/142.png",
       "large": "https://images.pokemontcg.io/sv2/142_hires.png"
     },
-    "flavorText": "It always scowls in an attempt to make opponents take it seriously, but even crying children will burst into laughter when they see Maschiff’s face."
+    "flavorText": "It always scowls in an attempt to make opponents take it seriously, but even crying children will burst into laughter when they see Maschiff's face."
   },
   {
     "id": "sv2-143",
@@ -8764,7 +8764,7 @@
       "small": "https://images.pokemontcg.io/sv2/147.png",
       "large": "https://images.pokemontcg.io/sv2/147_hires.png"
     },
-    "flavorText": "It gathers things up in an apron made from shed feathers added to the Pokémon’s chest feathers, then drops those things from high places for fun."
+    "flavorText": "It gathers things up in an apron made from shed feathers added to the Pokémon's chest feathers, then drops those things from high places for fun."
   },
   {
     "id": "sv2-148",
@@ -8833,7 +8833,7 @@
       "small": "https://images.pokemontcg.io/sv2/148.png",
       "large": "https://images.pokemontcg.io/sv2/148_hires.png"
     },
-    "flavorText": "Corviknight can’t serve as a taxi service in Paldea because the Pokémon’s natural predators will attack it while it flies, endangering the customer."
+    "flavorText": "Corviknight can't serve as a taxi service in Paldea because the Pokémon's natural predators will attack it while it flies, endangering the customer."
   },
   {
     "id": "sv2-149",
@@ -9257,7 +9257,7 @@
       "small": "https://images.pokemontcg.io/sv2/155.png",
       "large": "https://images.pokemontcg.io/sv2/155_hires.png"
     },
-    "flavorText": "Now that the brain waves from the head and tail are synced up, the psychic power of this Pokémon is 10 times stronger than Girafarig’s."
+    "flavorText": "Now that the brain waves from the head and tail are synced up, the psychic power of this Pokémon is 10 times stronger than Girafarig's."
   },
   {
     "id": "sv2-156",
@@ -9651,7 +9651,7 @@
           "Colorless",
           "Colorless"
         ],
-        "name": "Slacker’s Headstrike",
+        "name": "Slacker's Headstrike",
         "damage": "240",
         "text": "This Pokémon is now Asleep.",
         "convertedEnergyCost": 3
@@ -9686,7 +9686,7 @@
       "small": "https://images.pokemontcg.io/sv2/162.png",
       "large": "https://images.pokemontcg.io/sv2/162_hires.png"
     },
-    "flavorText": "It is the world’s most slothful Pokémon. However, it can exert horrifying power by releasing pent-up energy all at once."
+    "flavorText": "It is the world's most slothful Pokémon. However, it can exert horrifying power by releasing pent-up energy all at once."
   },
   {
     "id": "sv2-163",
@@ -9798,7 +9798,7 @@
       "small": "https://images.pokemontcg.io/sv2/164.png",
       "large": "https://images.pokemontcg.io/sv2/164_hires.png"
     },
-    "flavorText": "This Pokémon is brave and reckless. The white markings around a Rookidee’s eyes intimidate fainthearted Pokémon."
+    "flavorText": "This Pokémon is brave and reckless. The white markings around a Rookidee's eyes intimidate fainthearted Pokémon."
   },
   {
     "id": "sv2-165",
@@ -9866,7 +9866,7 @@
       "small": "https://images.pokemontcg.io/sv2/165.png",
       "large": "https://images.pokemontcg.io/sv2/165_hires.png"
     },
-    "flavorText": "It’s said that the reason behind Corvisquire’s high level of intelligence is the large size of its brain relative to those of other bird Pokémon."
+    "flavorText": "It's said that the reason behind Corvisquire's high level of intelligence is the large size of its brain relative to those of other bird Pokémon."
   },
   {
     "id": "sv2-166",
@@ -10209,7 +10209,7 @@
   },
   {
     "id": "sv2-172",
-    "name": "Boss’s Orders (Ghetsis)",
+    "name": "Boss's Orders (Ghetsis)",
     "supertype": "Trainer",
     "subtypes": [
       "Supporter"
@@ -11167,7 +11167,7 @@
       "small": "https://images.pokemontcg.io/sv2/200.png",
       "large": "https://images.pokemontcg.io/sv2/200_hires.png"
     },
-    "flavorText": "The females of a pride work together to bring down prey. It’s thanks to them that their pride doesn’t starve."
+    "flavorText": "The females of a pride work together to bring down prey. It's thanks to them that their pride doesn't starve."
   },
   {
     "id": "sv2-201",
@@ -11292,7 +11292,7 @@
       "small": "https://images.pokemontcg.io/sv2/202.png",
       "large": "https://images.pokemontcg.io/sv2/202_hires.png"
     },
-    "flavorText": "The combination of Crocalor’s fire energy and overflowing vitality has caused an egg-shaped fireball to appear on the Pokémon’s head."
+    "flavorText": "The combination of Crocalor's fire energy and overflowing vitality has caused an egg-shaped fireball to appear on the Pokémon's head."
   },
   {
     "id": "sv2-203",
@@ -12507,7 +12507,7 @@
       "small": "https://images.pokemontcg.io/sv2/222.png",
       "large": "https://images.pokemontcg.io/sv2/222_hires.png"
     },
-    "flavorText": "Extremely strong, it can change the landscape. It is so insolent that it doesn’t care about others."
+    "flavorText": "Extremely strong, it can change the landscape. It is so insolent that it doesn't care about others."
   },
   {
     "id": "sv2-223",
@@ -12690,7 +12690,7 @@
       "small": "https://images.pokemontcg.io/sv2/225.png",
       "large": "https://images.pokemontcg.io/sv2/225_hires.png"
     },
-    "flavorText": "This Pokémon is brave and reckless. The white markings around a Rookidee’s eyes intimidate fainthearted Pokémon."
+    "flavorText": "This Pokémon is brave and reckless. The white markings around a Rookidee's eyes intimidate fainthearted Pokémon."
   },
   {
     "id": "sv2-226",
@@ -12880,7 +12880,7 @@
       "small": "https://images.pokemontcg.io/sv2/228.png",
       "large": "https://images.pokemontcg.io/sv2/228_hires.png"
     },
-    "flavorText": "Now that the brain waves from the head and tail are synced up, the psychic power of this Pokémon is 10 times stronger than Girafarig’s."
+    "flavorText": "Now that the brain waves from the head and tail are synced up, the psychic power of this Pokémon is 10 times stronger than Girafarig's."
   },
   {
     "id": "sv2-229",
@@ -14134,7 +14134,7 @@
   },
   {
     "id": "sv2-248",
-    "name": "Boss’s Orders (Ghetsis)",
+    "name": "Boss's Orders (Ghetsis)",
     "supertype": "Trainer",
     "subtypes": [
       "Supporter"
@@ -14921,7 +14921,7 @@
   },
   {
     "id": "sv2-265",
-    "name": "Boss’s Orders (Ghetsis)",
+    "name": "Boss's Orders (Ghetsis)",
     "supertype": "Trainer",
     "subtypes": [
       "Supporter"

--- a/cards/en/svp.json
+++ b/cards/en/svp.json
@@ -1483,7 +1483,7 @@
       "small": "https://images.pokemontcg.io/svp/24.png",
       "large": "https://images.pokemontcg.io/svp/24_hires.png"
     },
-    "flavorText": "It’s very friendly and faithful to people. It will try to repel enemies by barking and biting."
+    "flavorText": "It's very friendly and faithful to people. It will try to repel enemies by barking and biting."
   },
   {
     "id": "svp-25",


### PR DESCRIPTION
Several apostrophes in names, names of attacks and flavor texts in those sets were nonstandard. Thanks to julien on Discord for pointing this out.