### PR TITLE
Fixed text of Lost World (col1-81)

### DIFF
--- a/cards/en/col1.json
+++ b/cards/en/col1.json
@@ -4606,7 +4606,7 @@
     ],
     "rules": [
       "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
-      "Once during each player's turn, if this player's opponent has 6 or more Pokémon in the Lost Zone, the player may choose to win the game."
+      "Once during each player's turn, if that player's opponent has 6 or more Pokémon in the Lost Zone, the player may choose to win the game."
     ],
     "number": "81",
     "artist": "Hideaki Hakozaki",


### PR DESCRIPTION
There was a small typo, "this" instead of "that"