### PR TITLE
Fixed "this Defending Pokémon" typo

### DIFF
--- a/cards/en/bw5.json
+++ b/cards/en/bw5.json
@@ -1259,7 +1259,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "10",
-        "text": "This Defending Pokémon is now Burned."
+        "text": "The Defending Pokémon is now Burned."
       }
     ],
     "weaknesses": [

--- a/cards/en/ex10.json
+++ b/cards/en/ex10.json
@@ -1407,7 +1407,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": "If Low Pressure System is in play, this Defending Pokémon is now Confused."
+        "text": "If Low Pressure System is in play, the Defending Pokémon is now Confused."
       }
     ],
     "weaknesses": [

--- a/cards/en/gym2.json
+++ b/cards/en/gym2.json
@@ -2875,7 +2875,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "20",
-        "text": "Flip a coin. If heads, this Defending Pokémon is now Poisoned. It now takes 20 Poison damage instead of 10 after each player's turn (even if it was already Poisoned)."
+        "text": "Flip a coin. If heads, the Defending Pokémon is now Poisoned. It now takes 20 Poison damage instead of 10 after each player's turn (even if it was already Poisoned)."
       }
     ],
     "weaknesses": [


### PR DESCRIPTION
A few cards had that instead of "the Defending Pokémon" in the attack text.