### PR TITLE
Added "glc" legalities to cards

### DIFF
--- a/cards/en/base1.json
+++ b/cards/en/base1.json
@@ -2811,7 +2811,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/45.png",
@@ -4182,7 +4183,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/69.png",
@@ -4401,7 +4403,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/81.png",
@@ -4438,7 +4441,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/83.png",
@@ -4457,7 +4461,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/84.png",
@@ -4512,7 +4517,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/87.png",
@@ -4640,7 +4646,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/94.png",
@@ -4660,7 +4667,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/95.png",
@@ -4682,7 +4690,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/96.png",
@@ -4701,7 +4710,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/97.png",
@@ -4720,7 +4730,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/98.png",
@@ -4739,7 +4750,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/99.png",
@@ -4758,7 +4770,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/100.png",
@@ -4777,7 +4790,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/101.png",
@@ -4796,7 +4810,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base1/102.png",

--- a/cards/en/base2.json
+++ b/cards/en/base2.json
@@ -3949,7 +3949,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base2/64.png",

--- a/cards/en/base3.json
+++ b/cards/en/base3.json
@@ -3421,7 +3421,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base3/59.png",
@@ -3458,7 +3459,8 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base3/61.png",

--- a/cards/en/base4.json
+++ b/cards/en/base4.json
@@ -4274,7 +4274,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/68.png",
@@ -6149,7 +6150,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/100.png",
@@ -6331,7 +6333,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/110.png",
@@ -6368,7 +6371,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/112.png",
@@ -6387,7 +6391,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/113.png",
@@ -6424,7 +6429,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/115.png",
@@ -6534,7 +6540,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/121.png",
@@ -6554,7 +6561,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/122.png",
@@ -6574,7 +6582,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/123.png",
@@ -6596,7 +6605,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/124.png",
@@ -6615,7 +6625,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/125.png",
@@ -6634,7 +6645,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/126.png",
@@ -6653,7 +6665,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/127.png",
@@ -6672,7 +6685,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/128.png",
@@ -6691,7 +6705,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/129.png",
@@ -6710,7 +6725,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base4/130.png",

--- a/cards/en/base6.json
+++ b/cards/en/base6.json
@@ -4259,7 +4259,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base6/69.png",
@@ -6003,7 +6004,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base6/99.png",
@@ -6155,7 +6157,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base6/107.png",
@@ -6212,7 +6215,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/base6/110.png",

--- a/cards/en/basep.json
+++ b/cards/en/basep.json
@@ -1605,7 +1605,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/basep/28.png",

--- a/cards/en/bw1.json
+++ b/cards/en/bw1.json
@@ -59,7 +59,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/1.png",
@@ -117,7 +118,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/2.png",
@@ -185,7 +187,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/3.png",
@@ -244,7 +247,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/4.png",
@@ -306,7 +310,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/5.png",
@@ -369,7 +374,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/6.png",
@@ -437,7 +443,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/7.png",
@@ -504,7 +511,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/8.png",
@@ -561,7 +569,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/9.png",
@@ -626,7 +635,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/10.png",
@@ -692,7 +702,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/11.png",
@@ -758,7 +769,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/12.png",
@@ -825,7 +837,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/13.png",
@@ -891,7 +904,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/14.png",
@@ -952,7 +966,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/15.png",
@@ -1005,7 +1020,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/16.png",
@@ -1070,7 +1086,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/17.png",
@@ -1136,7 +1153,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/18.png",
@@ -1202,7 +1220,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/19.png",
@@ -1264,7 +1283,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/20.png",
@@ -1326,7 +1346,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/21.png",
@@ -1386,7 +1407,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/22.png",
@@ -1438,7 +1460,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/23.png",
@@ -1500,7 +1523,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/24.png",
@@ -1562,7 +1586,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/25.png",
@@ -1623,7 +1648,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/26.png",
@@ -1684,7 +1710,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/27.png",
@@ -1736,7 +1763,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/28.png",
@@ -1800,7 +1828,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/29.png",
@@ -1853,7 +1882,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/30.png",
@@ -1915,7 +1945,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/31.png",
@@ -1974,7 +2005,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/32.png",
@@ -2036,7 +2068,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/33.png",
@@ -2096,7 +2129,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/34.png",
@@ -2145,7 +2179,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/35.png",
@@ -2202,7 +2237,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/36.png",
@@ -2267,7 +2303,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/37.png",
@@ -2329,7 +2366,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/38.png",
@@ -2391,7 +2429,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/39.png",
@@ -2443,7 +2482,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/40.png",
@@ -2494,7 +2534,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/41.png",
@@ -2555,7 +2596,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/42.png",
@@ -2615,7 +2657,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/43.png",
@@ -2666,7 +2709,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/44.png",
@@ -2717,7 +2761,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/45.png",
@@ -2776,7 +2821,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/46.png",
@@ -2837,7 +2883,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/47.png",
@@ -2899,7 +2946,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/48.png",
@@ -2959,7 +3007,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/49.png",
@@ -3016,7 +3065,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/50.png",
@@ -3081,7 +3131,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/51.png",
@@ -3144,7 +3195,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/52.png",
@@ -3209,7 +3261,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/53.png",
@@ -3274,7 +3327,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/54.png",
@@ -3335,7 +3389,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/55.png",
@@ -3397,7 +3452,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/56.png",
@@ -3456,7 +3512,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/57.png",
@@ -3508,7 +3565,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/58.png",
@@ -3570,7 +3628,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/59.png",
@@ -3634,7 +3693,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/60.png",
@@ -3696,7 +3756,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/61.png",
@@ -3754,7 +3815,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/62.png",
@@ -3823,7 +3885,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/63.png",
@@ -3893,7 +3956,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/64.png",
@@ -3963,7 +4027,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/65.png",
@@ -4030,7 +4095,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/66.png",
@@ -4095,7 +4161,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/67.png",
@@ -4152,7 +4219,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/68.png",
@@ -4218,7 +4286,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/69.png",
@@ -4276,7 +4345,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/70.png",
@@ -4341,7 +4411,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/71.png",
@@ -4398,7 +4469,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/72.png",
@@ -4464,7 +4536,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/73.png",
@@ -4522,7 +4595,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/74.png",
@@ -4592,7 +4666,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/75.png",
@@ -4658,7 +4733,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/76.png",
@@ -4719,7 +4795,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/77.png",
@@ -4770,7 +4847,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/78.png",
@@ -4830,7 +4908,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/79.png",
@@ -4890,7 +4969,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/80.png",
@@ -4951,7 +5031,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/81.png",
@@ -5015,7 +5096,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/82.png",
@@ -5079,7 +5161,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/83.png",
@@ -5136,7 +5219,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/84.png",
@@ -5204,7 +5288,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/85.png",
@@ -5271,7 +5356,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/86.png",
@@ -5321,7 +5407,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/87.png",
@@ -5372,7 +5459,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/88.png",
@@ -5431,7 +5519,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/89.png",
@@ -5492,7 +5581,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/90.png",
@@ -5554,7 +5644,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/91.png",
@@ -5578,7 +5669,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/92.png",
@@ -5602,7 +5694,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/93.png",
@@ -5626,7 +5719,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/94.png",
@@ -5649,7 +5743,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/95.png",
@@ -5672,7 +5767,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/96.png",
@@ -5696,7 +5792,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/97.png",
@@ -5719,7 +5816,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/98.png",
@@ -5742,7 +5840,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/99.png",
@@ -5766,7 +5865,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/100.png",
@@ -5789,7 +5889,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/101.png",
@@ -5812,7 +5913,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/102.png",
@@ -5835,7 +5937,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/103.png",
@@ -5859,7 +5962,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/104.png",
@@ -5878,7 +5982,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/105.png",
@@ -5897,7 +6002,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/106.png",
@@ -5916,7 +6022,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/107.png",
@@ -5935,7 +6042,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/108.png",
@@ -5954,7 +6062,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/109.png",
@@ -5973,7 +6082,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/110.png",
@@ -5992,7 +6102,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/111.png",
@@ -6011,7 +6122,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/112.png",
@@ -6072,7 +6184,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/113.png",
@@ -6133,7 +6246,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/114.png",
@@ -6195,7 +6309,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw1/115.png",

--- a/cards/en/bw10.json
+++ b/cards/en/bw10.json
@@ -43,7 +43,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/1.png",
@@ -102,7 +103,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/2.png",
@@ -172,7 +174,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/3.png",
@@ -239,7 +242,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/4.png",
@@ -303,7 +307,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/5.png",
@@ -355,7 +360,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/6.png",
@@ -418,7 +424,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/7.png",
@@ -474,7 +481,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/8.png",
@@ -598,7 +606,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/10.png",
@@ -722,7 +731,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/12.png",
@@ -783,7 +793,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/13.png",
@@ -844,7 +855,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/14.png",
@@ -908,7 +920,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/15.png",
@@ -970,7 +983,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/16.png",
@@ -1032,7 +1046,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/17.png",
@@ -1084,7 +1099,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/18.png",
@@ -1144,7 +1160,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/19.png",
@@ -1202,7 +1219,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/20.png",
@@ -1265,7 +1283,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/21.png",
@@ -1328,7 +1347,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/22.png",
@@ -1386,7 +1406,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/23.png",
@@ -1445,7 +1466,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/24.png",
@@ -1509,7 +1531,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/25.png",
@@ -1571,7 +1594,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/26.png",
@@ -1637,7 +1661,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/27.png",
@@ -1703,7 +1728,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/28.png",
@@ -1761,7 +1787,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/29.png",
@@ -1878,7 +1905,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/31.png",
@@ -1940,7 +1968,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/32.png",
@@ -2005,7 +2034,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/33.png",
@@ -2068,7 +2098,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/34.png",
@@ -2122,7 +2153,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/35.png",
@@ -2170,7 +2202,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/36.png",
@@ -2227,7 +2260,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/37.png",
@@ -2286,7 +2320,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/38.png",
@@ -2347,7 +2382,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/39.png",
@@ -2409,7 +2445,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/40.png",
@@ -2472,7 +2509,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/41.png",
@@ -2523,7 +2561,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/42.png",
@@ -2576,7 +2615,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/43.png",
@@ -2637,7 +2677,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/44.png",
@@ -2701,7 +2742,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/45.png",
@@ -2766,7 +2808,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/46.png",
@@ -2820,7 +2863,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/47.png",
@@ -2885,7 +2929,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/48.png",
@@ -2946,7 +2991,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/49.png",
@@ -3011,7 +3057,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/50.png",
@@ -3073,7 +3120,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/51.png",
@@ -3132,7 +3180,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/52.png",
@@ -3195,7 +3244,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/53.png",
@@ -3250,7 +3300,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/54.png",
@@ -3317,7 +3368,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/55.png",
@@ -3384,7 +3436,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/56.png",
@@ -3453,7 +3506,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/57.png",
@@ -3525,7 +3579,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/58.png",
@@ -3596,7 +3651,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/59.png",
@@ -3732,7 +3788,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/61.png",
@@ -3793,7 +3850,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/62.png",
@@ -3858,7 +3916,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/63.png",
@@ -3920,7 +3979,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/64.png",
@@ -4115,7 +4175,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/67.png",
@@ -4178,7 +4239,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/68.png",
@@ -4238,7 +4300,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/69.png",
@@ -4297,7 +4360,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/70.png",
@@ -4356,7 +4420,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/71.png",
@@ -4407,7 +4472,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/72.png",
@@ -4460,7 +4526,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/73.png",
@@ -4519,7 +4586,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/74.png",
@@ -4572,7 +4640,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/75.png",
@@ -4638,7 +4707,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/76.png",
@@ -4703,7 +4773,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/77.png",
@@ -4727,7 +4798,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/78.png",
@@ -4750,7 +4822,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/79.png",
@@ -4774,7 +4847,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/80.png",
@@ -4797,7 +4871,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/81.png",
@@ -4820,7 +4895,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/82.png",
@@ -4844,7 +4920,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/83.png",
@@ -4867,7 +4944,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/84.png",
@@ -4891,7 +4969,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/85.png",
@@ -4916,7 +4995,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/86.png",
@@ -4939,7 +5019,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/87.png",
@@ -4963,7 +5044,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/88.png",
@@ -4987,7 +5069,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/89.png",
@@ -5011,7 +5094,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/90.png",
@@ -5034,7 +5118,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/91.png",
@@ -5513,7 +5598,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/101.png",
@@ -5578,7 +5664,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/102.png",
@@ -5642,7 +5729,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/103.png",
@@ -5703,7 +5791,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/104.png",
@@ -5727,7 +5816,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw10/105.png",

--- a/cards/en/bw11.json
+++ b/cards/en/bw11.json
@@ -61,7 +61,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/1.png",
@@ -131,7 +132,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/2.png",
@@ -190,7 +192,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/3.png",
@@ -247,7 +250,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/4.png",
@@ -303,7 +307,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/5.png",
@@ -361,7 +366,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/6.png",
@@ -420,7 +426,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/7.png",
@@ -483,7 +490,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/8.png",
@@ -535,7 +543,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/9.png",
@@ -587,7 +596,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/10.png",
@@ -649,7 +659,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/11.png",
@@ -708,7 +719,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/12.png",
@@ -761,7 +773,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/13.png",
@@ -823,7 +836,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/14.png",
@@ -887,7 +901,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/15.png",
@@ -947,7 +962,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/16.png",
@@ -1009,7 +1025,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/17.png",
@@ -1073,7 +1090,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/18.png",
@@ -1139,7 +1157,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/19.png",
@@ -1191,7 +1210,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/20.png",
@@ -1242,7 +1262,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/21.png",
@@ -1311,7 +1332,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/22.png",
@@ -1367,7 +1389,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/23.png",
@@ -1482,7 +1505,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/25.png",
@@ -1548,7 +1572,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/26.png",
@@ -1610,7 +1635,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/27.png",
@@ -1671,7 +1697,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/28.png",
@@ -1789,7 +1816,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/30.png",
@@ -1854,7 +1882,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/31.png",
@@ -1923,7 +1952,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/32.png",
@@ -1975,7 +2005,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/33.png",
@@ -2029,7 +2060,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/34.png",
@@ -2091,7 +2123,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/35.png",
@@ -2148,7 +2181,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/36.png",
@@ -2200,7 +2234,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/37.png",
@@ -2253,7 +2288,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/38.png",
@@ -2312,7 +2348,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/39.png",
@@ -2373,7 +2410,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/40.png",
@@ -2437,7 +2475,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/41.png",
@@ -2500,7 +2539,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/42.png",
@@ -2561,7 +2601,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/43.png",
@@ -2758,7 +2799,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/46.png",
@@ -2815,7 +2857,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/47.png",
@@ -2872,7 +2915,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/48.png",
@@ -2931,7 +2975,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/49.png",
@@ -2990,7 +3035,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/50.png",
@@ -3051,7 +3097,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/51.png",
@@ -3180,7 +3227,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/53.png",
@@ -3299,7 +3347,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/55.png",
@@ -3359,7 +3408,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/56.png",
@@ -3411,7 +3461,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/57.png",
@@ -3472,7 +3523,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/58.png",
@@ -3524,7 +3576,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/59.png",
@@ -3589,7 +3642,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/60.png",
@@ -3632,7 +3686,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/61.png",
@@ -3684,7 +3739,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/62.png",
@@ -3744,7 +3800,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/63.png",
@@ -3801,7 +3858,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/64.png",
@@ -3865,7 +3923,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/65.png",
@@ -3922,7 +3981,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/66.png",
@@ -3986,7 +4046,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/67.png",
@@ -4046,7 +4107,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/68.png",
@@ -4107,7 +4169,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/69.png",
@@ -4159,7 +4222,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/70.png",
@@ -4221,7 +4285,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/71.png",
@@ -4280,7 +4345,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/72.png",
@@ -4331,7 +4397,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/73.png",
@@ -4392,7 +4459,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/74.png",
@@ -4444,7 +4512,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/75.png",
@@ -4503,7 +4572,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/76.png",
@@ -4625,7 +4695,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/78.png",
@@ -4686,7 +4757,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/79.png",
@@ -4743,7 +4815,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/80.png",
@@ -4804,7 +4877,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/81.png",
@@ -4942,7 +5016,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/83.png",
@@ -5005,7 +5080,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/84.png",
@@ -5070,7 +5146,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/85.png",
@@ -5129,7 +5206,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/86.png",
@@ -5178,7 +5256,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/87.png",
@@ -5312,7 +5391,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/89.png",
@@ -5379,7 +5459,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/90.png",
@@ -5446,7 +5527,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/91.png",
@@ -5507,7 +5589,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/92.png",
@@ -5568,7 +5651,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/93.png",
@@ -5629,7 +5713,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/94.png",
@@ -5691,7 +5776,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/95.png",
@@ -5750,7 +5836,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/96.png",
@@ -5812,7 +5899,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/97.png",
@@ -5877,7 +5965,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/98.png",
@@ -5938,7 +6027,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/99.png",
@@ -6199,7 +6289,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/103.png",
@@ -6260,7 +6351,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/104.png",
@@ -6318,7 +6410,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/105.png",
@@ -6370,7 +6463,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/106.png",
@@ -6432,7 +6526,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/107.png",
@@ -6497,7 +6592,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/108.png",
@@ -6520,7 +6616,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/109.png",
@@ -6543,7 +6640,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/110.png",
@@ -6567,7 +6665,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/111.png",
@@ -6591,7 +6690,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/112.png",
@@ -6613,7 +6713,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/113.png",
@@ -6674,7 +6775,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/114.png",
@@ -6735,7 +6837,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/115.png",
@@ -6797,7 +6900,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/RC1.png",
@@ -6860,7 +6964,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/RC2.png",
@@ -6919,7 +7024,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/RC3.png",
@@ -6983,7 +7089,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/RC4.png",
@@ -7044,7 +7151,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/RC5.png",
@@ -7105,7 +7213,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/RC6.png",
@@ -7166,7 +7275,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/RC7.png",
@@ -7227,7 +7337,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/RC8.png",
@@ -7290,7 +7401,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/RC9.png",
@@ -7350,7 +7462,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/RC10.png",
@@ -7480,7 +7593,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/RC12.png",
@@ -7537,7 +7651,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/RC13.png",
@@ -7595,7 +7710,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/RC14.png",
@@ -7658,7 +7774,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/RC15.png",
@@ -7722,7 +7839,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/RC16.png",
@@ -7773,7 +7891,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/RC17.png",
@@ -7824,7 +7943,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/RC18.png",
@@ -7882,7 +8002,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/RC19.png",
@@ -7905,7 +8026,8 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/RC20.png",
@@ -8033,7 +8155,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/RC22.png",
@@ -8092,7 +8215,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw11/RC23.png",

--- a/cards/en/bw2.json
+++ b/cards/en/bw2.json
@@ -59,7 +59,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/1.png",
@@ -127,7 +128,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/2.png",
@@ -187,7 +189,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/3.png",
@@ -248,7 +251,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/4.png",
@@ -311,7 +315,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/5.png",
@@ -374,7 +379,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/6.png",
@@ -433,7 +439,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/7.png",
@@ -493,7 +500,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/8.png",
@@ -550,7 +558,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/9.png",
@@ -607,7 +616,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/10.png",
@@ -667,7 +677,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/11.png",
@@ -732,7 +743,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/12.png",
@@ -799,7 +811,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/13.png",
@@ -865,7 +878,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/14.png",
@@ -932,7 +946,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/15.png",
@@ -999,7 +1014,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/16.png",
@@ -1065,7 +1081,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/17.png",
@@ -1126,7 +1143,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/18.png",
@@ -1187,7 +1205,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/19.png",
@@ -1250,7 +1269,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/20.png",
@@ -1314,7 +1334,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/21.png",
@@ -1375,7 +1396,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/22.png",
@@ -1436,7 +1458,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/23.png",
@@ -1495,7 +1518,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/24.png",
@@ -1553,7 +1577,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/25.png",
@@ -1620,7 +1645,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/26.png",
@@ -1687,7 +1713,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/27.png",
@@ -1749,7 +1776,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/28.png",
@@ -1802,7 +1830,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/29.png",
@@ -1867,7 +1896,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/30.png",
@@ -1928,7 +1958,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/31.png",
@@ -1982,7 +2013,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/32.png",
@@ -2033,7 +2065,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/33.png",
@@ -2088,7 +2121,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/34.png",
@@ -2147,7 +2181,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/35.png",
@@ -2199,7 +2234,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/36.png",
@@ -2264,7 +2300,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/37.png",
@@ -2326,7 +2363,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/38.png",
@@ -2391,7 +2429,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/39.png",
@@ -2453,7 +2492,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/40.png",
@@ -2518,7 +2558,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/41.png",
@@ -2583,7 +2624,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/42.png",
@@ -2644,7 +2686,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/43.png",
@@ -2696,7 +2739,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/44.png",
@@ -2758,7 +2802,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/45.png",
@@ -2821,7 +2866,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/46.png",
@@ -2880,7 +2926,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/47.png",
@@ -2940,7 +2987,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/48.png",
@@ -3003,7 +3051,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/49.png",
@@ -3065,7 +3114,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/50.png",
@@ -3132,7 +3182,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/51.png",
@@ -3198,7 +3249,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/52.png",
@@ -3262,7 +3314,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/53.png",
@@ -3329,7 +3382,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/54.png",
@@ -3388,7 +3442,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/55.png",
@@ -3455,7 +3510,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/56.png",
@@ -3523,7 +3579,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/57.png",
@@ -3573,7 +3630,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/58.png",
@@ -3622,7 +3680,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/59.png",
@@ -3675,7 +3734,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/60.png",
@@ -3739,7 +3799,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/61.png",
@@ -3805,7 +3866,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/62.png",
@@ -3868,7 +3930,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/63.png",
@@ -3926,7 +3989,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/64.png",
@@ -3992,7 +4056,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/65.png",
@@ -4059,7 +4124,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/66.png",
@@ -4126,7 +4192,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/67.png",
@@ -4193,7 +4260,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/68.png",
@@ -4258,7 +4326,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/69.png",
@@ -4317,7 +4386,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/70.png",
@@ -4376,7 +4446,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/71.png",
@@ -4443,7 +4514,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/72.png",
@@ -4510,7 +4582,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/73.png",
@@ -4578,7 +4651,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/74.png",
@@ -4647,7 +4721,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/75.png",
@@ -4716,7 +4791,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/76.png",
@@ -4783,7 +4859,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/77.png",
@@ -4834,7 +4911,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/78.png",
@@ -4893,7 +4971,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/79.png",
@@ -4951,7 +5030,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/80.png",
@@ -5020,7 +5100,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/81.png",
@@ -5082,7 +5163,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/82.png",
@@ -5142,7 +5224,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/83.png",
@@ -5193,7 +5276,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/84.png",
@@ -5252,7 +5336,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/85.png",
@@ -5319,7 +5404,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/86.png",
@@ -5386,7 +5472,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/87.png",
@@ -5453,7 +5540,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/88.png",
@@ -5518,7 +5606,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/89.png",
@@ -5541,7 +5630,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/90.png",
@@ -5564,7 +5654,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/91.png",
@@ -5588,7 +5679,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/92.png",
@@ -5612,7 +5704,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/93.png",
@@ -5635,7 +5728,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/94.png",
@@ -5659,7 +5753,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/95.png",
@@ -5682,7 +5777,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/96.png",
@@ -5741,7 +5837,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/97.png",
@@ -5806,7 +5903,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw2/98.png",

--- a/cards/en/bw3.json
+++ b/cards/en/bw3.json
@@ -44,7 +44,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/1.png",
@@ -106,7 +107,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/2.png",
@@ -165,7 +167,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/3.png",
@@ -232,7 +235,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/4.png",
@@ -297,7 +301,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/5.png",
@@ -359,7 +364,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/6.png",
@@ -422,7 +428,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/7.png",
@@ -483,7 +490,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/8.png",
@@ -540,7 +548,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/9.png",
@@ -606,7 +615,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/10.png",
@@ -668,7 +678,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/11.png",
@@ -722,7 +733,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/12.png",
@@ -786,7 +798,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/13.png",
@@ -842,7 +855,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/14.png",
@@ -891,7 +905,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/15.png",
@@ -954,7 +969,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/16.png",
@@ -1015,7 +1031,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/17.png",
@@ -1074,7 +1091,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/18.png",
@@ -1126,7 +1144,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/19.png",
@@ -1179,7 +1198,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/20.png",
@@ -1239,7 +1259,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/21.png",
@@ -1300,7 +1321,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/22.png",
@@ -1364,7 +1386,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/23.png",
@@ -1427,7 +1450,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/24.png",
@@ -1496,7 +1520,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/25.png",
@@ -1558,7 +1583,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/26.png",
@@ -1609,7 +1635,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/27.png",
@@ -1673,7 +1700,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/28.png",
@@ -1734,7 +1762,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/29.png",
@@ -1787,7 +1816,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/30.png",
@@ -1846,7 +1876,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/31.png",
@@ -1904,7 +1935,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/32.png",
@@ -1962,7 +1994,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/33.png",
@@ -2023,7 +2056,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/34.png",
@@ -2074,7 +2108,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/35.png",
@@ -2134,7 +2169,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/36.png",
@@ -2182,7 +2218,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/37.png",
@@ -2233,7 +2270,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/38.png",
@@ -2280,7 +2318,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/39.png",
@@ -2342,7 +2381,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/40.png",
@@ -2405,7 +2445,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/41.png",
@@ -2466,7 +2507,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/42.png",
@@ -2514,7 +2556,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/43.png",
@@ -2565,7 +2608,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/44.png",
@@ -2616,7 +2660,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/45.png",
@@ -2679,7 +2724,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/46.png",
@@ -2737,7 +2783,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/47.png",
@@ -2798,7 +2845,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/48.png",
@@ -2861,7 +2909,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/49.png",
@@ -2912,7 +2961,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/50.png",
@@ -2964,7 +3014,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/51.png",
@@ -3023,7 +3074,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/52.png",
@@ -3084,7 +3136,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/53.png",
@@ -3144,7 +3197,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/54.png",
@@ -3205,7 +3259,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/55.png",
@@ -3264,7 +3319,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/56.png",
@@ -3316,7 +3372,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/57.png",
@@ -3367,7 +3424,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/58.png",
@@ -3429,7 +3487,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/59.png",
@@ -3488,7 +3547,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/60.png",
@@ -3552,7 +3612,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/61.png",
@@ -3604,7 +3665,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/62.png",
@@ -3670,7 +3732,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/63.png",
@@ -3732,7 +3795,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/64.png",
@@ -3794,7 +3858,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/65.png",
@@ -3859,7 +3924,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/66.png",
@@ -3918,7 +3984,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/67.png",
@@ -3984,7 +4051,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/68.png",
@@ -4045,7 +4113,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/69.png",
@@ -4104,7 +4173,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/70.png",
@@ -4164,7 +4234,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/71.png",
@@ -4236,7 +4307,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/72.png",
@@ -4299,7 +4371,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/73.png",
@@ -4364,7 +4437,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/74.png",
@@ -4421,7 +4495,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/75.png",
@@ -4486,7 +4561,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/76.png",
@@ -4554,7 +4630,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/77.png",
@@ -4624,7 +4701,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/78.png",
@@ -4691,7 +4769,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/79.png",
@@ -4760,7 +4839,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/80.png",
@@ -4827,7 +4907,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/81.png",
@@ -4894,7 +4975,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/82.png",
@@ -4958,7 +5040,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/83.png",
@@ -5025,7 +5108,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/84.png",
@@ -5075,7 +5159,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/85.png",
@@ -5120,7 +5205,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/86.png",
@@ -5177,7 +5263,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/87.png",
@@ -5233,7 +5320,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/88.png",
@@ -5285,7 +5373,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/89.png",
@@ -5308,7 +5397,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/90.png",
@@ -5332,7 +5422,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/91.png",
@@ -5355,7 +5446,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/92.png",
@@ -5378,7 +5470,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/93.png",
@@ -5403,7 +5496,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/94.png",
@@ -5427,7 +5521,8 @@
     "legalities": {
       "standard": "Legal",
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/95.png",
@@ -5450,7 +5545,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/96.png",
@@ -5514,7 +5610,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/97.png",
@@ -5570,7 +5667,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/98.png",
@@ -5633,7 +5731,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/99.png",
@@ -5700,7 +5799,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/100.png",
@@ -5723,7 +5823,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/101.png",
@@ -5784,7 +5885,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw3/102.png",

--- a/cards/en/bw4.json
+++ b/cards/en/bw4.json
@@ -53,7 +53,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/1.png",
@@ -110,7 +111,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/2.png",
@@ -171,7 +173,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/3.png",
@@ -230,7 +233,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/4.png",
@@ -355,7 +359,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/6.png",
@@ -421,7 +426,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/7.png",
@@ -488,7 +494,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/8.png",
@@ -552,7 +559,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/9.png",
@@ -615,7 +623,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/10.png",
@@ -668,7 +677,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/11.png",
@@ -728,7 +738,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/12.png",
@@ -791,7 +802,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/13.png",
@@ -860,7 +872,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/14.png",
@@ -912,7 +925,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/15.png",
@@ -971,7 +985,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/16.png",
@@ -1025,7 +1040,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/17.png",
@@ -1076,7 +1092,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/18.png",
@@ -1129,7 +1146,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/19.png",
@@ -1189,7 +1207,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/20.png",
@@ -1250,7 +1269,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/21.png",
@@ -1377,7 +1397,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/23.png",
@@ -1431,7 +1452,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/24.png",
@@ -1490,7 +1512,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/25.png",
@@ -1551,7 +1574,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/26.png",
@@ -1620,7 +1644,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/27.png",
@@ -1672,7 +1697,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/28.png",
@@ -1731,7 +1757,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/29.png",
@@ -1788,7 +1815,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/30.png",
@@ -1849,7 +1877,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/31.png",
@@ -1913,7 +1942,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/32.png",
@@ -1972,7 +2002,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/33.png",
@@ -2034,7 +2065,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/34.png",
@@ -2095,7 +2127,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/35.png",
@@ -2158,7 +2191,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/36.png",
@@ -2221,7 +2255,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/37.png",
@@ -2349,7 +2384,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/39.png",
@@ -2409,7 +2445,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/40.png",
@@ -2478,7 +2515,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/41.png",
@@ -2539,7 +2577,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/42.png",
@@ -2590,7 +2629,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/43.png",
@@ -2653,7 +2693,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/44.png",
@@ -2711,7 +2752,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/45.png",
@@ -2771,7 +2813,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/46.png",
@@ -2823,7 +2866,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/47.png",
@@ -2880,7 +2924,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/48.png",
@@ -2929,7 +2974,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/49.png",
@@ -2990,7 +3036,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/50.png",
@@ -3110,7 +3157,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/52.png",
@@ -3175,7 +3223,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/53.png",
@@ -3303,7 +3352,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/55.png",
@@ -3368,7 +3418,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/56.png",
@@ -3428,7 +3479,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/57.png",
@@ -3481,7 +3533,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/58.png",
@@ -3540,7 +3593,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/59.png",
@@ -3601,7 +3655,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/60.png",
@@ -3652,7 +3707,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/61.png",
@@ -3712,7 +3768,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/62.png",
@@ -3773,7 +3830,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/63.png",
@@ -3830,7 +3888,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/64.png",
@@ -3901,7 +3960,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/65.png",
@@ -3973,7 +4033,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/66.png",
@@ -4024,7 +4085,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/67.png",
@@ -4083,7 +4145,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/68.png",
@@ -4150,7 +4213,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/69.png",
@@ -4216,7 +4280,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/70.png",
@@ -4275,7 +4340,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/71.png",
@@ -4339,7 +4405,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/72.png",
@@ -4407,7 +4474,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/73.png",
@@ -4474,7 +4542,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/74.png",
@@ -4545,7 +4614,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/75.png",
@@ -4612,7 +4682,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/76.png",
@@ -4672,7 +4743,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/77.png",
@@ -4734,7 +4806,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/78.png",
@@ -4796,7 +4869,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/79.png",
@@ -4857,7 +4931,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/80.png",
@@ -4916,7 +4991,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/81.png",
@@ -5051,7 +5127,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/83.png",
@@ -5112,7 +5189,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/84.png",
@@ -5170,7 +5248,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/85.png",
@@ -5193,7 +5272,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/86.png",
@@ -5218,7 +5298,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/87.png",
@@ -5241,7 +5322,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/88.png",
@@ -5265,7 +5347,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/89.png",
@@ -5288,7 +5371,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/90.png",
@@ -5311,7 +5395,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/91.png",
@@ -5333,7 +5418,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/92.png",
@@ -5356,7 +5442,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/93.png",
@@ -5821,7 +5908,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/100.png",
@@ -5880,7 +5968,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/101.png",
@@ -5945,7 +6034,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/102.png",
@@ -6012,7 +6102,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw4/103.png",

--- a/cards/en/bw5.json
+++ b/cards/en/bw5.json
@@ -61,7 +61,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/1.png",
@@ -133,7 +134,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/2.png",
@@ -201,7 +203,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/3.png",
@@ -254,7 +257,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/4.png",
@@ -320,7 +324,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/5.png",
@@ -385,7 +390,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/6.png",
@@ -448,7 +454,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/7.png",
@@ -511,7 +518,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/8.png",
@@ -573,7 +581,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/9.png",
@@ -627,7 +636,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/10.png",
@@ -682,7 +692,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/11.png",
@@ -742,7 +753,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/12.png",
@@ -859,7 +871,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/14.png",
@@ -920,7 +933,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/15.png",
@@ -983,7 +997,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/16.png",
@@ -1045,7 +1060,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/17.png",
@@ -1105,7 +1121,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/18.png",
@@ -1164,7 +1181,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/19.png",
@@ -1229,7 +1247,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/20.png",
@@ -1281,7 +1300,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/21.png",
@@ -1341,7 +1361,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/22.png",
@@ -1405,7 +1426,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/23.png",
@@ -1464,7 +1486,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/24.png",
@@ -1525,7 +1548,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/25.png",
@@ -1642,7 +1666,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/27.png",
@@ -1706,7 +1731,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/28.png",
@@ -1763,7 +1789,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/29.png",
@@ -1822,7 +1849,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/30.png",
@@ -1874,7 +1902,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/31.png",
@@ -1928,7 +1957,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/32.png",
@@ -1979,7 +2009,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/33.png",
@@ -2042,7 +2073,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/34.png",
@@ -2100,7 +2132,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/35.png",
@@ -2166,7 +2199,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/36.png",
@@ -2222,7 +2256,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/37.png",
@@ -2342,7 +2377,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/39.png",
@@ -2399,7 +2435,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/40.png",
@@ -2460,7 +2497,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/41.png",
@@ -2511,7 +2549,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/42.png",
@@ -2570,7 +2609,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/43.png",
@@ -2621,7 +2661,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/44.png",
@@ -2672,7 +2713,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/45.png",
@@ -2736,7 +2778,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/46.png",
@@ -2801,7 +2844,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/47.png",
@@ -2859,7 +2903,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/48.png",
@@ -2920,7 +2965,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/49.png",
@@ -2987,7 +3033,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/50.png",
@@ -3038,7 +3085,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/51.png",
@@ -3099,7 +3147,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/52.png",
@@ -3160,7 +3209,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/53.png",
@@ -3291,7 +3341,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/55.png",
@@ -3358,7 +3409,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/56.png",
@@ -3430,7 +3482,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/57.png",
@@ -3492,7 +3545,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/58.png",
@@ -3556,7 +3610,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/59.png",
@@ -3624,7 +3679,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/60.png",
@@ -3691,7 +3747,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/61.png",
@@ -3742,7 +3799,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/62.png",
@@ -3878,7 +3936,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/64.png",
@@ -3951,7 +4010,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/65.png",
@@ -4022,7 +4082,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/66.png",
@@ -4080,7 +4141,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/67.png",
@@ -4148,7 +4210,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/68.png",
@@ -4215,7 +4278,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/69.png",
@@ -4282,7 +4346,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/70.png",
@@ -4349,7 +4414,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/71.png",
@@ -4416,7 +4482,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/72.png",
@@ -4473,7 +4540,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/73.png",
@@ -4541,7 +4609,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/74.png",
@@ -4601,7 +4670,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/75.png",
@@ -4673,7 +4743,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/76.png",
@@ -4743,7 +4814,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/77.png",
@@ -4812,7 +4884,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/78.png",
@@ -4880,7 +4953,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/79.png",
@@ -4944,7 +5018,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/80.png",
@@ -4997,7 +5072,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/81.png",
@@ -5057,7 +5133,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/82.png",
@@ -5115,7 +5192,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/83.png",
@@ -5183,7 +5261,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/84.png",
@@ -5247,7 +5326,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/85.png",
@@ -5308,7 +5388,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/86.png",
@@ -5371,7 +5452,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/87.png",
@@ -5436,7 +5518,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/88.png",
@@ -5495,7 +5578,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/89.png",
@@ -5587,7 +5671,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/91.png",
@@ -5611,7 +5696,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/92.png",
@@ -5635,7 +5721,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/93.png",
@@ -5658,7 +5745,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/94.png",
@@ -5681,7 +5769,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/95.png",
@@ -5704,7 +5793,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/96.png",
@@ -5727,7 +5817,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/97.png",
@@ -5750,7 +5841,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/98.png",
@@ -5773,7 +5865,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/99.png",
@@ -5797,7 +5890,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/100.png",
@@ -5820,7 +5914,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/101.png",
@@ -5844,7 +5939,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/102.png",
@@ -6306,7 +6402,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/109.png",
@@ -6365,7 +6462,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/110.png",
@@ -6389,7 +6487,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw5/111.png",

--- a/cards/en/bw6.json
+++ b/cards/en/bw6.json
@@ -49,7 +49,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/1.png",
@@ -103,7 +104,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/2.png",
@@ -161,7 +163,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/3.png",
@@ -219,7 +222,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/4.png",
@@ -282,7 +286,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/5.png",
@@ -334,7 +339,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/6.png",
@@ -399,7 +405,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/7.png",
@@ -459,7 +466,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/8.png",
@@ -523,7 +531,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/9.png",
@@ -574,7 +583,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/10.png",
@@ -634,7 +644,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/11.png",
@@ -700,7 +711,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/12.png",
@@ -758,7 +770,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/13.png",
@@ -824,7 +837,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/14.png",
@@ -887,7 +901,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/15.png",
@@ -954,7 +969,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/16.png",
@@ -1011,7 +1027,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/17.png",
@@ -1062,7 +1079,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/18.png",
@@ -1118,7 +1136,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/19.png",
@@ -1181,7 +1200,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/20.png",
@@ -1243,7 +1263,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/21.png",
@@ -1361,7 +1382,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/23.png",
@@ -1426,7 +1448,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/24.png",
@@ -1490,7 +1513,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/25.png",
@@ -1554,7 +1578,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/26.png",
@@ -1605,7 +1630,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/27.png",
@@ -1665,7 +1691,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/28.png",
@@ -1718,7 +1745,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/29.png",
@@ -1784,7 +1812,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/30.png",
@@ -1850,7 +1879,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/31.png",
@@ -1901,7 +1931,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/32.png",
@@ -1960,7 +1991,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/33.png",
@@ -2011,7 +2043,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/34.png",
@@ -2074,7 +2107,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/35.png",
@@ -2138,7 +2172,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/36.png",
@@ -2199,7 +2234,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/37.png",
@@ -2260,7 +2296,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/38.png",
@@ -2323,7 +2360,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/39.png",
@@ -2382,7 +2420,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/40.png",
@@ -2443,7 +2482,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/41.png",
@@ -2495,7 +2535,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/42.png",
@@ -2551,7 +2592,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/43.png",
@@ -2610,7 +2652,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/44.png",
@@ -2669,7 +2712,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/45.png",
@@ -2787,7 +2831,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/47.png",
@@ -2833,7 +2878,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/48.png",
@@ -2884,7 +2930,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/49.png",
@@ -2945,7 +2992,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/50.png",
@@ -3004,7 +3052,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/51.png",
@@ -3061,7 +3110,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/52.png",
@@ -3125,7 +3175,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/53.png",
@@ -3185,7 +3236,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/54.png",
@@ -3236,7 +3288,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/55.png",
@@ -3299,7 +3352,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/56.png",
@@ -3361,7 +3415,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/57.png",
@@ -3426,7 +3481,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/58.png",
@@ -3492,7 +3548,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/59.png",
@@ -3559,7 +3616,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/60.png",
@@ -3625,7 +3683,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/61.png",
@@ -3678,7 +3737,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/62.png",
@@ -3739,7 +3799,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/63.png",
@@ -3802,7 +3863,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/64.png",
@@ -3867,7 +3929,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/65.png",
@@ -3932,7 +3995,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/66.png",
@@ -3998,7 +4062,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/67.png",
@@ -4062,7 +4127,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/68.png",
@@ -4121,7 +4187,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/69.png",
@@ -4187,7 +4254,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/70.png",
@@ -4319,7 +4387,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/72.png",
@@ -4387,7 +4456,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/73.png",
@@ -4455,7 +4525,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/74.png",
@@ -4521,7 +4592,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/75.png",
@@ -4578,7 +4650,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/76.png",
@@ -4644,7 +4717,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/77.png",
@@ -4703,7 +4777,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/78.png",
@@ -4775,7 +4850,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/79.png",
@@ -4842,7 +4918,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/80.png",
@@ -4986,7 +5063,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/82.png",
@@ -5050,7 +5128,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/83.png",
@@ -5108,7 +5187,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/84.png",
@@ -5233,7 +5313,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/86.png",
@@ -5294,7 +5375,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/87.png",
@@ -5356,7 +5438,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/88.png",
@@ -5416,7 +5499,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/89.png",
@@ -5475,7 +5559,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/90.png",
@@ -5531,7 +5616,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/91.png",
@@ -5660,7 +5746,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/93.png",
@@ -5723,7 +5810,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/94.png",
@@ -5788,7 +5876,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/95.png",
@@ -5853,7 +5942,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/96.png",
@@ -5914,7 +6004,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/97.png",
@@ -5979,7 +6070,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/98.png",
@@ -6030,7 +6122,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/99.png",
@@ -6089,7 +6182,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/100.png",
@@ -6141,7 +6235,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/101.png",
@@ -6194,7 +6289,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/102.png",
@@ -6256,7 +6352,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/103.png",
@@ -6323,7 +6420,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/104.png",
@@ -6380,7 +6478,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/105.png",
@@ -6433,7 +6532,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/106.png",
@@ -6497,7 +6597,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/107.png",
@@ -6558,7 +6659,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/108.png",
@@ -6619,7 +6721,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/109.png",
@@ -6677,7 +6780,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/110.png",
@@ -6744,7 +6848,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/111.png",
@@ -6806,7 +6911,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/112.png",
@@ -6829,7 +6935,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/113.png",
@@ -6853,7 +6960,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/114.png",
@@ -6877,7 +6985,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/115.png",
@@ -6900,7 +7009,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/116.png",
@@ -6922,7 +7032,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/117.png",
@@ -6944,7 +7055,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/118.png",
@@ -7402,7 +7514,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/125.png",
@@ -7461,7 +7574,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/126.png",
@@ -7532,7 +7646,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/127.png",
@@ -7593,7 +7708,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw6/128.png",

--- a/cards/en/bw7.json
+++ b/cards/en/bw7.json
@@ -59,7 +59,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/1.png",
@@ -130,7 +131,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/2.png",
@@ -197,7 +199,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/3.png",
@@ -263,7 +266,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/4.png",
@@ -332,7 +336,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/5.png",
@@ -402,7 +407,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/6.png",
@@ -463,7 +469,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/7.png",
@@ -523,7 +530,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/8.png",
@@ -647,7 +655,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/10.png",
@@ -708,7 +717,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/11.png",
@@ -771,7 +781,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/12.png",
@@ -832,7 +843,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/13.png",
@@ -889,7 +901,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/14.png",
@@ -953,7 +966,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/15.png",
@@ -1010,7 +1024,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/16.png",
@@ -1076,7 +1091,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/17.png",
@@ -1138,7 +1154,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/18.png",
@@ -1202,7 +1219,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/19.png",
@@ -1268,7 +1286,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/20.png",
@@ -1323,7 +1342,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/21.png",
@@ -1389,7 +1409,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/22.png",
@@ -1447,7 +1468,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/23.png",
@@ -1508,7 +1530,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/24.png",
@@ -1573,7 +1596,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/25.png",
@@ -1639,7 +1663,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/26.png",
@@ -1692,7 +1717,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/27.png",
@@ -1753,7 +1779,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/28.png",
@@ -1812,7 +1839,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/29.png",
@@ -1876,7 +1904,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/30.png",
@@ -1938,7 +1967,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/31.png",
@@ -1989,7 +2019,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/32.png",
@@ -2042,7 +2073,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/33.png",
@@ -2097,7 +2129,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/34.png",
@@ -2152,7 +2185,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/35.png",
@@ -2216,7 +2250,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/36.png",
@@ -2277,7 +2312,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/37.png",
@@ -2335,7 +2371,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/38.png",
@@ -2396,7 +2433,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/39.png",
@@ -2459,7 +2497,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/40.png",
@@ -2523,7 +2562,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/41.png",
@@ -2581,7 +2621,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/42.png",
@@ -2648,7 +2689,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/43.png",
@@ -2702,7 +2744,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/44.png",
@@ -2762,7 +2805,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/45.png",
@@ -2811,7 +2855,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/46.png",
@@ -2871,7 +2916,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/47.png",
@@ -2931,7 +2977,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/48.png",
@@ -3054,7 +3101,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/50.png",
@@ -3105,7 +3153,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/51.png",
@@ -3161,7 +3210,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/52.png",
@@ -3225,7 +3275,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/53.png",
@@ -3290,7 +3341,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/54.png",
@@ -3342,7 +3394,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/55.png",
@@ -3393,7 +3446,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/56.png",
@@ -3453,7 +3507,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/57.png",
@@ -3504,7 +3559,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/58.png",
@@ -3555,7 +3611,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/59.png",
@@ -3617,7 +3674,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/60.png",
@@ -3668,7 +3726,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/61.png",
@@ -3732,7 +3791,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/62.png",
@@ -3793,7 +3853,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/63.png",
@@ -3845,7 +3906,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/64.png",
@@ -3897,7 +3959,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/65.png",
@@ -3957,7 +4020,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/66.png",
@@ -4078,7 +4142,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/68.png",
@@ -4140,7 +4205,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/69.png",
@@ -4207,7 +4273,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/70.png",
@@ -4272,7 +4339,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/71.png",
@@ -4332,7 +4400,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/72.png",
@@ -4395,7 +4464,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/73.png",
@@ -4457,7 +4527,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/74.png",
@@ -4518,7 +4589,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/75.png",
@@ -4582,7 +4654,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/76.png",
@@ -4641,7 +4714,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/77.png",
@@ -4710,7 +4784,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/78.png",
@@ -4777,7 +4852,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/79.png",
@@ -4844,7 +4920,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/80.png",
@@ -4909,7 +4986,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/81.png",
@@ -4962,7 +5040,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/82.png",
@@ -5029,7 +5108,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/83.png",
@@ -5082,7 +5162,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/84.png",
@@ -5142,7 +5223,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/85.png",
@@ -5193,7 +5275,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/86.png",
@@ -5244,7 +5327,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/87.png",
@@ -5305,7 +5389,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/88.png",
@@ -5432,7 +5517,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/90.png",
@@ -5498,7 +5584,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/91.png",
@@ -5565,7 +5652,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/92.png",
@@ -5633,7 +5721,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/93.png",
@@ -5701,7 +5790,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/94.png",
@@ -5767,7 +5857,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/95.png",
@@ -5833,7 +5924,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/96.png",
@@ -5892,7 +5984,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/97.png",
@@ -5955,7 +6048,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/98.png",
@@ -6014,7 +6108,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/99.png",
@@ -6076,7 +6171,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/100.png",
@@ -6205,7 +6301,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/102.png",
@@ -6323,7 +6420,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/104.png",
@@ -6379,7 +6477,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/105.png",
@@ -6431,7 +6530,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/106.png",
@@ -6489,7 +6589,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/107.png",
@@ -6533,7 +6634,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/108.png",
@@ -6598,7 +6700,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/109.png",
@@ -6649,7 +6752,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/110.png",
@@ -6702,7 +6806,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/111.png",
@@ -6759,7 +6864,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/112.png",
@@ -6820,7 +6926,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/113.png",
@@ -6879,7 +6986,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/114.png",
@@ -6928,7 +7036,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/115.png",
@@ -6989,7 +7098,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/116.png",
@@ -7049,7 +7159,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/117.png",
@@ -7100,7 +7211,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/118.png",
@@ -7159,7 +7271,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/119.png",
@@ -7220,7 +7333,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/120.png",
@@ -7283,7 +7397,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/121.png",
@@ -7343,7 +7458,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/122.png",
@@ -7401,7 +7517,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/123.png",
@@ -7461,7 +7578,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/124.png",
@@ -7528,7 +7646,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/125.png",
@@ -7585,7 +7704,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/126.png",
@@ -7608,7 +7728,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/127.png",
@@ -7632,7 +7753,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/128.png",
@@ -7656,7 +7778,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/129.png",
@@ -7679,7 +7802,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/130.png",
@@ -7703,7 +7827,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/131.png",
@@ -7727,7 +7852,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/132.png",
@@ -7752,7 +7878,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/133.png",
@@ -7775,7 +7902,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/134.png",
@@ -7799,7 +7927,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/135.png",
@@ -7822,7 +7951,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/136.png",
@@ -8339,7 +8469,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/147.png",
@@ -8362,7 +8493,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/148.png",
@@ -8385,7 +8517,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/149.png",
@@ -8451,7 +8584,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/150.png",
@@ -8514,7 +8648,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/151.png",
@@ -8572,7 +8707,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/152.png",
@@ -8597,7 +8733,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw7/153.png",

--- a/cards/en/bw8.json
+++ b/cards/en/bw8.json
@@ -61,7 +61,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/1.png",
@@ -123,7 +124,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/2.png",
@@ -196,7 +198,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/3.png",
@@ -247,7 +250,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/4.png",
@@ -306,7 +310,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/5.png",
@@ -363,7 +368,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/6.png",
@@ -426,7 +432,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/7.png",
@@ -477,7 +484,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/8.png",
@@ -540,7 +548,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/9.png",
@@ -602,7 +611,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/10.png",
@@ -666,7 +676,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/11.png",
@@ -723,7 +734,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/12.png",
@@ -790,7 +802,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/13.png",
@@ -912,7 +925,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/15.png",
@@ -974,7 +988,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/16.png",
@@ -1030,7 +1045,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/17.png",
@@ -1155,7 +1171,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/19.png",
@@ -1216,7 +1233,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/20.png",
@@ -1267,7 +1285,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/21.png",
@@ -1327,7 +1346,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/22.png",
@@ -1387,7 +1407,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/23.png",
@@ -1438,7 +1459,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/24.png",
@@ -1563,7 +1585,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/26.png",
@@ -1630,7 +1653,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/27.png",
@@ -1696,7 +1720,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/28.png",
@@ -1748,7 +1773,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/29.png",
@@ -1813,7 +1839,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/30.png",
@@ -1873,7 +1900,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/31.png",
@@ -1925,7 +1953,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/32.png",
@@ -1979,7 +2008,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/33.png",
@@ -2034,7 +2064,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/34.png",
@@ -2085,7 +2116,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/35.png",
@@ -2138,7 +2170,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/36.png",
@@ -2198,7 +2231,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/37.png",
@@ -2251,7 +2285,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/38.png",
@@ -2310,7 +2345,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/39.png",
@@ -2373,7 +2409,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/40.png",
@@ -2438,7 +2475,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/41.png",
@@ -2499,7 +2537,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/42.png",
@@ -2550,7 +2589,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/43.png",
@@ -2613,7 +2653,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/44.png",
@@ -2667,7 +2708,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/45.png",
@@ -2728,7 +2770,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/46.png",
@@ -2789,7 +2832,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/47.png",
@@ -2919,7 +2963,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/49.png",
@@ -2970,7 +3015,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/50.png",
@@ -3025,7 +3071,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/51.png",
@@ -3082,7 +3129,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/52.png",
@@ -3147,7 +3195,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/53.png",
@@ -3206,7 +3255,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/54.png",
@@ -3267,7 +3317,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/55.png",
@@ -3329,7 +3380,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/56.png",
@@ -3381,7 +3433,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/57.png",
@@ -3440,7 +3493,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/58.png",
@@ -3491,7 +3545,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/59.png",
@@ -3544,7 +3599,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/60.png",
@@ -3606,7 +3662,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/61.png",
@@ -3671,7 +3728,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/62.png",
@@ -3732,7 +3790,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/63.png",
@@ -3794,7 +3853,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/64.png",
@@ -3847,7 +3907,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/65.png",
@@ -3910,7 +3971,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/66.png",
@@ -3975,7 +4037,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/67.png",
@@ -4027,7 +4090,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/68.png",
@@ -4088,7 +4152,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/69.png",
@@ -4149,7 +4214,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/70.png",
@@ -4218,7 +4284,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/71.png",
@@ -4288,7 +4355,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/72.png",
@@ -4346,7 +4414,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/73.png",
@@ -4408,7 +4477,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/74.png",
@@ -4469,7 +4539,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/75.png",
@@ -4532,7 +4603,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/76.png",
@@ -4593,7 +4665,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/77.png",
@@ -4652,7 +4725,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/78.png",
@@ -4716,7 +4790,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/79.png",
@@ -4784,7 +4859,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/80.png",
@@ -4849,7 +4925,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/81.png",
@@ -4916,7 +4993,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/82.png",
@@ -4983,7 +5061,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/83.png",
@@ -5049,7 +5128,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/84.png",
@@ -5117,7 +5197,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/85.png",
@@ -5185,7 +5266,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/86.png",
@@ -5251,7 +5333,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/87.png",
@@ -5319,7 +5402,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/88.png",
@@ -5389,7 +5473,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/89.png",
@@ -5456,7 +5541,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/90.png",
@@ -5523,7 +5609,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/91.png",
@@ -5588,7 +5675,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/92.png",
@@ -5719,7 +5807,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/94.png",
@@ -5914,7 +6003,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/97.png",
@@ -5972,7 +6062,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/98.png",
@@ -6030,7 +6121,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/99.png",
@@ -6096,7 +6188,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/100.png",
@@ -6159,7 +6252,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/101.png",
@@ -6210,7 +6304,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/102.png",
@@ -6268,7 +6363,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/103.png",
@@ -6330,7 +6426,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/104.png",
@@ -6393,7 +6490,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/105.png",
@@ -6458,7 +6556,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/106.png",
@@ -6524,7 +6623,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/107.png",
@@ -6645,7 +6745,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/109.png",
@@ -6696,7 +6797,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/110.png",
@@ -6757,7 +6859,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/111.png",
@@ -6817,7 +6920,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/112.png",
@@ -6879,7 +6983,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/113.png",
@@ -6941,7 +7046,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/114.png",
@@ -6999,7 +7105,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/115.png",
@@ -7064,7 +7171,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/116.png",
@@ -7087,7 +7195,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/117.png",
@@ -7111,7 +7220,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/118.png",
@@ -7135,7 +7245,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/119.png",
@@ -7159,7 +7270,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/120.png",
@@ -7182,7 +7294,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/121.png",
@@ -7206,7 +7319,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/122.png",
@@ -7230,7 +7344,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/123.png",
@@ -7254,7 +7369,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/124.png",
@@ -7278,7 +7394,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/125.png",
@@ -7301,7 +7418,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/126.png",
@@ -7324,7 +7442,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/127.png",
@@ -7696,7 +7815,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/135.png",
@@ -7762,7 +7882,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/136.png",
@@ -7824,7 +7945,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/137.png",
@@ -7847,7 +7969,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw8/138.png",

--- a/cards/en/bw9.json
+++ b/cards/en/bw9.json
@@ -43,7 +43,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/1.png",
@@ -96,7 +97,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/2.png",
@@ -152,7 +154,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/3.png",
@@ -217,7 +220,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/4.png",
@@ -284,7 +288,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/5.png",
@@ -351,7 +356,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/6.png",
@@ -419,7 +425,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/7.png",
@@ -487,7 +494,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/8.png",
@@ -545,7 +553,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/9.png",
@@ -610,7 +619,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/10.png",
@@ -678,7 +688,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/11.png",
@@ -741,7 +752,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/12.png",
@@ -870,7 +882,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/14.png",
@@ -934,7 +947,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/15.png",
@@ -994,7 +1008,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/16.png",
@@ -1057,7 +1072,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/17.png",
@@ -1108,7 +1124,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/18.png",
@@ -1160,7 +1177,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/19.png",
@@ -1221,7 +1239,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/20.png",
@@ -1274,7 +1293,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/21.png",
@@ -1334,7 +1354,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/22.png",
@@ -1394,7 +1415,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/23.png",
@@ -1445,7 +1467,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/24.png",
@@ -1510,7 +1533,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/25.png",
@@ -1575,7 +1599,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/26.png",
@@ -1627,7 +1652,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/27.png",
@@ -1680,7 +1706,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/28.png",
@@ -1740,7 +1767,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/29.png",
@@ -1798,7 +1826,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/30.png",
@@ -1861,7 +1890,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/31.png",
@@ -1913,7 +1943,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/32.png",
@@ -1971,7 +2002,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/33.png",
@@ -2031,7 +2063,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/34.png",
@@ -2084,7 +2117,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/35.png",
@@ -2145,7 +2179,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/36.png",
@@ -2202,7 +2237,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/37.png",
@@ -2329,7 +2365,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/39.png",
@@ -2381,7 +2418,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/40.png",
@@ -2447,7 +2485,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/41.png",
@@ -2510,7 +2549,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/42.png",
@@ -2561,7 +2601,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/43.png",
@@ -2627,7 +2668,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/44.png",
@@ -2690,7 +2732,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/45.png",
@@ -2756,7 +2799,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/46.png",
@@ -2812,7 +2856,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/47.png",
@@ -2871,7 +2916,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/48.png",
@@ -2924,7 +2970,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/49.png",
@@ -2985,7 +3032,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/50.png",
@@ -3049,7 +3097,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/51.png",
@@ -3110,7 +3159,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/52.png",
@@ -3223,7 +3273,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/54.png",
@@ -3285,7 +3336,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/55.png",
@@ -3345,7 +3397,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/56.png",
@@ -3407,7 +3460,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/57.png",
@@ -3477,7 +3531,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/58.png",
@@ -3528,7 +3583,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/59.png",
@@ -3588,7 +3644,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/60.png",
@@ -3655,7 +3712,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/61.png",
@@ -3720,7 +3778,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/62.png",
@@ -3783,7 +3842,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/63.png",
@@ -3848,7 +3908,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/64.png",
@@ -3906,7 +3967,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/65.png",
@@ -3972,7 +4034,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/66.png",
@@ -4039,7 +4102,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/67.png",
@@ -4098,7 +4162,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/68.png",
@@ -4168,7 +4233,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/69.png",
@@ -4237,7 +4303,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/70.png",
@@ -4294,7 +4361,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/71.png",
@@ -4352,7 +4420,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/72.png",
@@ -4419,7 +4488,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/73.png",
@@ -4487,7 +4557,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/74.png",
@@ -4557,7 +4628,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/75.png",
@@ -4616,7 +4688,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/76.png",
@@ -4687,7 +4760,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/77.png",
@@ -4759,7 +4833,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/78.png",
@@ -4833,7 +4908,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/79.png",
@@ -4898,7 +4974,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/80.png",
@@ -4959,7 +5036,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/81.png",
@@ -5022,7 +5100,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/82.png",
@@ -5087,7 +5166,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/83.png",
@@ -5145,7 +5225,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/84.png",
@@ -5324,7 +5405,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/87.png",
@@ -5380,7 +5462,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/88.png",
@@ -5448,7 +5531,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/89.png",
@@ -5517,7 +5601,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/90.png",
@@ -5574,7 +5659,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/91.png",
@@ -5641,7 +5727,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/92.png",
@@ -5702,7 +5789,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/93.png",
@@ -5757,7 +5845,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/94.png",
@@ -5814,7 +5903,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/95.png",
@@ -5873,7 +5963,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/96.png",
@@ -5942,7 +6033,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/97.png",
@@ -6037,7 +6129,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/99.png",
@@ -6061,7 +6154,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/100.png",
@@ -6085,7 +6179,8 @@
     "rarity": "Rare Holo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/101.png",
@@ -6109,7 +6204,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/102.png",
@@ -6133,7 +6229,8 @@
     "legalities": {
       "standard": "Legal",
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/103.png",
@@ -6158,7 +6255,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/104.png",
@@ -6182,7 +6280,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/105.png",
@@ -6205,7 +6304,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/106.png",
@@ -6672,7 +6772,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/115.png",
@@ -6695,7 +6796,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/116.png",
@@ -6752,7 +6854,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/117.png",
@@ -6809,7 +6912,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/118.png",
@@ -6869,7 +6973,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/119.png",
@@ -6928,7 +7033,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/120.png",
@@ -6951,7 +7057,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/121.png",
@@ -6975,7 +7082,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bw9/122.png",

--- a/cards/en/bwp.json
+++ b/cards/en/bwp.json
@@ -50,7 +50,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW01.png",
@@ -103,7 +104,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW02.png",
@@ -155,7 +157,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW03.png",
@@ -216,7 +219,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW004.png",
@@ -277,7 +281,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW005.png",
@@ -344,7 +349,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW06.png",
@@ -405,7 +411,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW07.png",
@@ -466,7 +473,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW08.png",
@@ -531,7 +539,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW09.png",
@@ -577,7 +586,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW10.png",
@@ -635,7 +645,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW11.png",
@@ -693,7 +704,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW12.png",
@@ -754,7 +766,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW13.png",
@@ -812,7 +825,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW14.png",
@@ -870,7 +884,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW15.png",
@@ -916,7 +931,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW16.png",
@@ -973,7 +989,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW17.png",
@@ -1026,7 +1043,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW18.png",
@@ -1092,7 +1110,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW19.png",
@@ -1155,7 +1174,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW20.png",
@@ -1217,7 +1237,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW21.png",
@@ -1276,7 +1297,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW22.png",
@@ -1337,7 +1359,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW23.png",
@@ -1398,7 +1421,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW24.png",
@@ -1466,7 +1490,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW25.png",
@@ -1512,7 +1537,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW26.png",
@@ -1573,7 +1599,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW27.png",
@@ -1596,7 +1623,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW28.png",
@@ -1619,7 +1647,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW29.png",
@@ -1642,7 +1671,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW30.png",
@@ -1665,7 +1695,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW31.png",
@@ -1721,7 +1752,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW32.png",
@@ -1782,7 +1814,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW33.png",
@@ -1845,7 +1878,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW34.png",
@@ -1906,7 +1940,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW35.png",
@@ -2130,7 +2165,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW39.png",
@@ -2190,7 +2226,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW40.png",
@@ -2249,7 +2286,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW41.png",
@@ -2314,7 +2352,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW42.png",
@@ -2379,7 +2418,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW43.png",
@@ -2440,7 +2480,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW44.png",
@@ -2696,7 +2737,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW48.png",
@@ -2761,7 +2803,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW49.png",
@@ -2784,7 +2827,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW50.png",
@@ -2845,7 +2889,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW51.png",
@@ -2897,7 +2942,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW52.png",
@@ -2956,7 +3002,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW53.png",
@@ -3018,7 +3065,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW54.png",
@@ -3077,7 +3125,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW55.png",
@@ -3138,7 +3187,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW56.png",
@@ -3201,7 +3251,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW57.png",
@@ -3263,7 +3314,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW58.png",
@@ -3325,7 +3377,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW59.png",
@@ -3384,7 +3437,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW60.png",
@@ -3638,7 +3692,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW64.png",
@@ -3689,7 +3744,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW65.png",
@@ -3745,7 +3801,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW66.png",
@@ -3806,7 +3863,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW67.png",
@@ -3865,7 +3923,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW68.png",
@@ -3924,7 +3983,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW69.png",
@@ -3987,7 +4047,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW70.png",
@@ -4048,7 +4109,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW71.png",
@@ -4113,7 +4175,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW72.png",
@@ -4182,7 +4245,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW73.png",
@@ -4247,7 +4311,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW74.png",
@@ -4308,7 +4373,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW75.png",
@@ -4365,7 +4431,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW76.png",
@@ -4427,7 +4494,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW77.png",
@@ -4488,7 +4556,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW78.png",
@@ -4557,7 +4626,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW79.png",
@@ -4618,7 +4688,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW80.png",
@@ -4871,7 +4942,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW84.png",
@@ -4930,7 +5002,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW85.png",
@@ -4993,7 +5066,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW86.png",
@@ -5058,7 +5132,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW87.png",
@@ -5118,7 +5193,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW88.png",
@@ -5179,7 +5255,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW89.png",
@@ -5238,7 +5315,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW90.png",
@@ -5294,7 +5372,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW91.png",
@@ -5352,7 +5431,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW92.png",
@@ -5420,7 +5500,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW93.png",
@@ -5488,7 +5569,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW94.png",
@@ -5511,7 +5593,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW95.png",
@@ -5648,7 +5731,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW97.png",
@@ -5703,7 +5787,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW98.png",
@@ -5764,7 +5849,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW99.png",
@@ -5787,7 +5873,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW100.png",
@@ -5848,7 +5935,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/bwp/BW101.png",

--- a/cards/en/cel25.json
+++ b/cards/en/cel25.json
@@ -60,7 +60,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -124,7 +125,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -190,7 +192,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -250,7 +253,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -313,7 +317,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -622,7 +627,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -686,7 +692,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -749,7 +756,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -808,7 +816,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -871,7 +880,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -941,7 +951,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1070,7 +1081,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1202,7 +1214,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1270,7 +1283,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1336,7 +1350,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1406,7 +1421,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1431,7 +1447,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1456,7 +1473,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1520,7 +1538,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {

--- a/cards/en/cel25c.json
+++ b/cards/en/cel25c.json
@@ -1084,7 +1084,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/cel25c/113_A.png",
@@ -1145,7 +1146,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/cel25c/114_A.png",

--- a/cards/en/col1.json
+++ b/cards/en/col1.json
@@ -3641,7 +3641,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/col1/61.png",
@@ -4526,7 +4527,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/col1/77.png",
@@ -4760,7 +4762,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/col1/88.png",
@@ -4779,7 +4782,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/col1/89.png",
@@ -4798,7 +4802,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/col1/90.png",
@@ -4817,7 +4822,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/col1/91.png",
@@ -4836,7 +4842,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/col1/92.png",
@@ -4855,7 +4862,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/col1/93.png",
@@ -4874,7 +4882,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/col1/94.png",
@@ -4893,7 +4902,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/col1/95.png",

--- a/cards/en/dc1.json
+++ b/cards/en/dc1.json
@@ -45,7 +45,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/1.png",
@@ -105,7 +106,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/2.png",
@@ -157,7 +159,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/3.png",
@@ -223,7 +226,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/4.png",
@@ -287,7 +291,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/5.png",
@@ -414,7 +419,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/7.png",
@@ -474,7 +480,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/8.png",
@@ -532,7 +539,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/9.png",
@@ -584,7 +592,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/10.png",
@@ -643,7 +652,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/11.png",
@@ -695,7 +705,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/12.png",
@@ -761,7 +772,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/13.png",
@@ -826,7 +838,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/14.png",
@@ -957,7 +970,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/16.png",
@@ -1024,7 +1038,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/17.png",
@@ -1091,7 +1106,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/18.png",
@@ -1158,7 +1174,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/19.png",
@@ -1209,7 +1226,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/20.png",
@@ -1263,7 +1281,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/21.png",
@@ -1322,7 +1341,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/22.png",
@@ -1357,7 +1377,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/23.png",
@@ -1392,7 +1413,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/24.png",
@@ -1415,7 +1437,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/25.png",
@@ -1438,7 +1461,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/26.png",
@@ -1461,7 +1485,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/27.png",
@@ -1484,7 +1509,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/28.png",
@@ -1507,7 +1533,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/29.png",
@@ -1530,7 +1557,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/30.png",
@@ -1553,7 +1581,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/31.png",
@@ -1576,7 +1605,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/32.png",
@@ -1600,7 +1630,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/33.png",
@@ -1624,7 +1655,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dc1/34.png",

--- a/cards/en/det1.json
+++ b/cards/en/det1.json
@@ -43,7 +43,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/det1/1.png",
@@ -103,7 +104,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/det1/2.png",
@@ -154,7 +156,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/det1/3.png",
@@ -205,7 +208,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/det1/4.png",
@@ -270,7 +274,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/det1/5.png",
@@ -330,7 +335,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/det1/6.png",
@@ -383,7 +389,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/det1/7.png",
@@ -434,7 +441,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/det1/8.png",
@@ -491,7 +499,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/det1/9.png",
@@ -560,7 +569,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/det1/10.png",
@@ -616,7 +626,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/det1/11.png",
@@ -677,7 +688,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/det1/12.png",
@@ -737,7 +749,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/det1/13.png",
@@ -794,7 +807,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/det1/14.png",
@@ -853,7 +867,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/det1/15.png",
@@ -907,7 +922,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/det1/16.png",
@@ -955,7 +971,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/det1/17.png",
@@ -1010,7 +1027,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/det1/18.png",

--- a/cards/en/dp1.json
+++ b/cards/en/dp1.json
@@ -6575,7 +6575,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/107.png",
@@ -6619,7 +6620,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/109.png",
@@ -6642,7 +6644,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/110.png",
@@ -6751,7 +6754,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/115.png",
@@ -6795,7 +6799,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/117.png",
@@ -6818,7 +6823,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/118.png",
@@ -6841,7 +6847,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/119.png",
@@ -7040,7 +7047,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/123.png",
@@ -7059,7 +7067,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/124.png",
@@ -7078,7 +7087,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/125.png",
@@ -7097,7 +7107,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/126.png",
@@ -7116,7 +7127,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/127.png",
@@ -7135,7 +7147,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/128.png",
@@ -7154,7 +7167,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/129.png",
@@ -7173,7 +7187,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp1/130.png",

--- a/cards/en/dp2.json
+++ b/cards/en/dp2.json
@@ -6663,7 +6663,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp2/114.png",

--- a/cards/en/dp3.json
+++ b/cards/en/dp3.json
@@ -7371,7 +7371,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp3/121.png",
@@ -7504,7 +7505,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp3/127.png",
@@ -7527,7 +7529,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp3/128.png",

--- a/cards/en/dp4.json
+++ b/cards/en/dp4.json
@@ -6006,7 +6006,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp4/102.png",

--- a/cards/en/dp5.json
+++ b/cards/en/dp5.json
@@ -5039,7 +5039,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp5/85.png",
@@ -5061,7 +5062,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp5/86.png",
@@ -5083,7 +5085,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp5/87.png",
@@ -5156,7 +5159,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp5/90.png",

--- a/cards/en/dp7.json
+++ b/cards/en/dp7.json
@@ -5511,7 +5511,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp7/84.png",
@@ -5534,7 +5535,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp7/85.png",
@@ -5684,7 +5686,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp7/92.png",
@@ -5707,7 +5710,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp7/93.png",
@@ -5750,7 +5754,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dp7/95.png",

--- a/cards/en/dv1.json
+++ b/cards/en/dv1.json
@@ -44,7 +44,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dv1/1.png",
@@ -104,7 +105,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dv1/2.png",
@@ -169,7 +171,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dv1/3.png",
@@ -232,7 +235,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dv1/4.png",
@@ -297,7 +301,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dv1/5.png",
@@ -358,7 +363,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dv1/6.png",
@@ -423,7 +429,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dv1/7.png",
@@ -483,7 +490,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dv1/8.png",
@@ -541,7 +549,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dv1/9.png",
@@ -601,7 +610,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dv1/10.png",
@@ -662,7 +672,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dv1/11.png",
@@ -722,7 +733,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dv1/12.png",
@@ -774,7 +786,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dv1/13.png",
@@ -835,7 +848,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dv1/14.png",
@@ -900,7 +914,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dv1/15.png",
@@ -963,7 +978,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dv1/16.png",
@@ -1024,7 +1040,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dv1/17.png",
@@ -1048,7 +1065,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dv1/18.png",
@@ -1070,7 +1088,8 @@
     "artist": "5ban Graphics",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dv1/19.png",
@@ -1094,7 +1113,8 @@
     "legalities": {
       "standard": "Legal",
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dv1/20.png",
@@ -1156,7 +1176,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/dv1/21.png",

--- a/cards/en/ecard1.json
+++ b/cards/en/ecard1.json
@@ -7885,7 +7885,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard1/137.png",
@@ -7909,7 +7910,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard1/138.png",
@@ -8178,7 +8180,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard1/151.png",
@@ -8216,7 +8219,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard1/153.png",
@@ -8235,7 +8239,8 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard1/154.png",
@@ -8273,7 +8278,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard1/156.png",
@@ -8293,7 +8299,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard1/157.png",
@@ -8353,7 +8360,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard1/160.png",
@@ -8371,7 +8379,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard1/161.png",
@@ -8389,7 +8398,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard1/162.png",
@@ -8407,7 +8417,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard1/163.png",
@@ -8425,7 +8436,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard1/164.png",
@@ -8443,7 +8455,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard1/165.png",

--- a/cards/en/ecard2.json
+++ b/cards/en/ecard2.json
@@ -6881,7 +6881,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard2/120.png",
@@ -7470,7 +7471,8 @@
     "rarity": "Rare",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard2/144.png",
@@ -7534,7 +7536,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard2/147.png",

--- a/cards/en/ecard3.json
+++ b/cards/en/ecard3.json
@@ -7156,7 +7156,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard3/125.png",
@@ -7193,7 +7194,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard3/127.png",
@@ -7212,7 +7214,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard3/128.png",
@@ -7553,7 +7556,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ecard3/140.png",

--- a/cards/en/ex1.json
+++ b/cards/en/ex1.json
@@ -4779,7 +4779,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex1/82.png",
@@ -4824,7 +4825,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex1/84.png",
@@ -4869,7 +4871,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex1/86.png",
@@ -4956,7 +4959,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex1/90.png",
@@ -4979,7 +4983,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex1/91.png",
@@ -5002,7 +5007,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex1/92.png",
@@ -5066,7 +5072,8 @@
     "rarity": "Rare",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex1/95.png",
@@ -5616,7 +5623,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex1/104.png",
@@ -5635,7 +5643,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex1/105.png",
@@ -5654,7 +5663,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex1/106.png",
@@ -5673,7 +5683,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex1/107.png",
@@ -5692,7 +5703,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex1/108.png",
@@ -5711,7 +5723,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex1/109.png",

--- a/cards/en/ex10.json
+++ b/cards/en/ex10.json
@@ -4753,7 +4753,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex10/81.png",
@@ -4819,7 +4820,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex10/84.png",
@@ -4886,7 +4888,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex10/87.png",
@@ -4974,7 +4977,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex10/91.png",
@@ -5040,7 +5044,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex10/94.png",
@@ -5063,7 +5068,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex10/95.png",
@@ -5169,7 +5175,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex10/100.png",

--- a/cards/en/ex11.json
+++ b/cards/en/ex11.json
@@ -5368,7 +5368,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex11/90.png",
@@ -5591,7 +5592,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex11/100.png",
@@ -5614,7 +5616,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex11/101.png",
@@ -5637,7 +5640,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex11/102.png",

--- a/cards/en/ex12.json
+++ b/cards/en/ex12.json
@@ -4608,7 +4608,8 @@
     "rarity": "Rare",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex12/81.png",

--- a/cards/en/ex13.json
+++ b/cards/en/ex13.json
@@ -5168,7 +5168,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex13/90.png",
@@ -5758,7 +5759,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex13/105.png",
@@ -5777,7 +5779,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex13/106.png",
@@ -5796,7 +5799,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex13/107.png",
@@ -5815,7 +5819,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex13/108.png",
@@ -5834,7 +5839,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex13/109.png",
@@ -5853,7 +5859,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex13/110.png",

--- a/cards/en/ex14.json
+++ b/cards/en/ex14.json
@@ -4256,7 +4256,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex14/71.png",
@@ -4497,7 +4498,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex14/82.png",
@@ -4583,7 +4585,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex14/86.png",
@@ -4606,7 +4609,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex14/87.png",

--- a/cards/en/ex15.json
+++ b/cards/en/ex15.json
@@ -4072,7 +4072,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex15/73.png",
@@ -4271,7 +4272,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex15/82.png",
@@ -4294,7 +4296,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex15/83.png",

--- a/cards/en/ex16.json
+++ b/cards/en/ex16.json
@@ -4285,7 +4285,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex16/73.png",
@@ -4329,7 +4330,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex16/75.png",
@@ -4374,7 +4376,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex16/77.png",
@@ -4692,7 +4695,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex16/91.png",
@@ -5446,7 +5450,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex16/103.png",
@@ -5465,7 +5470,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex16/104.png",
@@ -5484,7 +5490,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex16/105.png",
@@ -5503,7 +5510,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex16/106.png",
@@ -5522,7 +5530,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex16/107.png",
@@ -5541,7 +5550,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex16/108.png",

--- a/cards/en/ex2.json
+++ b/cards/en/ex2.json
@@ -5052,7 +5052,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex2/88.png",

--- a/cards/en/ex3.json
+++ b/cards/en/ex3.json
@@ -4859,7 +4859,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex3/84.png",
@@ -4948,7 +4949,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex3/88.png",

--- a/cards/en/ex6.json
+++ b/cards/en/ex6.json
@@ -5120,7 +5120,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex6/87.png",
@@ -5186,7 +5187,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex6/90.png",
@@ -5231,7 +5233,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex6/92.png",
@@ -5297,7 +5300,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex6/95.png",
@@ -5383,7 +5387,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex6/99.png",
@@ -5405,7 +5410,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex6/100.png",
@@ -5428,7 +5434,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex6/101.png",
@@ -5451,7 +5458,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex6/102.png",

--- a/cards/en/ex7.json
+++ b/cards/en/ex7.json
@@ -4972,7 +4972,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex7/83.png",
@@ -6278,7 +6279,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex7/111.png",

--- a/cards/en/ex9.json
+++ b/cards/en/ex9.json
@@ -4404,7 +4404,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex9/78.png",
@@ -4514,7 +4515,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex9/83.png",
@@ -5390,7 +5392,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex9/101.png",
@@ -5409,7 +5412,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex9/102.png",
@@ -5428,7 +5432,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex9/103.png",
@@ -5447,7 +5452,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex9/104.png",
@@ -5466,7 +5472,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex9/105.png",
@@ -5485,7 +5492,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/ex9/106.png",

--- a/cards/en/fut20.json
+++ b/cards/en/fut20.json
@@ -50,7 +50,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -108,7 +109,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -167,7 +169,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -225,7 +228,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -283,7 +287,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {

--- a/cards/en/g1.json
+++ b/cards/en/g1.json
@@ -180,7 +180,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/3.png",
@@ -241,7 +242,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/4.png",
@@ -307,7 +309,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/5.png",
@@ -358,7 +361,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/6.png",
@@ -418,7 +422,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/7.png",
@@ -482,7 +487,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/8.png",
@@ -542,7 +548,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/9.png",
@@ -856,7 +863,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/14.png",
@@ -911,7 +919,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/15.png",
@@ -973,7 +982,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/16.png",
@@ -1153,7 +1163,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/19.png",
@@ -1216,7 +1227,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/20.png",
@@ -1279,7 +1291,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/21.png",
@@ -1330,7 +1343,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/22.png",
@@ -1395,7 +1409,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/23.png",
@@ -1526,7 +1541,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/25.png",
@@ -1593,7 +1609,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/26.png",
@@ -1656,7 +1673,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/27.png",
@@ -1850,7 +1868,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/29.png",
@@ -1907,7 +1926,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/30.png",
@@ -1968,7 +1988,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/31.png",
@@ -2030,7 +2051,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/32.png",
@@ -2087,7 +2109,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/33.png",
@@ -2153,7 +2176,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/34.png",
@@ -2214,7 +2238,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/35.png",
@@ -2271,7 +2296,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/36.png",
@@ -2391,7 +2417,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/38.png",
@@ -2451,7 +2478,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/39.png",
@@ -2503,7 +2531,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/40.png",
@@ -2557,7 +2586,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/41.png",
@@ -2616,7 +2646,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/42.png",
@@ -2678,7 +2709,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/43.png",
@@ -2746,7 +2778,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/44.png",
@@ -2811,7 +2844,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/45.png",
@@ -2937,7 +2971,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/47.png",
@@ -2997,7 +3032,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/48.png",
@@ -3051,7 +3087,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/49.png",
@@ -3118,7 +3155,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/50.png",
@@ -3184,7 +3222,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/51.png",
@@ -3246,7 +3285,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/52.png",
@@ -3297,7 +3337,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/53.png",
@@ -3356,7 +3397,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/54.png",
@@ -3423,7 +3465,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/55.png",
@@ -3487,7 +3530,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/56.png",
@@ -3547,7 +3591,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/57.png",
@@ -3608,7 +3653,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/58.png",
@@ -3631,7 +3677,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/59.png",
@@ -3655,7 +3702,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/60.png",
@@ -3679,7 +3727,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/61.png",
@@ -3702,7 +3751,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/62.png",
@@ -3724,7 +3774,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/63.png",
@@ -3747,7 +3798,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/64.png",
@@ -3770,7 +3822,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/65.png",
@@ -3793,7 +3846,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/66.png",
@@ -3817,7 +3871,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/67.png",
@@ -3840,7 +3895,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/68.png",
@@ -3863,7 +3919,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/69.png",
@@ -3886,7 +3943,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/70.png",
@@ -3909,7 +3967,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/71.png",
@@ -3933,7 +3992,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/72.png",
@@ -3956,7 +4016,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/73.png",
@@ -3979,7 +4040,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/73a.png",
@@ -4001,7 +4063,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/74.png",
@@ -4020,7 +4083,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/75.png",
@@ -4039,7 +4103,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/76.png",
@@ -4058,7 +4123,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/77.png",
@@ -4077,7 +4143,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/78.png",
@@ -4096,7 +4163,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/79.png",
@@ -4115,7 +4183,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/80.png",
@@ -4134,7 +4203,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/81.png",
@@ -4153,7 +4223,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/82.png",
@@ -4171,7 +4242,8 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/83.png",
@@ -4232,7 +4304,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/RC1.png",
@@ -4284,7 +4357,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/RC2.png",
@@ -4337,7 +4411,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/RC3.png",
@@ -4401,7 +4476,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/RC4.png",
@@ -4464,7 +4540,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/RC5.png",
@@ -4577,7 +4654,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/RC7.png",
@@ -4636,7 +4714,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/RC8.png",
@@ -4699,7 +4778,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/RC9.png",
@@ -4762,7 +4842,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/RC10.png",
@@ -4819,7 +4900,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/RC11.png",
@@ -4872,7 +4954,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/RC12.png",
@@ -4931,7 +5014,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/RC13.png",
@@ -4982,7 +5066,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/RC14.png",
@@ -5042,7 +5127,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/RC15.png",
@@ -5108,7 +5194,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/RC16.png",
@@ -5165,7 +5252,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/RC17.png",
@@ -5233,7 +5321,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/RC18.png",
@@ -5300,7 +5389,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/RC19.png",
@@ -5367,7 +5457,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/RC20.png",
@@ -5502,7 +5593,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/RC22.png",
@@ -5559,7 +5651,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/RC23.png",
@@ -5624,7 +5717,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/RC24.png",
@@ -5681,7 +5775,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/RC25.png",
@@ -5705,7 +5800,8 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/RC26.png",
@@ -5728,7 +5824,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/RC27.png",
@@ -5856,7 +5953,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/g1/RC29.png",

--- a/cards/en/gym1.json
+++ b/cards/en/gym1.json
@@ -6064,7 +6064,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/gym1/127.png",
@@ -6083,7 +6084,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/gym1/128.png",
@@ -6102,7 +6104,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/gym1/129.png",
@@ -6121,7 +6124,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/gym1/130.png",
@@ -6140,7 +6144,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/gym1/131.png",
@@ -6159,7 +6164,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/gym1/132.png",

--- a/cards/en/gym2.json
+++ b/cards/en/gym2.json
@@ -6277,7 +6277,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/gym2/127.png",
@@ -6296,7 +6297,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/gym2/128.png",
@@ -6315,7 +6317,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/gym2/129.png",
@@ -6334,7 +6337,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/gym2/130.png",
@@ -6353,7 +6357,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/gym2/131.png",
@@ -6372,7 +6377,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/gym2/132.png",

--- a/cards/en/hgss1.json
+++ b/cards/en/hgss1.json
@@ -4233,7 +4233,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/72.png",
@@ -5246,7 +5247,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/90.png",
@@ -5269,7 +5271,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/91.png",
@@ -5292,7 +5295,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/92.png",
@@ -5314,7 +5318,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/93.png",
@@ -5336,7 +5341,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/94.png",
@@ -5359,7 +5365,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/95.png",
@@ -5382,7 +5389,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/96.png",
@@ -5426,7 +5434,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/98.png",
@@ -5514,7 +5523,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/102.png",
@@ -5536,7 +5546,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/103.png",
@@ -5558,7 +5569,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/104.png",
@@ -6221,7 +6233,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/115.png",
@@ -6240,7 +6253,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/116.png",
@@ -6259,7 +6273,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/117.png",
@@ -6278,7 +6293,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/118.png",
@@ -6297,7 +6313,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/119.png",
@@ -6316,7 +6333,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/120.png",
@@ -6335,7 +6353,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/121.png",
@@ -6354,7 +6373,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss1/122.png",

--- a/cards/en/hgss2.json
+++ b/cards/en/hgss2.json
@@ -4373,7 +4373,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss2/78.png",
@@ -4395,7 +4396,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss2/79.png",
@@ -4418,7 +4420,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss2/80.png",
@@ -4462,7 +4465,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/hgss2/82.png",

--- a/cards/en/mcd11.json
+++ b/cards/en/mcd11.json
@@ -49,7 +49,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd11/1.png",
@@ -114,7 +115,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd11/2.png",
@@ -166,7 +168,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd11/3.png",
@@ -217,7 +220,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd11/4.png",
@@ -278,7 +282,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd11/5.png",
@@ -329,7 +334,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd11/6.png",
@@ -379,7 +385,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd11/7.png",
@@ -432,7 +439,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd11/8.png",
@@ -498,7 +506,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd11/9.png",
@@ -564,7 +573,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd11/10.png",
@@ -629,7 +639,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd11/11.png",
@@ -678,7 +689,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd11/12.png",

--- a/cards/en/mcd12.json
+++ b/cards/en/mcd12.json
@@ -59,7 +59,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd12/1.png",
@@ -125,7 +126,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd12/2.png",
@@ -186,7 +188,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd12/3.png",
@@ -250,7 +253,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd12/4.png",
@@ -313,7 +317,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd12/5.png",
@@ -366,7 +371,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd12/6.png",
@@ -417,7 +423,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd12/7.png",
@@ -475,7 +482,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd12/8.png",
@@ -532,7 +540,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd12/9.png",
@@ -588,7 +597,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd12/10.png",
@@ -656,7 +666,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd12/11.png",
@@ -700,7 +711,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd12/12.png",

--- a/cards/en/mcd14.json
+++ b/cards/en/mcd14.json
@@ -42,7 +42,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd14/1.png",
@@ -102,7 +103,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd14/2.png",
@@ -162,7 +164,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd14/3.png",
@@ -222,7 +225,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd14/4.png",
@@ -288,7 +292,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd14/5.png",
@@ -344,7 +349,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd14/6.png",
@@ -402,7 +408,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd14/7.png",
@@ -460,7 +467,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd14/8.png",
@@ -516,7 +524,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd14/9.png",
@@ -567,7 +576,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd14/10.png",
@@ -623,7 +633,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd14/11.png",
@@ -682,7 +693,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd14/12.png",

--- a/cards/en/mcd15.json
+++ b/cards/en/mcd15.json
@@ -42,7 +42,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd15/1.png",
@@ -93,7 +94,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd15/2.png",
@@ -143,7 +145,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd15/3.png",
@@ -193,7 +196,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd15/4.png",
@@ -253,7 +257,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd15/5.png",
@@ -319,7 +324,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd15/6.png",
@@ -385,7 +391,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd15/7.png",
@@ -439,7 +446,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd15/8.png",
@@ -489,7 +497,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd15/9.png",
@@ -556,7 +565,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd15/10.png",
@@ -616,7 +626,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd15/11.png",
@@ -676,7 +687,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd15/12.png",

--- a/cards/en/mcd16.json
+++ b/cards/en/mcd16.json
@@ -51,7 +51,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd16/1.png",
@@ -101,7 +102,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd16/2.png",
@@ -151,7 +153,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd16/3.png",
@@ -201,7 +204,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd16/4.png",
@@ -251,7 +255,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd16/5.png",
@@ -317,7 +322,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd16/6.png",
@@ -375,7 +381,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd16/7.png",
@@ -440,7 +447,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd16/8.png",
@@ -496,7 +504,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd16/9.png",
@@ -560,7 +569,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd16/10.png",
@@ -610,7 +620,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd16/11.png",
@@ -677,7 +688,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd16/12.png",

--- a/cards/en/mcd17.json
+++ b/cards/en/mcd17.json
@@ -52,7 +52,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd17/1.png",
@@ -104,7 +105,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd17/2.png",
@@ -164,7 +166,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd17/3.png",
@@ -224,7 +227,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd17/4.png",
@@ -291,7 +295,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd17/5.png",
@@ -341,7 +346,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd17/6.png",
@@ -404,7 +410,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd17/7.png",
@@ -460,7 +467,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd17/8.png",
@@ -525,7 +533,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd17/9.png",
@@ -581,7 +590,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd17/10.png",
@@ -637,7 +647,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd17/11.png",
@@ -697,7 +708,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd17/12.png",

--- a/cards/en/mcd18.json
+++ b/cards/en/mcd18.json
@@ -45,7 +45,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd18/1.png",
@@ -96,7 +97,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd18/2.png",
@@ -146,7 +148,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd18/3.png",
@@ -212,7 +215,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd18/4.png",
@@ -276,7 +280,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd18/5.png",
@@ -328,7 +333,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd18/6.png",
@@ -389,7 +395,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd18/7.png",
@@ -454,7 +461,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd18/8.png",
@@ -514,7 +522,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd18/9.png",
@@ -578,7 +587,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd18/10.png",
@@ -643,7 +653,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd18/11.png",
@@ -702,7 +713,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd18/12.png",

--- a/cards/en/mcd19.json
+++ b/cards/en/mcd19.json
@@ -42,7 +42,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd19/1.png",
@@ -92,7 +93,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd19/2.png",
@@ -154,7 +156,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd19/3.png",
@@ -204,7 +207,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd19/4.png",
@@ -263,7 +267,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd19/5.png",
@@ -319,7 +324,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd19/6.png",
@@ -375,7 +381,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd19/7.png",
@@ -425,7 +432,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd19/8.png",
@@ -486,7 +494,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd19/9.png",
@@ -542,7 +551,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd19/10.png",
@@ -596,7 +606,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd19/11.png",
@@ -653,7 +664,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd19/12.png",

--- a/cards/en/mcd21.json
+++ b/cards/en/mcd21.json
@@ -44,7 +44,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd21/1.png",
@@ -94,7 +95,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd21/2.png",
@@ -144,7 +146,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd21/3.png",
@@ -207,7 +210,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd21/4.png",
@@ -264,7 +268,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd21/5.png",
@@ -324,7 +329,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd21/6.png",
@@ -384,7 +390,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd21/7.png",
@@ -435,7 +442,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -496,7 +504,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd21/9.png",
@@ -547,7 +556,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd21/10.png",
@@ -597,7 +607,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd21/11.png",
@@ -647,7 +658,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd21/12.png",
@@ -699,7 +711,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd21/13.png",
@@ -759,7 +772,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd21/14.png",
@@ -819,7 +833,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd21/15.png",
@@ -869,7 +884,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -920,7 +936,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd21/17.png",
@@ -970,7 +987,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd21/18.png",
@@ -1030,7 +1048,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd21/19.png",
@@ -1090,7 +1109,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd21/20.png",
@@ -1141,7 +1161,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd21/21.png",
@@ -1201,7 +1222,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd21/22.png",
@@ -1261,7 +1283,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd21/23.png",
@@ -1312,7 +1335,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1379,7 +1403,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/mcd21/25.png",

--- a/cards/en/mcd22.json
+++ b/cards/en/mcd22.json
@@ -53,7 +53,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -113,7 +114,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -165,7 +167,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -229,7 +232,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -279,7 +283,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -338,7 +343,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -401,7 +407,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -453,7 +460,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -508,7 +516,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -566,7 +575,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -614,7 +624,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -678,7 +689,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -745,7 +757,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -799,7 +812,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -849,7 +863,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {

--- a/cards/en/neo1.json
+++ b/cards/en/neo1.json
@@ -5232,7 +5232,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/neo1/98.png",
@@ -5328,7 +5329,8 @@
     "legalities": {
       "standard": "Legal",
       "expanded": "Legal",
-      "unlimited": "Legal"
+      "unlimited": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/neo1/103.png",
@@ -5390,7 +5392,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/neo1/106.png",
@@ -5409,7 +5412,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/neo1/107.png",
@@ -5428,7 +5432,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/neo1/108.png",
@@ -5447,7 +5452,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/neo1/109.png",
@@ -5466,7 +5472,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/neo1/110.png",
@@ -5485,7 +5492,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/neo1/111.png",

--- a/cards/en/pgo.json
+++ b/cards/en/pgo.json
@@ -55,7 +55,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -122,7 +123,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -186,7 +188,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -370,7 +373,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -431,7 +435,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -484,7 +489,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -552,7 +558,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -615,7 +622,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -742,7 +750,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -809,7 +818,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -875,7 +885,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -928,7 +939,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -994,7 +1006,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1057,7 +1070,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1185,7 +1199,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1248,7 +1263,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1311,7 +1327,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1376,7 +1393,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1438,7 +1456,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1498,7 +1517,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1560,7 +1580,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1623,7 +1644,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1678,7 +1700,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1733,7 +1756,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1793,7 +1817,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2005,7 +2030,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2068,7 +2094,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2135,7 +2162,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2197,7 +2225,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2267,7 +2296,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2320,7 +2350,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2385,7 +2416,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2443,7 +2475,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2563,7 +2596,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2627,7 +2661,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2693,7 +2728,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2767,7 +2803,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2828,7 +2865,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2900,7 +2938,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3222,7 +3261,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3287,7 +3327,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3333,7 +3374,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3403,7 +3445,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3466,7 +3509,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3530,7 +3574,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3588,7 +3633,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3709,7 +3755,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3770,7 +3817,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3839,7 +3887,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3909,7 +3958,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3976,7 +4026,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4001,7 +4052,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4026,7 +4078,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4051,7 +4104,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4076,7 +4130,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4100,7 +4155,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4125,7 +4181,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4150,7 +4207,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4644,7 +4702,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4864,7 +4923,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4889,7 +4949,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4915,7 +4976,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4940,7 +5002,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5036,7 +5099,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5061,7 +5125,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {

--- a/cards/en/pl1.json
+++ b/cards/en/pl1.json
@@ -6672,7 +6672,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/pl1/108.png",
@@ -6761,7 +6762,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/pl1/112.png",
@@ -6784,7 +6786,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/pl1/113.png",
@@ -6970,7 +6973,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/pl1/121.png",

--- a/cards/en/pl2.json
+++ b/cards/en/pl2.json
@@ -6689,7 +6689,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/pl2/114.png",

--- a/cards/en/pl3.json
+++ b/cards/en/pl3.json
@@ -8429,7 +8429,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/pl3/140.png",

--- a/cards/en/pl4.json
+++ b/cards/en/pl4.json
@@ -5307,7 +5307,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/pl4/88.png",

--- a/cards/en/pop2.json
+++ b/cards/en/pop2.json
@@ -500,7 +500,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/pop2/11.png",

--- a/cards/en/pop5.json
+++ b/cards/en/pop5.json
@@ -272,7 +272,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/pop5/6.png",
@@ -295,7 +296,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/pop5/7.png",

--- a/cards/en/pop8.json
+++ b/cards/en/pop8.json
@@ -552,7 +552,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/pop8/10.png",

--- a/cards/en/sm1.json
+++ b/cards/en/sm1.json
@@ -53,7 +53,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/1.png",
@@ -118,7 +119,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/2.png",
@@ -178,7 +180,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/3.png",
@@ -230,7 +233,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/4.png",
@@ -293,7 +297,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/5.png",
@@ -353,7 +358,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/6.png",
@@ -404,7 +410,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/7.png",
@@ -449,7 +456,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/8.png",
@@ -510,7 +518,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/9.png",
@@ -573,7 +582,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/10.png",
@@ -633,7 +643,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/11.png",
@@ -757,7 +768,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/13.png",
@@ -818,7 +830,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/14.png",
@@ -951,7 +964,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/16.png",
@@ -1009,7 +1023,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/17.png",
@@ -1069,7 +1084,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/18.png",
@@ -1132,7 +1148,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/19.png",
@@ -1191,7 +1208,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/20.png",
@@ -1245,7 +1263,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/21.png",
@@ -1309,7 +1328,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/22.png",
@@ -1369,7 +1389,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/23.png",
@@ -1430,7 +1451,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/24.png",
@@ -1494,7 +1516,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/25.png",
@@ -1557,7 +1580,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/26.png",
@@ -1685,7 +1709,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/28.png",
@@ -1739,7 +1764,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/29.png",
@@ -1801,7 +1827,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/30.png",
@@ -1867,7 +1894,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/31.png",
@@ -1929,7 +1957,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/32.png",
@@ -1981,7 +2010,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/33.png",
@@ -2044,7 +2074,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/34.png",
@@ -2180,7 +2211,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/36.png",
@@ -2237,7 +2269,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/37.png",
@@ -2304,7 +2337,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/38.png",
@@ -2365,7 +2399,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/39.png",
@@ -2430,7 +2465,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/40.png",
@@ -2492,7 +2528,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/41.png",
@@ -2634,7 +2671,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/43.png",
@@ -2689,7 +2727,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/44.png",
@@ -2740,7 +2779,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/45.png",
@@ -2799,7 +2839,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/46.png",
@@ -2854,7 +2895,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/47.png",
@@ -2914,7 +2956,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/48.png",
@@ -2982,7 +3025,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/49.png",
@@ -3049,7 +3093,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/50.png",
@@ -3121,7 +3166,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/51.png",
@@ -3188,7 +3234,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/52.png",
@@ -3251,7 +3298,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/53.png",
@@ -3308,7 +3356,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/54.png",
@@ -3372,7 +3421,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/55.png",
@@ -3434,7 +3484,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/56.png",
@@ -3498,7 +3549,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/57.png",
@@ -3560,7 +3612,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/58.png",
@@ -3622,7 +3675,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/59.png",
@@ -3684,7 +3738,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/60.png",
@@ -3809,7 +3864,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/62.png",
@@ -3869,7 +3925,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/63.png",
@@ -3920,7 +3977,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/64.png",
@@ -3975,7 +4033,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/65.png",
@@ -4117,7 +4176,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/67.png",
@@ -4183,7 +4243,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/68.png",
@@ -4237,7 +4298,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/69.png",
@@ -4304,7 +4366,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/70.png",
@@ -4369,7 +4432,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/71.png",
@@ -4433,7 +4497,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/72.png",
@@ -4491,7 +4556,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/73.png",
@@ -4555,7 +4621,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/74.png",
@@ -4617,7 +4684,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/75.png",
@@ -4670,7 +4738,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/76.png",
@@ -4739,7 +4808,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/77.png",
@@ -4796,7 +4866,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/78.png",
@@ -4860,7 +4931,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/79.png",
@@ -5007,7 +5079,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/81.png",
@@ -5067,7 +5140,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/82.png",
@@ -5137,7 +5211,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/83.png",
@@ -5208,7 +5283,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/84.png",
@@ -5277,7 +5353,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/85.png",
@@ -5343,7 +5420,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/86.png",
@@ -5408,7 +5486,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/87.png",
@@ -5474,7 +5553,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/88.png",
@@ -5609,7 +5689,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/90.png",
@@ -5676,7 +5757,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/91.png",
@@ -5733,7 +5815,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/92.png",
@@ -5795,7 +5878,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/93.png",
@@ -5856,7 +5940,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/94.png",
@@ -5920,7 +6005,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/95.png",
@@ -5986,7 +6072,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/96.png",
@@ -6043,7 +6130,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/97.png",
@@ -6107,7 +6195,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/98.png",
@@ -6169,7 +6258,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/99.png",
@@ -6309,7 +6399,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/101.png",
@@ -6375,7 +6466,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/101a.png",
@@ -6423,7 +6515,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/102.png",
@@ -6484,7 +6577,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/103.png",
@@ -6545,7 +6639,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/104.png",
@@ -6610,7 +6705,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/105.png",
@@ -6667,7 +6763,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/106.png",
@@ -6725,7 +6822,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/107.png",
@@ -6793,7 +6891,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/108.png",
@@ -6854,7 +6953,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/109.png",
@@ -6978,7 +7078,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/111.png",
@@ -7041,7 +7142,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/112.png",
@@ -7099,7 +7201,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/113.png",
@@ -7122,7 +7225,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/114.png",
@@ -7146,7 +7250,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/115.png",
@@ -7170,7 +7275,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/116.png",
@@ -7194,7 +7300,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/117.png",
@@ -7219,7 +7326,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/118.png",
@@ -7243,7 +7351,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/119.png",
@@ -7266,7 +7375,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/120.png",
@@ -7289,7 +7399,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/121.png",
@@ -7312,7 +7423,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/122.png",
@@ -7335,7 +7447,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/123.png",
@@ -7359,7 +7472,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/124.png",
@@ -7383,7 +7497,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/125.png",
@@ -7407,7 +7522,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/126.png",
@@ -7431,7 +7547,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/127.png",
@@ -7454,7 +7571,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/128.png",
@@ -7478,7 +7596,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/129.png",
@@ -7501,7 +7620,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/130.png",
@@ -7524,7 +7644,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/131.png",
@@ -7548,7 +7669,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/132.png",
@@ -7571,7 +7693,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/133.png",
@@ -7594,7 +7717,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/134.png",
@@ -7617,7 +7741,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/135.png",
@@ -7638,7 +7763,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/136.png",
@@ -7659,7 +7785,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/137.png",
@@ -8286,7 +8413,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/146.png",
@@ -8309,7 +8437,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/147.png",
@@ -8332,7 +8461,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/148.png",
@@ -8355,7 +8485,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/149.png",
@@ -8983,7 +9114,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/158.png",
@@ -9006,7 +9138,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/159.png",
@@ -9030,7 +9163,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/160.png",
@@ -9054,7 +9188,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/161.png",
@@ -9073,7 +9208,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/162.png",
@@ -9092,7 +9228,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/163.png",
@@ -9111,7 +9248,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/164.png",
@@ -9130,7 +9268,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/165.png",
@@ -9149,7 +9288,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/166.png",
@@ -9168,7 +9308,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/167.png",
@@ -9187,7 +9328,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/168.png",
@@ -9206,7 +9348,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/169.png",
@@ -9225,7 +9368,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/170.png",
@@ -9244,7 +9388,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/171.png",
@@ -9262,7 +9407,8 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm1/172.png",

--- a/cards/en/sm10.json
+++ b/cards/en/sm10.json
@@ -126,7 +126,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/2.png",
@@ -189,7 +190,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/3.png",
@@ -249,7 +251,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/4.png",
@@ -310,7 +313,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/5.png",
@@ -361,7 +365,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/6.png",
@@ -423,7 +428,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/7.png",
@@ -483,7 +489,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/8.png",
@@ -544,7 +551,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/9.png",
@@ -595,7 +603,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/10.png",
@@ -649,7 +658,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/11.png",
@@ -763,7 +773,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/13.png",
@@ -826,7 +837,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/14.png",
@@ -887,7 +899,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/15.png",
@@ -949,7 +962,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/16.png",
@@ -1011,7 +1025,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/17.png",
@@ -1074,7 +1089,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/18.png",
@@ -1130,7 +1146,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/19.png",
@@ -1271,7 +1288,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/21.png",
@@ -1337,7 +1355,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/22.png",
@@ -1399,7 +1418,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/23.png",
@@ -1460,7 +1480,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/24.png",
@@ -1519,7 +1540,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/25.png",
@@ -1570,7 +1592,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/26.png",
@@ -1632,7 +1655,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/27.png",
@@ -1684,7 +1708,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/28.png",
@@ -1742,7 +1767,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/29.png",
@@ -1793,7 +1819,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/30.png",
@@ -1850,7 +1877,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/31.png",
@@ -1911,7 +1939,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/32.png",
@@ -1962,7 +1991,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/33.png",
@@ -2023,7 +2053,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/34.png",
@@ -2152,7 +2183,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/36.png",
@@ -2203,7 +2235,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/37.png",
@@ -2267,7 +2300,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/38.png",
@@ -2330,7 +2364,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/39.png",
@@ -2381,7 +2416,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/40.png",
@@ -2441,7 +2477,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/41.png",
@@ -2504,7 +2541,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/42.png",
@@ -2565,7 +2603,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/43.png",
@@ -2618,7 +2657,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/44.png",
@@ -2680,7 +2720,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/45.png",
@@ -2741,7 +2782,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/46.png",
@@ -2807,7 +2849,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/47.png",
@@ -2858,7 +2901,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/48.png",
@@ -2907,7 +2951,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/49.png",
@@ -2967,7 +3012,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/50.png",
@@ -3018,7 +3064,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/51.png",
@@ -3070,7 +3117,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/52.png",
@@ -3129,7 +3177,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/53.png",
@@ -3187,7 +3236,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/54.png",
@@ -3254,7 +3304,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/55.png",
@@ -3320,7 +3371,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/56.png",
@@ -3464,7 +3516,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/58.png",
@@ -3530,7 +3583,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/59.png",
@@ -3595,7 +3649,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/60.png",
@@ -3735,7 +3790,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/62.png",
@@ -3795,7 +3851,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/63.png",
@@ -3862,7 +3919,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/64.png",
@@ -3931,7 +3989,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/65.png",
@@ -3991,7 +4050,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/66.png",
@@ -4056,7 +4116,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/67.png",
@@ -4113,7 +4174,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/68.png",
@@ -4171,7 +4233,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/69.png",
@@ -4231,7 +4294,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/70.png",
@@ -4294,7 +4358,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/71.png",
@@ -4353,7 +4418,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/72.png",
@@ -4405,7 +4471,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/73.png",
@@ -4464,7 +4531,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/74.png",
@@ -4522,7 +4590,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/75.png",
@@ -4577,7 +4646,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/76.png",
@@ -4634,7 +4704,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/77.png",
@@ -4698,7 +4769,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/78.png",
@@ -4760,7 +4832,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/79.png",
@@ -4820,7 +4893,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/80.png",
@@ -4881,7 +4955,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/81.png",
@@ -5021,7 +5096,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/83.png",
@@ -5081,7 +5157,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/84.png",
@@ -5139,7 +5216,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/85.png",
@@ -5188,7 +5266,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/86.png",
@@ -5251,7 +5330,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/87.png",
@@ -5320,7 +5400,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/88.png",
@@ -5386,7 +5467,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/89.png",
@@ -5446,7 +5528,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/90.png",
@@ -5507,7 +5590,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/91.png",
@@ -5559,7 +5643,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/92.png",
@@ -5626,7 +5711,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/93.png",
@@ -5694,7 +5780,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/94.png",
@@ -5760,7 +5847,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/95.png",
@@ -5812,7 +5900,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/96.png",
@@ -5873,7 +5962,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/97.png",
@@ -5934,7 +6024,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/98.png",
@@ -5994,7 +6085,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/99.png",
@@ -6033,7 +6125,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/100.png",
@@ -6091,7 +6184,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/101.png",
@@ -6142,7 +6236,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/102.png",
@@ -6200,7 +6295,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/103.png",
@@ -6264,7 +6360,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/104.png",
@@ -6328,7 +6425,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/105.png",
@@ -6389,7 +6487,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/106.png",
@@ -6517,7 +6616,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/108.png",
@@ -6652,7 +6752,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/110.png",
@@ -6716,7 +6817,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/111.png",
@@ -6765,7 +6867,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/112.png",
@@ -6830,7 +6933,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/113.png",
@@ -6890,7 +6994,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/114.png",
@@ -6960,7 +7065,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/115.png",
@@ -7031,7 +7137,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/116.png",
@@ -7093,7 +7200,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/117.png",
@@ -7150,7 +7258,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/118.png",
@@ -7216,7 +7325,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/119.png",
@@ -7356,7 +7466,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/121.png",
@@ -7419,7 +7530,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/122.png",
@@ -7486,7 +7598,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/123.png",
@@ -7557,7 +7670,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/124.png",
@@ -7629,7 +7743,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/125.png",
@@ -7695,7 +7810,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/126.png",
@@ -7759,7 +7875,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/127.png",
@@ -7816,7 +7933,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/128.png",
@@ -7884,7 +8002,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/129.png",
@@ -8003,7 +8122,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/131.png",
@@ -8060,7 +8180,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/132.png",
@@ -8115,7 +8236,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/133.png",
@@ -8174,7 +8296,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/134.png",
@@ -8240,7 +8363,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/135.png",
@@ -8297,7 +8421,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/136.png",
@@ -8365,7 +8490,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/137.png",
@@ -8428,7 +8554,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/138.png",
@@ -8485,7 +8612,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/139.png",
@@ -8625,7 +8753,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/141.png",
@@ -8690,7 +8819,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/142.png",
@@ -8741,7 +8871,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/143.png",
@@ -8791,7 +8922,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/144.png",
@@ -8858,7 +8990,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/145.png",
@@ -8914,7 +9047,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/146.png",
@@ -8975,7 +9109,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/147.png",
@@ -9029,7 +9164,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/148.png",
@@ -9169,7 +9305,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/150.png",
@@ -9231,7 +9368,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/151.png",
@@ -9284,7 +9422,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/152.png",
@@ -9348,7 +9487,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/153.png",
@@ -9408,7 +9548,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/154.png",
@@ -9469,7 +9610,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/155.png",
@@ -9532,7 +9674,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/156.png",
@@ -9591,7 +9734,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/157.png",
@@ -9651,7 +9795,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/158.png",
@@ -9713,7 +9858,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/159.png",
@@ -9776,7 +9922,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/160.png",
@@ -9813,7 +9960,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/161.png",
@@ -9876,7 +10024,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/162.png",
@@ -9979,7 +10128,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/164.png",
@@ -10002,7 +10152,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Banned"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/165.png",
@@ -10025,7 +10176,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/166.png",
@@ -10048,7 +10200,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/167.png",
@@ -10071,7 +10224,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/168.png",
@@ -10095,7 +10249,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/169.png",
@@ -10118,7 +10273,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/170.png",
@@ -10142,7 +10298,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/171.png",
@@ -10166,7 +10323,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/172.png",
@@ -10189,7 +10347,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/173.png",
@@ -10212,7 +10371,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/174.png",
@@ -10236,7 +10396,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/175.png",
@@ -10259,7 +10420,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/176.png",
@@ -10282,7 +10444,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/177.png",
@@ -10306,7 +10469,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/178.png",
@@ -10329,7 +10493,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/179.png",
@@ -10354,7 +10519,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/180.png",
@@ -10378,7 +10544,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/181.png",
@@ -10402,7 +10569,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/182.png",
@@ -10426,7 +10594,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/182a.png",
@@ -10450,7 +10619,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/182b.png",
@@ -10473,7 +10643,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/183.png",
@@ -10497,7 +10668,8 @@
     "rarity": "Rare Holo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/184.png",
@@ -10520,7 +10692,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/185.png",
@@ -10544,7 +10717,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/186.png",
@@ -10567,7 +10741,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/187.png",
@@ -10590,7 +10765,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/188.png",
@@ -10613,7 +10789,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/189.png",
@@ -10636,7 +10813,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/189a.png",
@@ -10659,7 +10837,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/190.png",
@@ -12130,7 +12309,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/209.png",
@@ -12153,7 +12333,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/210.png",
@@ -12176,7 +12357,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/211.png",
@@ -12200,7 +12382,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/212.png",
@@ -12224,7 +12407,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/213.png",
@@ -12247,7 +12431,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/214.png",
@@ -13330,7 +13515,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/229.png",
@@ -13354,7 +13540,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/230.png",
@@ -13377,7 +13564,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/231.png",
@@ -13402,7 +13590,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/232.png",
@@ -13426,7 +13615,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/233.png",
@@ -13449,7 +13639,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm10/234.png",

--- a/cards/en/sm11.json
+++ b/cards/en/sm11.json
@@ -133,7 +133,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/2.png",
@@ -194,7 +195,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/3.png",
@@ -251,7 +253,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/4.png",
@@ -302,7 +305,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/5.png",
@@ -362,7 +366,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/6.png",
@@ -420,7 +425,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/7.png",
@@ -480,7 +486,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/8.png",
@@ -537,7 +544,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/9.png",
@@ -589,7 +597,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/10.png",
@@ -649,7 +658,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/11.png",
@@ -701,7 +711,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/12.png",
@@ -752,7 +763,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/13.png",
@@ -810,7 +822,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/14.png",
@@ -870,7 +883,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/15.png",
@@ -928,7 +942,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/16.png",
@@ -989,7 +1004,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/17.png",
@@ -1054,7 +1070,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/18.png",
@@ -1113,7 +1130,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/19.png",
@@ -1171,7 +1189,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/20.png",
@@ -1223,7 +1242,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/21.png",
@@ -1286,7 +1306,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/22.png",
@@ -1352,7 +1373,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/23.png",
@@ -1417,7 +1439,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/24.png",
@@ -1545,7 +1568,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/26.png",
@@ -1596,7 +1620,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/27.png",
@@ -1647,7 +1672,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/28.png",
@@ -1699,7 +1725,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/29.png",
@@ -1749,7 +1776,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/30.png",
@@ -1801,7 +1829,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/31.png",
@@ -1856,7 +1885,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/32.png",
@@ -1907,7 +1937,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/33.png",
@@ -1957,7 +1988,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/34.png",
@@ -2083,7 +2115,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/36.png",
@@ -2135,7 +2168,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/37.png",
@@ -2193,7 +2227,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/38.png",
@@ -2244,7 +2279,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/39.png",
@@ -2290,7 +2326,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/40.png",
@@ -2344,7 +2381,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/41.png",
@@ -2410,7 +2448,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/42.png",
@@ -2467,7 +2506,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/43.png",
@@ -2532,7 +2572,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/44.png",
@@ -2592,7 +2633,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/45.png",
@@ -2640,7 +2682,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/46.png",
@@ -2773,7 +2816,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/48.png",
@@ -2833,7 +2877,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/49.png",
@@ -2884,7 +2929,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/50.png",
@@ -2946,7 +2992,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/51.png",
@@ -3004,7 +3051,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/52.png",
@@ -3063,7 +3111,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/53.png",
@@ -3202,7 +3251,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/55.png",
@@ -3270,7 +3320,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/56.png",
@@ -3336,7 +3387,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/57.png",
@@ -3393,7 +3445,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/58.png",
@@ -3463,7 +3516,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/59.png",
@@ -3529,7 +3583,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/60.png",
@@ -3586,7 +3641,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/61.png",
@@ -3641,7 +3697,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/62.png",
@@ -3698,7 +3755,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/63.png",
@@ -3755,7 +3813,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/64.png",
@@ -3814,7 +3873,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/65.png",
@@ -3881,7 +3941,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/66.png",
@@ -3935,7 +3996,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/67.png",
@@ -4001,7 +4063,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/68.png",
@@ -4066,7 +4129,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/69.png",
@@ -4132,7 +4196,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/70.png",
@@ -4313,7 +4378,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/73.png",
@@ -4375,7 +4441,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/74.png",
@@ -4441,7 +4508,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/75.png",
@@ -4497,7 +4565,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/76.png",
@@ -4534,7 +4603,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/77.png",
@@ -4794,7 +4864,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/80.png",
@@ -4858,7 +4929,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/81.png",
@@ -4922,7 +4994,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/82.png",
@@ -4979,7 +5052,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/83.png",
@@ -5036,7 +5110,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/84.png",
@@ -5084,7 +5159,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/85.png",
@@ -5147,7 +5223,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/86.png",
@@ -5210,7 +5287,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/87.png",
@@ -5261,7 +5339,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/88.png",
@@ -5320,7 +5399,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/89.png",
@@ -5371,7 +5451,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/90.png",
@@ -5431,7 +5512,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/91.png",
@@ -5497,7 +5579,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/92.png",
@@ -5556,7 +5639,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/93.png",
@@ -5616,7 +5700,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/94.png",
@@ -5680,7 +5765,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/95.png",
@@ -5732,7 +5818,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/96.png",
@@ -5783,7 +5870,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/97.png",
@@ -5844,7 +5932,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/98.png",
@@ -5904,7 +5993,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/99.png",
@@ -5951,7 +6041,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/100.png",
@@ -6012,7 +6103,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/101.png",
@@ -6075,7 +6167,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/102.png",
@@ -6129,7 +6222,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/103.png",
@@ -6194,7 +6288,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/104.png",
@@ -6255,7 +6350,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/105.png",
@@ -6380,7 +6476,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/107.png",
@@ -6439,7 +6536,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/108.png",
@@ -6490,7 +6588,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/109.png",
@@ -6549,7 +6648,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/110.png",
@@ -6607,7 +6707,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/111.png",
@@ -6668,7 +6769,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/112.png",
@@ -6730,7 +6832,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/113.png",
@@ -6783,7 +6886,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/114.png",
@@ -6834,7 +6938,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/115.png",
@@ -6885,7 +6990,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/116.png",
@@ -6944,7 +7050,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/117.png",
@@ -6996,7 +7103,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/118.png",
@@ -7057,7 +7165,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/119.png",
@@ -7115,7 +7224,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/120.png",
@@ -7179,7 +7289,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/121.png",
@@ -7244,7 +7355,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/122.png",
@@ -7302,7 +7414,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/123.png",
@@ -7357,7 +7470,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/124.png",
@@ -7576,7 +7690,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/127.png",
@@ -7633,7 +7748,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/128.png",
@@ -7690,7 +7806,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/129.png",
@@ -7754,7 +7871,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/130.png",
@@ -7812,7 +7930,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/131.png",
@@ -7930,7 +8049,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/133.png",
@@ -8002,7 +8122,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/134.png",
@@ -8059,7 +8180,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/135.png",
@@ -8125,7 +8247,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/136.png",
@@ -8194,7 +8317,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/137.png",
@@ -8262,7 +8386,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/138.png",
@@ -8328,7 +8453,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/139.png",
@@ -8394,7 +8520,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/140.png",
@@ -8537,7 +8664,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/142.png",
@@ -8594,7 +8722,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/143.png",
@@ -8652,7 +8781,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/144.png",
@@ -8706,7 +8836,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/145.png",
@@ -8835,7 +8966,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/147.png",
@@ -8895,7 +9027,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/148.png",
@@ -8949,7 +9082,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/149.png",
@@ -9014,7 +9148,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/150.png",
@@ -9074,7 +9209,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/151.png",
@@ -9210,7 +9346,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/153.png",
@@ -9269,7 +9406,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/154.png",
@@ -9334,7 +9472,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/155.png",
@@ -9393,7 +9532,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/156.png",
@@ -9454,7 +9594,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/157.png",
@@ -9506,7 +9647,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/158.png",
@@ -9562,7 +9704,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/159.png",
@@ -9699,7 +9842,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/161.png",
@@ -9762,7 +9906,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/162.png",
@@ -9823,7 +9968,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/163.png",
@@ -9881,7 +10027,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/164.png",
@@ -9939,7 +10086,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/165.png",
@@ -10005,7 +10153,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/166.png",
@@ -10067,7 +10216,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/167.png",
@@ -10132,7 +10282,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/168.png",
@@ -10195,7 +10346,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/169.png",
@@ -10257,7 +10409,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/170.png",
@@ -10320,7 +10473,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/171.png",
@@ -10379,7 +10533,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/172.png",
@@ -10416,7 +10571,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/173.png",
@@ -10483,7 +10639,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/174.png",
@@ -10551,7 +10708,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/175.png",
@@ -10617,7 +10775,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/176.png",
@@ -10673,7 +10832,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/177.png",
@@ -10738,7 +10898,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/178.png",
@@ -10795,7 +10956,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/179.png",
@@ -10847,7 +11009,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/180.png",
@@ -10897,7 +11060,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/181.png",
@@ -10958,7 +11122,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/182.png",
@@ -11016,7 +11181,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/183.png",
@@ -11078,7 +11244,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/184.png",
@@ -11133,7 +11300,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/185.png",
@@ -11156,7 +11324,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/186.png",
@@ -11179,7 +11348,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/187.png",
@@ -11202,7 +11372,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/188.png",
@@ -11226,7 +11397,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/189.png",
@@ -11249,7 +11421,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/190.png",
@@ -11272,7 +11445,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/191.png",
@@ -11295,7 +11469,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/191a.png",
@@ -11318,7 +11493,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/192.png",
@@ -11341,7 +11517,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/193.png",
@@ -11365,7 +11542,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/194.png",
@@ -11403,7 +11581,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/195.png",
@@ -11428,7 +11607,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/196.png",
@@ -11451,7 +11631,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/197.png",
@@ -11474,7 +11655,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/198.png",
@@ -11497,7 +11679,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/199.png",
@@ -11520,7 +11703,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/200.png",
@@ -11544,7 +11728,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/201.png",
@@ -11567,7 +11752,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/202.png",
@@ -11605,7 +11791,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/203.png",
@@ -11628,7 +11815,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/204.png",
@@ -11651,7 +11839,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Banned"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/205.png",
@@ -11674,7 +11863,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/206.png",
@@ -11697,7 +11887,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/206a.png",
@@ -11720,7 +11911,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/207.png",
@@ -11743,7 +11935,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/208.png",
@@ -11766,7 +11959,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/209.png",
@@ -11792,7 +11986,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/210.png",
@@ -11817,7 +12012,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/211.png",
@@ -11839,7 +12035,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/212.png",
@@ -11861,7 +12058,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/213.png",
@@ -13122,7 +13320,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/231.png",
@@ -13145,7 +13344,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/232.png",
@@ -13168,7 +13368,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/233.png",
@@ -13191,7 +13392,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/234.png",
@@ -13214,7 +13416,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/235.png",
@@ -13237,7 +13440,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/236.png",
@@ -14198,7 +14402,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/250.png",
@@ -14223,7 +14428,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/251.png",
@@ -14247,7 +14453,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/252.png",
@@ -14270,7 +14477,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/253.png",
@@ -14293,7 +14501,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/254.png",
@@ -14318,7 +14527,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/255.png",
@@ -14341,7 +14551,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/256.png",
@@ -14363,7 +14574,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/257.png",
@@ -14385,7 +14597,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm11/258.png",

--- a/cards/en/sm115.json
+++ b/cards/en/sm115.json
@@ -43,7 +43,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/1.png",
@@ -97,7 +98,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/2.png",
@@ -147,7 +149,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/3.png",
@@ -208,7 +211,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/4.png",
@@ -269,7 +273,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/5.png",
@@ -395,7 +400,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/7.png",
@@ -459,7 +465,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/8.png",
@@ -581,7 +588,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/10.png",
@@ -632,7 +640,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/11.png",
@@ -685,7 +694,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/12.png",
@@ -736,7 +746,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/13.png",
@@ -855,7 +866,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/15.png",
@@ -975,7 +987,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/17.png",
@@ -1038,7 +1051,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/18.png",
@@ -1106,7 +1120,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/19.png",
@@ -1234,7 +1249,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/21.png",
@@ -1300,7 +1316,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/22.png",
@@ -1359,7 +1376,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/23.png",
@@ -1426,7 +1444,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/24.png",
@@ -1477,7 +1496,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/25.png",
@@ -1529,7 +1549,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/26.png",
@@ -1588,7 +1609,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/27.png",
@@ -1639,7 +1661,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/28.png",
@@ -1697,7 +1720,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/29.png",
@@ -1755,7 +1779,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/30.png",
@@ -1869,7 +1894,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/32.png",
@@ -1921,7 +1947,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/33.png",
@@ -1988,7 +2015,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/34.png",
@@ -2054,7 +2082,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/35.png",
@@ -2190,7 +2219,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/37.png",
@@ -2256,7 +2286,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/38.png",
@@ -2323,7 +2354,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/39.png",
@@ -2391,7 +2423,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/40.png",
@@ -2458,7 +2491,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/41.png",
@@ -2594,7 +2628,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/43.png",
@@ -2726,7 +2761,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/45.png",
@@ -2780,7 +2816,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/46.png",
@@ -2830,7 +2867,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/47.png",
@@ -2898,7 +2936,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/48.png",
@@ -2956,7 +2995,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/49.png",
@@ -3009,7 +3049,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/50.png",
@@ -3032,7 +3073,8 @@
     "rarity": "Rare",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/51.png",
@@ -3056,7 +3098,8 @@
     "rarity": "Rare",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/52.png",
@@ -3079,7 +3122,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/53.png",
@@ -3102,7 +3146,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/54.png",
@@ -3125,7 +3170,8 @@
     "rarity": "Rare Holo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/55.png",
@@ -3149,7 +3195,8 @@
     "rarity": "Rare",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/56.png",
@@ -3172,7 +3219,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/57.png",
@@ -3195,7 +3243,8 @@
     "rarity": "Rare Holo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/58.png",
@@ -3218,7 +3267,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/59.png",
@@ -3242,7 +3292,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/60.png",
@@ -3265,7 +3316,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/61.png",
@@ -3288,7 +3340,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/62.png",
@@ -3311,7 +3364,8 @@
     "rarity": "Rare Holo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/63.png",
@@ -3334,7 +3388,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/64.png",
@@ -3357,7 +3412,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/65.png",
@@ -3454,7 +3510,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/67.png",
@@ -3477,7 +3534,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm115/68.png",

--- a/cards/en/sm12.json
+++ b/cards/en/sm12.json
@@ -122,7 +122,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/2.png",
@@ -176,7 +177,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/3.png",
@@ -298,7 +300,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/5.png",
@@ -360,7 +363,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/6.png",
@@ -411,7 +415,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/7.png",
@@ -472,7 +477,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/8.png",
@@ -533,7 +539,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/9.png",
@@ -597,7 +604,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/10.png",
@@ -657,7 +665,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/11.png",
@@ -716,7 +725,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/12.png",
@@ -776,7 +786,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/13.png",
@@ -826,7 +837,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/14.png",
@@ -877,7 +889,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/15.png",
@@ -935,7 +948,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/16.png",
@@ -996,7 +1010,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/17.png",
@@ -1047,7 +1062,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/18.png",
@@ -1109,7 +1125,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/19.png",
@@ -1168,7 +1185,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/20.png",
@@ -1226,7 +1244,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/21.png",
@@ -1356,7 +1375,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/23.png",
@@ -1411,7 +1431,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/24.png",
@@ -1470,7 +1491,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/25.png",
@@ -1523,7 +1545,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/26.png",
@@ -1584,7 +1607,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/27.png",
@@ -1645,7 +1669,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/28.png",
@@ -1705,7 +1730,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/29.png",
@@ -1761,7 +1787,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/30.png",
@@ -1824,7 +1851,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/31.png",
@@ -1891,7 +1919,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/32.png",
@@ -1953,7 +1982,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/33.png",
@@ -2017,7 +2047,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/34.png",
@@ -2151,7 +2182,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/36.png",
@@ -2215,7 +2247,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/37.png",
@@ -2344,7 +2377,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/39.png",
@@ -2405,7 +2439,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/40.png",
@@ -2464,7 +2499,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/41.png",
@@ -2523,7 +2559,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/42.png",
@@ -2574,7 +2611,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/43.png",
@@ -2630,7 +2668,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/44.png",
@@ -2684,7 +2723,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/45.png",
@@ -2750,7 +2790,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/46.png",
@@ -2803,7 +2844,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/47.png",
@@ -2868,7 +2910,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/48.png",
@@ -2930,7 +2973,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/49.png",
@@ -2984,7 +3028,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/50.png",
@@ -3050,7 +3095,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/51.png",
@@ -3114,7 +3160,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/52.png",
@@ -3176,7 +3223,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/53.png",
@@ -3229,7 +3277,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/54.png",
@@ -3293,7 +3342,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/55.png",
@@ -3353,7 +3403,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/56.png",
@@ -3408,7 +3459,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/57.png",
@@ -3459,7 +3511,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/58.png",
@@ -3517,7 +3570,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/59.png",
@@ -3582,7 +3636,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/60.png",
@@ -3645,7 +3700,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/61.png",
@@ -3704,7 +3760,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/62.png",
@@ -3828,7 +3885,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/64.png",
@@ -3890,7 +3948,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/65.png",
@@ -3958,7 +4017,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/66.png",
@@ -4023,7 +4083,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/67.png",
@@ -4080,7 +4141,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/68.png",
@@ -4148,7 +4210,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/69.png",
@@ -4211,7 +4274,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/70.png",
@@ -4277,7 +4341,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/71.png",
@@ -4341,7 +4406,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/72.png",
@@ -4404,7 +4470,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/73.png",
@@ -4459,7 +4526,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/74.png",
@@ -4586,7 +4654,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/76.png",
@@ -4644,7 +4713,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/77.png",
@@ -4701,7 +4771,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/78.png",
@@ -4767,7 +4838,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/79.png",
@@ -4827,7 +4899,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/80.png",
@@ -4890,7 +4963,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/81.png",
@@ -4948,7 +5022,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/82.png",
@@ -5012,7 +5087,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/83.png",
@@ -5072,7 +5148,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/84.png",
@@ -5136,7 +5213,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/85.png",
@@ -5199,7 +5277,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/86.png",
@@ -5265,7 +5344,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/87.png",
@@ -5329,7 +5409,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/88.png",
@@ -5388,7 +5469,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/89.png",
@@ -5456,7 +5538,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/90.png",
@@ -5508,7 +5591,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/91.png",
@@ -5566,7 +5650,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/92.png",
@@ -5633,7 +5718,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/93.png",
@@ -5700,7 +5786,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/94.png",
@@ -5828,7 +5915,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/96.png",
@@ -5878,7 +5966,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/97.png",
@@ -5945,7 +6034,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/98.png",
@@ -5996,7 +6086,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/99.png",
@@ -6054,7 +6145,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/100.png",
@@ -6109,7 +6201,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/101.png",
@@ -6174,7 +6267,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/102.png",
@@ -6230,7 +6324,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/103.png",
@@ -6287,7 +6382,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/104.png",
@@ -6352,7 +6448,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/105.png",
@@ -6417,7 +6514,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/106.png",
@@ -6477,7 +6575,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/107.png",
@@ -6529,7 +6628,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/108.png",
@@ -6589,7 +6689,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/109.png",
@@ -6726,7 +6827,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/111.png",
@@ -6788,7 +6890,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/112.png",
@@ -6849,7 +6952,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/113.png",
@@ -6910,7 +7014,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/114.png",
@@ -6971,7 +7076,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/115.png",
@@ -7024,7 +7130,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/116.png",
@@ -7085,7 +7192,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/117.png",
@@ -7135,7 +7243,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/118.png",
@@ -7187,7 +7296,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/119.png",
@@ -7248,7 +7358,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/120.png",
@@ -7310,7 +7421,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/121.png",
@@ -7371,7 +7483,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/122.png",
@@ -7433,7 +7546,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/123.png",
@@ -7492,7 +7606,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/124.png",
@@ -7551,7 +7666,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/125.png",
@@ -7613,7 +7729,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/126.png",
@@ -7679,7 +7796,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/127.png",
@@ -7746,7 +7864,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/128.png",
@@ -7893,7 +8012,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/130.png",
@@ -7963,7 +8083,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/131.png",
@@ -8020,7 +8141,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/132.png",
@@ -8084,7 +8206,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/133.png",
@@ -8151,7 +8274,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/134.png",
@@ -8216,7 +8340,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/135.png",
@@ -8286,7 +8411,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/136.png",
@@ -8353,7 +8479,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/137.png",
@@ -8419,7 +8546,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/138.png",
@@ -8490,7 +8618,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/139.png",
@@ -8553,7 +8682,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/140.png",
@@ -8624,7 +8754,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/141.png",
@@ -8691,7 +8822,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/142.png",
@@ -8902,7 +9034,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/144.png",
@@ -8957,7 +9090,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/145.png",
@@ -8994,7 +9128,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/146.png",
@@ -9052,7 +9187,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/147.png",
@@ -9113,7 +9249,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/148.png",
@@ -9170,7 +9307,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/149.png",
@@ -9227,7 +9365,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/150.png",
@@ -9293,7 +9432,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/151.png",
@@ -9357,7 +9497,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/152.png",
@@ -9414,7 +9555,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/153.png",
@@ -9479,7 +9621,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/154.png",
@@ -9546,7 +9689,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/155.png",
@@ -9814,7 +9958,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/159.png",
@@ -9866,7 +10011,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/160.png",
@@ -9929,7 +10075,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/161.png",
@@ -9990,7 +10137,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/162.png",
@@ -10050,7 +10198,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/163.png",
@@ -10108,7 +10257,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/164.png",
@@ -10243,7 +10393,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/166.png",
@@ -10310,7 +10461,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/167.png",
@@ -10347,7 +10499,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/168.png",
@@ -10406,7 +10559,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/169.png",
@@ -10465,7 +10619,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/170.png",
@@ -10526,7 +10681,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/171.png",
@@ -10590,7 +10746,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/172.png",
@@ -10648,7 +10805,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/173.png",
@@ -10710,7 +10868,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/174.png",
@@ -10774,7 +10933,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/175.png",
@@ -10834,7 +10994,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/176.png",
@@ -10891,7 +11052,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/177.png",
@@ -10958,7 +11120,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/178.png",
@@ -11020,7 +11183,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/179.png",
@@ -11080,7 +11244,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/180.png",
@@ -11133,7 +11298,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/181.png",
@@ -11192,7 +11358,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/182.png",
@@ -11242,7 +11409,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/183.png",
@@ -11337,7 +11505,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/185.png",
@@ -11362,7 +11531,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/186.png",
@@ -11385,7 +11555,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/187.png",
@@ -11408,7 +11579,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/188.png",
@@ -11433,7 +11605,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/189.png",
@@ -11470,7 +11643,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/190.png",
@@ -11493,7 +11667,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/191.png",
@@ -11517,7 +11692,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/192.png",
@@ -11542,7 +11718,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/193.png",
@@ -11566,7 +11743,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/194.png",
@@ -11589,7 +11767,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/195.png",
@@ -11613,7 +11792,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/196.png",
@@ -11638,7 +11818,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/197.png",
@@ -11663,7 +11844,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/198.png",
@@ -11688,7 +11870,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/199.png",
@@ -11711,7 +11894,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/200.png",
@@ -11734,7 +11918,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/201.png",
@@ -11759,7 +11944,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/202.png",
@@ -11782,7 +11968,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/203.png",
@@ -11806,7 +11993,8 @@
     "rarity": "Rare Holo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/204.png",
@@ -11829,7 +12017,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/205.png",
@@ -11852,7 +12041,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/206.png",
@@ -11878,7 +12068,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/207.png",
@@ -11901,7 +12092,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/208.png",
@@ -11923,7 +12115,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/209.png",
@@ -13233,7 +13426,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/228.png",
@@ -13258,7 +13452,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/229.png",
@@ -13282,7 +13477,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/230.png",
@@ -13307,7 +13503,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/231.png",
@@ -13330,7 +13527,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/232.png",
@@ -13353,7 +13551,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/233.png",
@@ -13378,7 +13577,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/234.png",
@@ -13401,7 +13601,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/235.png",
@@ -13425,7 +13626,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/236.png",
@@ -13485,7 +13687,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/237.png",
@@ -13541,7 +13744,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/238.png",
@@ -13594,7 +13798,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/239.png",
@@ -13653,7 +13858,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/240.png",
@@ -13721,7 +13927,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/241.png",
@@ -13778,7 +13985,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/242.png",
@@ -13837,7 +14045,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/243.png",
@@ -13895,7 +14104,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/244.png",
@@ -13946,7 +14156,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/245.png",
@@ -14007,7 +14218,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/246.png",
@@ -14078,7 +14290,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/247.png",
@@ -14138,7 +14351,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/248.png",
@@ -15167,7 +15381,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/263.png",
@@ -15191,7 +15406,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/264.png",
@@ -15215,7 +15431,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/265.png",
@@ -15238,7 +15455,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/266.png",
@@ -15263,7 +15481,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/267.png",
@@ -15286,7 +15505,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/268.png",
@@ -15309,7 +15529,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/269.png",
@@ -15332,7 +15553,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/270.png",
@@ -15354,7 +15576,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm12/271.png",

--- a/cards/en/sm2.json
+++ b/cards/en/sm2.json
@@ -44,7 +44,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/1.png",
@@ -98,7 +99,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/2.png",
@@ -159,7 +161,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/3.png",
@@ -210,7 +213,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/4.png",
@@ -269,7 +273,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/5.png",
@@ -331,7 +336,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/6.png",
@@ -393,7 +399,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/7.png",
@@ -454,7 +461,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/8.png",
@@ -513,7 +521,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/9.png",
@@ -569,7 +578,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/10.png",
@@ -620,7 +630,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/11.png",
@@ -672,7 +683,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/12.png",
@@ -728,7 +740,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/13.png",
@@ -786,7 +799,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/14.png",
@@ -847,7 +861,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/15.png",
@@ -905,7 +920,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/16.png",
@@ -967,7 +983,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/17.png",
@@ -1103,7 +1120,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/19.png",
@@ -1165,7 +1183,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/19a.png",
@@ -1224,7 +1243,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/20.png",
@@ -1285,7 +1305,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/21.png",
@@ -1346,7 +1367,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/21a.png",
@@ -1471,7 +1493,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/23.png",
@@ -1533,7 +1556,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/24.png",
@@ -1593,7 +1617,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/25.png",
@@ -1650,7 +1675,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/26.png",
@@ -1701,7 +1727,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/27.png",
@@ -1747,7 +1774,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/28.png",
@@ -1813,7 +1841,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/29.png",
@@ -1879,7 +1908,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/30.png",
@@ -1942,7 +1972,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/31.png",
@@ -2008,7 +2039,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/32.png",
@@ -2059,7 +2091,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/33.png",
@@ -2112,7 +2145,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/34.png",
@@ -2173,7 +2207,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/35.png",
@@ -2233,7 +2268,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/36.png",
@@ -2284,7 +2320,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/37.png",
@@ -2423,7 +2460,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/39.png",
@@ -2492,7 +2530,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/40.png",
@@ -2567,7 +2606,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/41.png",
@@ -2639,7 +2679,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/42.png",
@@ -2696,7 +2737,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/43.png",
@@ -2762,7 +2804,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/44.png",
@@ -2907,7 +2950,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/46.png",
@@ -3038,7 +3082,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/48.png",
@@ -3100,7 +3145,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/49.png",
@@ -3163,7 +3209,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/50.png",
@@ -3225,7 +3272,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/51.png",
@@ -3287,7 +3335,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/51a.png",
@@ -3338,7 +3387,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/52.png",
@@ -3401,7 +3451,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/53.png",
@@ -3461,7 +3512,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/54.png",
@@ -3517,7 +3569,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/55.png",
@@ -3580,7 +3633,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/56.png",
@@ -3708,7 +3762,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/58.png",
@@ -3772,7 +3827,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/59.png",
@@ -3963,7 +4019,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/61.png",
@@ -4016,7 +4073,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/62.png",
@@ -4069,7 +4127,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/63.png",
@@ -4131,7 +4190,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/64.png",
@@ -4194,7 +4254,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/65.png",
@@ -4251,7 +4312,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/66.png",
@@ -4302,7 +4364,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/67.png",
@@ -4362,7 +4425,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/68.png",
@@ -4427,7 +4491,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/69.png",
@@ -4489,7 +4554,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/70.png",
@@ -4554,7 +4620,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/71.png",
@@ -4607,7 +4674,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/72.png",
@@ -4668,7 +4736,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/73.png",
@@ -4793,7 +4862,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/75.png",
@@ -4859,7 +4929,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/76.png",
@@ -4924,7 +4995,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/77.png",
@@ -4981,7 +5053,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/78.png",
@@ -5046,7 +5119,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/79.png",
@@ -5097,7 +5171,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/80.png",
@@ -5161,7 +5236,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/81.png",
@@ -5232,7 +5308,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/82.png",
@@ -5289,7 +5366,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/83.png",
@@ -5360,7 +5438,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/84.png",
@@ -5508,7 +5587,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/86.png",
@@ -5577,7 +5657,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/87.png",
@@ -5644,7 +5725,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/88.png",
@@ -5710,7 +5792,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/89.png",
@@ -5767,7 +5850,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/90.png",
@@ -5827,7 +5911,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/91.png",
@@ -6051,7 +6136,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/93.png",
@@ -6112,7 +6198,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/94.png",
@@ -6176,7 +6263,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/95.png",
@@ -6238,7 +6326,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/96.png",
@@ -6298,7 +6387,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/97.png",
@@ -6358,7 +6448,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/98.png",
@@ -6422,7 +6513,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/99.png",
@@ -6564,7 +6656,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/101.png",
@@ -6626,7 +6719,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/102.png",
@@ -6683,7 +6777,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/103.png",
@@ -6747,7 +6842,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/104.png",
@@ -6805,7 +6901,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/105.png",
@@ -6871,7 +6968,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/106.png",
@@ -6932,7 +7030,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/107.png",
@@ -6992,7 +7091,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/108.png",
@@ -7059,7 +7159,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/109.png",
@@ -7127,7 +7228,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/110.png",
@@ -7188,7 +7290,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/111.png",
@@ -7251,7 +7354,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/112.png",
@@ -7310,7 +7414,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/113.png",
@@ -7368,7 +7473,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/114.png",
@@ -7463,7 +7569,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/116.png",
@@ -7486,7 +7593,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/117.png",
@@ -7509,7 +7617,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/118.png",
@@ -7532,7 +7641,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/119.png",
@@ -7555,7 +7665,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/120.png",
@@ -7579,7 +7690,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/121.png",
@@ -7603,7 +7715,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/121a.png",
@@ -7627,7 +7740,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/122.png",
@@ -7651,7 +7765,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/123.png",
@@ -7674,7 +7789,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/124.png",
@@ -7697,7 +7813,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/124a.png",
@@ -7720,7 +7837,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/125.png",
@@ -7743,7 +7861,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/125a.png",
@@ -7766,7 +7885,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/126.png",
@@ -7789,7 +7909,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/127.png",
@@ -7812,7 +7933,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/128.png",
@@ -7835,7 +7957,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/128a.png",
@@ -7858,7 +7981,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/129.png",
@@ -7881,7 +8005,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/130.png",
@@ -7904,7 +8029,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/130a.png",
@@ -8820,7 +8946,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/143.png",
@@ -8843,7 +8970,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/144.png",
@@ -8866,7 +8994,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/145.png",
@@ -10083,7 +10212,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/161.png",
@@ -10106,7 +10236,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/162.png",
@@ -10129,7 +10260,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/163.png",
@@ -10152,7 +10284,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/164.png",
@@ -10176,7 +10309,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/165.png",
@@ -10197,7 +10331,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/166.png",
@@ -10216,7 +10351,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/167.png",
@@ -10235,7 +10371,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/168.png",
@@ -10254,7 +10391,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm2/169.png",

--- a/cards/en/sm3.json
+++ b/cards/en/sm3.json
@@ -43,7 +43,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/1.png",
@@ -106,7 +107,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/2.png",
@@ -166,7 +168,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/3.png",
@@ -217,7 +220,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/4.png",
@@ -281,7 +285,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/5.png",
@@ -341,7 +346,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/6.png",
@@ -393,7 +399,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/7.png",
@@ -457,7 +464,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/8.png",
@@ -508,7 +516,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/9.png",
@@ -568,7 +577,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/10.png",
@@ -625,7 +635,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/11.png",
@@ -676,7 +687,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/12.png",
@@ -735,7 +747,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/13.png",
@@ -786,7 +799,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/14.png",
@@ -847,7 +861,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/15.png",
@@ -909,7 +924,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/16.png",
@@ -1046,7 +1062,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/18.png",
@@ -1107,7 +1124,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/18a.png",
@@ -1172,7 +1190,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/19.png",
@@ -1385,7 +1404,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/22.png",
@@ -1444,7 +1464,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/23.png",
@@ -1505,7 +1526,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/24.png",
@@ -1641,7 +1663,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/26.png",
@@ -1702,7 +1725,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/27.png",
@@ -1760,7 +1784,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/28.png",
@@ -1811,7 +1836,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/29.png",
@@ -1863,7 +1889,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/30.png",
@@ -1921,7 +1948,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/31.png",
@@ -1972,7 +2000,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/32.png",
@@ -2037,7 +2066,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/33.png",
@@ -2098,7 +2128,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/34.png",
@@ -2158,7 +2189,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/35.png",
@@ -2209,7 +2241,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/36.png",
@@ -2268,7 +2301,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/37.png",
@@ -2327,7 +2361,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/38.png",
@@ -2524,7 +2559,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/40.png",
@@ -2588,7 +2624,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/41.png",
@@ -2658,7 +2695,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/42.png",
@@ -2730,7 +2768,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/43.png",
@@ -2787,7 +2826,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/44.png",
@@ -2847,7 +2887,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/45.png",
@@ -2916,7 +2957,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/46.png",
@@ -2980,7 +3022,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/47.png",
@@ -3041,7 +3084,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/48.png",
@@ -3093,7 +3137,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/49.png",
@@ -3151,7 +3196,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/50.png",
@@ -3218,7 +3264,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/51.png",
@@ -3289,7 +3336,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/52.png",
@@ -3355,7 +3403,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/53.png",
@@ -3416,7 +3465,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/54.png",
@@ -3478,7 +3528,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/55.png",
@@ -3540,7 +3591,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/56.png",
@@ -3606,7 +3658,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/57.png",
@@ -3672,7 +3725,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/58.png",
@@ -3723,7 +3777,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/59.png",
@@ -3782,7 +3837,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/60.png",
@@ -3841,7 +3897,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/61.png",
@@ -3913,7 +3970,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/62.png",
@@ -4127,7 +4185,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/65.png",
@@ -4196,7 +4255,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/66.png",
@@ -4258,7 +4318,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/67.png",
@@ -4315,7 +4376,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/68.png",
@@ -4372,7 +4434,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/69.png",
@@ -4433,7 +4496,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/70.png",
@@ -4491,7 +4555,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/71.png",
@@ -4550,7 +4615,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/72.png",
@@ -4603,7 +4669,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/73.png",
@@ -4666,7 +4733,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/74.png",
@@ -4727,7 +4795,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/75.png",
@@ -4789,7 +4858,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/76.png",
@@ -4842,7 +4912,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/77.png",
@@ -4907,7 +4978,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/78.png",
@@ -4966,7 +5038,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/79.png",
@@ -5101,7 +5174,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/81.png",
@@ -5167,7 +5241,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/82.png",
@@ -5236,7 +5311,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/83.png",
@@ -5387,7 +5463,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/85.png",
@@ -5448,7 +5525,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/86.png",
@@ -5515,7 +5593,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/87.png",
@@ -5738,7 +5817,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/89.png",
@@ -5804,7 +5884,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/90.png",
@@ -5861,7 +5942,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/91.png",
@@ -5930,7 +6012,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/92.png",
@@ -5999,7 +6082,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/92a.png",
@@ -6138,7 +6222,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/94.png",
@@ -6191,7 +6276,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/95.png",
@@ -6253,7 +6339,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/96.png",
@@ -6310,7 +6397,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/97.png",
@@ -6378,7 +6466,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/98.png",
@@ -6514,7 +6603,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/100.png",
@@ -6565,7 +6655,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/101.png",
@@ -6623,7 +6714,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/102.png",
@@ -6683,7 +6775,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/103.png",
@@ -6746,7 +6839,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/104.png",
@@ -6805,7 +6899,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/105.png",
@@ -6864,7 +6959,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/105a.png",
@@ -6931,7 +7027,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/106.png",
@@ -6997,7 +7094,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/107.png",
@@ -7058,7 +7156,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/108.png",
@@ -7115,7 +7214,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/109.png",
@@ -7177,7 +7277,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/110.png",
@@ -7239,7 +7340,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/111.png",
@@ -7262,7 +7364,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/112.png",
@@ -7285,7 +7388,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/112a.png",
@@ -7309,7 +7413,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/113.png",
@@ -7333,7 +7438,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/114.png",
@@ -7356,7 +7462,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/115.png",
@@ -7379,7 +7486,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/115a.png",
@@ -7402,7 +7510,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/116.png",
@@ -7425,7 +7534,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/116a.png",
@@ -7448,7 +7558,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/117.png",
@@ -7471,7 +7582,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/118.png",
@@ -7494,7 +7606,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/119.png",
@@ -7517,7 +7630,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/120.png",
@@ -7540,7 +7654,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/121.png",
@@ -7563,7 +7678,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/122.png",
@@ -7586,7 +7702,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/123.png",
@@ -7609,7 +7726,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/124.png",
@@ -7632,7 +7750,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/125.png",
@@ -7656,7 +7775,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/126.png",
@@ -7679,7 +7799,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/127.png",
@@ -7703,7 +7824,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/128.png",
@@ -8694,7 +8816,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/142.png",
@@ -8717,7 +8840,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/143.png",
@@ -8740,7 +8864,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/144.png",
@@ -8763,7 +8888,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/145.png",
@@ -8786,7 +8912,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/146.png",
@@ -8809,7 +8936,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/147.png",
@@ -9797,7 +9925,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/161.png",
@@ -9821,7 +9950,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/162.png",
@@ -9844,7 +9974,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/163.png",
@@ -9867,7 +9998,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/164.png",
@@ -9890,7 +10022,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/165.png",
@@ -9913,7 +10046,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/166.png",
@@ -9932,7 +10066,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/167.png",
@@ -9951,7 +10086,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/168.png",
@@ -9969,7 +10105,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm3/169.png",

--- a/cards/en/sm35.json
+++ b/cards/en/sm35.json
@@ -45,7 +45,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/1.png",
@@ -113,7 +114,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/2.png",
@@ -175,7 +177,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/3.png",
@@ -227,7 +230,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/4.png",
@@ -288,7 +292,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/5.png",
@@ -347,7 +352,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/6.png",
@@ -405,7 +411,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/7.png",
@@ -464,7 +471,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/8.png",
@@ -522,7 +530,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/9.png",
@@ -734,7 +743,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/11.png",
@@ -788,7 +798,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/12.png",
@@ -845,7 +856,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/13.png",
@@ -907,7 +919,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/14.png",
@@ -958,7 +971,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/15.png",
@@ -1020,7 +1034,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/16.png",
@@ -1082,7 +1097,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/17.png",
@@ -1143,7 +1159,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/18.png",
@@ -1206,7 +1223,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/19.png",
@@ -1271,7 +1289,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/20.png",
@@ -1329,7 +1348,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/21.png",
@@ -1391,7 +1411,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/22.png",
@@ -1451,7 +1472,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/23.png",
@@ -1512,7 +1534,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/24.png",
@@ -1568,7 +1591,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/25.png",
@@ -1627,7 +1651,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/26.png",
@@ -1691,7 +1716,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/27.png",
@@ -1748,7 +1774,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/28.png",
@@ -1886,7 +1913,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/30.png",
@@ -1937,7 +1965,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/31.png",
@@ -2003,7 +2032,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/32.png",
@@ -2057,7 +2087,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/33.png",
@@ -2120,7 +2151,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/34.png",
@@ -2188,7 +2220,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/35.png",
@@ -2240,7 +2273,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/36.png",
@@ -2300,7 +2334,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/37.png",
@@ -2358,7 +2393,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/38.png",
@@ -2484,7 +2520,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/40.png",
@@ -2544,7 +2581,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/41.png",
@@ -2592,7 +2630,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/42.png",
@@ -2653,7 +2692,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/43.png",
@@ -2725,7 +2765,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/44.png",
@@ -2787,7 +2828,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/45.png",
@@ -2849,7 +2891,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/46.png",
@@ -2900,7 +2943,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/47.png",
@@ -2967,7 +3011,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/48.png",
@@ -3032,7 +3077,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/49.png",
@@ -3099,7 +3145,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/50.png",
@@ -3167,7 +3214,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/51.png",
@@ -3234,7 +3282,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/52.png",
@@ -3378,7 +3427,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/54.png",
@@ -3442,7 +3492,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/55.png",
@@ -3504,7 +3555,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/56.png",
@@ -3563,7 +3615,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/57.png",
@@ -3586,7 +3639,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/58.png",
@@ -3610,7 +3664,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/59.png",
@@ -3634,7 +3689,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/60.png",
@@ -3657,7 +3713,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/61.png",
@@ -3680,7 +3737,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/62.png",
@@ -3703,7 +3761,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/63.png",
@@ -3727,7 +3786,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/64.png",
@@ -3750,7 +3810,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/65.png",
@@ -3773,7 +3834,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/66.png",
@@ -3797,7 +3859,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/67.png",
@@ -3821,7 +3884,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/68.png",
@@ -3844,7 +3908,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/68a.png",
@@ -3865,7 +3930,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/69.png",
@@ -3887,7 +3953,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/70.png",
@@ -4058,7 +4125,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm35/73.png",

--- a/cards/en/sm4.json
+++ b/cards/en/sm4.json
@@ -43,7 +43,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/1.png",
@@ -96,7 +97,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/2.png",
@@ -150,7 +152,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/3.png",
@@ -210,7 +213,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/4.png",
@@ -261,7 +265,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/5.png",
@@ -321,7 +326,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/6.png",
@@ -382,7 +388,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/7.png",
@@ -435,7 +442,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/8.png",
@@ -494,7 +502,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/9.png",
@@ -546,7 +555,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/10.png",
@@ -605,7 +615,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/11.png",
@@ -666,7 +677,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/12.png",
@@ -720,7 +732,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/13.png",
@@ -786,7 +799,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/14.png",
@@ -837,7 +851,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/15.png",
@@ -893,7 +908,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/16.png",
@@ -953,7 +969,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/17.png",
@@ -1086,7 +1103,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/19.png",
@@ -1153,7 +1171,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/20.png",
@@ -1219,7 +1238,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/21.png",
@@ -1271,7 +1291,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/22.png",
@@ -1331,7 +1352,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/23.png",
@@ -1384,7 +1406,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/24.png",
@@ -1437,7 +1460,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/25.png",
@@ -1488,7 +1512,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/26.png",
@@ -1550,7 +1575,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/27.png",
@@ -1609,7 +1635,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/28.png",
@@ -1669,7 +1696,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/29.png",
@@ -1736,7 +1764,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/30.png",
@@ -1801,7 +1830,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/31.png",
@@ -1869,7 +1899,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/32.png",
@@ -1941,7 +1972,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/33.png",
@@ -2091,7 +2123,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/35.png",
@@ -2148,7 +2181,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/36.png",
@@ -2206,7 +2240,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/37.png",
@@ -2266,7 +2301,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/38.png",
@@ -2323,7 +2359,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/39.png",
@@ -2389,7 +2426,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/40.png",
@@ -2440,7 +2478,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/41.png",
@@ -2499,7 +2538,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/42.png",
@@ -2547,7 +2587,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/43.png",
@@ -2605,7 +2646,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/44.png",
@@ -2672,7 +2714,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/45.png",
@@ -2723,7 +2766,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/46.png",
@@ -2781,7 +2825,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/47.png",
@@ -2841,7 +2886,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/48.png",
@@ -2965,7 +3011,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/50.png",
@@ -3025,7 +3072,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/51.png",
@@ -3087,7 +3135,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/52.png",
@@ -3146,7 +3195,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/53.png",
@@ -3209,7 +3259,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/54.png",
@@ -3262,7 +3313,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/55.png",
@@ -3322,7 +3374,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/56.png",
@@ -3464,7 +3517,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/58.png",
@@ -3531,7 +3585,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/59.png",
@@ -3601,7 +3656,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/60.png",
@@ -3672,7 +3728,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/61.png",
@@ -3737,7 +3794,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/62.png",
@@ -3975,7 +4033,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/64.png",
@@ -4043,7 +4102,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/65.png",
@@ -4115,7 +4175,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/66.png",
@@ -4187,7 +4248,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/67.png",
@@ -4254,7 +4316,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/68.png",
@@ -4321,7 +4384,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/69.png",
@@ -4464,7 +4528,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/71.png",
@@ -4532,7 +4597,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/72.png",
@@ -4598,7 +4664,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/73.png",
@@ -4737,7 +4804,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/75.png",
@@ -4799,7 +4867,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/76.png",
@@ -4861,7 +4930,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/77.png",
@@ -4919,7 +4989,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/78.png",
@@ -4976,7 +5047,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/79.png",
@@ -5040,7 +5112,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/80.png",
@@ -5107,7 +5180,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/81.png",
@@ -5176,7 +5250,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/82.png",
@@ -5244,7 +5319,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/83.png",
@@ -5306,7 +5382,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/84.png",
@@ -5368,7 +5445,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/84a.png",
@@ -5419,7 +5497,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/85.png",
@@ -5468,7 +5547,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/86.png",
@@ -5521,7 +5601,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/87.png",
@@ -5586,7 +5667,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/88.png",
@@ -5647,7 +5729,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/89.png",
@@ -5744,7 +5827,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/91.png",
@@ -5768,7 +5852,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/92.png",
@@ -5791,7 +5876,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/93.png",
@@ -5815,7 +5901,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/94.png",
@@ -5838,7 +5925,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/95.png",
@@ -5861,7 +5949,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/96.png",
@@ -5884,7 +5973,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/97.png",
@@ -5908,7 +5998,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/98.png",
@@ -5931,7 +6022,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/99.png",
@@ -5953,7 +6045,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/100.png",
@@ -6604,7 +6697,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/109.png",
@@ -6627,7 +6721,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/110.png",
@@ -6650,7 +6745,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/111.png",
@@ -7302,7 +7398,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/120.png",
@@ -7326,7 +7423,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/121.png",
@@ -7348,7 +7446,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/122.png",
@@ -7370,7 +7469,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/123.png",
@@ -7389,7 +7489,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm4/124.png",

--- a/cards/en/sm5.json
+++ b/cards/en/sm5.json
@@ -43,7 +43,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/1.png",
@@ -101,7 +102,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/2.png",
@@ -168,7 +170,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/3.png",
@@ -220,7 +223,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/4.png",
@@ -280,7 +284,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/5.png",
@@ -342,7 +347,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/6.png",
@@ -406,7 +412,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/7.png",
@@ -474,7 +481,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/8.png",
@@ -540,7 +548,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/9.png",
@@ -591,7 +600,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/10.png",
@@ -647,7 +657,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/11.png",
@@ -706,7 +717,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/12.png",
@@ -834,7 +846,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/14.png",
@@ -892,7 +905,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/15.png",
@@ -943,7 +957,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/16.png",
@@ -1002,7 +1017,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/17.png",
@@ -1065,7 +1081,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/18.png",
@@ -1125,7 +1142,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/19.png",
@@ -1172,7 +1190,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/20.png",
@@ -1223,7 +1242,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/21.png",
@@ -1275,7 +1295,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/22.png",
@@ -1332,7 +1353,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/23.png",
@@ -1389,7 +1411,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/24.png",
@@ -1450,7 +1473,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/25.png",
@@ -1509,7 +1533,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/26.png",
@@ -1572,7 +1597,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/27.png",
@@ -1623,7 +1649,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/28.png",
@@ -1683,7 +1710,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/29.png",
@@ -1743,7 +1771,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/30.png",
@@ -1794,7 +1823,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/31.png",
@@ -1855,7 +1885,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/32.png",
@@ -1918,7 +1949,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/33.png",
@@ -1980,7 +2012,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/34.png",
@@ -2032,7 +2065,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/35.png",
@@ -2091,7 +2125,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/36.png",
@@ -2145,7 +2180,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/37.png",
@@ -2206,7 +2242,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/38.png",
@@ -2336,7 +2373,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/40.png",
@@ -2392,7 +2430,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/41.png",
@@ -2449,7 +2488,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/42.png",
@@ -2519,7 +2559,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/43.png",
@@ -2591,7 +2632,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/44.png",
@@ -2655,7 +2697,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/45.png",
@@ -2712,7 +2755,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/46.png",
@@ -2770,7 +2814,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/47.png",
@@ -2830,7 +2875,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/48.png",
@@ -2893,7 +2939,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/49.png",
@@ -2956,7 +3003,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/50.png",
@@ -3022,7 +3070,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/51.png",
@@ -3089,7 +3138,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/52.png",
@@ -3140,7 +3190,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/53.png",
@@ -3202,7 +3253,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/54.png",
@@ -3256,7 +3308,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/55.png",
@@ -3307,7 +3360,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/56.png",
@@ -3367,7 +3421,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/57.png",
@@ -3495,7 +3550,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/59.png",
@@ -3546,7 +3602,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/60.png",
@@ -3601,7 +3658,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/61.png",
@@ -3814,7 +3872,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/64.png",
@@ -3875,7 +3934,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/65.png",
@@ -3935,7 +3995,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/66.png",
@@ -3992,7 +4053,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/67.png",
@@ -4047,7 +4109,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/68.png",
@@ -4113,7 +4176,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/69.png",
@@ -4169,7 +4233,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/70.png",
@@ -4226,7 +4291,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/71.png",
@@ -4292,7 +4358,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/72.png",
@@ -4358,7 +4425,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/73.png",
@@ -4422,7 +4490,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/74.png",
@@ -4480,7 +4549,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/75.png",
@@ -4549,7 +4619,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/76.png",
@@ -4675,7 +4746,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/78.png",
@@ -4730,7 +4802,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/79.png",
@@ -4796,7 +4869,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/80.png",
@@ -4861,7 +4935,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/81.png",
@@ -4931,7 +5006,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/82.png",
@@ -4997,7 +5073,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/83.png",
@@ -5068,7 +5145,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/84.png",
@@ -5134,7 +5212,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/85.png",
@@ -5202,7 +5281,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/86.png",
@@ -5270,7 +5350,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/87.png",
@@ -5338,7 +5419,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/88.png",
@@ -5558,7 +5640,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/91.png",
@@ -5624,7 +5707,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/92.png",
@@ -5688,7 +5772,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/93.png",
@@ -5752,7 +5837,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/94.png",
@@ -5814,7 +5900,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/95.png",
@@ -5865,7 +5952,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/96.png",
@@ -5924,7 +6012,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/97.png",
@@ -5986,7 +6075,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/98.png",
@@ -6043,7 +6133,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/99.png",
@@ -6261,7 +6352,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/102.png",
@@ -6326,7 +6418,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/103.png",
@@ -6384,7 +6477,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/104.png",
@@ -6443,7 +6537,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/105.png",
@@ -6503,7 +6598,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/106.png",
@@ -6562,7 +6658,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/107.png",
@@ -6613,7 +6710,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/108.png",
@@ -6674,7 +6772,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/109.png",
@@ -6733,7 +6832,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/110.png",
@@ -6796,7 +6896,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/111.png",
@@ -6857,7 +6958,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/112.png",
@@ -6919,7 +7021,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/113.png",
@@ -6979,7 +7082,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Banned"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/114.png",
@@ -7040,7 +7144,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/115.png",
@@ -7175,7 +7280,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/117.png",
@@ -7199,7 +7305,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/118.png",
@@ -7222,7 +7329,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/119.png",
@@ -7245,7 +7353,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/119a.png",
@@ -7295,7 +7404,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/121.png",
@@ -7319,7 +7429,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/122.png",
@@ -7343,7 +7454,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/122a.png",
@@ -7367,7 +7479,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/123.png",
@@ -7390,7 +7503,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/124.png",
@@ -7413,7 +7527,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/125.png",
@@ -7436,7 +7551,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/125a.png",
@@ -7459,7 +7575,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/126.png",
@@ -7482,7 +7599,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/127.png",
@@ -7505,7 +7623,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/128.png",
@@ -7528,7 +7647,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/129.png",
@@ -7551,7 +7671,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/130.png",
@@ -7574,7 +7695,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/131.png",
@@ -7598,7 +7720,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/132.png",
@@ -7621,7 +7744,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/133.png",
@@ -7647,7 +7771,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/134.png",
@@ -7670,7 +7795,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/135.png",
@@ -7693,7 +7819,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/135a.png",
@@ -7739,7 +7866,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/137.png",
@@ -7761,7 +7889,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/138.png",
@@ -8482,7 +8611,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/148.png",
@@ -8505,7 +8635,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/149.png",
@@ -8528,7 +8659,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/150.png",
@@ -8551,7 +8683,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/151.png",
@@ -8574,7 +8707,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/152.png",
@@ -8597,7 +8731,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/153.png",
@@ -8620,7 +8755,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/153a.png",
@@ -8643,7 +8779,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/154.png",
@@ -8666,7 +8803,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/155.png",
@@ -8689,7 +8827,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/156.png",
@@ -9411,7 +9550,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/166.png",
@@ -9435,7 +9575,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/167.png",
@@ -9458,7 +9599,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/168.png",
@@ -9481,7 +9623,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/169.png",
@@ -9503,7 +9646,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/170.png",
@@ -9525,7 +9669,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm5/171.png",

--- a/cards/en/sm6.json
+++ b/cards/en/sm6.json
@@ -43,7 +43,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/1.png",
@@ -94,7 +95,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/2.png",
@@ -145,7 +147,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/2a.png",
@@ -199,7 +202,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/3.png",
@@ -260,7 +264,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/4.png",
@@ -319,7 +324,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/5.png",
@@ -370,7 +376,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/6.png",
@@ -423,7 +430,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/7.png",
@@ -478,7 +486,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/8.png",
@@ -541,7 +550,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/9.png",
@@ -602,7 +612,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/10.png",
@@ -658,7 +669,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/11.png",
@@ -718,7 +730,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/12.png",
@@ -780,7 +793,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/13.png",
@@ -831,7 +845,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/14.png",
@@ -892,7 +907,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/15.png",
@@ -956,7 +972,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/16.png",
@@ -1016,7 +1033,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/17.png",
@@ -1069,7 +1087,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/18.png",
@@ -1128,7 +1147,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/19.png",
@@ -1264,7 +1284,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/21.png",
@@ -1325,7 +1346,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/22.png",
@@ -1384,7 +1406,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/23.png",
@@ -1508,7 +1531,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/25.png",
@@ -1567,7 +1591,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/26.png",
@@ -1633,7 +1658,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/27.png",
@@ -1699,7 +1725,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/28.png",
@@ -1751,7 +1778,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/29.png",
@@ -1817,7 +1845,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/30.png",
@@ -1940,7 +1969,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/32.png",
@@ -1999,7 +2029,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/33.png",
@@ -2065,7 +2096,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/34.png",
@@ -2135,7 +2167,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/35.png",
@@ -2201,7 +2234,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/36.png",
@@ -2268,7 +2302,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/37.png",
@@ -2334,7 +2369,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/38.png",
@@ -2400,7 +2436,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/39.png",
@@ -2463,7 +2500,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/40.png",
@@ -2511,7 +2549,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/41.png",
@@ -2567,7 +2606,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/42.png",
@@ -2624,7 +2664,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/43.png",
@@ -2675,7 +2716,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/44.png",
@@ -2734,7 +2776,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/45.png",
@@ -2801,7 +2844,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/46.png",
@@ -2859,7 +2903,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/47.png",
@@ -2918,7 +2963,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/48.png",
@@ -2985,7 +3031,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/49.png",
@@ -3036,7 +3083,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/50.png",
@@ -3095,7 +3143,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/51.png",
@@ -3146,7 +3195,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/52.png",
@@ -3203,7 +3253,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/53.png",
@@ -3260,7 +3311,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/54.png",
@@ -3322,7 +3374,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/55.png",
@@ -3450,7 +3503,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/57.png",
@@ -3516,7 +3570,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/58.png",
@@ -3573,7 +3628,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/59.png",
@@ -3624,7 +3680,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/60.png",
@@ -3686,7 +3743,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/61.png",
@@ -3743,7 +3801,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/62.png",
@@ -3794,7 +3853,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/63.png",
@@ -3854,7 +3914,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/64.png",
@@ -3906,7 +3967,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/65.png",
@@ -3959,7 +4021,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/66.png",
@@ -4022,7 +4085,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/67.png",
@@ -4085,7 +4149,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/68.png",
@@ -4145,7 +4210,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/69.png",
@@ -4210,7 +4276,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/70.png",
@@ -4265,7 +4332,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/71.png",
@@ -4326,7 +4394,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/72.png",
@@ -4518,7 +4587,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/75.png",
@@ -4580,7 +4650,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/76.png",
@@ -4641,7 +4712,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/77.png",
@@ -4710,7 +4782,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/78.png",
@@ -4849,7 +4922,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/80.png",
@@ -4917,7 +4991,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/81.png",
@@ -5064,7 +5139,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/83.png",
@@ -5121,7 +5197,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/84.png",
@@ -5179,7 +5256,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/85.png",
@@ -5244,7 +5322,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/86.png",
@@ -5309,7 +5388,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/87.png",
@@ -5373,7 +5453,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/88.png",
@@ -5436,7 +5517,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/89.png",
@@ -5574,7 +5656,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/91.png",
@@ -5636,7 +5719,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/92.png",
@@ -5701,7 +5785,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/93.png",
@@ -5761,7 +5846,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/94.png",
@@ -5946,7 +6032,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/97.png",
@@ -6011,7 +6098,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/98.png",
@@ -6059,7 +6147,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/99.png",
@@ -6126,7 +6215,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/100.png",
@@ -6192,7 +6282,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/101.png",
@@ -6216,7 +6307,8 @@
     "rarity": "Rare",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/102.png",
@@ -6240,7 +6332,8 @@
     "rarity": "Rare",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/102a.png",
@@ -6264,7 +6357,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/103.png",
@@ -6287,7 +6381,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/104.png",
@@ -6311,7 +6406,8 @@
     "rarity": "Rare Holo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/105.png",
@@ -6334,7 +6430,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/106.png",
@@ -6357,7 +6454,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/107.png",
@@ -6381,7 +6479,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/108.png",
@@ -6405,7 +6504,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/109.png",
@@ -6453,7 +6553,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/111.png",
@@ -6477,7 +6578,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/112.png",
@@ -6501,7 +6603,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/112a.png",
@@ -6524,7 +6627,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/113.png",
@@ -6547,7 +6651,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/113a.png",
@@ -6570,7 +6675,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/114.png",
@@ -6593,7 +6699,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/115.png",
@@ -6619,7 +6726,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/116.png",
@@ -6665,7 +6773,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/118.png",
@@ -7371,7 +7480,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/128.png",
@@ -7394,7 +7504,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/129.png",
@@ -7418,7 +7529,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/130.png",
@@ -7441,7 +7553,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/131.png",
@@ -8147,7 +8260,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/141.png",
@@ -8170,7 +8284,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/142.png",
@@ -8194,7 +8309,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/143.png",
@@ -8218,7 +8334,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/144.png",
@@ -8241,7 +8358,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/145.png",
@@ -8263,7 +8381,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm6/146.png",

--- a/cards/en/sm7.json
+++ b/cards/en/sm7.json
@@ -44,7 +44,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/1.png",
@@ -106,7 +107,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/2.png",
@@ -165,7 +167,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/3.png",
@@ -226,7 +229,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/4.png",
@@ -287,7 +291,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/5.png",
@@ -345,7 +350,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/6.png",
@@ -396,7 +402,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/7.png",
@@ -457,7 +464,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/8.png",
@@ -509,7 +517,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/9.png",
@@ -565,7 +574,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/10.png",
@@ -621,7 +631,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/10a.png",
@@ -681,7 +692,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/11.png",
@@ -734,7 +746,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/12.png",
@@ -797,7 +810,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/13.png",
@@ -923,7 +937,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/15.png",
@@ -983,7 +998,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/16.png",
@@ -1031,7 +1047,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/17.png",
@@ -1079,7 +1096,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/18.png",
@@ -1137,7 +1155,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/19.png",
@@ -1195,7 +1214,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/20.png",
@@ -1254,7 +1274,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/21.png",
@@ -1316,7 +1337,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/22.png",
@@ -1378,7 +1400,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/23.png",
@@ -1438,7 +1461,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/24.png",
@@ -1489,7 +1513,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/25.png",
@@ -1550,7 +1575,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/26.png",
@@ -1614,7 +1640,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/27.png",
@@ -1749,7 +1776,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/29.png",
@@ -1814,7 +1842,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/30.png",
@@ -1935,7 +1964,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/32.png",
@@ -1996,7 +2026,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/33.png",
@@ -2062,7 +2093,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/34.png",
@@ -2122,7 +2154,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/35.png",
@@ -2173,7 +2206,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/36.png",
@@ -2233,7 +2267,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/37.png",
@@ -2292,7 +2327,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/38.png",
@@ -2347,7 +2383,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/39.png",
@@ -2402,7 +2439,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/40.png",
@@ -2463,7 +2501,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/41.png",
@@ -2523,7 +2562,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/42.png",
@@ -2568,7 +2608,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/43.png",
@@ -2626,7 +2667,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/44.png",
@@ -2685,7 +2727,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/45.png",
@@ -2748,7 +2791,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/46.png",
@@ -2813,7 +2857,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/47.png",
@@ -2956,7 +3001,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/49.png",
@@ -3021,7 +3067,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/50.png",
@@ -3078,7 +3125,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/51.png",
@@ -3136,7 +3184,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/52.png",
@@ -3200,7 +3249,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/53.png",
@@ -3264,7 +3314,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/54.png",
@@ -3329,7 +3380,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/55.png",
@@ -3452,7 +3504,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/57.png",
@@ -3513,7 +3566,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/58.png",
@@ -3564,7 +3618,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/59.png",
@@ -3614,7 +3669,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/60.png",
@@ -3669,7 +3725,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/61.png",
@@ -3724,7 +3781,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/62.png",
@@ -3791,7 +3849,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/63.png",
@@ -3848,7 +3907,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/64.png",
@@ -3911,7 +3971,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/65.png",
@@ -4045,7 +4106,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/67.png",
@@ -4106,7 +4168,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/68.png",
@@ -4165,7 +4228,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/69.png",
@@ -4230,7 +4294,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/70.png",
@@ -4292,7 +4357,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/71.png",
@@ -4352,7 +4418,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/72.png",
@@ -4414,7 +4481,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/73.png",
@@ -4475,7 +4543,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/74.png",
@@ -4538,7 +4607,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/75.png",
@@ -4599,7 +4669,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/76.png",
@@ -4659,7 +4730,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/77.png",
@@ -4711,7 +4783,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/78.png",
@@ -4772,7 +4845,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/79.png",
@@ -4833,7 +4907,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/80.png",
@@ -4898,7 +4973,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/81.png",
@@ -5035,7 +5111,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/83.png",
@@ -5102,7 +5179,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/84.png",
@@ -5249,7 +5327,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/86.png",
@@ -5320,7 +5399,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/87.png",
@@ -5369,7 +5449,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/88.png",
@@ -5439,7 +5520,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/89.png",
@@ -5580,7 +5662,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/91.png",
@@ -5645,7 +5728,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/92.png",
@@ -5705,7 +5789,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/93.png",
@@ -5765,7 +5850,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/94.png",
@@ -5830,7 +5916,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/95.png",
@@ -5895,7 +5982,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/96.png",
@@ -6030,7 +6118,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/98.png",
@@ -6096,7 +6185,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/99.png",
@@ -6158,7 +6248,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/100.png",
@@ -6214,7 +6305,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/101.png",
@@ -6345,7 +6437,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/103.png",
@@ -6398,7 +6491,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/104.png",
@@ -6453,7 +6547,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/105.png",
@@ -6514,7 +6609,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/106.png",
@@ -6747,7 +6843,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/110.png",
@@ -6804,7 +6901,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/111.png",
@@ -6871,7 +6969,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/112.png",
@@ -6932,7 +7031,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/113.png",
@@ -6996,7 +7096,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/114.png",
@@ -7056,7 +7157,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/115.png",
@@ -7118,7 +7220,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/116.png",
@@ -7172,7 +7275,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/117.png",
@@ -7228,7 +7332,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/118.png",
@@ -7294,7 +7399,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/119.png",
@@ -7345,7 +7451,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/120.png",
@@ -7402,7 +7509,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/121.png",
@@ -7459,7 +7567,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/122.png",
@@ -7482,7 +7591,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/123.png",
@@ -7505,7 +7615,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/123a.png",
@@ -7528,7 +7639,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/124.png",
@@ -7551,7 +7663,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/125.png",
@@ -7574,7 +7687,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/126.png",
@@ -7598,7 +7712,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/127.png",
@@ -7621,7 +7736,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/128.png",
@@ -7645,7 +7761,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/129.png",
@@ -7668,7 +7785,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/130.png",
@@ -7691,7 +7809,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/131.png",
@@ -7714,7 +7833,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/132.png",
@@ -7737,7 +7857,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Banned"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/133.png",
@@ -7761,7 +7882,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/134.png",
@@ -7784,7 +7906,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/135.png",
@@ -7807,7 +7930,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/136.png",
@@ -7830,7 +7954,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/137.png",
@@ -7853,7 +7978,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/138.png",
@@ -7876,7 +8002,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/139.png",
@@ -7899,7 +8026,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/140.png",
@@ -7922,7 +8050,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/141.png",
@@ -7946,7 +8075,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/142.png",
@@ -7969,7 +8099,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/143.png",
@@ -7992,7 +8123,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/144.png",
@@ -8015,7 +8147,8 @@
     "rarity": "Rare Holo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/145.png",
@@ -8038,7 +8171,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/146.png",
@@ -8062,7 +8196,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/147.png",
@@ -8085,7 +8220,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/148.png",
@@ -8108,7 +8244,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/148a.png",
@@ -8131,7 +8268,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/149.png",
@@ -8154,7 +8292,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/150.png",
@@ -8175,7 +8314,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/151.png",
@@ -8857,7 +8997,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/161.png",
@@ -8880,7 +9021,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/162.png",
@@ -8904,7 +9046,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/163.png",
@@ -8927,7 +9070,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/164.png",
@@ -8950,7 +9094,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/165.png",
@@ -8973,7 +9118,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/166.png",
@@ -8996,7 +9142,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/167.png",
@@ -9019,7 +9166,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/168.png",
@@ -9772,7 +9920,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/178.png",
@@ -9796,7 +9945,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/179.png",
@@ -9819,7 +9969,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/180.png",
@@ -9842,7 +9993,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/181.png",
@@ -9865,7 +10017,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/182.png",
@@ -9886,7 +10039,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm7/183.png",

--- a/cards/en/sm75.json
+++ b/cards/en/sm75.json
@@ -45,7 +45,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/1.png",
@@ -107,7 +108,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/2.png",
@@ -166,7 +168,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/3.png",
@@ -217,7 +220,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/4.png",
@@ -277,7 +281,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/5.png",
@@ -336,7 +341,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/6.png",
@@ -442,7 +448,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/8.png",
@@ -503,7 +510,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/9.png",
@@ -562,7 +570,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/10.png",
@@ -689,7 +698,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/12.png",
@@ -750,7 +760,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/13.png",
@@ -809,7 +820,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/14.png",
@@ -860,7 +872,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/15.png",
@@ -911,7 +924,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/16.png",
@@ -963,7 +977,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/17.png",
@@ -1085,7 +1100,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/19.png",
@@ -1146,7 +1162,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/20.png",
@@ -1206,7 +1223,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/21.png",
@@ -1266,7 +1284,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/22.png",
@@ -1331,7 +1350,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/23.png",
@@ -1390,7 +1410,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/24.png",
@@ -1451,7 +1472,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/25.png",
@@ -1510,7 +1532,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/26.png",
@@ -1561,7 +1584,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/27.png",
@@ -1619,7 +1643,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/28.png",
@@ -1679,7 +1704,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/29.png",
@@ -1735,7 +1761,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/30.png",
@@ -1790,7 +1817,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/31.png",
@@ -1841,7 +1869,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/32.png",
@@ -1906,7 +1935,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/33.png",
@@ -1958,7 +1988,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/34.png",
@@ -2011,7 +2042,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/35.png",
@@ -2078,7 +2110,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/36.png",
@@ -2208,7 +2241,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/38.png",
@@ -2266,7 +2300,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/39.png",
@@ -2323,7 +2358,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/40.png",
@@ -2380,7 +2416,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/40a.png",
@@ -2515,7 +2552,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/42.png",
@@ -2576,7 +2614,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/43.png",
@@ -2707,7 +2746,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/45.png",
@@ -2771,7 +2811,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/46.png",
@@ -2832,7 +2873,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/47.png",
@@ -2969,7 +3011,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/49.png",
@@ -3021,7 +3064,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/50.png",
@@ -3080,7 +3124,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/51.png",
@@ -3141,7 +3186,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/52.png",
@@ -3206,7 +3252,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/53.png",
@@ -3268,7 +3315,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/54.png",
@@ -3338,7 +3386,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/55.png",
@@ -3405,7 +3454,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/56.png",
@@ -3462,7 +3512,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/57.png",
@@ -3486,7 +3537,8 @@
     "rarity": "Rare Holo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/58.png",
@@ -3510,7 +3562,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/59.png",
@@ -3534,7 +3587,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/60.png",
@@ -3558,7 +3612,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/60a.png",
@@ -3607,7 +3662,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/62.png",
@@ -3630,7 +3686,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/63.png",
@@ -3654,7 +3711,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/64.png",
@@ -3976,7 +4034,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/69.png",
@@ -4000,7 +4059,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/70.png",
@@ -4324,7 +4384,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/75.png",
@@ -4348,7 +4409,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/76.png",
@@ -4371,7 +4433,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm75/77.png",

--- a/cards/en/sm8.json
+++ b/cards/en/sm8.json
@@ -56,7 +56,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/1.png",
@@ -121,7 +122,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/2.png",
@@ -173,7 +175,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/3.png",
@@ -233,7 +236,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/4.png",
@@ -294,7 +298,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/5.png",
@@ -345,7 +350,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/6.png",
@@ -409,7 +415,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/7.png",
@@ -469,7 +476,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/8.png",
@@ -529,7 +537,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/9.png",
@@ -590,7 +599,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/10.png",
@@ -647,7 +657,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/11.png",
@@ -704,7 +715,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/12.png",
@@ -765,7 +777,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/13.png",
@@ -816,7 +829,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/14.png",
@@ -868,7 +882,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/15.png",
@@ -923,7 +938,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/16.png",
@@ -1049,7 +1065,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/18.png",
@@ -1161,7 +1178,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/20.png",
@@ -1222,7 +1240,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/21.png",
@@ -1345,7 +1364,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/23.png",
@@ -1397,7 +1417,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/24.png",
@@ -1460,7 +1481,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/25.png",
@@ -1518,7 +1540,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/26.png",
@@ -1581,7 +1604,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/27.png",
@@ -1639,7 +1663,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/28.png",
@@ -1690,7 +1715,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/29.png",
@@ -1745,7 +1771,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/30.png",
@@ -1796,7 +1823,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/31.png",
@@ -1846,7 +1874,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/32.png",
@@ -1902,7 +1931,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/33.png",
@@ -2033,7 +2063,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/35.png",
@@ -2095,7 +2126,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/36.png",
@@ -2156,7 +2188,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/37.png",
@@ -2215,7 +2248,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/38.png",
@@ -2266,7 +2300,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/39.png",
@@ -2318,7 +2353,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/40.png",
@@ -2383,7 +2419,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/41.png",
@@ -2443,7 +2480,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/42.png",
@@ -2508,7 +2546,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/43.png",
@@ -2640,7 +2679,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/45.png",
@@ -2699,7 +2739,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/46.png",
@@ -2760,7 +2801,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/47.png",
@@ -2825,7 +2867,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/48.png",
@@ -2874,7 +2917,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/49.png",
@@ -2934,7 +2978,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/50.png",
@@ -2996,7 +3041,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/51.png",
@@ -3127,7 +3173,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/53.png",
@@ -3180,7 +3227,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/54.png",
@@ -3241,7 +3289,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/55.png",
@@ -3298,7 +3347,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/56.png",
@@ -3356,7 +3406,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/57.png",
@@ -3421,7 +3472,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/58.png",
@@ -3478,7 +3530,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/59.png",
@@ -3612,7 +3665,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/61.png",
@@ -3677,7 +3731,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/62.png",
@@ -3739,7 +3794,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/63.png",
@@ -3791,7 +3847,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/64.png",
@@ -3842,7 +3899,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/65.png",
@@ -3904,7 +3962,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/66.png",
@@ -3963,7 +4022,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/67.png",
@@ -4014,7 +4074,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/68.png",
@@ -4075,7 +4136,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/69.png",
@@ -4133,7 +4195,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/70.png",
@@ -4192,7 +4255,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/71.png",
@@ -4262,7 +4326,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/72.png",
@@ -4329,7 +4394,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/73.png",
@@ -4395,7 +4461,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/74.png",
@@ -4460,7 +4527,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/75.png",
@@ -4517,7 +4585,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/76.png",
@@ -4576,7 +4645,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/77.png",
@@ -4640,7 +4710,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/78.png",
@@ -4696,7 +4767,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/79.png",
@@ -4750,7 +4822,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/80.png",
@@ -4817,7 +4890,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/81.png",
@@ -4880,7 +4954,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/82.png",
@@ -4945,7 +5020,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/83.png",
@@ -5008,7 +5084,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/84.png",
@@ -5074,7 +5151,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/85.png",
@@ -5202,7 +5280,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/87.png",
@@ -5263,7 +5342,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/88.png",
@@ -5321,7 +5401,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/89.png",
@@ -5376,7 +5457,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/90.png",
@@ -5431,7 +5513,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/91.png",
@@ -5486,7 +5569,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/92.png",
@@ -5543,7 +5627,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/93.png",
@@ -5602,7 +5687,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/94.png",
@@ -5652,7 +5738,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/95.png",
@@ -5703,7 +5790,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/96.png",
@@ -5768,7 +5856,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/97.png",
@@ -5903,7 +5992,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/99.png",
@@ -5961,7 +6051,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/100.png",
@@ -6018,7 +6109,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/101.png",
@@ -6076,7 +6168,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/102.png",
@@ -6142,7 +6235,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/103.png",
@@ -6201,7 +6295,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/104.png",
@@ -6262,7 +6357,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/105.png",
@@ -6320,7 +6416,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/106.png",
@@ -6382,7 +6479,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/107.png",
@@ -6441,7 +6539,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/108.png",
@@ -6498,7 +6597,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/109.png",
@@ -6547,7 +6647,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/110.png",
@@ -6600,7 +6701,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/111.png",
@@ -6660,7 +6762,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/112.png",
@@ -6719,7 +6822,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/113.png",
@@ -6777,7 +6881,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/114.png",
@@ -6829,7 +6934,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/115.png",
@@ -6892,7 +6998,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/116.png",
@@ -6951,7 +7058,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/117.png",
@@ -7008,7 +7116,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/118.png",
@@ -7063,7 +7172,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/119.png",
@@ -7128,7 +7238,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/120.png",
@@ -7265,7 +7376,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/122.png",
@@ -7320,7 +7432,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/123.png",
@@ -7387,7 +7500,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/124.png",
@@ -7459,7 +7573,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/125.png",
@@ -7522,7 +7637,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/126.png",
@@ -7591,7 +7707,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/127.png",
@@ -7655,7 +7772,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/128.png",
@@ -7722,7 +7840,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/129.png",
@@ -7864,7 +7983,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/131.png",
@@ -8009,7 +8129,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/133.png",
@@ -8077,7 +8198,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/134.png",
@@ -8136,7 +8258,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/135.png",
@@ -8203,7 +8326,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/136.png",
@@ -8261,7 +8385,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/137.png",
@@ -8329,7 +8454,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/138.png",
@@ -8396,7 +8522,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/139.png",
@@ -8467,7 +8594,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/140.png",
@@ -8534,7 +8662,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/141.png",
@@ -8588,7 +8717,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/142.png",
@@ -8654,7 +8784,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/143.png",
@@ -8775,7 +8906,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/145.png",
@@ -8833,7 +8965,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/146.png",
@@ -8890,7 +9023,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/147.png",
@@ -8954,7 +9088,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/148.png",
@@ -9081,7 +9216,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/150.png",
@@ -9147,7 +9283,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/151.png",
@@ -9210,7 +9347,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/152.png",
@@ -9270,7 +9408,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/153.png",
@@ -9376,7 +9515,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/155.png",
@@ -9435,7 +9575,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/156.png",
@@ -9492,7 +9633,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/157.png",
@@ -9544,7 +9686,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/158.png",
@@ -9684,7 +9827,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/160.png",
@@ -9739,7 +9883,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/161.png",
@@ -9795,7 +9940,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/162.png",
@@ -9852,7 +9998,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/163.png",
@@ -9919,7 +10066,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/164.png",
@@ -9985,7 +10133,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/165.png",
@@ -10052,7 +10201,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/166.png",
@@ -10075,7 +10225,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/167.png",
@@ -10098,7 +10249,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/168.png",
@@ -10122,7 +10274,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/169.png",
@@ -10146,7 +10299,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/170.png",
@@ -10169,7 +10323,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/171.png",
@@ -10192,7 +10347,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/172.png",
@@ -10215,7 +10371,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/172a.png",
@@ -10238,7 +10395,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/173.png",
@@ -10262,7 +10420,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/174.png",
@@ -10286,7 +10445,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/175.png",
@@ -10310,7 +10470,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/176.png",
@@ -10334,7 +10495,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/177.png",
@@ -10383,7 +10545,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/179.png",
@@ -10432,7 +10595,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/181.png",
@@ -10481,7 +10645,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/183.png",
@@ -10504,7 +10669,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/184.png",
@@ -10527,7 +10693,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/185.png",
@@ -10551,7 +10718,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/186.png",
@@ -10574,7 +10742,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/187.png",
@@ -10597,7 +10766,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/187a.png",
@@ -10620,7 +10790,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/188.png",
@@ -10643,7 +10814,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/188a.png",
@@ -10666,7 +10838,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/189.png",
@@ -10689,7 +10862,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/189a.png",
@@ -10713,7 +10887,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/190.png",
@@ -10763,7 +10938,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/192.png",
@@ -10786,7 +10962,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/193.png",
@@ -10808,7 +10985,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/194.png",
@@ -11791,7 +11969,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/208.png",
@@ -11815,7 +11994,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/209.png",
@@ -11838,7 +12018,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/210.png",
@@ -11861,7 +12042,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/211.png",
@@ -11885,7 +12067,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/212.png",
@@ -11908,7 +12091,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/213.png",
@@ -11931,7 +12115,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/214.png",
@@ -12914,7 +13099,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/228.png",
@@ -12938,7 +13124,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/229.png",
@@ -12962,7 +13149,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/230.png",
@@ -12985,7 +13173,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/231.png",
@@ -13008,7 +13197,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/232.png",
@@ -13031,7 +13221,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/233.png",
@@ -13054,7 +13245,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/234.png",
@@ -13078,7 +13270,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/235.png",
@@ -13102,7 +13295,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm8/236.png",

--- a/cards/en/sm9.json
+++ b/cards/en/sm9.json
@@ -134,7 +134,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/2.png",
@@ -185,7 +186,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/3.png",
@@ -247,7 +249,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/4.png",
@@ -306,7 +309,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/5.png",
@@ -367,7 +371,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/6.png",
@@ -425,7 +430,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/7.png",
@@ -476,7 +482,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/8.png",
@@ -538,7 +545,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/9.png",
@@ -648,7 +656,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/11.png",
@@ -699,7 +708,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/12.png",
@@ -753,7 +763,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/13.png",
@@ -811,7 +822,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/14.png",
@@ -862,7 +874,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/15.png",
@@ -920,7 +933,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/16.png",
@@ -981,7 +995,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/17.png",
@@ -1040,7 +1055,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/18.png",
@@ -1107,7 +1123,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/19.png",
@@ -1158,7 +1175,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/20.png",
@@ -1222,7 +1240,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/21.png",
@@ -1281,7 +1300,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/22.png",
@@ -1342,7 +1362,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/23.png",
@@ -1407,7 +1428,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/24.png",
@@ -1467,7 +1489,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/25.png",
@@ -1519,7 +1542,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/26.png",
@@ -1579,7 +1603,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/27.png",
@@ -1630,7 +1655,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/28.png",
@@ -1681,7 +1707,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/29.png",
@@ -1744,7 +1771,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/30.png",
@@ -1803,7 +1831,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/31.png",
@@ -1866,7 +1895,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/32.png",
@@ -2002,7 +2032,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/34.png",
@@ -2072,7 +2103,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/35.png",
@@ -2145,7 +2177,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/36.png",
@@ -2216,7 +2249,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/37.png",
@@ -2273,7 +2307,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/38.png",
@@ -2336,7 +2371,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/39.png",
@@ -2391,7 +2427,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/40.png",
@@ -2448,7 +2485,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/41.png",
@@ -2517,7 +2555,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/42.png",
@@ -2663,7 +2702,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/44.png",
@@ -2730,7 +2770,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/45.png",
@@ -2787,7 +2828,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/46.png",
@@ -2844,7 +2886,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/47.png",
@@ -2906,7 +2949,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/48.png",
@@ -2974,7 +3018,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/49.png",
@@ -3040,7 +3085,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/50.png",
@@ -3172,7 +3218,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/52.png",
@@ -3303,7 +3350,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/54.png",
@@ -3366,7 +3414,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/55.png",
@@ -3426,7 +3475,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/56.png",
@@ -3487,7 +3537,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/57.png",
@@ -3551,7 +3602,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/58.png",
@@ -3614,7 +3666,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/59.png",
@@ -3665,7 +3718,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/60.png",
@@ -3725,7 +3779,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/61.png",
@@ -3777,7 +3832,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/62.png",
@@ -3836,7 +3892,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/63.png",
@@ -3902,7 +3959,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/64.png",
@@ -3947,7 +4005,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/65.png",
@@ -4003,7 +4062,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/66.png",
@@ -4124,7 +4184,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/68.png",
@@ -4182,7 +4243,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/69.png",
@@ -4237,7 +4299,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/70.png",
@@ -4298,7 +4361,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/71.png",
@@ -4358,7 +4422,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/72.png",
@@ -4417,7 +4482,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/73.png",
@@ -4476,7 +4542,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/74.png",
@@ -4528,7 +4595,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/75.png",
@@ -4586,7 +4654,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/76.png",
@@ -4638,7 +4707,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/77.png",
@@ -4697,7 +4767,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/78.png",
@@ -4750,7 +4821,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/79.png",
@@ -4803,7 +4875,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/80.png",
@@ -4856,7 +4929,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/81.png",
@@ -4987,7 +5061,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/83.png",
@@ -5053,7 +5128,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/84.png",
@@ -5125,7 +5201,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/85.png",
@@ -5191,7 +5268,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/86.png",
@@ -5256,7 +5334,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/87.png",
@@ -5319,7 +5398,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/88.png",
@@ -5370,7 +5450,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/89.png",
@@ -5427,7 +5508,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/90.png",
@@ -5494,7 +5576,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/91.png",
@@ -5560,7 +5643,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/92.png",
@@ -5627,7 +5711,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/93.png",
@@ -5699,7 +5784,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/94.png",
@@ -5759,7 +5845,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/95.png",
@@ -5986,7 +6073,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/98.png",
@@ -6048,7 +6136,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/99.png",
@@ -6113,7 +6202,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/100.png",
@@ -6179,7 +6269,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/101.png",
@@ -6238,7 +6329,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/102.png",
@@ -6306,7 +6398,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/103.png",
@@ -6373,7 +6466,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/104.png",
@@ -6440,7 +6534,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/105.png",
@@ -6572,7 +6667,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/107.png",
@@ -6632,7 +6728,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/108.png",
@@ -6698,7 +6795,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/109.png",
@@ -6760,7 +6858,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/110.png",
@@ -6818,7 +6917,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/111.png",
@@ -6870,7 +6970,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/112.png",
@@ -6986,7 +7087,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/114.png",
@@ -7048,7 +7150,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/115.png",
@@ -7100,7 +7203,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/116.png",
@@ -7159,7 +7263,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/117.png",
@@ -7213,7 +7318,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/118.png",
@@ -7273,7 +7379,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/119.png",
@@ -7430,7 +7537,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/121.png",
@@ -7487,7 +7595,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/122.png",
@@ -7553,7 +7662,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/123.png",
@@ -7616,7 +7726,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/124.png",
@@ -7677,7 +7788,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/125.png",
@@ -7736,7 +7848,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/126.png",
@@ -7802,7 +7915,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/127.png",
@@ -7862,7 +7976,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/128.png",
@@ -7912,7 +8027,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/129.png",
@@ -7978,7 +8094,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/130.png",
@@ -8045,7 +8162,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/131.png",
@@ -8103,7 +8221,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/132.png",
@@ -8126,7 +8245,8 @@
     "rarity": "Rare Holo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/133.png",
@@ -8175,7 +8295,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/135.png",
@@ -8199,7 +8320,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/136.png",
@@ -8223,7 +8345,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/137.png",
@@ -8247,7 +8370,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/138.png",
@@ -8270,7 +8394,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/139.png",
@@ -8294,7 +8419,8 @@
     "rarity": "Rare Holo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/140.png",
@@ -8318,7 +8444,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/141.png",
@@ -8342,7 +8469,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/142.png",
@@ -8366,7 +8494,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/143.png",
@@ -8389,7 +8518,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/144.png",
@@ -8412,7 +8542,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/145.png",
@@ -8435,7 +8566,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/146.png",
@@ -8458,7 +8590,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/147.png",
@@ -8482,7 +8615,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/148.png",
@@ -8506,7 +8640,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/149.png",
@@ -8529,7 +8664,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/150.png",
@@ -8553,7 +8689,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/151.png",
@@ -8576,7 +8713,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/152.png",
@@ -8599,7 +8737,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/152a.png",
@@ -8622,7 +8761,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/152b.png",
@@ -8645,7 +8785,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/153.png",
@@ -8668,7 +8809,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/154.png",
@@ -8694,7 +8836,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/155.png",
@@ -8717,7 +8860,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/156.png",
@@ -8741,7 +8885,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/157.png",
@@ -9767,7 +9912,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/172.png",
@@ -9791,7 +9937,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/173.png",
@@ -9815,7 +9962,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/174.png",
@@ -9839,7 +9987,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/175.png",
@@ -9862,7 +10011,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/176.png",
@@ -9885,7 +10035,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/177.png",
@@ -9909,7 +10060,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/178.png",
@@ -9932,7 +10084,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/179.png",
@@ -9956,7 +10109,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/180.png",
@@ -9979,7 +10133,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/181.png",
@@ -10773,7 +10928,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/192.png",
@@ -10796,7 +10952,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/193.png",
@@ -10819,7 +10976,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/194.png",
@@ -10843,7 +11001,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/195.png",
@@ -10866,7 +11025,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sm9/196.png",

--- a/cards/en/sma.json
+++ b/cards/en/sma.json
@@ -53,7 +53,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV1.png",
@@ -114,7 +115,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV2.png",
@@ -177,7 +179,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV3.png",
@@ -239,7 +242,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV4.png",
@@ -295,7 +299,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV5.png",
@@ -348,7 +353,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV6.png",
@@ -410,7 +416,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV7.png",
@@ -471,7 +478,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV8.png",
@@ -532,7 +540,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV9.png",
@@ -591,7 +600,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV10.png",
@@ -650,7 +660,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV11.png",
@@ -709,7 +720,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV12.png",
@@ -774,7 +786,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV13.png",
@@ -840,7 +853,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV14.png",
@@ -898,7 +912,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV15.png",
@@ -965,7 +980,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV16.png",
@@ -1016,7 +1032,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV17.png",
@@ -1075,7 +1092,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV18.png",
@@ -1137,7 +1155,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV19.png",
@@ -1194,7 +1213,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV20.png",
@@ -1254,7 +1274,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV21.png",
@@ -1311,7 +1332,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV22.png",
@@ -1363,7 +1385,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV23.png",
@@ -1424,7 +1447,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV24.png",
@@ -1491,7 +1515,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV25.png",
@@ -1552,7 +1577,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV26.png",
@@ -1618,7 +1644,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV27.png",
@@ -1688,7 +1715,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV28.png",
@@ -1754,7 +1782,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV29.png",
@@ -1811,7 +1840,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV30.png",
@@ -1882,7 +1912,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV31.png",
@@ -1944,7 +1975,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV32.png",
@@ -2000,7 +2032,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV33.png",
@@ -2057,7 +2090,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV34.png",
@@ -2126,7 +2160,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV35.png",
@@ -2190,7 +2225,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV36.png",
@@ -2247,7 +2283,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV37.png",
@@ -2298,7 +2335,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV38.png",
@@ -2360,7 +2398,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV39.png",
@@ -2417,7 +2456,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV40.png",
@@ -2483,7 +2523,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV41.png",
@@ -2550,7 +2591,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV42.png",
@@ -2607,7 +2649,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV43.png",
@@ -2665,7 +2708,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV44.png",
@@ -2726,7 +2770,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV45.png",
@@ -5385,7 +5430,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV81.png",
@@ -5408,7 +5454,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV82.png",
@@ -5431,7 +5478,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV83.png",
@@ -5454,7 +5502,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV84.png",
@@ -5477,7 +5526,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Banned"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV85.png",
@@ -5500,7 +5550,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV86.png",
@@ -5523,7 +5574,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV87.png",
@@ -5546,7 +5598,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV88.png",
@@ -5569,7 +5622,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV89.png",
@@ -5592,7 +5646,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sma/SV90.png",

--- a/cards/en/smp.json
+++ b/cards/en/smp.json
@@ -43,7 +43,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM01.png",
@@ -95,7 +96,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM02.png",
@@ -146,7 +148,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM03.png",
@@ -214,7 +217,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM04.png",
@@ -357,7 +361,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM06.png",
@@ -415,7 +420,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM07.png",
@@ -476,7 +482,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM08.png",
@@ -539,7 +546,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM09.png",
@@ -597,7 +605,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM10.png",
@@ -657,7 +666,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM11.png",
@@ -715,7 +725,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM12.png",
@@ -773,7 +784,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM13.png",
@@ -912,7 +924,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM15.png",
@@ -1129,7 +1142,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM18.png",
@@ -1192,7 +1206,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM19.png",
@@ -1258,7 +1273,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM20.png",
@@ -1318,7 +1334,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM21.png",
@@ -1379,7 +1396,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM22.png",
@@ -1440,7 +1458,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM23.png",
@@ -1501,7 +1520,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM24.png",
@@ -1560,7 +1580,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM25.png",
@@ -1619,7 +1640,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM26.png",
@@ -1681,7 +1703,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM27.png",
@@ -1748,7 +1771,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM28.png",
@@ -1800,7 +1824,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM29.png",
@@ -1862,7 +1887,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM30.png",
@@ -1924,7 +1950,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM30a.png",
@@ -1986,7 +2013,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM31.png",
@@ -2640,7 +2668,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM40.png",
@@ -2698,7 +2727,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM41.png",
@@ -2749,7 +2779,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM42.png",
@@ -2816,7 +2847,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM43.png",
@@ -2881,7 +2913,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM44.png",
@@ -2939,7 +2972,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM45.png",
@@ -2997,7 +3031,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM46.png",
@@ -3060,7 +3095,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM47.png",
@@ -3125,7 +3161,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM48.png",
@@ -3187,7 +3224,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM49.png",
@@ -3319,7 +3357,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM51.png",
@@ -3378,7 +3417,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM52.png",
@@ -3442,7 +3482,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM53.png",
@@ -3500,7 +3541,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM54.png",
@@ -3560,7 +3602,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM55.png",
@@ -3999,7 +4042,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM61.png",
@@ -4209,7 +4253,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM64.png",
@@ -4275,7 +4320,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM65.png",
@@ -4651,7 +4697,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM70.png",
@@ -4793,7 +4840,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM72.png",
@@ -4851,7 +4899,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM73.png",
@@ -4910,7 +4959,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM74.png",
@@ -4977,7 +5027,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM75.png",
@@ -5045,7 +5096,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM76.png",
@@ -5103,7 +5155,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM77.png",
@@ -5126,7 +5179,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM78.png",
@@ -5182,7 +5236,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM79.png",
@@ -5333,7 +5388,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM81.png",
@@ -5402,7 +5458,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM82.png",
@@ -5469,7 +5526,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM83.png",
@@ -5608,7 +5666,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM85.png",
@@ -5675,7 +5734,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM86.png",
@@ -5730,7 +5790,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM87.png",
@@ -5790,7 +5851,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM88.png",
@@ -5858,7 +5920,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM89.png",
@@ -6073,7 +6136,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM92.png",
@@ -6137,7 +6201,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM93.png",
@@ -6194,7 +6259,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM94.png",
@@ -6251,7 +6317,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM95.png",
@@ -6319,7 +6386,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM96.png",
@@ -6381,7 +6449,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM97.png",
@@ -6448,7 +6517,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM98.png",
@@ -6500,7 +6570,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM99.png",
@@ -7112,7 +7183,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM105.png",
@@ -7179,7 +7251,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM106.png",
@@ -7246,7 +7319,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM107.png",
@@ -7314,7 +7388,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM108.png",
@@ -7382,7 +7457,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM109.png",
@@ -7450,7 +7526,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM110.png",
@@ -7518,7 +7595,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM111.png",
@@ -7586,7 +7664,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM112.png",
@@ -7654,7 +7733,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM113.png",
@@ -7722,7 +7802,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM114.png",
@@ -7778,7 +7859,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM115.png",
@@ -7844,7 +7926,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM116.png",
@@ -7903,7 +7986,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM117.png",
@@ -7965,7 +8049,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM118.png",
@@ -8017,7 +8102,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM119.png",
@@ -8069,7 +8155,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM120.png",
@@ -8293,7 +8380,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM123.png",
@@ -8360,7 +8448,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM124.png",
@@ -8561,7 +8650,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM127.png",
@@ -8628,7 +8718,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM128.png",
@@ -8691,7 +8782,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM129.png",
@@ -8749,7 +8841,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM130.png",
@@ -8811,7 +8904,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM131.png",
@@ -8868,7 +8962,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM132.png",
@@ -9089,7 +9184,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM135.png",
@@ -9150,7 +9246,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM136.png",
@@ -9444,7 +9541,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM140.png",
@@ -9581,7 +9679,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM142.png",
@@ -9649,7 +9748,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM143.png",
@@ -9715,7 +9815,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM144.png",
@@ -9781,7 +9882,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM145.png",
@@ -9948,7 +10050,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM148.png",
@@ -10005,7 +10108,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM149.png",
@@ -10061,7 +10165,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM150.png",
@@ -10126,7 +10231,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM151.png",
@@ -10189,7 +10295,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM152.png",
@@ -10241,7 +10348,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM153.png",
@@ -10302,7 +10410,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM154.png",
@@ -10514,7 +10623,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM157.png",
@@ -10572,7 +10682,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM158.png",
@@ -10627,7 +10738,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM159.png",
@@ -10687,7 +10799,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM160.png",
@@ -10749,7 +10862,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM161.png",
@@ -10816,7 +10930,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM162.png",
@@ -10868,7 +10983,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM163.png",
@@ -10926,7 +11042,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM164.png",
@@ -10980,7 +11097,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM165.png",
@@ -11369,7 +11487,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM170.png",
@@ -11891,7 +12010,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM177.png",
@@ -12030,7 +12150,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM179.png",
@@ -12091,7 +12212,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM180.png",
@@ -12159,7 +12281,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM181.png",
@@ -12213,7 +12336,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM182.png",
@@ -12271,7 +12395,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM183.png",
@@ -12339,7 +12464,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM184.png",
@@ -12400,7 +12526,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM185.png",
@@ -12461,7 +12588,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM186.png",
@@ -12746,7 +12874,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM190.png",
@@ -13027,7 +13156,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM194.png",
@@ -13317,7 +13447,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM198.png",
@@ -13370,7 +13501,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM199.png",
@@ -13437,7 +13569,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM200.png",
@@ -13574,7 +13707,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM202.png",
@@ -13633,7 +13767,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM203.png",
@@ -13694,7 +13829,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM204.png",
@@ -13759,7 +13895,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM205.png",
@@ -13818,7 +13955,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM206.png",
@@ -13877,7 +14015,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM207.png",
@@ -13943,7 +14082,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM208.png",
@@ -14004,7 +14144,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM209.png",
@@ -14345,7 +14486,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM214.png",
@@ -14400,7 +14542,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM215.png",
@@ -14602,7 +14745,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM218.png",
@@ -14663,7 +14807,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM219.png",
@@ -14718,7 +14863,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM220.png",
@@ -14775,7 +14921,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM221.png",
@@ -14840,7 +14987,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM222.png",
@@ -14905,7 +15053,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM223.png",
@@ -14964,7 +15113,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM224.png",
@@ -15021,7 +15171,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM225.png",
@@ -15079,7 +15230,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM226.png",
@@ -15147,7 +15299,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM227.png",
@@ -15199,7 +15352,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM228.png",
@@ -15371,7 +15525,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM231.png",
@@ -15599,7 +15754,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM234.png",
@@ -15658,7 +15814,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM235.png",
@@ -15792,7 +15949,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM237.png",
@@ -15853,7 +16011,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM238.png",
@@ -16210,7 +16369,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM243.png",
@@ -16271,7 +16431,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM244.png",
@@ -16336,7 +16497,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM245.png",
@@ -16361,7 +16523,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/smp/SM246.png",

--- a/cards/en/sv1.json
+++ b/cards/en/sv1.json
@@ -42,7 +42,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -105,7 +106,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -155,7 +157,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -206,7 +209,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -264,7 +268,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -325,7 +330,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -385,7 +391,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -443,7 +450,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -504,7 +512,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -565,7 +574,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -625,7 +635,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -689,7 +700,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -749,7 +761,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -810,7 +823,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -871,7 +885,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -930,7 +945,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -981,7 +997,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1032,7 +1049,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1147,7 +1165,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1207,7 +1226,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1268,7 +1288,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1329,7 +1350,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1379,7 +1401,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1440,7 +1463,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1503,7 +1527,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1553,7 +1578,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1614,7 +1640,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1676,7 +1703,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1727,7 +1755,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1790,7 +1819,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1921,7 +1951,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1984,7 +2015,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2048,7 +2080,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2110,7 +2143,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2175,7 +2209,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2239,7 +2274,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2289,7 +2325,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2341,7 +2378,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2402,7 +2440,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2463,7 +2502,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2524,7 +2564,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2574,7 +2615,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2709,7 +2751,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2761,7 +2804,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2824,7 +2868,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2874,7 +2919,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2938,7 +2984,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2998,7 +3045,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3058,7 +3106,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3120,7 +3169,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3181,7 +3231,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3231,7 +3282,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3291,7 +3343,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3354,7 +3407,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3406,7 +3460,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3469,7 +3524,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3534,7 +3590,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3600,7 +3657,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3659,7 +3717,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3718,7 +3777,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3780,7 +3840,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3908,7 +3969,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3971,7 +4033,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4029,7 +4092,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4079,7 +4143,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4138,7 +4203,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4190,7 +4256,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4254,7 +4321,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4304,7 +4372,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4364,7 +4433,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4426,7 +4496,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4482,7 +4553,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4548,7 +4620,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4604,7 +4677,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4673,7 +4747,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4735,7 +4810,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4865,7 +4941,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4934,7 +5011,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4991,7 +5069,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5060,7 +5139,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5187,7 +5267,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5326,7 +5407,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5395,7 +5477,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5445,7 +5528,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5497,7 +5581,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5558,7 +5643,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5608,7 +5694,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5659,7 +5746,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5716,7 +5804,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5767,7 +5856,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5829,7 +5919,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5889,7 +5980,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5941,7 +6033,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5997,7 +6090,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6053,7 +6147,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6117,7 +6212,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6174,7 +6270,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6244,7 +6341,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6304,7 +6402,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6354,7 +6453,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6405,7 +6505,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6467,7 +6568,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6517,7 +6619,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6577,7 +6680,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6637,7 +6741,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6697,7 +6802,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6760,7 +6866,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6821,7 +6928,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6883,7 +6991,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6946,7 +7055,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7005,7 +7115,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7057,7 +7168,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7124,7 +7236,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7184,7 +7297,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7248,7 +7362,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7381,7 +7496,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7499,7 +7615,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7563,7 +7680,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7625,7 +7743,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7685,7 +7804,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7746,7 +7866,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7873,7 +7994,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7934,7 +8056,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7996,7 +8119,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8057,7 +8181,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8110,7 +8235,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8172,7 +8298,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8238,7 +8365,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8308,7 +8436,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8364,7 +8493,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8423,7 +8553,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8491,7 +8622,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8630,7 +8762,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8691,7 +8824,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8741,7 +8875,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8804,7 +8939,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8860,7 +8996,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8929,7 +9066,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8998,7 +9136,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9056,7 +9195,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9120,7 +9260,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9180,7 +9321,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9240,7 +9382,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9301,7 +9444,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9353,7 +9497,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9417,7 +9562,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9534,7 +9680,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9585,7 +9732,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9646,7 +9794,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9712,7 +9861,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9763,7 +9913,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9820,7 +9971,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9887,7 +10039,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9913,7 +10066,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9939,7 +10093,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9964,7 +10119,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9989,7 +10145,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10014,7 +10171,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10039,7 +10197,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10064,7 +10223,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10089,7 +10249,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10114,7 +10275,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10139,7 +10301,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10164,7 +10327,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10189,7 +10353,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10214,7 +10379,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10239,7 +10405,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10264,7 +10431,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10289,7 +10457,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10314,7 +10483,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10339,7 +10509,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10364,7 +10535,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10389,7 +10561,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10414,7 +10587,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10439,7 +10613,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10464,7 +10639,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10489,7 +10665,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10514,7 +10691,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10539,7 +10717,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10564,7 +10743,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10589,7 +10769,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10614,7 +10795,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10639,7 +10821,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10664,7 +10847,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10689,7 +10873,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10714,7 +10899,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10764,7 +10950,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10825,7 +11012,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10875,7 +11063,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10937,7 +11126,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10998,7 +11188,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11059,7 +11250,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11109,7 +11301,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11159,7 +11352,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11225,7 +11419,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11283,7 +11478,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11339,7 +11535,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11406,7 +11603,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11463,7 +11661,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11532,7 +11731,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11594,7 +11794,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11651,7 +11852,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11711,7 +11913,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11772,7 +11975,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11836,7 +12040,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11898,7 +12103,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11964,7 +12170,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12026,7 +12233,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12082,7 +12290,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12140,7 +12349,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12980,7 +13190,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13005,7 +13216,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13030,7 +13242,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13055,7 +13268,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13080,7 +13294,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13105,7 +13320,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13130,7 +13346,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13155,7 +13372,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13580,7 +13798,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13605,7 +13824,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13630,7 +13850,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13655,7 +13876,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13802,7 +14024,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13827,7 +14050,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13847,7 +14071,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sv1/257.png",
@@ -13866,7 +14091,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sv1/258.png",

--- a/cards/en/sv2.json
+++ b/cards/en/sv2.json
@@ -40,7 +40,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -98,7 +99,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -156,7 +158,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -208,7 +211,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -338,7 +342,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -399,7 +404,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -449,7 +455,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -510,7 +517,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -563,7 +571,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -625,7 +634,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -684,7 +694,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -735,7 +746,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -796,7 +808,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -909,7 +922,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -961,7 +975,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1025,7 +1040,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1084,7 +1100,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1134,7 +1151,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1195,7 +1213,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1245,7 +1264,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1295,7 +1315,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1359,7 +1380,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1409,7 +1431,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1460,7 +1483,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1593,7 +1617,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1650,7 +1675,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1716,7 +1742,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1775,7 +1802,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1837,7 +1865,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1895,7 +1924,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1946,7 +1976,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2008,7 +2039,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2071,7 +2103,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2188,7 +2221,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2250,7 +2284,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2376,7 +2411,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2426,7 +2462,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2494,7 +2531,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2545,7 +2583,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2608,7 +2647,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2668,7 +2708,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2727,7 +2768,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2788,7 +2830,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2839,7 +2882,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2889,7 +2933,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2950,7 +2995,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3068,7 +3114,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3130,7 +3177,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3195,7 +3243,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3258,7 +3307,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3309,7 +3359,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3371,7 +3422,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3435,7 +3487,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3496,7 +3549,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3618,7 +3672,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3740,7 +3795,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3800,7 +3856,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3860,7 +3917,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3922,7 +3980,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3979,7 +4038,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4029,7 +4089,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4091,7 +4152,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4151,7 +4213,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4204,7 +4267,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4265,7 +4329,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4315,7 +4380,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4376,7 +4442,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4437,7 +4504,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4487,7 +4555,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4547,7 +4616,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4681,7 +4751,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4748,7 +4819,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4812,7 +4884,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4872,7 +4945,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4933,7 +5007,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5001,7 +5076,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5132,7 +5208,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5197,7 +5274,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5260,7 +5338,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5326,7 +5405,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5393,7 +5473,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5459,7 +5540,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5595,7 +5677,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5665,7 +5748,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5737,7 +5821,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5795,7 +5880,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5865,7 +5951,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5932,7 +6019,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5992,7 +6080,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6053,7 +6142,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6103,7 +6193,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6165,7 +6256,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6229,7 +6321,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6289,7 +6382,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6349,7 +6443,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6411,7 +6506,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6474,7 +6570,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6535,7 +6632,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6586,7 +6684,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6638,7 +6737,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6691,7 +6791,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6753,7 +6854,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6803,7 +6905,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6864,7 +6967,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6925,7 +7029,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7042,7 +7147,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7104,7 +7210,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7155,7 +7262,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7217,7 +7325,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7271,7 +7380,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7332,7 +7442,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7382,7 +7493,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7433,7 +7545,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7493,7 +7606,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7618,7 +7732,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7678,7 +7793,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7808,7 +7924,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7876,7 +7993,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7926,7 +8044,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7985,7 +8104,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8048,7 +8168,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8107,7 +8228,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8167,7 +8289,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8218,7 +8341,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8281,7 +8405,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8343,7 +8468,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8393,7 +8519,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8456,7 +8583,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8521,7 +8649,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8580,7 +8709,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8630,7 +8760,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8690,7 +8821,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8757,7 +8889,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8826,7 +8959,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8885,7 +9019,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9024,7 +9159,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9069,7 +9205,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9187,7 +9324,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9250,7 +9388,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9311,7 +9450,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9376,7 +9516,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9433,7 +9574,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9500,7 +9642,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9552,7 +9695,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9616,7 +9760,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9679,7 +9824,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9735,7 +9881,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9791,7 +9938,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9859,7 +10007,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9920,7 +10069,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9980,7 +10130,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10043,7 +10194,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10173,7 +10325,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10199,7 +10352,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10224,7 +10378,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10249,7 +10404,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10274,7 +10430,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10299,7 +10456,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10324,7 +10482,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10349,7 +10508,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10374,7 +10534,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10399,7 +10560,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10424,7 +10586,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10449,7 +10612,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10474,7 +10638,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10499,7 +10664,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10524,7 +10690,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10549,7 +10716,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10574,7 +10742,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10599,7 +10768,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10624,7 +10794,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10649,7 +10820,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10675,7 +10847,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10698,7 +10871,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10721,7 +10895,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10747,7 +10922,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10810,7 +10986,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10871,7 +11048,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10930,7 +11108,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10991,7 +11170,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11041,7 +11221,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11098,7 +11279,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11160,7 +11342,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11222,7 +11405,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11285,7 +11469,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11335,7 +11520,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11386,7 +11572,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11447,7 +11634,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11498,7 +11686,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11559,7 +11748,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11610,7 +11800,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11674,7 +11865,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11735,7 +11927,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11797,7 +11990,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11862,7 +12056,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11929,7 +12124,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11999,7 +12195,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12066,7 +12263,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12127,7 +12325,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12191,7 +12390,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12254,7 +12454,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12315,7 +12516,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12377,7 +12579,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12437,7 +12640,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12500,7 +12704,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12560,7 +12765,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12627,7 +12833,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12683,7 +12890,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12746,7 +12954,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12810,7 +13019,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12873,7 +13083,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12938,7 +13149,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -14149,7 +14361,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -14174,7 +14387,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -14199,7 +14413,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -14224,7 +14439,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -14249,7 +14465,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -14274,7 +14491,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -14299,7 +14517,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -14324,7 +14543,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -14936,7 +15156,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -14961,7 +15182,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -14986,7 +15208,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -15011,7 +15234,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -15036,7 +15260,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -15061,7 +15286,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -15407,7 +15633,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -15432,7 +15659,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -15452,7 +15680,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sv2/278.png",
@@ -15471,7 +15700,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sv2/279.png",

--- a/cards/en/sv3.json
+++ b/cards/en/sv3.json
@@ -53,7 +53,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -118,7 +119,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -178,7 +180,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -242,7 +245,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -302,7 +306,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -355,7 +360,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -416,7 +422,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -479,7 +486,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -542,7 +550,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -595,7 +604,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -649,7 +659,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -711,7 +722,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -764,7 +776,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -819,7 +832,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -945,7 +959,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1009,7 +1024,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1071,7 +1087,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1124,7 +1141,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1178,7 +1196,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1239,7 +1258,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1355,7 +1375,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1411,7 +1432,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1472,7 +1494,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1525,7 +1548,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1581,7 +1605,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1644,7 +1669,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1705,7 +1731,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1765,7 +1792,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1821,7 +1849,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1886,7 +1915,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2016,7 +2046,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2083,7 +2114,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2136,7 +2168,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2200,7 +2233,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2263,7 +2297,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2314,7 +2349,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2378,7 +2414,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2441,7 +2478,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2563,7 +2601,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2622,7 +2661,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2684,7 +2724,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2737,7 +2778,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2798,7 +2840,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2851,7 +2894,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2912,7 +2956,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2965,7 +3010,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3021,7 +3067,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3082,7 +3129,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3146,7 +3194,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3210,7 +3259,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3260,7 +3310,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3313,7 +3364,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3368,7 +3420,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3421,7 +3474,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3472,7 +3526,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3535,7 +3590,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3590,7 +3646,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3652,7 +3709,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3715,7 +3773,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3781,7 +3840,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3844,7 +3904,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3976,7 +4037,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4042,7 +4104,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4106,7 +4169,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4165,7 +4229,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4218,7 +4283,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4280,7 +4346,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4404,7 +4471,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4458,7 +4526,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4513,7 +4582,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4566,7 +4636,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4628,7 +4699,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4735,7 +4807,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4789,7 +4862,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4916,7 +4990,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4980,7 +5055,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5035,7 +5111,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5102,7 +5179,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5166,7 +5244,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5230,7 +5309,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5281,7 +5361,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5350,7 +5431,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5418,7 +5500,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5483,7 +5566,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5549,7 +5633,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5609,7 +5694,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5676,7 +5762,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5809,7 +5896,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5876,7 +5964,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5946,7 +6035,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6009,7 +6099,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6080,7 +6171,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6206,7 +6298,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6257,7 +6350,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6320,7 +6414,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6384,7 +6479,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6449,7 +6545,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6513,7 +6610,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6578,7 +6676,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6625,7 +6724,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6679,7 +6779,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6738,7 +6839,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6804,7 +6906,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6871,7 +6974,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6937,7 +7041,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6990,7 +7095,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7053,7 +7159,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7116,7 +7223,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7180,7 +7288,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7306,7 +7415,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7361,7 +7471,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7609,7 +7720,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7665,7 +7777,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7729,7 +7842,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7793,7 +7907,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7855,7 +7970,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7918,7 +8034,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7982,7 +8099,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8046,7 +8164,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8239,7 +8358,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8293,7 +8413,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8354,7 +8475,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8417,7 +8539,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8478,7 +8601,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8546,7 +8670,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8613,7 +8738,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8678,7 +8804,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8748,7 +8875,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8817,7 +8945,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8889,7 +9018,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8947,7 +9077,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9006,7 +9137,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9077,7 +9209,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9148,7 +9281,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9214,7 +9348,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9273,7 +9408,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9407,7 +9543,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9468,7 +9605,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9584,7 +9722,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9643,7 +9782,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9759,7 +9899,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9805,7 +9946,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9864,7 +10006,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9925,7 +10068,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10050,7 +10194,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10120,7 +10265,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10183,7 +10329,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10244,7 +10391,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10313,7 +10461,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10366,7 +10515,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10431,7 +10581,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10495,7 +10646,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10556,7 +10708,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10615,7 +10768,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10668,7 +10822,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10721,7 +10876,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10783,7 +10939,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10845,7 +11002,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10966,7 +11124,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11021,7 +11180,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11085,7 +11245,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11149,7 +11310,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11213,7 +11375,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11280,7 +11443,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11305,7 +11469,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11330,7 +11495,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11355,7 +11521,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11381,7 +11548,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11406,7 +11574,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11431,7 +11600,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11456,7 +11626,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11481,7 +11652,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11506,7 +11678,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11531,7 +11704,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11556,7 +11730,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11581,7 +11756,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11646,7 +11822,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11707,7 +11884,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11769,7 +11947,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11831,7 +12010,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11878,7 +12058,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11941,7 +12122,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12004,7 +12186,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12072,7 +12255,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12131,7 +12315,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12190,7 +12375,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12251,7 +12437,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12304,7 +12491,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12856,7 +13044,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12881,7 +13070,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12906,7 +13096,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12931,7 +13122,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13212,7 +13404,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13237,7 +13430,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13327,7 +13521,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13344,7 +13539,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {

--- a/cards/en/sv3pt5.json
+++ b/cards/en/sv3pt5.json
@@ -46,7 +46,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -114,7 +115,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -243,7 +245,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -309,7 +312,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -439,7 +443,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -504,7 +509,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -621,7 +627,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -687,7 +694,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -748,7 +756,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -811,7 +820,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -875,7 +885,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -937,7 +948,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1006,7 +1018,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1062,7 +1075,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1126,7 +1140,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1180,7 +1195,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1228,7 +1244,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1294,7 +1311,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1356,7 +1374,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1411,7 +1430,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1542,7 +1562,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1602,7 +1623,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1663,7 +1685,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1726,7 +1749,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1780,7 +1804,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1845,7 +1870,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1910,7 +1936,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1963,7 +1990,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2029,7 +2057,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2092,7 +2121,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2155,7 +2185,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2218,7 +2249,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2272,7 +2304,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2400,7 +2433,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2531,7 +2565,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2591,7 +2626,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2645,7 +2681,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2708,7 +2745,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2769,7 +2807,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2833,7 +2872,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2895,7 +2935,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2960,7 +3001,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3022,7 +3064,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3085,7 +3128,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3146,7 +3190,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3209,7 +3254,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3269,7 +3315,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3331,7 +3378,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3393,7 +3441,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3446,7 +3495,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3509,7 +3559,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3563,7 +3614,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3629,7 +3681,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3682,7 +3735,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3747,7 +3801,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3810,7 +3865,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3869,7 +3925,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3929,7 +3986,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4064,7 +4122,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4120,7 +4179,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4180,7 +4240,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4243,7 +4304,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4308,7 +4370,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4371,7 +4434,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4434,7 +4498,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4498,7 +4563,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4562,7 +4628,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4629,7 +4696,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4761,7 +4829,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4823,7 +4892,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4894,7 +4964,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4963,7 +5034,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5026,7 +5098,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5092,7 +5165,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5160,7 +5234,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5219,7 +5294,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5283,7 +5359,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5337,7 +5414,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5401,7 +5479,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5455,7 +5534,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5521,7 +5601,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5576,7 +5657,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5630,7 +5712,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5689,7 +5772,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5757,7 +5841,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5820,7 +5905,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5889,7 +5975,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5950,7 +6037,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6017,7 +6105,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6081,7 +6170,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6148,7 +6238,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6201,7 +6292,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6262,7 +6354,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6316,7 +6409,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6381,7 +6475,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6441,7 +6536,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6503,7 +6599,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6565,7 +6662,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6623,7 +6721,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6681,7 +6780,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6735,7 +6835,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6795,7 +6896,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6862,7 +6964,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6931,7 +7034,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6994,7 +7098,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7048,7 +7153,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7177,7 +7283,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7233,7 +7340,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7296,7 +7404,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7359,7 +7468,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7413,7 +7523,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7472,7 +7583,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7532,7 +7644,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7592,7 +7705,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7723,7 +7837,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7788,7 +7903,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7851,7 +7967,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7912,7 +8029,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7965,7 +8083,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8029,7 +8148,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8090,7 +8210,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8147,7 +8268,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8216,7 +8338,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8279,7 +8402,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8337,7 +8461,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8400,7 +8525,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8453,7 +8579,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8509,7 +8636,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8570,7 +8698,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8626,7 +8755,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8687,7 +8817,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8750,7 +8881,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8812,7 +8944,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8878,7 +9011,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9013,7 +9147,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9070,7 +9205,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9129,7 +9265,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9184,7 +9321,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9253,7 +9391,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9350,7 +9489,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9383,7 +9523,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9416,7 +9557,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9441,7 +9583,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9466,7 +9609,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9491,7 +9635,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9516,7 +9661,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9541,7 +9687,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9566,7 +9713,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9591,7 +9739,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9616,7 +9765,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9641,7 +9791,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9666,7 +9817,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9691,7 +9843,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9746,7 +9899,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9814,7 +9968,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9877,7 +10032,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9943,7 +10099,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10006,7 +10163,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10071,7 +10229,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10124,7 +10283,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10188,7 +10348,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10251,7 +10412,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10313,7 +10475,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10378,7 +10541,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10434,7 +10598,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10488,7 +10653,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10548,7 +10714,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10604,7 +10771,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10663,7 +10831,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11486,7 +11655,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11511,7 +11681,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11536,7 +11707,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11561,7 +11733,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11923,7 +12096,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11948,7 +12122,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12037,7 +12212,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12060,7 +12236,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/207.png",

--- a/cards/en/sv4.json
+++ b/cards/en/sv4.json
@@ -44,7 +44,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -105,7 +106,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -233,7 +235,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -293,7 +296,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -347,7 +351,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -412,7 +417,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -465,7 +471,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -530,7 +537,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -583,7 +591,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -648,7 +657,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -709,7 +719,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -752,7 +763,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -800,7 +812,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -857,7 +870,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -916,7 +930,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -974,7 +989,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1035,7 +1051,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1084,7 +1101,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1148,7 +1166,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1209,7 +1228,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1272,7 +1292,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1330,7 +1351,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1381,7 +1403,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1438,7 +1461,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1497,7 +1521,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1615,7 +1640,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1672,7 +1698,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1725,7 +1752,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1780,7 +1808,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1841,7 +1870,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1894,7 +1924,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1954,7 +1985,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2007,7 +2039,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2067,7 +2100,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2121,7 +2155,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2232,7 +2267,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2295,7 +2331,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2359,7 +2396,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2419,7 +2457,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2473,7 +2512,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2529,7 +2569,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2589,7 +2630,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2720,7 +2762,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2785,7 +2828,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2848,7 +2892,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2963,7 +3008,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3011,7 +3057,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3068,7 +3115,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3125,7 +3173,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3188,7 +3237,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3245,7 +3295,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3303,7 +3354,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3418,7 +3470,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3469,7 +3522,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3526,7 +3580,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3590,7 +3645,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3652,7 +3708,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3705,7 +3762,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3756,7 +3814,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3818,7 +3877,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3878,7 +3938,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3995,7 +4056,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4122,7 +4184,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4188,7 +4251,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4255,7 +4319,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4322,7 +4387,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4383,7 +4449,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4522,7 +4589,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4589,7 +4657,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4642,7 +4711,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4696,7 +4766,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4758,7 +4829,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4814,7 +4886,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4862,7 +4935,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4911,7 +4985,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -4969,7 +5044,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5033,7 +5109,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5096,7 +5173,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5150,7 +5228,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5278,7 +5357,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5331,7 +5411,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5394,7 +5475,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5457,7 +5539,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5510,7 +5593,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5564,7 +5648,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5627,7 +5712,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5688,7 +5774,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5814,7 +5901,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5941,7 +6029,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -5990,7 +6079,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6041,7 +6131,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6101,7 +6192,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6161,7 +6253,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6224,7 +6317,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6284,7 +6378,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6406,7 +6501,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6475,7 +6571,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6536,7 +6633,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6601,7 +6699,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6661,7 +6760,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6724,7 +6824,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6785,7 +6886,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6850,7 +6952,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6914,7 +7017,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -6983,7 +7087,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7036,7 +7141,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7095,7 +7201,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7153,7 +7260,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7211,7 +7319,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7270,7 +7379,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7408,7 +7518,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7471,7 +7582,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7532,7 +7644,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7599,7 +7712,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7667,7 +7781,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7726,7 +7841,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7785,7 +7901,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7856,7 +7973,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7927,7 +8045,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -7994,7 +8113,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8134,7 +8254,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8269,7 +8390,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8441,7 +8563,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8494,7 +8617,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8548,7 +8672,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8607,7 +8732,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8670,7 +8796,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8732,7 +8859,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8784,7 +8912,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8838,7 +8967,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8903,7 +9033,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -8967,7 +9098,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9026,7 +9158,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9095,7 +9228,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9138,7 +9272,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9186,7 +9321,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9366,7 +9502,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9436,7 +9573,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9462,7 +9600,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9487,7 +9626,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9512,7 +9652,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9537,7 +9678,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9563,7 +9705,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9589,7 +9732,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9614,7 +9758,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9639,7 +9784,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9664,7 +9810,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9689,7 +9836,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9714,7 +9862,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9740,7 +9889,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9766,7 +9916,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9791,7 +9942,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9816,7 +9968,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9841,7 +9994,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9867,7 +10021,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9905,7 +10060,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9941,7 +10097,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -9977,7 +10134,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10013,7 +10171,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10039,7 +10198,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10064,7 +10224,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10087,7 +10248,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10152,7 +10314,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10217,7 +10380,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10275,7 +10439,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10324,7 +10489,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10382,7 +10548,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10436,7 +10603,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10485,7 +10653,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10541,7 +10710,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10606,7 +10776,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10663,7 +10834,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10714,7 +10886,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10771,7 +10944,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10835,7 +11009,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10888,7 +11063,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -10950,7 +11126,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11004,7 +11181,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11067,7 +11245,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11128,7 +11307,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11186,7 +11366,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11246,7 +11427,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11306,7 +11488,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11370,7 +11553,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11439,7 +11623,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11497,7 +11682,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11556,7 +11742,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11629,7 +11816,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11696,7 +11884,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11763,7 +11952,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11826,7 +12016,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11891,7 +12082,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -11960,7 +12152,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12019,7 +12212,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12077,7 +12271,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -12147,7 +12342,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13331,7 +13527,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13356,7 +13553,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13381,7 +13579,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13406,7 +13605,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13432,7 +13632,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13458,7 +13659,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13483,7 +13685,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13508,7 +13711,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13533,7 +13737,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -13558,7 +13763,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -14151,7 +14357,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -14176,7 +14383,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -14202,7 +14410,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -14228,7 +14437,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -14253,7 +14463,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -14278,7 +14489,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -14491,7 +14703,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -14516,7 +14729,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -14541,7 +14755,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -14564,7 +14779,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {

--- a/cards/en/sve.json
+++ b/cards/en/sve.json
@@ -11,7 +11,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sve/1.png",
@@ -30,7 +31,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sve/2.png",
@@ -49,7 +51,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sve/3.png",
@@ -68,7 +71,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sve/4.png",
@@ -87,7 +91,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sve/5.png",
@@ -106,7 +111,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sve/6.png",
@@ -125,7 +131,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sve/7.png",
@@ -144,7 +151,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/sve/8.png",

--- a/cards/en/svp.json
+++ b/cards/en/svp.json
@@ -41,7 +41,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -94,7 +95,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -145,7 +147,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -270,7 +273,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -326,7 +330,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -385,7 +390,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -453,7 +459,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -516,7 +523,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -579,7 +587,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -644,7 +653,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -711,7 +721,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -773,7 +784,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -838,7 +850,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -900,7 +913,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1156,7 +1170,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1216,7 +1231,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1284,7 +1300,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1351,7 +1368,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1411,7 +1429,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1477,7 +1496,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1528,7 +1548,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1584,7 +1605,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -1639,7 +1661,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2205,7 +2228,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2252,7 +2276,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2307,7 +2332,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2372,7 +2398,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2423,7 +2450,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2487,7 +2515,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2558,7 +2587,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2629,7 +2659,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2682,7 +2713,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2707,7 +2739,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2757,7 +2790,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2805,7 +2839,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -2854,7 +2889,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3045,7 +3081,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3109,7 +3146,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {
@@ -3337,7 +3375,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "G",
     "images": {

--- a/cards/en/swsh1.json
+++ b/cards/en/swsh1.json
@@ -105,7 +105,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -167,7 +168,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -228,7 +230,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -280,7 +283,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -339,7 +343,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -399,7 +404,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -449,7 +455,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -565,7 +572,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -627,7 +635,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -692,7 +701,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -758,7 +768,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -820,7 +831,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -887,7 +899,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -939,7 +952,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -991,7 +1005,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1055,7 +1070,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1113,7 +1129,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1174,7 +1191,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1233,7 +1251,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1285,7 +1304,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1345,7 +1365,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1536,7 +1557,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1588,7 +1610,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1648,7 +1671,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1712,7 +1736,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1764,7 +1789,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1826,7 +1852,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1890,7 +1917,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1953,7 +1981,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2012,7 +2041,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2072,7 +2102,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2134,7 +2165,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2197,7 +2229,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2250,7 +2283,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2314,7 +2348,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2367,7 +2402,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2429,7 +2465,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2492,7 +2529,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2546,7 +2584,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2608,7 +2647,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2660,7 +2700,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2722,7 +2763,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2783,7 +2825,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2837,7 +2880,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3014,7 +3058,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3073,7 +3118,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3189,7 +3235,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3251,7 +3298,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3312,7 +3360,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3375,7 +3424,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3433,7 +3483,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3493,7 +3544,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3558,7 +3610,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3624,7 +3677,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3683,7 +3737,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3735,7 +3790,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3794,7 +3850,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3856,7 +3913,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3917,7 +3975,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3970,7 +4029,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4032,7 +4092,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4094,7 +4155,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4146,7 +4208,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4197,7 +4260,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4317,7 +4381,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4379,7 +4444,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4441,7 +4507,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4499,7 +4566,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4550,7 +4618,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4599,7 +4668,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4775,7 +4845,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4839,7 +4910,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4897,7 +4969,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4966,7 +5039,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5032,7 +5106,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5171,7 +5246,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5239,7 +5315,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5297,7 +5374,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5363,7 +5441,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5483,7 +5562,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5533,7 +5613,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5594,7 +5675,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5653,7 +5735,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5717,7 +5800,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5782,7 +5866,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5852,7 +5937,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5919,7 +6005,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5977,7 +6064,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6039,7 +6127,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6091,7 +6180,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6152,7 +6242,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6281,7 +6372,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6335,7 +6427,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6388,7 +6481,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6450,7 +6544,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6512,7 +6607,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6571,7 +6667,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6624,7 +6721,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6678,7 +6776,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6741,7 +6840,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6792,7 +6892,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6982,7 +7083,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7047,7 +7149,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7106,7 +7209,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7233,7 +7337,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7299,7 +7404,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7361,7 +7467,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7420,7 +7527,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7472,7 +7580,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7533,7 +7642,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7601,7 +7711,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7667,7 +7778,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7732,7 +7844,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7791,7 +7904,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7859,7 +7973,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7923,7 +8038,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7991,7 +8107,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8058,7 +8175,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8126,7 +8244,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8187,7 +8306,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8258,7 +8378,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8460,7 +8581,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8654,7 +8776,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8722,7 +8845,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8784,7 +8908,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8836,7 +8961,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8893,7 +9019,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8952,7 +9079,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9003,7 +9131,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9071,7 +9200,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9140,7 +9270,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9193,7 +9324,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9256,7 +9388,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9318,7 +9451,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9412,7 +9546,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9436,7 +9571,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9461,7 +9597,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9486,7 +9623,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9511,7 +9649,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9536,7 +9675,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9561,7 +9701,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9585,7 +9726,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9610,7 +9752,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9634,7 +9777,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9658,7 +9802,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9683,7 +9828,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9708,7 +9854,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9732,7 +9879,8 @@
     "rarity": "Rare Holo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9756,7 +9904,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9780,7 +9929,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9805,7 +9955,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9829,7 +9980,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9854,7 +10006,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9879,7 +10032,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9903,7 +10057,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9928,7 +10083,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9953,7 +10109,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9978,7 +10135,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10003,7 +10161,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10027,7 +10186,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10052,7 +10212,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10077,7 +10238,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10101,7 +10263,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10127,7 +10290,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10150,7 +10314,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10977,7 +11142,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11001,7 +11167,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11026,7 +11193,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11050,7 +11218,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11306,7 +11475,8 @@
     "rarity": "Rare Rainbow",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11330,7 +11500,8 @@
     "rarity": "Rare Rainbow",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11355,7 +11526,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11379,7 +11551,8 @@
     "rarity": "Rare Rainbow",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11540,7 +11713,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11564,7 +11738,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11588,7 +11763,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11613,7 +11789,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {

--- a/cards/en/swsh10.json
+++ b/cards/en/swsh10.json
@@ -117,7 +117,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -177,7 +178,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -230,7 +232,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -284,7 +287,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -333,7 +337,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -390,7 +395,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -453,7 +459,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -506,7 +513,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -565,7 +573,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -628,7 +637,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -690,7 +700,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -753,7 +764,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -812,7 +824,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -865,7 +878,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -928,7 +942,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1108,7 +1123,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1173,7 +1189,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1226,7 +1243,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1287,7 +1305,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1349,7 +1368,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1413,7 +1433,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1666,7 +1687,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1729,7 +1751,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1855,7 +1878,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1923,7 +1947,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1991,7 +2016,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2052,7 +2078,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2107,7 +2134,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2174,7 +2202,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2237,7 +2266,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2299,7 +2329,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2479,7 +2510,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2533,7 +2565,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2592,7 +2625,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2655,7 +2689,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2715,7 +2750,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2834,7 +2870,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2897,7 +2934,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3091,7 +3129,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3156,7 +3195,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3358,7 +3398,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3420,7 +3461,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3480,7 +3522,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3539,7 +3582,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3606,7 +3650,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3665,7 +3710,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3726,7 +3772,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3793,7 +3840,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3852,7 +3900,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3909,7 +3958,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3974,7 +4024,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4038,7 +4089,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4094,7 +4146,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4151,7 +4204,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4217,7 +4271,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4281,7 +4336,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4345,7 +4401,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4538,7 +4595,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4601,7 +4659,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4666,7 +4725,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4728,7 +4788,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4863,7 +4924,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4931,7 +4993,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5056,7 +5119,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5248,7 +5312,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5311,7 +5376,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5436,7 +5502,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5487,7 +5554,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5549,7 +5617,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5611,7 +5680,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5674,7 +5744,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5733,7 +5804,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5855,7 +5927,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5916,7 +5989,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5976,7 +6050,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6165,7 +6240,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6345,7 +6421,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6405,7 +6482,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6474,7 +6552,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6535,7 +6614,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6602,7 +6682,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6671,7 +6752,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6745,7 +6827,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6814,7 +6897,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6874,7 +6958,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6942,7 +7027,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7147,7 +7233,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7216,7 +7303,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7328,7 +7416,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7396,7 +7485,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7463,7 +7553,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7532,7 +7623,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7596,7 +7688,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7660,7 +7753,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7725,7 +7819,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7777,7 +7872,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7836,7 +7932,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7890,7 +7987,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7953,7 +8051,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8018,7 +8117,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8082,7 +8182,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8141,7 +8242,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8209,7 +8311,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8360,7 +8463,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8385,7 +8489,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8410,7 +8515,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8435,7 +8541,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8460,7 +8567,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8485,7 +8593,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8510,7 +8619,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8534,7 +8644,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8559,7 +8670,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8584,7 +8696,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8609,7 +8722,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8634,7 +8748,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8659,7 +8774,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8683,7 +8799,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8708,7 +8825,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8733,7 +8851,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8758,7 +8877,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8785,7 +8905,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8810,7 +8931,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8835,7 +8957,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8859,7 +8982,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8884,7 +9008,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8909,7 +9034,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8934,7 +9060,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8959,7 +9086,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -10336,7 +10464,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -10361,7 +10490,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -10386,7 +10516,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -10411,7 +10542,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -10436,7 +10568,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -10461,7 +10594,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -10486,7 +10620,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -10511,7 +10646,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -10536,7 +10672,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11151,7 +11288,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11176,7 +11314,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11201,7 +11340,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11226,7 +11366,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11251,7 +11392,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11276,7 +11418,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11301,7 +11444,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11326,7 +11470,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11351,7 +11496,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11576,7 +11722,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11600,7 +11747,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11624,7 +11772,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11648,7 +11797,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11673,7 +11823,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11696,7 +11847,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {

--- a/cards/en/swsh10tg.json
+++ b/cards/en/swsh10tg.json
@@ -54,7 +54,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -112,7 +113,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -170,7 +172,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -229,7 +232,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -290,7 +294,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -356,7 +361,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -409,7 +415,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -472,7 +479,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -533,7 +541,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -592,7 +601,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -660,7 +670,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -727,7 +738,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1469,7 +1481,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1493,7 +1506,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1518,7 +1532,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1542,7 +1557,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1566,7 +1582,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {

--- a/cards/en/swsh11.json
+++ b/cards/en/swsh11.json
@@ -45,7 +45,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -102,7 +103,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -166,7 +168,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -220,7 +223,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -280,7 +284,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -345,7 +350,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -411,7 +417,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -470,7 +477,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -536,7 +544,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -599,7 +608,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -652,7 +662,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -707,7 +718,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -768,7 +780,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -821,7 +834,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -882,7 +896,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -936,7 +951,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -998,7 +1014,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1052,7 +1069,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1108,7 +1126,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1167,7 +1186,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1232,7 +1252,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1296,7 +1317,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1360,7 +1382,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1413,7 +1436,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1467,7 +1491,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1527,7 +1552,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1646,7 +1672,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1707,7 +1734,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1760,7 +1788,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1828,7 +1857,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1892,7 +1922,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1955,7 +1986,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2017,7 +2049,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2070,7 +2103,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2133,7 +2167,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2192,7 +2227,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2252,7 +2288,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2317,7 +2354,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2377,7 +2415,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2439,7 +2478,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2505,7 +2545,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2571,7 +2612,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2621,7 +2663,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2681,7 +2724,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2740,7 +2784,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2809,7 +2854,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2998,7 +3044,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3061,7 +3108,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3123,7 +3171,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3185,7 +3234,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3248,7 +3298,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3311,7 +3362,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3566,7 +3618,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3628,7 +3681,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3691,7 +3745,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3754,7 +3809,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3815,7 +3871,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3870,7 +3927,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3930,7 +3988,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3995,7 +4054,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4063,7 +4123,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4131,7 +4192,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4260,7 +4322,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4321,7 +4384,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4381,7 +4445,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4446,7 +4511,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4513,7 +4579,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4581,7 +4648,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4648,7 +4716,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4707,7 +4776,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4776,7 +4846,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4834,7 +4905,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4900,7 +4972,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4967,7 +5040,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5084,7 +5158,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5147,7 +5222,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5210,7 +5286,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5264,7 +5341,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5329,7 +5407,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5389,7 +5468,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5446,7 +5526,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5514,7 +5595,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5580,7 +5662,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5771,7 +5854,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5824,7 +5908,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5877,7 +5962,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5933,7 +6019,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5998,7 +6085,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6051,7 +6139,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6102,7 +6191,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6163,7 +6253,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6227,7 +6318,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6290,7 +6382,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6351,7 +6444,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6412,7 +6506,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6476,7 +6571,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6538,7 +6634,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6599,7 +6696,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6663,7 +6761,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6724,7 +6823,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6789,7 +6889,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6842,7 +6943,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6904,7 +7006,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6973,7 +7076,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7041,7 +7145,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7093,7 +7198,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7152,7 +7258,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7343,7 +7450,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7406,7 +7514,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7467,7 +7576,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7664,7 +7774,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7735,7 +7846,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7803,7 +7915,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7870,7 +7983,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8117,7 +8231,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8177,7 +8292,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8233,7 +8349,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8477,7 +8594,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8544,7 +8662,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8606,7 +8725,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8660,7 +8780,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8724,7 +8845,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8786,7 +8908,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8848,7 +8971,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8909,7 +9033,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9101,7 +9226,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9160,7 +9286,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9213,7 +9340,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9276,7 +9404,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9301,7 +9430,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9326,7 +9456,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9353,7 +9484,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9378,7 +9510,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9403,7 +9536,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9428,7 +9562,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9453,7 +9588,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9478,7 +9614,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9502,7 +9639,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9526,7 +9664,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9551,7 +9690,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9576,7 +9716,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9601,7 +9742,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9628,7 +9770,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9653,7 +9796,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9678,7 +9822,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9703,7 +9848,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9728,7 +9874,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9755,7 +9902,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9778,7 +9926,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -10895,7 +11044,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -10920,7 +11070,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -10945,7 +11096,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -10970,7 +11122,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -10995,7 +11148,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11020,7 +11174,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11045,7 +11200,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11070,7 +11226,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11534,7 +11691,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11559,7 +11717,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11584,7 +11743,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11609,7 +11769,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11634,7 +11795,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11659,7 +11821,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11684,7 +11847,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11709,7 +11873,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11858,7 +12023,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11882,7 +12048,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11907,7 +12074,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11932,7 +12100,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {

--- a/cards/en/swsh11tg.json
+++ b/cards/en/swsh11tg.json
@@ -51,7 +51,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -112,7 +113,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -172,7 +174,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -232,7 +235,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -294,7 +298,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -359,7 +364,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -427,7 +433,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -490,7 +497,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -549,7 +557,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -611,7 +620,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -666,7 +676,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1375,7 +1386,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1401,7 +1413,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1426,7 +1439,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1450,7 +1464,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1474,7 +1489,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1498,7 +1514,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {

--- a/cards/en/swsh12.json
+++ b/cards/en/swsh12.json
@@ -44,7 +44,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -101,7 +102,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -155,7 +157,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -214,7 +217,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -268,7 +272,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -321,7 +326,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -508,7 +514,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -569,7 +576,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -622,7 +630,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -683,7 +692,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -744,7 +754,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -804,7 +815,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -986,7 +998,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1047,7 +1060,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1112,7 +1126,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1176,7 +1191,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1230,7 +1246,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1289,7 +1306,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1349,7 +1367,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1476,7 +1495,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1540,7 +1560,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1602,7 +1623,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1656,7 +1678,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1716,7 +1739,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1780,7 +1804,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1847,7 +1872,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1910,7 +1936,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2168,7 +2195,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2236,7 +2264,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2300,7 +2329,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2362,7 +2392,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2424,7 +2455,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2488,7 +2520,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2557,7 +2590,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2618,7 +2652,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2678,7 +2713,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2737,7 +2773,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2799,7 +2836,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2853,7 +2891,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2915,7 +2954,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2968,7 +3008,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3030,7 +3071,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3093,7 +3135,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3156,7 +3199,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3217,7 +3261,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3273,7 +3318,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3336,7 +3382,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3393,7 +3440,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3654,7 +3702,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3723,7 +3772,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3788,7 +3838,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3847,7 +3898,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3911,7 +3963,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4104,7 +4157,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4168,7 +4222,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4228,7 +4283,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4420,7 +4476,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4487,7 +4544,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4553,7 +4611,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4620,7 +4679,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4680,7 +4740,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4742,7 +4803,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4808,7 +4870,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4867,7 +4930,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4934,7 +4998,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5003,7 +5068,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5069,7 +5135,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5132,7 +5199,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5196,7 +5264,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5255,7 +5324,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5321,7 +5391,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5380,7 +5451,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5440,7 +5512,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5507,7 +5580,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5626,7 +5700,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5691,7 +5766,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5753,7 +5829,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5814,7 +5891,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5869,7 +5947,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5932,7 +6011,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5986,7 +6066,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6052,7 +6133,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6107,7 +6189,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6171,7 +6254,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6234,7 +6318,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6348,7 +6433,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6398,7 +6484,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6456,7 +6543,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6524,7 +6612,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6593,7 +6682,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6714,7 +6804,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6776,7 +6867,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6831,7 +6923,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6889,7 +6982,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6951,7 +7045,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7004,7 +7099,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7067,7 +7163,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7117,7 +7214,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7186,7 +7284,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7248,7 +7347,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7315,7 +7415,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7453,7 +7554,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7523,7 +7625,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7582,7 +7685,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7646,7 +7750,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7714,7 +7819,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7779,7 +7885,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7836,7 +7943,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7955,7 +8063,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8016,7 +8125,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8076,7 +8186,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8133,7 +8244,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8185,7 +8297,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8239,7 +8352,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8417,7 +8531,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8680,7 +8795,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8739,7 +8855,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8808,7 +8925,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8861,7 +8979,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8923,7 +9042,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8994,7 +9114,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9060,7 +9181,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9120,7 +9242,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9188,7 +9311,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9243,7 +9367,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9268,7 +9393,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9293,7 +9419,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9318,7 +9445,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9345,7 +9473,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9372,7 +9501,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9399,7 +9529,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9424,7 +9555,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9448,7 +9580,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9473,7 +9606,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9500,7 +9634,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9524,7 +9659,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9549,7 +9685,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9574,7 +9711,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9599,7 +9737,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9624,7 +9763,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9649,7 +9789,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9674,7 +9815,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9697,7 +9839,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9720,7 +9863,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -10939,7 +11083,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -10964,7 +11109,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -10989,7 +11135,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11013,7 +11160,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11038,7 +11186,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11063,7 +11212,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11088,7 +11238,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11113,7 +11264,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11582,7 +11734,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11607,7 +11760,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11632,7 +11786,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11657,7 +11812,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11682,7 +11838,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11707,7 +11864,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11732,7 +11890,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11887,7 +12046,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11911,7 +12071,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11938,7 +12099,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11961,7 +12123,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {

--- a/cards/en/swsh12pt5.json
+++ b/cards/en/swsh12pt5.json
@@ -44,7 +44,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -100,7 +101,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -152,7 +154,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -217,7 +220,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -283,7 +287,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -336,7 +341,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -390,7 +396,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -454,7 +461,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -512,7 +520,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -565,7 +574,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -618,7 +628,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -678,7 +689,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -871,7 +883,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -931,7 +944,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -994,7 +1008,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1257,7 +1272,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1441,7 +1457,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1503,7 +1520,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1567,7 +1585,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1629,7 +1648,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1690,7 +1710,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1753,7 +1774,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1813,7 +1835,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1879,7 +1902,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1948,7 +1972,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2013,7 +2038,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2068,7 +2094,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2127,7 +2154,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2191,7 +2219,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2379,7 +2408,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2432,7 +2462,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2497,7 +2528,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2561,7 +2593,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2623,7 +2656,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2677,7 +2711,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2845,7 +2880,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2907,7 +2943,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2970,7 +3007,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3032,7 +3070,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3148,7 +3187,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3402,7 +3442,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3462,7 +3503,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3531,7 +3573,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3599,7 +3642,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3731,7 +3775,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3798,7 +3843,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3859,7 +3905,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3921,7 +3968,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4123,7 +4171,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4191,7 +4240,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4249,7 +4299,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4303,7 +4354,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4357,7 +4409,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4412,7 +4465,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4475,7 +4529,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4527,7 +4582,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4581,7 +4637,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4642,7 +4699,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4695,7 +4753,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4758,7 +4817,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4823,7 +4883,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4888,7 +4949,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4951,7 +5013,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5012,7 +5075,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5062,7 +5126,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5121,7 +5186,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5191,7 +5257,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5260,7 +5327,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5330,7 +5398,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5405,7 +5474,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5479,7 +5549,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5541,7 +5612,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5600,7 +5672,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5659,7 +5732,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5726,7 +5800,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5794,7 +5869,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6005,7 +6081,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6557,7 +6634,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6603,7 +6681,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6731,7 +6810,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6790,7 +6870,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6851,7 +6932,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6912,7 +6994,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7111,7 +7194,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7233,7 +7317,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7295,7 +7380,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7357,7 +7443,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7476,7 +7563,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7537,7 +7625,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7561,7 +7650,8 @@
     "rarity": "Rare Holo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7585,7 +7675,8 @@
     "rarity": "Rare Holo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7610,7 +7701,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7635,7 +7727,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7660,7 +7753,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7685,7 +7779,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7710,7 +7805,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7735,7 +7831,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7760,7 +7857,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7785,7 +7883,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7809,7 +7908,8 @@
     "rarity": "Rare Holo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7833,7 +7933,8 @@
     "rarity": "Rare Holo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7858,7 +7959,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7882,7 +7984,8 @@
     "rarity": "Rare Holo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7907,7 +8010,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7932,7 +8036,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7957,7 +8062,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7982,7 +8088,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8007,7 +8114,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8032,7 +8140,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8059,7 +8168,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8084,7 +8194,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8109,7 +8220,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8134,7 +8246,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8160,7 +8273,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8185,7 +8299,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8210,7 +8325,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8236,7 +8352,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8261,7 +8378,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8281,7 +8399,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swsh12pt5/152.png",
@@ -8300,7 +8419,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swsh12pt5/153.png",
@@ -8319,7 +8439,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swsh12pt5/154.png",
@@ -8338,7 +8459,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swsh12pt5/155.png",
@@ -8357,7 +8479,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swsh12pt5/156.png",
@@ -8376,7 +8499,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swsh12pt5/157.png",
@@ -8395,7 +8519,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swsh12pt5/158.png",
@@ -8414,7 +8539,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swsh12pt5/159.png",
@@ -8468,7 +8594,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {

--- a/cards/en/swsh12pt5gg.json
+++ b/cards/en/swsh12pt5gg.json
@@ -53,7 +53,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -112,7 +113,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -177,7 +179,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -236,7 +239,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -289,7 +293,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -346,7 +351,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -406,7 +412,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -470,7 +477,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -532,7 +540,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -596,7 +605,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -663,7 +673,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -724,7 +735,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -781,7 +793,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -839,7 +852,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -897,7 +911,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -957,7 +972,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1017,7 +1033,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1084,7 +1101,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1133,7 +1151,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1187,7 +1206,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1243,7 +1263,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1289,7 +1310,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1347,7 +1369,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1406,7 +1429,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1467,7 +1491,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1521,7 +1546,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1580,7 +1606,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1639,7 +1666,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1700,7 +1728,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1762,7 +1791,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1826,7 +1856,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1880,7 +1911,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1943,7 +1975,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2006,7 +2039,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3460,7 +3494,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3485,7 +3520,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3510,7 +3546,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3535,7 +3572,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3560,7 +3598,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3585,7 +3624,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3610,7 +3650,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3635,7 +3676,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3660,7 +3702,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3685,7 +3728,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {

--- a/cards/en/swsh12tg.json
+++ b/cards/en/swsh12tg.json
@@ -55,7 +55,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -117,7 +118,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -181,7 +183,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -246,7 +249,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -306,7 +310,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -366,7 +371,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -421,7 +427,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -479,7 +486,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -536,7 +544,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -596,7 +605,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -665,7 +675,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1383,7 +1394,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1408,7 +1420,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1433,7 +1446,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1458,7 +1472,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1483,7 +1498,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1507,7 +1523,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {

--- a/cards/en/swsh2.json
+++ b/cards/en/swsh2.json
@@ -50,7 +50,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -113,7 +114,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -173,7 +175,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -234,7 +237,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -294,7 +298,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -356,7 +361,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -418,7 +424,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -480,7 +487,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -543,7 +551,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -595,7 +604,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -655,7 +665,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -721,7 +732,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -787,7 +799,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -849,7 +862,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -912,7 +926,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -964,7 +979,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1209,7 +1225,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1261,7 +1278,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1319,7 +1337,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1379,7 +1398,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1441,7 +1461,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1502,7 +1523,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1633,7 +1655,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1693,7 +1716,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1756,7 +1780,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1820,7 +1845,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1872,7 +1898,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1932,7 +1959,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1991,7 +2019,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2052,7 +2081,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2241,7 +2271,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2299,7 +2330,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2351,7 +2383,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2419,7 +2452,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2487,7 +2521,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2556,7 +2591,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2675,7 +2711,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2730,7 +2767,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2794,7 +2832,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2848,7 +2887,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2914,7 +2954,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3108,7 +3149,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3160,7 +3202,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3219,7 +3262,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3278,7 +3322,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3392,7 +3437,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3448,7 +3494,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3512,7 +3559,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3576,7 +3624,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3628,7 +3677,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3688,7 +3738,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3748,7 +3799,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3800,7 +3852,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3860,7 +3913,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3925,7 +3979,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3990,7 +4045,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4106,7 +4162,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4168,7 +4225,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4408,7 +4466,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4469,7 +4528,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4528,7 +4588,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4586,7 +4647,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4651,7 +4713,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4710,7 +4773,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4775,7 +4839,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4838,7 +4903,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4898,7 +4964,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4969,7 +5036,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5037,7 +5105,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5106,7 +5175,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5170,7 +5240,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5232,7 +5303,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5292,7 +5364,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5357,7 +5430,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5415,7 +5489,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5484,7 +5559,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5544,7 +5620,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5742,7 +5819,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5804,7 +5882,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5869,7 +5948,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5921,7 +6001,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5982,7 +6063,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6035,7 +6117,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6095,7 +6178,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6149,7 +6233,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6212,7 +6297,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6267,7 +6353,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6331,7 +6418,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6384,7 +6472,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6451,7 +6540,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6514,7 +6604,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6638,7 +6729,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6766,7 +6858,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6818,7 +6911,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6877,7 +6971,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6931,7 +7026,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6995,7 +7091,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7055,7 +7152,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7108,7 +7206,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7168,7 +7267,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7226,7 +7326,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7293,7 +7394,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7475,7 +7577,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7540,7 +7643,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7601,7 +7705,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7668,7 +7773,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7737,7 +7843,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7804,7 +7911,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7872,7 +7980,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7941,7 +8050,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8011,7 +8121,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8077,7 +8188,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8136,7 +8248,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8208,7 +8321,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8275,7 +8389,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8492,7 +8607,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8560,7 +8676,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8628,7 +8745,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8691,7 +8809,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8754,7 +8873,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8822,7 +8942,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8893,7 +9014,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8961,7 +9083,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9024,7 +9147,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9090,7 +9214,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9154,7 +9279,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9218,7 +9344,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9284,7 +9411,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9346,7 +9474,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9405,7 +9534,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9492,7 +9622,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9517,7 +9648,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9541,7 +9673,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9566,7 +9699,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9590,7 +9724,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9614,7 +9749,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9638,7 +9774,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9662,7 +9799,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9687,7 +9825,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9712,7 +9851,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9737,7 +9877,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9761,7 +9902,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9785,7 +9927,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9809,7 +9952,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9833,7 +9977,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9857,7 +10002,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9881,7 +10027,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9904,7 +10051,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9927,7 +10075,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9950,7 +10099,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9973,7 +10123,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10908,7 +11059,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10932,7 +11084,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10957,7 +11110,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10981,7 +11135,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11454,7 +11609,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11478,7 +11634,8 @@
     "rarity": "Rare Rainbow",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11503,7 +11660,8 @@
     "rarity": "Rare Rainbow",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11527,7 +11685,8 @@
     "rarity": "Rare Rainbow",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11586,7 +11745,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11652,7 +11812,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11677,7 +11838,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11701,7 +11863,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11725,7 +11888,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11748,7 +11912,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {

--- a/cards/en/swsh3.json
+++ b/cards/en/swsh3.json
@@ -156,7 +156,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -218,7 +219,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -277,7 +279,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -339,7 +342,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -400,7 +404,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -452,7 +457,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -506,7 +512,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -553,7 +560,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -614,7 +622,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -667,7 +676,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -726,7 +736,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -788,7 +799,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -851,7 +863,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -912,7 +925,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -966,7 +980,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1029,7 +1044,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1290,7 +1306,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1354,7 +1371,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1414,7 +1432,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1478,7 +1497,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1540,7 +1560,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1601,7 +1622,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1664,7 +1686,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1717,7 +1740,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1778,7 +1802,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1837,7 +1862,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1902,7 +1928,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2085,7 +2112,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2145,7 +2173,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2205,7 +2234,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2257,7 +2287,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2317,7 +2348,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2376,7 +2408,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2438,7 +2471,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2499,7 +2533,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2561,7 +2596,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2627,7 +2663,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2679,7 +2716,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2733,7 +2771,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2792,7 +2831,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2855,7 +2895,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2919,7 +2960,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2977,7 +3019,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3040,7 +3083,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3103,7 +3147,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3164,7 +3209,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3229,7 +3275,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3281,7 +3328,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3334,7 +3382,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3395,7 +3444,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3448,7 +3498,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3509,7 +3560,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3631,7 +3683,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3694,7 +3747,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3757,7 +3811,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3818,7 +3873,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3883,7 +3939,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3942,7 +3999,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4004,7 +4062,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4066,7 +4125,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4175,7 +4235,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4238,7 +4299,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4303,7 +4365,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4371,7 +4434,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4441,7 +4505,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4508,7 +4573,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4580,7 +4646,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4654,7 +4721,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4705,7 +4773,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4767,7 +4836,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4828,7 +4898,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4891,7 +4962,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4949,7 +5021,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5013,7 +5086,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5065,7 +5139,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5125,7 +5200,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5187,7 +5263,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5253,7 +5330,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5320,7 +5398,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5372,7 +5451,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5425,7 +5505,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5484,7 +5565,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5541,7 +5623,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5608,7 +5691,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5675,7 +5759,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5810,7 +5895,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5870,7 +5956,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5932,7 +6019,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6060,7 +6148,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6125,7 +6214,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6187,7 +6277,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6246,7 +6337,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6365,7 +6457,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6427,7 +6520,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6486,7 +6580,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6538,7 +6633,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6604,7 +6700,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6665,7 +6762,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6715,7 +6813,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6767,7 +6866,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6827,7 +6927,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7281,7 +7382,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7350,7 +7452,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7423,7 +7526,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7491,7 +7595,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7558,7 +7663,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7617,7 +7723,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7689,7 +7796,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7759,7 +7867,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7896,7 +8005,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7967,7 +8077,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8029,7 +8140,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8098,7 +8210,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8160,7 +8273,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8211,7 +8325,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8263,7 +8378,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8322,7 +8438,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8378,7 +8495,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8441,7 +8559,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8507,7 +8626,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8574,7 +8694,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8636,7 +8757,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8697,7 +8819,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8907,7 +9030,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8976,7 +9100,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9039,7 +9164,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9097,7 +9223,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9158,7 +9285,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9211,7 +9339,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9269,7 +9398,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9321,7 +9451,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9381,7 +9512,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9439,7 +9571,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9509,7 +9642,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9575,7 +9709,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9600,7 +9735,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9625,7 +9761,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9649,7 +9786,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9674,7 +9812,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9698,7 +9837,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9722,7 +9862,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9746,7 +9887,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9770,7 +9912,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9794,7 +9937,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9818,7 +9962,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9844,7 +9989,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9868,7 +10014,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9892,7 +10039,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9916,7 +10064,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9941,7 +10090,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9965,7 +10115,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9989,7 +10140,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10012,7 +10164,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10035,7 +10188,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10058,7 +10212,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10681,7 +10836,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10705,7 +10861,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10729,7 +10886,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10753,7 +10911,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11086,7 +11245,8 @@
     "rarity": "Rare Rainbow",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11110,7 +11270,8 @@
     "rarity": "Rare Rainbow",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11172,7 +11333,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11235,7 +11397,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11260,7 +11423,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11284,7 +11448,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11307,7 +11472,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {

--- a/cards/en/swsh35.json
+++ b/cards/en/swsh35.json
@@ -111,7 +111,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -166,7 +167,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -216,7 +218,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -338,7 +341,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -397,7 +401,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -528,7 +533,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -594,7 +600,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -646,7 +653,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -696,7 +704,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1078,7 +1087,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1148,7 +1158,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1213,7 +1224,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1471,7 +1483,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1537,7 +1550,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1601,7 +1615,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1728,7 +1743,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1790,7 +1806,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1852,7 +1869,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1905,7 +1923,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2031,7 +2050,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2091,7 +2111,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2144,7 +2165,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2199,7 +2221,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2259,7 +2282,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2309,7 +2333,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2371,7 +2396,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2430,7 +2456,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2492,7 +2519,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2554,7 +2582,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2607,7 +2636,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2669,7 +2699,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2733,7 +2764,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2795,7 +2827,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2922,7 +2955,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2986,7 +3020,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3010,7 +3045,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3034,7 +3070,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3059,7 +3096,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3083,7 +3121,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3107,7 +3146,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3131,7 +3171,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3155,7 +3196,8 @@
     "rarity": "Rare Holo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3179,7 +3221,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3203,7 +3246,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3228,7 +3272,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3252,7 +3297,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3277,7 +3323,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3302,7 +3349,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3326,7 +3374,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3350,7 +3399,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3374,7 +3424,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3398,7 +3449,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3422,7 +3474,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3446,7 +3499,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3729,7 +3783,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3941,7 +3996,8 @@
     "rarity": "Rare Rainbow",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3965,7 +4021,8 @@
     "rarity": "Rare Rainbow",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4057,7 +4114,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {

--- a/cards/en/swsh4.json
+++ b/cards/en/swsh4.json
@@ -43,7 +43,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -107,7 +108,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -161,7 +163,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -213,7 +216,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -276,7 +280,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -339,7 +344,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -398,7 +404,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -461,7 +468,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -520,7 +528,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -572,7 +581,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -625,7 +635,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -685,7 +696,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -737,7 +749,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -793,7 +806,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -852,7 +866,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -914,7 +929,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -977,7 +993,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1040,7 +1057,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1102,7 +1120,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1349,7 +1368,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1413,7 +1433,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1473,7 +1494,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1533,7 +1555,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1597,7 +1620,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1663,7 +1687,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1787,7 +1812,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1843,7 +1869,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1906,7 +1933,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1968,7 +1996,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2033,7 +2062,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2093,7 +2123,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2269,7 +2300,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2336,7 +2368,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2392,7 +2425,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2454,7 +2488,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2514,7 +2549,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2691,7 +2727,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2750,7 +2787,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2809,7 +2847,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2875,7 +2914,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2993,7 +3033,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3055,7 +3096,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3110,7 +3152,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3162,7 +3205,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3222,7 +3266,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3274,7 +3319,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3334,7 +3380,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3393,7 +3440,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3458,7 +3506,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3521,7 +3570,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3584,7 +3634,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3630,7 +3681,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3689,7 +3741,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3751,7 +3804,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3810,7 +3864,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3875,7 +3930,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3927,7 +3983,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3985,7 +4042,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4049,7 +4107,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4107,7 +4166,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4178,7 +4238,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4244,7 +4305,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4309,7 +4371,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4367,7 +4430,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4431,7 +4495,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4483,7 +4548,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4538,7 +4604,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4587,7 +4654,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4648,7 +4716,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4706,7 +4775,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4767,7 +4837,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4826,7 +4897,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4887,7 +4959,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4949,7 +5022,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5012,7 +5086,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5071,7 +5146,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5134,7 +5210,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5198,7 +5275,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5258,7 +5336,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5321,7 +5400,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5373,7 +5453,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5436,7 +5517,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5500,7 +5582,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5563,7 +5646,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5625,7 +5709,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5686,7 +5771,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5750,7 +5836,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5814,7 +5901,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6013,7 +6101,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6074,7 +6163,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6135,7 +6225,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6197,7 +6288,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6258,7 +6350,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6317,7 +6410,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6441,7 +6535,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6506,7 +6601,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6571,7 +6667,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6636,7 +6733,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6700,7 +6798,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6768,7 +6867,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6836,7 +6936,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6908,7 +7009,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7052,7 +7154,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7125,7 +7228,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7192,7 +7296,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7256,7 +7361,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7324,7 +7430,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7391,7 +7498,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7461,7 +7569,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7521,7 +7630,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7579,7 +7689,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7645,7 +7756,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7844,7 +7956,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7912,7 +8025,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7981,7 +8095,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8042,7 +8157,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8111,7 +8227,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8170,7 +8287,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8232,7 +8350,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8285,7 +8404,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8351,7 +8471,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8415,7 +8536,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8473,7 +8595,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8537,7 +8660,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8727,7 +8851,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8785,7 +8910,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8853,7 +8979,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8922,7 +9049,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8946,7 +9074,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8970,7 +9099,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8995,7 +9125,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9019,7 +9150,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9043,7 +9175,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9067,7 +9200,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9092,7 +9226,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9116,7 +9251,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9140,7 +9276,8 @@
     "rarity": "Rare Holo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9165,7 +9302,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9189,7 +9327,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9213,7 +9352,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9237,7 +9377,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9263,7 +9404,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9288,7 +9430,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9312,7 +9455,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9335,7 +9479,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9358,7 +9503,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9381,7 +9527,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9404,7 +9551,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10298,7 +10446,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10322,7 +10471,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10347,7 +10497,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10371,7 +10522,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10395,7 +10547,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10419,7 +10572,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10443,7 +10597,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10826,7 +10981,8 @@
     "rarity": "Rare Rainbow",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10850,7 +11006,8 @@
     "rarity": "Rare Rainbow",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10875,7 +11032,8 @@
     "rarity": "Rare Rainbow",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10899,7 +11057,8 @@
     "rarity": "Rare Rainbow",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10923,7 +11082,8 @@
     "rarity": "Rare Rainbow",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10947,7 +11107,8 @@
     "rarity": "Rare Rainbow",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11006,7 +11167,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11065,7 +11227,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11090,7 +11253,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11115,7 +11279,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11140,7 +11305,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11165,7 +11331,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {

--- a/cards/en/swsh45.json
+++ b/cards/en/swsh45.json
@@ -54,7 +54,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -111,7 +112,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -170,7 +172,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -225,7 +228,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -285,7 +289,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -346,7 +351,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -399,7 +405,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -458,7 +465,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -639,7 +647,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -700,7 +709,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -762,7 +772,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -815,7 +826,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -875,7 +887,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -938,7 +951,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -991,7 +1005,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1167,7 +1182,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1221,7 +1237,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Banned"
     },
     "regulationMark": "D",
     "images": {
@@ -1274,7 +1291,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1325,7 +1343,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1383,7 +1402,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1448,7 +1468,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1512,7 +1533,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1574,7 +1596,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1625,7 +1648,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1678,7 +1702,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1737,7 +1762,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1789,7 +1815,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1849,7 +1876,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1909,7 +1937,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1966,7 +1995,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2025,7 +2055,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2084,7 +2115,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2322,7 +2354,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2374,7 +2407,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2433,7 +2467,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2495,7 +2530,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2679,7 +2715,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2731,7 +2768,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2792,7 +2830,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2854,7 +2893,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3039,7 +3079,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3293,7 +3334,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3317,7 +3359,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3342,7 +3385,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard":"Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3366,7 +3410,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3391,7 +3436,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard":"Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3416,7 +3462,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3441,7 +3488,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3465,7 +3513,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3553,7 +3602,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3577,7 +3627,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3601,7 +3652,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3625,7 +3677,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3649,7 +3702,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3673,7 +3727,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3697,7 +3752,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3721,7 +3777,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {

--- a/cards/en/swsh45sv.json
+++ b/cards/en/swsh45sv.json
@@ -52,7 +52,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -105,7 +106,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -164,7 +166,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -216,7 +219,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -277,7 +281,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -339,7 +344,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -391,7 +397,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -455,7 +462,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -513,7 +521,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -574,7 +583,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -633,7 +643,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -685,7 +696,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -743,7 +755,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -803,7 +816,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -855,7 +869,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -919,7 +934,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -978,7 +994,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1041,7 +1058,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1105,7 +1123,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1167,7 +1186,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1227,7 +1247,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1287,7 +1308,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1341,7 +1363,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1407,7 +1430,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1459,7 +1483,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1520,7 +1545,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1578,7 +1604,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1643,7 +1670,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1709,7 +1737,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1775,7 +1804,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1827,7 +1857,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1886,7 +1917,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1939,7 +1971,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1998,7 +2031,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2057,7 +2091,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2118,7 +2153,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2183,7 +2219,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2240,7 +2277,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2301,7 +2339,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2363,7 +2402,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2426,7 +2466,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2489,7 +2530,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2540,7 +2582,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2599,7 +2642,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2664,7 +2708,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2723,7 +2768,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2781,7 +2827,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2845,7 +2892,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2904,7 +2952,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2969,7 +3018,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3020,7 +3070,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3078,7 +3129,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3142,7 +3194,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3210,7 +3263,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3279,7 +3333,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3343,7 +3398,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3405,7 +3461,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3465,7 +3522,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3530,7 +3588,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3588,7 +3647,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3657,7 +3717,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3717,7 +3778,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3779,7 +3841,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3841,7 +3904,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3895,7 +3959,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3958,7 +4023,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4011,7 +4077,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4078,7 +4145,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4141,7 +4209,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4194,7 +4263,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4256,7 +4326,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4309,7 +4380,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4372,7 +4444,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4431,7 +4504,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4497,7 +4571,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4549,7 +4624,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4608,7 +4684,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4668,7 +4745,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4733,7 +4811,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4792,7 +4871,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4844,7 +4924,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4905,7 +4986,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4967,7 +5049,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5032,7 +5115,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5093,7 +5177,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5160,7 +5245,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5226,7 +5312,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5290,7 +5377,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5358,7 +5446,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5420,7 +5509,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5489,7 +5579,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5556,7 +5647,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5618,7 +5710,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5675,7 +5768,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5733,7 +5827,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5794,7 +5889,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5847,7 +5943,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5906,7 +6003,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5968,7 +6066,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6027,7 +6126,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6095,7 +6195,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6164,7 +6265,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6217,7 +6319,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -6279,7 +6382,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {

--- a/cards/en/swsh5.json
+++ b/cards/en/swsh5.json
@@ -44,7 +44,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -108,7 +109,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -172,7 +174,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -236,7 +239,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -298,7 +302,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -413,7 +418,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -474,7 +480,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -538,7 +545,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -598,7 +606,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -651,7 +660,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -718,7 +728,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -780,7 +791,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -833,7 +845,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -895,7 +908,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -957,7 +971,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1010,7 +1025,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1193,7 +1209,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1387,7 +1404,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1456,7 +1474,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1521,7 +1540,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1583,7 +1603,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1636,7 +1657,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1697,7 +1719,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1751,7 +1774,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1813,7 +1837,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1866,7 +1891,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1920,7 +1946,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1978,7 +2005,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2041,7 +2069,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2105,7 +2134,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2169,7 +2199,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2231,7 +2262,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2287,7 +2319,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2354,7 +2387,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2481,7 +2515,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2535,7 +2570,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2596,7 +2632,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2650,7 +2687,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2717,7 +2755,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2771,7 +2810,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2836,7 +2876,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2898,7 +2939,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2958,7 +3000,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3138,7 +3181,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3200,7 +3244,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3261,7 +3306,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3330,7 +3376,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3401,7 +3448,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3461,7 +3509,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3530,7 +3579,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3595,7 +3645,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3655,7 +3706,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3720,7 +3772,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3930,7 +3983,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3998,7 +4052,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4053,7 +4108,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4116,7 +4172,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4187,7 +4244,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4250,7 +4308,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4310,7 +4369,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4364,7 +4424,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4427,7 +4488,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4482,7 +4544,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4550,7 +4613,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4617,7 +4681,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4672,7 +4737,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4734,7 +4800,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4788,7 +4855,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4858,7 +4926,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4924,7 +4993,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4989,7 +5059,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5053,7 +5124,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5106,7 +5178,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5171,7 +5244,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5502,7 +5576,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5564,7 +5639,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5619,7 +5695,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5683,7 +5760,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5752,7 +5830,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5819,7 +5898,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5873,7 +5953,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5934,7 +6015,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6063,7 +6145,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6138,7 +6221,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6206,7 +6290,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6266,7 +6351,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6334,7 +6420,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6402,7 +6489,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6470,7 +6558,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6530,7 +6619,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6592,7 +6682,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6660,7 +6751,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6727,7 +6819,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6920,7 +7013,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6973,7 +7067,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7043,7 +7138,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7111,7 +7207,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7175,7 +7272,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7240,7 +7338,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7369,7 +7468,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7430,7 +7530,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7491,7 +7592,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7517,7 +7619,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7542,7 +7645,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7567,7 +7671,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7592,7 +7697,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7617,7 +7723,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7643,7 +7750,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7669,7 +7777,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7695,7 +7804,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7720,7 +7830,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7745,7 +7856,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7785,7 +7897,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7812,7 +7925,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7850,7 +7964,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7877,7 +7992,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7901,7 +8017,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7927,7 +8044,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7953,7 +8071,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7979,7 +8098,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8005,7 +8125,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8030,7 +8151,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8055,7 +8177,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9144,7 +9267,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9169,7 +9293,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9195,7 +9320,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9220,7 +9346,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9247,7 +9374,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9274,7 +9402,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9812,7 +9941,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9837,7 +9967,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9863,7 +9994,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9888,7 +10020,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9915,7 +10048,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9942,7 +10076,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10004,7 +10139,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10065,7 +10201,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10091,7 +10228,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10116,7 +10254,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10141,7 +10280,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10166,7 +10306,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {

--- a/cards/en/swsh6.json
+++ b/cards/en/swsh6.json
@@ -45,7 +45,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -102,7 +103,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -163,7 +165,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -226,7 +229,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -288,7 +292,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -350,7 +355,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -531,7 +537,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -594,7 +601,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -657,7 +665,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -719,7 +728,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -773,7 +783,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -838,7 +849,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -902,7 +914,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -957,7 +970,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1014,7 +1028,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1080,7 +1095,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1142,7 +1158,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1330,7 +1347,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1385,7 +1403,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1449,7 +1468,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1571,7 +1591,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1627,7 +1648,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1687,7 +1709,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1747,7 +1770,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1801,7 +1825,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1862,7 +1887,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1922,7 +1948,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1976,7 +2003,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2031,7 +2059,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2086,7 +2115,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2145,7 +2175,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2199,7 +2230,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2268,7 +2300,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2334,7 +2367,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2396,7 +2430,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2460,7 +2495,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2516,7 +2552,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2576,7 +2613,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2639,7 +2677,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2833,7 +2872,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2889,7 +2929,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2951,7 +2992,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3005,7 +3047,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3068,7 +3111,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3129,7 +3173,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3257,7 +3302,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3316,7 +3362,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3376,7 +3423,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3442,7 +3490,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3564,7 +3613,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3619,7 +3669,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3680,7 +3731,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3740,7 +3792,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3808,7 +3861,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3874,7 +3928,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3945,7 +4000,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4019,7 +4075,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4073,7 +4130,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4137,7 +4195,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4197,7 +4256,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4257,7 +4317,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4316,7 +4377,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4376,7 +4438,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4441,7 +4504,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4635,7 +4699,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4688,7 +4753,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4742,7 +4808,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4806,7 +4873,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4931,7 +4999,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4986,7 +5055,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5047,7 +5117,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5112,7 +5183,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5180,7 +5252,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5235,7 +5308,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5289,7 +5363,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5347,7 +5422,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5531,7 +5607,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5593,7 +5670,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5657,7 +5735,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5711,7 +5790,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5773,7 +5853,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5833,7 +5914,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5958,7 +6040,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6140,7 +6223,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6194,7 +6278,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6253,7 +6338,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6369,7 +6455,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6436,7 +6523,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6500,7 +6588,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6565,7 +6654,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6637,7 +6727,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6713,7 +6804,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6787,7 +6879,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7000,7 +7093,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7063,7 +7157,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7117,7 +7212,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7173,7 +7269,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7234,7 +7331,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7351,7 +7449,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7406,7 +7505,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7467,7 +7567,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7533,7 +7634,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7741,7 +7843,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7803,7 +7906,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7863,7 +7967,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7888,7 +7993,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7913,7 +8019,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7939,7 +8046,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7964,7 +8072,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7990,7 +8099,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8015,7 +8125,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8040,7 +8151,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8066,7 +8178,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8091,7 +8204,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8117,7 +8231,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8143,7 +8258,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8168,7 +8284,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8194,7 +8311,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8219,7 +8337,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8245,7 +8364,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8271,7 +8391,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8296,7 +8417,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8321,7 +8443,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8346,7 +8469,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8371,7 +8495,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8396,7 +8521,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8421,7 +8547,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8460,7 +8587,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8486,7 +8614,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8512,7 +8641,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8552,7 +8682,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8578,7 +8709,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8604,7 +8736,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8629,7 +8762,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8653,7 +8787,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8678,7 +8813,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10419,7 +10555,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10444,7 +10581,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10470,7 +10608,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10495,7 +10634,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10520,7 +10660,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10546,7 +10687,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10571,7 +10713,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10597,7 +10740,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10622,7 +10766,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10647,7 +10792,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10672,7 +10818,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10697,7 +10844,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10723,7 +10871,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11476,7 +11625,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11501,7 +11651,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11527,7 +11678,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11552,7 +11704,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11577,7 +11730,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11603,7 +11757,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11629,7 +11784,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11654,7 +11810,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11679,7 +11836,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11704,7 +11862,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11729,7 +11888,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11755,7 +11915,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11814,7 +11975,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11882,7 +12044,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11943,7 +12106,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11969,7 +12133,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11995,7 +12160,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12020,7 +12186,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12046,7 +12213,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12072,7 +12240,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12098,7 +12267,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12118,7 +12288,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swsh6/231.png",
@@ -12137,7 +12308,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swsh6/232.png",
@@ -12156,7 +12328,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swsh6/233.png",

--- a/cards/en/swsh7.json
+++ b/cards/en/swsh7.json
@@ -52,7 +52,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -102,7 +103,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -160,7 +162,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -215,7 +218,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -269,7 +273,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -331,7 +336,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -513,7 +519,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -565,7 +572,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -629,7 +637,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -694,7 +703,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -880,7 +890,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -938,7 +949,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -991,7 +1003,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1112,7 +1125,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1163,7 +1177,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1281,7 +1296,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1343,7 +1359,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1397,7 +1414,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1458,7 +1476,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1512,7 +1531,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1576,7 +1596,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1906,7 +1927,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1961,7 +1983,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2021,7 +2044,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2084,7 +2108,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2145,7 +2170,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2199,7 +2225,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2260,7 +2287,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2319,7 +2347,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2501,7 +2530,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2561,7 +2591,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2625,7 +2656,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2693,7 +2725,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2752,7 +2785,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2814,7 +2848,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2946,7 +2981,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3009,7 +3045,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3112,7 +3149,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3176,7 +3214,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3239,7 +3278,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3303,7 +3343,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3367,7 +3408,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3413,7 +3455,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3608,7 +3651,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3668,7 +3712,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3735,7 +3780,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3801,7 +3847,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4010,7 +4057,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4076,7 +4124,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4144,7 +4193,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4201,7 +4251,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4331,7 +4382,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4397,7 +4449,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4459,7 +4512,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4655,7 +4709,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4714,7 +4769,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4763,7 +4819,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4810,7 +4867,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4876,7 +4934,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4937,7 +4996,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4992,7 +5052,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5127,7 +5188,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5195,7 +5257,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5260,7 +5323,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5328,7 +5392,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5393,7 +5458,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5460,7 +5526,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5525,7 +5592,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5713,7 +5781,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5897,7 +5966,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5961,7 +6031,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6014,7 +6085,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6078,7 +6150,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6262,7 +6335,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6322,7 +6396,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6376,7 +6451,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6435,7 +6511,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6484,7 +6561,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6542,7 +6620,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6593,7 +6672,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6647,7 +6727,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6823,7 +6904,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6880,7 +6962,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6942,7 +7025,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7002,7 +7086,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7049,7 +7134,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7159,7 +7245,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7214,7 +7301,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7269,7 +7357,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7326,7 +7415,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7504,7 +7594,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7574,7 +7665,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7628,7 +7720,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7692,7 +7785,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7743,7 +7837,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7799,7 +7894,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7864,7 +7960,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7928,7 +8025,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7987,7 +8085,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8050,7 +8149,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8117,7 +8217,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8179,7 +8280,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8238,7 +8340,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8306,7 +8409,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8374,7 +8478,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8434,7 +8539,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8497,7 +8603,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8522,7 +8629,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8547,7 +8655,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8572,7 +8681,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8596,7 +8706,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8623,7 +8734,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8648,7 +8760,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8675,7 +8788,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8702,7 +8816,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8727,7 +8842,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8752,7 +8868,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8779,7 +8896,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8804,7 +8922,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8832,7 +8951,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8857,7 +8977,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8884,7 +9005,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8911,7 +9033,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8935,7 +9058,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8963,7 +9087,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8990,7 +9115,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9017,7 +9143,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9041,7 +9168,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9066,7 +9194,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9091,7 +9220,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9116,7 +9246,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9139,7 +9270,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11287,7 +11419,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11312,7 +11445,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11337,7 +11471,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11362,7 +11497,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11387,7 +11523,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12493,7 +12630,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12518,7 +12656,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12543,7 +12682,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12568,7 +12708,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12593,7 +12734,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12652,7 +12794,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12712,7 +12855,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12778,7 +12922,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12803,7 +12948,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12827,7 +12973,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12854,7 +13001,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12878,7 +13026,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12903,7 +13052,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12926,7 +13076,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -12946,7 +13097,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swsh7/235.png",
@@ -12965,7 +13117,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swsh7/236.png",
@@ -12984,7 +13137,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swsh7/237.png",

--- a/cards/en/swsh8.json
+++ b/cards/en/swsh8.json
@@ -53,7 +53,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -116,7 +117,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -175,7 +177,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -238,7 +241,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -301,7 +305,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -421,7 +426,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -482,7 +488,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -535,7 +542,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -601,7 +609,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -664,7 +673,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -725,7 +735,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -781,7 +792,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -835,7 +847,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -896,7 +909,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -959,7 +973,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1023,7 +1038,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1088,7 +1104,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1141,7 +1158,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1204,7 +1222,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1440,7 +1459,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1491,7 +1511,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1618,7 +1639,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1672,7 +1694,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1725,7 +1748,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1777,7 +1801,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1837,7 +1862,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1902,7 +1928,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1965,7 +1992,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2030,7 +2058,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2095,7 +2124,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2154,7 +2184,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2207,7 +2238,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2267,7 +2299,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2455,7 +2488,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2514,7 +2548,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2760,7 +2795,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2815,7 +2851,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2880,7 +2917,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2944,7 +2982,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3009,7 +3048,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3070,7 +3110,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3133,7 +3174,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3185,7 +3227,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3248,7 +3291,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3301,7 +3345,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3367,7 +3412,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3429,7 +3475,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3492,7 +3539,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3555,7 +3603,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3615,7 +3664,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3676,7 +3726,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3741,7 +3792,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3808,7 +3860,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3870,7 +3923,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3926,7 +3980,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -3987,7 +4042,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4047,7 +4103,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4100,7 +4157,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4161,7 +4219,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4213,7 +4272,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4267,7 +4327,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4331,7 +4392,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4461,7 +4523,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4524,7 +4587,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4650,7 +4714,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4835,7 +4900,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4891,7 +4957,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4944,7 +5011,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4995,7 +5063,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5048,7 +5117,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5110,7 +5180,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5231,7 +5302,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5292,7 +5364,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5343,7 +5416,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5403,7 +5477,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5466,7 +5541,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5521,7 +5597,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5569,7 +5646,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5628,7 +5706,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5691,7 +5770,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5757,7 +5837,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5821,7 +5902,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5884,7 +5966,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5945,7 +6028,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6013,7 +6097,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6074,7 +6159,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6125,7 +6211,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6309,7 +6396,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6372,7 +6460,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6425,7 +6514,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6487,7 +6577,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6538,7 +6629,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6601,7 +6693,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6664,7 +6757,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6730,7 +6824,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6927,7 +7022,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -6988,7 +7084,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7048,7 +7145,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7117,7 +7215,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7167,7 +7266,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7228,7 +7328,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7288,7 +7389,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7356,7 +7458,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7422,7 +7525,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7480,7 +7584,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7551,7 +7656,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7625,7 +7731,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7692,7 +7799,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7752,7 +7860,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7823,7 +7932,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7887,7 +7997,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7950,7 +8061,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8003,7 +8115,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8056,7 +8169,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8107,7 +8221,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8172,7 +8287,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8240,7 +8356,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8303,7 +8420,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8371,7 +8489,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8437,7 +8556,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8500,7 +8620,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8563,7 +8684,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8630,7 +8752,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8694,7 +8817,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8748,7 +8872,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8811,7 +8936,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8921,7 +9047,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8982,7 +9109,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9047,7 +9175,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9111,7 +9240,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9176,7 +9306,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9240,7 +9371,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9304,7 +9436,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9366,7 +9499,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9416,7 +9550,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9674,7 +9809,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9725,7 +9861,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9786,7 +9923,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9839,7 +9977,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9891,7 +10030,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9953,7 +10093,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10006,7 +10147,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10068,7 +10210,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10121,7 +10264,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10185,7 +10329,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10249,7 +10394,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10312,7 +10458,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10375,7 +10522,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10444,7 +10592,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10512,7 +10661,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10580,7 +10730,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10650,7 +10801,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10704,7 +10856,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10770,7 +10923,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10834,7 +10988,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10885,7 +11040,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10954,7 +11110,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11022,7 +11179,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11091,7 +11249,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11161,7 +11320,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11219,7 +11379,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11345,7 +11506,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11413,7 +11575,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11483,7 +11646,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11558,7 +11722,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11627,7 +11792,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11700,7 +11866,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11775,7 +11942,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11829,7 +11997,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11885,7 +12054,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11942,7 +12112,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12002,7 +12173,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12057,7 +12229,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12115,7 +12288,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12168,7 +12342,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12229,7 +12404,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12366,7 +12542,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12427,7 +12604,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12490,7 +12668,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12550,7 +12729,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12604,7 +12784,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12662,7 +12843,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12722,7 +12904,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12784,7 +12967,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12837,7 +13021,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12898,7 +13083,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12953,7 +13139,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -13006,7 +13193,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -13069,7 +13257,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -13137,7 +13326,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -13194,7 +13384,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -13386,7 +13577,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -13447,7 +13639,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -13510,7 +13703,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -13564,7 +13758,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -13626,7 +13821,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -13651,7 +13847,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -13677,7 +13874,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -13702,7 +13900,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -13728,7 +13927,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -13753,7 +13953,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -13778,7 +13979,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -13805,7 +14007,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -13832,7 +14035,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -13857,7 +14061,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -13883,7 +14088,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -13910,7 +14116,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -13935,7 +14142,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -13961,7 +14169,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -13985,7 +14194,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -14010,7 +14220,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -14035,7 +14246,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -14060,7 +14272,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -14085,7 +14298,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -14109,7 +14323,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -14136,7 +14351,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -14160,7 +14376,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -15030,7 +15247,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -15055,7 +15273,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -15081,7 +15300,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -15106,7 +15326,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -15131,7 +15352,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -15156,7 +15378,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -15181,7 +15404,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -15736,7 +15960,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -15761,7 +15986,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -15787,7 +16013,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -15812,7 +16039,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -15837,7 +16065,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -15862,7 +16091,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -15887,7 +16117,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -15951,7 +16182,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -15977,7 +16209,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -16000,7 +16233,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -16020,7 +16254,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swsh8/283.png",
@@ -16039,7 +16274,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/swsh8/284.png",

--- a/cards/en/swsh9.json
+++ b/cards/en/swsh9.json
@@ -54,7 +54,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -121,7 +122,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -174,7 +176,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -234,7 +237,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -293,7 +297,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -357,7 +362,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -422,7 +428,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -489,7 +496,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -544,7 +552,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -608,7 +617,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -673,7 +683,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -734,7 +745,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -911,7 +923,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1178,7 +1191,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1243,7 +1257,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1293,7 +1308,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1419,7 +1435,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1472,7 +1489,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1536,7 +1554,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1597,7 +1616,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1846,7 +1866,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1899,7 +1920,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -1964,7 +1986,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2028,7 +2051,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2093,7 +2117,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2146,7 +2171,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2200,7 +2226,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2259,7 +2286,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2313,7 +2341,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2374,7 +2403,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2493,7 +2523,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2546,7 +2577,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2611,7 +2643,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2674,7 +2707,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -2801,7 +2835,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2865,7 +2900,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -2975,7 +3011,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3029,7 +3066,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3089,7 +3127,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3140,7 +3179,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3203,7 +3243,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3265,7 +3306,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3327,7 +3369,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3395,7 +3438,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3521,7 +3565,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3591,7 +3636,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3650,7 +3696,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3711,7 +3758,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3779,7 +3827,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -3845,7 +3894,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4039,7 +4089,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4089,7 +4140,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4288,7 +4340,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4347,7 +4400,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -4408,7 +4462,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4464,7 +4519,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4517,7 +4573,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4571,7 +4628,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4632,7 +4690,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4696,7 +4755,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4750,7 +4810,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4810,7 +4871,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4874,7 +4936,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4924,7 +4987,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -4990,7 +5054,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5056,7 +5121,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5111,7 +5177,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5173,7 +5240,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5236,7 +5304,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5298,7 +5367,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5425,7 +5495,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5479,7 +5550,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5538,7 +5610,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5601,7 +5674,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5665,7 +5739,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -5727,7 +5802,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6016,7 +6092,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6088,7 +6165,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6159,7 +6237,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6226,7 +6305,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6295,7 +6375,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6367,7 +6448,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6435,7 +6517,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6613,7 +6696,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6662,7 +6746,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6715,7 +6800,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6762,7 +6848,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6821,7 +6908,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6877,7 +6965,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -6934,7 +7023,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7055,7 +7145,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7114,7 +7205,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7173,7 +7265,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7234,7 +7327,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7305,7 +7399,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7360,7 +7455,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7421,7 +7517,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7612,7 +7709,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7673,7 +7771,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7738,7 +7837,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7803,7 +7903,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7893,7 +7994,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7918,7 +8020,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7945,7 +8048,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7970,7 +8074,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -7995,7 +8100,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8020,7 +8126,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8047,7 +8154,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8074,7 +8182,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8098,7 +8207,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8123,7 +8233,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8148,7 +8259,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8173,7 +8285,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8198,7 +8311,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8225,7 +8339,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8250,7 +8365,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8274,7 +8390,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8299,7 +8416,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8326,7 +8444,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8351,7 +8470,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -8376,7 +8496,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8401,7 +8522,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8426,7 +8548,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -8449,7 +8572,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9446,7 +9570,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9471,7 +9596,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9496,7 +9622,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9521,7 +9648,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9546,7 +9674,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9571,7 +9700,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9852,7 +9982,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9877,7 +10008,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9902,7 +10034,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -9927,7 +10060,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -10209,7 +10343,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -10234,7 +10369,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {

--- a/cards/en/swsh9tg.json
+++ b/cards/en/swsh9tg.json
@@ -51,7 +51,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -110,7 +111,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -172,7 +174,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -231,7 +234,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -294,7 +298,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -360,7 +365,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -410,7 +416,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -469,7 +476,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -528,7 +536,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -589,7 +598,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -659,7 +669,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -718,7 +729,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1469,7 +1481,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1494,7 +1507,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1519,7 +1533,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1546,7 +1561,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -1573,7 +1589,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {

--- a/cards/en/swshp.json
+++ b/cards/en/swshp.json
@@ -44,7 +44,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -96,7 +97,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -149,7 +151,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -337,7 +340,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -396,7 +400,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -462,7 +467,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -519,7 +525,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -571,7 +578,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -633,7 +641,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -684,7 +693,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -752,7 +762,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1208,7 +1219,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1333,7 +1345,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1393,7 +1406,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1456,7 +1470,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1516,7 +1531,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1575,7 +1591,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1643,7 +1660,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1713,7 +1731,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1781,7 +1800,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1915,7 +1935,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -1981,7 +2002,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2051,7 +2073,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2117,7 +2140,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2176,7 +2200,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2235,7 +2260,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2296,7 +2322,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2358,7 +2385,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2421,7 +2449,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2489,7 +2518,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2551,7 +2581,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2620,7 +2651,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2868,7 +2900,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2934,7 +2967,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -2998,7 +3032,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3182,7 +3217,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3248,7 +3284,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3312,7 +3349,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3375,7 +3413,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3634,7 +3673,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3693,7 +3733,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -3760,7 +3801,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4147,7 +4189,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4211,7 +4254,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4272,7 +4316,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4341,7 +4386,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4393,7 +4439,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4455,7 +4502,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4515,7 +4563,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4576,7 +4625,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4638,7 +4688,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4701,7 +4752,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -4959,7 +5011,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5010,7 +5063,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5074,7 +5128,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5127,7 +5182,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5513,7 +5569,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5575,7 +5632,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5636,7 +5694,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5704,7 +5763,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -5766,7 +5826,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5828,7 +5889,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5885,7 +5947,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -5955,7 +6018,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7071,7 +7135,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7131,7 +7196,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7197,7 +7263,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7255,7 +7322,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7314,7 +7382,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7377,7 +7446,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7446,7 +7516,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7512,7 +7583,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7536,7 +7608,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7560,7 +7633,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -7624,7 +7698,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7690,7 +7765,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7745,7 +7821,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7805,7 +7882,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7877,7 +7955,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -7948,7 +8027,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8010,7 +8090,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -8072,7 +8153,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -9203,7 +9285,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9532,7 +9615,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -9585,7 +9669,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -10859,7 +10944,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10918,7 +11004,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -10977,7 +11064,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11038,7 +11126,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11092,7 +11181,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11159,7 +11249,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11213,7 +11304,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11280,7 +11372,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11351,7 +11444,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11477,7 +11571,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -11502,7 +11597,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "D",
     "images": {
@@ -11917,7 +12013,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -11977,7 +12074,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -12036,7 +12134,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -12097,7 +12196,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -12152,7 +12252,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12223,7 +12324,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12284,7 +12386,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12346,7 +12449,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -12400,7 +12504,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -13179,7 +13284,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -13245,7 +13351,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -13306,7 +13413,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -13373,7 +13481,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -13436,7 +13545,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -13504,7 +13614,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -13565,7 +13676,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -13636,7 +13748,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -14229,7 +14342,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -14291,7 +14405,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -14344,7 +14459,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -14580,7 +14696,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -14605,7 +14722,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -14630,7 +14748,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -14841,7 +14960,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -14894,7 +15014,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -14947,7 +15068,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -15011,7 +15133,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -15392,7 +15515,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -15457,7 +15581,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -15515,7 +15640,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -15575,7 +15701,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -15639,7 +15766,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -15692,7 +15820,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -15754,7 +15883,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -15819,7 +15949,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -16035,7 +16166,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -17222,7 +17354,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -17281,7 +17414,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -17345,7 +17479,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -17411,7 +17546,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -17471,7 +17607,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -17536,7 +17673,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -17596,7 +17734,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -17658,7 +17797,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -17724,7 +17864,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -17784,7 +17925,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -17844,7 +17986,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -18034,7 +18177,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -18089,7 +18233,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -18149,7 +18294,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -18844,7 +18990,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -18996,7 +19143,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "E",
     "images": {
@@ -19050,7 +19198,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -19105,7 +19254,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {
@@ -19158,7 +19308,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "regulationMark": "F",
     "images": {

--- a/cards/en/tk1a.json
+++ b/cards/en/tk1a.json
@@ -405,7 +405,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/tk1a/8.png",
@@ -427,7 +428,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/tk1a/9.png",
@@ -445,7 +447,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/tk1a/10.png",

--- a/cards/en/tk1b.json
+++ b/cards/en/tk1b.json
@@ -413,7 +413,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/tk1b/8.png",
@@ -435,7 +436,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/tk1b/9.png",
@@ -453,7 +455,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/tk1b/10.png",

--- a/cards/en/tk2a.json
+++ b/cards/en/tk2a.json
@@ -414,7 +414,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/tk2a/8.png",
@@ -436,7 +437,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/tk2a/9.png",
@@ -475,7 +477,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/tk2a/11.png",
@@ -493,7 +496,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/tk2a/12.png",

--- a/cards/en/tk2b.json
+++ b/cards/en/tk2b.json
@@ -451,7 +451,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/tk2b/9.png",
@@ -473,7 +474,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/tk2b/10.png",
@@ -491,7 +493,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/tk2b/11.png",
@@ -509,7 +512,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/tk2b/12.png",

--- a/cards/en/xy0.json
+++ b/cards/en/xy0.json
@@ -42,7 +42,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/1.png",
@@ -102,7 +103,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/2.png",
@@ -162,7 +164,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/3.png",
@@ -226,7 +229,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/4.png",
@@ -291,7 +295,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/5.png",
@@ -343,7 +348,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/6.png",
@@ -403,7 +409,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/7.png",
@@ -463,7 +470,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/8.png",
@@ -526,7 +534,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/9.png",
@@ -588,7 +597,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/10.png",
@@ -648,7 +658,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/11.png",
@@ -708,7 +719,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/12.png",
@@ -770,7 +782,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/13.png",
@@ -829,7 +842,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/14.png",
@@ -880,7 +894,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/15.png",
@@ -937,7 +952,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/16.png",
@@ -992,7 +1008,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/17.png",
@@ -1048,7 +1065,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/18.png",
@@ -1114,7 +1132,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/19.png",
@@ -1179,7 +1198,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/20.png",
@@ -1237,7 +1257,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/21.png",
@@ -1295,7 +1316,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/22.png",
@@ -1363,7 +1385,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/23.png",
@@ -1419,7 +1442,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/24.png",
@@ -1475,7 +1499,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/25.png",
@@ -1539,7 +1564,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/26.png",
@@ -1590,7 +1616,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/27.png",
@@ -1641,7 +1668,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/28.png",
@@ -1694,7 +1722,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/29.png",
@@ -1745,7 +1774,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/30.png",
@@ -1801,7 +1831,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/31.png",
@@ -1860,7 +1891,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/32.png",
@@ -1919,7 +1951,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/33.png",
@@ -1942,7 +1975,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/34.png",
@@ -1965,7 +1999,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/35.png",
@@ -1988,7 +2023,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/36.png",
@@ -2011,7 +2047,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/37.png",
@@ -2034,7 +2071,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/38.png",
@@ -2056,7 +2094,8 @@
     "artist": "Ken Sugimori",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy0/39.png",

--- a/cards/en/xy1.json
+++ b/cards/en/xy1.json
@@ -173,7 +173,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/3.png",
@@ -226,7 +227,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/4.png",
@@ -285,7 +287,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/5.png",
@@ -337,7 +340,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/6.png",
@@ -396,7 +400,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/7.png",
@@ -454,7 +459,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/8.png",
@@ -512,7 +518,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/9.png",
@@ -573,7 +580,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/10.png",
@@ -633,7 +641,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/11.png",
@@ -685,7 +694,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/12.png",
@@ -750,7 +760,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/13.png",
@@ -812,7 +823,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/14.png",
@@ -863,7 +875,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/15.png",
@@ -928,7 +941,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/16.png",
@@ -988,7 +1002,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/17.png",
@@ -1051,7 +1066,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/18.png",
@@ -1112,7 +1128,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/19.png",
@@ -1166,7 +1183,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/20.png",
@@ -1229,7 +1247,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/21.png",
@@ -1290,7 +1309,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/22.png",
@@ -1350,7 +1370,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/23.png",
@@ -1401,7 +1422,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/24.png",
@@ -1463,7 +1485,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/25.png",
@@ -1522,7 +1545,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/26.png",
@@ -1590,7 +1614,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/27.png",
@@ -1651,7 +1676,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/28.png",
@@ -1828,7 +1854,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/31.png",
@@ -1891,7 +1918,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/32.png",
@@ -1943,7 +1971,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/33.png",
@@ -2003,7 +2032,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/34.png",
@@ -2062,7 +2092,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/35.png",
@@ -2120,7 +2151,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/36.png",
@@ -2181,7 +2213,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/37.png",
@@ -2241,7 +2274,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/38.png",
@@ -2292,7 +2326,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/39.png",
@@ -2345,7 +2380,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/40.png",
@@ -2401,7 +2437,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/41.png",
@@ -2468,7 +2505,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/42.png",
@@ -2531,7 +2569,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/43.png",
@@ -2589,7 +2628,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/44.png",
@@ -2648,7 +2688,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/45.png",
@@ -2765,7 +2806,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/47.png",
@@ -2825,7 +2867,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/48.png",
@@ -2876,7 +2919,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/49.png",
@@ -2938,7 +2982,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/50.png",
@@ -2992,7 +3037,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/51.png",
@@ -3047,7 +3093,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/52.png",
@@ -3110,7 +3157,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/53.png",
@@ -3179,7 +3227,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/54.png",
@@ -3245,7 +3294,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/55.png",
@@ -3303,7 +3353,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/56.png",
@@ -3369,7 +3420,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/57.png",
@@ -3430,7 +3482,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/58.png",
@@ -3490,7 +3543,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/59.png",
@@ -3554,7 +3608,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/60.png",
@@ -3622,7 +3677,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/61.png",
@@ -3686,7 +3742,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/62.png",
@@ -3744,7 +3801,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/63.png",
@@ -3804,7 +3862,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/64.png",
@@ -3857,7 +3916,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/65.png",
@@ -3923,7 +3983,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/66.png",
@@ -3985,7 +4046,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/67.png",
@@ -4037,7 +4099,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/68.png",
@@ -4108,7 +4171,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/69.png",
@@ -4180,7 +4244,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/70.png",
@@ -4251,7 +4316,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/71.png",
@@ -4318,7 +4384,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/72.png",
@@ -4384,7 +4451,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/73.png",
@@ -4448,7 +4516,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/74.png",
@@ -4515,7 +4584,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/75.png",
@@ -4581,7 +4651,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/76.png",
@@ -4648,7 +4719,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/77.png",
@@ -4714,7 +4786,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/78.png",
@@ -4920,7 +4993,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/81.png",
@@ -4986,7 +5060,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/82.png",
@@ -5044,7 +5119,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/83.png",
@@ -5104,7 +5180,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/84.png",
@@ -5171,7 +5248,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/85.png",
@@ -5238,7 +5316,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/86.png",
@@ -5304,7 +5383,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/87.png",
@@ -5363,7 +5443,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/88.png",
@@ -5429,7 +5510,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/89.png",
@@ -5496,7 +5578,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/90.png",
@@ -5563,7 +5646,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/91.png",
@@ -5630,7 +5714,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/92.png",
@@ -5695,7 +5780,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/93.png",
@@ -5762,7 +5848,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/94.png",
@@ -5826,7 +5913,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/95.png",
@@ -5892,7 +5980,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/96.png",
@@ -6023,7 +6112,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/98.png",
@@ -6089,7 +6179,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/99.png",
@@ -6149,7 +6240,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/100.png",
@@ -6203,7 +6295,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/101.png",
@@ -6261,7 +6354,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/102.png",
@@ -6325,7 +6419,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/103.png",
@@ -6385,7 +6480,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/104.png",
@@ -6444,7 +6540,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/105.png",
@@ -6498,7 +6595,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/106.png",
@@ -6561,7 +6659,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/107.png",
@@ -6622,7 +6721,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/108.png",
@@ -6686,7 +6786,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/109.png",
@@ -6751,7 +6852,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/110.png",
@@ -6803,7 +6905,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/111.png",
@@ -6865,7 +6968,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/112.png",
@@ -6932,7 +7036,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/113.png",
@@ -6989,7 +7094,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/114.png",
@@ -7012,7 +7118,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/115.png",
@@ -7035,7 +7142,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/116.png",
@@ -7058,7 +7166,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/117.png",
@@ -7082,7 +7191,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/118.png",
@@ -7106,7 +7216,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/119.png",
@@ -7129,7 +7240,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/120.png",
@@ -7153,7 +7265,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/121.png",
@@ -7176,7 +7289,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/122.png",
@@ -7199,7 +7313,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/123.png",
@@ -7222,7 +7337,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/124.png",
@@ -7245,7 +7361,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/125.png",
@@ -7268,7 +7385,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/126.png",
@@ -7292,7 +7410,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/127.png",
@@ -7315,7 +7434,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/128.png",
@@ -7338,7 +7458,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/129.png",
@@ -7360,7 +7481,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/130.png",
@@ -7382,7 +7504,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/131.png",
@@ -7401,7 +7524,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/132.png",
@@ -7420,7 +7544,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/133.png",
@@ -7439,7 +7564,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/134.png",
@@ -7458,7 +7584,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/135.png",
@@ -7477,7 +7604,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/136.png",
@@ -7496,7 +7624,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/137.png",
@@ -7515,7 +7644,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/138.png",
@@ -7534,7 +7664,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/139.png",
@@ -7552,7 +7683,8 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy1/140.png",

--- a/cards/en/xy10.json
+++ b/cards/en/xy10.json
@@ -50,7 +50,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/1.png",
@@ -101,7 +102,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/2.png",
@@ -162,7 +164,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/3.png",
@@ -222,7 +225,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/4.png",
@@ -273,7 +277,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/5.png",
@@ -332,7 +337,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/6.png",
@@ -391,7 +397,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/7.png",
@@ -442,7 +449,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/8.png",
@@ -508,7 +516,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/9.png",
@@ -569,7 +578,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/10.png",
@@ -620,7 +630,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/11.png",
@@ -682,7 +693,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/12.png",
@@ -743,7 +755,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/13.png",
@@ -832,7 +845,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/15.png",
@@ -895,7 +909,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/16.png",
@@ -951,7 +966,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/17.png",
@@ -1009,7 +1025,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/18.png",
@@ -1172,7 +1189,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/21.png",
@@ -1225,7 +1243,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/22.png",
@@ -1285,7 +1304,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/23.png",
@@ -1349,7 +1369,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/24.png",
@@ -1518,7 +1539,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/27.png",
@@ -1581,7 +1603,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/28.png",
@@ -1632,7 +1655,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/29.png",
@@ -1683,7 +1707,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/30.png",
@@ -1743,7 +1768,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/31.png",
@@ -1795,7 +1821,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/32.png",
@@ -1847,7 +1874,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/33.png",
@@ -1900,7 +1928,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/34.png",
@@ -1950,7 +1979,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/35.png",
@@ -1997,7 +2027,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/36.png",
@@ -2055,7 +2086,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/37.png",
@@ -2110,7 +2142,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/38.png",
@@ -2172,7 +2205,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/39.png",
@@ -2223,7 +2257,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/40.png",
@@ -2284,7 +2319,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/41.png",
@@ -2336,7 +2372,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/42.png",
@@ -2521,7 +2558,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/44.png",
@@ -2572,7 +2610,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/45.png",
@@ -2623,7 +2662,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/46.png",
@@ -2683,7 +2723,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/47.png",
@@ -2747,7 +2788,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/48.png",
@@ -2804,7 +2846,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/49.png",
@@ -2860,7 +2903,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/50.png",
@@ -2960,7 +3004,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/52.png",
@@ -3021,7 +3066,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/53.png",
@@ -3306,7 +3352,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/56.png",
@@ -3374,7 +3421,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/57.png",
@@ -3440,7 +3488,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/58.png",
@@ -3507,7 +3556,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/59.png",
@@ -3575,7 +3625,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/60.png",
@@ -3641,7 +3692,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/61.png",
@@ -3749,7 +3801,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/63.png",
@@ -3884,7 +3937,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/65.png",
@@ -3952,7 +4006,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/66.png",
@@ -4016,7 +4071,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/67.png",
@@ -4075,7 +4131,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/68.png",
@@ -4194,7 +4251,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/70.png",
@@ -4245,7 +4303,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/71.png",
@@ -4430,7 +4489,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/74.png",
@@ -4493,7 +4553,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/75.png",
@@ -4557,7 +4618,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/76.png",
@@ -4622,7 +4684,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/77.png",
@@ -4686,7 +4749,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/78.png",
@@ -4792,7 +4856,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/80.png",
@@ -4856,7 +4921,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/81.png",
@@ -4920,7 +4986,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/82.png",
@@ -5167,7 +5234,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/86.png",
@@ -5218,7 +5286,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/87.png",
@@ -5276,7 +5345,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/88.png",
@@ -5335,7 +5405,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/89.png",
@@ -5359,7 +5430,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/90.png",
@@ -5383,7 +5455,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/91.png",
@@ -5407,7 +5480,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/92.png",
@@ -5431,7 +5505,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/93.png",
@@ -5455,7 +5530,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/94.png",
@@ -5478,7 +5554,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/95.png",
@@ -5501,7 +5578,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/96.png",
@@ -5525,7 +5603,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/97.png",
@@ -5548,7 +5627,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/98.png",
@@ -5571,7 +5651,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/99.png",
@@ -5594,7 +5675,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/100.png",
@@ -5617,7 +5699,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/101.png",
@@ -5640,7 +5723,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/102.png",
@@ -5663,7 +5747,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/103.png",
@@ -5686,7 +5771,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/104.png",
@@ -5709,7 +5795,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/105.png",
@@ -5732,7 +5819,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/105a.png",
@@ -5755,7 +5843,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/106.png",
@@ -5778,7 +5867,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/107.png",
@@ -5815,7 +5905,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/108.png",
@@ -5838,7 +5929,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/109.png",
@@ -5861,7 +5953,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/110.png",
@@ -5885,7 +5978,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/111.png",
@@ -5908,7 +6002,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/111a.png",
@@ -5931,7 +6026,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/112.png",
@@ -5955,7 +6051,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/113.png",
@@ -5977,7 +6074,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/114.png",
@@ -6001,7 +6099,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/115.png",
@@ -6537,7 +6636,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy10/124.png",

--- a/cards/en/xy11.json
+++ b/cards/en/xy11.json
@@ -57,7 +57,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/1.png",
@@ -123,7 +124,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/2.png",
@@ -174,7 +176,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/3.png",
@@ -226,7 +229,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/4.png",
@@ -284,7 +288,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/5.png",
@@ -352,7 +357,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/6.png",
@@ -412,7 +418,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/7.png",
@@ -506,7 +513,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/9.png",
@@ -568,7 +576,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/10.png",
@@ -629,7 +638,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/11.png",
@@ -687,7 +697,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/12.png",
@@ -747,7 +758,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/13.png",
@@ -800,7 +812,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/14.png",
@@ -861,7 +874,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/15.png",
@@ -921,7 +935,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/16.png",
@@ -980,7 +995,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/17.png",
@@ -1041,7 +1057,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/18.png",
@@ -1103,7 +1120,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/19.png",
@@ -1163,7 +1181,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/20.png",
@@ -1257,7 +1276,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/22.png",
@@ -1319,7 +1339,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/23.png",
@@ -1422,7 +1443,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/25.png",
@@ -1550,7 +1572,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/27.png",
@@ -1602,7 +1625,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/28.png",
@@ -1663,7 +1687,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/29.png",
@@ -1715,7 +1740,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/30.png",
@@ -1769,7 +1795,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/31.png",
@@ -1831,7 +1858,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/32.png",
@@ -1882,7 +1910,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/33.png",
@@ -1941,7 +1970,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/34.png",
@@ -2044,7 +2074,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/36.png",
@@ -2108,7 +2139,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/37.png",
@@ -2175,7 +2207,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/38.png",
@@ -2245,7 +2278,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/39.png",
@@ -2310,7 +2344,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/40.png",
@@ -2363,7 +2398,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/41.png",
@@ -2428,7 +2464,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/42.png",
@@ -2489,7 +2526,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/43.png",
@@ -2554,7 +2592,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/44.png",
@@ -2615,7 +2654,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/45.png",
@@ -2672,7 +2712,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/46.png",
@@ -2738,7 +2779,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/47.png",
@@ -2795,7 +2837,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/48.png",
@@ -2863,7 +2906,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/49.png",
@@ -2927,7 +2971,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/50.png",
@@ -2987,7 +3032,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/51.png",
@@ -3047,7 +3093,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/52.png",
@@ -3106,7 +3153,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/53.png",
@@ -3169,7 +3217,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/54.png",
@@ -3232,7 +3281,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/55.png",
@@ -3294,7 +3344,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/56.png",
@@ -3355,7 +3406,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/57.png",
@@ -3406,7 +3458,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/58.png",
@@ -3464,7 +3517,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/59.png",
@@ -3521,7 +3575,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/60.png",
@@ -3584,7 +3639,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/61.png",
@@ -3636,7 +3692,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/62.png",
@@ -3693,7 +3750,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/63.png",
@@ -3760,7 +3818,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/64.png",
@@ -3826,7 +3885,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/65.png",
@@ -4089,7 +4149,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/69.png",
@@ -4160,7 +4221,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/70.png",
@@ -4218,7 +4280,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/71.png",
@@ -4289,7 +4352,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/72.png",
@@ -4355,7 +4419,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/73.png",
@@ -4420,7 +4485,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/74.png",
@@ -4543,7 +4609,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/76.png",
@@ -4612,7 +4679,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/77.png",
@@ -4809,7 +4877,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/80.png",
@@ -4875,7 +4944,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/81.png",
@@ -4978,7 +5048,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/83.png",
@@ -5040,7 +5111,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/84.png",
@@ -5105,7 +5177,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/85.png",
@@ -5168,7 +5241,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/86.png",
@@ -5273,7 +5347,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/88.png",
@@ -5332,7 +5407,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/89.png",
@@ -5393,7 +5469,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/90.png",
@@ -5453,7 +5530,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/91.png",
@@ -5510,7 +5588,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/92.png",
@@ -5578,7 +5657,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/93.png",
@@ -5635,7 +5715,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/94.png",
@@ -5693,7 +5774,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/95.png",
@@ -5751,7 +5833,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/96.png",
@@ -5813,7 +5896,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/97.png",
@@ -5836,7 +5920,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/98.png",
@@ -5859,7 +5944,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/99.png",
@@ -5882,7 +5968,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/100.png",
@@ -5906,7 +5993,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/101.png",
@@ -5930,7 +6018,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/102.png",
@@ -5953,7 +6042,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/103.png",
@@ -5976,7 +6066,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/104.png",
@@ -5999,7 +6090,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/105.png",
@@ -6023,7 +6115,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/106.png",
@@ -6456,7 +6549,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/113.png",
@@ -6479,7 +6573,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy11/114.png",

--- a/cards/en/xy12.json
+++ b/cards/en/xy12.json
@@ -174,7 +174,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/3.png",
@@ -239,7 +240,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/4.png",
@@ -291,7 +293,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/5.png",
@@ -356,7 +359,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/6.png",
@@ -412,7 +416,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/7.png",
@@ -477,7 +482,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/8.png",
@@ -539,7 +545,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/9.png",
@@ -605,7 +612,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/10.png",
@@ -673,7 +681,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/11.png",
@@ -852,7 +861,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/14.png",
@@ -913,7 +923,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/15.png",
@@ -1018,7 +1029,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/17.png",
@@ -1079,7 +1091,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/18.png",
@@ -1142,7 +1155,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/19.png",
@@ -1207,7 +1221,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/20.png",
@@ -1385,7 +1400,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/23.png",
@@ -1451,7 +1467,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/24.png",
@@ -1513,7 +1530,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/25.png",
@@ -1701,7 +1719,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/28.png",
@@ -1764,7 +1783,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/29.png",
@@ -1816,7 +1836,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/30.png",
@@ -1874,7 +1895,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/31.png",
@@ -1967,7 +1989,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/33.png",
@@ -2033,7 +2056,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/34.png",
@@ -2101,7 +2125,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/35.png",
@@ -2168,7 +2193,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/36.png",
@@ -2236,7 +2262,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/37.png",
@@ -2307,7 +2334,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/38.png",
@@ -2365,7 +2393,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/39.png",
@@ -2430,7 +2459,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/40.png",
@@ -2499,7 +2529,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/41.png",
@@ -2564,7 +2595,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/42.png",
@@ -2616,7 +2648,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/43.png",
@@ -2681,7 +2714,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/44.png",
@@ -2745,7 +2779,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/45.png",
@@ -2856,7 +2891,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/47.png",
@@ -2925,7 +2961,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/48.png",
@@ -2987,7 +3024,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/49.png",
@@ -3040,7 +3078,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/50.png",
@@ -3101,7 +3140,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/51.png",
@@ -3234,7 +3274,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/53.png",
@@ -3286,7 +3327,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/54.png",
@@ -3346,7 +3388,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/55.png",
@@ -3408,7 +3451,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/56.png",
@@ -3462,7 +3506,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/57.png",
@@ -3528,7 +3573,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/58.png",
@@ -3588,7 +3634,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/59.png",
@@ -3695,7 +3742,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/61.png",
@@ -3756,7 +3804,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/62.png",
@@ -3825,7 +3874,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/63.png",
@@ -4012,7 +4062,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/66.png",
@@ -4071,7 +4122,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/67.png",
@@ -4140,7 +4192,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/68.png",
@@ -4198,7 +4251,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/69.png",
@@ -4265,7 +4319,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/70.png",
@@ -4317,7 +4372,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/71.png",
@@ -4410,7 +4466,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/73.png",
@@ -4433,7 +4490,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/74.png",
@@ -4457,7 +4515,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/75.png",
@@ -4480,7 +4539,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/76.png",
@@ -4504,7 +4564,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/77.png",
@@ -4527,7 +4588,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/78.png",
@@ -4550,7 +4612,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/79.png",
@@ -4573,7 +4636,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/80.png",
@@ -4597,7 +4661,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/81.png",
@@ -4620,7 +4685,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/82.png",
@@ -4644,7 +4710,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/83.png",
@@ -4667,7 +4734,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/84.png",
@@ -4690,7 +4758,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/85.png",
@@ -4714,7 +4783,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/86.png",
@@ -4737,7 +4807,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/87.png",
@@ -4761,7 +4832,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/88.png",
@@ -4785,7 +4857,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/89.png",
@@ -4807,7 +4880,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/90.png",
@@ -4826,7 +4900,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/91.png",
@@ -4845,7 +4920,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/92.png",
@@ -4864,7 +4940,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/93.png",
@@ -4883,7 +4960,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/94.png",
@@ -4902,7 +4980,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/95.png",
@@ -4921,7 +5000,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/96.png",
@@ -4940,7 +5020,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/97.png",
@@ -4959,7 +5040,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/98.png",
@@ -4977,7 +5059,8 @@
     "rarity": "Common",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/99.png",
@@ -5446,7 +5529,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/107.png",
@@ -5469,7 +5553,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/108.png",
@@ -5520,7 +5605,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/109.png",
@@ -5583,7 +5669,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/110.png",
@@ -5636,7 +5723,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/111.png",
@@ -5697,7 +5785,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/112.png",
@@ -5720,7 +5809,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy12/113.png",

--- a/cards/en/xy2.json
+++ b/cards/en/xy2.json
@@ -50,7 +50,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/1.png",
@@ -111,7 +112,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/2.png",
@@ -177,7 +179,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/3.png",
@@ -230,7 +233,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/4.png",
@@ -281,7 +285,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/5.png",
@@ -344,7 +349,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/6.png",
@@ -403,7 +409,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/7.png",
@@ -464,7 +471,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/8.png",
@@ -524,7 +532,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/9.png",
@@ -582,7 +591,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/10.png",
@@ -836,7 +846,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/14.png",
@@ -891,7 +902,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/15.png",
@@ -951,7 +963,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/16.png",
@@ -1009,7 +1022,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/17.png",
@@ -1063,7 +1077,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/18.png",
@@ -1116,7 +1131,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/19.png",
@@ -1175,7 +1191,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/20.png",
@@ -1231,7 +1248,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/21.png",
@@ -1282,7 +1300,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/22.png",
@@ -1341,7 +1360,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/23.png",
@@ -1394,7 +1414,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/24.png",
@@ -1460,7 +1481,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/25.png",
@@ -1526,7 +1548,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/26.png",
@@ -1584,7 +1607,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/27.png",
@@ -1645,7 +1669,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/28.png",
@@ -1704,7 +1729,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/29.png",
@@ -1767,7 +1793,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/30.png",
@@ -1833,7 +1860,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/31.png",
@@ -1900,7 +1928,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/32.png",
@@ -1969,7 +1998,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/33.png",
@@ -2036,7 +2066,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/34.png",
@@ -2174,7 +2205,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/36.png",
@@ -2240,7 +2272,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/37.png",
@@ -2306,7 +2339,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/38.png",
@@ -2376,7 +2410,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/39.png",
@@ -2442,7 +2477,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/40.png",
@@ -2566,7 +2602,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/42.png",
@@ -2626,7 +2663,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/43.png",
@@ -2677,7 +2715,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/44.png",
@@ -2739,7 +2778,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/45.png",
@@ -2807,7 +2847,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/46.png",
@@ -2872,7 +2913,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/47.png",
@@ -2926,7 +2968,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/48.png",
@@ -2988,7 +3031,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/49.png",
@@ -3055,7 +3099,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/50.png",
@@ -3122,7 +3167,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/51.png",
@@ -3188,7 +3234,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/52.png",
@@ -3255,7 +3302,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/53.png",
@@ -3323,7 +3371,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/54.png",
@@ -3391,7 +3440,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/55.png",
@@ -3450,7 +3500,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/56.png",
@@ -3520,7 +3571,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/57.png",
@@ -3579,7 +3631,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/58.png",
@@ -3647,7 +3700,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/59.png",
@@ -3712,7 +3766,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/60.png",
@@ -3776,7 +3831,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/61.png",
@@ -3833,7 +3889,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/62.png",
@@ -3890,7 +3947,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/63.png",
@@ -3955,7 +4013,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/64.png",
@@ -4023,7 +4082,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/65.png",
@@ -4087,7 +4147,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/66.png",
@@ -4154,7 +4215,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/67.png",
@@ -4220,7 +4282,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/68.png",
@@ -4341,7 +4404,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/70.png",
@@ -4399,7 +4463,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/71.png",
@@ -4461,7 +4526,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/72.png",
@@ -4526,7 +4592,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/73.png",
@@ -4586,7 +4653,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/74.png",
@@ -4643,7 +4711,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/75.png",
@@ -4711,7 +4780,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/76.png",
@@ -4778,7 +4848,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/77.png",
@@ -4963,7 +5034,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/80.png",
@@ -5024,7 +5096,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/81.png",
@@ -5083,7 +5156,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/82.png",
@@ -5143,7 +5217,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/83.png",
@@ -5195,7 +5270,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/84.png",
@@ -5253,7 +5329,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/85.png",
@@ -5310,7 +5387,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/86.png",
@@ -5370,7 +5448,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/87.png",
@@ -5393,7 +5472,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/88.png",
@@ -5416,7 +5496,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/88a.png",
@@ -5439,7 +5520,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/89.png",
@@ -5462,7 +5544,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/90.png",
@@ -5485,7 +5568,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/91.png",
@@ -5509,7 +5593,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/92.png",
@@ -5532,7 +5617,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/93.png",
@@ -5555,7 +5641,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/94.png",
@@ -5579,7 +5666,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/95.png",
@@ -5602,7 +5690,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/96.png",
@@ -5625,7 +5714,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/97.png",
@@ -5648,7 +5738,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/98.png",
@@ -5672,7 +5763,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/99.png",
@@ -5963,7 +6055,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/104.png",
@@ -5986,7 +6079,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/105.png",
@@ -6009,7 +6103,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy2/106.png",

--- a/cards/en/xy3.json
+++ b/cards/en/xy3.json
@@ -53,7 +53,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/1.png",
@@ -118,7 +119,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/2.png",
@@ -177,7 +179,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/3.png",
@@ -353,7 +356,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/6.png",
@@ -413,7 +417,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/7.png",
@@ -466,7 +471,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/8.png",
@@ -521,7 +527,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/9.png",
@@ -583,7 +590,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/10.png",
@@ -646,7 +654,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/11.png",
@@ -698,7 +707,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/12.png",
@@ -762,7 +772,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/13.png",
@@ -825,7 +836,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/14.png",
@@ -887,7 +899,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/15.png",
@@ -951,7 +964,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/16.png",
@@ -1016,7 +1030,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/17.png",
@@ -1074,7 +1089,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/18.png",
@@ -1134,7 +1150,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/19.png",
@@ -1262,7 +1279,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/21.png",
@@ -1327,7 +1345,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/22.png",
@@ -1389,7 +1408,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/23.png",
@@ -1450,7 +1470,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/24.png",
@@ -1518,7 +1539,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/25.png",
@@ -1579,7 +1601,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/26.png",
@@ -1637,7 +1660,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/27.png",
@@ -1704,7 +1728,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/28.png",
@@ -1772,7 +1797,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/29.png",
@@ -1840,7 +1866,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/30.png",
@@ -1904,7 +1931,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/31.png",
@@ -1967,7 +1995,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/32.png",
@@ -2033,7 +2062,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/33.png",
@@ -2096,7 +2126,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/34.png",
@@ -2158,7 +2189,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/35.png",
@@ -2219,7 +2251,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/36.png",
@@ -2276,7 +2309,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/37.png",
@@ -2339,7 +2373,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/38.png",
@@ -2400,7 +2435,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/39.png",
@@ -2462,7 +2498,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/40.png",
@@ -2521,7 +2558,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/41.png",
@@ -2592,7 +2630,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/42.png",
@@ -2664,7 +2703,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/43.png",
@@ -2716,7 +2756,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/44.png",
@@ -2770,7 +2811,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/45.png",
@@ -2829,7 +2871,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/46.png",
@@ -2887,7 +2930,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/47.png",
@@ -2947,7 +2991,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/48.png",
@@ -3006,7 +3051,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/49.png",
@@ -3068,7 +3114,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/50.png",
@@ -3132,7 +3179,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/51.png",
@@ -3193,7 +3241,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/52.png",
@@ -3254,7 +3303,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/53.png",
@@ -3503,7 +3553,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/56.png",
@@ -3562,7 +3613,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/57.png",
@@ -3621,7 +3673,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/58.png",
@@ -3683,7 +3736,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/59.png",
@@ -3736,7 +3790,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/60.png",
@@ -3804,7 +3859,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/61.png",
@@ -3869,7 +3925,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/62.png",
@@ -3926,7 +3983,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/63.png",
@@ -4061,7 +4119,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/65.png",
@@ -4120,7 +4179,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/66.png",
@@ -4187,7 +4247,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/67.png",
@@ -4256,7 +4317,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/68.png",
@@ -4323,7 +4385,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/69.png",
@@ -4380,7 +4443,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/70.png",
@@ -4446,7 +4510,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/71.png",
@@ -4512,7 +4577,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/72.png",
@@ -4574,7 +4640,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/73.png",
@@ -4698,7 +4765,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/75.png",
@@ -4758,7 +4826,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/76.png",
@@ -4816,7 +4885,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/77.png",
@@ -4871,7 +4941,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/78.png",
@@ -4937,7 +5008,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/79.png",
@@ -5003,7 +5075,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/80.png",
@@ -5057,7 +5130,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/81.png",
@@ -5121,7 +5195,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/82.png",
@@ -5187,7 +5262,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/83.png",
@@ -5238,7 +5314,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/84.png",
@@ -5297,7 +5374,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/85.png",
@@ -5363,7 +5441,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/86.png",
@@ -5430,7 +5509,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/87.png",
@@ -5453,7 +5533,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/88.png",
@@ -5477,7 +5558,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/89.png",
@@ -5500,7 +5582,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/90.png",
@@ -5524,7 +5607,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/91.png",
@@ -5547,7 +5631,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/92.png",
@@ -5570,7 +5655,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/93.png",
@@ -5593,7 +5679,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/94.png",
@@ -5616,7 +5703,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/95.png",
@@ -5639,7 +5727,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/96.png",
@@ -5662,7 +5751,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/97.png",
@@ -5685,7 +5775,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/98.png",
@@ -5709,7 +5800,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/99.png",
@@ -5732,7 +5824,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/100.png",
@@ -5755,7 +5848,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/101.png",
@@ -5778,7 +5872,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/102.png",
@@ -5800,7 +5895,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/103.png",
@@ -5824,7 +5920,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/104.png",
@@ -6118,7 +6215,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/109.png",
@@ -6141,7 +6239,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/110.png",
@@ -6164,7 +6263,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy3/111.png",

--- a/cards/en/xy4.json
+++ b/cards/en/xy4.json
@@ -44,7 +44,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/1.png",
@@ -104,7 +105,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/2.png",
@@ -162,7 +164,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/3.png",
@@ -224,7 +227,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/4.png",
@@ -285,7 +289,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/5.png",
@@ -348,7 +353,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/6.png",
@@ -408,7 +414,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/7.png",
@@ -469,7 +476,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/8.png",
@@ -538,7 +546,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/9.png",
@@ -604,7 +613,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/10.png",
@@ -666,7 +676,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/11.png",
@@ -726,7 +737,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/12.png",
@@ -789,7 +801,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/13.png",
@@ -852,7 +865,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/14.png",
@@ -903,7 +917,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/15.png",
@@ -968,7 +983,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/16.png",
@@ -1033,7 +1049,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/17.png",
@@ -1084,7 +1101,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/18.png",
@@ -1143,7 +1161,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/19.png",
@@ -1195,7 +1214,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/20.png",
@@ -1257,7 +1277,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/21.png",
@@ -1319,7 +1340,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/22.png",
@@ -1565,7 +1587,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/25.png",
@@ -1632,7 +1655,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/26.png",
@@ -1698,7 +1722,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/27.png",
@@ -1756,7 +1781,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/28.png",
@@ -1824,7 +1850,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/29.png",
@@ -1889,7 +1916,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/30.png",
@@ -1946,7 +1974,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/31.png",
@@ -2007,7 +2036,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/32.png",
@@ -2065,7 +2095,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/33.png",
@@ -2255,7 +2286,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/36.png",
@@ -2318,7 +2350,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/37.png",
@@ -2381,7 +2414,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/38.png",
@@ -2443,7 +2477,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/39.png",
@@ -2503,7 +2538,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/40.png",
@@ -2560,7 +2596,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/41.png",
@@ -2630,7 +2667,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/42.png",
@@ -2695,7 +2733,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/43.png",
@@ -2764,7 +2803,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/44.png",
@@ -2830,7 +2870,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/45.png",
@@ -2882,7 +2923,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/46.png",
@@ -2942,7 +2984,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/47.png",
@@ -2996,7 +3039,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/48.png",
@@ -3061,7 +3105,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/49.png",
@@ -3122,7 +3167,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/50.png",
@@ -3190,7 +3236,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/51.png",
@@ -3256,7 +3303,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/52.png",
@@ -3323,7 +3371,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/53.png",
@@ -3390,7 +3439,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/54.png",
@@ -3442,7 +3492,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/55.png",
@@ -3499,7 +3550,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/56.png",
@@ -3564,7 +3616,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/57.png",
@@ -3696,7 +3749,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/59.png",
@@ -3753,7 +3807,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/60.png",
@@ -3819,7 +3874,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/61.png",
@@ -3961,7 +4017,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/63.png",
@@ -4029,7 +4086,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/64.png",
@@ -4229,7 +4287,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/66.png",
@@ -4364,7 +4423,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/68.png",
@@ -4428,7 +4488,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/69.png",
@@ -4493,7 +4554,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/70.png",
@@ -4558,7 +4620,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/71.png",
@@ -4610,7 +4673,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/72.png",
@@ -4664,7 +4728,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/73.png",
@@ -4725,7 +4790,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/74.png",
@@ -4787,7 +4853,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/75.png",
@@ -4852,7 +4919,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/76.png",
@@ -4913,7 +4981,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/77.png",
@@ -4970,7 +5039,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/78.png",
@@ -5037,7 +5107,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/79.png",
@@ -5101,7 +5172,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/80.png",
@@ -5166,7 +5238,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/81.png",
@@ -5226,7 +5299,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/82.png",
@@ -5277,7 +5351,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/83.png",
@@ -5342,7 +5417,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/84.png",
@@ -5406,7 +5482,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/85.png",
@@ -5471,7 +5548,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/86.png",
@@ -5533,7 +5611,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/87.png",
@@ -5595,7 +5674,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/88.png",
@@ -5662,7 +5742,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/89.png",
@@ -5722,7 +5803,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/90.png",
@@ -5745,7 +5827,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/91.png",
@@ -5768,7 +5851,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/92.png",
@@ -5791,7 +5875,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/93.png",
@@ -5814,7 +5899,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/94.png",
@@ -5838,7 +5924,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/95.png",
@@ -5861,7 +5948,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/96.png",
@@ -5886,7 +5974,8 @@
     "rarity": "Rare Holo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/97.png",
@@ -5911,7 +6000,8 @@
     "rarity": "Rare Holo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/98.png",
@@ -5934,7 +6024,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Banned"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/99.png",
@@ -5958,7 +6049,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/100.png",
@@ -5981,7 +6073,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/101.png",
@@ -6005,7 +6098,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/102.png",
@@ -6028,7 +6122,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/103.png",
@@ -6052,7 +6147,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/104.png",
@@ -6075,7 +6171,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/105.png",
@@ -6098,7 +6195,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/106.png",
@@ -6121,7 +6219,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/107.png",
@@ -6145,7 +6244,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/108.png",
@@ -6168,7 +6268,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/109.png",
@@ -6191,7 +6292,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/110.png",
@@ -6213,7 +6315,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/111.png",
@@ -6237,7 +6340,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/112.png",
@@ -6536,7 +6640,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/117.png",
@@ -6559,7 +6664,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Banned"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/118.png",
@@ -6582,7 +6688,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy4/119.png",

--- a/cards/en/xy5.json
+++ b/cards/en/xy5.json
@@ -43,7 +43,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/1.png",
@@ -97,7 +98,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/2.png",
@@ -152,7 +154,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/3.png",
@@ -216,7 +219,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/4.png",
@@ -282,7 +286,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/5.png",
@@ -333,7 +338,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/6.png",
@@ -396,7 +402,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/7.png",
@@ -455,7 +462,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/8.png",
@@ -520,7 +528,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/9.png",
@@ -572,7 +581,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/10.png",
@@ -635,7 +645,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/11.png",
@@ -694,7 +705,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/12.png",
@@ -745,7 +757,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/13.png",
@@ -804,7 +817,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/14.png",
@@ -855,7 +869,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/15.png",
@@ -917,7 +932,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/16.png",
@@ -975,7 +991,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/17.png",
@@ -1032,7 +1049,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/18.png",
@@ -1156,7 +1174,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/20.png",
@@ -1214,7 +1233,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/21.png",
@@ -1278,7 +1298,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/22.png",
@@ -1341,7 +1362,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/23.png",
@@ -1408,7 +1430,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/24.png",
@@ -1459,7 +1482,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/25.png",
@@ -1523,7 +1547,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/26.png",
@@ -1585,7 +1610,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/27.png",
@@ -1644,7 +1670,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/28.png",
@@ -1765,7 +1792,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/30.png",
@@ -1827,7 +1855,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/31.png",
@@ -1878,7 +1907,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/32.png",
@@ -1939,7 +1969,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/33.png",
@@ -2005,7 +2036,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/34.png",
@@ -2070,7 +2102,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/35.png",
@@ -2134,7 +2167,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/36.png",
@@ -2199,7 +2233,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/37.png",
@@ -2317,7 +2352,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/39.png",
@@ -2379,7 +2415,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/40.png",
@@ -2449,7 +2486,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/41.png",
@@ -2510,7 +2548,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/42.png",
@@ -2561,7 +2600,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/43.png",
@@ -2620,7 +2660,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/44.png",
@@ -2673,7 +2714,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/45.png",
@@ -2726,7 +2768,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/46.png",
@@ -2792,7 +2835,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/47.png",
@@ -2857,7 +2901,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/48.png",
@@ -2910,7 +2955,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/49.png",
@@ -2970,7 +3016,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/50.png",
@@ -3025,7 +3072,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/51.png",
@@ -3079,7 +3127,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/52.png",
@@ -3143,7 +3192,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/53.png",
@@ -3330,7 +3380,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/56.png",
@@ -3389,7 +3440,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/57.png",
@@ -3457,7 +3509,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/58.png",
@@ -3524,7 +3577,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/59.png",
@@ -3585,7 +3639,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/60.png",
@@ -3652,7 +3707,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/61.png",
@@ -3709,7 +3765,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/62.png",
@@ -3780,7 +3837,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/63.png",
@@ -3845,7 +3903,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/64.png",
@@ -3912,7 +3971,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/65.png",
@@ -3973,7 +4033,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/66.png",
@@ -4037,7 +4098,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/67.png",
@@ -4100,7 +4162,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/68.png",
@@ -4165,7 +4228,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/69.png",
@@ -4216,7 +4280,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/70.png",
@@ -4272,7 +4337,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/71.png",
@@ -4333,7 +4399,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/72.png",
@@ -4378,7 +4445,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/73.png",
@@ -4432,7 +4500,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/74.png",
@@ -4501,7 +4570,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/75.png",
@@ -4567,7 +4637,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/76.png",
@@ -4633,7 +4704,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/77.png",
@@ -4698,7 +4770,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/78.png",
@@ -4749,7 +4822,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/79.png",
@@ -4809,7 +4883,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/80.png",
@@ -4872,7 +4947,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/81.png",
@@ -4933,7 +5009,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/82.png",
@@ -4991,7 +5068,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/83.png",
@@ -5055,7 +5133,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/84.png",
@@ -5250,7 +5329,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/87.png",
@@ -5316,7 +5396,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/88.png",
@@ -5368,7 +5449,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/89.png",
@@ -5430,7 +5512,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/90.png",
@@ -5561,7 +5644,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/92.png",
@@ -5771,7 +5855,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/95.png",
@@ -5838,7 +5923,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/96.png",
@@ -5910,7 +5996,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/97.png",
@@ -5968,7 +6055,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/98.png",
@@ -6039,7 +6127,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/99.png",
@@ -6105,7 +6194,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/100.png",
@@ -6170,7 +6260,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/101.png",
@@ -6238,7 +6329,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/102.png",
@@ -6306,7 +6398,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/103.png",
@@ -6378,7 +6471,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/104.png",
@@ -6571,7 +6665,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/107.png",
@@ -6635,7 +6730,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/108.png",
@@ -6698,7 +6794,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/109.png",
@@ -6756,7 +6853,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/110.png",
@@ -6817,7 +6915,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/111.png",
@@ -6877,7 +6976,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/112.png",
@@ -6938,7 +7038,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/113.png",
@@ -6997,7 +7098,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/114.png",
@@ -7054,7 +7156,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/115.png",
@@ -7116,7 +7219,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/116.png",
@@ -7173,7 +7277,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/117.png",
@@ -7235,7 +7340,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/118.png",
@@ -7293,7 +7399,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/119.png",
@@ -7346,7 +7453,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/120.png",
@@ -7411,7 +7519,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/121.png",
@@ -7434,7 +7543,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/122.png",
@@ -7458,7 +7568,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/123.png",
@@ -7482,7 +7593,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/124.png",
@@ -7505,7 +7617,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/125.png",
@@ -7529,7 +7642,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/126.png",
@@ -7553,7 +7667,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/127.png",
@@ -7578,7 +7693,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/128.png",
@@ -7601,7 +7717,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/129.png",
@@ -7625,7 +7742,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/130.png",
@@ -7649,7 +7767,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/131.png",
@@ -7673,7 +7792,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/132.png",
@@ -7697,7 +7817,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/133.png",
@@ -7720,7 +7841,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/134.png",
@@ -7744,7 +7866,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/135.png",
@@ -7767,7 +7890,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/136.png",
@@ -7790,7 +7914,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/137.png",
@@ -7813,7 +7938,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/138.png",
@@ -7836,7 +7962,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/139.png",
@@ -7859,7 +7986,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/140.png",
@@ -7883,7 +8011,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/141.png",
@@ -7907,7 +8036,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/142.png",
@@ -7931,7 +8061,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/143.png",
@@ -7955,7 +8086,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/144.png",
@@ -8780,7 +8912,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/157.png",
@@ -8804,7 +8937,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/158.png",
@@ -8827,7 +8961,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/159.png",
@@ -8851,7 +8986,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/160.png",
@@ -8874,7 +9010,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/161.png",
@@ -8897,7 +9034,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/162.png",
@@ -8921,7 +9059,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/163.png",
@@ -8945,7 +9084,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy5/164.png",

--- a/cards/en/xy6.json
+++ b/cards/en/xy6.json
@@ -52,7 +52,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/1.png",
@@ -114,7 +115,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/2.png",
@@ -176,7 +178,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/3.png",
@@ -230,7 +233,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/4.png",
@@ -284,7 +288,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/5.png",
@@ -348,7 +353,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/6.png",
@@ -411,7 +417,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/7.png",
@@ -475,7 +482,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/8.png",
@@ -526,7 +534,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/9.png",
@@ -582,7 +591,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/10.png",
@@ -634,7 +644,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/11.png",
@@ -697,7 +708,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/12.png",
@@ -755,7 +767,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/13.png",
@@ -803,7 +816,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/14.png",
@@ -858,7 +872,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/15.png",
@@ -924,7 +939,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/16.png",
@@ -994,7 +1010,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/17.png",
@@ -1051,7 +1068,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/18.png",
@@ -1120,7 +1138,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/19.png",
@@ -1187,7 +1206,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/20.png",
@@ -1254,7 +1274,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/21.png",
@@ -1320,7 +1341,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/22.png",
@@ -1386,7 +1408,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/23.png",
@@ -1443,7 +1466,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/24.png",
@@ -1508,7 +1532,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/25.png",
@@ -1629,7 +1654,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/27.png",
@@ -1685,7 +1711,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/28.png",
@@ -1744,7 +1771,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/29.png",
@@ -1801,7 +1829,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/30.png",
@@ -1865,7 +1894,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/31.png",
@@ -1934,7 +1964,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/32.png",
@@ -1992,7 +2023,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/33.png",
@@ -2166,7 +2198,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/36.png",
@@ -2225,7 +2258,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/37.png",
@@ -2288,7 +2322,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/38.png",
@@ -2353,7 +2388,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/39.png",
@@ -2415,7 +2451,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/40.png",
@@ -2482,7 +2519,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/41.png",
@@ -2546,7 +2584,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/42.png",
@@ -2603,7 +2642,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/43.png",
@@ -2672,7 +2712,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/44.png",
@@ -2739,7 +2780,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/45.png",
@@ -2807,7 +2849,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/46.png",
@@ -2871,7 +2914,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/47.png",
@@ -2935,7 +2979,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/48.png",
@@ -2996,7 +3041,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/49.png",
@@ -3060,7 +3106,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/50.png",
@@ -3120,7 +3167,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/51.png",
@@ -3189,7 +3237,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/52.png",
@@ -3248,7 +3297,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/53.png",
@@ -3300,7 +3350,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/54.png",
@@ -3361,7 +3412,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/55.png",
@@ -3424,7 +3476,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/56.png",
@@ -3499,7 +3552,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/57.png",
@@ -3868,7 +3922,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/63.png",
@@ -3929,7 +3984,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/64.png",
@@ -3987,7 +4043,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/65.png",
@@ -4054,7 +4111,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/66.png",
@@ -4116,7 +4174,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/67.png",
@@ -4169,7 +4228,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/68.png",
@@ -4233,7 +4293,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/69.png",
@@ -4290,7 +4351,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/70.png",
@@ -4356,7 +4418,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/71.png",
@@ -4427,7 +4490,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/72.png",
@@ -4484,7 +4548,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/73.png",
@@ -4551,7 +4616,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/74.png",
@@ -4885,7 +4951,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/78.png",
@@ -4944,7 +5011,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/79.png",
@@ -5010,7 +5078,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/80.png",
@@ -5077,7 +5146,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/81.png",
@@ -5134,7 +5204,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/82.png",
@@ -5158,7 +5229,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/83.png",
@@ -5182,7 +5254,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/84.png",
@@ -5206,7 +5279,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/85.png",
@@ -5229,7 +5303,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/86.png",
@@ -5253,7 +5328,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/87.png",
@@ -5276,7 +5352,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/88.png",
@@ -5300,7 +5377,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/89.png",
@@ -5323,7 +5401,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/90.png",
@@ -5347,7 +5426,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/91.png",
@@ -5370,7 +5450,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/92.png",
@@ -5393,7 +5474,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/92a.png",
@@ -5417,7 +5499,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/93.png",
@@ -5440,7 +5523,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/94.png",
@@ -5464,7 +5548,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/95.png",
@@ -5487,7 +5572,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/96.png",
@@ -5510,7 +5596,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/97.png",
@@ -6108,7 +6195,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/107.png",
@@ -6131,7 +6219,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/108.png",
@@ -6155,7 +6244,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/109.png",
@@ -6178,7 +6268,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy6/110.png",

--- a/cards/en/xy7.json
+++ b/cards/en/xy7.json
@@ -43,7 +43,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/1.png",
@@ -97,7 +98,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/2.png",
@@ -157,7 +159,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/3.png",
@@ -216,7 +219,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/4.png",
@@ -267,7 +271,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/5.png",
@@ -324,7 +329,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/6.png",
@@ -498,7 +504,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/9.png",
@@ -553,7 +560,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/10.png",
@@ -616,7 +624,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/11.png",
@@ -674,7 +683,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/12.png",
@@ -732,7 +742,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/13.png",
@@ -791,7 +802,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/14.png",
@@ -857,7 +869,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/15.png",
@@ -910,7 +923,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/16.png",
@@ -969,7 +983,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/17.png",
@@ -1034,7 +1049,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/18.png",
@@ -1085,7 +1101,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/19.png",
@@ -1150,7 +1167,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/20.png",
@@ -1218,7 +1236,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/21.png",
@@ -1277,7 +1296,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/22.png",
@@ -1335,7 +1355,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/23.png",
@@ -1397,7 +1418,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/24.png",
@@ -1524,7 +1546,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/26.png",
@@ -1725,7 +1748,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/29.png",
@@ -1780,7 +1804,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/30.png",
@@ -1841,7 +1866,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/31.png",
@@ -1896,7 +1922,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/32.png",
@@ -1956,7 +1983,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/33.png",
@@ -2016,7 +2044,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/34.png",
@@ -2088,7 +2117,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/35.png",
@@ -2276,7 +2306,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/38.png",
@@ -2339,7 +2370,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/39.png",
@@ -2401,7 +2433,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/40.png",
@@ -2465,7 +2498,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/41.png",
@@ -2663,7 +2697,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/44.png",
@@ -2720,7 +2755,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/45.png",
@@ -2784,7 +2820,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/46.png",
@@ -2853,7 +2890,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/47.png",
@@ -2925,7 +2963,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/48.png",
@@ -2993,7 +3032,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/49.png",
@@ -3068,7 +3108,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/50.png",
@@ -3136,7 +3177,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/51.png",
@@ -3203,7 +3245,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/52.png",
@@ -3273,7 +3316,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/53.png",
@@ -3338,7 +3382,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/54.png",
@@ -3395,7 +3440,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/55.png",
@@ -3460,7 +3506,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/56.png",
@@ -3583,7 +3630,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/58.png",
@@ -3647,7 +3695,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/59.png",
@@ -3711,7 +3760,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/60.png",
@@ -3762,7 +3812,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/61.png",
@@ -3821,7 +3872,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/62.png",
@@ -3889,7 +3941,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/63.png",
@@ -3950,7 +4003,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/64.png",
@@ -4014,7 +4068,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/65.png",
@@ -4075,7 +4130,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/66.png",
@@ -4139,7 +4195,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/67.png",
@@ -4234,7 +4291,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/69.png",
@@ -4258,7 +4316,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/70.png",
@@ -4281,7 +4340,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/71.png",
@@ -4305,7 +4365,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/72.png",
@@ -4328,7 +4389,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/73.png",
@@ -4351,7 +4413,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Banned"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/74.png",
@@ -4374,7 +4437,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/75.png",
@@ -4397,7 +4461,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/75a.png",
@@ -4421,7 +4486,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/76.png",
@@ -4445,7 +4511,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/77.png",
@@ -4468,7 +4535,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/78.png",
@@ -4491,7 +4559,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/79.png",
@@ -4515,7 +4584,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/80.png",
@@ -4539,7 +4609,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/81.png",
@@ -4563,7 +4634,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/82.png",
@@ -4587,7 +4659,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/83.png",
@@ -5343,7 +5416,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/95.png",
@@ -5558,7 +5632,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/99.png",
@@ -5581,7 +5656,8 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy7/100.png",

--- a/cards/en/xy8.json
+++ b/cards/en/xy8.json
@@ -43,7 +43,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/1.png",
@@ -103,7 +104,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/2.png",
@@ -163,7 +165,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/3.png",
@@ -214,7 +217,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/4.png",
@@ -265,7 +269,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/5.png",
@@ -324,7 +329,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/6.png",
@@ -386,7 +392,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/7.png",
@@ -448,7 +455,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/8.png",
@@ -510,7 +518,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/9.png",
@@ -576,7 +585,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/10.png",
@@ -642,7 +652,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/11.png",
@@ -747,7 +758,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/13.png",
@@ -810,7 +822,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/14.png",
@@ -868,7 +881,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/15.png",
@@ -930,7 +944,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/16.png",
@@ -991,7 +1006,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/17.png",
@@ -1052,7 +1068,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/18.png",
@@ -1105,7 +1122,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/19.png",
@@ -1167,7 +1185,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/20.png",
@@ -1337,7 +1356,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/23.png",
@@ -1396,7 +1416,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/24.png",
@@ -1448,7 +1469,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/25.png",
@@ -1502,7 +1524,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/26.png",
@@ -1553,7 +1576,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/27.png",
@@ -1612,7 +1636,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/28.png",
@@ -1663,7 +1688,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/29.png",
@@ -1722,7 +1748,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/30.png",
@@ -1783,7 +1810,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/31.png",
@@ -1844,7 +1872,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/32.png",
@@ -1903,7 +1932,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/33.png",
@@ -2082,7 +2112,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/36.png",
@@ -2135,7 +2166,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/37.png",
@@ -2193,7 +2225,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/38.png",
@@ -2257,7 +2290,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/39.png",
@@ -2323,7 +2357,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/40.png",
@@ -2374,7 +2409,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/41.png",
@@ -2433,7 +2469,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/42.png",
@@ -2494,7 +2531,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/43.png",
@@ -2557,7 +2595,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/44.png",
@@ -2618,7 +2657,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/45.png",
@@ -2669,7 +2709,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/46.png",
@@ -2722,7 +2763,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/47.png",
@@ -2789,7 +2831,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/48.png",
@@ -2852,7 +2895,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/49.png",
@@ -2960,7 +3004,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/51.png",
@@ -3027,7 +3072,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/52.png",
@@ -3096,7 +3142,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/53.png",
@@ -3162,7 +3209,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/54.png",
@@ -3225,7 +3273,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/55.png",
@@ -3293,7 +3342,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/56.png",
@@ -3347,7 +3397,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/57.png",
@@ -3404,7 +3455,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/58.png",
@@ -3470,7 +3522,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/59.png",
@@ -3531,7 +3584,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/60.png",
@@ -3835,7 +3889,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/65.png",
@@ -3899,7 +3954,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/66.png",
@@ -3960,7 +4016,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/67.png",
@@ -4021,7 +4078,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/68.png",
@@ -4084,7 +4142,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/69.png",
@@ -4142,7 +4201,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/70.png",
@@ -4208,7 +4268,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/71.png",
@@ -4272,7 +4333,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/72.png",
@@ -4323,7 +4385,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/73.png",
@@ -4382,7 +4445,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/74.png",
@@ -4443,7 +4507,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/75.png",
@@ -4503,7 +4568,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/76.png",
@@ -4556,7 +4622,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/77.png",
@@ -4616,7 +4683,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/78.png",
@@ -4720,7 +4788,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/80.png",
@@ -4785,7 +4854,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/81.png",
@@ -4847,7 +4917,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/82.png",
@@ -4902,7 +4973,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/83.png",
@@ -4960,7 +5032,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/84.png",
@@ -5019,7 +5092,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/85.png",
@@ -5072,7 +5146,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/86.png",
@@ -5136,7 +5211,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/87.png",
@@ -5202,7 +5278,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/88.png",
@@ -5269,7 +5346,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/89.png",
@@ -5336,7 +5414,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/90.png",
@@ -5400,7 +5479,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/91.png",
@@ -5499,7 +5579,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/93.png",
@@ -5563,7 +5644,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/94.png",
@@ -5622,7 +5704,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/95.png",
@@ -5691,7 +5774,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/96.png",
@@ -5753,7 +5837,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/97.png",
@@ -5822,7 +5907,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/98.png",
@@ -5891,7 +5977,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/99.png",
@@ -5958,7 +6045,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/100.png",
@@ -6015,7 +6103,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/101.png",
@@ -6083,7 +6172,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/102.png",
@@ -6147,7 +6237,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/103.png",
@@ -6241,7 +6332,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/105.png",
@@ -6305,7 +6397,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/106.png",
@@ -6374,7 +6467,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/107.png",
@@ -6437,7 +6531,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/108.png",
@@ -6500,7 +6595,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/109.png",
@@ -6564,7 +6660,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/110.png",
@@ -6634,7 +6731,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/111.png",
@@ -6694,7 +6792,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/112.png",
@@ -6788,7 +6887,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/114.png",
@@ -6855,7 +6955,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/115.png",
@@ -6922,7 +7023,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/116.png",
@@ -6986,7 +7088,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/117.png",
@@ -7047,7 +7150,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/118.png",
@@ -7105,7 +7209,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/119.png",
@@ -7172,7 +7277,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/120.png",
@@ -7225,7 +7331,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/121.png",
@@ -7290,7 +7397,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/122.png",
@@ -7346,7 +7454,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/123.png",
@@ -7403,7 +7512,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/124.png",
@@ -7460,7 +7570,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/125.png",
@@ -7528,7 +7639,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/126.png",
@@ -7595,7 +7707,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/127.png",
@@ -7659,7 +7772,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/128.png",
@@ -7717,7 +7831,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/129.png",
@@ -7786,7 +7901,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/130.png",
@@ -7843,7 +7959,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/131.png",
@@ -7910,7 +8027,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/132.png",
@@ -7934,7 +8052,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/133.png",
@@ -7957,7 +8076,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/134.png",
@@ -7980,7 +8100,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/135.png",
@@ -8003,7 +8124,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/136.png",
@@ -8027,7 +8149,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/137.png",
@@ -8050,7 +8173,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/138.png",
@@ -8074,7 +8198,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/139.png",
@@ -8097,7 +8222,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/140.png",
@@ -8121,7 +8247,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/141.png",
@@ -8145,7 +8272,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/142.png",
@@ -8169,7 +8297,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/143.png",
@@ -8193,7 +8322,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/144.png",
@@ -8217,7 +8347,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/145.png",
@@ -8240,7 +8371,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/146.png",
@@ -8263,7 +8395,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/146a.png",
@@ -8286,7 +8419,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/147.png",
@@ -8309,7 +8443,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/148.png",
@@ -8333,7 +8468,8 @@
     "legalities": {
       "standard": "Legal",
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/149.png",
@@ -8356,7 +8492,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/150.png",
@@ -8380,7 +8517,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/151.png",
@@ -8402,7 +8540,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/152.png",
@@ -8918,7 +9057,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/161.png",
@@ -8941,7 +9081,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy8/162.png",

--- a/cards/en/xy9.json
+++ b/cards/en/xy9.json
@@ -53,7 +53,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/1.png",
@@ -116,7 +117,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/2.png",
@@ -176,7 +178,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/3.png",
@@ -227,7 +230,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/4.png",
@@ -278,7 +282,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/5.png",
@@ -336,7 +341,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/6.png",
@@ -387,7 +393,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/7.png",
@@ -446,7 +453,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/8.png",
@@ -504,7 +512,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/9.png",
@@ -557,7 +566,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/10.png",
@@ -618,7 +628,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/11.png",
@@ -682,7 +693,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/12.png",
@@ -746,7 +758,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/13.png",
@@ -872,7 +885,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/15.png",
@@ -924,7 +938,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/16.png",
@@ -984,7 +999,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/17.png",
@@ -1084,7 +1100,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/19.png",
@@ -1145,7 +1162,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/20.png",
@@ -1203,7 +1221,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/21.png",
@@ -1255,7 +1274,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/22.png",
@@ -1307,7 +1327,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/23.png",
@@ -1368,7 +1389,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/24.png",
@@ -1415,7 +1437,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/25.png",
@@ -1601,7 +1624,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/28.png",
@@ -1664,7 +1688,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/29.png",
@@ -1721,7 +1746,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/30.png",
@@ -1906,7 +1932,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/33.png",
@@ -1972,7 +1999,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/34.png",
@@ -2035,7 +2063,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/35.png",
@@ -2092,7 +2121,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/36.png",
@@ -2154,7 +2184,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/37.png",
@@ -2205,7 +2236,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/38.png",
@@ -2257,7 +2289,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/39.png",
@@ -2311,7 +2344,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/40.png",
@@ -2401,7 +2435,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/42.png",
@@ -2464,7 +2499,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/43.png",
@@ -2530,7 +2566,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/44.png",
@@ -2598,7 +2635,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/45.png",
@@ -2665,7 +2703,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/46.png",
@@ -2766,7 +2805,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/48.png",
@@ -2829,7 +2869,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/49.png",
@@ -2891,7 +2932,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/50.png",
@@ -2949,7 +2991,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/51.png",
@@ -3064,7 +3107,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/53.png",
@@ -3130,7 +3174,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/54.png",
@@ -3194,7 +3239,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/55.png",
@@ -3246,7 +3292,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/56.png",
@@ -3307,7 +3354,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/57.png",
@@ -3358,7 +3406,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/58.png",
@@ -3417,7 +3466,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/59.png",
@@ -3475,7 +3525,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/60.png",
@@ -3535,7 +3586,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/61.png",
@@ -3606,7 +3658,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/62.png",
@@ -3657,7 +3710,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/63.png",
@@ -3715,7 +3769,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/64.png",
@@ -3781,7 +3836,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/65.png",
@@ -3873,7 +3929,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/67.png",
@@ -3924,7 +3981,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/68.png",
@@ -3976,7 +4034,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/69.png",
@@ -4031,7 +4090,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/70.png",
@@ -4093,7 +4153,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/71.png",
@@ -4161,7 +4222,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/72.png",
@@ -4228,7 +4290,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/73.png",
@@ -4366,7 +4429,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/75.png",
@@ -4563,7 +4627,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/78.png",
@@ -4622,7 +4687,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/79.png",
@@ -4691,7 +4757,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/80.png",
@@ -4758,7 +4825,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/81.png",
@@ -4824,7 +4892,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/82.png",
@@ -4950,7 +5019,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/84.png",
@@ -5015,7 +5085,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/85.png",
@@ -5075,7 +5146,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/86.png",
@@ -5126,7 +5198,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/87.png",
@@ -5178,7 +5251,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/88.png",
@@ -5277,7 +5351,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/90.png",
@@ -5335,7 +5410,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/91.png",
@@ -5463,7 +5539,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/93.png",
@@ -5525,7 +5602,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/94.png",
@@ -5583,7 +5661,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/95.png",
@@ -5606,7 +5685,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/96.png",
@@ -5631,7 +5711,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/97.png",
@@ -5654,7 +5735,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/98.png",
@@ -5677,7 +5759,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/98a.png",
@@ -5700,7 +5783,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/98b.png",
@@ -5724,7 +5808,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/99.png",
@@ -5748,7 +5833,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/100.png",
@@ -5772,7 +5858,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/101.png",
@@ -5795,7 +5882,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/102.png",
@@ -5818,7 +5906,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/103.png",
@@ -5841,7 +5930,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/104.png",
@@ -5865,7 +5955,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/105.png",
@@ -5889,7 +5980,8 @@
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/106.png",
@@ -5912,7 +6004,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/107.png",
@@ -5935,7 +6028,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/107a.png",
@@ -5959,7 +6053,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/108.png",
@@ -5982,7 +6077,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Banned"
+      "expanded": "Banned",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/109.png",
@@ -6006,7 +6102,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/110.png",
@@ -6030,7 +6127,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/111.png",
@@ -6053,7 +6151,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/112.png",
@@ -6077,7 +6176,8 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/113.png",
@@ -6616,7 +6716,8 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xy9/122.png",

--- a/cards/en/xyp.json
+++ b/cards/en/xyp.json
@@ -53,7 +53,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY01.png",
@@ -114,7 +115,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY02.png",
@@ -175,7 +177,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY03.png",
@@ -241,7 +244,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY04.png",
@@ -307,7 +311,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY05.png",
@@ -373,7 +378,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY06.png",
@@ -640,7 +646,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY10.png",
@@ -693,7 +700,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY11.png",
@@ -761,7 +769,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY12.png",
@@ -820,7 +829,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY13.png",
@@ -888,7 +898,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY14.png",
@@ -956,7 +967,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY15.png",
@@ -1019,7 +1031,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY16.png",
@@ -1348,7 +1361,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY21.png",
@@ -1414,7 +1428,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY22.png",
@@ -1475,7 +1490,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY23.png",
@@ -1538,7 +1554,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY24.png",
@@ -1674,7 +1691,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY26.png",
@@ -1697,7 +1715,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY27.png",
@@ -1972,7 +1991,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY31.png",
@@ -2041,7 +2061,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY32.png",
@@ -2064,7 +2085,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY33.png",
@@ -2256,7 +2278,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY36.png",
@@ -2307,7 +2330,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY37.png",
@@ -2368,7 +2392,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY38.png",
@@ -2432,7 +2457,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY39.png",
@@ -2488,7 +2514,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY40.png",
@@ -2893,7 +2920,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY46.png",
@@ -2957,7 +2985,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY47.png",
@@ -3015,7 +3044,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY48.png",
@@ -3081,7 +3111,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY49.png",
@@ -3141,7 +3172,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY50.png",
@@ -3205,7 +3237,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY51.png",
@@ -3269,7 +3302,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY52.png",
@@ -3535,7 +3569,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY56.png",
@@ -3605,7 +3640,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY57.png",
@@ -3674,7 +3710,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY58.png",
@@ -3740,7 +3777,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY59.png",
@@ -3808,7 +3846,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY60.png",
@@ -4063,7 +4102,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY64.png",
@@ -4123,7 +4163,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY65.png",
@@ -4261,7 +4302,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY67.png",
@@ -4325,7 +4367,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY67a.png",
@@ -4391,7 +4434,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY68.png",
@@ -4786,7 +4830,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY74.png",
@@ -4848,7 +4893,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY75.png",
@@ -4916,7 +4962,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY76.png",
@@ -4984,7 +5031,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY77.png",
@@ -5043,7 +5091,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY78.png",
@@ -5103,7 +5152,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY79.png",
@@ -5167,7 +5217,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY80.png",
@@ -5231,7 +5282,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY81.png",
@@ -5292,7 +5344,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY82.png",
@@ -5352,7 +5405,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY83.png",
@@ -5654,7 +5708,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY88.png",
@@ -5722,7 +5777,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY89.png",
@@ -5781,7 +5837,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY90.png",
@@ -5804,7 +5861,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY91.png",
@@ -5861,7 +5919,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY92.png",
@@ -5920,7 +5979,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY93.png",
@@ -5986,7 +6046,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY94.png",
@@ -6053,7 +6114,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY95.png",
@@ -6121,7 +6183,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY96.png",
@@ -6278,7 +6341,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY99.png",
@@ -6340,7 +6404,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY100.png",
@@ -6402,7 +6467,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY101.png",
@@ -6623,7 +6689,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY105.png",
@@ -6888,7 +6955,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY109.png",
@@ -6947,7 +7015,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY110.png",
@@ -7004,7 +7073,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY111.png",
@@ -7068,7 +7138,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY112.png",
@@ -7126,7 +7197,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY113.png",
@@ -7193,7 +7265,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY114.png",
@@ -7253,7 +7326,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY115.png",
@@ -7314,7 +7388,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY116.png",
@@ -7372,7 +7447,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY117.png",
@@ -7429,7 +7505,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY118.png",
@@ -7496,7 +7573,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY119.png",
@@ -7554,7 +7632,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY120.png",
@@ -8025,7 +8104,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY127.png",
@@ -8087,7 +8167,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY128.png",
@@ -8148,7 +8229,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY129.png",
@@ -8217,7 +8299,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY130.png",
@@ -8268,7 +8351,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY131.png",
@@ -8325,7 +8409,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY132.png",
@@ -8574,7 +8659,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY137.png",
@@ -8625,7 +8711,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY138.png",
@@ -8693,7 +8780,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY139.png",
@@ -8754,7 +8842,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY140.png",
@@ -8816,7 +8905,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY141.png",
@@ -8875,7 +8965,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY142.png",
@@ -8926,7 +9017,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY143.png",
@@ -8986,7 +9078,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY144.png",
@@ -9046,7 +9139,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY145.png",
@@ -9105,7 +9199,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY146.png",
@@ -9165,7 +9260,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY147.png",
@@ -9573,7 +9669,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY152.png",
@@ -9640,7 +9737,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY153.png",
@@ -9795,7 +9893,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY156.png",
@@ -9933,7 +10032,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY159.png",
@@ -9997,7 +10097,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY160.png",
@@ -10059,7 +10160,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY161.png",
@@ -10118,7 +10220,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY162.png",
@@ -10176,7 +10279,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY163.png",
@@ -10241,7 +10345,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY164.png",
@@ -10304,7 +10409,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY165.png",
@@ -10510,7 +10616,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY169.png",
@@ -10659,7 +10766,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY172.png",
@@ -10883,7 +10991,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY176.png",
@@ -10906,7 +11015,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY177.png",
@@ -10929,7 +11039,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY177a.png",
@@ -10992,7 +11103,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY178.png",
@@ -11054,7 +11166,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY179.png",
@@ -11313,7 +11426,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY184.png",
@@ -11378,7 +11492,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY185.png",
@@ -11441,7 +11556,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY186.png",
@@ -11498,7 +11614,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY187.png",
@@ -11558,7 +11675,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY188.png",
@@ -11616,7 +11734,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY189.png",
@@ -11674,7 +11793,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY190.png",
@@ -11731,7 +11851,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY191.png",
@@ -11790,7 +11911,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY192.png",
@@ -11848,7 +11970,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY193.png",
@@ -11915,7 +12038,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY194.png",
@@ -11979,7 +12103,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY195.png",
@@ -12046,7 +12171,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY196.png",
@@ -12107,7 +12233,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY197.png",
@@ -12249,7 +12376,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY199.png",
@@ -12375,7 +12503,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY201.png",
@@ -12444,7 +12573,8 @@
     ],
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY202.png",
@@ -12467,7 +12597,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY203.png",
@@ -12490,7 +12621,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY204.png",
@@ -12513,7 +12645,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY205.png",
@@ -12536,7 +12669,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY206.png",
@@ -12559,7 +12693,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY207.png",
@@ -12582,7 +12717,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY208.png",
@@ -12605,7 +12741,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY209.png",
@@ -12628,7 +12765,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY210.png",
@@ -12652,7 +12790,8 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
-      "expanded": "Legal"
+      "expanded": "Legal",
+      "glc": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/xyp/XY211.png",


### PR DESCRIPTION
There was a small discussion on Discord, and pretty much everyone involved agreed to have legalities for Gym Leader Challenge on this API

I didn't add any legality to cards that are neither expanded legal nor expanded banned. I also didn't add any legality to rule box and ace spec cards. Every other card is either "Legal" or "Banned"

I haven't added set legalities, but at the end of the day the set legalities are exactly the same as expanded, so I don't know if we really need them