### PR TITLE
Fixed "evolvesTo"

### DIFF
--- a/cards/en/base1.json
+++ b/cards/en/base1.json
@@ -132,7 +132,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Blissey"
+      "Blissey",
+      "Blissey ex"
     ],
     "attacks": [
       {
@@ -269,7 +270,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Clefable",
+      "Clefable ex"
     ],
     "attacks": [
       {
@@ -468,6 +470,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Machoke",
+    "evolvesTo": [
+      "Machamp LV.X",
+      "Machamp BREAK"
+    ],
     "abilities": [
       {
         "name": "Strikes Back",
@@ -530,7 +536,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "attacks": [
       {
@@ -594,6 +601,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Mewtwo LV.X"
+    ],
     "attacks": [
       {
         "name": "Psychic",
@@ -656,6 +666,9 @@
       "Grass"
     ],
     "evolvesFrom": "Nidorino",
+    "evolvesTo": [
+      "Nidoking BREAK"
+    ],
     "attacks": [
       {
         "name": "Thrash",
@@ -720,6 +733,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "attacks": [
       {
         "name": "Lure",
@@ -847,6 +863,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Agility",
@@ -1100,7 +1120,9 @@
     ],
     "evolvesFrom": "Dratini",
     "evolvesTo": [
-      "Dragonite"
+      "Dragonite",
+      "Dragonite ex",
+      "Dragonite-GX"
     ],
     "attacks": [
       {
@@ -1357,7 +1379,8 @@
     ],
     "evolvesFrom": "Pidgey",
     "evolvesTo": [
-      "Pidgeot"
+      "Pidgeot",
+      "Pidgeot ex"
     ],
     "attacks": [
       {
@@ -1426,6 +1449,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "attacks": [
       {
         "name": "Flamethrower",
@@ -1492,7 +1518,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "attacks": [
       {
@@ -1621,7 +1650,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "attacks": [
       {
@@ -1670,9 +1701,6 @@
     "hp": "50",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Sirfetch'd"
     ],
     "attacks": [
       {
@@ -1740,7 +1768,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -1793,7 +1823,8 @@
     ],
     "evolvesFrom": "Gastly",
     "evolvesTo": [
-      "Gengar"
+      "Gengar",
+      "Gengar ex"
     ],
     "attacks": [
       {
@@ -1855,7 +1886,8 @@
     ],
     "evolvesFrom": "Bulbasaur",
     "evolvesTo": [
-      "Venusaur"
+      "Venusaur",
+      "Venusaur ex"
     ],
     "attacks": [
       {
@@ -1980,7 +2012,8 @@
     ],
     "evolvesFrom": "Abra",
     "evolvesTo": [
-      "Alakazam"
+      "Alakazam",
+      "Alakazam ex"
     ],
     "attacks": [
       {
@@ -2110,7 +2143,8 @@
     ],
     "evolvesFrom": "Machop",
     "evolvesTo": [
-      "Machamp"
+      "Machamp",
+      "Machamp-GX"
     ],
     "attacks": [
       {
@@ -2177,7 +2211,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -2369,7 +2406,8 @@
     "evolvesFrom": "Poliwag",
     "evolvesTo": [
       "Poliwrath",
-      "Politoed"
+      "Politoed",
+      "Politoed ex"
     ],
     "attacks": [
       {
@@ -2432,7 +2470,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Porygon2"
+      "Porygon2",
+      "Dark Porygon2"
     ],
     "attacks": [
       {
@@ -2499,6 +2538,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Rattata",
+    "evolvesTo": [
+      "Raticate BREAK"
+    ],
     "attacks": [
       {
         "name": "Bite",
@@ -2565,7 +2607,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Dewgong"
+      "Dewgong",
+      "Light Dewgong"
     ],
     "attacks": [
       {
@@ -2617,7 +2660,9 @@
     ],
     "evolvesFrom": "Squirtle",
     "evolvesTo": [
-      "Blastoise"
+      "Blastoise",
+      "Blastoise ex",
+      "Blastoise-GX"
     ],
     "attacks": [
       {
@@ -2680,7 +2725,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Kadabra"
+      "Kadabra",
+      "Dark Kadabra"
     ],
     "attacks": [
       {
@@ -2727,7 +2773,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ivysaur"
+      "Ivysaur",
+      "Dark Ivysaur"
     ],
     "attacks": [
       {
@@ -2831,7 +2878,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -2892,7 +2940,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Dugtrio"
+      "Dugtrio",
+      "Dark Dugtrio"
     ],
     "attacks": [
       {
@@ -3008,7 +3057,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Hypno"
+      "Hypno",
+      "Dark Hypno"
     ],
     "attacks": [
       {
@@ -3069,7 +3119,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Haunter",
+      "Dark Haunter"
     ],
     "attacks": [
       {
@@ -3126,7 +3177,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Weezing"
+      "Weezing",
+      "Dark Weezing",
+      "Galarian Weezing"
     ],
     "attacks": [
       {
@@ -3178,7 +3231,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Machoke"
+      "Machoke",
+      "Dark Machoke",
+      "Light Machoke"
     ],
     "attacks": [
       {
@@ -3229,7 +3284,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -3405,7 +3461,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Steelix"
+      "Steelix",
+      "Dark Steelix",
+      "Steelix ex"
     ],
     "attacks": [
       {
@@ -3526,7 +3584,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -3638,7 +3700,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Rapidash"
+      "Rapidash",
+      "Dark Rapidash"
     ],
     "attacks": [
       {
@@ -3700,7 +3763,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Raticate"
+      "Raticate",
+      "Dark Raticate"
     ],
     "attacks": [
       {
@@ -3753,7 +3817,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Sandslash"
+      "Sandslash",
+      "Dark Sandslash"
     ],
     "attacks": [
       {
@@ -3810,7 +3875,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wartortle"
+      "Wartortle",
+      "Dark Wartortle"
     ],
     "attacks": [
       {
@@ -3871,6 +3937,9 @@
       "Water"
     ],
     "evolvesFrom": "Staryu",
+    "evolvesTo": [
+      "Starmie BREAK"
+    ],
     "attacks": [
       {
         "name": "Recover",
@@ -3932,7 +4001,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Starmie"
+      "Starmie",
+      "Starmie-GX"
     ],
     "attacks": [
       {
@@ -4047,7 +4117,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {
@@ -4098,7 +4171,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {

--- a/cards/en/base2.json
+++ b/cards/en/base2.json
@@ -329,7 +329,6 @@
     "types": [
       "Psychic"
     ],
-    "evolvesFrom": "Mime Jr.",
     "abilities": [
       {
         "name": "Invisible Wall",
@@ -638,7 +637,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesFrom": "Munchlax",
     "abilities": [
       {
         "name": "Thick Skinned",
@@ -1330,7 +1328,6 @@
     "types": [
       "Psychic"
     ],
-    "evolvesFrom": "Mime Jr.",
     "abilities": [
       {
         "name": "Invisible Wall",
@@ -1639,7 +1636,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesFrom": "Munchlax",
     "abilities": [
       {
         "name": "Thick Skinned",
@@ -3700,7 +3696,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesFrom": "Pichu",
     "evolvesTo": [
       "Raichu"
     ],

--- a/cards/en/base2.json
+++ b/cards/en/base2.json
@@ -574,7 +574,11 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor",
+      "Scizor ex",
+      "Dark Scizor",
+      "Scizor-GX",
+      "Kleavor"
     ],
     "attacks": [
       {
@@ -636,6 +640,9 @@
     "hp": "90",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Snorlax LV.X"
     ],
     "abilities": [
       {
@@ -1573,7 +1580,11 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor",
+      "Scizor ex",
+      "Dark Scizor",
+      "Scizor-GX",
+      "Kleavor"
     ],
     "attacks": [
       {
@@ -1635,6 +1646,9 @@
     "hp": "90",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Snorlax LV.X"
     ],
     "abilities": [
       {
@@ -2261,7 +2275,9 @@
     "evolvesFrom": "Oddish",
     "evolvesTo": [
       "Vileplume",
-      "Bellossom"
+      "Bellossom",
+      "Vileplume ex",
+      "Vileplume-GX"
     ],
     "attacks": [
       {
@@ -2391,6 +2407,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Cubone",
+    "evolvesTo": [
+      "Marowak BREAK"
+    ],
     "attacks": [
       {
         "name": "Bonemerang",
@@ -2645,6 +2664,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Mankey",
+    "evolvesTo": [
+      "Annihilape ex",
+      "Annihilape"
+    ],
     "attacks": [
       {
         "name": "Fury Swipes",
@@ -3085,7 +3108,10 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Marowak"
+      "Marowak",
+      "Dark Marowak",
+      "Alolan Marowak-GX",
+      "Alolan Marowak"
     ],
     "attacks": [
       {
@@ -3159,7 +3185,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -3226,7 +3272,10 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Exeggutor"
+      "Exeggutor",
+      "Dark Exeggutor",
+      "Alolan Exeggutor-GX",
+      "Alolan Exeggutor"
     ],
     "attacks": [
       {
@@ -3334,7 +3383,11 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Wigglytuff"
+      "Wigglytuff",
+      "Dark Wigglytuff",
+      "Light Wigglytuff",
+      "Wigglytuff ex",
+      "Wigglytuff-GX"
     ],
     "attacks": [
       {
@@ -3401,7 +3454,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Primeape"
+      "Primeape",
+      "Dark Primeape"
     ],
     "abilities": [
       {
@@ -3455,7 +3509,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -3574,7 +3630,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Gloom"
+      "Gloom",
+      "Dark Gloom"
     ],
     "attacks": [
       {
@@ -3697,7 +3754,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -3883,7 +3944,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Venomoth"
+      "Venomoth",
+      "Light Venomoth",
+      "Venomoth-GX"
     ],
     "attacks": [
       {

--- a/cards/en/base3.json
+++ b/cards/en/base3.json
@@ -2277,7 +2277,6 @@
     "types": [
       "Fire"
     ],
-    "evolvesFrom": "Magby",
     "evolvesTo": [
       "Magmortar"
     ],

--- a/cards/en/base3.json
+++ b/cards/en/base3.json
@@ -249,6 +249,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Haunter",
+    "evolvesTo": [
+      "Gengar LV.X"
+    ],
     "abilities": [
       {
         "name": "Curse",
@@ -308,7 +311,8 @@
     ],
     "evolvesFrom": "Gastly",
     "evolvesTo": [
-      "Gengar"
+      "Gengar",
+      "Gengar ex"
     ],
     "abilities": [
       {
@@ -606,7 +610,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "attacks": [
       {
@@ -791,6 +796,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Gigashock",
@@ -1132,6 +1141,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Haunter",
+    "evolvesTo": [
+      "Gengar LV.X"
+    ],
     "abilities": [
       {
         "name": "Curse",
@@ -1191,7 +1203,8 @@
     ],
     "evolvesFrom": "Gastly",
     "evolvesTo": [
-      "Gengar"
+      "Gengar",
+      "Gengar ex"
     ],
     "abilities": [
       {
@@ -1489,7 +1502,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "attacks": [
       {
@@ -1674,6 +1688,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Gigashock",
@@ -1900,7 +1918,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Haunter",
+      "Dark Haunter"
     ],
     "attacks": [
       {
@@ -1958,7 +1977,8 @@
     ],
     "evolvesFrom": "Zubat",
     "evolvesTo": [
-      "Crobat"
+      "Crobat",
+      "Crobat ex"
     ],
     "attacks": [
       {
@@ -2024,6 +2044,9 @@
       "Water"
     ],
     "evolvesFrom": "Psyduck",
+    "evolvesTo": [
+      "Golduck BREAK"
+    ],
     "attacks": [
       {
         "name": "Psyshock",
@@ -2152,7 +2175,8 @@
     ],
     "evolvesFrom": "Geodude",
     "evolvesTo": [
-      "Golem"
+      "Golem",
+      "Golem ex"
     ],
     "attacks": [
       {
@@ -2339,6 +2363,9 @@
       "Water"
     ],
     "evolvesFrom": "Omanyte",
+    "evolvesTo": [
+      "Omastar BREAK"
+    ],
     "attacks": [
       {
         "name": "Water Gun",
@@ -2466,7 +2493,9 @@
     ],
     "evolvesFrom": "Horsea",
     "evolvesTo": [
-      "Kingdra"
+      "Kingdra",
+      "Kingdra ex",
+      "Kingdra-GX"
     ],
     "attacks": [
       {
@@ -2702,7 +2731,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Arbok"
+      "Arbok",
+      "Dark Arbok",
+      "Arbok ex"
     ],
     "attacks": [
       {
@@ -2815,7 +2846,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Muk"
+      "Muk",
+      "Dark Muk",
+      "Muk ex"
     ],
     "attacks": [
       {
@@ -2923,7 +2956,8 @@
     ],
     "evolvesFrom": "Mysterious Fossil",
     "evolvesTo": [
-      "Kabutops"
+      "Kabutops",
+      "Kabutops ex"
     ],
     "abilities": [
       {
@@ -3102,7 +3136,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Golduck",
+      "Dark Golduck",
+      "Light Golduck"
     ],
     "attacks": [
       {
@@ -3223,7 +3259,11 @@
     ],
     "evolvesTo": [
       "Slowbro",
-      "Slowking"
+      "Slowking",
+      "Dark Slowbro",
+      "Dark Slowking",
+      "Light Slowbro",
+      "Slowking ex"
     ],
     "attacks": [
       {
@@ -3338,7 +3378,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Golbat"
+      "Golbat",
+      "Dark Golbat"
     ],
     "attacks": [
       {
@@ -3469,6 +3510,13 @@
     "name": "Mysterious Fossil",
     "supertype": "Trainer",
     "hp": "10",
+    "evolvesTo": [
+      "Aerodactyl",
+      "Kabuto",
+      "Omanyte",
+      "Dark Omanyte",
+      "Aerodactyl ex"
+    ],
     "rules": [
       "Play Mysterious Fossil as if it were a Basic Pokémon. While in play, Mysterious Fossil counts as a Pokémon (instead of a Trainer card). Mysterious Fossil has no attacks, can't retreat, and can't be Asleep, Confused, Paralyzed, or Poisoned. If Mysterious Fossil is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Mysterious Fossil from play."
     ],

--- a/cards/en/base4.json
+++ b/cards/en/base4.json
@@ -1686,7 +1686,6 @@
     "types": [
       "Psychic"
     ],
-    "evolvesFrom": "Mime Jr.",
     "abilities": [
       {
         "name": "Invisible Wall",
@@ -1874,7 +1873,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesFrom": "Munchlax",
     "abilities": [
       {
         "name": "Thick Skinned",

--- a/cards/en/base4.json
+++ b/cards/en/base4.json
@@ -132,7 +132,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Blissey"
+      "Blissey",
+      "Blissey ex"
     ],
     "attacks": [
       {
@@ -335,7 +336,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Clefable",
+      "Clefable ex"
     ],
     "attacks": [
       {
@@ -535,7 +537,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "attacks": [
       {
@@ -599,6 +602,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Mewtwo LV.X"
+    ],
     "attacks": [
       {
         "name": "Psychic",
@@ -661,6 +667,9 @@
       "Grass"
     ],
     "evolvesFrom": "Nidorino",
+    "evolvesTo": [
+      "Nidoking BREAK"
+    ],
     "attacks": [
       {
         "name": "Thrash",
@@ -789,6 +798,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "attacks": [
       {
         "name": "Lure",
@@ -979,6 +991,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Agility",
@@ -1042,7 +1058,11 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor",
+      "Scizor ex",
+      "Dark Scizor",
+      "Scizor-GX",
+      "Kleavor"
     ],
     "attacks": [
       {
@@ -1363,7 +1383,9 @@
     ],
     "evolvesFrom": "Dratini",
     "evolvesTo": [
-      "Dragonite"
+      "Dragonite",
+      "Dragonite ex",
+      "Dragonite-GX"
     ],
     "attacks": [
       {
@@ -1744,7 +1766,8 @@
     ],
     "evolvesFrom": "Pidgey",
     "evolvesTo": [
-      "Pidgeot"
+      "Pidgeot",
+      "Pidgeot ex"
     ],
     "attacks": [
       {
@@ -1872,6 +1895,9 @@
     "hp": "90",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Snorlax LV.X"
     ],
     "abilities": [
       {
@@ -2060,6 +2086,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "attacks": [
       {
         "name": "Flamethrower",
@@ -2190,7 +2219,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "attacks": [
       {
@@ -2379,7 +2411,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "attacks": [
       {
@@ -2488,9 +2522,6 @@
     "hp": "50",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Sirfetch'd"
     ],
     "attacks": [
       {
@@ -2623,7 +2654,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -2676,7 +2709,8 @@
     ],
     "evolvesFrom": "Gastly",
     "evolvesTo": [
-      "Gengar"
+      "Gengar",
+      "Gengar ex"
     ],
     "attacks": [
       {
@@ -2738,7 +2772,8 @@
     ],
     "evolvesFrom": "Bulbasaur",
     "evolvesTo": [
-      "Venusaur"
+      "Venusaur",
+      "Venusaur ex"
     ],
     "attacks": [
       {
@@ -2863,7 +2898,8 @@
     ],
     "evolvesFrom": "Abra",
     "evolvesTo": [
-      "Alakazam"
+      "Alakazam",
+      "Alakazam ex"
     ],
     "attacks": [
       {
@@ -3062,7 +3098,8 @@
     ],
     "evolvesFrom": "Machop",
     "evolvesTo": [
-      "Machamp"
+      "Machamp",
+      "Machamp-GX"
     ],
     "attacks": [
       {
@@ -3129,7 +3166,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -3253,6 +3293,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Cubone",
+    "evolvesTo": [
+      "Marowak BREAK"
+    ],
     "attacks": [
       {
         "name": "Bonemerang",
@@ -3575,7 +3618,8 @@
     "evolvesFrom": "Poliwag",
     "evolvesTo": [
       "Poliwrath",
-      "Politoed"
+      "Politoed",
+      "Politoed ex"
     ],
     "attacks": [
       {
@@ -3638,6 +3682,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Rattata",
+    "evolvesTo": [
+      "Raticate BREAK"
+    ],
     "attacks": [
       {
         "name": "Bite",
@@ -3837,7 +3884,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Dewgong"
+      "Dewgong",
+      "Light Dewgong"
     ],
     "attacks": [
       {
@@ -3956,7 +4004,9 @@
     ],
     "evolvesFrom": "Squirtle",
     "evolvesTo": [
-      "Blastoise"
+      "Blastoise",
+      "Blastoise ex",
+      "Blastoise-GX"
     ],
     "attacks": [
       {
@@ -4081,7 +4131,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Kadabra"
+      "Kadabra",
+      "Dark Kadabra"
     ],
     "attacks": [
       {
@@ -4188,7 +4239,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ivysaur"
+      "Ivysaur",
+      "Dark Ivysaur"
     ],
     "attacks": [
       {
@@ -4292,7 +4344,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -4353,7 +4406,10 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Marowak"
+      "Marowak",
+      "Dark Marowak",
+      "Alolan Marowak-GX",
+      "Alolan Marowak"
     ],
     "attacks": [
       {
@@ -4420,7 +4476,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Dugtrio"
+      "Dugtrio",
+      "Dark Dugtrio"
     ],
     "attacks": [
       {
@@ -4536,7 +4593,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Hypno"
+      "Hypno",
+      "Dark Hypno"
     ],
     "attacks": [
       {
@@ -4597,7 +4655,10 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Exeggutor"
+      "Exeggutor",
+      "Dark Exeggutor",
+      "Alolan Exeggutor-GX",
+      "Alolan Exeggutor"
     ],
     "attacks": [
       {
@@ -4658,7 +4719,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Haunter",
+      "Dark Haunter"
     ],
     "attacks": [
       {
@@ -4762,7 +4824,11 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Wigglytuff"
+      "Wigglytuff",
+      "Dark Wigglytuff",
+      "Light Wigglytuff",
+      "Wigglytuff ex",
+      "Wigglytuff-GX"
     ],
     "attacks": [
       {
@@ -4829,7 +4895,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Machoke"
+      "Machoke",
+      "Dark Machoke",
+      "Light Machoke"
     ],
     "attacks": [
       {
@@ -4880,7 +4948,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -4941,7 +5010,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -5175,7 +5246,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Steelix"
+      "Steelix",
+      "Dark Steelix",
+      "Steelix ex"
     ],
     "attacks": [
       {
@@ -5358,7 +5431,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -5470,7 +5547,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Raticate"
+      "Raticate",
+      "Dark Raticate"
     ],
     "attacks": [
       {
@@ -5593,7 +5671,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Sandslash"
+      "Sandslash",
+      "Dark Sandslash"
     ],
     "attacks": [
       {
@@ -5714,7 +5793,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wartortle"
+      "Wartortle",
+      "Dark Wartortle"
     ],
     "attacks": [
       {
@@ -5775,6 +5855,9 @@
       "Water"
     ],
     "evolvesFrom": "Staryu",
+    "evolvesTo": [
+      "Starmie BREAK"
+    ],
     "attacks": [
       {
         "name": "Recover",
@@ -5836,7 +5919,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Starmie"
+      "Starmie",
+      "Starmie-GX"
     ],
     "attacks": [
       {
@@ -5951,7 +6035,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Venomoth"
+      "Venomoth",
+      "Light Venomoth",
+      "Venomoth-GX"
     ],
     "attacks": [
       {
@@ -6012,7 +6098,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {
@@ -6063,7 +6152,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {

--- a/cards/en/base5.json
+++ b/cards/en/base5.json
@@ -392,7 +392,7 @@
     ],
     "evolvesFrom": "Zubat",
     "evolvesTo": [
-      "Crobat"
+      "Dark Crobat"
     ],
     "abilities": [
       {
@@ -643,9 +643,6 @@
       "Lightning"
     ],
     "evolvesFrom": "Magnemite",
-    "evolvesTo": [
-      "Magnezone"
-    ],
     "attacks": [
       {
         "name": "Sonicboom",
@@ -1322,7 +1319,7 @@
     ],
     "evolvesFrom": "Zubat",
     "evolvesTo": [
-      "Crobat"
+      "Dark Crobat"
     ],
     "abilities": [
       {
@@ -1573,9 +1570,6 @@
       "Lightning"
     ],
     "evolvesFrom": "Magnemite",
-    "evolvesTo": [
-      "Magnezone"
-    ],
     "attacks": [
       {
         "name": "Sonicboom",
@@ -1816,7 +1810,7 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Dark Charizard"
     ],
     "attacks": [
       {
@@ -1881,7 +1875,7 @@
     ],
     "evolvesFrom": "Dratini",
     "evolvesTo": [
-      "Dragonite"
+      "Dark Dragonite"
     ],
     "abilities": [
       {
@@ -2061,8 +2055,7 @@
     ],
     "evolvesFrom": "Oddish",
     "evolvesTo": [
-      "Vileplume",
-      "Bellossom"
+      "Dark Vileplume"
     ],
     "abilities": [
       {
@@ -2244,7 +2237,7 @@
     ],
     "evolvesFrom": "Abra",
     "evolvesTo": [
-      "Alakazam"
+      "Dark Alakazam"
     ],
     "abilities": [
       {
@@ -2305,7 +2298,7 @@
     ],
     "evolvesFrom": "Machop",
     "evolvesTo": [
-      "Machamp"
+      "Dark Machamp"
     ],
     "attacks": [
       {
@@ -2665,7 +2658,7 @@
     ],
     "evolvesFrom": "Squirtle",
     "evolvesTo": [
-      "Blastoise"
+      "Dark Blastoise"
     ],
     "attacks": [
       {
@@ -2726,7 +2719,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -2788,7 +2784,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Porygon2"
+      "Porygon2",
+      "Dark Porygon2"
     ],
     "attacks": [
       {
@@ -2852,7 +2849,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Kadabra"
+      "Kadabra",
+      "Dark Kadabra"
     ],
     "attacks": [
       {
@@ -2912,7 +2910,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "abilities": [
       {
@@ -3037,7 +3036,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Dugtrio"
+      "Dugtrio",
+      "Dark Dugtrio"
     ],
     "attacks": [
       {
@@ -3100,7 +3100,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "attacks": [
       {
@@ -3152,7 +3154,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Hypno"
+      "Hypno",
+      "Dark Hypno"
     ],
     "abilities": [
       {
@@ -3218,7 +3221,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -3285,7 +3308,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Arbok"
+      "Arbok",
+      "Dark Arbok",
+      "Arbok ex"
     ],
     "attacks": [
       {
@@ -3346,7 +3371,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Muk"
+      "Muk",
+      "Dark Muk",
+      "Muk ex"
     ],
     "attacks": [
       {
@@ -3407,7 +3434,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Weezing"
+      "Weezing",
+      "Dark Weezing",
+      "Galarian Weezing"
     ],
     "attacks": [
       {
@@ -3468,7 +3497,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Machoke"
+      "Machoke",
+      "Dark Machoke",
+      "Light Machoke"
     ],
     "attacks": [
       {
@@ -3531,7 +3562,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -3593,7 +3625,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Primeape"
+      "Primeape",
+      "Dark Primeape"
     ],
     "attacks": [
       {
@@ -3650,7 +3683,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -3708,7 +3743,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Gloom"
+      "Gloom",
+      "Dark Gloom"
     ],
     "attacks": [
       {
@@ -3768,7 +3804,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Rapidash"
+      "Rapidash",
+      "Dark Rapidash"
     ],
     "attacks": [
       {
@@ -3820,7 +3857,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Golduck",
+      "Dark Golduck",
+      "Light Golduck"
     ],
     "attacks": [
       {
@@ -3881,7 +3920,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Raticate"
+      "Raticate",
+      "Dark Raticate"
     ],
     "abilities": [
       {
@@ -3942,7 +3982,11 @@
     ],
     "evolvesTo": [
       "Slowbro",
-      "Slowking"
+      "Slowking",
+      "Dark Slowbro",
+      "Dark Slowking",
+      "Light Slowbro",
+      "Slowking ex"
     ],
     "attacks": [
       {
@@ -4002,7 +4046,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wartortle"
+      "Wartortle",
+      "Dark Wartortle"
     ],
     "attacks": [
       {
@@ -4054,7 +4099,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {
@@ -4105,7 +4153,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Golbat"
+      "Golbat",
+      "Dark Golbat"
     ],
     "attacks": [
       {

--- a/cards/en/base6.json
+++ b/cards/en/base6.json
@@ -3062,7 +3062,7 @@
     "types": [
       "Grass"
     ],
-    "evolvesFrom": "Kakuna",
+    "evolvesFrom": "Weedle",
     "evolvesTo": [
       "Beedrill"
     ],

--- a/cards/en/base6.json
+++ b/cards/en/base6.json
@@ -618,6 +618,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Haunter",
+    "evolvesTo": [
+      "Gengar LV.X"
+    ],
     "abilities": [
       {
         "name": "Curse",
@@ -868,6 +871,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Machoke",
+    "evolvesTo": [
+      "Machamp LV.X",
+      "Machamp BREAK"
+    ],
     "abilities": [
       {
         "name": "Strikes Back",
@@ -988,6 +995,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "attacks": [
       {
         "name": "Lure",
@@ -1675,7 +1685,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "attacks": [
       {
@@ -1738,6 +1749,9 @@
     "hp": "60",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Mewtwo LV.X"
     ],
     "attacks": [
       {
@@ -1861,6 +1875,9 @@
       "Grass"
     ],
     "evolvesFrom": "Nidorino",
+    "evolvesTo": [
+      "Nidoking BREAK"
+    ],
     "attacks": [
       {
         "name": "Thrash",
@@ -2053,7 +2070,8 @@
     ],
     "evolvesFrom": "Pidgey",
     "evolvesTo": [
-      "Pidgeot"
+      "Pidgeot",
+      "Pidgeot ex"
     ],
     "attacks": [
       {
@@ -2196,6 +2214,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "attacks": [
       {
         "name": "Flamethrower",
@@ -2262,7 +2283,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "attacks": [
       {
@@ -2327,7 +2351,7 @@
     ],
     "evolvesFrom": "Dratini",
     "evolvesTo": [
-      "Dragonite"
+      "Dark Dragonite"
     ],
     "abilities": [
       {
@@ -2389,7 +2413,7 @@
     ],
     "evolvesFrom": "Squirtle",
     "evolvesTo": [
-      "Blastoise"
+      "Dark Blastoise"
     ],
     "attacks": [
       {
@@ -2640,6 +2664,9 @@
       "Water"
     ],
     "evolvesFrom": "Psyduck",
+    "evolvesTo": [
+      "Golduck BREAK"
+    ],
     "attacks": [
       {
         "name": "Psyshock",
@@ -2701,7 +2728,8 @@
     ],
     "evolvesFrom": "Geodude",
     "evolvesTo": [
-      "Golem"
+      "Golem",
+      "Golem ex"
     ],
     "attacks": [
       {
@@ -2765,7 +2793,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -2818,7 +2848,8 @@
     ],
     "evolvesFrom": "Gastly",
     "evolvesTo": [
-      "Gengar"
+      "Gengar",
+      "Gengar ex"
     ],
     "abilities": [
       {
@@ -2874,7 +2905,8 @@
     ],
     "evolvesFrom": "Bulbasaur",
     "evolvesTo": [
-      "Venusaur"
+      "Venusaur",
+      "Venusaur ex"
     ],
     "attacks": [
       {
@@ -2939,7 +2971,8 @@
     ],
     "evolvesFrom": "Mysterious Fossil",
     "evolvesTo": [
-      "Kabutops"
+      "Kabutops",
+      "Kabutops ex"
     ],
     "abilities": [
       {
@@ -2998,7 +3031,8 @@
     ],
     "evolvesFrom": "Abra",
     "evolvesTo": [
-      "Alakazam"
+      "Alakazam",
+      "Alakazam ex"
     ],
     "attacks": [
       {
@@ -3128,7 +3162,8 @@
     ],
     "evolvesFrom": "Machop",
     "evolvesTo": [
-      "Machamp"
+      "Machamp",
+      "Machamp-GX"
     ],
     "attacks": [
       {
@@ -3195,7 +3230,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -3255,7 +3293,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -3565,6 +3605,9 @@
       "Water"
     ],
     "evolvesFrom": "Omanyte",
+    "evolvesTo": [
+      "Omastar BREAK"
+    ],
     "attacks": [
       {
         "name": "Water Gun",
@@ -3625,6 +3668,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Mankey",
+    "evolvesTo": [
+      "Annihilape ex",
+      "Annihilape"
+    ],
     "attacks": [
       {
         "name": "Fury Swipes",
@@ -3743,6 +3790,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Rattata",
+    "evolvesTo": [
+      "Raticate BREAK"
+    ],
     "attacks": [
       {
         "name": "Bite",
@@ -3876,7 +3926,9 @@
     ],
     "evolvesFrom": "Horsea",
     "evolvesTo": [
-      "Kingdra"
+      "Kingdra",
+      "Kingdra ex",
+      "Kingdra-GX"
     ],
     "attacks": [
       {
@@ -3937,6 +3989,9 @@
     "hp": "90",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Snorlax LV.X"
     ],
     "abilities": [
       {
@@ -4128,7 +4183,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Kadabra"
+      "Kadabra",
+      "Dark Kadabra"
     ],
     "attacks": [
       {
@@ -4175,7 +4231,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ivysaur"
+      "Ivysaur",
+      "Dark Ivysaur"
     ],
     "attacks": [
       {
@@ -4279,7 +4336,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -4393,7 +4451,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "attacks": [
       {
@@ -4444,7 +4504,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Hypno"
+      "Hypno",
+      "Dark Hypno"
     ],
     "abilities": [
       {
@@ -4510,7 +4571,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -4577,7 +4658,10 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Exeggutor"
+      "Exeggutor",
+      "Dark Exeggutor",
+      "Alolan Exeggutor-GX",
+      "Alolan Exeggutor"
     ],
     "attacks": [
       {
@@ -4638,7 +4722,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Haunter",
+      "Dark Haunter"
     ],
     "attacks": [
       {
@@ -4747,7 +4832,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Muk"
+      "Muk",
+      "Dark Muk",
+      "Muk ex"
     ],
     "attacks": [
       {
@@ -4807,7 +4894,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Machoke"
+      "Machoke",
+      "Dark Machoke",
+      "Light Machoke"
     ],
     "attacks": [
       {
@@ -4870,7 +4959,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -4931,7 +5021,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Primeape"
+      "Primeape",
+      "Dark Primeape"
     ],
     "attacks": [
       {
@@ -5100,7 +5191,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Steelix"
+      "Steelix",
+      "Dark Steelix",
+      "Steelix ex"
     ],
     "attacks": [
       {
@@ -5221,7 +5314,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -5273,7 +5370,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Rapidash"
+      "Rapidash",
+      "Dark Rapidash"
     ],
     "attacks": [
       {
@@ -5335,7 +5433,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Golduck",
+      "Dark Golduck",
+      "Light Golduck"
     ],
     "attacks": [
       {
@@ -5396,7 +5496,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Raticate"
+      "Raticate",
+      "Dark Raticate"
     ],
     "attacks": [
       {
@@ -5519,7 +5620,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Sandslash"
+      "Sandslash",
+      "Dark Sandslash"
     ],
     "attacks": [
       {
@@ -5576,7 +5678,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Dewgong"
+      "Dewgong",
+      "Light Dewgong"
     ],
     "attacks": [
       {
@@ -5628,7 +5731,11 @@
     ],
     "evolvesTo": [
       "Slowbro",
-      "Slowking"
+      "Slowking",
+      "Dark Slowbro",
+      "Dark Slowking",
+      "Light Slowbro",
+      "Slowking ex"
     ],
     "attacks": [
       {
@@ -5753,7 +5860,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wartortle"
+      "Wartortle",
+      "Dark Wartortle"
     ],
     "attacks": [
       {
@@ -5868,7 +5976,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {
@@ -5919,7 +6030,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {
@@ -6185,6 +6298,13 @@
     "name": "Mysterious Fossil",
     "supertype": "Trainer",
     "hp": "10",
+    "evolvesTo": [
+      "Aerodactyl",
+      "Kabuto",
+      "Omanyte",
+      "Dark Omanyte",
+      "Aerodactyl ex"
+    ],
     "rules": [
       "Play Mysterious Fossil as if it were a Basic Pokémon. While in play, Mysterious Fossil counts as a Pokémon (instead of a Trainer card). Mysterious Fossil has no attacks, can't retreat, and can't be affected by Special Conditions. If Mysterious Fossil is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Mysterious Fossil from play. You can put Pokémon that evolve from Mysterious Fossil on this card."
     ],

--- a/cards/en/basep.json
+++ b/cards/en/basep.json
@@ -1737,7 +1737,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesFrom": "Clefairy",
     "evolvesTo": [
       "Clefairy"
     ],

--- a/cards/en/basep.json
+++ b/cards/en/basep.json
@@ -12,7 +12,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -134,6 +138,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Mewtwo LV.X"
+    ],
     "attacks": [
       {
         "name": "Energy Absorption",
@@ -195,7 +202,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -316,6 +327,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "attacks": [
       {
         "name": "Quick Attack",
@@ -376,7 +390,11 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Wigglytuff"
+      "Wigglytuff",
+      "Dark Wigglytuff",
+      "Light Wigglytuff",
+      "Wigglytuff ex",
+      "Wigglytuff-GX"
     ],
     "attacks": [
       {
@@ -560,7 +578,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -625,7 +645,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "abilities": [
       {
@@ -683,6 +723,9 @@
     "hp": "60",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Mewtwo LV.X"
     ],
     "attacks": [
       {
@@ -804,6 +847,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Mewtwo LV.X"
+    ],
     "attacks": [
       {
         "name": "Energy Absorption",
@@ -863,9 +909,6 @@
     "hp": "50",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Porygon2"
     ],
     "attacks": [
       {
@@ -1016,9 +1059,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesTo": [
-      "Persian"
-    ],
     "attacks": [
       {
         "name": "Miraculous Comeback",
@@ -1074,7 +1114,7 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Kadabra"
+      "Sabrina's Kadabra"
     ],
     "attacks": [
       {
@@ -1130,7 +1170,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Golduck",
+      "Dark Golduck",
+      "Light Golduck"
     ],
     "attacks": [
       {
@@ -1339,9 +1381,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesTo": [
-      "Raichu"
-    ],
     "attacks": [
       {
         "name": "Birthday Surprise",
@@ -1390,9 +1429,6 @@
     "hp": "40",
     "types": [
       "Lightning"
-    ],
-    "evolvesTo": [
-      "Raichu"
     ],
     "attacks": [
       {
@@ -1454,7 +1490,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -1515,7 +1555,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -1571,9 +1615,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesTo": [
-      "Raichu"
-    ],
     "attacks": [
       {
         "name": "Surf",
@@ -1625,7 +1666,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Azumarill"
+      "Azumarill",
+      "Light Azumarill"
     ],
     "attacks": [
       {
@@ -1677,7 +1719,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Togetic"
+      "Togetic",
+      "Light Togetic"
     ],
     "attacks": [
       {
@@ -2289,6 +2332,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Machoke",
+    "evolvesTo": [
+      "Machamp LV.X",
+      "Machamp BREAK"
+    ],
     "attacks": [
       {
         "name": "Seething Anger",
@@ -2416,7 +2463,11 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor",
+      "Scizor ex",
+      "Dark Scizor",
+      "Scizor-GX",
+      "Kleavor"
     ],
     "attacks": [
       {
@@ -2647,6 +2698,9 @@
     "hp": "90",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Snorlax LV.X"
     ],
     "abilities": [
       {

--- a/cards/en/basep.json
+++ b/cards/en/basep.json
@@ -1960,7 +1960,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesFrom": "Pikachu",
     "evolvesTo": [
       "Pikachu"
     ],
@@ -2005,7 +2004,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesFrom": "Jigglypuff",
     "evolvesTo": [
       "Jigglypuff"
     ],

--- a/cards/en/bw1.json
+++ b/cards/en/bw1.json
@@ -523,7 +523,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Lilligant"
+      "Lilligant",
+      "Hisuian Lilligant"
     ],
     "attacks": [
       {
@@ -1756,7 +1757,8 @@
     ],
     "evolvesFrom": "Oshawott",
     "evolvesTo": [
-      "Samurott"
+      "Samurott",
+      "Hisuian Samurott"
     ],
     "attacks": [
       {
@@ -1820,7 +1822,8 @@
     ],
     "evolvesFrom": "Oshawott",
     "evolvesTo": [
-      "Samurott"
+      "Samurott",
+      "Hisuian Samurott"
     ],
     "attacks": [
       {
@@ -4237,7 +4240,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Zoroark"
+      "Zoroark",
+      "Zoroark-GX"
     ],
     "attacks": [
       {
@@ -4295,6 +4299,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Zorua",
+    "evolvesTo": [
+      "Zoroark BREAK"
+    ],
     "attacks": [
       {
         "name": "Nasty Plot",
@@ -4417,6 +4424,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Vullaby",
+    "evolvesTo": [
+      "Mandibuzz BREAK"
+    ],
     "attacks": [
       {
         "name": "Blindside",
@@ -6152,7 +6162,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {

--- a/cards/en/bw10.json
+++ b/cards/en/bw10.json
@@ -122,7 +122,8 @@
     ],
     "evolvesFrom": "Root Fossil Lileep",
     "evolvesTo": [
-      "Cradily"
+      "Cradily",
+      "Cradily ex"
     ],
     "rules": [
       "Put this card onto your Bench only with the effect of Root Fossil Lileep"
@@ -678,7 +679,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Volcarona"
+      "Volcarona",
+      "Volcarona-GX"
     ],
     "attacks": [
       {
@@ -802,7 +804,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wartortle"
+      "Wartortle",
+      "Dark Wartortle"
     ],
     "attacks": [
       {
@@ -864,7 +867,9 @@
     ],
     "evolvesFrom": "Squirtle",
     "evolvesTo": [
-      "Blastoise"
+      "Blastoise",
+      "Blastoise ex",
+      "Blastoise-GX"
     ],
     "attacks": [
       {
@@ -1051,7 +1056,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Octillery"
+      "Octillery",
+      "Dark Octillery"
     ],
     "attacks": [
       {
@@ -1222,7 +1228,8 @@
     ],
     "evolvesTo": [
       "Glalie",
-      "Froslass"
+      "Froslass",
+      "Froslass ex"
     ],
     "attacks": [
       {
@@ -1591,7 +1598,8 @@
     ],
     "evolvesFrom": "Cover Fossil",
     "evolvesTo": [
-      "Carracosta"
+      "Carracosta",
+      "Carracosta-GX"
     ],
     "rules": [
       "Put this card onto your Bench only with the effect of Cover Fossil"
@@ -2140,6 +2148,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Uxie LV.X"
+    ],
     "attacks": [
       {
         "name": "Psypower",
@@ -2187,6 +2198,9 @@
     "hp": "60",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Mesprit LV.X"
     ],
     "abilities": [
       {
@@ -2244,6 +2258,9 @@
     "hp": "60",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Azelf LV.X"
     ],
     "attacks": [
       {
@@ -2785,7 +2802,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Machoke"
+      "Machoke",
+      "Dark Machoke",
+      "Light Machoke"
     ],
     "attacks": [
       {
@@ -2840,7 +2859,8 @@
     ],
     "evolvesFrom": "Machop",
     "evolvesTo": [
-      "Machamp"
+      "Machamp",
+      "Machamp-GX"
     ],
     "attacks": [
       {
@@ -2904,6 +2924,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Machoke",
+    "evolvesTo": [
+      "Machamp LV.X",
+      "Machamp BREAK"
+    ],
     "abilities": [
       {
         "name": "Badge of Discipline",
@@ -2965,6 +2989,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Machoke",
+    "evolvesTo": [
+      "Machamp LV.X",
+      "Machamp BREAK"
+    ],
     "attacks": [
       {
         "name": "Knock Off",
@@ -3269,7 +3297,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Houndoom",
+      "Dark Houndoom",
+      "Houndoom ex"
     ],
     "attacks": [
       {
@@ -3473,7 +3503,8 @@
     ],
     "evolvesFrom": "Aron",
     "evolvesTo": [
-      "Aggron"
+      "Aggron",
+      "Aggron ex"
     ],
     "attacks": [
       {
@@ -3813,7 +3844,9 @@
     ],
     "evolvesFrom": "Bagon",
     "evolvesTo": [
-      "Salamence"
+      "Salamence",
+      "Salamence ex",
+      "Salamence-GX"
     ],
     "attacks": [
       {
@@ -3877,6 +3910,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Shelgon",
+    "evolvesTo": [
+      "Salamence LV.X"
+    ],
     "abilities": [
       {
         "name": "Breakwing",
@@ -4375,7 +4411,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Porygon2"
+      "Porygon2",
+      "Dark Porygon2"
     ],
     "attacks": [
       {
@@ -4427,7 +4464,8 @@
     ],
     "evolvesFrom": "Porygon",
     "evolvesTo": [
-      "Porygon-Z"
+      "Porygon-Z",
+      "Porygon-Z-GX"
     ],
     "attacks": [
       {
@@ -4480,6 +4518,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Porygon2",
+    "evolvesTo": [
+      "Porygon-Z LV.X"
+    ],
     "abilities": [
       {
         "name": "Plasma Transfer",
@@ -4538,7 +4579,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Ursaring"
+      "Ursaring",
+      "Dark Ursaring"
     ],
     "attacks": [
       {
@@ -4592,6 +4634,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Teddiursa",
+    "evolvesTo": [
+      "Ursaluna"
+    ],
     "attacks": [
       {
         "name": "Adrenalash",
@@ -4741,6 +4786,9 @@
     "subtypes": [
       "Item"
     ],
+    "evolvesTo": [
+      "Tirtouga"
+    ],
     "rules": [
       "Look at the bottom 7 cards of your deck. You may reveal a Tirtouga you find there and put it onto your Bench. Shuffle the other cards back into your deck.",
       "You may play as many Item cards as you like during your turn (before your attack)."
@@ -4810,6 +4858,9 @@
     "supertype": "Trainer",
     "subtypes": [
       "Item"
+    ],
+    "evolvesTo": [
+      "Archen"
     ],
     "rules": [
       "Look at the bottom 7 cards of your deck. You may reveal an Archen you find there and put it onto your Bench. Shuffle the other cards back into your deck.",
@@ -4929,6 +4980,9 @@
     "supertype": "Trainer",
     "subtypes": [
       "Item"
+    ],
+    "evolvesTo": [
+      "Lileep"
     ],
     "rules": [
       "Look at the bottom 7 cards of your deck. You may reveal a Lileep you find there and put it onto your Bench. Shuffle the other cards back into your deck.",
@@ -5532,7 +5586,10 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Exeggutor"
+      "Exeggutor",
+      "Dark Exeggutor",
+      "Alolan Exeggutor-GX",
+      "Alolan Exeggutor"
     ],
     "abilities": [
       {
@@ -5661,6 +5718,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Dusclops",
+    "evolvesTo": [
+      "Dusknoir LV.X"
+    ],
     "abilities": [
       {
         "name": "Sinister Hand",

--- a/cards/en/bw11.json
+++ b/cards/en/bw11.json
@@ -80,6 +80,9 @@
       "Grass"
     ],
     "evolvesFrom": "Tangela",
+    "evolvesTo": [
+      "Tangrowth LV.X"
+    ],
     "attacks": [
       {
         "name": "Bind Down",
@@ -966,7 +969,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -1029,7 +1033,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "attacks": [
       {
@@ -1158,7 +1165,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {
@@ -1210,6 +1219,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "attacks": [
       {
         "name": "Color Coordination",
@@ -1757,7 +1769,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -2048,6 +2063,10 @@
       "Water"
     ],
     "evolvesFrom": "Prinplup",
+    "evolvesTo": [
+      "Empoleon LV.X",
+      "Empoleon BREAK"
+    ],
     "attacks": [
       {
         "name": "Surf",
@@ -2220,7 +2239,8 @@
     ],
     "evolvesFrom": "Oshawott",
     "evolvesTo": [
-      "Samurott"
+      "Samurott",
+      "Hisuian Samurott"
     ],
     "attacks": [
       {
@@ -3136,6 +3156,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Mewtwo LV.X"
+    ],
     "attacks": [
       {
         "name": "Power Edge",
@@ -3545,7 +3568,9 @@
     "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
-      "Gallade"
+      "Gallade",
+      "Gardevoir ex",
+      "Gardevoir-GX"
     ],
     "attacks": [
       {
@@ -3651,7 +3676,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Toxicroak"
+      "Toxicroak",
+      "Toxicroak ex"
     ],
     "attacks": [
       {
@@ -4644,7 +4670,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lucario"
+      "Lucario",
+      "Lucario-GX",
+      "Lucario ex"
     ],
     "attacks": [
       {
@@ -4705,6 +4733,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Riolu",
+    "evolvesTo": [
+      "Lucario LV.X"
+    ],
     "abilities": [
       {
         "name": "Reflexive Retaliation",
@@ -5264,7 +5295,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Zoroark"
+      "Zoroark",
+      "Zoroark-GX"
     ],
     "attacks": [
       {
@@ -5331,6 +5363,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Zorua",
+    "evolvesTo": [
+      "Zoroark BREAK"
+    ],
     "attacks": [
       {
         "name": "Brutal Bash",
@@ -5649,7 +5684,8 @@
     ],
     "evolvesFrom": "Gible",
     "evolvesTo": [
-      "Garchomp"
+      "Garchomp",
+      "Garchomp ex"
     ],
     "attacks": [
       {
@@ -5710,6 +5746,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Gabite",
+    "evolvesTo": [
+      "Garchomp LV.X"
+    ],
     "attacks": [
       {
         "name": "Mach Cut",
@@ -5896,6 +5935,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Zweilous",
+    "evolvesTo": [
+      "Hydreigon BREAK"
+    ],
     "abilities": [
       {
         "name": "Dark Trance",
@@ -6160,7 +6202,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Altaria"
+      "Altaria",
+      "Altaria ex",
+      "Altaria-GX"
     ],
     "attacks": [
       {
@@ -6938,7 +6982,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -7124,7 +7170,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -7248,7 +7298,9 @@
     "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
-      "Gallade"
+      "Gallade",
+      "Gardevoir ex",
+      "Gardevoir-GX"
     ],
     "attacks": [
       {
@@ -7309,6 +7361,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Kirlia",
+    "evolvesTo": [
+      "Gardevoir LV.X"
+    ],
     "attacks": [
       {
         "name": "Psybeam",
@@ -7563,7 +7618,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -7614,7 +7689,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Ursaring"
+      "Ursaring",
+      "Dark Ursaring"
     ],
     "attacks": [
       {
@@ -7677,6 +7753,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Teddiursa",
+    "evolvesTo": [
+      "Ursaluna"
+    ],
     "attacks": [
       {
         "name": "Picnic Weather",

--- a/cards/en/bw11.json
+++ b/cards/en/bw11.json
@@ -7245,7 +7245,7 @@
     "types": [
       "Psychic"
     ],
-    "evolvesFrom": "Kirlia",
+    "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
       "Gallade"

--- a/cards/en/bw2.json
+++ b/cards/en/bw2.json
@@ -512,7 +512,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Whimsicott"
+      "Whimsicott",
+      "Whimsicott-GX"
     ],
     "attacks": [
       {
@@ -569,7 +570,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Whimsicott"
+      "Whimsicott",
+      "Whimsicott-GX"
     ],
     "attacks": [
       {
@@ -751,7 +753,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Lilligant"
+      "Lilligant",
+      "Hisuian Lilligant"
     ],
     "attacks": [
       {
@@ -4011,7 +4014,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Zoroark"
+      "Zoroark",
+      "Zoroark-GX"
     ],
     "attacks": [
       {
@@ -4078,6 +4082,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Zorua",
+    "evolvesTo": [
+      "Zoroark BREAK"
+    ],
     "attacks": [
       {
         "name": "Fury Swipes",
@@ -4212,6 +4219,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Vullaby",
+    "evolvesTo": [
+      "Mandibuzz BREAK"
+    ],
     "attacks": [
       {
         "name": "Bone Rush",
@@ -5271,7 +5281,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Braviary"
+      "Braviary",
+      "Hisuian Braviary"
     ],
     "attacks": [
       {
@@ -5338,7 +5349,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Braviary"
+      "Braviary",
+      "Hisuian Braviary"
     ],
     "attacks": [
       {

--- a/cards/en/bw3.json
+++ b/cards/en/bw3.json
@@ -184,7 +184,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Lilligant"
+      "Lilligant",
+      "Hisuian Lilligant"
     ],
     "attacks": [
       {
@@ -1093,7 +1094,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Volcarona"
+      "Volcarona",
+      "Volcarona-GX"
     ],
     "attacks": [
       {
@@ -1145,7 +1147,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Volcarona"
+      "Volcarona",
+      "Volcarona-GX"
     ],
     "attacks": [
       {
@@ -1447,7 +1450,8 @@
     ],
     "evolvesFrom": "Cover Fossil",
     "evolvesTo": [
-      "Carracosta"
+      "Carracosta",
+      "Carracosta-GX"
     ],
     "rules": [
       "Put this card onto your Bench only with the effect of Cover Fossil"
@@ -2533,7 +2537,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Cofagrigus"
+      "Cofagrigus",
+      "Cofagrigus ex"
     ],
     "attacks": [
       {
@@ -2584,7 +2589,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Cofagrigus"
+      "Cofagrigus",
+      "Cofagrigus ex"
     ],
     "attacks": [
       {
@@ -3224,6 +3230,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Elgyem",
+    "evolvesTo": [
+      "Beheeyem BREAK"
+    ],
     "attacks": [
       {
         "name": "Synchronoise",
@@ -4440,6 +4449,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Pawniard",
+    "evolvesTo": [
+      "Kingambit"
+    ],
     "attacks": [
       {
         "name": "Finishing Blow",
@@ -4643,6 +4655,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Zweilous",
+    "evolvesTo": [
+      "Hydreigon BREAK"
+    ],
     "abilities": [
       {
         "name": "Dark Aura",
@@ -4846,6 +4861,9 @@
       "Metal"
     ],
     "evolvesFrom": "Pawniard",
+    "evolvesTo": [
+      "Kingambit"
+    ],
     "attacks": [
       {
         "name": "Energy Stream",
@@ -5299,6 +5317,9 @@
     "subtypes": [
       "Item"
     ],
+    "evolvesTo": [
+      "Tirtouga"
+    ],
     "rules": [
       "Look at the bottom 7 cards of your deck. You may reveal a Tirtouga you find there and put it onto your Bench. Shuffle the other cards back into your deck.",
       "You may play as many Item cards as you like during your turn (before your attack)."
@@ -5368,6 +5389,9 @@
     "supertype": "Trainer",
     "subtypes": [
       "Item"
+    ],
+    "evolvesTo": [
+      "Archen"
     ],
     "rules": [
       "Look at the bottom 7 cards of your deck. You may reveal an Archen you find there and put it onto your Bench. Shuffle the other cards back into your deck.",
@@ -5742,7 +5766,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {

--- a/cards/en/bw4.json
+++ b/cards/en/bw4.json
@@ -571,7 +571,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -634,7 +636,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -687,6 +691,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "abilities": [
       {
         "name": "Blazing Mane",
@@ -747,6 +754,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "attacks": [
       {
         "name": "Crunch",
@@ -1336,7 +1346,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Starmie"
+      "Starmie",
+      "Starmie-GX"
     ],
     "attacks": [
       {
@@ -1396,6 +1407,9 @@
       "Water"
     ],
     "evolvesFrom": "Staryu",
+    "evolvesTo": [
+      "Starmie BREAK"
+    ],
     "attacks": [
       {
         "name": "Confuse Ray",
@@ -2307,7 +2321,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -2368,6 +2386,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Thundershock",
@@ -2730,6 +2752,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Luxio",
+    "evolvesTo": [
+      "Luxray BREAK"
+    ],
     "attacks": [
       {
         "name": "Flash Impact",
@@ -3076,7 +3101,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Muk"
+      "Muk",
+      "Dark Muk",
+      "Muk ex"
     ],
     "attacks": [
       {
@@ -3324,7 +3351,9 @@
     "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
-      "Gallade"
+      "Gallade",
+      "Gardevoir ex",
+      "Gardevoir-GX"
     ],
     "attacks": [
       {
@@ -3387,6 +3416,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Kirlia",
+    "evolvesTo": [
+      "Gardevoir LV.X"
+    ],
     "abilities": [
       {
         "name": "Psychic Mirage",
@@ -3671,6 +3703,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Elgyem",
+    "evolvesTo": [
+      "Beheeyem BREAK"
+    ],
     "attacks": [
       {
         "name": "Brain Control",
@@ -3731,7 +3766,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lucario"
+      "Lucario",
+      "Lucario-GX",
+      "Lucario ex"
     ],
     "attacks": [
       {
@@ -3792,6 +3829,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Riolu",
+    "evolvesTo": [
+      "Lucario LV.X"
+    ],
     "abilities": [
       {
         "name": "Reflexive Retaliation",
@@ -3920,6 +3960,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Hippopotas",
+    "evolvesTo": [
+      "Hippowdon LV.X"
+    ],
     "attacks": [
       {
         "name": "Sand Bazooka",
@@ -4102,7 +4145,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Weavile"
+      "Weavile",
+      "Weavile-GX"
     ],
     "attacks": [
       {
@@ -4236,7 +4280,9 @@
     ],
     "evolvesFrom": "Seedot",
     "evolvesTo": [
-      "Shiftry"
+      "Shiftry",
+      "Shiftry ex",
+      "Shiftry-GX"
     ],
     "attacks": [
       {
@@ -4564,6 +4610,9 @@
       "Metal"
     ],
     "evolvesFrom": "Bronzor",
+    "evolvesTo": [
+      "Bronzong BREAK"
+    ],
     "abilities": [
       {
         "name": "Heal Block",
@@ -4691,7 +4740,11 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Wigglytuff"
+      "Wigglytuff",
+      "Dark Wigglytuff",
+      "Light Wigglytuff",
+      "Wigglytuff ex",
+      "Wigglytuff-GX"
     ],
     "attacks": [
       {
@@ -4815,7 +4868,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -5899,6 +5954,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Zorua",
+    "evolvesTo": [
+      "Zoroark BREAK"
+    ],
     "attacks": [
       {
         "name": "Nasty Plot",
@@ -5964,6 +6022,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Zweilous",
+    "evolvesTo": [
+      "Hydreigon BREAK"
+    ],
     "abilities": [
       {
         "name": "Dark Aura",

--- a/cards/en/bw5.json
+++ b/cards/en/bw5.json
@@ -11,7 +11,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ivysaur"
+      "Ivysaur",
+      "Dark Ivysaur"
     ],
     "attacks": [
       {
@@ -81,7 +82,8 @@
     ],
     "evolvesFrom": "Bulbasaur",
     "evolvesTo": [
-      "Venusaur"
+      "Venusaur",
+      "Venusaur ex"
     ],
     "attacks": [
       {
@@ -220,7 +222,11 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor",
+      "Scizor ex",
+      "Dark Scizor",
+      "Scizor-GX",
+      "Kleavor"
     ],
     "attacks": [
       {
@@ -339,6 +345,9 @@
       "Grass"
     ],
     "evolvesFrom": "Eevee",
+    "evolvesTo": [
+      "Leafeon LV.X"
+    ],
     "attacks": [
       {
         "name": "Quick Attack",
@@ -940,7 +949,9 @@
     ],
     "evolvesFrom": "Torchic",
     "evolvesTo": [
-      "Blaziken"
+      "Blaziken",
+      "Blaziken ex",
+      "Blaziken-GX"
     ],
     "attacks": [
       {
@@ -1183,7 +1194,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Volcarona"
+      "Volcarona",
+      "Volcarona-GX"
     ],
     "attacks": [
       {
@@ -1248,7 +1260,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Volcarona"
+      "Volcarona",
+      "Volcarona-GX"
     ],
     "attacks": [
       {
@@ -1361,7 +1374,11 @@
     ],
     "evolvesTo": [
       "Slowbro",
-      "Slowking"
+      "Slowking",
+      "Dark Slowbro",
+      "Dark Slowking",
+      "Light Slowbro",
+      "Slowking ex"
     ],
     "attacks": [
       {
@@ -1544,6 +1561,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Primal Kyogre-EX"
+    ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -1725,6 +1745,10 @@
       "Water"
     ],
     "evolvesFrom": "Prinplup",
+    "evolvesTo": [
+      "Empoleon LV.X",
+      "Empoleon BREAK"
+    ],
     "abilities": [
       {
         "name": "Diving Draw",
@@ -1782,6 +1806,9 @@
       "Water"
     ],
     "evolvesFrom": "Eevee",
+    "evolvesTo": [
+      "Glaceon LV.X"
+    ],
     "attacks": [
       {
         "name": "Quick Attack",
@@ -3006,7 +3033,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Cofagrigus"
+      "Cofagrigus",
+      "Cofagrigus ex"
     ],
     "attacks": [
       {
@@ -3178,6 +3206,9 @@
     "hp": "180",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Primal Groudon-EX"
     ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
@@ -4167,7 +4198,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Zoroark"
+      "Zoroark",
+      "Zoroark-GX"
     ],
     "attacks": [
       {
@@ -4234,7 +4266,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Zoroark"
+      "Zoroark",
+      "Zoroark-GX"
     ],
     "attacks": [
       {
@@ -4301,6 +4334,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Zorua",
+    "evolvesTo": [
+      "Zoroark BREAK"
+    ],
     "attacks": [
       {
         "name": "Brutal Bash",
@@ -4368,6 +4404,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Pawniard",
+    "evolvesTo": [
+      "Kingambit"
+    ],
     "attacks": [
       {
         "name": "Slash",
@@ -4831,6 +4870,9 @@
       "Metal"
     ],
     "evolvesFrom": "Pawniard",
+    "evolvesTo": [
+      "Kingambit"
+    ],
     "attacks": [
       {
         "name": "Aerial Ace",
@@ -4899,7 +4941,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Blissey"
+      "Blissey",
+      "Blissey ex"
     ],
     "attacks": [
       {
@@ -4963,7 +5006,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Blissey"
+      "Blissey",
+      "Blissey ex"
     ],
     "attacks": [
       {
@@ -5083,7 +5127,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -5141,7 +5205,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -5718,6 +5802,9 @@
     "subtypes": [
       "Item"
     ],
+    "evolvesTo": [
+      "Aerodactyl"
+    ],
     "rules": [
       "Look at the bottom 7 cards of your deck. You may reveal an Aerodactyl you find there and put it onto your Bench. Shuffle the other cards back into your deck.",
       "You may play as many Item cards as you like during your turn (before your attack)."
@@ -5928,6 +6015,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Primal Kyogre-EX"
+    ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -6056,6 +6146,9 @@
     "hp": "180",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Primal Groudon-EX"
     ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
@@ -6265,6 +6358,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Kirlia",
+    "evolvesTo": [
+      "Gardevoir LV.X"
+    ],
     "abilities": [
       {
         "name": "Psychic Mirage",

--- a/cards/en/bw6.json
+++ b/cards/en/bw6.json
@@ -238,6 +238,9 @@
       "Grass"
     ],
     "evolvesFrom": "Yanma",
+    "evolvesTo": [
+      "Yanmega BREAK"
+    ],
     "attacks": [
       {
         "name": "Agility",
@@ -479,7 +482,8 @@
     ],
     "evolvesFrom": "Wurmple",
     "evolvesTo": [
-      "Dustox"
+      "Dustox",
+      "Dustox ex"
     ],
     "attacks": [
       {
@@ -542,7 +546,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ninjask"
+      "Ninjask",
+      "Shedinja"
     ],
     "attacks": [
       {
@@ -593,9 +598,6 @@
       "Grass"
     ],
     "evolvesFrom": "Nincada",
-    "evolvesTo": [
-      "Shedinja"
-    ],
     "abilities": [
       {
         "name": "Cast-off Shell",
@@ -1030,7 +1032,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {
@@ -1081,6 +1085,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "abilities": [
       {
         "name": "Bright Look",
@@ -1200,6 +1207,9 @@
       "Fire"
     ],
     "evolvesFrom": "Magmar",
+    "evolvesTo": [
+      "Magmortar LV.X"
+    ],
     "attacks": [
       {
         "name": "Flame Screen",
@@ -1329,7 +1339,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -1445,7 +1458,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wailord"
+      "Wailord",
+      "Wailord ex"
     ],
     "attacks": [
       {
@@ -1573,7 +1587,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Milotic"
+      "Milotic",
+      "Milotic ex"
     ],
     "attacks": [
       {
@@ -1738,7 +1753,8 @@
     ],
     "evolvesFrom": "Spheal",
     "evolvesTo": [
-      "Walrein"
+      "Walrein",
+      "Walrein ex"
     ],
     "attacks": [
       {
@@ -2218,7 +2234,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Flaaffy"
+      "Flaaffy",
+      "Dark Flaaffy"
     ],
     "attacks": [
       {
@@ -2280,7 +2297,9 @@
     ],
     "evolvesFrom": "Mareep",
     "evolvesTo": [
-      "Ampharos"
+      "Ampharos",
+      "Ampharos ex",
+      "Ampharos-GX"
     ],
     "attacks": [
       {
@@ -2401,7 +2420,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Manectric",
+      "Manectric ex"
     ],
     "attacks": [
       {
@@ -2462,7 +2482,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Manectric",
+      "Manectric ex"
     ],
     "attacks": [
       {
@@ -3511,7 +3532,10 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Marowak"
+      "Marowak",
+      "Dark Marowak",
+      "Alolan Marowak-GX",
+      "Alolan Marowak"
     ],
     "attacks": [
       {
@@ -3578,6 +3602,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Cubone",
+    "evolvesTo": [
+      "Marowak BREAK"
+    ],
     "attacks": [
       {
         "name": "Bone Lock",
@@ -3697,7 +3724,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Claydol"
+      "Claydol",
+      "Claydol ex"
     ],
     "attacks": [
       {
@@ -4271,7 +4299,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Honchkrow"
+      "Honchkrow",
+      "Honchkrow-GX"
     ],
     "attacks": [
       {
@@ -4338,6 +4367,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Murkrow",
+    "evolvesTo": [
+      "Honchkrow LV.X"
+    ],
     "attacks": [
       {
         "name": "Whirlwind",
@@ -4406,7 +4438,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Houndoom",
+      "Dark Houndoom",
+      "Houndoom ex"
     ],
     "attacks": [
       {
@@ -4723,7 +4757,8 @@
     ],
     "evolvesFrom": "Aron",
     "evolvesTo": [
-      "Aggron"
+      "Aggron",
+      "Aggron ex"
     ],
     "attacks": [
       {
@@ -5314,7 +5349,8 @@
     ],
     "evolvesFrom": "Gible",
     "evolvesTo": [
-      "Garchomp"
+      "Garchomp",
+      "Garchomp ex"
     ],
     "attacks": [
       {
@@ -5376,7 +5412,8 @@
     ],
     "evolvesFrom": "Gible",
     "evolvesTo": [
-      "Garchomp"
+      "Garchomp",
+      "Garchomp ex"
     ],
     "abilities": [
       {
@@ -5435,6 +5472,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Gabite",
+    "evolvesTo": [
+      "Garchomp LV.X"
+    ],
     "attacks": [
       {
         "name": "Mach Cut",
@@ -5494,6 +5534,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Gabite",
+    "evolvesTo": [
+      "Garchomp LV.X"
+    ],
     "attacks": [
       {
         "name": "Jet Headbutt",
@@ -5872,6 +5915,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Zweilous",
+    "evolvesTo": [
+      "Hydreigon BREAK"
+    ],
     "abilities": [
       {
         "name": "Dark Trance",
@@ -5933,6 +5979,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Zweilous",
+    "evolvesTo": [
+      "Hydreigon BREAK"
+    ],
     "attacks": [
       {
         "name": "Consume",
@@ -6275,7 +6324,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Altaria"
+      "Altaria",
+      "Altaria ex",
+      "Altaria-GX"
     ],
     "attacks": [
       {
@@ -6342,7 +6393,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Altaria"
+      "Altaria",
+      "Altaria ex",
+      "Altaria-GX"
     ],
     "attacks": [
       {
@@ -6696,7 +6749,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Braviary"
+      "Braviary",
+      "Hisuian Braviary"
     ],
     "attacks": [
       {

--- a/cards/en/bw7.json
+++ b/cards/en/bw7.json
@@ -11,7 +11,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Gloom"
+      "Gloom",
+      "Dark Gloom"
     ],
     "attacks": [
       {
@@ -80,7 +81,9 @@
     "evolvesFrom": "Oddish",
     "evolvesTo": [
       "Vileplume",
-      "Bellossom"
+      "Bellossom",
+      "Vileplume ex",
+      "Vileplume-GX"
     ],
     "attacks": [
       {
@@ -351,6 +354,9 @@
       "Grass"
     ],
     "evolvesFrom": "Tangela",
+    "evolvesTo": [
+      "Tangrowth LV.X"
+    ],
     "attacks": [
       {
         "name": "Hundred Furious Lashes",
@@ -421,7 +427,11 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor",
+      "Scizor ex",
+      "Dark Scizor",
+      "Scizor-GX",
+      "Kleavor"
     ],
     "attacks": [
       {
@@ -606,6 +616,9 @@
     "hp": "70",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Shaymin LV.X"
     ],
     "attacks": [
       {
@@ -851,7 +864,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Whimsicott"
+      "Whimsicott",
+      "Whimsicott-GX"
     ],
     "attacks": [
       {
@@ -972,7 +986,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Lilligant"
+      "Lilligant",
+      "Hisuian Lilligant"
     ],
     "attacks": [
       {
@@ -1095,7 +1110,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -1158,7 +1174,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "attacks": [
       {
@@ -1287,7 +1306,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Camerupt"
+      "Camerupt",
+      "Camerupt ex"
     ],
     "attacks": [
       {
@@ -1772,7 +1792,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wartortle"
+      "Wartortle",
+      "Dark Wartortle"
     ],
     "abilities": [
       {
@@ -1832,7 +1853,9 @@
     ],
     "evolvesFrom": "Squirtle",
     "evolvesTo": [
-      "Blastoise"
+      "Blastoise",
+      "Blastoise ex",
+      "Blastoise-GX"
     ],
     "attacks": [
       {
@@ -1957,7 +1980,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Golduck",
+      "Dark Golduck",
+      "Light Golduck"
     ],
     "attacks": [
       {
@@ -2008,7 +2033,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Golduck",
+      "Dark Golduck",
+      "Light Golduck"
     ],
     "attacks": [
       {
@@ -2061,6 +2088,9 @@
       "Water"
     ],
     "evolvesFrom": "Psyduck",
+    "evolvesTo": [
+      "Golduck BREAK"
+    ],
     "attacks": [
       {
         "name": "Confuse Ray",
@@ -2116,6 +2146,9 @@
       "Water"
     ],
     "evolvesFrom": "Psyduck",
+    "evolvesTo": [
+      "Golduck BREAK"
+    ],
     "attacks": [
       {
         "name": "Amnesia",
@@ -2171,7 +2204,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Azumarill"
+      "Azumarill",
+      "Light Azumarill"
     ],
     "attacks": [
       {
@@ -2416,7 +2450,8 @@
     ],
     "evolvesFrom": "Oshawott",
     "evolvesTo": [
-      "Samurott"
+      "Samurott",
+      "Hisuian Samurott"
     ],
     "attacks": [
       {
@@ -3011,7 +3046,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -3073,7 +3112,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {
@@ -3244,6 +3286,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Electabuzz",
+    "evolvesTo": [
+      "Electivire LV.X"
+    ],
     "attacks": [
       {
         "name": "Electriwave",
@@ -3309,7 +3354,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Lanturn"
+      "Lanturn",
+      "Light Lanturn"
     ],
     "attacks": [
       {
@@ -3470,6 +3516,9 @@
     "hp": "90",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Wobbuffet BREAK"
     ],
     "attacks": [
       {
@@ -3636,7 +3685,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Dusclops"
+      "Dusclops",
+      "Dusclops ex"
     ],
     "attacks": [
       {
@@ -3751,6 +3801,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Dusclops",
+    "evolvesTo": [
+      "Dusknoir LV.X"
+    ],
     "abilities": [
       {
         "name": "Sinister Hand",
@@ -3812,7 +3865,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Toxicroak"
+      "Toxicroak",
+      "Toxicroak ex"
     ],
     "attacks": [
       {
@@ -3864,7 +3918,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Toxicroak"
+      "Toxicroak",
+      "Toxicroak ex"
     ],
     "attacks": [
       {
@@ -4660,7 +4715,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Sandslash"
+      "Sandslash",
+      "Dark Sandslash"
     ],
     "attacks": [
       {
@@ -4863,6 +4919,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Gligar",
+    "evolvesTo": [
+      "Gliscor LV.X"
+    ],
     "attacks": [
       {
         "name": "Poison Ring",
@@ -4928,7 +4987,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Hariyama"
+      "Hariyama",
+      "Hariyama ex"
     ],
     "attacks": [
       {
@@ -5584,6 +5644,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Vullaby",
+    "evolvesTo": [
+      "Mandibuzz BREAK"
+    ],
     "attacks": [
       {
         "name": "Gust",
@@ -5912,7 +5975,9 @@
     ],
     "evolvesFrom": "Trapinch",
     "evolvesTo": [
-      "Flygon"
+      "Flygon",
+      "Flygon ex",
+      "Flygon-GX"
     ],
     "attacks": [
       {
@@ -5974,6 +6039,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Vibrava",
+    "evolvesTo": [
+      "Flygon LV.X"
+    ],
     "abilities": [
       {
         "name": "Sand Slammer",
@@ -6291,7 +6359,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Raticate"
+      "Raticate",
+      "Dark Raticate"
     ],
     "attacks": [
       {
@@ -6342,6 +6411,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Rattata",
+    "evolvesTo": [
+      "Raticate BREAK"
+    ],
     "attacks": [
       {
         "name": "Gnaw Through",
@@ -6398,7 +6470,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -6448,9 +6522,6 @@
     "hp": "60",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Sirfetch'd"
     ],
     "attacks": [
       {
@@ -6551,6 +6622,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Snorlax LV.X"
+    ],
     "attacks": [
       {
         "name": "Double Lariat",
@@ -6617,7 +6691,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Togetic"
+      "Togetic",
+      "Light Togetic"
     ],
     "attacks": [
       {
@@ -6666,6 +6741,9 @@
     "hp": "60",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Dudunsparce"
     ],
     "attacks": [
       {
@@ -6778,7 +6856,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Delcatty"
+      "Delcatty",
+      "Delcatty ex"
     ],
     "attacks": [
       {

--- a/cards/en/bw8.json
+++ b/cards/en/bw8.json
@@ -143,6 +143,9 @@
       "Grass"
     ],
     "evolvesFrom": "Grotle",
+    "evolvesTo": [
+      "Torterra LV.X"
+    ],
     "attacks": [
       {
         "name": "Guard Press",
@@ -215,7 +218,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Vespiquen"
+      "Vespiquen",
+      "Vespiquen ex"
     ],
     "attacks": [
       {
@@ -994,6 +998,9 @@
       "Fire"
     ],
     "evolvesFrom": "Monferno",
+    "evolvesTo": [
+      "Infernape LV.X"
+    ],
     "attacks": [
       {
         "name": "Torment",
@@ -1406,7 +1413,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wartortle"
+      "Wartortle",
+      "Dark Wartortle"
     ],
     "attacks": [
       {
@@ -1529,7 +1537,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Piloswine"
+      "Piloswine",
+      "Light Piloswine"
     ],
     "attacks": [
       {
@@ -1892,7 +1901,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Sharpedo"
+      "Sharpedo",
+      "Sharpedo ex"
     ],
     "attacks": [
       {
@@ -2457,7 +2467,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -2518,7 +2529,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -2570,7 +2582,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "attacks": [
       {
@@ -2633,7 +2646,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "attacks": [
       {
@@ -2687,6 +2701,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Magneton",
+    "evolvesTo": [
+      "Magnezone LV.X"
+    ],
     "abilities": [
       {
         "name": "Dual Brains",
@@ -2747,6 +2764,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Magneton",
+    "evolvesTo": [
+      "Magnezone LV.X"
+    ],
     "attacks": [
       {
         "name": "Double Assist",
@@ -3044,7 +3064,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Golbat"
+      "Golbat",
+      "Dark Golbat"
     ],
     "attacks": [
       {
@@ -3101,7 +3122,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Golbat"
+      "Golbat",
+      "Dark Golbat"
     ],
     "abilities": [
       {
@@ -3167,7 +3189,8 @@
     ],
     "evolvesFrom": "Zubat",
     "evolvesTo": [
-      "Crobat"
+      "Crobat",
+      "Crobat ex"
     ],
     "attacks": [
       {
@@ -3226,6 +3249,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Golbat",
+    "evolvesTo": [
+      "Crobat BREAK"
+    ],
     "abilities": [
       {
         "name": "Night Sight",
@@ -3286,7 +3312,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Weezing"
+      "Weezing",
+      "Dark Weezing",
+      "Galarian Weezing"
     ],
     "attacks": [
       {
@@ -3348,7 +3376,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Weezing"
+      "Weezing",
+      "Dark Weezing",
+      "Galarian Weezing"
     ],
     "attacks": [
       {
@@ -3512,7 +3542,9 @@
     "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
-      "Gallade"
+      "Gallade",
+      "Gardevoir ex",
+      "Gardevoir-GX"
     ],
     "attacks": [
       {
@@ -3624,6 +3656,9 @@
     "hp": "130",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Giratina LV.X"
     ],
     "attacks": [
       {
@@ -4108,6 +4143,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Elgyem",
+    "evolvesTo": [
+      "Beheeyem BREAK"
+    ],
     "attacks": [
       {
         "name": "Lock Up",
@@ -4168,7 +4206,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Donphan"
+      "Donphan",
+      "Dark Donphan"
     ],
     "attacks": [
       {
@@ -4427,7 +4466,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lucario"
+      "Lucario",
+      "Lucario-GX",
+      "Lucario ex"
     ],
     "attacks": [
       {
@@ -4488,7 +4529,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lucario"
+      "Lucario",
+      "Lucario-GX",
+      "Lucario ex"
     ],
     "attacks": [
       {
@@ -4551,6 +4594,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Riolu",
+    "evolvesTo": [
+      "Lucario LV.X"
+    ],
     "attacks": [
       {
         "name": "Kick",
@@ -4612,6 +4658,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Riolu",
+    "evolvesTo": [
+      "Lucario LV.X"
+    ],
     "abilities": [
       {
         "name": "Dual Armor",
@@ -5872,7 +5921,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Clefable",
+      "Clefable ex"
     ],
     "attacks": [
       {
@@ -6115,6 +6165,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Snorlax LV.X"
+    ],
     "abilities": [
       {
         "name": "Block",
@@ -6178,7 +6231,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Togetic"
+      "Togetic",
+      "Light Togetic"
     ],
     "attacks": [
       {
@@ -6413,7 +6467,8 @@
     ],
     "evolvesFrom": "Whismur",
     "evolvesTo": [
-      "Exploud"
+      "Exploud",
+      "Exploud ex"
     ],
     "attacks": [
       {
@@ -6612,7 +6667,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Delcatty"
+      "Delcatty",
+      "Delcatty ex"
     ],
     "attacks": [
       {
@@ -6960,7 +7016,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Braviary"
+      "Braviary",
+      "Hisuian Braviary"
     ],
     "attacks": [
       {

--- a/cards/en/bw9.json
+++ b/cards/en/bw9.json
@@ -171,7 +171,10 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Exeggutor"
+      "Exeggutor",
+      "Dark Exeggutor",
+      "Alolan Exeggutor-GX",
+      "Alolan Exeggutor"
     ],
     "abilities": [
       {
@@ -371,7 +374,9 @@
     ],
     "evolvesFrom": "Treecko",
     "evolvesTo": [
-      "Sceptile"
+      "Sceptile",
+      "Sceptile ex",
+      "Sceptile-GX"
     ],
     "attacks": [
       {
@@ -506,7 +511,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Cacturne"
+      "Cacturne",
+      "Cacturne ex"
     ],
     "attacks": [
       {
@@ -630,6 +636,9 @@
       "Grass"
     ],
     "evolvesFrom": "Eevee",
+    "evolvesTo": [
+      "Leafeon LV.X"
+    ],
     "attacks": [
       {
         "name": "Energy Crush",
@@ -1128,7 +1137,9 @@
     ],
     "evolvesFrom": "Horsea",
     "evolvesTo": [
-      "Kingdra"
+      "Kingdra",
+      "Kingdra ex",
+      "Kingdra-GX"
     ],
     "attacks": [
       {
@@ -1354,6 +1365,9 @@
       "Water"
     ],
     "evolvesFrom": "Eevee",
+    "evolvesTo": [
+      "Glaceon LV.X"
+    ],
     "abilities": [
       {
         "name": "Freeze Zone",
@@ -1880,7 +1894,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {
@@ -2050,7 +2067,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Lanturn"
+      "Lanturn",
+      "Light Lanturn"
     ],
     "attacks": [
       {
@@ -2646,7 +2664,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Muk"
+      "Muk",
+      "Dark Muk",
+      "Muk ex"
     ],
     "attacks": [
       {
@@ -3005,7 +3025,9 @@
     ],
     "evolvesFrom": "Beldum",
     "evolvesTo": [
-      "Metagross"
+      "Metagross",
+      "Metagross ex",
+      "Metagross-GX"
     ],
     "attacks": [
       {
@@ -3190,7 +3212,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Cofagrigus"
+      "Cofagrigus",
+      "Cofagrigus ex"
     ],
     "attacks": [
       {
@@ -3242,7 +3265,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Cofagrigus"
+      "Cofagrigus",
+      "Cofagrigus ex"
     ],
     "attacks": [
       {
@@ -3426,6 +3450,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Nidorino",
+    "evolvesTo": [
+      "Nidoking BREAK"
+    ],
     "attacks": [
       {
         "name": "Lovestrike",
@@ -3496,7 +3523,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Primeape"
+      "Primeape",
+      "Dark Primeape"
     ],
     "attacks": [
       {
@@ -3547,6 +3575,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Mankey",
+    "evolvesTo": [
+      "Annihilape ex",
+      "Annihilape"
+    ],
     "attacks": [
       {
         "name": "Fury Swipes",
@@ -3607,7 +3639,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Steelix"
+      "Steelix",
+      "Dark Steelix",
+      "Steelix ex"
     ],
     "attacks": [
       {
@@ -3674,7 +3708,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Hariyama"
+      "Hariyama",
+      "Hariyama ex"
     ],
     "attacks": [
       {
@@ -3867,7 +3902,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Weavile"
+      "Weavile",
+      "Weavile-GX"
     ],
     "attacks": [
       {
@@ -4372,6 +4408,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Pawniard",
+    "evolvesTo": [
+      "Kingambit"
+    ],
     "attacks": [
       {
         "name": "Slash",
@@ -4439,6 +4478,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Pawniard",
+    "evolvesTo": [
+      "Kingambit"
+    ],
     "attacks": [
       {
         "name": "Cut Down",
@@ -4707,6 +4749,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Zweilous",
+    "evolvesTo": [
+      "Hydreigon BREAK"
+    ],
     "attacks": [
       {
         "name": "Tractorbeam",
@@ -4917,7 +4962,9 @@
       "Dragon"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "attacks": [
       {
@@ -4979,7 +5026,9 @@
     ],
     "evolvesFrom": "Dratini",
     "evolvesTo": [
-      "Dragonite"
+      "Dragonite",
+      "Dragonite ex",
+      "Dragonite-GX"
     ],
     "attacks": [
       {
@@ -5291,7 +5340,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Raticate"
+      "Raticate",
+      "Dark Raticate"
     ],
     "attacks": [
       {
@@ -5344,6 +5394,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Rattata",
+    "evolvesTo": [
+      "Raticate BREAK"
+    ],
     "attacks": [
       {
         "name": "Transfer Junk",
@@ -5406,7 +5459,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -5474,7 +5547,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -5593,6 +5686,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Hoothoot",
+    "evolvesTo": [
+      "Noctowl BREAK"
+    ],
     "attacks": [
       {
         "name": "Powerful Vision",
@@ -6714,6 +6810,10 @@
       "Water"
     ],
     "evolvesFrom": "Prinplup",
+    "evolvesTo": [
+      "Empoleon LV.X",
+      "Empoleon BREAK"
+    ],
     "abilities": [
       {
         "name": "Diving Draw",
@@ -6888,6 +6988,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Gabite",
+    "evolvesTo": [
+      "Garchomp LV.X"
+    ],
     "attacks": [
       {
         "name": "Mach Cut",

--- a/cards/en/bwp.json
+++ b/cards/en/bwp.json
@@ -485,6 +485,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Zorua",
+    "evolvesTo": [
+      "Zoroark BREAK"
+    ],
     "attacks": [
       {
         "name": "Nasty Plot",
@@ -654,7 +657,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Zoroark"
+      "Zoroark",
+      "Zoroark-GX"
     ],
     "attacks": [
       {
@@ -1045,6 +1049,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Zorua",
+    "evolvesTo": [
+      "Zoroark BREAK"
+    ],
     "attacks": [
       {
         "name": "Punishment",
@@ -1740,7 +1747,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lucario"
+      "Lucario",
+      "Lucario-GX",
+      "Lucario ex"
     ],
     "attacks": [
       {
@@ -1864,7 +1873,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -2804,6 +2815,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Golbat",
+    "evolvesTo": [
+      "Crobat BREAK"
+    ],
     "abilities": [
       {
         "name": "Night Sight",
@@ -2916,6 +2930,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Vibrava",
+    "evolvesTo": [
+      "Flygon LV.X"
+    ],
     "abilities": [
       {
         "name": "Sand Slammer",
@@ -2975,7 +2992,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -3096,6 +3117,10 @@
       "Water"
     ],
     "evolvesFrom": "Prinplup",
+    "evolvesTo": [
+      "Empoleon LV.X",
+      "Empoleon BREAK"
+    ],
     "attacks": [
       {
         "name": "Fury Attack",
@@ -3657,7 +3682,11 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Wigglytuff"
+      "Wigglytuff",
+      "Dark Wigglytuff",
+      "Light Wigglytuff",
+      "Wigglytuff ex",
+      "Wigglytuff-GX"
     ],
     "attacks": [
       {
@@ -3708,6 +3737,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "abilities": [
       {
         "name": "Bright Look",
@@ -4132,6 +4164,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Darkrai LV.X"
+    ],
     "attacks": [
       {
         "name": "Hide in Shadows",
@@ -4200,6 +4235,9 @@
     "hp": "130",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Giratina LV.X"
     ],
     "attacks": [
       {
@@ -4384,7 +4422,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -4446,6 +4488,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Quick Attack",
@@ -4832,6 +4878,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Porygon2",
+    "evolvesTo": [
+      "Porygon-Z LV.X"
+    ],
     "abilities": [
       {
         "name": "Plasma Transfer",
@@ -4890,6 +4939,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Riolu",
+    "evolvesTo": [
+      "Lucario LV.X"
+    ],
     "abilities": [
       {
         "name": "Intuition",
@@ -5012,6 +5064,9 @@
       "Grass"
     ],
     "evolvesFrom": "Eevee",
+    "evolvesTo": [
+      "Leafeon LV.X"
+    ],
     "attacks": [
       {
         "name": "Quick Attack",
@@ -5198,6 +5253,9 @@
       "Water"
     ],
     "evolvesFrom": "Eevee",
+    "evolvesTo": [
+      "Glaceon LV.X"
+    ],
     "attacks": [
       {
         "name": "Quick Attack",
@@ -5446,7 +5504,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -5606,7 +5684,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {

--- a/cards/en/cel25.json
+++ b/cards/en/cel25.json
@@ -10,6 +10,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Ho-Oh BREAK"
+    ],
     "attacks": [
       {
         "cost": [
@@ -209,6 +212,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Palkia LV.X"
+    ],
     "abilities": [
       {
         "type": "Ability",
@@ -270,7 +276,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -334,7 +344,7 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Flying Pikachu VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -402,9 +412,6 @@
       "Lightning"
     ],
     "evolvesFrom": "Flying Pikachu V",
-    "evolvesTo": [
-      "Raichu"
-    ],
     "rules": [
       "VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -463,7 +470,7 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Surfing Pikachu VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -520,9 +527,6 @@
       "Lightning"
     ],
     "evolvesFrom": "Surfing Pikachu V",
-    "evolvesTo": [
-      "Raichu"
-    ],
     "rules": [
       "VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -705,6 +709,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Xerneas BREAK"
+    ],
     "attacks": [
       {
         "cost": [
@@ -830,7 +837,9 @@
     "evolvesFrom": "Cosmog",
     "evolvesTo": [
       "Solgaleo",
-      "Lunala"
+      "Lunala",
+      "Lunala-GX",
+      "Solgaleo-GX"
     ],
     "attacks": [
       {
@@ -961,6 +970,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Zacian VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -1090,6 +1102,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Zamazenta VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -1151,6 +1166,9 @@
     "hp": "120",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Yveltal BREAK"
     ],
     "attacks": [
       {
@@ -1220,6 +1238,9 @@
     "hp": "130",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Dialga LV.X"
     ],
     "attacks": [
       {
@@ -1354,6 +1375,9 @@
     "hp": "130",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Lugia BREAK"
     ],
     "attacks": [
       {

--- a/cards/en/cel25c.json
+++ b/cards/en/cel25c.json
@@ -509,9 +509,6 @@
     "types": [
       "Water"
     ],
-    "evolvesTo": [
-      "Gyarados"
-    ],
     "rules": [
       "You can't have more than 1 Shining Magikarp in your deck."
     ],
@@ -1163,6 +1160,9 @@
     "hp": "170",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "M Mewtwo-EX"
     ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."

--- a/cards/en/col1.json
+++ b/cards/en/col1.json
@@ -118,6 +118,9 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Dialga LV.X"
+    ],
     "attacks": [
       {
         "name": "Time Rewind",
@@ -483,6 +486,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Ho-Oh BREAK"
+    ],
     "attacks": [
       {
         "name": "Combustion",
@@ -725,6 +731,9 @@
       "Grass"
     ],
     "evolvesFrom": "Eevee",
+    "evolvesTo": [
+      "Leafeon LV.X"
+    ],
     "attacks": [
       {
         "name": "Miasma Wind",
@@ -788,6 +797,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Riolu",
+    "evolvesTo": [
+      "Lucario LV.X"
+    ],
     "attacks": [
       {
         "name": "Dimension Sphere",
@@ -846,6 +858,9 @@
     "hp": "100",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Lugia BREAK"
     ],
     "attacks": [
       {
@@ -918,6 +933,9 @@
       "Fire"
     ],
     "evolvesFrom": "Magmar",
+    "evolvesTo": [
+      "Magmortar LV.X"
+    ],
     "attacks": [
       {
         "name": "Hard Crush",
@@ -981,6 +999,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "abilities": [
       {
         "name": "Roast Reveal",
@@ -1097,6 +1118,9 @@
     "hp": "100",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Palkia LV.X"
     ],
     "attacks": [
       {
@@ -1390,9 +1414,6 @@
     "hp": "30",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Clefairy"
     ],
     "abilities": [
       {
@@ -1932,6 +1953,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Snorlax LV.X"
+    ],
     "attacks": [
       {
         "name": "Layabout",
@@ -1997,6 +2021,9 @@
       "Grass"
     ],
     "evolvesFrom": "Tangela",
+    "evolvesTo": [
+      "Tangrowth LV.X"
+    ],
     "attacks": [
       {
         "name": "Grind",
@@ -2124,11 +2151,6 @@
     "types": [
       "Fighting"
     ],
-    "evolvesTo": [
-      "Hitmonlee",
-      "Hitmonchan",
-      "Hitmontop"
-    ],
     "abilities": [
       {
         "name": "Sweet Sleeping Face",
@@ -2174,6 +2196,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Teddiursa",
+    "evolvesTo": [
+      "Ursaluna"
+    ],
     "attacks": [
       {
         "name": "Confront",
@@ -2354,7 +2379,8 @@
     ],
     "evolvesFrom": "Chikorita",
     "evolvesTo": [
-      "Meganium"
+      "Meganium",
+      "Meganium ex"
     ],
     "attacks": [
       {
@@ -2423,7 +2449,8 @@
     ],
     "evolvesFrom": "Totodile",
     "evolvesTo": [
-      "Feraligatr"
+      "Feraligatr",
+      "Feraligatr ex"
     ],
     "attacks": [
       {
@@ -2557,7 +2584,9 @@
     ],
     "evolvesFrom": "Mareep",
     "evolvesTo": [
-      "Ampharos"
+      "Ampharos",
+      "Ampharos ex",
+      "Ampharos-GX"
     ],
     "attacks": [
       {
@@ -2743,9 +2772,6 @@
     "types": [
       "Fire"
     ],
-    "evolvesTo": [
-      "Magmar"
-    ],
     "abilities": [
       {
         "name": "Sweet Sleeping Face",
@@ -2836,7 +2862,8 @@
     ],
     "evolvesFrom": "Pidgey",
     "evolvesTo": [
-      "Pidgeot"
+      "Pidgeot",
+      "Pidgeot ex"
     ],
     "attacks": [
       {
@@ -2905,7 +2932,9 @@
     ],
     "evolvesFrom": "Cyndaquil",
     "evolvesTo": [
-      "Typhlosion"
+      "Typhlosion",
+      "Typhlosion ex",
+      "Hisuian Typhlosion"
     ],
     "attacks": [
       {
@@ -2967,7 +2996,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lucario"
+      "Lucario",
+      "Lucario-GX",
+      "Lucario ex"
     ],
     "attacks": [
       {
@@ -3201,7 +3232,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Clefable",
+      "Clefable ex"
     ],
     "attacks": [
       {
@@ -3260,7 +3292,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Quilava"
+      "Quilava",
+      "Dark Quilava"
     ],
     "attacks": [
       {
@@ -3317,7 +3350,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -3493,7 +3546,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Houndoom",
+      "Dark Houndoom",
+      "Houndoom ex"
     ],
     "attacks": [
       {
@@ -3549,7 +3604,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Weezing"
+      "Weezing",
+      "Dark Weezing",
+      "Galarian Weezing"
     ],
     "attacks": [
       {
@@ -3609,7 +3666,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -3720,7 +3780,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Flaaffy"
+      "Flaaffy",
+      "Dark Flaaffy"
     ],
     "attacks": [
       {
@@ -3905,7 +3966,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Donphan"
+      "Donphan",
+      "Dark Donphan"
     ],
     "abilities": [
       {
@@ -4035,7 +4097,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Forretress"
+      "Forretress",
+      "Dark Forretress",
+      "Forretress ex"
     ],
     "attacks": [
       {
@@ -4156,7 +4220,11 @@
     ],
     "evolvesTo": [
       "Slowbro",
-      "Slowking"
+      "Slowking",
+      "Dark Slowbro",
+      "Dark Slowking",
+      "Light Slowbro",
+      "Slowking ex"
     ],
     "attacks": [
       {
@@ -4336,7 +4404,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Ursaring"
+      "Ursaring",
+      "Dark Ursaring"
     ],
     "attacks": [
       {
@@ -4386,7 +4455,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Croconaw"
+      "Croconaw",
+      "Dark Croconaw"
     ],
     "attacks": [
       {
@@ -4439,7 +4509,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {
@@ -4960,6 +5032,9 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Dialga LV.X"
+    ],
     "attacks": [
       {
         "name": "Time Rewind",
@@ -5128,6 +5203,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Ho-Oh BREAK"
+    ],
     "attacks": [
       {
         "name": "Combustion",
@@ -5251,6 +5329,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Lugia BREAK"
+    ],
     "attacks": [
       {
         "name": "Linear Attack",
@@ -5320,6 +5401,9 @@
     "hp": "100",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Palkia LV.X"
     ],
     "attacks": [
       {

--- a/cards/en/dc1.json
+++ b/cards/en/dc1.json
@@ -11,7 +11,7 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Camerupt"
+      "Team Magma's Camerupt"
     ],
     "attacks": [
       {
@@ -124,7 +124,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Sealeo"
+      "Team Aqua's Sealeo"
     ],
     "attacks": [
       {
@@ -177,7 +177,7 @@
     ],
     "evolvesFrom": "Team Aqua's Spheal",
     "evolvesTo": [
-      "Walrein"
+      "Team Aqua's Walrein"
     ],
     "attacks": [
       {
@@ -370,7 +370,7 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Muk"
+      "Team Aqua's Muk"
     ],
     "attacks": [
       {
@@ -551,7 +551,7 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Claydol"
+      "Team Magma's Claydol"
     ],
     "attacks": [
       {
@@ -662,7 +662,7 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lairon"
+      "Team Magma's Lairon"
     ],
     "attacks": [
       {
@@ -715,7 +715,7 @@
     ],
     "evolvesFrom": "Team Magma's Aron",
     "evolvesTo": [
-      "Aggron"
+      "Team Magma's Aggron"
     ],
     "attacks": [
       {
@@ -909,7 +909,7 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Mightyena"
+      "Team Aqua's Mightyena"
     ],
     "attacks": [
       {
@@ -976,7 +976,7 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Mightyena"
+      "Team Magma's Mightyena"
     ],
     "attacks": [
       {
@@ -1177,7 +1177,7 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Sharpedo"
+      "Team Aqua's Sharpedo"
     ],
     "attacks": [
       {

--- a/cards/en/det1.json
+++ b/cards/en/det1.json
@@ -11,7 +11,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ivysaur"
+      "Ivysaur",
+      "Dark Ivysaur"
     ],
     "attacks": [
       {
@@ -173,7 +174,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -289,6 +291,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "abilities": [
       {
         "name": "Security Guard",
@@ -349,7 +354,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Golduck",
+      "Dark Golduck",
+      "Light Golduck"
     ],
     "attacks": [
       {
@@ -402,7 +409,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -453,6 +463,9 @@
       "Water"
     ],
     "evolvesFrom": "Frogadier",
+    "evolvesTo": [
+      "Greninja BREAK"
+    ],
     "abilities": [
       {
         "name": "Evasion Jutsu",
@@ -508,9 +521,6 @@
     "hp": "90",
     "types": [
       "Lightning"
-    ],
-    "evolvesTo": [
-      "Raichu"
     ],
     "attacks": [
       {
@@ -634,6 +644,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Mewtwo LV.X"
+    ],
     "attacks": [
       {
         "name": "Psyjack",
@@ -696,6 +709,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Machoke",
+    "evolvesTo": [
+      "Machamp LV.X",
+      "Machamp BREAK"
+    ],
     "attacks": [
       {
         "name": "Directing Traffic",
@@ -756,7 +773,11 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Wigglytuff"
+      "Wigglytuff",
+      "Dark Wigglytuff",
+      "Light Wigglytuff",
+      "Wigglytuff ex",
+      "Wigglytuff-GX"
     ],
     "attacks": [
       {

--- a/cards/en/dp1.json
+++ b/cards/en/dp1.json
@@ -11,6 +11,9 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Dialga LV.X"
+    ],
     "attacks": [
       {
         "name": "Time Bellow",
@@ -78,6 +81,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Dusclops",
+    "evolvesTo": [
+      "Dusknoir LV.X"
+    ],
     "abilities": [
       {
         "name": "Dark Palm",
@@ -144,6 +150,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Electabuzz",
+    "evolvesTo": [
+      "Electivire LV.X"
+    ],
     "abilities": [
       {
         "name": "Intense Voltage",
@@ -211,6 +220,10 @@
       "Water"
     ],
     "evolvesFrom": "Prinplup",
+    "evolvesTo": [
+      "Empoleon LV.X",
+      "Empoleon BREAK"
+    ],
     "attacks": [
       {
         "name": "Ice Blade",
@@ -273,6 +286,9 @@
       "Fire"
     ],
     "evolvesFrom": "Monferno",
+    "evolvesTo": [
+      "Infernape LV.X"
+    ],
     "attacks": [
       {
         "name": "Meteor Punch",
@@ -328,6 +344,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Riolu",
+    "evolvesTo": [
+      "Lucario LV.X"
+    ],
     "attacks": [
       {
         "name": "Feint",
@@ -387,6 +406,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Luxio",
+    "evolvesTo": [
+      "Luxray BREAK"
+    ],
     "abilities": [
       {
         "name": "Gleam Eyes",
@@ -452,6 +474,9 @@
       "Metal"
     ],
     "evolvesFrom": "Magneton",
+    "evolvesTo": [
+      "Magnezone LV.X"
+    ],
     "abilities": [
       {
         "name": "Magnetize",
@@ -642,6 +667,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Palkia LV.X"
+    ],
     "attacks": [
       {
         "name": "Spacial Rend",
@@ -703,6 +731,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Rhydon",
+    "evolvesTo": [
+      "Rhyperior LV.X"
+    ],
     "abilities": [
       {
         "name": "Earth Fissure",
@@ -1026,6 +1057,9 @@
       "Grass"
     ],
     "evolvesFrom": "Grotle",
+    "evolvesTo": [
+      "Torterra LV.X"
+    ],
     "attacks": [
       {
         "name": "Body Slam",
@@ -1408,6 +1442,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Skorupi",
+    "evolvesTo": [
+      "Drapion LV.X"
+    ],
     "attacks": [
       {
         "name": "Stomp",
@@ -1656,6 +1693,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Haunter",
+    "evolvesTo": [
+      "Gengar LV.X"
+    ],
     "attacks": [
       {
         "name": "Life Drain",
@@ -1781,6 +1821,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Hippopotas",
+    "evolvesTo": [
+      "Hippowdon LV.X"
+    ],
     "attacks": [
       {
         "name": "Vacuum Up",
@@ -1912,6 +1955,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Machoke",
+    "evolvesTo": [
+      "Machamp LV.X",
+      "Machamp BREAK"
+    ],
     "attacks": [
       {
         "name": "Revenge",
@@ -2034,9 +2081,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesTo": [
-      "Snorlax"
-    ],
     "abilities": [
       {
         "name": "Baby Evolution",
@@ -2094,6 +2138,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Hoothoot",
+    "evolvesTo": [
+      "Noctowl BREAK"
+    ],
     "attacks": [
       {
         "name": "See Beyond",
@@ -2282,6 +2329,9 @@
     "hp": "100",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Snorlax LV.X"
     ],
     "attacks": [
       {
@@ -2550,6 +2600,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Wobbuffet BREAK"
+    ],
     "attacks": [
       {
         "name": "Countercharge",
@@ -2600,9 +2653,6 @@
     "hp": "40",
     "types": [
       "Psychic"
-    ],
-    "evolvesTo": [
-      "Wobbuffet"
     ],
     "abilities": [
       {
@@ -2658,9 +2708,6 @@
     "hp": "40",
     "types": [
       "Grass"
-    ],
-    "evolvesTo": [
-      "Roselia"
     ],
     "abilities": [
       {
@@ -2719,7 +2766,8 @@
     ],
     "evolvesFrom": "Wurmple",
     "evolvesTo": [
-      "Dustox"
+      "Dustox",
+      "Dustox ex"
     ],
     "attacks": [
       {
@@ -2984,9 +3032,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesTo": [
-      "Electabuzz"
-    ],
     "abilities": [
       {
         "name": "Baby Evolution",
@@ -3121,7 +3166,8 @@
     ],
     "evolvesFrom": "Gastly",
     "evolvesTo": [
-      "Gengar"
+      "Gengar",
+      "Gengar ex"
     ],
     "attacks": [
       {
@@ -3316,7 +3362,8 @@
     ],
     "evolvesFrom": "Machop",
     "evolvesTo": [
-      "Machamp"
+      "Machamp",
+      "Machamp-GX"
     ],
     "attacks": [
       {
@@ -3381,7 +3428,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "attacks": [
       {
@@ -3449,9 +3497,6 @@
     "hp": "40",
     "types": [
       "Water"
-    ],
-    "evolvesTo": [
-      "Mantine"
     ],
     "abilities": [
       {
@@ -3574,7 +3619,9 @@
     ],
     "evolvesFrom": "Seedot",
     "evolvesTo": [
-      "Shiftry"
+      "Shiftry",
+      "Shiftry ex",
+      "Shiftry-GX"
     ],
     "attacks": [
       {
@@ -3831,7 +3878,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lucario"
+      "Lucario",
+      "Lucario-GX",
+      "Lucario ex"
     ],
     "attacks": [
       {
@@ -4290,9 +4339,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesTo": [
-      "Marill"
-    ],
     "abilities": [
       {
         "name": "Baby Evolution",
@@ -4407,9 +4453,6 @@
     "hp": "40",
     "types": [
       "Fighting"
-    ],
-    "evolvesTo": [
-      "Sudowoodo"
     ],
     "abilities": [
       {
@@ -4770,7 +4813,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Clefable",
+      "Clefable ex"
     ],
     "attacks": [
       {
@@ -4830,9 +4874,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesTo": [
-      "Clefairy"
-    ],
     "abilities": [
       {
         "name": "Baby Evolution",
@@ -4889,7 +4930,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Vespiquen"
+      "Vespiquen",
+      "Vespiquen ex"
     ],
     "attacks": [
       {
@@ -4956,7 +4998,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Dusclops"
+      "Dusclops",
+      "Dusclops ex"
     ],
     "attacks": [
       {
@@ -5092,7 +5135,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Haunter",
+      "Dark Haunter"
     ],
     "attacks": [
       {
@@ -5338,7 +5382,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Machoke"
+      "Machoke",
+      "Dark Machoke",
+      "Light Machoke"
     ],
     "attacks": [
       {
@@ -5390,7 +5436,8 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -5457,7 +5504,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Azumarill"
+      "Azumarill",
+      "Light Azumarill"
     ],
     "attacks": [
       {
@@ -5518,7 +5566,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Medicham"
+      "Medicham",
+      "Medicham ex"
     ],
     "attacks": [
       {
@@ -5701,7 +5750,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Steelix"
+      "Steelix",
+      "Dark Steelix",
+      "Steelix ex"
     ],
     "attacks": [
       {
@@ -5825,7 +5876,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Rapidash"
+      "Rapidash",
+      "Dark Rapidash"
     ],
     "attacks": [
       {
@@ -6201,7 +6253,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Weavile"
+      "Weavile",
+      "Weavile-GX"
     ],
     "attacks": [
       {

--- a/cards/en/dp2.json
+++ b/cards/en/dp2.json
@@ -200,6 +200,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Azelf LV.X"
+    ],
     "abilities": [
       {
         "name": "Downer Material",
@@ -314,6 +317,9 @@
       "Metal"
     ],
     "evolvesFrom": "Bronzor",
+    "evolvesTo": [
+      "Bronzong BREAK"
+    ],
     "abilities": [
       {
         "name": "Miracle Oracle",
@@ -500,6 +506,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Gabite",
+    "evolvesTo": [
+      "Garchomp LV.X"
+    ],
     "abilities": [
       {
         "name": "Rainbow Scale",
@@ -554,6 +563,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Murkrow",
+    "evolvesTo": [
+      "Honchkrow LV.X"
+    ],
     "abilities": [
       {
         "name": "Dark Genes",
@@ -675,6 +687,9 @@
       "Fire"
     ],
     "evolvesFrom": "Magmar",
+    "evolvesTo": [
+      "Magmortar LV.X"
+    ],
     "attacks": [
       {
         "name": "Smoke Bomb",
@@ -804,6 +819,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Mesprit LV.X"
+    ],
     "abilities": [
       {
         "name": "Upper Material",
@@ -861,6 +879,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Electromagnetic Induction",
@@ -1054,6 +1076,9 @@
     "hp": "60",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Uxie LV.X"
     ],
     "abilities": [
       {
@@ -1351,6 +1376,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Golbat",
+    "evolvesTo": [
+      "Crobat BREAK"
+    ],
     "abilities": [
       {
         "name": "Evolutionary Toxic",
@@ -1901,6 +1929,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "abilities": [
       {
         "name": "Color Shift",
@@ -2251,6 +2282,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Teddiursa",
+    "evolvesTo": [
+      "Ursaluna"
+    ],
     "attacks": [
       {
         "name": "Bad Temper",
@@ -2446,7 +2480,8 @@
     ],
     "evolvesFrom": "Chikorita",
     "evolvesTo": [
-      "Meganium"
+      "Meganium",
+      "Meganium ex"
     ],
     "attacks": [
       {
@@ -2511,9 +2546,6 @@
     "hp": "40",
     "types": [
       "Psychic"
-    ],
-    "evolvesTo": [
-      "Chimecho"
     ],
     "abilities": [
       {
@@ -2634,7 +2666,8 @@
     ],
     "evolvesFrom": "Totodile",
     "evolvesTo": [
-      "Feraligatr"
+      "Feraligatr",
+      "Feraligatr ex"
     ],
     "abilities": [
       {
@@ -2814,6 +2847,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Dudunsparce"
+    ],
     "attacks": [
       {
         "name": "Snake Hook",
@@ -2873,7 +2909,8 @@
     ],
     "evolvesFrom": "Gible",
     "evolvesTo": [
-      "Garchomp"
+      "Garchomp",
+      "Garchomp ex"
     ],
     "attacks": [
       {
@@ -2932,6 +2969,9 @@
     "hp": "70",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Farigiraf"
     ],
     "attacks": [
       {
@@ -2993,7 +3033,8 @@
     ],
     "evolvesFrom": "Zubat",
     "evolvesTo": [
-      "Crobat"
+      "Crobat",
+      "Crobat ex"
     ],
     "attacks": [
       {
@@ -3047,7 +3088,8 @@
     ],
     "evolvesFrom": "Geodude",
     "evolvesTo": [
-      "Golem"
+      "Golem",
+      "Golem ex"
     ],
     "attacks": [
       {
@@ -3117,9 +3159,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesTo": [
-      "Chansey"
-    ],
     "abilities": [
       {
         "name": "Baby Evolution",
@@ -3177,7 +3216,8 @@
     ],
     "evolvesFrom": "Aron",
     "evolvesTo": [
-      "Aggron"
+      "Aggron",
+      "Aggron ex"
     ],
     "attacks": [
       {
@@ -3556,7 +3596,9 @@
     ],
     "evolvesFrom": "Larvitar",
     "evolvesTo": [
-      "Tyranitar"
+      "Tyranitar",
+      "Tyranitar ex",
+      "Tyranitar-GX"
     ],
     "attacks": [
       {
@@ -3622,7 +3664,9 @@
     ],
     "evolvesFrom": "Cyndaquil",
     "evolvesTo": [
-      "Typhlosion"
+      "Typhlosion",
+      "Typhlosion ex",
+      "Hisuian Typhlosion"
     ],
     "attacks": [
       {
@@ -3741,7 +3785,8 @@
     ],
     "evolvesFrom": "Spheal",
     "evolvesTo": [
-      "Walrein"
+      "Walrein",
+      "Walrein ex"
     ],
     "attacks": [
       {
@@ -4158,7 +4203,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Kadabra"
+      "Kadabra",
+      "Dark Kadabra"
     ],
     "attacks": [
       {
@@ -4563,7 +4609,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Blissey"
+      "Blissey",
+      "Blissey ex"
     ],
     "attacks": [
       {
@@ -4694,7 +4741,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Toxicroak"
+      "Toxicroak",
+      "Toxicroak ex"
     ],
     "attacks": [
       {
@@ -4755,7 +4803,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Quilava"
+      "Quilava",
+      "Dark Quilava"
     ],
     "attacks": [
       {
@@ -4883,7 +4932,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Manectric",
+      "Manectric ex"
     ],
     "attacks": [
       {
@@ -4940,7 +4990,10 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Exeggutor"
+      "Exeggutor",
+      "Dark Exeggutor",
+      "Alolan Exeggutor-GX",
+      "Alolan Exeggutor"
     ],
     "attacks": [
       {
@@ -5222,7 +5275,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Pupitar"
+      "Pupitar",
+      "Dark Pupitar"
     ],
     "attacks": [
       {
@@ -5288,9 +5342,6 @@
     "types": [
       "Fire"
     ],
-    "evolvesTo": [
-      "Magmar"
-    ],
     "abilities": [
       {
         "name": "Baby Evolution",
@@ -5347,7 +5398,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -5408,7 +5462,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Honchkrow"
+      "Honchkrow",
+      "Honchkrow-GX"
     ],
     "attacks": [
       {
@@ -5596,9 +5651,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesTo": [
-      "Pikachu"
-    ],
     "abilities": [
       {
         "name": "Baby Evolution",
@@ -5661,7 +5713,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "abilities": [
       {
@@ -5726,7 +5782,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Octillery"
+      "Octillery",
+      "Dark Octillery"
     ],
     "attacks": [
       {
@@ -5787,7 +5844,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Sandslash"
+      "Sandslash",
+      "Dark Sandslash"
     ],
     "attacks": [
       {
@@ -5854,7 +5912,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Dewgong"
+      "Dewgong",
+      "Light Dewgong"
     ],
     "attacks": [
       {
@@ -6018,7 +6077,8 @@
     ],
     "evolvesTo": [
       "Glalie",
-      "Froslass"
+      "Froslass",
+      "Froslass ex"
     ],
     "attacks": [
       {
@@ -6201,7 +6261,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ariados"
+      "Ariados",
+      "Dark Ariados"
     ],
     "attacks": [
       {
@@ -6313,7 +6374,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Ursaring"
+      "Ursaring",
+      "Dark Ursaring"
     ],
     "attacks": [
       {
@@ -6374,7 +6436,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Croconaw"
+      "Croconaw",
+      "Dark Croconaw"
     ],
     "attacks": [
       {
@@ -6434,7 +6497,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {
@@ -6486,7 +6551,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Golbat"
+      "Golbat",
+      "Dark Golbat"
     ],
     "attacks": [
       {
@@ -6700,6 +6766,9 @@
       "Item"
     ],
     "hp": "50",
+    "evolvesTo": [
+      "Shieldon"
+    ],
     "rules": [
       "Play Armor Fossil as if it were a Colorless Basic Pokémon. (Armor Fossil counts as a Trainer card as well, but if Armor Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Armor Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Armor Fossil from play. (This doesn't count as a Knocked Out Pokémon.)"
     ],
@@ -6729,6 +6798,9 @@
       "Item"
     ],
     "hp": "50",
+    "evolvesTo": [
+      "Cranidos"
+    ],
     "rules": [
       "Play Skull Fossil as if it were a Colorless Basic Pokémon. (Skull Fossil counts as a Trainer card as well, but if Skull Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Skull Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Skull Fossil from play. (This doesn't count as a Knocked Out Pokémon.)"
     ],

--- a/cards/en/dp3.json
+++ b/cards/en/dp3.json
@@ -262,6 +262,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Vibrava",
+    "evolvesTo": [
+      "Flygon LV.X"
+    ],
     "abilities": [
       {
         "name": "Irritating Buzz",
@@ -388,6 +391,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Kirlia",
+    "evolvesTo": [
+      "Gardevoir LV.X"
+    ],
     "abilities": [
       {
         "name": "Telepass",
@@ -583,6 +589,9 @@
     "hp": "90",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Ho-Oh BREAK"
     ],
     "abilities": [
       {
@@ -831,6 +840,9 @@
     "hp": "90",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Lugia BREAK"
     ],
     "attacks": [
       {
@@ -1082,6 +1094,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Shelgon",
+    "evolvesTo": [
+      "Salamence LV.X"
+    ],
     "attacks": [
       {
         "name": "Direct Hit",
@@ -1332,6 +1347,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "abilities": [
       {
         "name": "Flame Dash",
@@ -1520,6 +1538,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Electabuzz",
+    "evolvesTo": [
+      "Electivire LV.X"
+    ],
     "abilities": [
       {
         "name": "Motor Drive",
@@ -1704,6 +1725,9 @@
       "Water"
     ],
     "evolvesFrom": "Psyduck",
+    "evolvesTo": [
+      "Golduck BREAK"
+    ],
     "attacks": [
       {
         "name": "Encore",
@@ -1895,6 +1919,9 @@
       "Fire"
     ],
     "evolvesFrom": "Magmar",
+    "evolvesTo": [
+      "Magmortar LV.X"
+    ],
     "abilities": [
       {
         "name": "Flame Body",
@@ -2086,6 +2113,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Nidorino",
+    "evolvesTo": [
+      "Nidoking BREAK"
+    ],
     "attacks": [
       {
         "name": "Poison Rub",
@@ -2825,7 +2855,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "attacks": [
       {
@@ -3016,9 +3049,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesTo": [
-      "Sirfetch'd"
-    ],
     "attacks": [
       {
         "name": "Swords Dance",
@@ -3084,7 +3114,9 @@
     ],
     "evolvesFrom": "Mareep",
     "evolvesTo": [
-      "Ampharos"
+      "Ampharos",
+      "Ampharos ex",
+      "Ampharos-GX"
     ],
     "attacks": [
       {
@@ -3153,7 +3185,8 @@
     ],
     "evolvesFrom": "Bulbasaur",
     "evolvesTo": [
-      "Venusaur"
+      "Venusaur",
+      "Venusaur ex"
     ],
     "attacks": [
       {
@@ -3275,7 +3308,9 @@
     "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
-      "Gallade"
+      "Gallade",
+      "Gardevoir ex",
+      "Gardevoir-GX"
     ],
     "attacks": [
       {
@@ -3583,7 +3618,8 @@
     ],
     "evolvesFrom": "Pidgey",
     "evolvesTo": [
-      "Pidgeot"
+      "Pidgeot",
+      "Pidgeot ex"
     ],
     "attacks": [
       {
@@ -3771,6 +3807,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Rattata",
+    "evolvesTo": [
+      "Raticate BREAK"
+    ],
     "attacks": [
       {
         "name": "Gnaw Off",
@@ -3944,7 +3983,9 @@
     ],
     "evolvesFrom": "Bagon",
     "evolvesTo": [
-      "Salamence"
+      "Salamence",
+      "Salamence ex",
+      "Salamence-GX"
     ],
     "attacks": [
       {
@@ -4129,9 +4170,6 @@
     "hp": "50",
     "types": [
       "Psychic"
-    ],
-    "evolvesTo": [
-      "Jynx"
     ],
     "abilities": [
       {
@@ -4529,7 +4567,9 @@
     ],
     "evolvesFrom": "Trapinch",
     "evolvesTo": [
-      "Flygon"
+      "Flygon",
+      "Flygon ex",
+      "Flygon-GX"
     ],
     "attacks": [
       {
@@ -4598,7 +4638,9 @@
     ],
     "evolvesFrom": "Squirtle",
     "evolvesTo": [
-      "Blastoise"
+      "Blastoise",
+      "Blastoise ex",
+      "Blastoise-GX"
     ],
     "attacks": [
       {
@@ -4728,7 +4770,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ivysaur"
+      "Ivysaur",
+      "Dark Ivysaur"
     ],
     "attacks": [
       {
@@ -4789,7 +4832,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Wormadam"
+      "Wormadam Plant Cloak"
     ],
     "abilities": [
       {
@@ -4847,7 +4890,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Wormadam"
+      "Wormadam Sandy Cloak"
     ],
     "abilities": [
       {
@@ -4905,7 +4948,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Wormadam"
+      "Wormadam Trash Cloak"
     ],
     "abilities": [
       {
@@ -4963,7 +5006,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Sharpedo"
+      "Sharpedo",
+      "Sharpedo ex"
     ],
     "attacks": [
       {
@@ -5030,7 +5074,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -5091,7 +5136,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Clefable",
+      "Clefable ex"
     ],
     "rules": [
       "Moon Stone: Clefairy can evolve during the turn you play it."
@@ -5142,9 +5188,6 @@
     "hp": "70",
     "types": [
       "Water"
-    ],
-    "evolvesTo": [
-      "Cursola"
     ],
     "attacks": [
       {
@@ -5205,7 +5248,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Dugtrio"
+      "Dugtrio",
+      "Dark Dugtrio"
     ],
     "attacks": [
       {
@@ -5272,7 +5316,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Dusclops"
+      "Dusclops",
+      "Dusclops ex"
     ],
     "rules": [
       "Reaper Cloth: Duskull can evolve during the turn you play it."
@@ -5400,7 +5445,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Muk"
+      "Muk",
+      "Dark Muk",
+      "Muk ex"
     ],
     "attacks": [
       {
@@ -5461,7 +5508,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -5773,7 +5822,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Flaaffy"
+      "Flaaffy",
+      "Dark Flaaffy"
     ],
     "attacks": [
       {
@@ -5840,7 +5890,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Honchkrow"
+      "Honchkrow",
+      "Honchkrow-GX"
     ],
     "rules": [
       "Dusk Stone: Murkrow can evolve during the turn you play it."
@@ -6026,7 +6077,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Donphan"
+      "Donphan",
+      "Dark Donphan"
     ],
     "attacks": [
       {
@@ -6160,7 +6212,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Golduck",
+      "Dark Golduck",
+      "Light Golduck"
     ],
     "attacks": [
       {
@@ -6336,7 +6390,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Raticate"
+      "Raticate",
+      "Dark Raticate"
     ],
     "attacks": [
       {
@@ -6513,7 +6568,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gastrodon"
+      "Gastrodon East Sea"
     ],
     "attacks": [
       {
@@ -6574,7 +6629,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gastrodon"
+      "Gastrodon West Sea"
     ],
     "attacks": [
       {
@@ -6757,7 +6812,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Banette"
+      "Banette",
+      "Banette ex",
+      "Banette-GX"
     ],
     "attacks": [
       {
@@ -6881,7 +6938,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wartortle"
+      "Wartortle",
+      "Dark Wartortle"
     ],
     "attacks": [
       {
@@ -6940,6 +6998,9 @@
     "hp": "70",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Wyrdeer"
     ],
     "attacks": [
       {
@@ -7000,7 +7061,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Sunflora"
+      "Sunflora",
+      "Light Sunflora"
     ],
     "attacks": [
       {
@@ -7132,7 +7194,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Venomoth"
+      "Venomoth",
+      "Light Venomoth",
+      "Venomoth-GX"
     ],
     "attacks": [
       {
@@ -7192,7 +7256,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {

--- a/cards/en/dp4.json
+++ b/cards/en/dp4.json
@@ -71,6 +71,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Cresselia LV.X"
+    ],
     "attacks": [
       {
         "name": "Moon Twinkle",
@@ -129,6 +132,9 @@
     "hp": "70",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Darkrai LV.X"
     ],
     "attacks": [
       {
@@ -194,6 +200,9 @@
     "hp": "80",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Darkrai LV.X"
     ],
     "attacks": [
       {
@@ -324,6 +333,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Porygon2",
+    "evolvesTo": [
+      "Porygon-Z LV.X"
+    ],
     "abilities": [
       {
         "name": "Conversion",
@@ -574,6 +586,9 @@
       "Grass"
     ],
     "evolvesFrom": "Tangela",
+    "evolvesTo": [
+      "Tangrowth LV.X"
+    ],
     "attacks": [
       {
         "name": "Power Whip",
@@ -940,6 +955,9 @@
     "hp": "90",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Dialga LV.X"
     ],
     "attacks": [
       {
@@ -1574,6 +1592,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Palkia LV.X"
+    ],
     "attacks": [
       {
         "name": "Spacial Rend",
@@ -1635,6 +1656,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Mankey",
+    "evolvesTo": [
+      "Annihilape ex",
+      "Annihilape"
+    ],
     "abilities": [
       {
         "name": "Anger Point",
@@ -2112,7 +2137,9 @@
     ],
     "evolvesFrom": "Torchic",
     "evolvesTo": [
-      "Blaziken"
+      "Blaziken",
+      "Blaziken ex",
+      "Blaziken-GX"
     ],
     "attacks": [
       {
@@ -2411,7 +2438,9 @@
     ],
     "evolvesFrom": "Treecko",
     "evolvesTo": [
-      "Sceptile"
+      "Sceptile",
+      "Sceptile ex",
+      "Sceptile-GX"
     ],
     "attacks": [
       {
@@ -2657,7 +2686,8 @@
     ],
     "evolvesFrom": "Whismur",
     "evolvesTo": [
-      "Exploud"
+      "Exploud",
+      "Exploud ex"
     ],
     "attacks": [
       {
@@ -2782,7 +2812,8 @@
     ],
     "evolvesFrom": "Mudkip",
     "evolvesTo": [
-      "Swampert"
+      "Swampert",
+      "Swampert ex"
     ],
     "attacks": [
       {
@@ -2974,7 +3005,8 @@
     ],
     "evolvesFrom": "Porygon",
     "evolvesTo": [
-      "Porygon-Z"
+      "Porygon-Z",
+      "Porygon-Z-GX"
     ],
     "abilities": [
       {
@@ -3522,7 +3554,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wailord"
+      "Wailord",
+      "Wailord ex"
     ],
     "attacks": [
       {
@@ -3646,7 +3679,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Claydol"
+      "Claydol",
+      "Claydol ex"
     ],
     "attacks": [
       {
@@ -3768,7 +3802,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Cacturne"
+      "Cacturne",
+      "Cacturne ex"
     ],
     "attacks": [
       {
@@ -3955,7 +3990,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Hypno"
+      "Hypno",
+      "Dark Hypno"
     ],
     "attacks": [
       {
@@ -4016,7 +4052,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Arbok"
+      "Arbok",
+      "Dark Arbok",
+      "Arbok ex"
     ],
     "attacks": [
       {
@@ -4077,7 +4115,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Milotic"
+      "Milotic",
+      "Milotic ex"
     ],
     "attacks": [
       {
@@ -4198,7 +4237,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Houndoom",
+      "Dark Houndoom",
+      "Houndoom ex"
     ],
     "attacks": [
       {
@@ -4257,9 +4298,6 @@
     "hp": "50",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Jigglypuff"
     ],
     "abilities": [
       {
@@ -4373,7 +4411,11 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Wigglytuff"
+      "Wigglytuff",
+      "Dark Wigglytuff",
+      "Light Wigglytuff",
+      "Wigglytuff ex",
+      "Wigglytuff-GX"
     ],
     "attacks": [
       {
@@ -4496,7 +4538,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Weezing"
+      "Weezing",
+      "Dark Weezing",
+      "Galarian Weezing"
     ],
     "attacks": [
       {
@@ -4732,7 +4776,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Hariyama"
+      "Hariyama",
+      "Hariyama ex"
     ],
     "attacks": [
       {
@@ -4794,7 +4839,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Primeape"
+      "Primeape",
+      "Dark Primeape"
     ],
     "attacks": [
       {
@@ -4917,7 +4963,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Porygon2"
+      "Porygon2",
+      "Dark Porygon2"
     ],
     "attacks": [
       {
@@ -4979,7 +5026,11 @@
     ],
     "evolvesTo": [
       "Slowbro",
-      "Slowking"
+      "Slowking",
+      "Dark Slowbro",
+      "Dark Slowking",
+      "Light Slowbro",
+      "Slowking ex"
     ],
     "attacks": [
       {
@@ -5040,7 +5091,10 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Magcargo"
+      "Magcargo",
+      "Dark Magcargo",
+      "Magcargo ex",
+      "Magcargo-GX"
     ],
     "attacks": [
       {
@@ -5219,7 +5273,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Altaria"
+      "Altaria",
+      "Altaria ex",
+      "Altaria-GX"
     ],
     "attacks": [
       {
@@ -5348,7 +5404,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Togetic"
+      "Togetic",
+      "Light Togetic"
     ],
     "attacks": [
       {

--- a/cards/en/dp5.json
+++ b/cards/en/dp5.json
@@ -75,6 +75,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Cresselia LV.X"
+    ],
     "attacks": [
       {
         "name": "Future Sight",
@@ -133,6 +136,9 @@
     "hp": "80",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Darkrai LV.X"
     ],
     "abilities": [
       {
@@ -207,6 +213,9 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Dialga LV.X"
+    ],
     "rules": [
       "Adamant Orb: If an Active Pokémon has Weakness to Metal type, Dialga's attacks do 20 more damage to that Pokémon (before applying Weakness and Resistance)."
     ],
@@ -278,6 +287,9 @@
       "Water"
     ],
     "evolvesFrom": "Eevee",
+    "evolvesTo": [
+      "Glaceon LV.X"
+    ],
     "attacks": [
       {
         "name": "Snow Cloak",
@@ -397,6 +409,9 @@
       "Grass"
     ],
     "evolvesFrom": "Eevee",
+    "evolvesTo": [
+      "Leafeon LV.X"
+    ],
     "attacks": [
       {
         "name": "Bind Down",
@@ -527,6 +542,9 @@
     "hp": "90",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Mewtwo LV.X"
     ],
     "attacks": [
       {
@@ -660,6 +678,9 @@
     "hp": "100",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Palkia LV.X"
     ],
     "rules": [
       "Lustrous Orb: If an Active Pokémon has Weakness to Water type, Palkia's attacks do 20 more damage to that Pokémon (before applying Weakness and Resistance)."
@@ -975,6 +996,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Bronzor",
+    "evolvesTo": [
+      "Bronzong BREAK"
+    ],
     "abilities": [
       {
         "name": "Cursed Alloy",
@@ -1050,6 +1074,10 @@
       "Water"
     ],
     "evolvesFrom": "Prinplup",
+    "evolvesTo": [
+      "Empoleon LV.X",
+      "Empoleon BREAK"
+    ],
     "attacks": [
       {
         "name": "Dual Splash",
@@ -1231,6 +1259,9 @@
       "Water"
     ],
     "evolvesFrom": "Eevee",
+    "evolvesTo": [
+      "Glaceon LV.X"
+    ],
     "attacks": [
       {
         "name": "Ice Shot",
@@ -1292,6 +1323,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Hippopotas",
+    "evolvesTo": [
+      "Hippowdon LV.X"
+    ],
     "attacks": [
       {
         "name": "Vacuum Sand",
@@ -1354,6 +1388,9 @@
       "Fire"
     ],
     "evolvesFrom": "Monferno",
+    "evolvesTo": [
+      "Infernape LV.X"
+    ],
     "attacks": [
       {
         "name": "Mach Punch",
@@ -1470,6 +1507,9 @@
       "Grass"
     ],
     "evolvesFrom": "Eevee",
+    "evolvesTo": [
+      "Leafeon LV.X"
+    ],
     "attacks": [
       {
         "name": "Sprial Drain",
@@ -1601,6 +1641,9 @@
       "Water"
     ],
     "evolvesFrom": "Omanyte",
+    "evolvesTo": [
+      "Omastar BREAK"
+    ],
     "abilities": [
       {
         "name": "Primal Swirl",
@@ -1846,6 +1889,9 @@
       "Grass"
     ],
     "evolvesFrom": "Grotle",
+    "evolvesTo": [
+      "Torterra LV.X"
+    ],
     "attacks": [
       {
         "name": "Earthquake",
@@ -2783,6 +2829,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Agility",
@@ -2845,7 +2895,11 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor",
+      "Scizor ex",
+      "Dark Scizor",
+      "Scizor-GX",
+      "Kleavor"
     ],
     "attacks": [
       {
@@ -3335,7 +3389,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Wormadam"
+      "Wormadam Sandy Cloak"
     ],
     "attacks": [
       {
@@ -3569,9 +3623,6 @@
     "types": [
       "Psychic"
     ],
-    "evolvesTo": [
-      "Chimecho"
-    ],
     "abilities": [
       {
         "name": "Baby Evolution",
@@ -3628,7 +3679,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Vespiquen"
+      "Vespiquen",
+      "Vespiquen ex"
     ],
     "attacks": [
       {
@@ -3695,7 +3747,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Toxicroak"
+      "Toxicroak",
+      "Toxicroak ex"
     ],
     "attacks": [
       {
@@ -3828,7 +3881,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -3895,7 +3968,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -3955,7 +4048,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Manectric",
+      "Manectric ex"
     ],
     "attacks": [
       {
@@ -4147,7 +4241,8 @@
     ],
     "evolvesFrom": "Dome Fossil",
     "evolvesTo": [
-      "Kabutops"
+      "Kabutops",
+      "Kabutops ex"
     ],
     "abilities": [
       {
@@ -4203,9 +4298,6 @@
     "hp": "60",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Snorlax"
     ],
     "abilities": [
       {
@@ -4325,7 +4417,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -4507,7 +4603,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gastrodon"
+      "Gastrodon East Sea"
     ],
     "attacks": [
       {
@@ -5002,6 +5098,9 @@
       "Item"
     ],
     "hp": "50",
+    "evolvesTo": [
+      "Aerodactyl"
+    ],
     "rules": [
       "Play Old Amber as if it were a Colorless Basic Pokémon. (Old Amber counts as a Trainer card as well, but if Old Amber is Knocked Out, this counts as a Knocked Out Pokémon.) Old Amber can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Old Amber from play. (This doesn't count as a Knocked Out Pokémon.)"
     ],
@@ -5119,6 +5218,9 @@
       "Item"
     ],
     "hp": "50",
+    "evolvesTo": [
+      "Kabuto"
+    ],
     "rules": [
       "Play Dome Fossil as if it were a Colorless Basic Pokémon. (Dome Fossil counts as a Trainer card as well, but if Dome Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Dome Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Dome Fossil from play. (This doesn't count as a Knocked Out Pokémon.)"
     ],
@@ -5171,6 +5273,9 @@
       "Item"
     ],
     "hp": "50",
+    "evolvesTo": [
+      "Omanyte"
+    ],
     "rules": [
       "Play Helix Fossil as if it were a Colorless Basic Pokémon. (Helix Fossil counts as a Trainer card as well, but if Helix Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Helix Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Helix Fossil from play. (This doesn't count as a Knocked Out Pokémon.)"
     ],

--- a/cards/en/dp6.json
+++ b/cards/en/dp6.json
@@ -197,6 +197,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Giratina LV.X"
+    ],
     "attacks": [
       {
         "name": "Shadow Force",
@@ -267,6 +270,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Gligar",
+    "evolvesTo": [
+      "Gliscor LV.X"
+    ],
     "attacks": [
       {
         "name": "Burning Poison",
@@ -330,6 +336,9 @@
     "hp": "100",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Heatran LV.X"
     ],
     "abilities": [
       {
@@ -451,6 +460,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Luxio",
+    "evolvesTo": [
+      "Luxray BREAK"
+    ],
     "abilities": [
       {
         "name": "Rivalry",
@@ -657,6 +669,9 @@
     "hp": "80",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Mewtwo LV.X"
     ],
     "attacks": [
       {
@@ -901,6 +916,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Regigigas LV.X"
+    ],
     "abilities": [
       {
         "name": "Slow Start",
@@ -1019,6 +1037,9 @@
       "Grass"
     ],
     "evolvesFrom": "Yanma",
+    "evolvesTo": [
+      "Yanmega BREAK"
+    ],
     "attacks": [
       {
         "name": "Sonic Wave",
@@ -1139,6 +1160,9 @@
     "hp": "70",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Azelf LV.X"
     ],
     "abilities": [
       {
@@ -1791,6 +1815,9 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Heatran LV.X"
+    ],
     "abilities": [
       {
         "name": "Smelt",
@@ -2041,6 +2068,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Mesprit LV.X"
+    ],
     "abilities": [
       {
         "name": "Psychic Bind",
@@ -2216,6 +2246,9 @@
     "hp": "100",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Regigigas LV.X"
     ],
     "abilities": [
       {
@@ -2560,6 +2593,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Uxie LV.X"
+    ],
     "abilities": [
       {
         "name": "Set Up",
@@ -2738,7 +2774,8 @@
     ],
     "evolvesFrom": "Claw Fossil",
     "evolvesTo": [
-      "Armaldo"
+      "Armaldo",
+      "Armaldo ex"
     ],
     "attacks": [
       {
@@ -3087,7 +3124,9 @@
     ],
     "evolvesFrom": "Dratini",
     "evolvesTo": [
-      "Dragonite"
+      "Dragonite",
+      "Dragonite ex",
+      "Dragonite-GX"
     ],
     "attacks": [
       {
@@ -3270,6 +3309,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Gligar",
+    "evolvesTo": [
+      "Gliscor LV.X"
+    ],
     "attacks": [
       {
         "name": "Poison Jab",
@@ -3647,6 +3689,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Riolu",
+    "evolvesTo": [
+      "Lucario LV.X"
+    ],
     "attacks": [
       {
         "name": "Focus Blast",
@@ -3777,6 +3822,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Cubone",
+    "evolvesTo": [
+      "Marowak BREAK"
+    ],
     "attacks": [
       {
         "name": "Heavy Bone",
@@ -3844,7 +3892,9 @@
     ],
     "evolvesFrom": "Beldum",
     "evolvesTo": [
-      "Metagross"
+      "Metagross",
+      "Metagross ex",
+      "Metagross-GX"
     ],
     "attacks": [
       {
@@ -3915,7 +3965,9 @@
     ],
     "evolvesFrom": "Beldum",
     "evolvesTo": [
-      "Metagross"
+      "Metagross",
+      "Metagross ex",
+      "Metagross-GX"
     ],
     "attacks": [
       {
@@ -4050,9 +4102,6 @@
       "Grass"
     ],
     "evolvesFrom": "Nincada",
-    "evolvesTo": [
-      "Shedinja"
-    ],
     "abilities": [
       {
         "name": "Cast-off Shell",
@@ -4241,7 +4290,9 @@
     ],
     "evolvesFrom": "Horsea",
     "evolvesTo": [
-      "Kingdra"
+      "Kingdra",
+      "Kingdra ex",
+      "Kingdra-GX"
     ],
     "attacks": [
       {
@@ -4303,6 +4354,9 @@
       "Water"
     ],
     "evolvesFrom": "Staryu",
+    "evolvesTo": [
+      "Starmie BREAK"
+    ],
     "attacks": [
       {
         "name": "Star Boomerang",
@@ -4766,6 +4820,9 @@
     "hp": "60",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Unown VSTAR"
     ],
     "abilities": [
       {
@@ -5247,7 +5304,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Lanturn"
+      "Lanturn",
+      "Light Lanturn"
     ],
     "attacks": [
       {
@@ -5308,7 +5366,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Lanturn"
+      "Lanturn",
+      "Light Lanturn"
     ],
     "attacks": [
       {
@@ -5369,7 +5428,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Crawdaunt"
+      "Crawdaunt",
+      "Crawdaunt ex"
     ],
     "attacks": [
       {
@@ -5430,7 +5490,10 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Marowak"
+      "Marowak",
+      "Dark Marowak",
+      "Alolan Marowak-GX",
+      "Alolan Marowak"
     ],
     "attacks": [
       {
@@ -5497,7 +5560,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "attacks": [
       {
@@ -5625,7 +5690,10 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Exeggutor"
+      "Exeggutor",
+      "Dark Exeggutor",
+      "Alolan Exeggutor-GX",
+      "Alolan Exeggutor"
     ],
     "attacks": [
       {
@@ -5820,7 +5888,9 @@
     "evolvesFrom": "Oddish",
     "evolvesTo": [
       "Vileplume",
-      "Bellossom"
+      "Bellossom",
+      "Vileplume ex",
+      "Vileplume-GX"
     ],
     "attacks": [
       {
@@ -5883,7 +5953,9 @@
     "evolvesFrom": "Oddish",
     "evolvesTo": [
       "Vileplume",
-      "Bellossom"
+      "Bellossom",
+      "Vileplume ex",
+      "Vileplume-GX"
     ],
     "attacks": [
       {
@@ -6244,7 +6316,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Houndoom",
+      "Dark Houndoom",
+      "Houndoom ex"
     ],
     "attacks": [
       {
@@ -6310,7 +6384,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ledian"
+      "Ledian",
+      "Light Ledian"
     ],
     "attacks": [
       {
@@ -6378,7 +6453,8 @@
     ],
     "evolvesFrom": "Root Fossil",
     "evolvesTo": [
-      "Cradily"
+      "Cradily",
+      "Cradily ex"
     ],
     "attacks": [
       {
@@ -6440,7 +6516,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -6567,7 +6645,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ninjask"
+      "Ninjask",
+      "Shedinja"
     ],
     "attacks": [
       {
@@ -6688,7 +6767,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Camerupt"
+      "Camerupt",
+      "Camerupt ex"
     ],
     "attacks": [
       {
@@ -6751,7 +6831,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Gloom"
+      "Gloom",
+      "Dark Gloom"
     ],
     "attacks": [
       {
@@ -6811,7 +6892,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Gloom"
+      "Gloom",
+      "Dark Gloom"
     ],
     "attacks": [
       {
@@ -6872,7 +6954,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Forretress"
+      "Forretress",
+      "Dark Forretress",
+      "Forretress ex"
     ],
     "attacks": [
       {
@@ -6995,7 +7079,8 @@
     "evolvesFrom": "Poliwag",
     "evolvesTo": [
       "Poliwrath",
-      "Politoed"
+      "Politoed",
+      "Politoed ex"
     ],
     "attacks": [
       {
@@ -7058,7 +7143,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Mightyena"
+      "Mightyena",
+      "Mightyena ex"
     ],
     "attacks": [
       {
@@ -7125,7 +7211,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lucario"
+      "Lucario",
+      "Lucario-GX",
+      "Lucario ex"
     ],
     "attacks": [
       {
@@ -7253,7 +7341,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Delcatty"
+      "Delcatty",
+      "Delcatty ex"
     ],
     "attacks": [
       {
@@ -7313,7 +7402,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Weavile"
+      "Weavile",
+      "Weavile-GX"
     ],
     "attacks": [
       {
@@ -7441,7 +7531,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Starmie"
+      "Starmie",
+      "Starmie-GX"
     ],
     "attacks": [
       {
@@ -7502,7 +7593,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Piloswine"
+      "Piloswine",
+      "Light Piloswine"
     ],
     "attacks": [
       {
@@ -7694,11 +7786,6 @@
     "hp": "60",
     "types": [
       "Fighting"
-    ],
-    "evolvesTo": [
-      "Hitmonlee",
-      "Hitmonchan",
-      "Hitmontop"
     ],
     "abilities": [
       {
@@ -8097,6 +8184,9 @@
       "Item"
     ],
     "hp": "40",
+    "evolvesTo": [
+      "Anorith"
+    ],
     "rules": [
       "Play Claw Fossil as if it were a Colorless Basic Pokémon. (Claw Fossil counts as a Trainer card as well, but if Claw Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Claw Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Claw Fossil from play. (This doesn't count as a Knocked Out Pokémon.)"
     ],
@@ -8126,6 +8216,9 @@
       "Item"
     ],
     "hp": "40",
+    "evolvesTo": [
+      "Lileep"
+    ],
     "rules": [
       "Play Root Fossil as if it were a Colorless Basic Pokémon. (Root Fossil counts as a Trainer card as well, but if Root Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Root Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Root Fossil from play. (This doesn't count as a Knocked Out Pokémon.)"
     ],

--- a/cards/en/dp7.json
+++ b/cards/en/dp7.json
@@ -12,6 +12,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Dusclops",
+    "evolvesTo": [
+      "Dusknoir LV.X"
+    ],
     "abilities": [
       {
         "name": "Shadow Command",
@@ -87,6 +90,10 @@
       "Metal"
     ],
     "evolvesFrom": "Prinplup",
+    "evolvesTo": [
+      "Empoleon LV.X",
+      "Empoleon BREAK"
+    ],
     "abilities": [
       {
         "name": "Emperor Aura",
@@ -155,6 +162,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Monferno",
+    "evolvesTo": [
+      "Infernape LV.X"
+    ],
     "abilities": [
       {
         "name": "Blaze Dance",
@@ -279,6 +289,9 @@
       "Metal"
     ],
     "evolvesFrom": "Magneton",
+    "evolvesTo": [
+      "Magnezone LV.X"
+    ],
     "abilities": [
       {
         "name": "Magnetic Search",
@@ -353,6 +366,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Magneton",
+    "evolvesTo": [
+      "Magnezone LV.X"
+    ],
     "abilities": [
       {
         "name": "Super Connectivity",
@@ -483,6 +499,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Slice",
@@ -553,6 +573,9 @@
     "hp": "100",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Regigigas LV.X"
     ],
     "abilities": [
       {
@@ -699,6 +722,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Grotle",
+    "evolvesTo": [
+      "Torterra LV.X"
+    ],
     "abilities": [
       {
         "name": "Sunshine Song",
@@ -845,6 +871,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Bronzor",
+    "evolvesTo": [
+      "Bronzong BREAK"
+    ],
     "abilities": [
       {
         "name": "Cycler",
@@ -992,6 +1021,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Skorupi",
+    "evolvesTo": [
+      "Drapion LV.X"
+    ],
     "attacks": [
       {
         "name": "Scorpion Grapple",
@@ -1132,6 +1164,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Dusclops",
+    "evolvesTo": [
+      "Dusknoir LV.X"
+    ],
     "abilities": [
       {
         "name": "Spirit Pulse",
@@ -1197,6 +1232,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Haunter",
+    "evolvesTo": [
+      "Gengar LV.X"
+    ],
     "abilities": [
       {
         "name": "Fainting Spell",
@@ -1343,6 +1381,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Machoke",
+    "evolvesTo": [
+      "Machamp LV.X",
+      "Machamp BREAK"
+    ],
     "attacks": [
       {
         "name": "Take Out",
@@ -1615,6 +1657,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Shelgon",
+    "evolvesTo": [
+      "Salamence LV.X"
+    ],
     "abilities": [
       {
         "name": "Battle Rush",
@@ -1969,6 +2014,9 @@
       "Grass"
     ],
     "evolvesFrom": "Tangela",
+    "evolvesTo": [
+      "Tangrowth LV.X"
+    ],
     "abilities": [
       {
         "name": "Green Renewal",
@@ -2260,9 +2308,6 @@
     "hp": "40",
     "types": [
       "Psychic"
-    ],
-    "evolvesTo": [
-      "Roselia"
     ],
     "abilities": [
       {
@@ -2591,9 +2636,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesTo": [
-      "Sirfetch'd"
-    ],
     "attacks": [
       {
         "name": "Go and Collect",
@@ -2659,7 +2701,9 @@
     ],
     "evolvesFrom": "Treecko",
     "evolvesTo": [
-      "Sceptile"
+      "Sceptile",
+      "Sceptile ex",
+      "Sceptile-GX"
     ],
     "attacks": [
       {
@@ -2728,7 +2772,8 @@
     ],
     "evolvesFrom": "Gastly",
     "evolvesTo": [
-      "Gengar"
+      "Gengar",
+      "Gengar ex"
     ],
     "attacks": [
       {
@@ -2795,7 +2840,8 @@
     ],
     "evolvesFrom": "Machop",
     "evolvesTo": [
-      "Machamp"
+      "Machamp",
+      "Machamp-GX"
     ],
     "attacks": [
       {
@@ -2858,7 +2904,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "attacks": [
       {
@@ -2928,7 +2975,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "attacks": [
       {
@@ -3061,9 +3109,6 @@
     "hp": "50",
     "types": [
       "Lightning"
-    ],
-    "evolvesTo": [
-      "Pikachu"
     ],
     "abilities": [
       {
@@ -3201,7 +3246,9 @@
     ],
     "evolvesFrom": "Larvitar",
     "evolvesTo": [
-      "Tyranitar"
+      "Tyranitar",
+      "Tyranitar ex",
+      "Tyranitar-GX"
     ],
     "abilities": [
       {
@@ -3329,7 +3376,11 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor",
+      "Scizor ex",
+      "Dark Scizor",
+      "Scizor-GX",
+      "Kleavor"
     ],
     "attacks": [
       {
@@ -3393,7 +3444,9 @@
     ],
     "evolvesFrom": "Bagon",
     "evolvesTo": [
-      "Salamence"
+      "Salamence",
+      "Salamence ex",
+      "Salamence-GX"
     ],
     "attacks": [
       {
@@ -3856,7 +3909,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Vespiquen"
+      "Vespiquen",
+      "Vespiquen ex"
     ],
     "rules": [
       "Honey: Once during your turn, when you put Combee from your hand onto your Bench, you may search your discard pile for a Basic Pokémon and put it onto your Bench."
@@ -3981,7 +4035,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Dusclops"
+      "Dusclops",
+      "Dusclops ex"
     ],
     "attacks": [
       {
@@ -4048,7 +4103,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Dusclops"
+      "Dusclops",
+      "Dusclops ex"
     ],
     "attacks": [
       {
@@ -4175,7 +4231,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Haunter",
+      "Dark Haunter"
     ],
     "attacks": [
       {
@@ -4241,7 +4298,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Pupitar"
+      "Pupitar",
+      "Dark Pupitar"
     ],
     "attacks": [
       {
@@ -4308,7 +4366,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Machoke"
+      "Machoke",
+      "Dark Machoke",
+      "Light Machoke"
     ],
     "attacks": [
       {
@@ -4369,7 +4429,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -4429,7 +4492,8 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "rules": [
       "Magnet: Magnemite's Retreat Cost is Colorless less for each Magnemite on your Bench."
@@ -4489,7 +4553,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -4622,7 +4687,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Steelix"
+      "Steelix",
+      "Dark Steelix",
+      "Steelix ex"
     ],
     "attacks": [
       {
@@ -4686,7 +4753,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -4756,7 +4827,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Rapidash"
+      "Rapidash",
+      "Dark Rapidash"
     ],
     "attacks": [
       {
@@ -5133,7 +5205,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Piloswine"
+      "Piloswine",
+      "Light Piloswine"
     ],
     "attacks": [
       {
@@ -5332,7 +5405,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {
@@ -5398,7 +5474,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {
@@ -6068,7 +6147,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -6130,7 +6210,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "attacks": [
       {
@@ -6330,7 +6413,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Dusclops"
+      "Dusclops",
+      "Dusclops ex"
     ],
     "attacks": [
       {
@@ -6405,7 +6489,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {

--- a/cards/en/dpp.json
+++ b/cards/en/dpp.json
@@ -890,7 +890,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "abilities": [
       {
@@ -1151,6 +1155,9 @@
       "Fire"
     ],
     "evolvesFrom": "Magmar",
+    "evolvesTo": [
+      "Magmortar LV.X"
+    ],
     "attacks": [
       {
         "name": "Smoke Bomb",
@@ -1214,6 +1221,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Electromagnetic Induction",
@@ -1394,6 +1405,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Darkrai LV.X"
+    ],
     "rules": [
       "Enigma Berry: If Darkrai is damaged by an attack from your opponent's Fighting Pokémon, remove 4 damage counters at the end of that turn."
     ],
@@ -1482,6 +1496,9 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Dialga LV.X"
+    ],
     "attacks": [
       {
         "name": "Time Bellow",
@@ -1547,6 +1564,9 @@
     "hp": "90",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Palkia LV.X"
     ],
     "attacks": [
       {
@@ -1860,6 +1880,9 @@
       "Metal"
     ],
     "evolvesFrom": "Magneton",
+    "evolvesTo": [
+      "Magnezone LV.X"
+    ],
     "attacks": [
       {
         "name": "Mirror Shot",
@@ -1929,6 +1952,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Dusclops",
+    "evolvesTo": [
+      "Dusknoir LV.X"
+    ],
     "abilities": [
       {
         "name": "Dark Hide",
@@ -2056,6 +2082,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Porygon2",
+    "evolvesTo": [
+      "Porygon-Z LV.X"
+    ],
     "abilities": [
       {
         "name": "Install",
@@ -2122,6 +2151,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Gligar",
+    "evolvesTo": [
+      "Gliscor LV.X"
+    ],
     "abilities": [
       {
         "name": "Bind Eye",
@@ -2385,6 +2417,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Regigigas LV.X"
+    ],
     "attacks": [
       {
         "name": "Drag Off",
@@ -2635,6 +2670,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Magneton",
+    "evolvesTo": [
+      "Magnezone LV.X"
+    ],
     "attacks": [
       {
         "name": "Charge Beam",
@@ -2921,6 +2959,9 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Dialga LV.X"
+    ],
     "attacks": [
       {
         "name": "Time Call",
@@ -2987,6 +3028,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Arceus LV.X"
+    ],
     "rules": [
       "You may have as many of this card in your deck as you like."
     ],
@@ -3041,6 +3085,9 @@
     "hp": "90",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Cresselia LV.X"
     ],
     "abilities": [
       {
@@ -3099,6 +3146,9 @@
     "hp": "90",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Darkrai LV.X"
     ],
     "abilities": [
       {

--- a/cards/en/dv1.json
+++ b/cards/en/dv1.json
@@ -11,7 +11,9 @@
       "Dragon"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "attacks": [
       {
@@ -63,7 +65,9 @@
       "Dragon"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "attacks": [
       {
@@ -124,7 +128,9 @@
     ],
     "evolvesFrom": "Dratini",
     "evolvesTo": [
-      "Dragonite"
+      "Dragonite",
+      "Dragonite ex",
+      "Dragonite-GX"
     ],
     "attacks": [
       {
@@ -189,7 +195,9 @@
     ],
     "evolvesFrom": "Dratini",
     "evolvesTo": [
-      "Dragonite"
+      "Dragonite",
+      "Dragonite ex",
+      "Dragonite-GX"
     ],
     "attacks": [
       {
@@ -378,7 +386,9 @@
     ],
     "evolvesFrom": "Bagon",
     "evolvesTo": [
-      "Salamence"
+      "Salamence",
+      "Salamence ex",
+      "Salamence-GX"
     ],
     "attacks": [
       {
@@ -442,6 +452,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Shelgon",
+    "evolvesTo": [
+      "Salamence LV.X"
+    ],
     "abilities": [
       {
         "name": "Scornful Storm",

--- a/cards/en/ecard1.json
+++ b/cards/en/ecard1.json
@@ -701,6 +701,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Haunter",
+    "evolvesTo": [
+      "Gengar LV.X"
+    ],
     "abilities": [
       {
         "name": "Chaos Move",
@@ -882,6 +885,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Machoke",
+    "evolvesTo": [
+      "Machamp LV.X",
+      "Machamp BREAK"
+    ],
     "abilities": [
       {
         "name": "Terraforming",
@@ -1096,6 +1103,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Mewtwo LV.X"
+    ],
     "attacks": [
       {
         "name": "Hypnosis",
@@ -1155,6 +1165,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "attacks": [
       {
         "name": "Mislead",
@@ -1376,6 +1389,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Plasma",
@@ -2719,6 +2736,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Haunter",
+    "evolvesTo": [
+      "Gengar LV.X"
+    ],
     "abilities": [
       {
         "name": "Chaos Move",
@@ -2900,6 +2920,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Machoke",
+    "evolvesTo": [
+      "Machamp LV.X",
+      "Machamp BREAK"
+    ],
     "abilities": [
       {
         "name": "Terraforming",
@@ -3180,6 +3204,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Mewtwo LV.X"
+    ],
     "attacks": [
       {
         "name": "Hypnosis",
@@ -3239,6 +3266,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "attacks": [
       {
         "name": "Mislead",
@@ -3460,6 +3490,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Plasma",
@@ -4055,7 +4089,8 @@
     ],
     "evolvesFrom": "Chikorita",
     "evolvesTo": [
-      "Meganium"
+      "Meganium",
+      "Meganium ex"
     ],
     "attacks": [
       {
@@ -4120,7 +4155,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Blissey"
+      "Blissey",
+      "Blissey ex"
     ],
     "attacks": [
       {
@@ -4183,7 +4219,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "attacks": [
       {
@@ -4245,7 +4284,8 @@
     ],
     "evolvesFrom": "Totodile",
     "evolvesTo": [
-      "Feraligatr"
+      "Feraligatr",
+      "Feraligatr ex"
     ],
     "attacks": [
       {
@@ -4307,7 +4347,9 @@
     ],
     "evolvesFrom": "Dratini",
     "evolvesTo": [
-      "Dragonite"
+      "Dragonite",
+      "Dragonite ex",
+      "Dragonite-GX"
     ],
     "attacks": [
       {
@@ -4413,7 +4455,9 @@
     ],
     "evolvesFrom": "Mareep",
     "evolvesTo": [
-      "Ampharos"
+      "Ampharos",
+      "Ampharos ex",
+      "Ampharos-GX"
     ],
     "attacks": [
       {
@@ -4476,7 +4520,9 @@
     "evolvesFrom": "Oddish",
     "evolvesTo": [
       "Vileplume",
-      "Bellossom"
+      "Bellossom",
+      "Vileplume ex",
+      "Vileplume-GX"
     ],
     "attacks": [
       {
@@ -4538,7 +4584,8 @@
     ],
     "evolvesFrom": "Geodude",
     "evolvesTo": [
-      "Golem"
+      "Golem",
+      "Golem ex"
     ],
     "attacks": [
       {
@@ -4602,7 +4649,8 @@
     ],
     "evolvesFrom": "Gastly",
     "evolvesTo": [
-      "Gengar"
+      "Gengar",
+      "Gengar ex"
     ],
     "attacks": [
       {
@@ -4727,7 +4775,8 @@
     ],
     "evolvesFrom": "Bulbasaur",
     "evolvesTo": [
-      "Venusaur"
+      "Venusaur",
+      "Venusaur ex"
     ],
     "attacks": [
       {
@@ -4847,7 +4896,8 @@
     ],
     "evolvesFrom": "Abra",
     "evolvesTo": [
-      "Alakazam"
+      "Alakazam",
+      "Alakazam ex"
     ],
     "attacks": [
       {
@@ -4907,7 +4957,8 @@
     ],
     "evolvesFrom": "Machop",
     "evolvesTo": [
-      "Machamp"
+      "Machamp",
+      "Machamp-GX"
     ],
     "attacks": [
       {
@@ -5088,7 +5139,8 @@
     ],
     "evolvesFrom": "Pidgey",
     "evolvesTo": [
-      "Pidgeot"
+      "Pidgeot",
+      "Pidgeot ex"
     ],
     "attacks": [
       {
@@ -5142,7 +5194,8 @@
     "evolvesFrom": "Poliwag",
     "evolvesTo": [
       "Poliwrath",
-      "Politoed"
+      "Politoed",
+      "Politoed ex"
     ],
     "attacks": [
       {
@@ -5204,7 +5257,9 @@
     ],
     "evolvesFrom": "Larvitar",
     "evolvesTo": [
-      "Tyranitar"
+      "Tyranitar",
+      "Tyranitar ex",
+      "Tyranitar-GX"
     ],
     "attacks": [
       {
@@ -5254,7 +5309,9 @@
     ],
     "evolvesFrom": "Cyndaquil",
     "evolvesTo": [
-      "Typhlosion"
+      "Typhlosion",
+      "Typhlosion ex",
+      "Hisuian Typhlosion"
     ],
     "attacks": [
       {
@@ -5316,7 +5373,9 @@
     ],
     "evolvesFrom": "Squirtle",
     "evolvesTo": [
-      "Blastoise"
+      "Blastoise",
+      "Blastoise ex",
+      "Blastoise-GX"
     ],
     "attacks": [
       {
@@ -5375,7 +5434,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Kadabra"
+      "Kadabra",
+      "Dark Kadabra"
     ],
     "attacks": [
       {
@@ -5433,7 +5493,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ivysaur"
+      "Ivysaur",
+      "Dark Ivysaur"
     ],
     "attacks": [
       {
@@ -5492,7 +5553,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ivysaur"
+      "Ivysaur",
+      "Dark Ivysaur"
     ],
     "attacks": [
       {
@@ -5610,7 +5672,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -5669,7 +5732,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -5858,7 +5922,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Clefable",
+      "Clefable ex"
     ],
     "attacks": [
       {
@@ -5914,9 +5979,6 @@
     "hp": "60",
     "types": [
       "Water"
-    ],
-    "evolvesTo": [
-      "Cursola"
     ],
     "attacks": [
       {
@@ -5978,7 +6040,10 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Marowak"
+      "Marowak",
+      "Dark Marowak",
+      "Alolan Marowak-GX",
+      "Alolan Marowak"
     ],
     "attacks": [
       {
@@ -6043,7 +6108,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Quilava"
+      "Quilava",
+      "Dark Quilava"
     ],
     "attacks": [
       {
@@ -6102,7 +6168,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Quilava"
+      "Quilava",
+      "Dark Quilava"
     ],
     "attacks": [
       {
@@ -6161,7 +6228,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Dugtrio"
+      "Dugtrio",
+      "Dark Dugtrio"
     ],
     "attacks": [
       {
@@ -6216,7 +6284,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "attacks": [
       {
@@ -6260,7 +6330,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Arbok"
+      "Arbok",
+      "Dark Arbok",
+      "Arbok ex"
     ],
     "attacks": [
       {
@@ -6309,7 +6381,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Haunter",
+      "Dark Haunter"
     ],
     "attacks": [
       {
@@ -6517,7 +6590,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Houndoom",
+      "Dark Houndoom",
+      "Houndoom ex"
     ],
     "attacks": [
       {
@@ -6572,7 +6647,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Weezing"
+      "Weezing",
+      "Dark Weezing",
+      "Galarian Weezing"
     ],
     "attacks": [
       {
@@ -6681,7 +6758,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Pupitar"
+      "Pupitar",
+      "Dark Pupitar"
     ],
     "attacks": [
       {
@@ -6740,7 +6818,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Machoke"
+      "Machoke",
+      "Dark Machoke",
+      "Light Machoke"
     ],
     "attacks": [
       {
@@ -6799,7 +6879,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -6848,7 +6931,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Flaaffy"
+      "Flaaffy",
+      "Dark Flaaffy"
     ],
     "attacks": [
       {
@@ -6897,7 +6981,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Azumarill"
+      "Azumarill",
+      "Light Azumarill"
     ],
     "attacks": [
       {
@@ -6956,7 +7041,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -7015,7 +7102,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Gloom"
+      "Gloom",
+      "Dark Gloom"
     ],
     "attacks": [
       {
@@ -7139,7 +7227,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -7257,7 +7349,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Rapidash"
+      "Rapidash",
+      "Dark Rapidash"
     ],
     "attacks": [
       {
@@ -7363,7 +7456,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Raticate"
+      "Raticate",
+      "Dark Raticate"
     ],
     "attacks": [
       {
@@ -7526,7 +7620,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wartortle"
+      "Wartortle",
+      "Dark Wartortle"
     ],
     "attacks": [
       {
@@ -7585,7 +7680,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wartortle"
+      "Wartortle",
+      "Dark Wartortle"
     ],
     "attacks": [
       {
@@ -7702,7 +7798,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Croconaw"
+      "Croconaw",
+      "Dark Croconaw"
     ],
     "attacks": [
       {
@@ -7761,7 +7858,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Croconaw"
+      "Croconaw",
+      "Dark Croconaw"
     ],
     "attacks": [
       {
@@ -7820,7 +7918,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {

--- a/cards/en/ecard1.json
+++ b/cards/en/ecard1.json
@@ -2957,7 +2957,6 @@
     "types": [
       "Fire"
     ],
-    "evolvesFrom": "Magmar",
     "evolvesTo": [
       "Magmar"
     ],

--- a/cards/en/ecard1.json
+++ b/cards/en/ecard1.json
@@ -1213,7 +1213,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesFrom": "Pikachu",
     "evolvesTo": [
       "Pikachu"
     ],

--- a/cards/en/ecard2.json
+++ b/cards/en/ecard2.json
@@ -474,7 +474,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesFrom": "Electabuzz",
     "evolvesTo": [
       "Electabuzz"
     ],
@@ -3545,7 +3544,6 @@
     "types": [
       "Psychic"
     ],
-    "evolvesFrom": "Jynx",
     "evolvesTo": [
       "Jynx"
     ],

--- a/cards/en/ecard2.json
+++ b/cards/en/ecard2.json
@@ -70,6 +70,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "abilities": [
       {
         "name": "Extreme Speed",
@@ -1209,7 +1212,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "abilities": [
       {
@@ -1329,6 +1333,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Nidorino",
+    "evolvesTo": [
+      "Nidoking BREAK"
+    ],
     "abilities": [
       {
         "name": "Earth Rage",
@@ -1394,6 +1401,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "attacks": [
       {
         "name": "Miracle Tail",
@@ -1567,7 +1577,8 @@
     ],
     "evolvesFrom": "Porygon",
     "evolvesTo": [
-      "Porygon-Z"
+      "Porygon-Z",
+      "Porygon-Z-GX"
     ],
     "abilities": [
       {
@@ -1624,6 +1635,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Mankey",
+    "evolvesTo": [
+      "Annihilape ex",
+      "Annihilape"
+    ],
     "attacks": [
       {
         "name": "Karate Chop",
@@ -2716,7 +2731,9 @@
     ],
     "evolvesFrom": "Mareep",
     "evolvesTo": [
-      "Ampharos"
+      "Ampharos",
+      "Ampharos ex",
+      "Ampharos-GX"
     ],
     "attacks": [
       {
@@ -2833,7 +2850,9 @@
     "evolvesFrom": "Oddish",
     "evolvesTo": [
       "Vileplume",
-      "Bellossom"
+      "Bellossom",
+      "Vileplume ex",
+      "Vileplume-GX"
     ],
     "abilities": [
       {
@@ -2891,6 +2910,9 @@
       "Water"
     ],
     "evolvesFrom": "Psyduck",
+    "evolvesTo": [
+      "Golduck BREAK"
+    ],
     "attacks": [
       {
         "name": "Slash",
@@ -2950,7 +2972,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -3000,7 +3024,8 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -3065,7 +3090,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Azumarill"
+      "Azumarill",
+      "Light Azumarill"
     ],
     "attacks": [
       {
@@ -3124,6 +3150,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Cubone",
+    "evolvesTo": [
+      "Marowak BREAK"
+    ],
     "attacks": [
       {
         "name": "Triple Bone",
@@ -3251,7 +3280,9 @@
     ],
     "evolvesFrom": "Larvitar",
     "evolvesTo": [
-      "Tyranitar"
+      "Tyranitar",
+      "Tyranitar ex",
+      "Tyranitar-GX"
     ],
     "attacks": [
       {
@@ -3302,7 +3333,11 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor",
+      "Scizor ex",
+      "Dark Scizor",
+      "Scizor-GX",
+      "Kleavor"
     ],
     "attacks": [
       {
@@ -3363,7 +3398,9 @@
     ],
     "evolvesFrom": "Horsea",
     "evolvesTo": [
-      "Kingdra"
+      "Kingdra",
+      "Kingdra ex",
+      "Kingdra-GX"
     ],
     "attacks": [
       {
@@ -3591,7 +3628,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ariados"
+      "Ariados",
+      "Dark Ariados"
     ],
     "attacks": [
       {
@@ -3698,7 +3736,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {
@@ -3992,7 +4033,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Blissey"
+      "Blissey",
+      "Blissey ex"
     ],
     "attacks": [
       {
@@ -4053,7 +4095,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Lanturn"
+      "Lanturn",
+      "Light Lanturn"
     ],
     "attacks": [
       {
@@ -4112,7 +4155,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Lanturn"
+      "Lanturn",
+      "Light Lanturn"
     ],
     "attacks": [
       {
@@ -4171,7 +4215,10 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Marowak"
+      "Marowak",
+      "Dark Marowak",
+      "Alolan Marowak-GX",
+      "Alolan Marowak"
     ],
     "attacks": [
       {
@@ -4300,7 +4347,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Hypno"
+      "Hypno",
+      "Dark Hypno"
     ],
     "attacks": [
       {
@@ -4366,7 +4414,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -4424,7 +4492,10 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Exeggutor"
+      "Exeggutor",
+      "Dark Exeggutor",
+      "Alolan Exeggutor-GX",
+      "Alolan Exeggutor"
     ],
     "attacks": [
       {
@@ -4482,7 +4553,10 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Exeggutor"
+      "Exeggutor",
+      "Dark Exeggutor",
+      "Alolan Exeggutor-GX",
+      "Alolan Exeggutor"
     ],
     "attacks": [
       {
@@ -4589,7 +4663,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Muk"
+      "Muk",
+      "Dark Muk",
+      "Muk ex"
     ],
     "attacks": [
       {
@@ -4638,7 +4714,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -4974,7 +5052,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Houndoom",
+      "Dark Houndoom",
+      "Houndoom ex"
     ],
     "attacks": [
       {
@@ -5033,7 +5113,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Houndoom",
+      "Dark Houndoom",
+      "Houndoom ex"
     ],
     "attacks": [
       {
@@ -5148,7 +5230,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Pupitar"
+      "Pupitar",
+      "Dark Pupitar"
     ],
     "attacks": [
       {
@@ -5268,7 +5351,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "abilities": [
       {
@@ -5325,7 +5409,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Primeape"
+      "Primeape",
+      "Dark Primeape"
     ],
     "attacks": [
       {
@@ -5384,7 +5469,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Flaaffy"
+      "Flaaffy",
+      "Dark Flaaffy"
     ],
     "attacks": [
       {
@@ -5613,7 +5699,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Gloom"
+      "Gloom",
+      "Dark Gloom"
     ],
     "attacks": [
       {
@@ -5672,7 +5759,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Steelix"
+      "Steelix",
+      "Dark Steelix",
+      "Steelix ex"
     ],
     "attacks": [
       {
@@ -5782,7 +5871,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Donphan"
+      "Donphan",
+      "Dark Donphan"
     ],
     "attacks": [
       {
@@ -5905,7 +5995,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Rapidash"
+      "Rapidash",
+      "Dark Rapidash"
     ],
     "attacks": [
       {
@@ -5964,7 +6055,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Porygon2"
+      "Porygon2",
+      "Dark Porygon2"
     ],
     "attacks": [
       {
@@ -6022,7 +6114,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Golduck",
+      "Dark Golduck",
+      "Light Golduck"
     ],
     "attacks": [
       {
@@ -6081,7 +6175,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Octillery"
+      "Octillery",
+      "Dark Octillery"
     ],
     "attacks": [
       {
@@ -6130,7 +6225,11 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor",
+      "Scizor ex",
+      "Dark Scizor",
+      "Scizor-GX",
+      "Kleavor"
     ],
     "attacks": [
       {
@@ -6254,7 +6353,11 @@
     ],
     "evolvesTo": [
       "Slowbro",
-      "Slowking"
+      "Slowking",
+      "Dark Slowbro",
+      "Dark Slowking",
+      "Light Slowbro",
+      "Slowking ex"
     ],
     "attacks": [
       {
@@ -6369,7 +6472,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Weavile"
+      "Weavile",
+      "Weavile-GX"
     ],
     "attacks": [
       {
@@ -6434,7 +6538,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ariados"
+      "Ariados",
+      "Dark Ariados"
     ],
     "attacks": [
       {
@@ -6609,7 +6714,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Togetic"
+      "Togetic",
+      "Light Togetic"
     ],
     "attacks": [
       {
@@ -6667,7 +6773,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {
@@ -6716,7 +6825,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {
@@ -7620,6 +7731,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Lugia BREAK"
+    ],
     "abilities": [
       {
         "name": "Crystal Type",
@@ -7689,6 +7803,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Nidorino",
+    "evolvesTo": [
+      "Nidoking BREAK"
+    ],
     "abilities": [
       {
         "name": "Crystal Type",
@@ -7818,6 +7935,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "abilities": [
       {
         "name": "Extreme Speed",
@@ -8613,7 +8733,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "abilities": [
       {
@@ -8733,6 +8854,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Nidorino",
+    "evolvesTo": [
+      "Nidoking BREAK"
+    ],
     "abilities": [
       {
         "name": "Earth Rage",
@@ -8798,6 +8922,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "attacks": [
       {
         "name": "Miracle Tail",

--- a/cards/en/ecard3.json
+++ b/cards/en/ecard3.json
@@ -123,6 +123,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "abilities": [
       {
         "name": "Energy Recharge",
@@ -312,6 +315,9 @@
       "Grass"
     ],
     "evolvesFrom": "Golbat",
+    "evolvesTo": [
+      "Crobat BREAK"
+    ],
     "abilities": [
       {
         "name": "Carry Off",
@@ -556,6 +562,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Haunter",
+    "evolvesTo": [
+      "Gengar LV.X"
+    ],
     "abilities": [
       {
         "name": "Manipulate",
@@ -915,6 +924,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Machoke",
+    "evolvesTo": [
+      "Machamp LV.X",
+      "Machamp BREAK"
+    ],
     "abilities": [
       {
         "name": "Immunity",
@@ -1104,7 +1117,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "abilities": [
       {
@@ -1163,7 +1177,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "attacks": [
       {
@@ -1361,6 +1376,9 @@
       "Water"
     ],
     "evolvesFrom": "Omanyte",
+    "evolvesTo": [
+      "Omastar BREAK"
+    ],
     "abilities": [
       {
         "name": "Primal Stare",
@@ -1613,6 +1631,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Zzzap",
@@ -1799,6 +1821,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Staryu",
+    "evolvesTo": [
+      "Starmie BREAK"
+    ],
     "attacks": [
       {
         "name": "Energy Burst",
@@ -2233,7 +2258,8 @@
     ],
     "evolvesFrom": "Mysterious Fossil",
     "evolvesTo": [
-      "Kabutops"
+      "Kabutops",
+      "Kabutops ex"
     ],
     "abilities": [
       {
@@ -2291,7 +2317,8 @@
     ],
     "evolvesFrom": "Machop",
     "evolvesTo": [
-      "Machamp"
+      "Machamp",
+      "Machamp-GX"
     ],
     "attacks": [
       {
@@ -2416,6 +2443,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Hoothoot",
+    "evolvesTo": [
+      "Noctowl BREAK"
+    ],
     "abilities": [
       {
         "name": "Investigate",
@@ -2659,6 +2689,9 @@
       "Water"
     ],
     "evolvesFrom": "Staryu",
+    "evolvesTo": [
+      "Starmie BREAK"
+    ],
     "attacks": [
       {
         "name": "Water Gun",
@@ -2716,6 +2749,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Wobbuffet BREAK"
+    ],
     "abilities": [
       {
         "name": "Mirror Coat",
@@ -2772,7 +2808,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Kadabra"
+      "Kadabra",
+      "Dark Kadabra"
     ],
     "abilities": [
       {
@@ -2968,7 +3005,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Dugtrio"
+      "Dugtrio",
+      "Dark Dugtrio"
     ],
     "attacks": [
       {
@@ -3140,6 +3178,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Dudunsparce"
+    ],
     "abilities": [
       {
         "name": "Slippery Skin",
@@ -3201,7 +3242,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -3258,9 +3319,6 @@
     "hp": "50",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Sirfetch'd"
     ],
     "attacks": [
       {
@@ -3391,7 +3449,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Haunter",
+      "Dark Haunter"
     ],
     "attacks": [
       {
@@ -3444,6 +3503,9 @@
     "hp": "60",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Farigiraf"
     ],
     "attacks": [
       {
@@ -3562,7 +3624,8 @@
     ],
     "evolvesFrom": "Zubat",
     "evolvesTo": [
-      "Crobat"
+      "Crobat",
+      "Crobat ex"
     ],
     "attacks": [
       {
@@ -3683,7 +3746,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -3743,7 +3808,8 @@
     ],
     "evolvesFrom": "Gastly",
     "evolvesTo": [
-      "Gengar"
+      "Gengar",
+      "Gengar ex"
     ],
     "attacks": [
       {
@@ -3932,7 +3998,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Houndoom",
+      "Dark Houndoom",
+      "Houndoom ex"
     ],
     "attacks": [
       {
@@ -4036,7 +4104,11 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Wigglytuff"
+      "Wigglytuff",
+      "Dark Wigglytuff",
+      "Light Wigglytuff",
+      "Wigglytuff ex",
+      "Wigglytuff-GX"
     ],
     "attacks": [
       {
@@ -4096,7 +4168,8 @@
     ],
     "evolvesFrom": "Abra",
     "evolvesTo": [
-      "Alakazam"
+      "Alakazam",
+      "Alakazam ex"
     ],
     "attacks": [
       {
@@ -4273,7 +4346,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ledian"
+      "Ledian",
+      "Light Ledian"
     ],
     "attacks": [
       {
@@ -4337,7 +4411,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ledian"
+      "Ledian",
+      "Light Ledian"
     ],
     "attacks": [
       {
@@ -4396,7 +4471,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Machoke"
+      "Machoke",
+      "Dark Machoke",
+      "Light Machoke"
     ],
     "attacks": [
       {
@@ -4455,7 +4532,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -4513,7 +4593,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -4635,7 +4716,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -4684,7 +4767,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Honchkrow"
+      "Honchkrow",
+      "Honchkrow-GX"
     ],
     "attacks": [
       {
@@ -4807,6 +4891,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Nidorina"
+    ],
     "attacks": [
       {
         "name": "Call for Family",
@@ -4861,6 +4948,9 @@
     "hp": "50",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Nidorina"
     ],
     "attacks": [
       {
@@ -4973,7 +5063,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -5023,7 +5117,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Forretress"
+      "Forretress",
+      "Dark Forretress",
+      "Forretress ex"
     ],
     "attacks": [
       {
@@ -5072,7 +5168,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Forretress"
+      "Forretress",
+      "Dark Forretress",
+      "Forretress ex"
     ],
     "attacks": [
       {
@@ -5183,7 +5281,8 @@
     "evolvesFrom": "Poliwag",
     "evolvesTo": [
       "Poliwrath",
-      "Politoed"
+      "Politoed",
+      "Politoed ex"
     ],
     "attacks": [
       {
@@ -5243,6 +5342,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Rattata",
+    "evolvesTo": [
+      "Raticate BREAK"
+    ],
     "attacks": [
       {
         "name": "Scratch",
@@ -5300,7 +5402,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Raticate"
+      "Raticate",
+      "Dark Raticate"
     ],
     "attacks": [
       {
@@ -5424,7 +5527,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Sandslash"
+      "Sandslash",
+      "Dark Sandslash"
     ],
     "attacks": [
       {
@@ -5553,7 +5657,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Dewgong"
+      "Dewgong",
+      "Light Dewgong"
     ],
     "attacks": [
       {
@@ -5602,7 +5707,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Dewgong"
+      "Dewgong",
+      "Light Dewgong"
     ],
     "attacks": [
       {
@@ -5780,7 +5886,10 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Magcargo"
+      "Magcargo",
+      "Dark Magcargo",
+      "Magcargo ex",
+      "Magcargo-GX"
     ],
     "attacks": [
       {
@@ -5839,7 +5948,10 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Magcargo"
+      "Magcargo",
+      "Dark Magcargo",
+      "Magcargo ex",
+      "Magcargo-GX"
     ],
     "attacks": [
       {
@@ -5888,6 +6000,9 @@
     "hp": "80",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Snorlax LV.X"
     ],
     "abilities": [
       {
@@ -6005,6 +6120,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Wyrdeer"
+    ],
     "attacks": [
       {
         "name": "Threaten",
@@ -6062,7 +6180,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Starmie"
+      "Starmie",
+      "Starmie-GX"
     ],
     "attacks": [
       {
@@ -6120,7 +6239,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Starmie"
+      "Starmie",
+      "Starmie-GX"
     ],
     "attacks": [
       {
@@ -6244,7 +6364,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Sunflora"
+      "Sunflora",
+      "Light Sunflora"
     ],
     "attacks": [
       {
@@ -6308,7 +6429,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Piloswine"
+      "Piloswine",
+      "Light Piloswine"
     ],
     "attacks": [
       {
@@ -6366,7 +6488,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Piloswine"
+      "Piloswine",
+      "Light Piloswine"
     ],
     "attacks": [
       {
@@ -6431,7 +6554,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Ursaring"
+      "Ursaring",
+      "Dark Ursaring"
     ],
     "attacks": [
       {
@@ -6490,6 +6614,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Teddiursa",
+    "evolvesTo": [
+      "Ursaluna"
+    ],
     "attacks": [
       {
         "name": "Bear Hug",
@@ -6607,7 +6734,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Venomoth"
+      "Venomoth",
+      "Light Venomoth",
+      "Venomoth-GX"
     ],
     "attacks": [
       {
@@ -6666,7 +6795,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {
@@ -6899,7 +7031,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Golbat"
+      "Golbat",
+      "Dark Golbat"
     ],
     "attacks": [
       {
@@ -6963,7 +7096,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Golbat"
+      "Golbat",
+      "Dark Golbat"
     ],
     "attacks": [
       {
@@ -7791,6 +7925,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Golbat",
+    "evolvesTo": [
+      "Crobat BREAK"
+    ],
     "abilities": [
       {
         "name": "Crystal Type",
@@ -8120,6 +8257,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "abilities": [
       {
         "name": "Energy Recharge",
@@ -8309,6 +8449,9 @@
       "Grass"
     ],
     "evolvesFrom": "Golbat",
+    "evolvesTo": [
+      "Crobat BREAK"
+    ],
     "abilities": [
       {
         "name": "Carry Off",
@@ -8553,6 +8696,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Haunter",
+    "evolvesTo": [
+      "Gengar LV.X"
+    ],
     "abilities": [
       {
         "name": "Manipulate",
@@ -8912,6 +9058,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Machoke",
+    "evolvesTo": [
+      "Machamp LV.X",
+      "Machamp BREAK"
+    ],
     "abilities": [
       {
         "name": "Immunity",
@@ -9101,7 +9251,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "abilities": [
       {
@@ -9160,7 +9311,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "attacks": [
       {
@@ -9553,6 +9705,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Zzzap",
@@ -9739,6 +9895,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Staryu",
+    "evolvesTo": [
+      "Starmie BREAK"
+    ],
     "attacks": [
       {
         "name": "Energy Burst",

--- a/cards/en/ecard3.json
+++ b/cards/en/ecard3.json
@@ -2865,7 +2865,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesFrom": "Clefairy",
     "evolvesTo": [
       "Clefairy"
     ],

--- a/cards/en/ecard3.json
+++ b/cards/en/ecard3.json
@@ -3990,7 +3990,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesFrom": "Jigglypuff",
     "evolvesTo": [
       "Jigglypuff"
     ],

--- a/cards/en/ex1.json
+++ b/cards/en/ex1.json
@@ -387,6 +387,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Kirlia",
+    "evolvesTo": [
+      "Gardevoir LV.X"
+    ],
     "abilities": [
       {
         "name": "Psy Shadow",
@@ -1554,7 +1557,8 @@
     ],
     "evolvesFrom": "Wurmple",
     "evolvesTo": [
-      "Dustox"
+      "Dustox",
+      "Dustox ex"
     ],
     "abilities": [
       {
@@ -1612,7 +1616,9 @@
     ],
     "evolvesFrom": "Torchic",
     "evolvesTo": [
-      "Blaziken"
+      "Blaziken",
+      "Blaziken ex",
+      "Blaziken-GX"
     ],
     "attacks": [
       {
@@ -1673,7 +1679,9 @@
     ],
     "evolvesFrom": "Torchic",
     "evolvesTo": [
-      "Blaziken"
+      "Blaziken",
+      "Blaziken ex",
+      "Blaziken-GX"
     ],
     "abilities": [
       {
@@ -1787,7 +1795,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Manectric",
+      "Manectric ex"
     ],
     "attacks": [
       {
@@ -1853,7 +1862,9 @@
     ],
     "evolvesFrom": "Treecko",
     "evolvesTo": [
-      "Sceptile"
+      "Sceptile",
+      "Sceptile ex",
+      "Sceptile-GX"
     ],
     "attacks": [
       {
@@ -1921,7 +1932,9 @@
     ],
     "evolvesFrom": "Treecko",
     "evolvesTo": [
-      "Sceptile"
+      "Sceptile",
+      "Sceptile ex",
+      "Sceptile-GX"
     ],
     "abilities": [
       {
@@ -2045,7 +2058,9 @@
     "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
-      "Gallade"
+      "Gallade",
+      "Gardevoir ex",
+      "Gardevoir-GX"
     ],
     "attacks": [
       {
@@ -2107,7 +2122,9 @@
     "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
-      "Gallade"
+      "Gallade",
+      "Gardevoir ex",
+      "Gardevoir-GX"
     ],
     "attacks": [
       {
@@ -2166,7 +2183,8 @@
     ],
     "evolvesFrom": "Aron",
     "evolvesTo": [
-      "Aggron"
+      "Aggron",
+      "Aggron ex"
     ],
     "attacks": [
       {
@@ -2235,7 +2253,8 @@
     ],
     "evolvesFrom": "Aron",
     "evolvesTo": [
-      "Aggron"
+      "Aggron",
+      "Aggron ex"
     ],
     "attacks": [
       {
@@ -2426,7 +2445,8 @@
     ],
     "evolvesFrom": "Mudkip",
     "evolvesTo": [
-      "Swampert"
+      "Swampert",
+      "Swampert ex"
     ],
     "attacks": [
       {
@@ -2487,7 +2507,8 @@
     ],
     "evolvesFrom": "Mudkip",
     "evolvesTo": [
-      "Swampert"
+      "Swampert",
+      "Swampert ex"
     ],
     "abilities": [
       {
@@ -2667,7 +2688,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Delcatty"
+      "Delcatty",
+      "Delcatty ex"
     ],
     "attacks": [
       {
@@ -2903,7 +2925,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wailord"
+      "Wailord",
+      "Wailord ex"
     ],
     "attacks": [
       {
@@ -3086,7 +3109,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Sharpedo"
+      "Sharpedo",
+      "Sharpedo ex"
     ],
     "abilities": [
       {
@@ -3142,7 +3166,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Manectric",
+      "Manectric ex"
     ],
     "attacks": [
       {
@@ -3197,7 +3222,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Manectric",
+      "Manectric ex"
     ],
     "attacks": [
       {
@@ -3262,7 +3288,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Weezing"
+      "Weezing",
+      "Dark Weezing",
+      "Galarian Weezing"
     ],
     "attacks": [
       {
@@ -3370,7 +3398,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Hariyama"
+      "Hariyama",
+      "Hariyama ex"
     ],
     "attacks": [
       {
@@ -3429,7 +3458,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Hariyama"
+      "Hariyama",
+      "Hariyama ex"
     ],
     "attacks": [
       {
@@ -3488,7 +3518,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Hariyama"
+      "Hariyama",
+      "Hariyama ex"
     ],
     "attacks": [
       {
@@ -3645,7 +3676,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Camerupt"
+      "Camerupt",
+      "Camerupt ex"
     ],
     "attacks": [
       {
@@ -3704,7 +3736,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Donphan"
+      "Donphan",
+      "Dark Donphan"
     ],
     "attacks": [
       {
@@ -3763,7 +3796,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Mightyena"
+      "Mightyena",
+      "Mightyena ex"
     ],
     "attacks": [
       {
@@ -3818,7 +3852,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Mightyena"
+      "Mightyena",
+      "Mightyena ex"
     ],
     "attacks": [
       {
@@ -3883,7 +3918,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Mightyena"
+      "Mightyena",
+      "Mightyena ex"
     ],
     "attacks": [
       {
@@ -4160,7 +4196,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Delcatty"
+      "Delcatty",
+      "Delcatty ex"
     ],
     "attacks": [
       {
@@ -4218,7 +4255,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Delcatty"
+      "Delcatty",
+      "Delcatty ex"
     ],
     "attacks": [
       {
@@ -5086,7 +5124,7 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Blissey"
+      "Blissey ex"
     ],
     "rules": [
       "When Pokémon-ex has been Knocked Out, your opponent takes 2 Prize cards."
@@ -5151,9 +5189,6 @@
     "hp": "90",
     "types": [
       "Lightning"
-    ],
-    "evolvesTo": [
-      "Electivire"
     ],
     "rules": [
       "When Pokémon-ex has been Knocked Out, your opponent takes 2 Prize cards."
@@ -5348,9 +5383,6 @@
     "types": [
       "Fire"
     ],
-    "evolvesTo": [
-      "Magmortar"
-    ],
     "rules": [
       "When Pokémon-ex has been Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -5477,7 +5509,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor ex"
     ],
     "rules": [
       "When Pokémon-ex has been Knocked Out, your opponent takes 2 Prize cards."
@@ -5545,9 +5577,6 @@
     "hp": "80",
     "types": [
       "Darkness"
-    ],
-    "evolvesTo": [
-      "Weavile"
     ],
     "rules": [
       "When Pokémon-ex has been Knocked Out, your opponent takes 2 Prize cards."

--- a/cards/en/ex10.json
+++ b/cards/en/ex10.json
@@ -707,7 +707,8 @@
     ],
     "evolvesFrom": "Porygon",
     "evolvesTo": [
-      "Porygon-Z"
+      "Porygon-Z",
+      "Porygon-Z-GX"
     ],
     "abilities": [
       {
@@ -1080,6 +1081,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Teddiursa",
+    "evolvesTo": [
+      "Ursaluna"
+    ],
     "abilities": [
       {
         "name": "Intimidating Ring",
@@ -1205,7 +1209,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Blissey"
+      "Blissey",
+      "Blissey ex"
     ],
     "attacks": [
       {
@@ -1263,9 +1268,6 @@
     "hp": "50",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Clefairy"
     ],
     "abilities": [
       {
@@ -1388,9 +1390,6 @@
     "hp": "50",
     "types": [
       "Lightning"
-    ],
-    "evolvesTo": [
-      "Electabuzz"
     ],
     "abilities": [
       {
@@ -1640,6 +1639,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Ho-Oh BREAK"
+    ],
     "attacks": [
       {
         "name": "Gust",
@@ -1764,6 +1766,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Lugia BREAK"
+    ],
     "attacks": [
       {
         "name": "Aeroblast",
@@ -1814,7 +1819,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Honchkrow"
+      "Honchkrow",
+      "Honchkrow-GX"
     ],
     "attacks": [
       {
@@ -1878,9 +1884,6 @@
     "types": [
       "Water"
     ],
-    "evolvesTo": [
-      "Jynx"
-    ],
     "abilities": [
       {
         "name": "Baby Evolution",
@@ -1933,6 +1936,9 @@
     "hp": "70",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Wyrdeer"
     ],
     "attacks": [
       {
@@ -1989,11 +1995,6 @@
     "hp": "40",
     "types": [
       "Fighting"
-    ],
-    "evolvesTo": [
-      "Hitmonlee",
-      "Hitmonchan",
-      "Hitmontop"
     ],
     "abilities": [
       {
@@ -2106,7 +2107,8 @@
     ],
     "evolvesFrom": "Chikorita",
     "evolvesTo": [
-      "Meganium"
+      "Meganium",
+      "Meganium ex"
     ],
     "attacks": [
       {
@@ -2228,9 +2230,6 @@
     "types": [
       "Water"
     ],
-    "evolvesTo": [
-      "Cursola"
-    ],
     "attacks": [
       {
         "name": "Cry for Help",
@@ -2288,7 +2287,8 @@
     ],
     "evolvesFrom": "Totodile",
     "evolvesTo": [
-      "Feraligatr"
+      "Feraligatr",
+      "Feraligatr ex"
     ],
     "attacks": [
       {
@@ -2606,6 +2606,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Hoothoot",
+    "evolvesTo": [
+      "Noctowl BREAK"
+    ],
     "attacks": [
       {
         "name": "Spearhead",
@@ -2736,7 +2739,9 @@
     ],
     "evolvesFrom": "Cyndaquil",
     "evolvesTo": [
-      "Typhlosion"
+      "Typhlosion",
+      "Typhlosion ex",
+      "Hisuian Typhlosion"
     ],
     "attacks": [
       {
@@ -2797,7 +2802,11 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor",
+      "Scizor ex",
+      "Dark Scizor",
+      "Scizor-GX",
+      "Kleavor"
     ],
     "attacks": [
       {
@@ -3146,7 +3155,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Lanturn"
+      "Lanturn",
+      "Light Lanturn"
     ],
     "attacks": [
       {
@@ -3204,7 +3214,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Clefable",
+      "Clefable ex"
     ],
     "attacks": [
       {
@@ -3263,7 +3274,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Quilava"
+      "Quilava",
+      "Dark Quilava"
     ],
     "attacks": [
       {
@@ -3329,7 +3341,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "abilities": [
       {
@@ -3386,7 +3418,9 @@
     ],
     "evolvesFrom": "Mareep",
     "evolvesTo": [
-      "Ampharos"
+      "Ampharos",
+      "Ampharos ex",
+      "Ampharos-GX"
     ],
     "attacks": [
       {
@@ -3510,7 +3544,9 @@
     "evolvesFrom": "Oddish",
     "evolvesTo": [
       "Vileplume",
-      "Bellossom"
+      "Bellossom",
+      "Vileplume ex",
+      "Vileplume-GX"
     ],
     "attacks": [
       {
@@ -3625,7 +3661,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Houndoom",
+      "Dark Houndoom",
+      "Houndoom ex"
     ],
     "attacks": [
       {
@@ -3674,7 +3712,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Pupitar"
+      "Pupitar",
+      "Dark Pupitar"
     ],
     "attacks": [
       {
@@ -3733,7 +3772,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Flaaffy"
+      "Flaaffy",
+      "Dark Flaaffy"
     ],
     "attacks": [
       {
@@ -3837,7 +3877,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Gloom"
+      "Gloom",
+      "Dark Gloom"
     ],
     "attacks": [
       {
@@ -3886,7 +3927,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Steelix"
+      "Steelix",
+      "Dark Steelix",
+      "Steelix ex"
     ],
     "attacks": [
       {
@@ -3947,7 +3990,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Forretress"
+      "Forretress",
+      "Dark Forretress",
+      "Forretress ex"
     ],
     "attacks": [
       {
@@ -4056,7 +4101,8 @@
     "evolvesFrom": "Poliwag",
     "evolvesTo": [
       "Poliwrath",
-      "Politoed"
+      "Politoed",
+      "Politoed ex"
     ],
     "attacks": [
       {
@@ -4106,7 +4152,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Porygon2"
+      "Porygon2",
+      "Dark Porygon2"
     ],
     "attacks": [
       {
@@ -4156,7 +4203,9 @@
     ],
     "evolvesFrom": "Larvitar",
     "evolvesTo": [
-      "Tyranitar"
+      "Tyranitar",
+      "Tyranitar ex",
+      "Tyranitar-GX"
     ],
     "attacks": [
       {
@@ -4213,7 +4262,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Octillery"
+      "Octillery",
+      "Dark Octillery"
     ],
     "attacks": [
       {
@@ -4272,7 +4322,11 @@
     ],
     "evolvesTo": [
       "Slowbro",
-      "Slowking"
+      "Slowking",
+      "Dark Slowbro",
+      "Dark Slowking",
+      "Light Slowbro",
+      "Slowking ex"
     ],
     "attacks": [
       {
@@ -4331,7 +4385,10 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Magcargo"
+      "Magcargo",
+      "Dark Magcargo",
+      "Magcargo ex",
+      "Magcargo-GX"
     ],
     "attacks": [
       {
@@ -4438,7 +4495,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ariados"
+      "Ariados",
+      "Dark Ariados"
     ],
     "attacks": [
       {
@@ -4497,7 +4555,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Sunflora"
+      "Sunflora",
+      "Light Sunflora"
     ],
     "attacks": [
       {
@@ -4562,7 +4621,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Ursaring"
+      "Ursaring",
+      "Dark Ursaring"
     ],
     "attacks": [
       {
@@ -4620,7 +4680,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Croconaw"
+      "Croconaw",
+      "Dark Croconaw"
     ],
     "attacks": [
       {

--- a/cards/en/ex11.json
+++ b/cards/en/ex11.json
@@ -68,6 +68,9 @@
       "Metal"
     ],
     "evolvesFrom": "Golbat",
+    "evolvesTo": [
+      "Crobat BREAK"
+    ],
     "rules": [
       "This Pokémon is both Grass Metal type."
     ],
@@ -330,6 +333,9 @@
       "Metal"
     ],
     "evolvesFrom": "Kirlia",
+    "evolvesTo": [
+      "Gardevoir LV.X"
+    ],
     "rules": [
       "This Pokémon is both Psychic Metal type."
     ],
@@ -632,6 +638,9 @@
       "Metal"
     ],
     "evolvesFrom": "Cubone",
+    "evolvesTo": [
+      "Marowak BREAK"
+    ],
     "rules": [
       "This Pokémon is both Fighting Metal type."
     ],
@@ -760,6 +769,9 @@
     "types": [
       "Fire",
       "Metal"
+    ],
+    "evolvesTo": [
+      "Mewtwo LV.X"
     ],
     "rules": [
       "This Pokémon is both Fire Metal type."
@@ -901,6 +913,9 @@
       "Metal"
     ],
     "evolvesFrom": "Shelgon",
+    "evolvesTo": [
+      "Salamence LV.X"
+    ],
     "rules": [
       "This Pokémon is both Fire Metal type."
     ],
@@ -975,6 +990,9 @@
       "Metal"
     ],
     "evolvesFrom": "Staryu",
+    "evolvesTo": [
+      "Starmie BREAK"
+    ],
     "rules": [
       "This Pokémon is both Water Metal type."
     ],
@@ -1288,9 +1306,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesTo": [
-      "Marill"
-    ],
     "abilities": [
       {
         "name": "Baby Evolution",
@@ -1392,9 +1407,6 @@
       "Metal"
     ],
     "evolvesFrom": "Holon's Magnemite",
-    "evolvesTo": [
-      "Magnezone"
-    ],
     "rules": [
       "You may attach this as an Energy card from your hand to 1 of your Pokémon that already has an Energy card attached to it. When you attach this card, return an Energy card attached to that Pokémon to your hand. While attached, this card is a Special Energy card and provides every type of Energy but 2 Energy at a time. (Has no effect other than providing Energy.)"
     ],
@@ -1585,7 +1597,8 @@
     ],
     "evolvesFrom": "Porygon",
     "evolvesTo": [
-      "Porygon-Z"
+      "Porygon-Z",
+      "Porygon-Z-GX"
     ],
     "abilities": [
       {
@@ -1878,6 +1891,9 @@
       "Metal"
     ],
     "evolvesFrom": "Staryu",
+    "evolvesTo": [
+      "Starmie BREAK"
+    ],
     "rules": [
       "This Pokémon is both Water Metal type."
     ],
@@ -2496,7 +2512,9 @@
     ],
     "evolvesFrom": "Dratini",
     "evolvesTo": [
-      "Dragonite"
+      "Dragonite",
+      "Dragonite ex",
+      "Dragonite-GX"
     ],
     "attacks": [
       {
@@ -2568,7 +2586,9 @@
     ],
     "evolvesFrom": "Dratini",
     "evolvesTo": [
-      "Dragonite"
+      "Dragonite",
+      "Dragonite ex",
+      "Dragonite-GX"
     ],
     "attacks": [
       {
@@ -2630,7 +2650,8 @@
     ],
     "evolvesFrom": "Zubat",
     "evolvesTo": [
-      "Crobat"
+      "Crobat",
+      "Crobat ex"
     ],
     "attacks": [
       {
@@ -2882,7 +2903,9 @@
     "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
-      "Gallade"
+      "Gallade",
+      "Gardevoir ex",
+      "Gardevoir-GX"
     ],
     "attacks": [
       {
@@ -2942,7 +2965,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "attacks": [
       {
@@ -3010,7 +3034,9 @@
     ],
     "evolvesFrom": "Beldum",
     "evolvesTo": [
-      "Metagross"
+      "Metagross",
+      "Metagross ex",
+      "Metagross-GX"
     ],
     "attacks": [
       {
@@ -3134,7 +3160,9 @@
     ],
     "evolvesFrom": "Larvitar",
     "evolvesTo": [
-      "Tyranitar"
+      "Tyranitar",
+      "Tyranitar ex",
+      "Tyranitar-GX"
     ],
     "attacks": [
       {
@@ -3244,7 +3272,9 @@
     ],
     "evolvesFrom": "Bagon",
     "evolvesTo": [
-      "Salamence"
+      "Salamence",
+      "Salamence ex",
+      "Salamence-GX"
     ],
     "attacks": [
       {
@@ -3316,7 +3346,9 @@
     ],
     "evolvesFrom": "Bagon",
     "evolvesTo": [
-      "Salamence"
+      "Salamence",
+      "Salamence ex",
+      "Salamence-GX"
     ],
     "abilities": [
       {
@@ -3689,7 +3721,10 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Marowak"
+      "Marowak",
+      "Dark Marowak",
+      "Alolan Marowak-GX",
+      "Alolan Marowak"
     ],
     "attacks": [
       {
@@ -3964,7 +3999,9 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "attacks": [
       {
@@ -4033,7 +4070,9 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "attacks": [
       {
@@ -4092,7 +4131,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Hypno"
+      "Hypno",
+      "Dark Hypno"
     ],
     "attacks": [
       {
@@ -4158,7 +4198,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -4214,7 +4274,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -4273,7 +4353,7 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Holon's Magneton"
     ],
     "rules": [
       "You may attach this as an Energy card from your hand to 1 of your Pokémon. While attached, this card is a Special Energy card and provides Colorless Energy."
@@ -4331,7 +4411,7 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Holon's Electrode"
     ],
     "rules": [
       "You may attach this as an Energy card from your hand to 1 of your Pokémon. While attached, this card is a Special Energy card and provides Colorless Energy."
@@ -4383,7 +4463,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Weezing"
+      "Weezing",
+      "Dark Weezing",
+      "Galarian Weezing"
     ],
     "attacks": [
       {
@@ -4442,7 +4524,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Pupitar"
+      "Pupitar",
+      "Dark Pupitar"
     ],
     "attacks": [
       {
@@ -4501,7 +4584,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -4565,7 +4649,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Hariyama"
+      "Hariyama",
+      "Hariyama ex"
     ],
     "attacks": [
       {
@@ -4614,7 +4699,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Azumarill"
+      "Azumarill",
+      "Light Azumarill"
     ],
     "attacks": [
       {
@@ -4673,7 +4759,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -4731,7 +4819,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Rapidash"
+      "Rapidash",
+      "Dark Rapidash"
     ],
     "attacks": [
       {
@@ -4780,7 +4869,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Mightyena"
+      "Mightyena",
+      "Mightyena ex"
     ],
     "attacks": [
       {
@@ -4845,7 +4935,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Porygon2"
+      "Porygon2",
+      "Dark Porygon2"
     ],
     "attacks": [
       {
@@ -4954,7 +5045,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Sandslash"
+      "Sandslash",
+      "Dark Sandslash"
     ],
     "attacks": [
       {
@@ -5014,7 +5106,11 @@
     ],
     "evolvesTo": [
       "Slowbro",
-      "Slowking"
+      "Slowking",
+      "Dark Slowbro",
+      "Dark Slowking",
+      "Light Slowbro",
+      "Slowking ex"
     ],
     "attacks": [
       {
@@ -5073,7 +5169,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Starmie"
+      "Starmie",
+      "Starmie-GX"
     ],
     "attacks": [
       {
@@ -5132,7 +5229,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Starmie"
+      "Starmie",
+      "Starmie-GX"
     ],
     "attacks": [
       {
@@ -5294,7 +5392,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Golbat"
+      "Golbat",
+      "Dark Golbat"
     ],
     "attacks": [
       {

--- a/cards/en/ex12.json
+++ b/cards/en/ex12.json
@@ -283,6 +283,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Haunter",
+    "evolvesTo": [
+      "Gengar LV.X"
+    ],
     "abilities": [
       {
         "name": "Shadow Curse",
@@ -546,6 +549,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Machoke",
+    "evolvesTo": [
+      "Machamp LV.X",
+      "Machamp BREAK"
+    ],
     "attacks": [
       {
         "name": "Derail",
@@ -1005,6 +1012,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Farigiraf"
+    ],
     "abilities": [
       {
         "name": "Rear Sensor",
@@ -1373,7 +1383,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "abilities": [
       {
@@ -1448,6 +1459,9 @@
       "Water"
     ],
     "evolvesFrom": "Omanyte",
+    "evolvesTo": [
+      "Omastar BREAK"
+    ],
     "abilities": [
       {
         "name": "Ancient Fang",
@@ -1757,6 +1771,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Wobbuffet BREAK"
+    ],
     "abilities": [
       {
         "name": "Stages of Evolution",
@@ -1824,7 +1841,8 @@
     ],
     "evolvesFrom": "Claw Fossil",
     "evolvesTo": [
-      "Armaldo"
+      "Armaldo",
+      "Armaldo ex"
     ],
     "attacks": [
       {
@@ -1884,7 +1902,8 @@
     ],
     "evolvesFrom": "Wurmple",
     "evolvesTo": [
-      "Dustox"
+      "Dustox",
+      "Dustox ex"
     ],
     "abilities": [
       {
@@ -1940,6 +1959,9 @@
     "hp": "50",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Dudunsparce"
     ],
     "abilities": [
       {
@@ -2119,7 +2141,8 @@
     ],
     "evolvesFrom": "Geodude",
     "evolvesTo": [
-      "Golem"
+      "Golem",
+      "Golem ex"
     ],
     "abilities": [
       {
@@ -2178,7 +2201,8 @@
     ],
     "evolvesFrom": "Gastly",
     "evolvesTo": [
-      "Gengar"
+      "Gengar",
+      "Gengar ex"
     ],
     "attacks": [
       {
@@ -2245,7 +2269,8 @@
     ],
     "evolvesFrom": "Mysterious Fossil",
     "evolvesTo": [
-      "Kabutops"
+      "Kabutops",
+      "Kabutops ex"
     ],
     "abilities": [
       {
@@ -2367,7 +2392,8 @@
     ],
     "evolvesFrom": "Aron",
     "evolvesTo": [
-      "Aggron"
+      "Aggron",
+      "Aggron ex"
     ],
     "attacks": [
       {
@@ -2435,7 +2461,8 @@
     ],
     "evolvesFrom": "Machop",
     "evolvesTo": [
-      "Machamp"
+      "Machamp",
+      "Machamp-GX"
     ],
     "abilities": [
       {
@@ -2574,7 +2601,9 @@
     ],
     "evolvesFrom": "Seedot",
     "evolvesTo": [
-      "Shiftry"
+      "Shiftry",
+      "Shiftry ex",
+      "Shiftry-GX"
     ],
     "attacks": [
       {
@@ -2696,7 +2725,8 @@
     ],
     "evolvesFrom": "Spheal",
     "evolvesTo": [
-      "Walrein"
+      "Walrein",
+      "Walrein ex"
     ],
     "abilities": [
       {
@@ -2887,7 +2917,9 @@
     ],
     "evolvesFrom": "Trapinch",
     "evolvesTo": [
-      "Flygon"
+      "Flygon",
+      "Flygon ex",
+      "Flygon-GX"
     ],
     "attacks": [
       {
@@ -3129,7 +3161,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Lanturn"
+      "Lanturn",
+      "Light Lanturn"
     ],
     "attacks": [
       {
@@ -3247,7 +3280,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Haunter",
+      "Dark Haunter"
     ],
     "attacks": [
       {
@@ -3361,7 +3395,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Muk"
+      "Muk",
+      "Dark Muk",
+      "Muk ex"
     ],
     "attacks": [
       {
@@ -3420,7 +3456,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -3480,7 +3518,8 @@
     ],
     "evolvesFrom": "Root Fossil",
     "evolvesTo": [
-      "Cradily"
+      "Cradily",
+      "Cradily ex"
     ],
     "attacks": [
       {
@@ -3540,7 +3579,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Machoke"
+      "Machoke",
+      "Dark Machoke",
+      "Light Machoke"
     ],
     "attacks": [
       {
@@ -3587,9 +3628,6 @@
     "hp": "40",
     "types": [
       "Fire"
-    ],
-    "evolvesTo": [
-      "Magmar"
     ],
     "abilities": [
       {
@@ -3645,7 +3683,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -3875,7 +3914,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Banette"
+      "Banette",
+      "Banette ex",
+      "Banette-GX"
     ],
     "attacks": [
       {
@@ -3940,7 +3981,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Delcatty"
+      "Delcatty",
+      "Delcatty ex"
     ],
     "attacks": [
       {
@@ -4157,7 +4199,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {
@@ -4216,7 +4261,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wailord"
+      "Wailord",
+      "Wailord ex"
     ],
     "attacks": [
       {
@@ -4334,9 +4380,6 @@
     "hp": "50",
     "types": [
       "Psychic"
-    ],
-    "evolvesTo": [
-      "Wobbuffet"
     ],
     "abilities": [
       {
@@ -4521,6 +4564,9 @@
       "Item"
     ],
     "hp": "40",
+    "evolvesTo": [
+      "Anorith"
+    ],
     "rules": [
       "Play Claw Fossil as if it were a Basic Pokémon. While in play, Claw Fossil counts as a Colorless Pokémon (as well as a Trainer card). Claw Fossil has no attacks of its own, can't retreat, and can't be affected by any Special Conditions. If Claw Fossil is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Claw Fossil from play."
     ],
@@ -4550,6 +4596,13 @@
       "Item"
     ],
     "hp": "50",
+    "evolvesTo": [
+      "Aerodactyl",
+      "Kabuto",
+      "Omanyte",
+      "Dark Omanyte",
+      "Aerodactyl ex"
+    ],
     "rules": [
       "Play Mysterious Fossil as if it were a Basic Pokémon. While in play, Mysterious Fossil counts as a Colorless Pokémon (as well as a Trainer card). Mysterious Fossil has no attacks of its own, can't retreat, and can't be affected by any Special Conditions. If Mysterious Fossil is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Mysterious Fossil from play."
     ],
@@ -4572,6 +4625,9 @@
       "Item"
     ],
     "hp": "40",
+    "evolvesTo": [
+      "Lileep"
+    ],
     "rules": [
       "Play Root Fossil as if it were a Basic Pokémon. While in play, Root Fossil counts as a Colorless Pokémon (as well as a Trainer card). Root Fossil has no attacks of its own, can't retreat, and can't be affected by any Special Conditions. If Root Fossil is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Root Fossil from play."
     ],
@@ -5335,7 +5391,11 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {

--- a/cards/en/ex13.json
+++ b/cards/en/ex13.json
@@ -358,6 +358,9 @@
       "Metal"
     ],
     "evolvesFrom": "Vibrava",
+    "evolvesTo": [
+      "Flygon LV.X"
+    ],
     "rules": [
       "This Pokémon is both Grass Metal type."
     ],
@@ -780,6 +783,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Omanyte",
+    "evolvesTo": [
+      "Omastar BREAK"
+    ],
     "attacks": [
       {
         "name": "Bind",
@@ -906,6 +912,10 @@
       "Metal"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Zzzap",
@@ -1478,6 +1488,9 @@
     "hp": "70",
     "types": [
       "Lightning"
+    ],
+    "evolvesTo": [
+      "Mewtwo LV.X"
     ],
     "attacks": [
       {
@@ -2340,7 +2353,9 @@
     ],
     "evolvesFrom": "Torchic",
     "evolvesTo": [
-      "Blaziken"
+      "Blaziken",
+      "Blaziken ex",
+      "Blaziken-GX"
     ],
     "attacks": [
       {
@@ -2520,7 +2535,9 @@
     "evolvesFrom": "Oddish",
     "evolvesTo": [
       "Vileplume",
-      "Bellossom"
+      "Bellossom",
+      "Vileplume ex",
+      "Vileplume-GX"
     ],
     "attacks": [
       {
@@ -2579,6 +2596,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Psyduck",
+    "evolvesTo": [
+      "Golduck BREAK"
+    ],
     "abilities": [
       {
         "name": "Delta Block",
@@ -2684,7 +2704,8 @@
     ],
     "evolvesFrom": "Aron",
     "evolvesTo": [
-      "Aggron"
+      "Aggron",
+      "Aggron ex"
     ],
     "attacks": [
       {
@@ -2928,7 +2949,8 @@
     ],
     "evolvesFrom": "Pidgey",
     "evolvesTo": [
-      "Pidgeot"
+      "Pidgeot",
+      "Pidgeot ex"
     ],
     "attacks": [
       {
@@ -2984,6 +3006,10 @@
       "Fire"
     ],
     "evolvesFrom": "Mankey",
+    "evolvesTo": [
+      "Annihilape ex",
+      "Annihilape"
+    ],
     "attacks": [
       {
         "name": "Wreck",
@@ -3039,6 +3065,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Thundershock",
@@ -3099,7 +3129,9 @@
     ],
     "evolvesFrom": "Horsea",
     "evolvesTo": [
-      "Kingdra"
+      "Kingdra",
+      "Kingdra ex",
+      "Kingdra-GX"
     ],
     "attacks": [
       {
@@ -3216,7 +3248,9 @@
     ],
     "evolvesFrom": "Trapinch",
     "evolvesTo": [
-      "Flygon"
+      "Flygon",
+      "Flygon ex",
+      "Flygon-GX"
     ],
     "attacks": [
       {
@@ -3344,6 +3378,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Wobbuffet BREAK"
+    ],
     "attacks": [
       {
         "name": "Call for Friends",
@@ -3403,7 +3440,8 @@
     ],
     "evolvesFrom": "Claw Fossil",
     "evolvesTo": [
-      "Armaldo"
+      "Armaldo",
+      "Armaldo ex"
     ],
     "attacks": [
       {
@@ -3528,7 +3566,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Claydol"
+      "Claydol",
+      "Claydol ex"
     ],
     "attacks": [
       {
@@ -3645,7 +3684,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Sharpedo"
+      "Sharpedo",
+      "Sharpedo ex"
     ],
     "attacks": [
       {
@@ -3704,7 +3744,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Crawdaunt"
+      "Crawdaunt",
+      "Crawdaunt ex"
     ],
     "attacks": [
       {
@@ -3764,7 +3805,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Crawdaunt"
+      "Crawdaunt",
+      "Crawdaunt ex"
     ],
     "attacks": [
       {
@@ -3822,7 +3864,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Manectric",
+      "Manectric ex"
     ],
     "attacks": [
       {
@@ -3877,7 +3920,10 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Exeggutor"
+      "Exeggutor",
+      "Dark Exeggutor",
+      "Alolan Exeggutor-GX",
+      "Alolan Exeggutor"
     ],
     "attacks": [
       {
@@ -3996,7 +4042,8 @@
     ],
     "evolvesFrom": "Mysterious Fossil",
     "evolvesTo": [
-      "Kabutops"
+      "Kabutops",
+      "Kabutops ex"
     ],
     "attacks": [
       {
@@ -4057,7 +4104,8 @@
     ],
     "evolvesFrom": "Root Fossil",
     "evolvesTo": [
-      "Cradily"
+      "Cradily",
+      "Cradily ex"
     ],
     "attacks": [
       {
@@ -4117,7 +4165,10 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -4166,7 +4217,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Primeape"
+      "Primeape",
+      "Dark Primeape"
     ],
     "attacks": [
       {
@@ -4226,7 +4278,9 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "rules": [
       "This Pokémon is both Darkness Metal type."
@@ -4288,7 +4342,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Camerupt"
+      "Camerupt",
+      "Camerupt ex"
     ],
     "attacks": [
       {
@@ -4347,7 +4402,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gloom"
+      "Gloom",
+      "Dark Gloom"
     ],
     "attacks": [
       {
@@ -4465,7 +4521,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Donphan"
+      "Donphan",
+      "Dark Donphan"
     ],
     "attacks": [
       {
@@ -4521,9 +4578,6 @@
     "hp": "50",
     "types": [
       "Metal"
-    ],
-    "evolvesTo": [
-      "Pikachu"
     ],
     "abilities": [
       {
@@ -4634,7 +4688,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -4693,7 +4751,11 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -4753,7 +4815,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Mightyena"
+      "Mightyena",
+      "Mightyena ex"
     ],
     "attacks": [
       {
@@ -4818,7 +4881,9 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Golduck",
+      "Dark Golduck",
+      "Light Golduck"
     ],
     "attacks": [
       {
@@ -5183,6 +5248,9 @@
       "Item"
     ],
     "hp": "40",
+    "evolvesTo": [
+      "Anorith"
+    ],
     "rules": [
       "Play Claw Fossil as if it were a Basic Pokémon. While in play, Claw Fossil counts as a Colorless Pokémon (as well as a Trainer card). Claw Fossil has no attacks of its own, can't retreat, and can't be affected by any Special Conditions. If Claw Fossil is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Claw Fossil from play."
     ],
@@ -5212,6 +5280,13 @@
       "Item"
     ],
     "hp": "50",
+    "evolvesTo": [
+      "Aerodactyl",
+      "Kabuto",
+      "Omanyte",
+      "Dark Omanyte",
+      "Aerodactyl ex"
+    ],
     "rules": [
       "Play Mysterious Fossil as if it were a Basic Pokémon. While in play, Mysterious Fossil counts as a Colorless Pokémon (as well as a Trainer card). Mysterious Fossil has no attacks of its own, can't retreat, and can't be affected by any Special Conditions. If Mysterious Fossil is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Mysterious Fossil from play."
     ],
@@ -5234,6 +5309,9 @@
       "Item"
     ],
     "hp": "40",
+    "evolvesTo": [
+      "Lileep"
+    ],
     "rules": [
       "Play Root Fossil as if it were a Basic Pokémon. While in play, Root Fossil counts as a Colorless Pokémon (as well as a Trainer card). Root Fossil has no attacks of its own, can't retreat, and can't be affected by any Special Conditions. If Root Fossil is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Root Fossil from play."
     ],

--- a/cards/en/ex14.json
+++ b/cards/en/ex14.json
@@ -951,7 +951,9 @@
     ],
     "evolvesFrom": "Torchic",
     "evolvesTo": [
-      "Blaziken"
+      "Blaziken",
+      "Blaziken ex",
+      "Blaziken-GX"
     ],
     "attacks": [
       {
@@ -1147,7 +1149,9 @@
     ],
     "evolvesFrom": "Treecko",
     "evolvesTo": [
-      "Sceptile"
+      "Sceptile",
+      "Sceptile ex",
+      "Sceptile-GX"
     ],
     "attacks": [
       {
@@ -1270,9 +1274,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesTo": [
-      "Jigglypuff"
-    ],
     "abilities": [
       {
         "name": "Hover Lift",
@@ -1387,7 +1388,8 @@
     ],
     "evolvesFrom": "Whismur",
     "evolvesTo": [
-      "Exploud"
+      "Exploud",
+      "Exploud ex"
     ],
     "attacks": [
       {
@@ -1449,7 +1451,8 @@
     ],
     "evolvesFrom": "Mudkip",
     "evolvesTo": [
-      "Swampert"
+      "Swampert",
+      "Swampert ex"
     ],
     "attacks": [
       {
@@ -1773,7 +1776,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "attacks": [
       {
@@ -1835,7 +1841,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "attacks": [
       {
@@ -1897,7 +1906,9 @@
     ],
     "evolvesFrom": "Torchic",
     "evolvesTo": [
-      "Blaziken"
+      "Blaziken",
+      "Blaziken ex",
+      "Blaziken-GX"
     ],
     "attacks": [
       {
@@ -1960,7 +1971,9 @@
     ],
     "evolvesFrom": "Treecko",
     "evolvesTo": [
-      "Sceptile"
+      "Sceptile",
+      "Sceptile ex",
+      "Sceptile-GX"
     ],
     "attacks": [
       {
@@ -2087,7 +2100,8 @@
     ],
     "evolvesFrom": "Bulbasaur",
     "evolvesTo": [
-      "Venusaur"
+      "Venusaur",
+      "Venusaur ex"
     ],
     "attacks": [
       {
@@ -2149,7 +2163,8 @@
     ],
     "evolvesFrom": "Bulbasaur",
     "evolvesTo": [
-      "Venusaur"
+      "Venusaur",
+      "Venusaur ex"
     ],
     "attacks": [
       {
@@ -2211,7 +2226,8 @@
     ],
     "evolvesFrom": "Aron",
     "evolvesTo": [
-      "Aggron"
+      "Aggron",
+      "Aggron ex"
     ],
     "attacks": [
       {
@@ -2341,7 +2357,8 @@
     ],
     "evolvesFrom": "Mudkip",
     "evolvesTo": [
-      "Swampert"
+      "Swampert",
+      "Swampert ex"
     ],
     "attacks": [
       {
@@ -2403,7 +2420,9 @@
     ],
     "evolvesFrom": "Seedot",
     "evolvesTo": [
-      "Shiftry"
+      "Shiftry",
+      "Shiftry ex",
+      "Shiftry-GX"
     ],
     "attacks": [
       {
@@ -2469,7 +2488,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Banette"
+      "Banette",
+      "Banette ex",
+      "Banette-GX"
     ],
     "attacks": [
       {
@@ -2534,7 +2555,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Delcatty"
+      "Delcatty",
+      "Delcatty ex"
     ],
     "attacks": [
       {
@@ -2594,7 +2616,9 @@
     ],
     "evolvesFrom": "Squirtle",
     "evolvesTo": [
-      "Blastoise"
+      "Blastoise",
+      "Blastoise ex",
+      "Blastoise-GX"
     ],
     "attacks": [
       {
@@ -2656,7 +2680,9 @@
     ],
     "evolvesFrom": "Squirtle",
     "evolvesTo": [
-      "Blastoise"
+      "Blastoise",
+      "Blastoise ex",
+      "Blastoise-GX"
     ],
     "attacks": [
       {
@@ -2771,7 +2797,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ivysaur"
+      "Ivysaur",
+      "Dark Ivysaur"
     ],
     "attacks": [
       {
@@ -2829,7 +2856,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ivysaur"
+      "Ivysaur",
+      "Dark Ivysaur"
     ],
     "attacks": [
       {
@@ -2888,7 +2916,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Cacturne"
+      "Cacturne",
+      "Cacturne ex"
     ],
     "attacks": [
       {
@@ -2947,7 +2976,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -3006,7 +3036,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -3065,7 +3096,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Dugtrio"
+      "Dugtrio",
+      "Dark Dugtrio"
     ],
     "attacks": [
       {
@@ -3124,7 +3156,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Dusclops"
+      "Dusclops",
+      "Dusclops ex"
     ],
     "attacks": [
       {
@@ -3188,7 +3221,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Manectric",
+      "Manectric ex"
     ],
     "attacks": [
       {
@@ -3252,7 +3286,11 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Wigglytuff"
+      "Wigglytuff",
+      "Dark Wigglytuff",
+      "Light Wigglytuff",
+      "Wigglytuff ex",
+      "Wigglytuff-GX"
     ],
     "attacks": [
       {
@@ -3407,7 +3445,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Medicham"
+      "Medicham",
+      "Medicham ex"
     ],
     "attacks": [
       {
@@ -3581,7 +3620,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Camerupt"
+      "Camerupt",
+      "Camerupt ex"
     ],
     "attacks": [
       {
@@ -3794,7 +3834,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wartortle"
+      "Wartortle",
+      "Dark Wartortle"
     ],
     "attacks": [
       {
@@ -3854,7 +3895,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wartortle"
+      "Wartortle",
+      "Dark Wartortle"
     ],
     "abilities": [
       {

--- a/cards/en/ex15.json
+++ b/cards/en/ex15.json
@@ -328,6 +328,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Nidorino",
+    "evolvesTo": [
+      "Nidoking BREAK"
+    ],
     "attacks": [
       {
         "name": "Linear Attack",
@@ -446,6 +449,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "abilities": [
       {
         "name": "Volunteer",
@@ -559,6 +565,9 @@
     "hp": "80",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Snorlax LV.X"
     ],
     "abilities": [
       {
@@ -1239,7 +1248,9 @@
     ],
     "evolvesFrom": "Horsea",
     "evolvesTo": [
-      "Kingdra"
+      "Kingdra",
+      "Kingdra ex",
+      "Kingdra-GX"
     ],
     "attacks": [
       {
@@ -1354,7 +1365,9 @@
     ],
     "evolvesFrom": "Trapinch",
     "evolvesTo": [
-      "Flygon"
+      "Flygon",
+      "Flygon ex",
+      "Flygon-GX"
     ],
     "abilities": [
       {
@@ -1478,7 +1491,8 @@
     ],
     "evolvesFrom": "Chikorita",
     "evolvesTo": [
-      "Meganium"
+      "Meganium",
+      "Meganium ex"
     ],
     "attacks": [
       {
@@ -1535,7 +1549,8 @@
     ],
     "evolvesFrom": "Totodile",
     "evolvesTo": [
-      "Feraligatr"
+      "Feraligatr",
+      "Feraligatr ex"
     ],
     "attacks": [
       {
@@ -1596,7 +1611,9 @@
     ],
     "evolvesFrom": "Dratini",
     "evolvesTo": [
-      "Dragonite"
+      "Dragonite",
+      "Dragonite ex",
+      "Dragonite-GX"
     ],
     "attacks": [
       {
@@ -1709,7 +1726,9 @@
     ],
     "evolvesFrom": "Mareep",
     "evolvesTo": [
-      "Ampharos"
+      "Ampharos",
+      "Ampharos ex",
+      "Ampharos-GX"
     ],
     "attacks": [
       {
@@ -1820,7 +1839,9 @@
     "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
-      "Gallade"
+      "Gallade",
+      "Gardevoir ex",
+      "Gardevoir-GX"
     ],
     "attacks": [
       {
@@ -1883,7 +1904,9 @@
     "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
-      "Gallade"
+      "Gallade",
+      "Gardevoir ex",
+      "Gardevoir-GX"
     ],
     "attacks": [
       {
@@ -2069,7 +2092,9 @@
     ],
     "evolvesFrom": "Cyndaquil",
     "evolvesTo": [
-      "Typhlosion"
+      "Typhlosion",
+      "Typhlosion ex",
+      "Hisuian Typhlosion"
     ],
     "attacks": [
       {
@@ -2131,7 +2156,9 @@
     ],
     "evolvesFrom": "Horsea",
     "evolvesTo": [
-      "Kingdra"
+      "Kingdra",
+      "Kingdra ex",
+      "Kingdra-GX"
     ],
     "attacks": [
       {
@@ -2193,7 +2220,9 @@
     ],
     "evolvesFrom": "Bagon",
     "evolvesTo": [
-      "Salamence"
+      "Salamence",
+      "Salamence ex",
+      "Salamence-GX"
     ],
     "attacks": [
       {
@@ -2361,7 +2390,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Togetic"
+      "Togetic",
+      "Light Togetic"
     ],
     "attacks": [
       {
@@ -2411,7 +2441,9 @@
     ],
     "evolvesFrom": "Trapinch",
     "evolvesTo": [
-      "Flygon"
+      "Flygon",
+      "Flygon ex",
+      "Flygon-GX"
     ],
     "attacks": [
       {
@@ -2572,7 +2604,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Quilava"
+      "Quilava",
+      "Dark Quilava"
     ],
     "attacks": [
       {
@@ -2622,7 +2655,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "attacks": [
       {
@@ -2665,7 +2700,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arbok"
+      "Arbok",
+      "Dark Arbok",
+      "Arbok ex"
     ],
     "attacks": [
       {
@@ -2723,9 +2760,6 @@
     "types": [
       "Fighting"
     ],
-    "evolvesTo": [
-      "Electabuzz"
-    ],
     "abilities": [
       {
         "name": "Baby Evolution",
@@ -2780,7 +2814,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Milotic"
+      "Milotic",
+      "Milotic ex"
     ],
     "attacks": [
       {
@@ -2878,7 +2913,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Pupitar"
+      "Pupitar",
+      "Dark Pupitar"
     ],
     "attacks": [
       {
@@ -2937,7 +2973,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Pupitar"
+      "Pupitar",
+      "Dark Pupitar"
     ],
     "attacks": [
       {
@@ -2996,7 +3033,8 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Ledian"
+      "Ledian",
+      "Light Ledian"
     ],
     "attacks": [
       {
@@ -3054,7 +3092,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Flaaffy"
+      "Flaaffy",
+      "Dark Flaaffy"
     ],
     "attacks": [
       {
@@ -3269,7 +3308,9 @@
     ],
     "evolvesFrom": "Larvitar",
     "evolvesTo": [
-      "Tyranitar"
+      "Tyranitar",
+      "Tyranitar ex",
+      "Tyranitar-GX"
     ],
     "attacks": [
       {
@@ -3319,7 +3360,9 @@
     ],
     "evolvesFrom": "Larvitar",
     "evolvesTo": [
-      "Tyranitar"
+      "Tyranitar",
+      "Tyranitar ex",
+      "Tyranitar-GX"
     ],
     "attacks": [
       {
@@ -3486,7 +3529,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Dewgong"
+      "Dewgong",
+      "Light Dewgong"
     ],
     "attacks": [
       {
@@ -3593,9 +3637,6 @@
     "types": [
       "Fire"
     ],
-    "evolvesTo": [
-      "Jynx"
-    ],
     "abilities": [
       {
         "name": "Baby Evolution",
@@ -3650,7 +3691,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Altaria"
+      "Altaria",
+      "Altaria ex",
+      "Altaria-GX"
     ],
     "attacks": [
       {
@@ -3760,7 +3803,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Croconaw"
+      "Croconaw",
+      "Dark Croconaw"
     ],
     "attacks": [
       {
@@ -3927,7 +3971,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {

--- a/cards/en/ex16.json
+++ b/cards/en/ex16.json
@@ -517,6 +517,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Kirlia",
+    "evolvesTo": [
+      "Gardevoir LV.X"
+    ],
     "abilities": [
       {
         "name": "Psy Shadow",
@@ -639,6 +642,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Machoke",
+    "evolvesTo": [
+      "Machamp LV.X",
+      "Machamp BREAK"
+    ],
     "abilities": [
       {
         "name": "Overzealous",
@@ -707,6 +714,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Plasma",
@@ -951,7 +962,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "abilities": [
       {
@@ -1137,6 +1149,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "abilities": [
       {
         "name": "Safeguard",
@@ -1203,6 +1218,9 @@
       "Water"
     ],
     "evolvesFrom": "Omanyte",
+    "evolvesTo": [
+      "Omastar BREAK"
+    ],
     "attacks": [
       {
         "name": "Pull Down",
@@ -1259,9 +1277,6 @@
     "hp": "50",
     "types": [
       "Lightning"
-    ],
-    "evolvesTo": [
-      "Pikachu"
     ],
     "abilities": [
       {
@@ -1436,6 +1451,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Wobbuffet BREAK"
+    ],
     "abilities": [
       {
         "name": "Safeguard",
@@ -1557,7 +1575,8 @@
     ],
     "evolvesFrom": "Claw Fossil",
     "evolvesTo": [
-      "Armaldo"
+      "Armaldo",
+      "Armaldo ex"
     ],
     "abilities": [
       {
@@ -1677,7 +1696,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "attacks": [
       {
@@ -1738,7 +1760,9 @@
     ],
     "evolvesFrom": "Torchic",
     "evolvesTo": [
-      "Blaziken"
+      "Blaziken",
+      "Blaziken ex",
+      "Blaziken-GX"
     ],
     "abilities": [
       {
@@ -1863,7 +1887,9 @@
     "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
-      "Gallade"
+      "Gallade",
+      "Gardevoir ex",
+      "Gardevoir-GX"
     ],
     "attacks": [
       {
@@ -1923,7 +1949,8 @@
     ],
     "evolvesFrom": "Aron",
     "evolvesTo": [
-      "Aggron"
+      "Aggron",
+      "Aggron ex"
     ],
     "attacks": [
       {
@@ -1992,7 +2019,8 @@
     ],
     "evolvesFrom": "Machop",
     "evolvesTo": [
-      "Machamp"
+      "Machamp",
+      "Machamp-GX"
     ],
     "attacks": [
       {
@@ -2119,7 +2147,9 @@
     ],
     "evolvesFrom": "Beldum",
     "evolvesTo": [
-      "Metagross"
+      "Metagross",
+      "Metagross ex",
+      "Metagross-GX"
     ],
     "abilities": [
       {
@@ -2184,7 +2214,9 @@
     ],
     "evolvesFrom": "Seedot",
     "evolvesTo": [
-      "Shiftry"
+      "Shiftry",
+      "Shiftry ex",
+      "Shiftry-GX"
     ],
     "attacks": [
       {
@@ -2251,7 +2283,8 @@
     ],
     "evolvesFrom": "Spheal",
     "evolvesTo": [
-      "Walrein"
+      "Walrein",
+      "Walrein ex"
     ],
     "attacks": [
       {
@@ -2363,7 +2396,9 @@
     ],
     "evolvesFrom": "Bagon",
     "evolvesTo": [
-      "Salamence"
+      "Salamence",
+      "Salamence ex",
+      "Salamence-GX"
     ],
     "attacks": [
       {
@@ -2436,7 +2471,9 @@
     ],
     "evolvesFrom": "Trapinch",
     "evolvesTo": [
-      "Flygon"
+      "Flygon",
+      "Flygon ex",
+      "Flygon-GX"
     ],
     "attacks": [
       {
@@ -2690,7 +2727,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Claydol"
+      "Claydol",
+      "Claydol ex"
     ],
     "attacks": [
       {
@@ -2805,7 +2843,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Cacturne"
+      "Cacturne",
+      "Cacturne ex"
     ],
     "attacks": [
       {
@@ -2854,7 +2893,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Sharpedo"
+      "Sharpedo",
+      "Sharpedo ex"
     ],
     "abilities": [
       {
@@ -2917,7 +2957,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -2966,7 +3007,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Lanturn"
+      "Lanturn",
+      "Light Lanturn"
     ],
     "attacks": [
       {
@@ -3025,7 +3067,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Dusclops"
+      "Dusclops",
+      "Dusclops ex"
     ],
     "attacks": [
       {
@@ -3082,7 +3125,8 @@
     ],
     "evolvesFrom": "Mysterious Fossil",
     "evolvesTo": [
-      "Kabutops"
+      "Kabutops",
+      "Kabutops ex"
     ],
     "attacks": [
       {
@@ -3143,7 +3187,8 @@
     ],
     "evolvesFrom": "Root Fossil",
     "evolvesTo": [
-      "Cradily"
+      "Cradily",
+      "Cradily ex"
     ],
     "attacks": [
       {
@@ -3205,7 +3250,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Machoke"
+      "Machoke",
+      "Dark Machoke",
+      "Light Machoke"
     ],
     "attacks": [
       {
@@ -3264,7 +3311,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -3329,7 +3377,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Medicham"
+      "Medicham",
+      "Medicham ex"
     ],
     "attacks": [
       {
@@ -3447,7 +3496,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -3506,7 +3559,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Mightyena"
+      "Mightyena",
+      "Mightyena ex"
     ],
     "attacks": [
       {
@@ -3679,7 +3733,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Banette"
+      "Banette",
+      "Banette ex",
+      "Banette-GX"
     ],
     "attacks": [
       {
@@ -3734,7 +3790,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Delcatty"
+      "Delcatty",
+      "Delcatty ex"
     ],
     "attacks": [
       {
@@ -3852,7 +3909,8 @@
     ],
     "evolvesTo": [
       "Glalie",
-      "Froslass"
+      "Froslass",
+      "Froslass ex"
     ],
     "attacks": [
       {
@@ -3970,7 +4028,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Altaria"
+      "Altaria",
+      "Altaria ex",
+      "Altaria-GX"
     ],
     "attacks": [
       {
@@ -4123,7 +4183,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {
@@ -4180,9 +4242,6 @@
     "hp": "50",
     "types": [
       "Psychic"
-    ],
-    "evolvesTo": [
-      "Wobbuffet"
     ],
     "abilities": [
       {
@@ -4521,6 +4580,9 @@
       "Item"
     ],
     "hp": "40",
+    "evolvesTo": [
+      "Anorith"
+    ],
     "rules": [
       "Play Claw Fossil as if it were a Basic Pokémon. While in play Claw Fossil counts as a Colorless Pokémon (as well as a Trainer card). Claw Fossil has no attacks of its own, can't retreat, and can't be affected by any Special Conditions. If Claw Fossil is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Claw Fossil from play."
     ],
@@ -4550,6 +4612,13 @@
       "Item"
     ],
     "hp": "50",
+    "evolvesTo": [
+      "Aerodactyl",
+      "Kabuto",
+      "Omanyte",
+      "Dark Omanyte",
+      "Aerodactyl ex"
+    ],
     "rules": [
       "Play Mysterious Fossil as if it were a Basic Pokémon. While in play, Mysterious Fossil counts as a Colorless Pokémon (as well as a Trainer card). Mysterious Fossil has no attacks of its own, can't retreat, and can't be affected by any Special Conditions. If Mysterious Fossil is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Mysterious Fossil from play."
     ],
@@ -4572,6 +4641,9 @@
       "Item"
     ],
     "hp": "40",
+    "evolvesTo": [
+      "Lileep"
+    ],
     "rules": [
       "Play Root Fossil as if it were a Basic Pokémon. While in play, Root Fossil counts as a Colorless Pokémon (as well as a Trainer card). Root Fossil has no attacks of its own, can't retreat, and can't be affected by any Special Conditions. If Root Fossil is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Root Fossil from play."
     ],

--- a/cards/en/ex2.json
+++ b/cards/en/ex2.json
@@ -860,6 +860,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "abilities": [
       {
         "name": "Fire Veil",
@@ -974,6 +977,9 @@
       "Water"
     ],
     "evolvesFrom": "Psyduck",
+    "evolvesTo": [
+      "Golduck BREAK"
+    ],
     "abilities": [
       {
         "name": "Chaos Flash",
@@ -1083,6 +1089,9 @@
       "Water"
     ],
     "evolvesFrom": "Omanyte",
+    "evolvesTo": [
+      "Omastar BREAK"
+    ],
     "attacks": [
       {
         "name": "Pull Down",
@@ -1139,9 +1148,6 @@
     "hp": "40",
     "types": [
       "Lightning"
-    ],
-    "evolvesTo": [
-      "Pikachu"
     ],
     "abilities": [
       {
@@ -1506,6 +1512,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Wobbuffet BREAK"
+    ],
     "abilities": [
       {
         "name": "Safeguard",
@@ -1564,7 +1573,8 @@
     ],
     "evolvesFrom": "Claw Fossil",
     "evolvesTo": [
-      "Armaldo"
+      "Armaldo",
+      "Armaldo ex"
     ],
     "attacks": [
       {
@@ -1624,7 +1634,8 @@
     ],
     "evolvesFrom": "Claw Fossil",
     "evolvesTo": [
-      "Armaldo"
+      "Armaldo",
+      "Armaldo ex"
     ],
     "attacks": [
       {
@@ -1797,9 +1808,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesTo": [
-      "Marill"
-    ],
     "abilities": [
       {
         "name": "Baby Evolution",
@@ -1854,7 +1862,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Claydol"
+      "Claydol",
+      "Claydol ex"
     ],
     "attacks": [
       {
@@ -2085,9 +2094,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesTo": [
-      "Electabuzz"
-    ],
     "abilities": [
       {
         "name": "Baby Evolution",
@@ -2267,7 +2273,8 @@
     ],
     "evolvesFrom": "Mysterious Fossil",
     "evolvesTo": [
-      "Kabutops"
+      "Kabutops",
+      "Kabutops ex"
     ],
     "abilities": [
       {
@@ -2336,7 +2343,9 @@
     "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
-      "Gallade"
+      "Gallade",
+      "Gardevoir ex",
+      "Gardevoir-GX"
     ],
     "attacks": [
       {
@@ -2398,7 +2407,8 @@
     ],
     "evolvesFrom": "Aron",
     "evolvesTo": [
-      "Aggron"
+      "Aggron",
+      "Aggron ex"
     ],
     "attacks": [
       {
@@ -2466,7 +2476,8 @@
     ],
     "evolvesFrom": "Root Fossil",
     "evolvesTo": [
-      "Cradily"
+      "Cradily",
+      "Cradily ex"
     ],
     "attacks": [
       {
@@ -2527,7 +2538,8 @@
     ],
     "evolvesFrom": "Root Fossil",
     "evolvesTo": [
-      "Cradily"
+      "Cradily",
+      "Cradily ex"
     ],
     "attacks": [
       {
@@ -2759,7 +2771,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Honchkrow"
+      "Honchkrow",
+      "Honchkrow-GX"
     ],
     "attacks": [
       {
@@ -2825,7 +2838,9 @@
     ],
     "evolvesFrom": "Seedot",
     "evolvesTo": [
-      "Shiftry"
+      "Shiftry",
+      "Shiftry ex",
+      "Shiftry-GX"
     ],
     "attacks": [
       {
@@ -2887,7 +2902,9 @@
     ],
     "evolvesFrom": "Seedot",
     "evolvesTo": [
-      "Shiftry"
+      "Shiftry",
+      "Shiftry ex",
+      "Shiftry-GX"
     ],
     "attacks": [
       {
@@ -2999,7 +3016,9 @@
     ],
     "evolvesFrom": "Cyndaquil",
     "evolvesTo": [
-      "Typhlosion"
+      "Typhlosion",
+      "Typhlosion ex",
+      "Hisuian Typhlosion"
     ],
     "attacks": [
       {
@@ -3184,9 +3203,6 @@
     "types": [
       "Psychic"
     ],
-    "evolvesTo": [
-      "Wobbuffet"
-    ],
     "abilities": [
       {
         "name": "Baby Evolution",
@@ -3354,7 +3370,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Cacturne"
+      "Cacturne",
+      "Cacturne ex"
     ],
     "abilities": [
       {
@@ -3410,7 +3427,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Cacturne"
+      "Cacturne",
+      "Cacturne ex"
     ],
     "attacks": [
       {
@@ -3459,7 +3477,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Quilava"
+      "Quilava",
+      "Dark Quilava"
     ],
     "attacks": [
       {
@@ -3515,6 +3534,9 @@
     "hp": "50",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Dudunsparce"
     ],
     "attacks": [
       {
@@ -3572,7 +3594,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Dusclops"
+      "Dusclops",
+      "Dusclops ex"
     ],
     "attacks": [
       {
@@ -3636,7 +3659,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Dusclops"
+      "Dusclops",
+      "Dusclops ex"
     ],
     "attacks": [
       {
@@ -3708,7 +3732,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -3766,7 +3810,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Arbok"
+      "Arbok",
+      "Dark Arbok",
+      "Arbok ex"
     ],
     "attacks": [
       {
@@ -3815,7 +3861,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "abilities": [
       {
@@ -3987,7 +4035,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Azumarill"
+      "Azumarill",
+      "Light Azumarill"
     ],
     "attacks": [
       {
@@ -4155,7 +4204,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Steelix"
+      "Steelix",
+      "Dark Steelix",
+      "Steelix ex"
     ],
     "attacks": [
       {
@@ -4218,7 +4269,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -4278,7 +4333,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Golduck",
+      "Dark Golduck",
+      "Light Golduck"
     ],
     "attacks": [
       {
@@ -4385,7 +4442,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Sandslash"
+      "Sandslash",
+      "Dark Sandslash"
     ],
     "attacks": [
       {
@@ -4597,7 +4655,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Delcatty"
+      "Delcatty",
+      "Delcatty ex"
     ],
     "attacks": [
       {
@@ -4828,7 +4887,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wailord"
+      "Wailord",
+      "Wailord ex"
     ],
     "attacks": [
       {
@@ -5089,6 +5149,9 @@
       "Item"
     ],
     "hp": "40",
+    "evolvesTo": [
+      "Anorith"
+    ],
     "rules": [
       "Play Claw Fossil as if it were a Basic Pokémon. While in play, Claw Fossil counts as a Colorless Pokémon (instead of a Trainer card). Claw Fossil has no attacks of its own, can't retreat, and can't be affected by any Special Conditions. If Claw Fossil is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Claw Fossil from play."
     ],
@@ -5118,6 +5181,13 @@
       "Item"
     ],
     "hp": "10",
+    "evolvesTo": [
+      "Aerodactyl",
+      "Kabuto",
+      "Omanyte",
+      "Dark Omanyte",
+      "Aerodactyl ex"
+    ],
     "rules": [
       "Play Mysterious Fossil as if it were a Basic Pokémon. While in play, Mysterious Fossil counts as a Colorless Pokémon (instead of a Trainer card). Mysterious Fossil has no attacks of its own, can't retreat, and can't be affected by any Special Conditions. If Mysterious is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Mysterious Fossil from play."
     ],
@@ -5140,6 +5210,9 @@
       "Item"
     ],
     "hp": "40",
+    "evolvesTo": [
+      "Lileep"
+    ],
     "rules": [
       "Play Root Fossil as if it were a Basic Pokémon. While in play, Root Fossil counts as a Colorless Pokémon (instead of a Trainer card). Root Fossil has no attacks of its own, can't retreat, and can't be affected by any Special Conditions. If Root Fossil is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Root Fossil from play."
     ],

--- a/cards/en/ex3.json
+++ b/cards/en/ex3.json
@@ -4960,8 +4960,8 @@
     "name": "Ampharos ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
-      "EX"
+      "Stage 2",
+      "ex"
     ],
     "hp": "150",
     "types": [
@@ -5028,8 +5028,8 @@
     "name": "Dragonite ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
-      "EX"
+      "Stage 2",
+      "ex"
     ],
     "hp": "150",
     "types": [
@@ -5110,8 +5110,8 @@
     "name": "Golem ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
-      "EX"
+      "Stage 2",
+      "ex"
     ],
     "hp": "160",
     "types": [
@@ -5184,8 +5184,8 @@
     "name": "Kingdra ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
-      "EX"
+      "Stage 2",
+      "ex"
     ],
     "hp": "150",
     "types": [
@@ -5253,7 +5253,7 @@
     "supertype": "Pokémon",
     "subtypes": [
       "Basic",
-      "EX"
+      "ex"
     ],
     "hp": "90",
     "types": [
@@ -5325,7 +5325,7 @@
     "supertype": "Pokémon",
     "subtypes": [
       "Basic",
-      "EX"
+      "ex"
     ],
     "hp": "100",
     "types": [
@@ -5396,8 +5396,8 @@
     "name": "Magcargo ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
-      "EX"
+      "Stage 1",
+      "ex"
     ],
     "hp": "100",
     "types": [
@@ -5460,8 +5460,8 @@
     "name": "Muk ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
-      "EX"
+      "Stage 1",
+      "ex"
     ],
     "hp": "100",
     "types": [
@@ -5531,7 +5531,7 @@
     "supertype": "Pokémon",
     "subtypes": [
       "Basic",
-      "EX"
+      "ex"
     ],
     "hp": "100",
     "types": [

--- a/cards/en/ex3.json
+++ b/cards/en/ex3.json
@@ -197,6 +197,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Vibrava",
+    "evolvesTo": [
+      "Flygon LV.X"
+    ],
     "attacks": [
       {
         "name": "Energy Shower",
@@ -594,6 +597,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Shelgon",
+    "evolvesTo": [
+      "Salamence LV.X"
+    ],
     "abilities": [
       {
         "name": "Dragon Wind",
@@ -836,7 +842,9 @@
     ],
     "evolvesFrom": "Dratini",
     "evolvesTo": [
-      "Dragonite"
+      "Dragonite",
+      "Dragonite ex",
+      "Dragonite-GX"
     ],
     "attacks": [
       {
@@ -908,6 +916,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Vibrava",
+    "evolvesTo": [
+      "Flygon LV.X"
+    ],
     "abilities": [
       {
         "name": "Sand Guard",
@@ -957,6 +968,9 @@
     "hp": "70",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Farigiraf"
     ],
     "attacks": [
       {
@@ -1016,7 +1030,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "abilities": [
       {
@@ -1079,9 +1094,6 @@
       "Grass"
     ],
     "evolvesFrom": "Nincada",
-    "evolvesTo": [
-      "Shedinja"
-    ],
     "abilities": [
       {
         "name": "Loose Shell",
@@ -1133,6 +1145,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Shelgon",
+    "evolvesTo": [
+      "Salamence LV.X"
+    ],
     "abilities": [
       {
         "name": "Intimidating Fang",
@@ -1185,7 +1200,9 @@
     ],
     "evolvesFrom": "Bagon",
     "evolvesTo": [
-      "Salamence"
+      "Salamence",
+      "Salamence ex",
+      "Salamence-GX"
     ],
     "attacks": [
       {
@@ -1319,7 +1336,9 @@
     ],
     "evolvesFrom": "Trapinch",
     "evolvesTo": [
-      "Flygon"
+      "Flygon",
+      "Flygon ex",
+      "Flygon-GX"
     ],
     "attacks": [
       {
@@ -1518,7 +1537,9 @@
     ],
     "evolvesFrom": "Torchic",
     "evolvesTo": [
-      "Blaziken"
+      "Blaziken",
+      "Blaziken ex",
+      "Blaziken-GX"
     ],
     "attacks": [
       {
@@ -1579,7 +1600,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "attacks": [
       {
@@ -1648,7 +1671,9 @@
     ],
     "evolvesFrom": "Mareep",
     "evolvesTo": [
-      "Ampharos"
+      "Ampharos",
+      "Ampharos ex",
+      "Ampharos-GX"
     ],
     "attacks": [
       {
@@ -1780,7 +1805,8 @@
     ],
     "evolvesFrom": "Geodude",
     "evolvesTo": [
-      "Golem"
+      "Golem",
+      "Golem ex"
     ],
     "attacks": [
       {
@@ -1844,7 +1870,8 @@
     ],
     "evolvesFrom": "Geodude",
     "evolvesTo": [
-      "Golem"
+      "Golem",
+      "Golem ex"
     ],
     "attacks": [
       {
@@ -1908,7 +1935,9 @@
     ],
     "evolvesFrom": "Treecko",
     "evolvesTo": [
-      "Sceptile"
+      "Sceptile",
+      "Sceptile ex",
+      "Sceptile-GX"
     ],
     "attacks": [
       {
@@ -2149,7 +2178,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "attacks": [
       {
@@ -2211,7 +2241,8 @@
     ],
     "evolvesFrom": "Mudkip",
     "evolvesTo": [
-      "Swampert"
+      "Swampert",
+      "Swampert ex"
     ],
     "attacks": [
       {
@@ -2261,7 +2292,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Medicham"
+      "Medicham",
+      "Medicham ex"
     ],
     "attacks": [
       {
@@ -2320,9 +2352,6 @@
       "Grass"
     ],
     "evolvesFrom": "Nincada",
-    "evolvesTo": [
-      "Shedinja"
-    ],
     "attacks": [
       {
         "name": "Supersonic",
@@ -2377,7 +2406,9 @@
     ],
     "evolvesFrom": "Horsea",
     "evolvesTo": [
-      "Kingdra"
+      "Kingdra",
+      "Kingdra ex",
+      "Kingdra-GX"
     ],
     "attacks": [
       {
@@ -2438,7 +2469,9 @@
     ],
     "evolvesFrom": "Horsea",
     "evolvesTo": [
-      "Kingdra"
+      "Kingdra",
+      "Kingdra ex",
+      "Kingdra-GX"
     ],
     "attacks": [
       {
@@ -2500,7 +2533,9 @@
     ],
     "evolvesFrom": "Bagon",
     "evolvesTo": [
-      "Salamence"
+      "Salamence",
+      "Salamence ex",
+      "Salamence-GX"
     ],
     "abilities": [
       {
@@ -2553,7 +2588,9 @@
     ],
     "evolvesFrom": "Bagon",
     "evolvesTo": [
-      "Salamence"
+      "Salamence",
+      "Salamence ex",
+      "Salamence-GX"
     ],
     "attacks": [
       {
@@ -2609,7 +2646,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Banette"
+      "Banette",
+      "Banette ex",
+      "Banette-GX"
     ],
     "attacks": [
       {
@@ -2674,7 +2713,8 @@
     ],
     "evolvesTo": [
       "Glalie",
-      "Froslass"
+      "Froslass",
+      "Froslass ex"
     ],
     "attacks": [
       {
@@ -2783,7 +2823,9 @@
     ],
     "evolvesFrom": "Trapinch",
     "evolvesTo": [
-      "Flygon"
+      "Flygon",
+      "Flygon ex",
+      "Flygon-GX"
     ],
     "abilities": [
       {
@@ -2835,7 +2877,9 @@
     ],
     "evolvesFrom": "Trapinch",
     "evolvesTo": [
-      "Flygon"
+      "Flygon",
+      "Flygon ex",
+      "Flygon-GX"
     ],
     "attacks": [
       {
@@ -3123,7 +3167,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Crawdaunt"
+      "Crawdaunt",
+      "Crawdaunt ex"
     ],
     "attacks": [
       {
@@ -3181,7 +3226,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Crawdaunt"
+      "Crawdaunt",
+      "Crawdaunt ex"
     ],
     "attacks": [
       {
@@ -3240,7 +3286,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Crawdaunt"
+      "Crawdaunt",
+      "Crawdaunt ex"
     ],
     "attacks": [
       {
@@ -3406,7 +3453,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Muk"
+      "Muk",
+      "Dark Muk",
+      "Muk ex"
     ],
     "attacks": [
       {
@@ -3523,7 +3572,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Houndoom",
+      "Dark Houndoom",
+      "Houndoom ex"
     ],
     "attacks": [
       {
@@ -3588,7 +3639,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -3647,7 +3701,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -3712,7 +3767,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -3767,7 +3823,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -3816,7 +3873,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Flaaffy"
+      "Flaaffy",
+      "Dark Flaaffy"
     ],
     "attacks": [
       {
@@ -3920,7 +3978,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ninjask"
+      "Ninjask",
+      "Shedinja"
     ],
     "attacks": [
       {
@@ -3969,7 +4028,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ninjask"
+      "Ninjask",
+      "Shedinja"
     ],
     "attacks": [
       {
@@ -4028,7 +4088,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ninjask"
+      "Ninjask",
+      "Shedinja"
     ],
     "attacks": [
       {
@@ -4077,7 +4138,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Camerupt"
+      "Camerupt",
+      "Camerupt ex"
     ],
     "attacks": [
       {
@@ -4136,7 +4198,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Camerupt"
+      "Camerupt",
+      "Camerupt ex"
     ],
     "attacks": [
       {
@@ -4195,7 +4258,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Forretress"
+      "Forretress",
+      "Dark Forretress",
+      "Forretress ex"
     ],
     "abilities": [
       {
@@ -4252,7 +4317,10 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Magcargo"
+      "Magcargo",
+      "Dark Magcargo",
+      "Magcargo ex",
+      "Magcargo-GX"
     ],
     "attacks": [
       {
@@ -4420,7 +4488,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Altaria"
+      "Altaria",
+      "Altaria ex",
+      "Altaria-GX"
     ],
     "attacks": [
       {
@@ -5608,7 +5678,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -5668,7 +5739,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "attacks": [
       {

--- a/cards/en/ex4.json
+++ b/cards/en/ex4.json
@@ -665,9 +665,6 @@
       "Darkness"
     ],
     "evolvesFrom": "Team Magma's Rhyhorn",
-    "evolvesTo": [
-      "Rhyperior"
-    ],
     "rules": [
       "This Pokémon is both Fighting Darkness type."
     ],
@@ -792,6 +789,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Spark",
@@ -976,7 +977,7 @@
     ],
     "evolvesFrom": "Team Aqua's Spheal",
     "evolvesTo": [
-      "Walrein"
+      "Team Aqua's Walrein"
     ],
     "attacks": [
       {
@@ -1206,7 +1207,7 @@
     ],
     "evolvesFrom": "Team Magma's Aron",
     "evolvesTo": [
-      "Aggron"
+      "Team Magma's Aggron"
     ],
     "attacks": [
       {
@@ -1331,9 +1332,6 @@
       "Fighting"
     ],
     "evolvesFrom": "Team Magma's Rhyhorn",
-    "evolvesTo": [
-      "Rhyperior"
-    ],
     "attacks": [
       {
         "name": "Second Strike",
@@ -1452,7 +1450,7 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Cacturne"
+      "Team Aqua's Cacturne"
     ],
     "rules": [
       "This Pokémon is both Grass Darkness type."
@@ -1514,7 +1512,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Sharpedo"
+      "Team Aqua's Sharpedo"
     ],
     "abilities": [
       {
@@ -1571,7 +1569,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Crawdaunt"
+      "Team Aqua's Crawdaunt"
     ],
     "attacks": [
       {
@@ -1630,7 +1628,7 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Team Aqua's Manectric"
     ],
     "attacks": [
       {
@@ -1886,7 +1884,7 @@
     ],
     "evolvesFrom": "Team Aqua's Spheal",
     "evolvesTo": [
-      "Walrein"
+      "Team Aqua's Walrein"
     ],
     "attacks": [
       {
@@ -1948,7 +1946,7 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Claydol"
+      "Team Magma's Claydol"
     ],
     "attacks": [
       {
@@ -2125,7 +2123,7 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Team Magma's Houndoom"
     ],
     "attacks": [
       {
@@ -2185,7 +2183,7 @@
     ],
     "evolvesFrom": "Team Magma's Aron",
     "evolvesTo": [
-      "Aggron"
+      "Team Magma's Aggron"
     ],
     "attacks": [
       {
@@ -2306,7 +2304,7 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Rhydon"
+      "Team Magma's Rhydon"
     ],
     "attacks": [
       {
@@ -2366,7 +2364,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ivysaur"
+      "Ivysaur",
+      "Dark Ivysaur"
     ],
     "attacks": [
       {
@@ -2424,7 +2423,10 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Marowak"
+      "Marowak",
+      "Dark Marowak",
+      "Alolan Marowak-GX",
+      "Alolan Marowak"
     ],
     "attacks": [
       {
@@ -2473,7 +2475,11 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Wigglytuff"
+      "Wigglytuff",
+      "Dark Wigglytuff",
+      "Light Wigglytuff",
+      "Wigglytuff ex",
+      "Wigglytuff-GX"
     ],
     "attacks": [
       {
@@ -2532,7 +2538,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -2591,7 +2599,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -2650,7 +2662,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Golduck",
+      "Dark Golduck",
+      "Light Golduck"
     ],
     "attacks": [
       {
@@ -2709,7 +2723,11 @@
     ],
     "evolvesTo": [
       "Slowbro",
-      "Slowking"
+      "Slowking",
+      "Dark Slowbro",
+      "Dark Slowking",
+      "Light Slowbro",
+      "Slowking ex"
     ],
     "attacks": [
       {
@@ -2768,7 +2786,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wartortle"
+      "Wartortle",
+      "Dark Wartortle"
     ],
     "abilities": [
       {
@@ -2824,7 +2843,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Sharpedo"
+      "Team Aqua's Sharpedo"
     ],
     "attacks": [
       {
@@ -2883,7 +2902,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Sharpedo"
+      "Team Aqua's Sharpedo"
     ],
     "attacks": [
       {
@@ -2942,7 +2961,7 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Lanturn"
+      "Team Aqua's Lanturn"
     ],
     "attacks": [
       {
@@ -3007,7 +3026,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Crawdaunt"
+      "Team Aqua's Crawdaunt"
     ],
     "attacks": [
       {
@@ -3056,7 +3075,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Crawdaunt"
+      "Team Aqua's Crawdaunt"
     ],
     "attacks": [
       {
@@ -3115,7 +3134,7 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Team Aqua's Manectric"
     ],
     "attacks": [
       {
@@ -3180,7 +3199,7 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Team Aqua's Manectric"
     ],
     "attacks": [
       {
@@ -3245,7 +3264,7 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Mightyena"
+      "Team Aqua's Mightyena"
     ],
     "attacks": [
       {
@@ -3310,7 +3329,7 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Mightyena"
+      "Team Aqua's Mightyena"
     ],
     "attacks": [
       {
@@ -3375,7 +3394,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Sealeo"
+      "Team Aqua's Sealeo"
     ],
     "attacks": [
       {
@@ -3424,7 +3443,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Sealeo"
+      "Team Aqua's Sealeo"
     ],
     "attacks": [
       {
@@ -3483,7 +3502,7 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lairon"
+      "Team Magma's Lairon"
     ],
     "attacks": [
       {
@@ -3542,7 +3561,7 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lairon"
+      "Team Magma's Lairon"
     ],
     "attacks": [
       {
@@ -3591,7 +3610,7 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Claydol"
+      "Team Magma's Claydol"
     ],
     "attacks": [
       {
@@ -3650,7 +3669,7 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Claydol"
+      "Team Magma's Claydol"
     ],
     "attacks": [
       {
@@ -3709,7 +3728,7 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Team Magma's Houndoom"
     ],
     "attacks": [
       {
@@ -3768,7 +3787,7 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Team Magma's Houndoom"
     ],
     "attacks": [
       {
@@ -3827,7 +3846,7 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Camerupt"
+      "Team Magma's Camerupt"
     ],
     "attacks": [
       {
@@ -3886,7 +3905,7 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Mightyena"
+      "Team Magma's Mightyena"
     ],
     "attacks": [
       {
@@ -3941,7 +3960,7 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Mightyena"
+      "Team Magma's Mightyena"
     ],
     "attacks": [
       {
@@ -4006,7 +4025,7 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Rhydon"
+      "Team Magma's Rhydon"
     ],
     "attacks": [
       {
@@ -4065,7 +4084,7 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Rhydon"
+      "Team Magma's Rhydon"
     ],
     "attacks": [
       {

--- a/cards/en/ex5.json
+++ b/cards/en/ex5.json
@@ -128,6 +128,9 @@
       "Grass"
     ],
     "evolvesFrom": "Golbat",
+    "evolvesTo": [
+      "Crobat BREAK"
+    ],
     "attacks": [
       {
         "name": "Flutter Trick",
@@ -497,6 +500,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Machoke",
+    "evolvesTo": [
+      "Machamp LV.X",
+      "Machamp BREAK"
+    ],
     "abilities": [
       {
         "name": "Overzealous",
@@ -1236,7 +1243,9 @@
     ],
     "evolvesFrom": "Beldum",
     "evolvesTo": [
-      "Metagross"
+      "Metagross",
+      "Metagross ex",
+      "Metagross-GX"
     ],
     "attacks": [
       {
@@ -1302,6 +1311,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "abilities": [
       {
         "name": "Safeguard",
@@ -1919,9 +1931,6 @@
     "types": [
       "Water"
     ],
-    "evolvesTo": [
-      "Cursola"
-    ],
     "attacks": [
       {
         "name": "Coral Glow",
@@ -2105,7 +2114,9 @@
     "evolvesFrom": "Oddish",
     "evolvesTo": [
       "Vileplume",
-      "Bellossom"
+      "Bellossom",
+      "Vileplume ex",
+      "Vileplume-GX"
     ],
     "attacks": [
       {
@@ -2167,7 +2178,8 @@
     ],
     "evolvesFrom": "Zubat",
     "evolvesTo": [
-      "Crobat"
+      "Crobat",
+      "Crobat ex"
     ],
     "attacks": [
       {
@@ -2224,9 +2236,6 @@
     "hp": "50",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Jigglypuff"
     ],
     "abilities": [
       {
@@ -2340,7 +2349,8 @@
     ],
     "evolvesFrom": "Whismur",
     "evolvesTo": [
-      "Exploud"
+      "Exploud",
+      "Exploud ex"
     ],
     "attacks": [
       {
@@ -2458,7 +2468,8 @@
     ],
     "evolvesFrom": "Machop",
     "evolvesTo": [
-      "Machamp"
+      "Machamp",
+      "Machamp-GX"
     ],
     "abilities": [
       {
@@ -2573,7 +2584,9 @@
     ],
     "evolvesFrom": "Beldum",
     "evolvesTo": [
-      "Metagross"
+      "Metagross",
+      "Metagross ex",
+      "Metagross-GX"
     ],
     "attacks": [
       {
@@ -2636,7 +2649,9 @@
     ],
     "evolvesFrom": "Beldum",
     "evolvesTo": [
-      "Metagross"
+      "Metagross",
+      "Metagross ex",
+      "Metagross-GX"
     ],
     "abilities": [
       {
@@ -2701,7 +2716,9 @@
     ],
     "evolvesFrom": "Seedot",
     "evolvesTo": [
-      "Shiftry"
+      "Shiftry",
+      "Shiftry ex",
+      "Shiftry-GX"
     ],
     "attacks": [
       {
@@ -2837,7 +2854,8 @@
     ],
     "evolvesFrom": "Spheal",
     "evolvesTo": [
-      "Walrein"
+      "Walrein",
+      "Walrein ex"
     ],
     "attacks": [
       {
@@ -2952,6 +2970,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Staryu",
+    "evolvesTo": [
+      "Starmie BREAK"
+    ],
     "attacks": [
       {
         "name": "Water Arrow",
@@ -3122,7 +3143,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Claydol"
+      "Claydol",
+      "Claydol ex"
     ],
     "attacks": [
       {
@@ -3171,7 +3193,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Claydol"
+      "Claydol",
+      "Claydol ex"
     ],
     "attacks": [
       {
@@ -3343,7 +3366,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Lanturn"
+      "Lanturn",
+      "Light Lanturn"
     ],
     "attacks": [
       {
@@ -3402,7 +3426,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Lanturn"
+      "Lanturn",
+      "Light Lanturn"
     ],
     "attacks": [
       {
@@ -3519,7 +3544,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Quilava"
+      "Quilava",
+      "Dark Quilava"
     ],
     "attacks": [
       {
@@ -3633,7 +3659,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Milotic"
+      "Milotic",
+      "Milotic ex"
     ],
     "attacks": [
       {
@@ -3749,7 +3776,11 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Wigglytuff"
+      "Wigglytuff",
+      "Dark Wigglytuff",
+      "Light Wigglytuff",
+      "Wigglytuff ex",
+      "Wigglytuff-GX"
     ],
     "attacks": [
       {
@@ -3808,7 +3839,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Machoke"
+      "Machoke",
+      "Dark Machoke",
+      "Light Machoke"
     ],
     "attacks": [
       {
@@ -3867,7 +3900,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Medicham"
+      "Medicham",
+      "Medicham ex"
     ],
     "attacks": [
       {
@@ -3925,7 +3959,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Medicham"
+      "Medicham",
+      "Medicham ex"
     ],
     "attacks": [
       {
@@ -4046,7 +4081,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Gloom"
+      "Gloom",
+      "Dark Gloom"
     ],
     "attacks": [
       {
@@ -4285,7 +4321,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Banette"
+      "Banette",
+      "Banette ex",
+      "Banette-GX"
     ],
     "attacks": [
       {
@@ -4341,7 +4379,8 @@
     ],
     "evolvesTo": [
       "Glalie",
-      "Froslass"
+      "Froslass",
+      "Froslass ex"
     ],
     "attacks": [
       {
@@ -4449,7 +4488,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Starmie"
+      "Starmie",
+      "Starmie-GX"
     ],
     "abilities": [
       {
@@ -4610,7 +4650,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Togetic"
+      "Togetic",
+      "Light Togetic"
     ],
     "attacks": [
       {
@@ -4659,7 +4700,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Croconaw"
+      "Croconaw",
+      "Dark Croconaw"
     ],
     "attacks": [
       {
@@ -4718,7 +4760,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {
@@ -4777,7 +4822,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {
@@ -4884,7 +4931,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Golbat"
+      "Golbat",
+      "Dark Golbat"
     ],
     "attacks": [
       {

--- a/cards/en/ex6.json
+++ b/cards/en/ex6.json
@@ -378,6 +378,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Cubone",
+    "evolvesTo": [
+      "Marowak BREAK"
+    ],
     "attacks": [
       {
         "name": "Linear Attack",
@@ -437,6 +440,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Nidorino",
+    "evolvesTo": [
+      "Nidoking BREAK"
+    ],
     "abilities": [
       {
         "name": "Power Gene",
@@ -696,6 +702,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Recharge",
@@ -873,6 +883,9 @@
     "hp": "90",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Snorlax LV.X"
     ],
     "abilities": [
       {
@@ -1055,6 +1068,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "attacks": [
       {
         "name": "Flare",
@@ -1115,7 +1131,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Blissey"
+      "Blissey",
+      "Blissey ex"
     ],
     "attacks": [
       {
@@ -1360,9 +1377,6 @@
     "hp": "70",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Sirfetch'd"
     ],
     "attacks": [
       {
@@ -1612,7 +1626,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "attacks": [
       {
@@ -1679,6 +1694,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Mankey",
+    "evolvesTo": [
+      "Annihilape ex",
+      "Annihilape"
+    ],
     "attacks": [
       {
         "name": "Toss",
@@ -1733,7 +1752,11 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor",
+      "Scizor ex",
+      "Dark Scizor",
+      "Scizor-GX",
+      "Kleavor"
     ],
     "abilities": [
       {
@@ -1855,7 +1878,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "attacks": [
       {
@@ -1916,7 +1942,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Hypno"
+      "Hypno",
+      "Dark Hypno"
     ],
     "attacks": [
       {
@@ -1974,7 +2001,10 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Exeggutor"
+      "Exeggutor",
+      "Dark Exeggutor",
+      "Alolan Exeggutor-GX",
+      "Alolan Exeggutor"
     ],
     "attacks": [
       {
@@ -2034,7 +2064,8 @@
     ],
     "evolvesFrom": "Gastly",
     "evolvesTo": [
-      "Gengar"
+      "Gengar",
+      "Gengar ex"
     ],
     "abilities": [
       {
@@ -2098,7 +2129,8 @@
     ],
     "evolvesFrom": "Bulbasaur",
     "evolvesTo": [
-      "Venusaur"
+      "Venusaur",
+      "Venusaur ex"
     ],
     "attacks": [
       {
@@ -2276,7 +2308,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Primeape"
+      "Primeape",
+      "Dark Primeape"
     ],
     "attacks": [
       {
@@ -2515,7 +2548,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Steelix"
+      "Steelix",
+      "Dark Steelix",
+      "Steelix ex"
     ],
     "attacks": [
       {
@@ -2698,7 +2733,8 @@
     ],
     "evolvesFrom": "Pidgey",
     "evolvesTo": [
-      "Pidgeot"
+      "Pidgeot",
+      "Pidgeot ex"
     ],
     "attacks": [
       {
@@ -2761,7 +2797,8 @@
     "evolvesFrom": "Poliwag",
     "evolvesTo": [
       "Poliwrath",
-      "Politoed"
+      "Politoed",
+      "Politoed ex"
     ],
     "attacks": [
       {
@@ -2820,7 +2857,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Porygon2"
+      "Porygon2",
+      "Dark Porygon2"
     ],
     "attacks": [
       {
@@ -2879,6 +2917,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Rattata",
+    "evolvesTo": [
+      "Raticate BREAK"
+    ],
     "abilities": [
       {
         "name": "Thick Skin",
@@ -2999,7 +3040,9 @@
     ],
     "evolvesFrom": "Squirtle",
     "evolvesTo": [
-      "Blastoise"
+      "Blastoise",
+      "Blastoise ex",
+      "Blastoise-GX"
     ],
     "attacks": [
       {
@@ -3224,7 +3267,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ivysaur"
+      "Ivysaur",
+      "Dark Ivysaur"
     ],
     "attacks": [
       {
@@ -3283,7 +3327,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ivysaur"
+      "Ivysaur",
+      "Dark Ivysaur"
     ],
     "attacks": [
       {
@@ -3400,7 +3445,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -3449,7 +3495,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -3508,7 +3555,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Clefable",
+      "Clefable ex"
     ],
     "attacks": [
       {
@@ -3567,7 +3615,10 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Marowak"
+      "Marowak",
+      "Dark Marowak",
+      "Alolan Marowak-GX",
+      "Alolan Marowak"
     ],
     "attacks": [
       {
@@ -3626,7 +3677,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Dugtrio"
+      "Dugtrio",
+      "Dark Dugtrio"
     ],
     "attacks": [
       {
@@ -3740,7 +3792,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Haunter",
+      "Dark Haunter"
     ],
     "attacks": [
       {
@@ -3795,7 +3848,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -3856,7 +3911,11 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Wigglytuff"
+      "Wigglytuff",
+      "Dark Wigglytuff",
+      "Light Wigglytuff",
+      "Wigglytuff ex",
+      "Wigglytuff-GX"
     ],
     "attacks": [
       {
@@ -3974,7 +4033,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -4033,7 +4095,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -4098,7 +4161,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -4397,7 +4462,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -4505,7 +4574,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Rapidash"
+      "Rapidash",
+      "Dark Rapidash"
     ],
     "attacks": [
       {
@@ -4555,7 +4625,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Raticate"
+      "Raticate",
+      "Dark Raticate"
     ],
     "attacks": [
       {
@@ -4613,7 +4684,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Dewgong"
+      "Dewgong",
+      "Light Dewgong"
     ],
     "attacks": [
       {
@@ -4721,7 +4793,11 @@
     ],
     "evolvesTo": [
       "Slowbro",
-      "Slowking"
+      "Slowking",
+      "Dark Slowbro",
+      "Dark Slowking",
+      "Light Slowbro",
+      "Slowking ex"
     ],
     "attacks": [
       {
@@ -4835,7 +4911,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wartortle"
+      "Wartortle",
+      "Dark Wartortle"
     ],
     "attacks": [
       {
@@ -4884,7 +4961,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wartortle"
+      "Wartortle",
+      "Dark Wartortle"
     ],
     "attacks": [
       {
@@ -4943,7 +5021,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Venomoth"
+      "Venomoth",
+      "Light Venomoth",
+      "Venomoth-GX"
     ],
     "attacks": [
       {
@@ -5001,7 +5081,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "abilities": [
       {
@@ -6082,7 +6165,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {

--- a/cards/en/ex7.json
+++ b/cards/en/ex7.json
@@ -1489,9 +1489,6 @@
     "types": [
       "Fire"
     ],
-    "evolvesTo": [
-      "Magmar"
-    ],
     "abilities": [
       {
         "name": "Baby Evolution",
@@ -1906,7 +1903,7 @@
     ],
     "evolvesFrom": "Dratini",
     "evolvesTo": [
-      "Dragonite"
+      "Dark Dragonite"
     ],
     "abilities": [
       {
@@ -1974,7 +1971,7 @@
     ],
     "evolvesFrom": "Dratini",
     "evolvesTo": [
-      "Dragonite"
+      "Dark Dragonite"
     ],
     "attacks": [
       {
@@ -2047,7 +2044,7 @@
     ],
     "evolvesFrom": "Mareep",
     "evolvesTo": [
-      "Ampharos"
+      "Dark Ampharos"
     ],
     "rules": [
       "This Pokémon is both Lightning Darkness type."
@@ -2111,7 +2108,7 @@
     ],
     "evolvesFrom": "Zubat",
     "evolvesTo": [
-      "Crobat"
+      "Dark Crobat"
     ],
     "rules": [
       "This Pokémon is both Grass Darkness type."
@@ -2423,9 +2420,6 @@
       "Darkness"
     ],
     "evolvesFrom": "Magnemite",
-    "evolvesTo": [
-      "Magnezone"
-    ],
     "rules": [
       "This Pokémon is both Lightning Darkness type."
     ],
@@ -2490,7 +2484,7 @@
     ],
     "evolvesFrom": "Larvitar",
     "evolvesTo": [
-      "Tyranitar"
+      "Dark Tyranitar"
     ],
     "rules": [
       "This Pokémon is both Fighting Darkness type."
@@ -2554,7 +2548,7 @@
     ],
     "evolvesFrom": "Larvitar",
     "evolvesTo": [
-      "Tyranitar"
+      "Dark Tyranitar"
     ],
     "rules": [
       "This Pokémon is both Fighting Darkness type."
@@ -2857,7 +2851,7 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Persian"
+      "Rocket's Persian ex"
     ],
     "attacks": [
       {
@@ -2973,7 +2967,9 @@
     ],
     "evolvesFrom": "Horsea",
     "evolvesTo": [
-      "Kingdra"
+      "Kingdra",
+      "Kingdra ex",
+      "Kingdra-GX"
     ],
     "attacks": [
       {
@@ -3093,7 +3089,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Togetic"
+      "Togetic",
+      "Light Togetic"
     ],
     "attacks": [
       {
@@ -3152,7 +3149,10 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Marowak"
+      "Marowak",
+      "Dark Marowak",
+      "Alolan Marowak-GX",
+      "Alolan Marowak"
     ],
     "attacks": [
       {
@@ -3210,7 +3210,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "attacks": [
       {
@@ -3253,7 +3255,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "attacks": [
       {
@@ -3322,7 +3326,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Hypno"
+      "Hypno",
+      "Dark Hypno"
     ],
     "abilities": [
       {
@@ -3378,7 +3383,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Arbok"
+      "Arbok",
+      "Dark Arbok",
+      "Arbok ex"
     ],
     "attacks": [
       {
@@ -3427,7 +3434,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Muk"
+      "Muk",
+      "Dark Muk",
+      "Muk ex"
     ],
     "attacks": [
       {
@@ -3607,7 +3616,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Houndoom",
+      "Dark Houndoom",
+      "Houndoom ex"
     ],
     "attacks": [
       {
@@ -3666,7 +3677,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Houndoom",
+      "Dark Houndoom",
+      "Houndoom ex"
     ],
     "abilities": [
       {
@@ -3722,7 +3735,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Weezing"
+      "Weezing",
+      "Dark Weezing",
+      "Galarian Weezing"
     ],
     "abilities": [
       {
@@ -3778,7 +3793,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Pupitar"
+      "Pupitar",
+      "Dark Pupitar"
     ],
     "attacks": [
       {
@@ -3827,7 +3843,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Pupitar"
+      "Pupitar",
+      "Dark Pupitar"
     ],
     "attacks": [
       {
@@ -3886,7 +3903,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ledian"
+      "Ledian",
+      "Light Ledian"
     ],
     "attacks": [
       {
@@ -3945,7 +3963,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -3994,7 +4015,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -4043,7 +4065,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Flaaffy"
+      "Flaaffy",
+      "Dark Flaaffy"
     ],
     "attacks": [
       {
@@ -4102,7 +4125,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Azumarill"
+      "Azumarill",
+      "Light Azumarill"
     ],
     "attacks": [
       {
@@ -4151,7 +4175,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Steelix"
+      "Steelix",
+      "Dark Steelix",
+      "Steelix ex"
     ],
     "attacks": [
       {
@@ -4212,7 +4238,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Golduck",
+      "Dark Golduck",
+      "Light Golduck"
     ],
     "attacks": [
       {
@@ -4270,7 +4298,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Raticate"
+      "Raticate",
+      "Dark Raticate"
     ],
     "abilities": [
       {
@@ -4326,7 +4355,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Raticate"
+      "Raticate",
+      "Dark Raticate"
     ],
     "attacks": [
       {
@@ -4384,7 +4414,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Octillery"
+      "Octillery",
+      "Dark Octillery"
     ],
     "attacks": [
       {
@@ -4442,7 +4473,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Sandslash"
+      "Sandslash",
+      "Dark Sandslash"
     ],
     "attacks": [
       {
@@ -4560,7 +4592,11 @@
     ],
     "evolvesTo": [
       "Slowbro",
-      "Slowking"
+      "Slowking",
+      "Dark Slowbro",
+      "Dark Slowking",
+      "Light Slowbro",
+      "Slowking ex"
     ],
     "abilities": [
       {
@@ -4616,7 +4652,10 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Magcargo"
+      "Magcargo",
+      "Dark Magcargo",
+      "Magcargo ex",
+      "Magcargo-GX"
     ],
     "attacks": [
       {
@@ -4676,7 +4715,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ariados"
+      "Ariados",
+      "Dark Ariados"
     ],
     "attacks": [
       {
@@ -4735,7 +4775,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Piloswine"
+      "Piloswine",
+      "Light Piloswine"
     ],
     "attacks": [
       {
@@ -4794,7 +4835,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {
@@ -4908,7 +4952,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Golbat"
+      "Golbat",
+      "Dark Golbat"
     ],
     "attacks": [
       {
@@ -5674,7 +5719,7 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Rocket's Scizor ex"
     ],
     "rules": [
       "When Pokémon-ex has been Knocked Out, your opponent takes 2 Prize cards."
@@ -5749,9 +5794,6 @@
     "hp": "90",
     "types": [
       "Darkness"
-    ],
-    "evolvesTo": [
-      "Weavile"
     ],
     "rules": [
       "When Pokémon-ex has been Knocked Out, your opponent takes 2 Prize cards."
@@ -6215,7 +6257,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "attacks": [
       {

--- a/cards/en/ex8.json
+++ b/cards/en/ex8.json
@@ -769,9 +769,6 @@
       "Grass"
     ],
     "evolvesFrom": "Nincada",
-    "evolvesTo": [
-      "Shedinja"
-    ],
     "abilities": [
       {
         "name": "Fast Protection",
@@ -1838,7 +1835,8 @@
     ],
     "evolvesFrom": "Zubat",
     "evolvesTo": [
-      "Crobat"
+      "Crobat",
+      "Crobat ex"
     ],
     "abilities": [
       {
@@ -2365,7 +2363,9 @@
     ],
     "evolvesFrom": "Beldum",
     "evolvesTo": [
-      "Metagross"
+      "Metagross",
+      "Metagross ex",
+      "Metagross-GX"
     ],
     "attacks": [
       {
@@ -2539,7 +2539,9 @@
     ],
     "evolvesFrom": "Seedot",
     "evolvesTo": [
-      "Shiftry"
+      "Shiftry",
+      "Shiftry ex",
+      "Shiftry-GX"
     ],
     "attacks": [
       {
@@ -2655,7 +2657,9 @@
     ],
     "evolvesFrom": "Bagon",
     "evolvesTo": [
-      "Salamence"
+      "Salamence",
+      "Salamence ex",
+      "Salamence-GX"
     ],
     "abilities": [
       {
@@ -2847,6 +2851,9 @@
       "Water"
     ],
     "evolvesFrom": "Staryu",
+    "evolvesTo": [
+      "Starmie BREAK"
+    ],
     "abilities": [
       {
         "name": "Core Guard",
@@ -3154,7 +3161,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Claydol"
+      "Claydol",
+      "Claydol ex"
     ],
     "attacks": [
       {
@@ -3321,7 +3329,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Sharpedo"
+      "Sharpedo",
+      "Sharpedo ex"
     ],
     "attacks": [
       {
@@ -3386,7 +3395,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Crawdaunt"
+      "Crawdaunt",
+      "Crawdaunt ex"
     ],
     "abilities": [
       {
@@ -3442,7 +3452,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Dusclops"
+      "Dusclops",
+      "Dusclops ex"
     ],
     "attacks": [
       {
@@ -3507,7 +3518,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Manectric",
+      "Manectric ex"
     ],
     "attacks": [
       {
@@ -3572,7 +3584,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Manectric",
+      "Manectric ex"
     ],
     "attacks": [
       {
@@ -3689,7 +3702,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Weezing"
+      "Weezing",
+      "Dark Weezing",
+      "Galarian Weezing"
     ],
     "attacks": [
       {
@@ -3797,7 +3812,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -3856,7 +3874,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Hariyama"
+      "Hariyama",
+      "Hariyama ex"
     ],
     "attacks": [
       {
@@ -3971,7 +3990,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ninjask"
+      "Ninjask",
+      "Shedinja"
     ],
     "attacks": [
       {
@@ -4030,7 +4050,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Camerupt"
+      "Camerupt",
+      "Camerupt ex"
     ],
     "abilities": [
       {
@@ -4086,7 +4107,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Donphan"
+      "Donphan",
+      "Dark Donphan"
     ],
     "attacks": [
       {
@@ -4145,7 +4167,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Mightyena"
+      "Mightyena",
+      "Mightyena ex"
     ],
     "attacks": [
       {
@@ -4390,7 +4413,10 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Magcargo"
+      "Magcargo",
+      "Dark Magcargo",
+      "Magcargo ex",
+      "Magcargo-GX"
     ],
     "attacks": [
       {
@@ -4449,7 +4475,10 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Magcargo"
+      "Magcargo",
+      "Dark Magcargo",
+      "Magcargo ex",
+      "Magcargo-GX"
     ],
     "attacks": [
       {
@@ -4568,7 +4597,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Starmie"
+      "Starmie",
+      "Starmie-GX"
     ],
     "attacks": [
       {
@@ -4666,7 +4696,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Altaria"
+      "Altaria",
+      "Altaria ex",
+      "Altaria-GX"
     ],
     "abilities": [
       {
@@ -4898,7 +4930,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Golbat"
+      "Golbat",
+      "Dark Golbat"
     ],
     "abilities": [
       {

--- a/cards/en/ex9.json
+++ b/cards/en/ex9.json
@@ -212,6 +212,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Kirlia",
+    "evolvesTo": [
+      "Gardevoir LV.X"
+    ],
     "abilities": [
       {
         "name": "Heal Dance",
@@ -1479,7 +1482,9 @@
     ],
     "evolvesFrom": "Torchic",
     "evolvesTo": [
-      "Blaziken"
+      "Blaziken",
+      "Blaziken ex",
+      "Blaziken-GX"
     ],
     "attacks": [
       {
@@ -1664,7 +1669,9 @@
     ],
     "evolvesFrom": "Treecko",
     "evolvesTo": [
-      "Sceptile"
+      "Sceptile",
+      "Sceptile ex",
+      "Sceptile-GX"
     ],
     "attacks": [
       {
@@ -1963,7 +1970,9 @@
     "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
-      "Gallade"
+      "Gallade",
+      "Gardevoir ex",
+      "Gardevoir-GX"
     ],
     "attacks": [
       {
@@ -2078,7 +2087,8 @@
     ],
     "evolvesFrom": "Whismur",
     "evolvesTo": [
-      "Exploud"
+      "Exploud",
+      "Exploud ex"
     ],
     "attacks": [
       {
@@ -2140,7 +2150,8 @@
     ],
     "evolvesFrom": "Mudkip",
     "evolvesTo": [
-      "Swampert"
+      "Swampert",
+      "Swampert ex"
     ],
     "attacks": [
       {
@@ -2260,6 +2271,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "attacks": [
       {
         "name": "Confuse Ray",
@@ -2556,7 +2570,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Claydol"
+      "Claydol",
+      "Claydol ex"
     ],
     "attacks": [
       {
@@ -2616,7 +2631,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Cacturne"
+      "Cacturne",
+      "Cacturne ex"
     ],
     "attacks": [
       {
@@ -2720,7 +2736,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Dusclops"
+      "Dusclops",
+      "Dusclops ex"
     ],
     "attacks": [
       {
@@ -2775,7 +2792,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Manectric",
+      "Manectric ex"
     ],
     "attacks": [
       {
@@ -2830,7 +2848,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Manectric",
+      "Manectric ex"
     ],
     "attacks": [
       {
@@ -2895,7 +2914,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Milotic"
+      "Milotic",
+      "Milotic ex"
     ],
     "abilities": [
       {
@@ -2952,7 +2972,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Milotic"
+      "Milotic",
+      "Milotic ex"
     ],
     "attacks": [
       {
@@ -3060,7 +3081,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Pupitar"
+      "Pupitar",
+      "Dark Pupitar"
     ],
     "attacks": [
       {
@@ -3166,7 +3188,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Hariyama"
+      "Hariyama",
+      "Hariyama ex"
     ],
     "attacks": [
       {
@@ -3215,7 +3238,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Medicham"
+      "Medicham",
+      "Medicham ex"
     ],
     "attacks": [
       {
@@ -3323,7 +3347,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Camerupt"
+      "Camerupt",
+      "Camerupt ex"
     ],
     "attacks": [
       {
@@ -3381,7 +3406,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Camerupt"
+      "Camerupt",
+      "Camerupt ex"
     ],
     "attacks": [
       {
@@ -3440,9 +3466,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesTo": [
-      "Pikachu"
-    ],
     "abilities": [
       {
         "name": "Baby Evolution",
@@ -3497,7 +3520,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -3730,7 +3757,8 @@
     ],
     "evolvesTo": [
       "Glalie",
-      "Froslass"
+      "Froslass",
+      "Froslass ex"
     ],
     "attacks": [
       {
@@ -3877,7 +3905,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Altaria"
+      "Altaria",
+      "Altaria ex",
+      "Altaria-GX"
     ],
     "abilities": [
       {
@@ -4098,7 +4128,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {
@@ -4158,7 +4191,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {
@@ -4924,9 +4959,6 @@
       "Psychic"
     ],
     "evolvesFrom": "Duskull",
-    "evolvesTo": [
-      "Dusknoir"
-    ],
     "rules": [
       "When Pokémon-ex has been Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -5502,9 +5534,6 @@
     "hp": "70",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Sirfetch'd"
     ],
     "attacks": [
       {

--- a/cards/en/g1.json
+++ b/cards/en/g1.json
@@ -814,7 +814,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Rapidash"
+      "Rapidash",
+      "Dark Rapidash"
     ],
     "attacks": [
       {
@@ -1298,7 +1299,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -1545,7 +1549,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -1612,6 +1620,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Circle Circuit",
@@ -1869,7 +1881,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Golbat"
+      "Golbat",
+      "Dark Golbat"
     ],
     "attacks": [
       {
@@ -1927,7 +1940,8 @@
     ],
     "evolvesFrom": "Zubat",
     "evolvesTo": [
-      "Crobat"
+      "Crobat",
+      "Crobat ex"
     ],
     "abilities": [
       {
@@ -1988,7 +2002,11 @@
     ],
     "evolvesTo": [
       "Slowbro",
-      "Slowking"
+      "Slowking",
+      "Dark Slowbro",
+      "Dark Slowking",
+      "Light Slowbro",
+      "Slowking ex"
     ],
     "attacks": [
       {
@@ -2049,7 +2067,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Haunter",
+      "Dark Haunter"
     ],
     "attacks": [
       {
@@ -2107,7 +2126,8 @@
     ],
     "evolvesFrom": "Gastly",
     "evolvesTo": [
-      "Gengar"
+      "Gengar",
+      "Gengar ex"
     ],
     "abilities": [
       {
@@ -2172,6 +2192,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Haunter",
+    "evolvesTo": [
+      "Gengar LV.X"
+    ],
     "attacks": [
       {
         "name": "Sinister Fog",
@@ -2349,7 +2372,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Dugtrio"
+      "Dugtrio",
+      "Dark Dugtrio"
     ],
     "attacks": [
       {
@@ -2470,7 +2494,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Machoke"
+      "Machoke",
+      "Dark Machoke",
+      "Light Machoke"
     ],
     "attacks": [
       {
@@ -2523,7 +2549,8 @@
     ],
     "evolvesFrom": "Machop",
     "evolvesTo": [
-      "Machamp"
+      "Machamp",
+      "Machamp-GX"
     ],
     "attacks": [
       {
@@ -2576,6 +2603,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Machoke",
+    "evolvesTo": [
+      "Machamp LV.X",
+      "Machamp BREAK"
+    ],
     "abilities": [
       {
         "name": "Fighting Fury",
@@ -2698,7 +2729,8 @@
     ],
     "evolvesFrom": "Geodude",
     "evolvesTo": [
-      "Golem"
+      "Golem",
+      "Golem ex"
     ],
     "attacks": [
       {
@@ -3070,7 +3102,8 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Clefable",
+      "Clefable ex"
     ],
     "attacks": [
       {
@@ -3265,7 +3298,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -3564,6 +3599,9 @@
     "hp": "130",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Snorlax LV.X"
     ],
     "abilities": [
       {
@@ -4303,7 +4341,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -4357,7 +4396,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "attacks": [
       {
@@ -4545,7 +4587,8 @@
     ],
     "evolvesTo": [
       "Glalie",
-      "Froslass"
+      "Froslass",
+      "Froslass ex"
     ],
     "attacks": [
       {
@@ -4655,6 +4698,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Circle Circuit",
@@ -4779,6 +4826,9 @@
     "hp": "110",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Wobbuffet BREAK"
     ],
     "abilities": [
       {
@@ -5059,6 +5109,9 @@
     "hp": "130",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Yveltal BREAK"
     ],
     "attacks": [
       {
@@ -5521,7 +5574,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Altaria"
+      "Altaria",
+      "Altaria ex",
+      "Altaria-GX"
     ],
     "attacks": [
       {
@@ -5808,7 +5863,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {

--- a/cards/en/gym1.json
+++ b/cards/en/gym1.json
@@ -65,9 +65,6 @@
       "Fighting"
     ],
     "evolvesFrom": "Brock's Rhyhorn",
-    "evolvesTo": [
-      "Rhyperior"
-    ],
     "abilities": [
       {
         "name": "Bench Guard",
@@ -200,9 +197,6 @@
       "Colorless"
     ],
     "evolvesFrom": "Erika's Dratini",
-    "evolvesTo": [
-      "Dragonite"
-    ],
     "attacks": [
       {
         "name": "Blizzard",
@@ -322,9 +316,6 @@
     "hp": "70",
     "types": [
       "Lightning"
-    ],
-    "evolvesTo": [
-      "Electivire"
     ],
     "attacks": [
       {
@@ -446,9 +437,6 @@
       "Lightning"
     ],
     "evolvesFrom": "Lt. Surge's Magnemite",
-    "evolvesTo": [
-      "Magnezone"
-    ],
     "abilities": [
       {
         "name": "Energy Charge",
@@ -508,9 +496,6 @@
       "Water"
     ],
     "evolvesFrom": "Misty's Horsea",
-    "evolvesTo": [
-      "Kingdra"
-    ],
     "attacks": [
       {
         "name": "Tail Snap",
@@ -737,9 +722,6 @@
     "hp": "60",
     "types": [
       "Grass"
-    ],
-    "evolvesTo": [
-      "Scizor"
     ],
     "attacks": [
       {
@@ -1019,9 +1001,6 @@
     "types": [
       "Fighting"
     ],
-    "evolvesTo": [
-      "Steelix"
-    ],
     "attacks": [
       {
         "name": "Bind",
@@ -1083,7 +1062,7 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Rhydon"
+      "Brock's Rhydon"
     ],
     "attacks": [
       {
@@ -1217,7 +1196,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Golbat"
+      "Brock's Golbat"
     ],
     "attacks": [
       {
@@ -1279,7 +1258,7 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Erika's Clefable"
     ],
     "attacks": [
       {
@@ -1401,9 +1380,6 @@
     "hp": "60",
     "types": [
       "Lightning"
-    ],
-    "evolvesTo": [
-      "Electivire"
     ],
     "attacks": [
       {
@@ -1584,7 +1560,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Seaking"
+      "Misty's Seaking"
     ],
     "attacks": [
       {
@@ -1683,7 +1659,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Tentacruel"
+      "Misty's Tentacruel"
     ],
     "attacks": [
       {
@@ -1863,7 +1839,7 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Blaine's Arcanine"
     ],
     "attacks": [
       {
@@ -1988,9 +1964,6 @@
     "types": [
       "Fire"
     ],
-    "evolvesTo": [
-      "Magmortar"
-    ],
     "attacks": [
       {
         "name": "Firebreathing",
@@ -2051,7 +2024,7 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Graveler"
+      "Brock's Graveler"
     ],
     "attacks": [
       {
@@ -2111,9 +2084,6 @@
       "Grass"
     ],
     "evolvesFrom": "Brock's Zubat",
-    "evolvesTo": [
-      "Crobat"
-    ],
     "attacks": [
       {
         "name": "Dive",
@@ -2180,7 +2150,7 @@
     ],
     "evolvesFrom": "Brock's Geodude",
     "evolvesTo": [
-      "Golem"
+      "Brock's Golem"
     ],
     "attacks": [
       {
@@ -2231,9 +2201,6 @@
     "hp": "80",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Lickilicky"
     ],
     "attacks": [
       {
@@ -2303,7 +2270,7 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Erika's Dragonair"
     ],
     "abilities": [
       {
@@ -2361,7 +2328,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Exeggutor"
+      "Erika's Exeggutor"
     ],
     "attacks": [
       {
@@ -2482,8 +2449,7 @@
     ],
     "evolvesFrom": "Erika's Oddish",
     "evolvesTo": [
-      "Vileplume",
-      "Bellossom"
+      "Erika's Vileplume"
     ],
     "attacks": [
       {
@@ -2545,8 +2511,7 @@
     ],
     "evolvesFrom": "Erika's Oddish",
     "evolvesTo": [
-      "Vileplume",
-      "Bellossom"
+      "Erika's Vileplume"
     ],
     "attacks": [
       {
@@ -2608,7 +2573,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Gloom"
+      "Erika's Gloom"
     ],
     "abilities": [
       {
@@ -2667,7 +2632,7 @@
     ],
     "evolvesFrom": "Erika's Bellsprout",
     "evolvesTo": [
-      "Victreebel"
+      "Erika's Victreebel"
     ],
     "attacks": [
       {
@@ -2728,7 +2693,7 @@
     ],
     "evolvesFrom": "Erika's Bellsprout",
     "evolvesTo": [
-      "Victreebel"
+      "Erika's Victreebel"
     ],
     "attacks": [
       {
@@ -2791,7 +2756,7 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Lt. Surge's Magneton"
     ],
     "attacks": [
       {
@@ -2901,7 +2866,7 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Fearow"
+      "Lt. Surge's Fearow"
     ],
     "attacks": [
       {
@@ -2954,8 +2919,7 @@
     ],
     "evolvesFrom": "Misty's Poliwag",
     "evolvesTo": [
-      "Poliwrath",
-      "Politoed"
+      "Misty's Poliwrath"
     ],
     "attacks": [
       {
@@ -3018,7 +2982,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Misty's Golduck"
     ],
     "attacks": [
       {
@@ -3195,7 +3159,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Tentacruel"
+      "Misty's Tentacruel"
     ],
     "attacks": [
       {
@@ -3247,7 +3211,7 @@
     ],
     "evolvesFrom": "Sabrina's Gastly",
     "evolvesTo": [
-      "Gengar"
+      "Sabrina's Gengar"
     ],
     "attacks": [
       {
@@ -3411,7 +3375,7 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Blaine's Charmeleon"
     ],
     "attacks": [
       {
@@ -3471,7 +3435,7 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Blaine's Arcanine"
     ],
     "attacks": [
       {
@@ -3522,7 +3486,7 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Rapidash"
+      "Blaine's Rapidash"
     ],
     "attacks": [
       {
@@ -3634,7 +3598,7 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Blaine's Ninetales"
     ],
     "abilities": [
       {
@@ -3693,7 +3657,7 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Graveler"
+      "Brock's Graveler"
     ],
     "attacks": [
       {
@@ -3753,7 +3717,7 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Primeape"
+      "Brock's Primeape"
     ],
     "attacks": [
       {
@@ -3808,7 +3772,7 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Primeape"
+      "Brock's Primeape"
     ],
     "attacks": [
       {
@@ -3862,9 +3826,6 @@
     "hp": "100",
     "types": [
       "Fighting"
-    ],
-    "evolvesTo": [
-      "Steelix"
     ],
     "attacks": [
       {
@@ -3927,7 +3888,7 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Rhydon"
+      "Brock's Rhydon"
     ],
     "attacks": [
       {
@@ -3986,7 +3947,7 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Sandslash"
+      "Brock's Sandslash"
     ],
     "attacks": [
       {
@@ -4052,7 +4013,7 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Sandslash"
+      "Brock's Sandslash"
     ],
     "attacks": [
       {
@@ -4109,7 +4070,7 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Brock's Ninetales"
     ],
     "attacks": [
       {
@@ -4169,7 +4130,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Golbat"
+      "Brock's Golbat"
     ],
     "attacks": [
       {
@@ -4231,7 +4192,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Weepinbell"
+      "Erika's Weepinbell"
     ],
     "attacks": [
       {
@@ -4291,7 +4252,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Weepinbell"
+      "Erika's Weepinbell"
     ],
     "attacks": [
       {
@@ -4341,7 +4302,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Exeggutor"
+      "Erika's Exeggutor"
     ],
     "attacks": [
       {
@@ -4401,7 +4362,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Gloom"
+      "Erika's Gloom"
     ],
     "attacks": [
       {
@@ -4459,9 +4420,6 @@
     "hp": "60",
     "types": [
       "Grass"
-    ],
-    "evolvesTo": [
-      "Tangrowth"
     ],
     "attacks": [
       {
@@ -4523,7 +4481,7 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Lt. Surge's Magneton"
     ],
     "attacks": [
       {
@@ -4583,7 +4541,7 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Lt. Surge's Raichu"
     ],
     "attacks": [
       {
@@ -4643,7 +4601,7 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Raticate"
+      "Lt. Surge's Raticate"
     ],
     "attacks": [
       {
@@ -4709,7 +4667,7 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Fearow"
+      "Lt. Surge's Fearow"
     ],
     "attacks": [
       {
@@ -4771,7 +4729,7 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Lt. Surge's Electrode"
     ],
     "attacks": [
       {
@@ -4831,7 +4789,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Seaking"
+      "Misty's Seaking"
     ],
     "attacks": [
       {
@@ -4890,7 +4848,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Seadra"
+      "Misty's Seadra"
     ],
     "attacks": [
       {
@@ -4946,7 +4904,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Poliwhirl"
+      "Misty's Poliwhirl"
     ],
     "attacks": [
       {
@@ -5006,7 +4964,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Dewgong"
+      "Misty's Dewgong"
     ],
     "attacks": [
       {
@@ -5057,7 +5015,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Cloyster"
+      "Misty's Cloyster"
     ],
     "attacks": [
       {
@@ -5117,7 +5075,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Starmie"
+      "Misty's Starmie"
     ],
     "attacks": [
       {
@@ -5168,7 +5126,7 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Kadabra"
+      "Sabrina's Kadabra"
     ],
     "attacks": [
       {
@@ -5214,7 +5172,7 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Hypno"
+      "Sabrina's Hypno"
     ],
     "attacks": [
       {
@@ -5274,7 +5232,7 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Sabrina's Haunter"
     ],
     "attacks": [
       {
@@ -5382,8 +5340,7 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Slowbro",
-      "Slowking"
+      "Sabrina's Slowbro"
     ],
     "attacks": [
       {
@@ -5434,7 +5391,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Venomoth"
+      "Sabrina's Venomoth"
     ],
     "attacks": [
       {

--- a/cards/en/gym2.json
+++ b/cards/en/gym2.json
@@ -1445,9 +1445,6 @@
       "Colorless"
     ],
     "evolvesFrom": "Koga's Pidgey",
-    "evolvesTo": [
-      "Pidgeot"
-    ],
     "attacks": [
       {
         "name": "Quick Turn",
@@ -1695,7 +1692,7 @@
     ],
     "evolvesFrom": "Blaine's Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Blaine's Charizard"
     ],
     "attacks": [
       {
@@ -1869,7 +1866,7 @@
     ],
     "evolvesFrom": "Brock's Geodude",
     "evolvesTo": [
-      "Golem"
+      "Brock's Golem"
     ],
     "attacks": [
       {
@@ -2054,7 +2051,7 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Brock's Ninetales"
     ],
     "attacks": [
       {
@@ -2114,7 +2111,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Weepinbell"
+      "Erika's Weepinbell"
     ],
     "abilities": [
       {
@@ -2171,7 +2168,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ivysaur"
+      "Erika's Ivysaur"
     ],
     "attacks": [
       {
@@ -2231,7 +2228,7 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Erika's Clefable"
     ],
     "attacks": [
       {
@@ -2298,7 +2295,7 @@
     ],
     "evolvesFrom": "Erika's Bulbasaur",
     "evolvesTo": [
-      "Venusaur"
+      "Erika's Venusaur"
     ],
     "abilities": [
       {
@@ -2359,7 +2356,7 @@
     ],
     "evolvesFrom": "Giovanni's Machop",
     "evolvesTo": [
-      "Machamp"
+      "Giovanni's Machamp"
     ],
     "attacks": [
       {
@@ -2421,7 +2418,7 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Giovanni's Persian"
     ],
     "attacks": [
       {
@@ -2488,7 +2485,7 @@
     ],
     "evolvesFrom": "Giovanni's Nidoran ♀",
     "evolvesTo": [
-      "Nidoqueen"
+      "Giovanni's Nidoqueen"
     ],
     "attacks": [
       {
@@ -2552,7 +2549,7 @@
     ],
     "evolvesFrom": "Giovanni's Nidoran ♂",
     "evolvesTo": [
-      "Nidoking"
+      "Giovanni's Nidoking"
     ],
     "attacks": [
       {
@@ -2605,9 +2602,6 @@
       "Grass"
     ],
     "evolvesFrom": "Koga's Zubat",
-    "evolvesTo": [
-      "Crobat"
-    ],
     "attacks": [
       {
         "name": "Bite",
@@ -2671,7 +2665,7 @@
     ],
     "evolvesFrom": "Koga's Weedle",
     "evolvesTo": [
-      "Beedrill"
+      "Koga's Beedrill"
     ],
     "abilities": [
       {
@@ -2729,7 +2723,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Weezing"
+      "Koga's Weezing"
     ],
     "attacks": [
       {
@@ -2789,7 +2783,7 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Pidgeotto"
+      "Koga's Pidgeotto"
     ],
     "attacks": [
       {
@@ -2916,14 +2910,7 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Vaporeon",
-      "Jolteon",
-      "Flareon",
-      "Sylveon",
-      "Espeon",
-      "Umbreon",
-      "Leafeon",
-      "Glaceon"
+      "Lt. Surge's Jolteon"
     ],
     "attacks": [
       {
@@ -3174,7 +3161,7 @@
     ],
     "evolvesFrom": "Sabrina's Gastly",
     "evolvesTo": [
-      "Gengar"
+      "Sabrina's Gengar"
     ],
     "attacks": [
       {
@@ -3349,7 +3336,7 @@
     ],
     "evolvesFrom": "Sabrina's Abra",
     "evolvesTo": [
-      "Alakazam"
+      "Sabrina's Alakazam"
     ],
     "attacks": [
       {
@@ -3458,7 +3445,7 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Blaine's Charmeleon"
     ],
     "attacks": [
       {
@@ -3508,7 +3495,7 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Dodrio"
+      "Blaine's Dodrio"
     ],
     "attacks": [
       {
@@ -3570,7 +3557,7 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Blaine's Arcanine"
     ],
     "attacks": [
       {
@@ -3630,9 +3617,6 @@
     "types": [
       "Fighting"
     ],
-    "evolvesTo": [
-      "Primeape"
-    ],
     "attacks": [
       {
         "name": "Pranks",
@@ -3686,7 +3670,7 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Rapidash"
+      "Blaine's Rapidash"
     ],
     "attacks": [
       {
@@ -3735,9 +3719,6 @@
     "hp": "60",
     "types": [
       "Fighting"
-    ],
-    "evolvesTo": [
-      "Rhydon"
     ],
     "attacks": [
       {
@@ -3805,7 +3786,7 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Blaine's Ninetales"
     ],
     "attacks": [
       {
@@ -3864,7 +3845,7 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Dugtrio"
+      "Brock's Dugtrio"
     ],
     "attacks": [
       {
@@ -3930,7 +3911,7 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Graveler"
+      "Brock's Graveler"
     ],
     "attacks": [
       {
@@ -3978,9 +3959,6 @@
     "hp": "50",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Wigglytuff"
     ],
     "attacks": [
       {
@@ -4046,7 +4024,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Gloom"
+      "Erika's Gloom"
     ],
     "attacks": [
       {
@@ -4094,9 +4072,6 @@
     "hp": "50",
     "types": [
       "Grass"
-    ],
-    "evolvesTo": [
-      "Parasect"
     ],
     "attacks": [
       {
@@ -4156,7 +4131,7 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Machoke"
+      "Giovanni's Machoke"
     ],
     "attacks": [
       {
@@ -4216,7 +4191,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Giovanni's Gyarados"
     ],
     "attacks": [
       {
@@ -4276,7 +4251,7 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Giovanni's Persian"
     ],
     "attacks": [
       {
@@ -4344,7 +4319,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Nidorina"
+      "Giovanni's Nidorina"
     ],
     "attacks": [
       {
@@ -4404,7 +4379,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Nidorino"
+      "Giovanni's Nidorino"
     ],
     "attacks": [
       {
@@ -4463,7 +4438,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Arbok"
+      "Koga's Arbok"
     ],
     "attacks": [
       {
@@ -4513,7 +4488,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Muk"
+      "Koga's Muk"
     ],
     "attacks": [
       {
@@ -4573,7 +4548,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Weezing"
+      "Koga's Weezing"
     ],
     "attacks": [
       {
@@ -4623,7 +4598,7 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Pidgeotto"
+      "Koga's Pidgeotto"
     ],
     "attacks": [
       {
@@ -4689,9 +4664,6 @@
     "types": [
       "Grass"
     ],
-    "evolvesTo": [
-      "Tangrowth"
-    ],
     "attacks": [
       {
         "name": "Sleep Powder",
@@ -4751,7 +4723,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Kakuna"
+      "Koga's Kakuna"
     ],
     "attacks": [
       {
@@ -4811,7 +4783,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Golbat"
+      "Koga's Golbat"
     ],
     "attacks": [
       {
@@ -4864,7 +4836,7 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Lt. Surge's Raichu"
     ],
     "attacks": [
       {
@@ -4911,7 +4883,7 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Raticate"
+      "Lt. Surge's Raticate"
     ],
     "attacks": [
       {
@@ -4973,7 +4945,7 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Lt. Surge's Electrode"
     ],
     "attacks": [
       {
@@ -5024,7 +4996,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Seadra"
+      "Misty's Seadra"
     ],
     "attacks": [
       {
@@ -5071,7 +5043,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Misty's Gyarados"
     ],
     "attacks": [
       {
@@ -5130,7 +5102,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Poliwhirl"
+      "Misty's Poliwhirl"
     ],
     "attacks": [
       {
@@ -5190,7 +5162,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Misty's Golduck"
     ],
     "attacks": [
       {
@@ -5240,7 +5212,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Dewgong"
+      "Misty's Dewgong"
     ],
     "attacks": [
       {
@@ -5300,7 +5272,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Starmie"
+      "Misty's Starmie"
     ],
     "attacks": [
       {
@@ -5350,7 +5322,7 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Kadabra"
+      "Sabrina's Kadabra"
     ],
     "attacks": [
       {
@@ -5406,7 +5378,7 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Kadabra"
+      "Sabrina's Kadabra"
     ],
     "attacks": [
       {
@@ -5465,7 +5437,7 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Hypno"
+      "Sabrina's Hypno"
     ],
     "attacks": [
       {
@@ -5525,7 +5497,7 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Sabrina's Haunter"
     ],
     "attacks": [
       {
@@ -5581,7 +5553,7 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Sabrina's Haunter"
     ],
     "abilities": [
       {
@@ -5637,9 +5609,6 @@
     "hp": "40",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Porygon2"
     ],
     "attacks": [
       {
@@ -5705,7 +5674,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Sabrina's Golduck"
     ],
     "attacks": [
       {

--- a/cards/en/hgss1.json
+++ b/cards/en/hgss1.json
@@ -11,6 +11,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "attacks": [
       {
         "name": "Sharp Fang",
@@ -380,6 +383,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "abilities": [
       {
         "name": "Roast Reveal",
@@ -437,6 +443,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Hoothoot",
+    "evolvesTo": [
+      "Noctowl BREAK"
+    ],
     "abilities": [
       {
         "name": "Night Sight",
@@ -570,6 +579,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Iron Tail",
@@ -740,6 +753,9 @@
     "hp": "90",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Wobbuffet BREAK"
     ],
     "attacks": [
       {
@@ -976,9 +992,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesTo": [
-      "Clefairy"
-    ],
     "abilities": [
       {
         "name": "Sweet Sleeping Face",
@@ -1080,9 +1093,6 @@
     "hp": "60",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Sirfetch'd"
     ],
     "attacks": [
       {
@@ -1631,9 +1641,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesTo": [
-      "Pikachu"
-    ],
     "abilities": [
       {
         "name": "Sweet Sleeping Face",
@@ -1739,9 +1746,6 @@
     "hp": "30",
     "types": [
       "Psychic"
-    ],
-    "evolvesTo": [
-      "Jynx"
     ],
     "abilities": [
       {
@@ -1910,11 +1914,6 @@
     "types": [
       "Fighting"
     ],
-    "evolvesTo": [
-      "Hitmonlee",
-      "Hitmonchan",
-      "Hitmontop"
-    ],
     "abilities": [
       {
         "name": "Sweet Sleeping Face",
@@ -2020,7 +2019,8 @@
     ],
     "evolvesFrom": "Chikorita",
     "evolvesTo": [
-      "Meganium"
+      "Meganium",
+      "Meganium ex"
     ],
     "attacks": [
       {
@@ -2148,9 +2148,6 @@
     "types": [
       "Water"
     ],
-    "evolvesTo": [
-      "Cursola"
-    ],
     "attacks": [
       {
         "name": "Recover",
@@ -2210,7 +2207,8 @@
     ],
     "evolvesFrom": "Totodile",
     "evolvesTo": [
-      "Feraligatr"
+      "Feraligatr",
+      "Feraligatr ex"
     ],
     "attacks": [
       {
@@ -2405,6 +2403,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Dudunsparce"
+    ],
     "attacks": [
       {
         "name": "Glare",
@@ -2463,7 +2464,9 @@
     ],
     "evolvesFrom": "Mareep",
     "evolvesTo": [
-      "Ampharos"
+      "Ampharos",
+      "Ampharos ex",
+      "Ampharos-GX"
     ],
     "attacks": [
       {
@@ -2588,9 +2591,6 @@
     "hp": "30",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Jigglypuff"
     ],
     "abilities": [
       {
@@ -2881,7 +2881,9 @@
     ],
     "evolvesFrom": "Cyndaquil",
     "evolvesTo": [
-      "Typhlosion"
+      "Typhlosion",
+      "Typhlosion ex",
+      "Hisuian Typhlosion"
     ],
     "attacks": [
       {
@@ -3104,6 +3106,9 @@
       "Water"
     ],
     "evolvesFrom": "Staryu",
+    "evolvesTo": [
+      "Starmie BREAK"
+    ],
     "attacks": [
       {
         "name": "Cosmic Cyclone",
@@ -3367,7 +3372,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Blissey"
+      "Blissey",
+      "Blissey ex"
     ],
     "attacks": [
       {
@@ -3496,7 +3502,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Clefable",
+      "Clefable ex"
     ],
     "attacks": [
       {
@@ -3555,7 +3562,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Quilava"
+      "Quilava",
+      "Dark Quilava"
     ],
     "attacks": [
       {
@@ -3615,7 +3623,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Hypno"
+      "Hypno",
+      "Dark Hypno"
     ],
     "attacks": [
       {
@@ -3676,7 +3685,10 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Exeggutor"
+      "Exeggutor",
+      "Dark Exeggutor",
+      "Alolan Exeggutor-GX",
+      "Alolan Exeggutor"
     ],
     "attacks": [
       {
@@ -3724,6 +3736,9 @@
     "hp": "70",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Farigiraf"
     ],
     "attacks": [
       {
@@ -3783,7 +3798,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -3967,7 +3984,11 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Wigglytuff"
+      "Wigglytuff",
+      "Dark Wigglytuff",
+      "Light Wigglytuff",
+      "Wigglytuff ex",
+      "Wigglytuff-GX"
     ],
     "attacks": [
       {
@@ -4075,7 +4096,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Weezing"
+      "Weezing",
+      "Dark Weezing",
+      "Galarian Weezing"
     ],
     "attacks": [
       {
@@ -4135,7 +4158,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ledian"
+      "Ledian",
+      "Light Ledian"
     ],
     "attacks": [
       {
@@ -4201,7 +4225,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -4252,7 +4279,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Flaaffy"
+      "Flaaffy",
+      "Dark Flaaffy"
     ],
     "attacks": [
       {
@@ -4318,7 +4346,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Azumarill"
+      "Azumarill",
+      "Light Azumarill"
     ],
     "attacks": [
       {
@@ -4379,7 +4408,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -4499,7 +4530,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Donphan"
+      "Donphan",
+      "Dark Donphan"
     ],
     "attacks": [
       {
@@ -4556,7 +4588,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -4622,7 +4658,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Sandslash"
+      "Sandslash",
+      "Dark Sandslash"
     ],
     "attacks": [
       {
@@ -4747,7 +4784,11 @@
     ],
     "evolvesTo": [
       "Slowbro",
-      "Slowking"
+      "Slowking",
+      "Dark Slowbro",
+      "Dark Slowking",
+      "Light Slowbro",
+      "Slowking ex"
     ],
     "attacks": [
       {
@@ -4859,7 +4900,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ariados"
+      "Ariados",
+      "Dark Ariados"
     ],
     "attacks": [
       {
@@ -4918,7 +4960,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Starmie"
+      "Starmie",
+      "Starmie-GX"
     ],
     "attacks": [
       {
@@ -4968,7 +5011,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Sunflora"
+      "Sunflora",
+      "Light Sunflora"
     ],
     "attacks": [
       {
@@ -5034,7 +5078,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Croconaw"
+      "Croconaw",
+      "Dark Croconaw"
     ],
     "attacks": [
       {
@@ -5094,7 +5139,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {

--- a/cards/en/hgss2.json
+++ b/cards/en/hgss2.json
@@ -65,6 +65,9 @@
       "Fire"
     ],
     "evolvesFrom": "Magmar",
+    "evolvesTo": [
+      "Magmortar LV.X"
+    ],
     "attacks": [
       {
         "name": "Hard Crush",
@@ -427,6 +430,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Shaymin LV.X"
+    ],
     "abilities": [
       {
         "name": "Celebration Wind",
@@ -548,6 +554,9 @@
       "Grass"
     ],
     "evolvesFrom": "Grotle",
+    "evolvesTo": [
+      "Torterra LV.X"
+    ],
     "attacks": [
       {
         "name": "Giga Drain",
@@ -792,6 +801,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Golbat",
+    "evolvesTo": [
+      "Crobat BREAK"
+    ],
     "attacks": [
       {
         "name": "Supersonic",
@@ -1091,6 +1103,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Riolu",
+    "evolvesTo": [
+      "Lucario LV.X"
+    ],
     "attacks": [
       {
         "name": "Bulk Up",
@@ -1149,6 +1164,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "attacks": [
       {
         "name": "Heat Acceleration",
@@ -1269,6 +1287,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Mankey",
+    "evolvesTo": [
+      "Annihilape ex",
+      "Annihilape"
+    ],
     "attacks": [
       {
         "name": "Low Kick",
@@ -1581,6 +1603,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Teddiursa",
+    "evolvesTo": [
+      "Ursaluna"
+    ],
     "attacks": [
       {
         "name": "Confront",
@@ -1702,6 +1727,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Dudunsparce"
+    ],
     "attacks": [
       {
         "name": "Return",
@@ -1751,7 +1779,8 @@
     ],
     "evolvesFrom": "Zubat",
     "evolvesTo": [
-      "Crobat"
+      "Crobat",
+      "Crobat ex"
     ],
     "attacks": [
       {
@@ -1935,7 +1964,9 @@
     ],
     "evolvesFrom": "Beldum",
     "evolvesTo": [
-      "Metagross"
+      "Metagross",
+      "Metagross ex",
+      "Metagross-GX"
     ],
     "attacks": [
       {
@@ -2060,7 +2091,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Camerupt"
+      "Camerupt",
+      "Camerupt ex"
     ],
     "attacks": [
       {
@@ -2185,7 +2217,8 @@
     "evolvesFrom": "Poliwag",
     "evolvesTo": [
       "Poliwrath",
-      "Politoed"
+      "Politoed",
+      "Politoed ex"
     ],
     "attacks": [
       {
@@ -2246,7 +2279,9 @@
     ],
     "evolvesFrom": "Larvitar",
     "evolvesTo": [
-      "Tyranitar"
+      "Tyranitar",
+      "Tyranitar ex",
+      "Tyranitar-GX"
     ],
     "abilities": [
       {
@@ -2311,7 +2346,9 @@
     ],
     "evolvesFrom": "Larvitar",
     "evolvesTo": [
-      "Tyranitar"
+      "Tyranitar",
+      "Tyranitar ex",
+      "Tyranitar-GX"
     ],
     "attacks": [
       {
@@ -2380,7 +2417,9 @@
     ],
     "evolvesFrom": "Horsea",
     "evolvesTo": [
-      "Kingdra"
+      "Kingdra",
+      "Kingdra ex",
+      "Kingdra-GX"
     ],
     "attacks": [
       {
@@ -2501,7 +2540,9 @@
     ],
     "evolvesFrom": "Squirtle",
     "evolvesTo": [
-      "Blastoise"
+      "Blastoise",
+      "Blastoise ex",
+      "Blastoise-GX"
     ],
     "attacks": [
       {
@@ -2841,7 +2882,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Lanturn"
+      "Lanturn",
+      "Light Lanturn"
     ],
     "attacks": [
       {
@@ -2961,7 +3003,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Pupitar"
+      "Pupitar",
+      "Dark Pupitar"
     ],
     "attacks": [
       {
@@ -3026,7 +3069,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Pupitar"
+      "Pupitar",
+      "Dark Pupitar"
     ],
     "attacks": [
       {
@@ -3152,7 +3196,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Primeape"
+      "Primeape",
+      "Dark Primeape"
     ],
     "attacks": [
       {
@@ -3333,7 +3378,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Steelix"
+      "Steelix",
+      "Dark Steelix",
+      "Steelix ex"
     ],
     "abilities": [
       {
@@ -3396,7 +3443,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Steelix"
+      "Steelix",
+      "Dark Steelix",
+      "Steelix ex"
     ],
     "attacks": [
       {
@@ -3510,7 +3559,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Octillery"
+      "Octillery",
+      "Dark Octillery"
     ],
     "attacks": [
       {
@@ -3570,7 +3620,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lucario"
+      "Lucario",
+      "Lucario-GX",
+      "Lucario ex"
     ],
     "attacks": [
       {
@@ -3745,7 +3797,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wartortle"
+      "Wartortle",
+      "Dark Wartortle"
     ],
     "attacks": [
       {
@@ -3804,6 +3857,9 @@
     "hp": "70",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Wyrdeer"
     ],
     "attacks": [
       {
@@ -3864,7 +3920,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Ursaring"
+      "Ursaring",
+      "Dark Ursaring"
     ],
     "attacks": [
       {
@@ -4043,7 +4100,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {
@@ -4152,7 +4211,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Golbat"
+      "Golbat",
+      "Dark Golbat"
     ],
     "attacks": [
       {
@@ -4503,6 +4563,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Golbat",
+    "evolvesTo": [
+      "Crobat BREAK"
+    ],
     "attacks": [
       {
         "name": "Severe Poison",
@@ -4832,6 +4895,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Teddiursa",
+    "evolvesTo": [
+      "Ursaluna"
+    ],
     "abilities": [
       {
         "name": "Berserk",

--- a/cards/en/hgss3.json
+++ b/cards/en/hgss3.json
@@ -199,6 +199,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Gligar",
+    "evolvesTo": [
+      "Gliscor LV.X"
+    ],
     "attacks": [
       {
         "name": "Ninja Fang",
@@ -894,6 +897,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Murkrow",
+    "evolvesTo": [
+      "Honchkrow LV.X"
+    ],
     "attacks": [
       {
         "name": "Whirlwind",
@@ -960,6 +966,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Murkrow",
+    "evolvesTo": [
+      "Honchkrow LV.X"
+    ],
     "attacks": [
       {
         "name": "Shadow Bind",
@@ -1027,6 +1036,9 @@
       "Grass"
     ],
     "evolvesFrom": "Eevee",
+    "evolvesTo": [
+      "Leafeon LV.X"
+    ],
     "attacks": [
       {
         "name": "Miasma Wind",
@@ -1650,7 +1662,9 @@
     "evolvesFrom": "Oddish",
     "evolvesTo": [
       "Vileplume",
-      "Bellossom"
+      "Bellossom",
+      "Vileplume ex",
+      "Vileplume-GX"
     ],
     "attacks": [
       {
@@ -1763,7 +1777,8 @@
     ],
     "evolvesFrom": "Aron",
     "evolvesTo": [
-      "Aggron"
+      "Aggron",
+      "Aggron ex"
     ],
     "attacks": [
       {
@@ -1833,7 +1848,9 @@
     ],
     "evolvesFrom": "Beldum",
     "evolvesTo": [
-      "Metagross"
+      "Metagross",
+      "Metagross ex",
+      "Metagross-GX"
     ],
     "attacks": [
       {
@@ -2021,6 +2038,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Pain-full Punch",
@@ -2081,6 +2102,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Rattata",
+    "evolvesTo": [
+      "Raticate BREAK"
+    ],
     "attacks": [
       {
         "name": "Razor-Sharp Incisors",
@@ -2191,7 +2215,11 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor",
+      "Scizor ex",
+      "Dark Scizor",
+      "Scizor-GX",
+      "Kleavor"
     ],
     "attacks": [
       {
@@ -2680,7 +2708,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Vespiquen"
+      "Vespiquen",
+      "Vespiquen ex"
     ],
     "attacks": [
       {
@@ -2868,7 +2897,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -2935,7 +2984,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -3052,7 +3121,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Muk"
+      "Muk",
+      "Dark Muk",
+      "Muk ex"
     ],
     "attacks": [
       {
@@ -3229,7 +3300,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Houndoom",
+      "Dark Houndoom",
+      "Houndoom ex"
     ],
     "attacks": [
       {
@@ -3286,7 +3359,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Houndoom",
+      "Dark Houndoom",
+      "Houndoom ex"
     ],
     "attacks": [
       {
@@ -3342,7 +3417,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Hariyama"
+      "Hariyama",
+      "Hariyama ex"
     ],
     "attacks": [
       {
@@ -3534,7 +3610,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Honchkrow"
+      "Honchkrow",
+      "Honchkrow-GX"
     ],
     "attacks": [
       {
@@ -3590,7 +3667,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Honchkrow"
+      "Honchkrow",
+      "Honchkrow-GX"
     ],
     "attacks": [
       {
@@ -3657,7 +3735,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Gloom"
+      "Gloom",
+      "Dark Gloom"
     ],
     "attacks": [
       {
@@ -3716,7 +3795,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -3772,7 +3855,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Forretress"
+      "Forretress",
+      "Dark Forretress",
+      "Forretress ex"
     ],
     "attacks": [
       {
@@ -3823,7 +3908,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Forretress"
+      "Forretress",
+      "Dark Forretress",
+      "Forretress ex"
     ],
     "attacks": [
       {
@@ -3884,7 +3971,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Raticate"
+      "Raticate",
+      "Dark Raticate"
     ],
     "attacks": [
       {
@@ -3934,7 +4022,11 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor",
+      "Scizor ex",
+      "Dark Scizor",
+      "Scizor-GX",
+      "Kleavor"
     ],
     "attacks": [
       {
@@ -3997,7 +4089,11 @@
     ],
     "evolvesTo": [
       "Slowbro",
-      "Slowking"
+      "Slowking",
+      "Dark Slowbro",
+      "Dark Slowking",
+      "Light Slowbro",
+      "Slowking ex"
     ],
     "attacks": [
       {
@@ -4058,7 +4154,10 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Magcargo"
+      "Magcargo",
+      "Dark Magcargo",
+      "Magcargo ex",
+      "Magcargo-GX"
     ],
     "abilities": [
       {
@@ -4118,7 +4217,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Weavile"
+      "Weavile",
+      "Weavile-GX"
     ],
     "attacks": [
       {
@@ -4236,7 +4336,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Togetic"
+      "Togetic",
+      "Light Togetic"
     ],
     "attacks": [
       {
@@ -4621,6 +4722,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "abilities": [
       {
         "name": "Voltage Increase",

--- a/cards/en/hgss4.json
+++ b/cards/en/hgss4.json
@@ -200,6 +200,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Skorupi",
+    "evolvesTo": [
+      "Drapion LV.X"
+    ],
     "attacks": [
       {
         "name": "Toxic Fang",
@@ -335,6 +338,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Nidorino",
+    "evolvesTo": [
+      "Nidoking BREAK"
+    ],
     "abilities": [
       {
         "name": "Pheromone Stamina",
@@ -401,6 +407,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Porygon2",
+    "evolvesTo": [
+      "Porygon-Z LV.X"
+    ],
     "abilities": [
       {
         "name": "Dimension Transfer",
@@ -861,6 +870,9 @@
       "Metal"
     ],
     "evolvesFrom": "Bronzor",
+    "evolvesTo": [
+      "Bronzong BREAK"
+    ],
     "attacks": [
       {
         "name": "Legend Ceremony",
@@ -1179,6 +1191,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Electabuzz",
+    "evolvesTo": [
+      "Electivire LV.X"
+    ],
     "attacks": [
       {
         "name": "Plasma",
@@ -1245,9 +1260,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesTo": [
-      "Electabuzz"
-    ],
     "abilities": [
       {
         "name": "Sweet Sleeping Face",
@@ -1293,6 +1305,9 @@
       "Water"
     ],
     "evolvesFrom": "Psyduck",
+    "evolvesTo": [
+      "Golduck BREAK"
+    ],
     "abilities": [
       {
         "name": "Natural Remedy",
@@ -1527,6 +1542,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Machoke",
+    "evolvesTo": [
+      "Machamp LV.X",
+      "Machamp BREAK"
+    ],
     "attacks": [
       {
         "name": "Vital Throw",
@@ -1587,6 +1606,9 @@
       "Fire"
     ],
     "evolvesFrom": "Magmar",
+    "evolvesTo": [
+      "Magmortar LV.X"
+    ],
     "attacks": [
       {
         "name": "Top Burner",
@@ -1893,7 +1915,9 @@
     ],
     "evolvesFrom": "Dratini",
     "evolvesTo": [
-      "Dragonite"
+      "Dragonite",
+      "Dragonite ex",
+      "Dragonite-GX"
     ],
     "attacks": [
       {
@@ -2089,7 +2113,8 @@
     ],
     "evolvesFrom": "Gastly",
     "evolvesTo": [
-      "Gengar"
+      "Gengar",
+      "Gengar ex"
     ],
     "attacks": [
       {
@@ -2213,7 +2238,8 @@
     ],
     "evolvesFrom": "Aron",
     "evolvesTo": [
-      "Aggron"
+      "Aggron",
+      "Aggron ex"
     ],
     "attacks": [
       {
@@ -2391,7 +2417,8 @@
     ],
     "evolvesFrom": "Machop",
     "evolvesTo": [
-      "Machamp"
+      "Machamp",
+      "Machamp-GX"
     ],
     "attacks": [
       {
@@ -2451,9 +2478,6 @@
     "hp": "30",
     "types": [
       "Fire"
-    ],
-    "evolvesTo": [
-      "Magmar"
     ],
     "abilities": [
       {
@@ -2563,7 +2587,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "attacks": [
       {
@@ -2629,6 +2654,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Cubone",
+    "evolvesTo": [
+      "Marowak BREAK"
+    ],
     "attacks": [
       {
         "name": "Bonemerang",
@@ -2821,7 +2849,8 @@
     ],
     "evolvesFrom": "Pidgey",
     "evolvesTo": [
-      "Pidgeot"
+      "Pidgeot",
+      "Pidgeot ex"
     ],
     "attacks": [
       {
@@ -2957,7 +2986,8 @@
     ],
     "evolvesFrom": "Porygon",
     "evolvesTo": [
-      "Porygon-Z"
+      "Porygon-Z",
+      "Porygon-Z-GX"
     ],
     "abilities": [
       {
@@ -3130,7 +3160,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wailord"
+      "Wailord",
+      "Wailord ex"
     ],
     "attacks": [
       {
@@ -3257,6 +3288,9 @@
       "Grass"
     ],
     "evolvesFrom": "Yanma",
+    "evolvesTo": [
+      "Yanmega BREAK"
+    ],
     "attacks": [
       {
         "name": "Shoot Through",
@@ -3574,7 +3608,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Sharpedo"
+      "Sharpedo",
+      "Sharpedo ex"
     ],
     "attacks": [
       {
@@ -3633,7 +3668,10 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Marowak"
+      "Marowak",
+      "Dark Marowak",
+      "Alolan Marowak-GX",
+      "Alolan Marowak"
     ],
     "abilities": [
       {
@@ -3697,7 +3735,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Dugtrio"
+      "Dugtrio",
+      "Dark Dugtrio"
     ],
     "attacks": [
       {
@@ -3763,7 +3802,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "attacks": [
       {
@@ -3823,7 +3864,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Haunter",
+      "Dark Haunter"
     ],
     "attacks": [
       {
@@ -4048,7 +4090,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Machoke"
+      "Machoke",
+      "Dark Machoke",
+      "Light Machoke"
     ],
     "attacks": [
       {
@@ -4110,7 +4154,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -4361,7 +4406,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Rapidash"
+      "Rapidash",
+      "Dark Rapidash"
     ],
     "attacks": [
       {
@@ -4421,7 +4467,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Porygon2"
+      "Porygon2",
+      "Dark Porygon2"
     ],
     "attacks": [
       {
@@ -4481,7 +4528,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Golduck",
+      "Dark Golduck",
+      "Light Golduck"
     ],
     "attacks": [
       {
@@ -4531,7 +4580,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Banette"
+      "Banette",
+      "Banette ex",
+      "Banette-GX"
     ],
     "attacks": [
       {
@@ -4697,7 +4748,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Altaria"
+      "Altaria",
+      "Altaria ex",
+      "Altaria-GX"
     ],
     "attacks": [
       {
@@ -4753,7 +4806,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Piloswine"
+      "Piloswine",
+      "Light Piloswine"
     ],
     "attacks": [
       {
@@ -4864,7 +4918,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Venomoth"
+      "Venomoth",
+      "Light Venomoth",
+      "Venomoth-GX"
     ],
     "attacks": [
       {
@@ -4982,7 +5038,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {
@@ -5412,6 +5471,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Haunter",
+    "evolvesTo": [
+      "Gengar LV.X"
+    ],
     "abilities": [
       {
         "name": "Catastrophe",
@@ -5479,6 +5541,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Machoke",
+    "evolvesTo": [
+      "Machamp LV.X",
+      "Machamp BREAK"
+    ],
     "abilities": [
       {
         "name": "Fighting Tag",
@@ -5550,6 +5616,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Magneton",
+    "evolvesTo": [
+      "Magnezone LV.X"
+    ],
     "abilities": [
       {
         "name": "Magnetic Draw",
@@ -5664,6 +5733,9 @@
       "Grass"
     ],
     "evolvesFrom": "Yanma",
+    "evolvesTo": [
+      "Yanmega BREAK"
+    ],
     "abilities": [
       {
         "name": "Insight",

--- a/cards/en/hsp.json
+++ b/cards/en/hsp.json
@@ -10,6 +10,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Ho-Oh BREAK"
+    ],
     "attacks": [
       {
         "name": "Combustion",
@@ -76,6 +79,9 @@
     "hp": "90",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Lugia BREAK"
     ],
     "attacks": [
       {
@@ -144,7 +150,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -210,6 +220,9 @@
     "hp": "90",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Wobbuffet BREAK"
     ],
     "abilities": [
       {
@@ -332,6 +345,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Hoothoot",
+    "evolvesTo": [
+      "Noctowl BREAK"
+    ],
     "abilities": [
       {
         "name": "Night Scope",
@@ -693,9 +709,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesTo": [
-      "Clefairy"
-    ],
     "abilities": [
       {
         "name": "Sweet Sleeping Face",
@@ -739,9 +752,6 @@
     "hp": "30",
     "types": [
       "Psychic"
-    ],
-    "evolvesTo": [
-      "Jynx"
     ],
     "abilities": [
       {
@@ -1200,7 +1210,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Porygon2"
+      "Porygon2",
+      "Dark Porygon2"
     ],
     "attacks": [
       {
@@ -1261,7 +1272,8 @@
     ],
     "evolvesFrom": "Porygon",
     "evolvesTo": [
-      "Porygon-Z"
+      "Porygon-Z",
+      "Porygon-Z-GX"
     ],
     "abilities": [
       {

--- a/cards/en/mcd11.json
+++ b/cards/en/mcd11.json
@@ -451,7 +451,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Zoroark"
+      "Zoroark",
+      "Zoroark-GX"
     ],
     "attacks": [
       {

--- a/cards/en/mcd12.json
+++ b/cards/en/mcd12.json
@@ -270,7 +270,8 @@
     ],
     "evolvesFrom": "Oshawott",
     "evolvesTo": [
-      "Samurott"
+      "Samurott",
+      "Hisuian Samurott"
     ],
     "attacks": [
       {

--- a/cards/en/mcd14.json
+++ b/cards/en/mcd14.json
@@ -241,7 +241,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {

--- a/cards/en/mcd15.json
+++ b/cards/en/mcd15.json
@@ -162,7 +162,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Starmie"
+      "Starmie",
+      "Starmie-GX"
     ],
     "attacks": [
       {
@@ -272,7 +273,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -338,7 +343,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Manectric",
+      "Manectric ex"
     ],
     "attacks": [
       {
@@ -458,7 +464,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Medicham"
+      "Medicham",
+      "Medicham ex"
     ],
     "attacks": [
       {
@@ -508,7 +515,8 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Azumarill"
+      "Azumarill",
+      "Light Azumarill"
     ],
     "attacks": [
       {
@@ -635,7 +643,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Delcatty"
+      "Delcatty",
+      "Delcatty ex"
     ],
     "attacks": [
       {

--- a/cards/en/mcd16.json
+++ b/cards/en/mcd16.json
@@ -11,7 +11,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {
@@ -170,7 +172,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -220,7 +225,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Croconaw"
+      "Croconaw",
+      "Dark Croconaw"
     ],
     "attacks": [
       {
@@ -270,7 +276,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -394,7 +404,11 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Wigglytuff"
+      "Wigglytuff",
+      "Dark Wigglytuff",
+      "Light Wigglytuff",
+      "Wigglytuff ex",
+      "Wigglytuff-GX"
     ],
     "attacks": [
       {
@@ -459,7 +473,8 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Togetic"
+      "Togetic",
+      "Light Togetic"
     ],
     "attacks": [
       {
@@ -579,7 +594,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -636,7 +653,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {

--- a/cards/en/mcd17.json
+++ b/cards/en/mcd17.json
@@ -243,7 +243,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -423,7 +427,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Persian"
+      "Alolan Persian",
+      "Alolan Persian-GX"
     ],
     "attacks": [
       {
@@ -479,7 +484,7 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Dugtrio"
+      "Alolan Dugtrio"
     ],
     "attacks": [
       {
@@ -656,7 +661,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Gumshoos"
+      "Gumshoos",
+      "Gumshoos-GX"
     ],
     "attacks": [
       {

--- a/cards/en/mcd18.json
+++ b/cards/en/mcd18.json
@@ -11,7 +11,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -64,7 +66,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Golduck",
+      "Dark Golduck",
+      "Light Golduck"
     ],
     "attacks": [
       {
@@ -165,7 +169,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -232,7 +240,11 @@
     ],
     "evolvesTo": [
       "Slowbro",
-      "Slowking"
+      "Slowking",
+      "Dark Slowbro",
+      "Dark Slowking",
+      "Light Slowbro",
+      "Slowking ex"
     ],
     "attacks": [
       {
@@ -295,7 +307,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Machoke"
+      "Machoke",
+      "Dark Machoke",
+      "Light Machoke"
     ],
     "attacks": [
       {
@@ -347,7 +361,10 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Marowak"
+      "Marowak",
+      "Dark Marowak",
+      "Alolan Marowak-GX",
+      "Alolan Marowak"
     ],
     "attacks": [
       {
@@ -408,7 +425,8 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -473,7 +491,9 @@
       "Dragon"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "attacks": [
       {
@@ -533,7 +553,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Blissey"
+      "Blissey",
+      "Blissey ex"
     ],
     "attacks": [
       {
@@ -604,7 +625,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "abilities": [
       {
@@ -662,7 +703,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Porygon2"
+      "Porygon2",
+      "Dark Porygon2"
     ],
     "attacks": [
       {

--- a/cards/en/mcd19.json
+++ b/cards/en/mcd19.json
@@ -173,7 +173,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Sandslash"
+      "Alolan Sandslash",
+      "Alolan Sandslash-GX"
     ],
     "attacks": [
       {
@@ -282,7 +283,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -338,7 +343,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Haunter",
+      "Dark Haunter"
     ],
     "attacks": [
       {
@@ -394,7 +400,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Primeape"
+      "Primeape",
+      "Dark Primeape"
     ],
     "attacks": [
       {
@@ -444,7 +451,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Steelix"
+      "Steelix",
+      "Dark Steelix",
+      "Steelix ex"
     ],
     "attacks": [
       {
@@ -505,7 +514,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Persian"
+      "Alolan Persian",
+      "Alolan Persian-GX"
     ],
     "attacks": [
       {
@@ -622,7 +632,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {

--- a/cards/en/mcd21.json
+++ b/cards/en/mcd21.json
@@ -11,7 +11,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ivysaur"
+      "Ivysaur",
+      "Dark Ivysaur"
     ],
     "attacks": [
       {
@@ -455,7 +456,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -515,7 +517,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Quilava"
+      "Quilava",
+      "Dark Quilava"
     ],
     "attacks": [
       {
@@ -889,7 +892,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wartortle"
+      "Wartortle",
+      "Dark Wartortle"
     ],
     "attacks": [
       {
@@ -939,7 +943,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Croconaw"
+      "Croconaw",
+      "Dark Croconaw"
     ],
     "attacks": [
       {
@@ -1332,7 +1337,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {

--- a/cards/en/mcd22.json
+++ b/cards/en/mcd22.json
@@ -11,7 +11,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ledian"
+      "Ledian",
+      "Light Ledian"
     ],
     "attacks": [
       {
@@ -185,7 +186,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -358,7 +361,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -421,7 +428,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Lanturn"
+      "Lanturn",
+      "Light Lanturn"
     ],
     "attacks": [
       {
@@ -474,7 +482,9 @@
     ],
     "evolvesFrom": "Mareep",
     "evolvesTo": [
-      "Ampharos"
+      "Ampharos",
+      "Ampharos ex",
+      "Ampharos-GX"
     ],
     "attacks": [
       {

--- a/cards/en/neo1.json
+++ b/cards/en/neo1.json
@@ -661,7 +661,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesFrom": "Pikachu",
     "evolvesTo": [
       "Pikachu"
     ],

--- a/cards/en/neo1.json
+++ b/cards/en/neo1.json
@@ -482,6 +482,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Lugia BREAK"
+    ],
     "attacks": [
       {
         "name": "Elemental Blast",
@@ -1298,7 +1301,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Honchkrow"
+      "Honchkrow",
+      "Honchkrow-GX"
     ],
     "attacks": [
       {
@@ -1355,7 +1359,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Weavile"
+      "Weavile",
+      "Weavile-GX"
     ],
     "attacks": [
       {
@@ -1535,7 +1540,8 @@
     ],
     "evolvesFrom": "Chikorita",
     "evolvesTo": [
-      "Meganium"
+      "Meganium",
+      "Meganium ex"
     ],
     "attacks": [
       {
@@ -1600,7 +1606,8 @@
     ],
     "evolvesFrom": "Chikorita",
     "evolvesTo": [
-      "Meganium"
+      "Meganium",
+      "Meganium ex"
     ],
     "attacks": [
       {
@@ -1663,7 +1670,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Clefable",
+      "Clefable ex"
     ],
     "attacks": [
       {
@@ -1733,7 +1741,8 @@
     ],
     "evolvesFrom": "Totodile",
     "evolvesTo": [
-      "Feraligatr"
+      "Feraligatr",
+      "Feraligatr ex"
     ],
     "attacks": [
       {
@@ -1797,7 +1806,8 @@
     ],
     "evolvesFrom": "Totodile",
     "evolvesTo": [
-      "Feraligatr"
+      "Feraligatr",
+      "Feraligatr ex"
     ],
     "attacks": [
       {
@@ -1925,7 +1935,9 @@
     ],
     "evolvesFrom": "Mareep",
     "evolvesTo": [
-      "Ampharos"
+      "Ampharos",
+      "Ampharos ex",
+      "Ampharos-GX"
     ],
     "attacks": [
       {
@@ -2055,7 +2067,9 @@
     "evolvesFrom": "Oddish",
     "evolvesTo": [
       "Vileplume",
-      "Bellossom"
+      "Bellossom",
+      "Vileplume ex",
+      "Vileplume-GX"
     ],
     "attacks": [
       {
@@ -2426,6 +2440,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Hoothoot",
+    "evolvesTo": [
+      "Noctowl BREAK"
+    ],
     "abilities": [
       {
         "name": "Glaring Gaze",
@@ -2486,7 +2503,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Donphan"
+      "Donphan",
+      "Dark Donphan"
     ],
     "attacks": [
       {
@@ -2694,7 +2712,9 @@
     ],
     "evolvesFrom": "Cyndaquil",
     "evolvesTo": [
-      "Typhlosion"
+      "Typhlosion",
+      "Typhlosion ex",
+      "Hisuian Typhlosion"
     ],
     "attacks": [
       {
@@ -2757,7 +2777,9 @@
     ],
     "evolvesFrom": "Cyndaquil",
     "evolvesTo": [
-      "Typhlosion"
+      "Typhlosion",
+      "Typhlosion ex",
+      "Hisuian Typhlosion"
     ],
     "attacks": [
       {
@@ -2821,7 +2843,9 @@
     ],
     "evolvesFrom": "Horsea",
     "evolvesTo": [
-      "Kingdra"
+      "Kingdra",
+      "Kingdra ex",
+      "Kingdra-GX"
     ],
     "attacks": [
       {
@@ -2996,7 +3020,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Togetic"
+      "Togetic",
+      "Light Togetic"
     ],
     "attacks": [
       {
@@ -3235,7 +3260,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Lanturn"
+      "Lanturn",
+      "Light Lanturn"
     ],
     "attacks": [
       {
@@ -3295,7 +3321,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Quilava"
+      "Quilava",
+      "Dark Quilava"
     ],
     "attacks": [
       {
@@ -3356,7 +3383,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Quilava"
+      "Quilava",
+      "Dark Quilava"
     ],
     "attacks": [
       {
@@ -3415,6 +3443,9 @@
     "hp": "60",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Farigiraf"
     ],
     "attacks": [
       {
@@ -3710,7 +3741,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ledian"
+      "Ledian",
+      "Light Ledian"
     ],
     "attacks": [
       {
@@ -3828,7 +3860,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Flaaffy"
+      "Flaaffy",
+      "Dark Flaaffy"
     ],
     "attacks": [
       {
@@ -3889,7 +3922,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Azumarill"
+      "Azumarill",
+      "Light Azumarill"
     ],
     "attacks": [
       {
@@ -4013,7 +4047,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Gloom"
+      "Gloom",
+      "Dark Gloom"
     ],
     "attacks": [
       {
@@ -4074,7 +4109,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Steelix"
+      "Steelix",
+      "Dark Steelix",
+      "Steelix ex"
     ],
     "attacks": [
       {
@@ -4136,7 +4173,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -4314,7 +4355,11 @@
     ],
     "evolvesTo": [
       "Slowbro",
-      "Slowking"
+      "Slowking",
+      "Dark Slowbro",
+      "Dark Slowking",
+      "Light Slowbro",
+      "Slowking ex"
     ],
     "attacks": [
       {
@@ -4441,7 +4486,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ariados"
+      "Ariados",
+      "Dark Ariados"
     ],
     "attacks": [
       {
@@ -4499,6 +4545,9 @@
     "hp": "60",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Wyrdeer"
     ],
     "attacks": [
       {
@@ -4628,7 +4677,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Sunflora"
+      "Sunflora",
+      "Light Sunflora"
     ],
     "attacks": [
       {
@@ -4691,7 +4741,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Piloswine"
+      "Piloswine",
+      "Light Piloswine"
     ],
     "attacks": [
       {
@@ -4748,7 +4799,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Croconaw"
+      "Croconaw",
+      "Dark Croconaw"
     ],
     "attacks": [
       {
@@ -4809,7 +4861,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Croconaw"
+      "Croconaw",
+      "Dark Croconaw"
     ],
     "attacks": [
       {

--- a/cards/en/neo2.json
+++ b/cards/en/neo2.json
@@ -3926,7 +3926,6 @@
     "types": [
       "Fighting"
     ],
-    "evolvesFrom": "HitmonchanHitmonleeHitmontop",
     "evolvesTo": [
       "Hitmonlee",
       "Hitmonchan",

--- a/cards/en/neo2.json
+++ b/cards/en/neo2.json
@@ -2423,7 +2423,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesFrom": "Jigglypuff",
     "evolvesTo": [
       "Jigglypuff"
     ],

--- a/cards/en/neo2.json
+++ b/cards/en/neo2.json
@@ -256,7 +256,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Houndoom",
+      "Dark Houndoom",
+      "Houndoom ex"
     ],
     "attacks": [
       {
@@ -376,7 +378,8 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -873,6 +876,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Teddiursa",
+    "evolvesTo": [
+      "Ursaluna"
+    ],
     "attacks": [
       {
         "name": "Headpress",
@@ -941,6 +947,9 @@
     "hp": "90",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Wobbuffet BREAK"
     ],
     "attacks": [
       {
@@ -1430,7 +1439,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Houndoom",
+      "Dark Houndoom",
+      "Houndoom ex"
     ],
     "attacks": [
       {
@@ -1550,7 +1561,8 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -2047,6 +2059,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Teddiursa",
+    "evolvesTo": [
+      "Ursaluna"
+    ],
     "attacks": [
       {
         "name": "Headpress",
@@ -2115,6 +2130,9 @@
     "hp": "90",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Wobbuffet BREAK"
     ],
     "attacks": [
       {
@@ -2230,9 +2248,6 @@
     "types": [
       "Water"
     ],
-    "evolvesTo": [
-      "Cursola"
-    ],
     "attacks": [
       {
         "name": "Recover",
@@ -2299,7 +2314,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "abilities": [
       {
@@ -2363,7 +2398,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Houndoom",
+      "Dark Houndoom",
+      "Houndoom ex"
     ],
     "attacks": [
       {
@@ -2582,6 +2619,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Omanyte",
+    "evolvesTo": [
+      "Omastar BREAK"
+    ],
     "attacks": [
       {
         "name": "Squeeze",
@@ -2645,7 +2685,8 @@
     "evolvesFrom": "Poliwag",
     "evolvesTo": [
       "Poliwrath",
-      "Politoed"
+      "Politoed",
+      "Politoed ex"
     ],
     "attacks": [
       {
@@ -2708,7 +2749,9 @@
     ],
     "evolvesFrom": "Larvitar",
     "evolvesTo": [
-      "Tyranitar"
+      "Tyranitar",
+      "Tyranitar ex",
+      "Tyranitar-GX"
     ],
     "attacks": [
       {
@@ -2776,7 +2819,11 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor",
+      "Scizor ex",
+      "Dark Scizor",
+      "Scizor-GX",
+      "Kleavor"
     ],
     "attacks": [
       {
@@ -3240,6 +3287,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Dudunsparce"
+    ],
     "attacks": [
       {
         "name": "Glare",
@@ -3345,7 +3395,8 @@
     ],
     "evolvesFrom": "Mysterious Fossil",
     "evolvesTo": [
-      "Kabutops"
+      "Kabutops",
+      "Kabutops ex"
     ],
     "abilities": [
       {
@@ -3404,7 +3455,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Pupitar"
+      "Pupitar",
+      "Dark Pupitar"
     ],
     "attacks": [
       {
@@ -3461,7 +3513,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Flaaffy"
+      "Flaaffy",
+      "Dark Flaaffy"
     ],
     "attacks": [
       {
@@ -3629,7 +3682,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Forretress"
+      "Forretress",
+      "Dark Forretress",
+      "Forretress ex"
     ],
     "attacks": [
       {
@@ -3808,7 +3863,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ariados"
+      "Ariados",
+      "Dark Ariados"
     ],
     "attacks": [
       {
@@ -3860,7 +3916,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Ursaring"
+      "Ursaring",
+      "Dark Ursaring"
     ],
     "attacks": [
       {

--- a/cards/en/neo3.json
+++ b/cards/en/neo3.json
@@ -3190,7 +3190,6 @@
     "types": [
       "Psychic"
     ],
-    "evolvesFrom": "Jynx",
     "evolvesTo": [
       "Jynx"
     ],

--- a/cards/en/neo3.json
+++ b/cards/en/neo3.json
@@ -196,6 +196,9 @@
       "Grass"
     ],
     "evolvesFrom": "Golbat",
+    "evolvesTo": [
+      "Crobat BREAK"
+    ],
     "attacks": [
       {
         "name": "Triggered Poison",
@@ -570,7 +573,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "abilities": [
       {
@@ -700,7 +704,8 @@
     ],
     "evolvesFrom": "Porygon",
     "evolvesTo": [
-      "Porygon-Z"
+      "Porygon-Z",
+      "Porygon-Z-GX"
     ],
     "abilities": [
       {
@@ -1160,6 +1165,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Lugia BREAK"
+    ],
     "attacks": [
       {
         "name": "Aerowing",
@@ -1219,6 +1227,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Thundershock",
@@ -1399,7 +1411,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Weavile"
+      "Weavile",
+      "Weavile-GX"
     ],
     "attacks": [
       {
@@ -1456,6 +1469,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Staryu",
+    "evolvesTo": [
+      "Starmie BREAK"
+    ],
     "attacks": [
       {
         "name": "Confuse Ray",
@@ -1628,7 +1644,9 @@
     ],
     "evolvesFrom": "Mareep",
     "evolvesTo": [
-      "Ampharos"
+      "Ampharos",
+      "Ampharos ex",
+      "Ampharos-GX"
     ],
     "attacks": [
       {
@@ -1691,7 +1709,8 @@
     ],
     "evolvesFrom": "Zubat",
     "evolvesTo": [
-      "Crobat"
+      "Crobat",
+      "Crobat ex"
     ],
     "attacks": [
       {
@@ -1755,7 +1774,8 @@
     ],
     "evolvesFrom": "Geodude",
     "evolvesTo": [
-      "Golem"
+      "Golem",
+      "Golem ex"
     ],
     "attacks": [
       {
@@ -2247,6 +2267,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Wyrdeer"
+    ],
     "attacks": [
       {
         "name": "Terrorize",
@@ -2492,7 +2515,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Lanturn"
+      "Lanturn",
+      "Light Lanturn"
     ],
     "attacks": [
       {
@@ -2550,9 +2574,6 @@
     "hp": "50",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Sirfetch'd"
     ],
     "attacks": [
       {
@@ -2718,7 +2739,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Honchkrow"
+      "Honchkrow",
+      "Honchkrow-GX"
     ],
     "attacks": [
       {
@@ -2963,7 +2985,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Octillery"
+      "Octillery",
+      "Dark Octillery"
     ],
     "attacks": [
       {
@@ -3129,7 +3152,10 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Magcargo"
+      "Magcargo",
+      "Dark Magcargo",
+      "Magcargo ex",
+      "Magcargo-GX"
     ],
     "attacks": [
       {
@@ -3302,7 +3328,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Starmie"
+      "Starmie",
+      "Starmie-GX"
     ],
     "attacks": [
       {
@@ -3362,7 +3389,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Piloswine"
+      "Piloswine",
+      "Light Piloswine"
     ],
     "attacks": [
       {
@@ -3487,7 +3515,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Golbat"
+      "Golbat",
+      "Dark Golbat"
     ],
     "attacks": [
       {
@@ -3722,9 +3751,6 @@
     "hp": "30",
     "types": [
       "Water"
-    ],
-    "evolvesTo": [
-      "Gyarados"
     ],
     "rules": [
       "You can't have more than 1 Shining Magikarp in your deck."

--- a/cards/en/neo4.json
+++ b/cards/en/neo4.json
@@ -433,9 +433,6 @@
       "Colorless"
     ],
     "evolvesFrom": "Porygon",
-    "evolvesTo": [
-      "Porygon-Z"
-    ],
     "abilities": [
       {
         "name": "Spatial Distortion",
@@ -873,9 +870,6 @@
       "Colorless"
     ],
     "evolvesFrom": "Togepi",
-    "evolvesTo": [
-      "Togekiss"
-    ],
     "abilities": [
       {
         "name": "Gift",
@@ -1255,7 +1249,7 @@
     ],
     "evolvesFrom": "Dratini",
     "evolvesTo": [
-      "Dragonite"
+      "Light Dragonite"
     ],
     "attacks": [
       {
@@ -1500,9 +1494,6 @@
       "Water"
     ],
     "evolvesFrom": "Swinub",
-    "evolvesTo": [
-      "Mamoswine"
-    ],
     "abilities": [
       {
         "name": "Fluffy Wool",
@@ -1801,7 +1792,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Blissey"
+      "Blissey",
+      "Blissey ex"
     ],
     "attacks": [
       {
@@ -1872,7 +1864,7 @@
     ],
     "evolvesFrom": "Totodile",
     "evolvesTo": [
-      "Feraligatr"
+      "Dark Feraligatr"
     ],
     "attacks": [
       {
@@ -1986,7 +1978,7 @@
     ],
     "evolvesFrom": "Mareep",
     "evolvesTo": [
-      "Ampharos"
+      "Dark Ampharos"
     ],
     "attacks": [
       {
@@ -2108,7 +2100,7 @@
     ],
     "evolvesFrom": "Gastly",
     "evolvesTo": [
-      "Gengar"
+      "Dark Gengar"
     ],
     "attacks": [
       {
@@ -2166,7 +2158,7 @@
     ],
     "evolvesFrom": "Mysterious Fossil",
     "evolvesTo": [
-      "Omastar"
+      "Dark Omastar"
     ],
     "attacks": [
       {
@@ -2218,7 +2210,7 @@
     ],
     "evolvesFrom": "Larvitar",
     "evolvesTo": [
-      "Tyranitar"
+      "Dark Tyranitar"
     ],
     "attacks": [
       {
@@ -2288,7 +2280,7 @@
     ],
     "evolvesFrom": "Cyndaquil",
     "evolvesTo": [
-      "Typhlosion"
+      "Dark Typhlosion"
     ],
     "attacks": [
       {
@@ -2538,7 +2530,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Houndoom",
+      "Dark Houndoom",
+      "Houndoom ex"
     ],
     "attacks": [
       {
@@ -2599,7 +2593,11 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Wigglytuff"
+      "Wigglytuff",
+      "Dark Wigglytuff",
+      "Light Wigglytuff",
+      "Wigglytuff ex",
+      "Wigglytuff-GX"
     ],
     "attacks": [
       {
@@ -2896,7 +2894,7 @@
     ],
     "evolvesFrom": "Machop",
     "evolvesTo": [
-      "Machamp"
+      "Light Machamp"
     ],
     "attacks": [
       {
@@ -3265,7 +3263,11 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor",
+      "Scizor ex",
+      "Dark Scizor",
+      "Scizor-GX",
+      "Kleavor"
     ],
     "attacks": [
       {
@@ -3334,7 +3336,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Togetic"
+      "Togetic",
+      "Light Togetic"
     ],
     "attacks": [
       {
@@ -3627,7 +3630,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Quilava"
+      "Quilava",
+      "Dark Quilava"
     ],
     "attacks": [
       {
@@ -3738,7 +3742,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "attacks": [
       {
@@ -3798,7 +3804,10 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Exeggutor"
+      "Exeggutor",
+      "Dark Exeggutor",
+      "Alolan Exeggutor-GX",
+      "Alolan Exeggutor"
     ],
     "attacks": [
       {
@@ -3858,7 +3867,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Haunter",
+      "Dark Haunter"
     ],
     "attacks": [
       {
@@ -3903,6 +3913,9 @@
     "hp": "60",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Farigiraf"
     ],
     "attacks": [
       {
@@ -4012,7 +4025,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -4123,7 +4138,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Pupitar"
+      "Pupitar",
+      "Dark Pupitar"
     ],
     "attacks": [
       {
@@ -4190,7 +4206,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ledian"
+      "Ledian",
+      "Light Ledian"
     ],
     "attacks": [
       {
@@ -4305,7 +4322,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Machoke"
+      "Machoke",
+      "Dark Machoke",
+      "Light Machoke"
     ],
     "attacks": [
       {
@@ -4422,7 +4441,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Flaaffy"
+      "Flaaffy",
+      "Dark Flaaffy"
     ],
     "attacks": [
       {
@@ -4473,7 +4493,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Donphan"
+      "Donphan",
+      "Dark Donphan"
     ],
     "attacks": [
       {
@@ -4530,7 +4551,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Forretress"
+      "Forretress",
+      "Dark Forretress",
+      "Forretress ex"
     ],
     "attacks": [
       {
@@ -4583,7 +4606,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Porygon2"
+      "Porygon2",
+      "Dark Porygon2"
     ],
     "attacks": [
       {
@@ -4641,7 +4665,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Golduck",
+      "Dark Golduck",
+      "Light Golduck"
     ],
     "attacks": [
       {
@@ -4702,7 +4728,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Octillery"
+      "Octillery",
+      "Dark Octillery"
     ],
     "attacks": [
       {
@@ -4749,7 +4776,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Dewgong"
+      "Dewgong",
+      "Light Dewgong"
     ],
     "attacks": [
       {
@@ -4801,7 +4829,10 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Magcargo"
+      "Magcargo",
+      "Dark Magcargo",
+      "Magcargo ex",
+      "Magcargo-GX"
     ],
     "attacks": [
       {
@@ -4854,7 +4885,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Sunflora"
+      "Sunflora",
+      "Light Sunflora"
     ],
     "attacks": [
       {
@@ -4916,7 +4948,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Piloswine"
+      "Piloswine",
+      "Light Piloswine"
     ],
     "attacks": [
       {
@@ -4974,7 +5007,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Croconaw"
+      "Croconaw",
+      "Dark Croconaw"
     ],
     "attacks": [
       {
@@ -5259,7 +5293,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Venomoth"
+      "Venomoth",
+      "Light Venomoth",
+      "Venomoth-GX"
     ],
     "attacks": [
       {
@@ -5320,7 +5356,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {

--- a/cards/en/np.json
+++ b/cards/en/np.json
@@ -187,7 +187,9 @@
     ],
     "evolvesFrom": "Treecko",
     "evolvesTo": [
-      "Sceptile"
+      "Sceptile",
+      "Sceptile ex",
+      "Sceptile-GX"
     ],
     "attacks": [
       {
@@ -497,7 +499,9 @@
     ],
     "evolvesFrom": "Torchic",
     "evolvesTo": [
-      "Blaziken"
+      "Blaziken",
+      "Blaziken ex",
+      "Blaziken-GX"
     ],
     "attacks": [
       {
@@ -617,7 +621,8 @@
     ],
     "evolvesFrom": "Mudkip",
     "evolvesTo": [
-      "Swampert"
+      "Swampert",
+      "Swampert ex"
     ],
     "attacks": [
       {
@@ -677,7 +682,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -736,7 +745,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -1319,7 +1330,9 @@
     ],
     "evolvesFrom": "Beldum",
     "evolvesTo": [
-      "Metagross"
+      "Metagross",
+      "Metagross ex",
+      "Metagross-GX"
     ],
     "attacks": [
       {
@@ -1441,6 +1454,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Vibrava",
+    "evolvesTo": [
+      "Flygon LV.X"
+    ],
     "attacks": [
       {
         "name": "Sand Pit",
@@ -1946,7 +1962,11 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {

--- a/cards/en/pgo.json
+++ b/cards/en/pgo.json
@@ -11,7 +11,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ivysaur"
+      "Ivysaur",
+      "Dark Ivysaur"
     ],
     "attacks": [
       {
@@ -76,7 +77,8 @@
     ],
     "evolvesFrom": "Bulbasaur",
     "evolvesTo": [
-      "Venusaur"
+      "Venusaur",
+      "Venusaur ex"
     ],
     "attacks": [
       {
@@ -337,7 +339,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ariados"
+      "Ariados",
+      "Dark Ariados"
     ],
     "attacks": [
       {
@@ -451,7 +454,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -505,7 +509,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "attacks": [
       {
@@ -762,7 +769,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Camerupt"
+      "Camerupt",
+      "Camerupt ex"
     ],
     "attacks": [
       {
@@ -895,7 +903,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wartortle"
+      "Wartortle",
+      "Dark Wartortle"
     ],
     "attacks": [
       {
@@ -949,7 +958,9 @@
     ],
     "evolvesFrom": "Squirtle",
     "evolvesTo": [
-      "Blastoise"
+      "Blastoise",
+      "Blastoise ex",
+      "Blastoise-GX"
     ],
     "attacks": [
       {
@@ -1142,7 +1153,11 @@
     ],
     "evolvesTo": [
       "Slowbro",
-      "Slowking"
+      "Slowking",
+      "Dark Slowbro",
+      "Dark Slowking",
+      "Light Slowbro",
+      "Slowking ex"
     ],
     "attacks": [
       {
@@ -1268,7 +1283,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -1518,7 +1536,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golisopod"
+      "Golisopod",
+      "Golisopod-GX",
+      "Golisopod ex"
     ],
     "abilities": [
       {
@@ -1643,7 +1663,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -1698,7 +1722,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -1812,6 +1840,9 @@
     "hp": "220",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Mewtwo VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -2217,7 +2248,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Steelix"
+      "Steelix",
+      "Dark Steelix",
+      "Steelix ex"
     ],
     "attacks": [
       {
@@ -2287,7 +2320,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Pupitar"
+      "Pupitar",
+      "Dark Pupitar"
     ],
     "attacks": [
       {
@@ -2341,7 +2375,9 @@
     ],
     "evolvesFrom": "Larvitar",
     "evolvesTo": [
-      "Tyranitar"
+      "Tyranitar",
+      "Tyranitar ex",
+      "Tyranitar-GX"
     ],
     "attacks": [
       {
@@ -2529,7 +2565,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Raticate"
+      "Alolan Raticate",
+      "Alolan Raticate-GX"
     ],
     "attacks": [
       {
@@ -2787,7 +2824,9 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Melmetal"
+      "Melmetal",
+      "Melmetal-GX",
+      "Melmetal ex"
     ],
     "attacks": [
       {
@@ -2919,6 +2958,9 @@
     "hp": "220",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Melmetal VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -3057,6 +3099,9 @@
     "types": [
       "Dragon"
     ],
+    "evolvesTo": [
+      "Dragonite VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -3177,7 +3222,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Blissey"
+      "Blissey",
+      "Blissey ex"
     ],
     "attacks": [
       {
@@ -3360,7 +3406,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -3421,6 +3487,9 @@
     "hp": "150",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Snorlax LV.X"
     ],
     "abilities": [
       {
@@ -4236,6 +4305,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Mewtwo VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -4440,6 +4512,9 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Melmetal VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -4512,6 +4587,9 @@
     "hp": "230",
     "types": [
       "Dragon"
+    ],
+    "evolvesTo": [
+      "Dragonite VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."

--- a/cards/en/pl1.json
+++ b/cards/en/pl1.json
@@ -3060,7 +3060,7 @@
     "types": [
       "Lightning"
     ],
-    "evolvesFrom": "Flaaffy",
+    "evolvesFrom": "Mareep",
     "evolvesTo": [
       "Ampharos"
     ],

--- a/cards/en/pl1.json
+++ b/cards/en/pl1.json
@@ -287,6 +287,9 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Dialga LV.X"
+    ],
     "abilities": [
       {
         "name": "Reverse Time",
@@ -351,6 +354,9 @@
     "hp": "100",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Dialga LV.X"
     ],
     "abilities": [
       {
@@ -417,6 +423,9 @@
     "hp": "100",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Dialga G LV.X"
     ],
     "attacks": [
       {
@@ -485,6 +494,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Kirlia",
+    "evolvesTo": [
+      "Gardevoir LV.X"
+    ],
     "abilities": [
       {
         "name": "Psychic Connect",
@@ -550,6 +562,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Giratina LV.X"
+    ],
     "abilities": [
       {
         "name": "Let Loose",
@@ -613,6 +628,9 @@
     "hp": "100",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Giratina LV.X"
     ],
     "attacks": [
       {
@@ -759,6 +777,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Palkia G LV.X"
+    ],
     "attacks": [
       {
         "name": "Splashing Turn",
@@ -884,6 +905,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Shaymin LV.X"
+    ],
     "attacks": [
       {
         "name": "Flower Aroma",
@@ -947,6 +971,9 @@
     "hp": "80",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Shaymin LV.X"
     ],
     "attacks": [
       {
@@ -1486,6 +1513,9 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Dialga LV.X"
+    ],
     "attacks": [
       {
         "name": "Energy Stream",
@@ -1688,6 +1718,10 @@
       "Water"
     ],
     "evolvesFrom": "Prinplup",
+    "evolvesTo": [
+      "Empoleon LV.X",
+      "Empoleon BREAK"
+    ],
     "attacks": [
       {
         "name": "Knock Off",
@@ -1748,6 +1782,9 @@
     "hp": "100",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Giratina LV.X"
     ],
     "attacks": [
       {
@@ -1817,6 +1854,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Giratina LV.X"
+    ],
     "attacks": [
       {
         "name": "Dragon Claw",
@@ -1885,6 +1925,9 @@
       "Water"
     ],
     "evolvesFrom": "Psyduck",
+    "evolvesTo": [
+      "Golduck BREAK"
+    ],
     "attacks": [
       {
         "name": "Swim",
@@ -2004,6 +2047,9 @@
       "Fire"
     ],
     "evolvesFrom": "Monferno",
+    "evolvesTo": [
+      "Infernape LV.X"
+    ],
     "attacks": [
       {
         "name": "Rushing Flames",
@@ -2310,6 +2356,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "attacks": [
       {
         "name": "Flame Bash",
@@ -2363,6 +2412,9 @@
     "hp": "100",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Palkia LV.X"
     ],
     "attacks": [
       {
@@ -2424,6 +2476,9 @@
     "hp": "80",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Shaymin LV.X"
     ],
     "attacks": [
       {
@@ -2491,6 +2546,9 @@
       "Grass"
     ],
     "evolvesFrom": "Grotle",
+    "evolvesTo": [
+      "Torterra LV.X"
+    ],
     "attacks": [
       {
         "name": "Green Blast",
@@ -2815,7 +2873,8 @@
     ],
     "evolvesFrom": "Wurmple",
     "evolvesTo": [
-      "Dustox"
+      "Dustox",
+      "Dustox ex"
     ],
     "attacks": [
       {
@@ -2878,7 +2937,9 @@
     ],
     "evolvesFrom": "Torchic",
     "evolvesTo": [
-      "Blaziken"
+      "Blaziken",
+      "Blaziken ex",
+      "Blaziken-GX"
     ],
     "attacks": [
       {
@@ -3062,7 +3123,9 @@
     ],
     "evolvesFrom": "Mareep",
     "evolvesTo": [
-      "Ampharos"
+      "Ampharos",
+      "Ampharos ex",
+      "Ampharos-GX"
     ],
     "attacks": [
       {
@@ -3269,7 +3332,9 @@
     "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
-      "Gallade"
+      "Gallade",
+      "Gardevoir ex",
+      "Gardevoir-GX"
     ],
     "attacks": [
       {
@@ -3396,6 +3461,9 @@
       "Metal"
     ],
     "evolvesFrom": "Riolu",
+    "evolvesTo": [
+      "Lucario LV.X"
+    ],
     "attacks": [
       {
         "name": "Aura Sphere",
@@ -4161,7 +4229,9 @@
     ],
     "evolvesFrom": "Squirtle",
     "evolvesTo": [
-      "Blastoise"
+      "Blastoise",
+      "Blastoise ex",
+      "Blastoise-GX"
     ],
     "attacks": [
       {
@@ -4287,7 +4357,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Cacturne"
+      "Cacturne",
+      "Cacturne ex"
     ],
     "attacks": [
       {
@@ -4418,7 +4489,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Blissey"
+      "Blissey",
+      "Blissey ex"
     ],
     "attacks": [
       {
@@ -4541,7 +4613,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Vespiquen"
+      "Vespiquen",
+      "Vespiquen ex"
     ],
     "attacks": [
       {
@@ -4608,7 +4681,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Dugtrio"
+      "Dugtrio",
+      "Dark Dugtrio"
     ],
     "attacks": [
       {
@@ -4674,6 +4748,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Dudunsparce"
+    ],
     "attacks": [
       {
         "name": "Call for Family",
@@ -4732,7 +4809,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Manectric",
+      "Manectric ex"
     ],
     "attacks": [
       {
@@ -4795,7 +4873,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Muk"
+      "Muk",
+      "Dark Muk",
+      "Muk ex"
     ],
     "attacks": [
       {
@@ -4854,9 +4934,6 @@
     "hp": "60",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Chansey"
     ],
     "abilities": [
       {
@@ -5223,7 +5300,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Flaaffy"
+      "Flaaffy",
+      "Dark Flaaffy"
     ],
     "attacks": [
       {
@@ -5477,7 +5555,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Mightyena"
+      "Mightyena",
+      "Mightyena ex"
     ],
     "attacks": [
       {
@@ -5543,7 +5622,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Golduck",
+      "Dark Golduck",
+      "Light Golduck"
     ],
     "attacks": [
       {
@@ -5726,7 +5807,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Octillery"
+      "Octillery",
+      "Dark Octillery"
     ],
     "attacks": [
       {
@@ -5787,7 +5869,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lucario"
+      "Lucario",
+      "Lucario-GX",
+      "Lucario ex"
     ],
     "attacks": [
       {
@@ -5848,7 +5932,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Banette"
+      "Banette",
+      "Banette ex",
+      "Banette-GX"
     ],
     "attacks": [
       {
@@ -5914,7 +6000,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Delcatty"
+      "Delcatty",
+      "Delcatty ex"
     ],
     "attacks": [
       {
@@ -6092,7 +6179,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wartortle"
+      "Wartortle",
+      "Dark Wartortle"
     ],
     "attacks": [
       {
@@ -6153,7 +6241,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Altaria"
+      "Altaria",
+      "Altaria ex",
+      "Altaria-GX"
     ],
     "attacks": [
       {
@@ -6460,7 +6550,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {
@@ -6905,6 +6997,9 @@
       "Item"
     ],
     "hp": "50",
+    "evolvesTo": [
+      "Shieldon"
+    ],
     "rules": [
       "Play Armor Fossil as if it were a Colorless Basic Pokémon. (Armor Fossil counts as a Trainer card as well, but if Armor Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Armor Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Armor Fossil from play. (This doesn't count as a Knocked Out Pokémon.)"
     ],
@@ -6934,6 +7029,9 @@
       "Item"
     ],
     "hp": "50",
+    "evolvesTo": [
+      "Cranidos"
+    ],
     "rules": [
       "Play Skull Fossil as if it were a Colorless Basic Pokémon. (Skull Fossil counts as a Trainer card as well, but if Skull Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Skull Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Skull Fossil from play. (This doesn't count as a Knocked Out Pokémon.)"
     ],
@@ -7503,7 +7601,11 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor",
+      "Scizor ex",
+      "Dark Scizor",
+      "Scizor-GX",
+      "Kleavor"
     ],
     "attacks": [
       {
@@ -7634,7 +7736,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Altaria"
+      "Altaria",
+      "Altaria ex",
+      "Altaria-GX"
     ],
     "attacks": [
       {
@@ -7708,7 +7812,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {

--- a/cards/en/pl2.json
+++ b/cards/en/pl2.json
@@ -12,6 +12,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "abilities": [
       {
         "name": "Flare Condition",
@@ -214,6 +217,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Floatzel GL LV.X"
+    ],
     "attacks": [
       {
         "name": "Incite",
@@ -272,6 +278,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Vibrava",
+    "evolvesTo": [
+      "Flygon LV.X"
+    ],
     "abilities": [
       {
         "name": "Rainbow Float",
@@ -521,6 +530,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Luxray GL LV.X"
+    ],
     "attacks": [
       {
         "name": "Bite",
@@ -586,6 +598,9 @@
     "hp": "80",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Mismagius GL LV.X"
     ],
     "attacks": [
       {
@@ -1238,6 +1253,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Gallade E4 LV.X"
+    ],
     "attacks": [
       {
         "name": "Chop Up",
@@ -1580,6 +1598,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Hippopotas",
+    "evolvesTo": [
+      "Hippowdon LV.X"
+    ],
     "abilities": [
       {
         "name": "Sand Cover",
@@ -1848,6 +1869,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Nidorino",
+    "evolvesTo": [
+      "Nidoking BREAK"
+    ],
     "abilities": [
       {
         "name": "Territoriality",
@@ -2125,6 +2149,9 @@
     "hp": "100",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Snorlax LV.X"
     ],
     "attacks": [
       {
@@ -2446,6 +2473,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Alakazam E4 LV.X"
+    ],
     "attacks": [
       {
         "name": "Recover",
@@ -2634,6 +2664,9 @@
       "Water"
     ],
     "evolvesFrom": "Eevee",
+    "evolvesTo": [
+      "Glaceon LV.X"
+    ],
     "abilities": [
       {
         "name": "Frost Wind",
@@ -2765,6 +2798,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Infernape E4 LV.X"
+    ],
     "attacks": [
       {
         "name": "Split Bomb",
@@ -2826,7 +2862,8 @@
     ],
     "evolvesFrom": "Aron",
     "evolvesTo": [
-      "Aggron"
+      "Aggron",
+      "Aggron ex"
     ],
     "attacks": [
       {
@@ -2896,6 +2933,9 @@
       "Grass"
     ],
     "evolvesFrom": "Eevee",
+    "evolvesTo": [
+      "Leafeon LV.X"
+    ],
     "abilities": [
       {
         "name": "Energy Refresh",
@@ -3215,6 +3255,9 @@
       "Water"
     ],
     "evolvesFrom": "Staryu",
+    "evolvesTo": [
+      "Starmie BREAK"
+    ],
     "abilities": [
       {
         "name": "Aqua Recycle",
@@ -3422,7 +3465,9 @@
     ],
     "evolvesFrom": "Trapinch",
     "evolvesTo": [
-      "Flygon"
+      "Flygon",
+      "Flygon ex",
+      "Flygon-GX"
     ],
     "attacks": [
       {
@@ -3739,7 +3784,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Sharpedo"
+      "Sharpedo",
+      "Sharpedo ex"
     ],
     "attacks": [
       {
@@ -3812,7 +3858,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -4060,7 +4126,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -4375,7 +4443,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Weezing"
+      "Weezing",
+      "Dark Weezing",
+      "Galarian Weezing"
     ],
     "attacks": [
       {
@@ -4435,9 +4505,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesTo": [
-      "Snorlax"
-    ],
     "abilities": [
       {
         "name": "Baby Evolution",
@@ -4494,9 +4561,6 @@
     "hp": "70",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Snorlax"
     ],
     "abilities": [
       {
@@ -4807,7 +4871,9 @@
     ],
     "evolvesFrom": "Seedot",
     "evolvesTo": [
-      "Shiftry"
+      "Shiftry",
+      "Shiftry ex",
+      "Shiftry-GX"
     ],
     "attacks": [
       {
@@ -4939,7 +5005,8 @@
     ],
     "evolvesFrom": "Spheal",
     "evolvesTo": [
-      "Walrein"
+      "Walrein",
+      "Walrein ex"
     ],
     "attacks": [
       {
@@ -5067,7 +5134,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gastrodon"
+      "Gastrodon East Sea"
     ],
     "attacks": [
       {
@@ -5127,7 +5194,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gastrodon"
+      "Gastrodon West Sea"
     ],
     "attacks": [
       {
@@ -5187,6 +5254,9 @@
     "hp": "100",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Snorlax LV.X"
     ],
     "abilities": [
       {
@@ -5321,7 +5391,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Starmie"
+      "Starmie",
+      "Starmie-GX"
     ],
     "attacks": [
       {
@@ -6533,7 +6604,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -6593,9 +6668,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesTo": [
-      "Raichu"
-    ],
     "attacks": [
       {
         "name": "Thundershock",
@@ -6654,9 +6726,6 @@
     "hp": "50",
     "types": [
       "Lightning"
-    ],
-    "evolvesTo": [
-      "Raichu"
     ],
     "attacks": [
       {

--- a/cards/en/pl3.json
+++ b/cards/en/pl3.json
@@ -12,6 +12,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Absol G LV.X"
+    ],
     "attacks": [
       {
         "name": "Feint Attack",
@@ -76,6 +79,9 @@
     "hp": "80",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Blaziken FB LV.X"
     ],
     "attacks": [
       {
@@ -199,6 +205,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Electivire FB LV.X"
+    ],
     "attacks": [
       {
         "name": "Dump and Draw",
@@ -266,6 +275,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Gabite",
+    "evolvesTo": [
+      "Garchomp LV.X"
+    ],
     "abilities": [
       {
         "name": "Dragon Intimidation",
@@ -329,6 +341,9 @@
       "Fire"
     ],
     "evolvesFrom": "Magmar",
+    "evolvesTo": [
+      "Magmortar LV.X"
+    ],
     "abilities": [
       {
         "name": "Evolutionary Flame",
@@ -463,6 +478,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Rayquaza C LV.X"
+    ],
     "attacks": [
       {
         "name": "Trash Burst",
@@ -596,6 +614,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Rhydon",
+    "evolvesTo": [
+      "Rhyperior LV.X"
+    ],
     "attacks": [
       {
         "name": "Raging Drill",
@@ -666,6 +687,9 @@
     "hp": "80",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Staraptor FB LV.X"
     ],
     "attacks": [
       {
@@ -872,6 +896,9 @@
       "Grass"
     ],
     "evolvesFrom": "Yanma",
+    "evolvesTo": [
+      "Yanmega BREAK"
+    ],
     "abilities": [
       {
         "name": "Speed Boost",
@@ -1259,6 +1286,9 @@
     "hp": "100",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Charizard G LV.X"
     ],
     "attacks": [
       {
@@ -1830,6 +1860,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Murkrow",
+    "evolvesTo": [
+      "Honchkrow LV.X"
+    ],
     "abilities": [
       {
         "name": "Darkness Restore",
@@ -2437,6 +2470,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Mankey",
+    "evolvesTo": [
+      "Annihilape ex",
+      "Annihilape"
+    ],
     "attacks": [
       {
         "name": "Top Drop",
@@ -3104,6 +3141,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "attacks": [
       {
         "name": "Overrun",
@@ -3681,7 +3721,8 @@
     ],
     "evolvesFrom": "Gible",
     "evolvesTo": [
-      "Garchomp"
+      "Garchomp",
+      "Garchomp ex"
     ],
     "attacks": [
       {
@@ -3741,6 +3782,9 @@
     "hp": "80",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Garchomp C LV.X"
     ],
     "attacks": [
       {
@@ -3867,7 +3911,8 @@
     ],
     "evolvesFrom": "Bulbasaur",
     "evolvesTo": [
-      "Venusaur"
+      "Venusaur",
+      "Venusaur ex"
     ],
     "abilities": [
       {
@@ -3989,7 +4034,8 @@
     ],
     "evolvesFrom": "Whismur",
     "evolvesTo": [
-      "Exploud"
+      "Exploud",
+      "Exploud ex"
     ],
     "attacks": [
       {
@@ -4179,7 +4225,8 @@
     ],
     "evolvesFrom": "Mudkip",
     "evolvesTo": [
-      "Swampert"
+      "Swampert",
+      "Swampert ex"
     ],
     "abilities": [
       {
@@ -4298,7 +4345,9 @@
     ],
     "evolvesFrom": "Beldum",
     "evolvesTo": [
-      "Metagross"
+      "Metagross",
+      "Metagross ex",
+      "Metagross-GX"
     ],
     "abilities": [
       {
@@ -4489,7 +4538,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Honchkrow"
+      "Honchkrow",
+      "Honchkrow-GX"
     ],
     "attacks": [
       {
@@ -4556,9 +4606,6 @@
       "Grass"
     ],
     "evolvesFrom": "Nincada",
-    "evolvesTo": [
-      "Shedinja"
-    ],
     "attacks": [
       {
         "name": "Circling Dive",
@@ -4619,7 +4666,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Camerupt"
+      "Camerupt",
+      "Camerupt ex"
     ],
     "attacks": [
       {
@@ -4806,6 +4854,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Quick Attack",
@@ -5427,7 +5479,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wailord"
+      "Wailord",
+      "Wailord ex"
     ],
     "attacks": [
       {
@@ -5558,7 +5611,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Claydol"
+      "Claydol",
+      "Claydol ex"
     ],
     "attacks": [
       {
@@ -5799,7 +5853,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ivysaur"
+      "Ivysaur",
+      "Dark Ivysaur"
     ],
     "attacks": [
       {
@@ -6111,9 +6166,6 @@
     "types": [
       "Psychic"
     ],
-    "evolvesTo": [
-      "Chimecho"
-    ],
     "abilities": [
       {
         "name": "Baby Evolution",
@@ -6170,7 +6222,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Vespiquen"
+      "Vespiquen",
+      "Vespiquen ex"
     ],
     "attacks": [
       {
@@ -6237,7 +6290,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Crawdaunt"
+      "Crawdaunt",
+      "Crawdaunt ex"
     ],
     "attacks": [
       {
@@ -6297,7 +6351,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Toxicroak"
+      "Toxicroak",
+      "Toxicroak ex"
     ],
     "attacks": [
       {
@@ -6477,7 +6532,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Milotic"
+      "Milotic",
+      "Milotic ex"
     ],
     "attacks": [
       {
@@ -6719,7 +6775,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -6842,7 +6900,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -6893,7 +6954,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -6960,7 +7022,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Primeape"
+      "Primeape",
+      "Dark Primeape"
     ],
     "attacks": [
       {
@@ -7011,7 +7074,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Medicham"
+      "Medicham",
+      "Medicham ex"
     ],
     "attacks": [
       {
@@ -7072,7 +7136,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -7250,7 +7316,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ninjask"
+      "Ninjask",
+      "Shedinja"
     ],
     "attacks": [
       {
@@ -7433,7 +7500,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -7692,7 +7763,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Sandslash"
+      "Sandslash",
+      "Dark Sandslash"
     ],
     "attacks": [
       {
@@ -7749,7 +7821,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Dewgong"
+      "Dewgong",
+      "Light Dewgong"
     ],
     "attacks": [
       {
@@ -8239,7 +8312,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Golbat"
+      "Golbat",
+      "Dark Golbat"
     ],
     "attacks": [
       {

--- a/cards/en/pl4.json
+++ b/cards/en/pl4.json
@@ -142,6 +142,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Heatran LV.X"
+    ],
     "attacks": [
       {
         "name": "Fire Fang",
@@ -267,6 +270,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Luxio",
+    "evolvesTo": [
+      "Luxray BREAK"
+    ],
     "attacks": [
       {
         "name": "Flash",
@@ -464,6 +470,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Shelgon",
+    "evolvesTo": [
+      "Salamence LV.X"
+    ],
     "abilities": [
       {
         "name": "Top Accelerator",
@@ -602,6 +611,9 @@
       "Grass"
     ],
     "evolvesFrom": "Tangela",
+    "evolvesTo": [
+      "Tangrowth LV.X"
+    ],
     "attacks": [
       {
         "name": "Leaf Guard",
@@ -860,6 +872,9 @@
       "Metal"
     ],
     "evolvesFrom": "Bronzor",
+    "evolvesTo": [
+      "Bronzong BREAK"
+    ],
     "attacks": [
       {
         "name": "Oracle Arrow",
@@ -992,6 +1007,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Haunter",
+    "evolvesTo": [
+      "Gengar LV.X"
+    ],
     "abilities": [
       {
         "name": "Curse",
@@ -1052,6 +1070,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Haunter",
+    "evolvesTo": [
+      "Gengar LV.X"
+    ],
     "attacks": [
       {
         "name": "Sharpshooting",
@@ -1443,6 +1464,9 @@
       "Water"
     ],
     "evolvesFrom": "Omanyte",
+    "evolvesTo": [
+      "Omastar BREAK"
+    ],
     "attacks": [
       {
         "name": "Time Spiral",
@@ -1571,9 +1595,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesTo": [
-      "Pikachu"
-    ],
     "abilities": [
       {
         "name": "Baby Evolution",
@@ -1693,6 +1714,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Boosted Voltage",
@@ -1821,6 +1846,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Rattata",
+    "evolvesTo": [
+      "Raticate BREAK"
+    ],
     "attacks": [
       {
         "name": "Recruit",
@@ -2078,6 +2106,9 @@
       "Metal"
     ],
     "evolvesFrom": "Bronzor",
+    "evolvesTo": [
+      "Bronzong BREAK"
+    ],
     "attacks": [
       {
         "name": "Wide Laser",
@@ -2216,7 +2247,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "attacks": [
       {
@@ -2279,7 +2313,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Haunter",
+      "Dark Haunter"
     ],
     "attacks": [
       {
@@ -2347,7 +2382,8 @@
     ],
     "evolvesFrom": "Geodude",
     "evolvesTo": [
-      "Golem"
+      "Golem",
+      "Golem ex"
     ],
     "attacks": [
       {
@@ -2419,7 +2455,9 @@
     ],
     "evolvesFrom": "Treecko",
     "evolvesTo": [
-      "Sceptile"
+      "Sceptile",
+      "Sceptile ex",
+      "Sceptile-GX"
     ],
     "attacks": [
       {
@@ -2487,7 +2525,9 @@
     ],
     "evolvesFrom": "Treecko",
     "evolvesTo": [
-      "Sceptile"
+      "Sceptile",
+      "Sceptile ex",
+      "Sceptile-GX"
     ],
     "attacks": [
       {
@@ -2618,7 +2658,8 @@
     ],
     "evolvesFrom": "Gastly",
     "evolvesTo": [
-      "Gengar"
+      "Gengar",
+      "Gengar ex"
     ],
     "abilities": [
       {
@@ -2684,7 +2725,8 @@
     ],
     "evolvesFrom": "Gastly",
     "evolvesTo": [
-      "Gengar"
+      "Gengar",
+      "Gengar ex"
     ],
     "attacks": [
       {
@@ -2949,7 +2991,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Rapidash"
+      "Rapidash",
+      "Dark Rapidash"
     ],
     "attacks": [
       {
@@ -3066,7 +3109,9 @@
     ],
     "evolvesFrom": "Bagon",
     "evolvesTo": [
-      "Salamence"
+      "Salamence",
+      "Salamence ex",
+      "Salamence-GX"
     ],
     "attacks": [
       {
@@ -3558,8 +3603,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Wormadam",
-      "Mothim"
+      "Wormadam Plant Cloak"
     ],
     "abilities": [
       {
@@ -3618,8 +3662,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Wormadam",
-      "Mothim"
+      "Wormadam Sandy Cloak"
     ],
     "abilities": [
       {
@@ -3678,8 +3721,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Wormadam",
-      "Mothim"
+      "Wormadam Trash Cloak"
     ],
     "abilities": [
       {
@@ -3738,7 +3780,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -3866,7 +3909,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Toxicroak"
+      "Toxicroak",
+      "Toxicroak ex"
     ],
     "attacks": [
       {
@@ -3927,7 +3971,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Manectric",
+      "Manectric ex"
     ],
     "attacks": [
       {
@@ -3994,7 +4039,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Manectric",
+      "Manectric ex"
     ],
     "attacks": [
       {
@@ -4051,7 +4097,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Haunter",
+      "Dark Haunter"
     ],
     "attacks": [
       {
@@ -4238,7 +4285,8 @@
     ],
     "evolvesFrom": "Dome Fossil",
     "evolvesTo": [
-      "Kabutops"
+      "Kabutops",
+      "Kabutops ex"
     ],
     "attacks": [
       {
@@ -4299,7 +4347,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Hariyama"
+      "Hariyama",
+      "Hariyama ex"
     ],
     "attacks": [
       {
@@ -4484,7 +4533,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -4552,7 +4605,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Rapidash"
+      "Rapidash",
+      "Dark Rapidash"
     ],
     "attacks": [
       {
@@ -4613,7 +4667,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Raticate"
+      "Raticate",
+      "Dark Raticate"
     ],
     "attacks": [
       {
@@ -4728,7 +4783,8 @@
     ],
     "evolvesTo": [
       "Glalie",
-      "Froslass"
+      "Froslass",
+      "Froslass ex"
     ],
     "attacks": [
       {
@@ -5322,6 +5378,9 @@
       "Item"
     ],
     "hp": "50",
+    "evolvesTo": [
+      "Aerodactyl"
+    ],
     "rules": [
       "Play Old Amber as if it were a Colorless Basic Pokémon. (Old Amber counts as a Trainer card as well, but if Old Amber is Knocked Out, this counts as a Knocked Out Pokémon.) Old Amber can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Old Amber from play. (This doesn't count as a Knocked Out Pokémon.)"
     ],
@@ -5395,6 +5454,9 @@
       "Item"
     ],
     "hp": "50",
+    "evolvesTo": [
+      "Kabuto"
+    ],
     "rules": [
       "Play Dome Fossil as if it were a Colorless Basic Pokémon. (Dome Fossil counts as a Trainer card as well, but if Dome Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Dome Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Dome Fossil from play. (This doesn't count as a Knocked Out Pokémon.)"
     ],
@@ -5424,6 +5486,9 @@
       "Item"
     ],
     "hp": "50",
+    "evolvesTo": [
+      "Omanyte"
+    ],
     "rules": [
       "Play Helix Fossil as if it were a Colorless Basic Pokémon. (Helix Fossil counts as a Trainer card as well, but if Helix Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Helix Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Helix Fossil from play. (This doesn't count as a Knocked Out Pokémon.)"
     ],
@@ -5869,7 +5934,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Rapidash"
+      "Rapidash",
+      "Dark Rapidash"
     ],
     "abilities": [
       {
@@ -5991,6 +6057,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Arceus LV.X"
+    ],
     "rules": [
       "You may have as many of this card in your deck as you like."
     ],
@@ -6048,6 +6117,9 @@
     "hp": "90",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Arceus LV.X"
     ],
     "rules": [
       "You may have as many of this card in your deck as you like."
@@ -6108,6 +6180,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Arceus LV.X"
+    ],
     "rules": [
       "You may have as many of this card in your deck as you like."
     ],
@@ -6160,6 +6235,9 @@
     "hp": "90",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Arceus LV.X"
     ],
     "rules": [
       "You may have as many of this card in your deck as you like."
@@ -6214,6 +6292,9 @@
     "hp": "80",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Arceus LV.X"
     ],
     "rules": [
       "You may have as many of this card in your deck as you like."
@@ -6277,6 +6358,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Arceus LV.X"
+    ],
     "rules": [
       "You may have as many of this card in your deck as you like."
     ],
@@ -6335,6 +6419,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Arceus LV.X"
+    ],
     "rules": [
       "You may have as many of this card in your deck as you like."
     ],
@@ -6387,6 +6474,9 @@
     "hp": "80",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Arceus LV.X"
     ],
     "rules": [
       "You may have as many of this card in your deck as you like."
@@ -6447,6 +6537,9 @@
     "hp": "90",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Arceus LV.X"
     ],
     "rules": [
       "You may have as many of this card in your deck as you like."

--- a/cards/en/pop1.json
+++ b/cards/en/pop1.json
@@ -883,8 +883,8 @@
     "name": "Armaldo ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
-      "EX"
+      "Stage 2",
+      "ex"
     ],
     "hp": "160",
     "types": [
@@ -954,8 +954,8 @@
     "name": "Tyranitar ex",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic",
-      "EX"
+      "Stage 2",
+      "ex"
     ],
     "hp": "150",
     "types": [

--- a/cards/en/pop1.json
+++ b/cards/en/pop1.json
@@ -434,7 +434,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Honchkrow"
+      "Honchkrow",
+      "Honchkrow-GX"
     ],
     "abilities": [
       {
@@ -498,7 +499,9 @@
     ],
     "evolvesFrom": "Larvitar",
     "evolvesTo": [
-      "Tyranitar"
+      "Tyranitar",
+      "Tyranitar ex",
+      "Tyranitar-GX"
     ],
     "attacks": [
       {
@@ -605,7 +608,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Pupitar"
+      "Pupitar",
+      "Dark Pupitar"
     ],
     "attacks": [
       {

--- a/cards/en/pop2.json
+++ b/cards/en/pop2.json
@@ -360,7 +360,8 @@
     ],
     "evolvesFrom": "Bulbasaur",
     "evolvesTo": [
-      "Venusaur"
+      "Venusaur",
+      "Venusaur ex"
     ],
     "attacks": [
       {
@@ -519,7 +520,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ivysaur"
+      "Ivysaur",
+      "Dark Ivysaur"
     ],
     "attacks": [
       {
@@ -578,7 +580,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Cacturne"
+      "Cacturne",
+      "Cacturne ex"
     ],
     "attacks": [
       {
@@ -683,7 +686,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Donphan"
+      "Donphan",
+      "Dark Donphan"
     ],
     "attacks": [
       {
@@ -742,7 +746,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {

--- a/cards/en/pop3.json
+++ b/cards/en/pop3.json
@@ -394,7 +394,9 @@
     ],
     "evolvesFrom": "Torchic",
     "evolvesTo": [
-      "Blaziken"
+      "Blaziken",
+      "Blaziken ex",
+      "Blaziken-GX"
     ],
     "attacks": [
       {
@@ -677,7 +679,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -737,7 +759,8 @@
     ],
     "evolvesFrom": "Bulbasaur",
     "evolvesTo": [
-      "Venusaur"
+      "Venusaur",
+      "Venusaur ex"
     ],
     "attacks": [
       {
@@ -798,7 +821,8 @@
     ],
     "evolvesFrom": "Mudkip",
     "evolvesTo": [
-      "Swampert"
+      "Swampert",
+      "Swampert ex"
     ],
     "attacks": [
       {
@@ -856,9 +880,6 @@
     "hp": "60",
     "types": [
       "Lightning"
-    ],
-    "evolvesTo": [
-      "Pikachu"
     ],
     "attacks": [
       {

--- a/cards/en/pop4.json
+++ b/cards/en/pop4.json
@@ -121,6 +121,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Vibrava",
+    "evolvesTo": [
+      "Flygon LV.X"
+    ],
     "abilities": [
       {
         "name": "Levitate",
@@ -308,7 +311,9 @@
     ],
     "evolvesFrom": "Torchic",
     "evolvesTo": [
-      "Blaziken"
+      "Blaziken",
+      "Blaziken ex",
+      "Blaziken-GX"
     ],
     "attacks": [
       {
@@ -369,7 +374,9 @@
     ],
     "evolvesFrom": "Treecko",
     "evolvesTo": [
-      "Sceptile"
+      "Sceptile",
+      "Sceptile ex",
+      "Sceptile-GX"
     ],
     "attacks": [
       {
@@ -604,7 +611,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -654,7 +665,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wartortle"
+      "Wartortle",
+      "Dark Wartortle"
     ],
     "abilities": [
       {
@@ -772,6 +784,9 @@
     "hp": "80",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Wobbuffet BREAK"
     ],
     "attacks": [
       {

--- a/cards/en/pop5.json
+++ b/cards/en/pop5.json
@@ -10,6 +10,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Ho-Oh BREAK"
+    ],
     "attacks": [
       {
         "name": "Fire Wing",
@@ -69,6 +72,9 @@
     "hp": "80",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Lugia BREAK"
     ],
     "attacks": [
       {
@@ -207,7 +213,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "attacks": [
       {
@@ -356,7 +365,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -415,7 +425,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -464,7 +476,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -524,7 +540,11 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {

--- a/cards/en/pop6.json
+++ b/cards/en/pop6.json
@@ -78,6 +78,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Riolu",
+    "evolvesTo": [
+      "Lucario LV.X"
+    ],
     "attacks": [
       {
         "name": "Feint",
@@ -440,7 +443,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lucario"
+      "Lucario",
+      "Lucario-GX",
+      "Lucario ex"
     ],
     "attacks": [
       {
@@ -491,7 +496,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "rules": [
       "Oran Berry: Remove 1 damage counter from Pikachu at the end of your turn."

--- a/cards/en/pop7.json
+++ b/cards/en/pop7.json
@@ -391,7 +391,9 @@
     ],
     "evolvesFrom": "Mareep",
     "evolvesTo": [
-      "Ampharos"
+      "Ampharos",
+      "Ampharos ex",
+      "Ampharos-GX"
     ],
     "attacks": [
       {
@@ -461,7 +463,9 @@
     "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
-      "Gallade"
+      "Gallade",
+      "Gardevoir ex",
+      "Gardevoir-GX"
     ],
     "attacks": [
       {
@@ -521,6 +525,9 @@
     "hp": "70",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Wyrdeer"
     ],
     "attacks": [
       {
@@ -645,8 +652,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Wormadam",
-      "Mothim"
+      "Wormadam Plant Cloak"
     ],
     "abilities": [
       {
@@ -704,8 +710,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Wormadam",
-      "Mothim"
+      "Wormadam Sandy Cloak"
     ],
     "abilities": [
       {
@@ -761,9 +766,6 @@
     "hp": "70",
     "types": [
       "Water"
-    ],
-    "evolvesTo": [
-      "Cursola"
     ],
     "attacks": [
       {
@@ -824,7 +826,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Flaaffy"
+      "Flaaffy",
+      "Dark Flaaffy"
     ],
     "attacks": [
       {

--- a/cards/en/pop8.json
+++ b/cards/en/pop8.json
@@ -11,6 +11,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Heatran LV.X"
+    ],
     "attacks": [
       {
         "name": "Body Slam",
@@ -75,6 +78,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Riolu",
+    "evolvesTo": [
+      "Lucario LV.X"
+    ],
     "attacks": [
       {
         "name": "Blocking Punch",
@@ -136,6 +142,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Luxio",
+    "evolvesTo": [
+      "Luxray BREAK"
+    ],
     "abilities": [
       {
         "name": "Intimidating Fang",
@@ -270,6 +279,9 @@
       "Grass"
     ],
     "evolvesFrom": "Yanma",
+    "evolvesTo": [
+      "Yanmega BREAK"
+    ],
     "attacks": [
       {
         "name": "Supersonic",
@@ -655,7 +667,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Toxicroak"
+      "Toxicroak",
+      "Toxicroak ex"
     ],
     "attacks": [
       {
@@ -714,9 +727,6 @@
     "hp": "60",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Chansey"
     ],
     "abilities": [
       {
@@ -835,7 +845,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lucario"
+      "Lucario",
+      "Lucario-GX",
+      "Lucario ex"
     ],
     "abilities": [
       {

--- a/cards/en/pop9.json
+++ b/cards/en/pop9.json
@@ -12,6 +12,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Gabite",
+    "evolvesTo": [
+      "Garchomp LV.X"
+    ],
     "attacks": [
       {
         "name": "Dragon Rage",
@@ -125,6 +128,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Slam",
@@ -190,6 +197,9 @@
     "hp": "100",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Regigigas LV.X"
     ],
     "attacks": [
       {
@@ -380,7 +390,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Toxicroak"
+      "Toxicroak",
+      "Toxicroak ex"
     ],
     "attacks": [
       {
@@ -443,7 +454,8 @@
     ],
     "evolvesFrom": "Gible",
     "evolvesTo": [
-      "Garchomp"
+      "Garchomp",
+      "Garchomp ex"
     ],
     "attacks": [
       {
@@ -628,9 +640,6 @@
     "hp": "40",
     "types": [
       "Lightning"
-    ],
-    "evolvesTo": [
-      "Pikachu"
     ],
     "abilities": [
       {
@@ -868,7 +877,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {

--- a/cards/en/ru1.json
+++ b/cards/en/ru1.json
@@ -117,6 +117,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "attacks": [
       {
         "name": "Flame Tail",
@@ -163,6 +166,9 @@
     "hp": "110",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Heatran LV.X"
     ],
     "attacks": [
       {
@@ -216,6 +222,9 @@
       "Water"
     ],
     "evolvesFrom": "Staryu",
+    "evolvesTo": [
+      "Starmie BREAK"
+    ],
     "attacks": [
       {
         "name": "Spiral Drain",
@@ -321,7 +330,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -431,6 +444,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Mewtwo LV.X"
+    ],
     "attacks": [
       {
         "name": "Super Psy Bolt",
@@ -533,7 +549,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Dugtrio"
+      "Dugtrio",
+      "Dark Dugtrio"
     ],
     "attacks": [
       {
@@ -588,6 +605,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Riolu",
+    "evolvesTo": [
+      "Lucario LV.X"
+    ],
     "attacks": [
       {
         "name": "Metal Claw",
@@ -760,7 +780,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Raticate"
+      "Raticate",
+      "Dark Raticate"
     ],
     "attacks": [
       {

--- a/cards/en/si1.json
+++ b/cards/en/si1.json
@@ -115,7 +115,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Steelix"
+      "Steelix",
+      "Dark Steelix",
+      "Steelix ex"
     ],
     "attacks": [
       {
@@ -179,7 +181,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Togetic"
+      "Togetic",
+      "Light Togetic"
     ],
     "attacks": [
       {
@@ -229,7 +232,8 @@
     ],
     "evolvesFrom": "Bulbasaur",
     "evolvesTo": [
-      "Venusaur"
+      "Venusaur",
+      "Venusaur ex"
     ],
     "attacks": [
       {
@@ -288,6 +292,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Rattata",
+    "evolvesTo": [
+      "Raticate BREAK"
+    ],
     "attacks": [
       {
         "name": "Sharp Teeth",
@@ -338,7 +345,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ledian"
+      "Ledian",
+      "Light Ledian"
     ],
     "attacks": [
       {
@@ -403,7 +411,11 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Wigglytuff"
+      "Wigglytuff",
+      "Dark Wigglytuff",
+      "Light Wigglytuff",
+      "Wigglytuff ex",
+      "Wigglytuff-GX"
     ],
     "attacks": [
       {
@@ -590,7 +602,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Azumarill"
+      "Azumarill",
+      "Light Azumarill"
     ],
     "attacks": [
       {
@@ -812,7 +825,9 @@
     ],
     "evolvesFrom": "Squirtle",
     "evolvesTo": [
-      "Blastoise"
+      "Blastoise",
+      "Blastoise ex",
+      "Blastoise-GX"
     ],
     "attacks": [
       {
@@ -987,6 +1002,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Mankey",
+    "evolvesTo": [
+      "Annihilape ex",
+      "Annihilape"
+    ],
     "attacks": [
       {
         "name": "Low Kick",

--- a/cards/en/sm1.json
+++ b/cards/en/sm1.json
@@ -530,7 +530,10 @@
     ],
     "evolvesFrom": "Rowlet",
     "evolvesTo": [
-      "Decidueye"
+      "Decidueye",
+      "Decidueye-GX",
+      "Hisuian Decidueye",
+      "Decidueye ex"
     ],
     "attacks": [
       {
@@ -776,7 +779,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Lurantis"
+      "Lurantis",
+      "Lurantis-GX"
     ],
     "attacks": [
       {
@@ -1089,7 +1093,9 @@
     ],
     "evolvesFrom": "Bounsweet",
     "evolvesTo": [
-      "Tsareena"
+      "Tsareena",
+      "Tsareena-GX",
+      "Tsareena ex"
     ],
     "attacks": [
       {
@@ -1210,7 +1216,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -1264,6 +1272,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "attacks": [
       {
         "name": "Searing Flame",
@@ -1450,7 +1461,8 @@
     ],
     "evolvesFrom": "Litten",
     "evolvesTo": [
-      "Incineroar"
+      "Incineroar",
+      "Incineroar-GX"
     ],
     "attacks": [
       {
@@ -1652,7 +1664,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Golduck",
+      "Dark Golduck",
+      "Light Golduck"
     ],
     "attacks": [
       {
@@ -1704,6 +1718,9 @@
       "Water"
     ],
     "evolvesFrom": "Psyduck",
+    "evolvesTo": [
+      "Golduck BREAK"
+    ],
     "attacks": [
       {
         "name": "Scratch",
@@ -1822,7 +1839,8 @@
     "evolvesFrom": "Poliwag",
     "evolvesTo": [
       "Poliwrath",
-      "Politoed"
+      "Politoed",
+      "Politoed ex"
     ],
     "attacks": [
       {
@@ -2136,9 +2154,6 @@
     "types": [
       "Water"
     ],
-    "evolvesTo": [
-      "Cursola"
-    ],
     "attacks": [
       {
         "name": "Call for Family",
@@ -2385,7 +2400,8 @@
     ],
     "evolvesFrom": "Popplio",
     "evolvesTo": [
-      "Primarina"
+      "Primarina",
+      "Primarina-GX"
     ],
     "attacks": [
       {
@@ -2933,7 +2949,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Lanturn"
+      "Lanturn",
+      "Light Lanturn"
     ],
     "attacks": [
       {
@@ -3069,7 +3086,8 @@
     ],
     "evolvesFrom": "Grubbin",
     "evolvesTo": [
-      "Vikavolt"
+      "Vikavolt",
+      "Vikavolt-GX"
     ],
     "attacks": [
       {
@@ -3270,7 +3288,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Golbat"
+      "Golbat",
+      "Dark Golbat"
     ],
     "attacks": [
       {
@@ -3328,7 +3347,8 @@
     ],
     "evolvesFrom": "Zubat",
     "evolvesTo": [
-      "Crobat"
+      "Crobat",
+      "Crobat ex"
     ],
     "attacks": [
       {
@@ -3391,6 +3411,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Golbat",
+    "evolvesTo": [
+      "Crobat BREAK"
+    ],
     "attacks": [
       {
         "name": "Triple Poison",
@@ -3453,7 +3476,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Muk"
+      "Alolan Muk",
+      "Alolan Muk-GX"
     ],
     "attacks": [
       {
@@ -3579,7 +3603,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Hypno"
+      "Hypno",
+      "Dark Hypno"
     ],
     "attacks": [
       {
@@ -3777,7 +3802,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Toxapex"
+      "Toxapex",
+      "Toxapex-GX"
     ],
     "attacks": [
       {
@@ -3941,7 +3967,9 @@
     "evolvesFrom": "Cosmog",
     "evolvesTo": [
       "Solgaleo",
-      "Lunala"
+      "Lunala",
+      "Lunala-GX",
+      "Solgaleo-GX"
     ],
     "attacks": [
       {
@@ -4074,7 +4102,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Hariyama"
+      "Hariyama",
+      "Hariyama ex"
     ],
     "attacks": [
       {
@@ -4510,7 +4539,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Palossand"
+      "Palossand",
+      "Palossand-GX"
     ],
     "attacks": [
       {
@@ -4636,7 +4666,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Raticate"
+      "Alolan Raticate",
+      "Alolan Raticate-GX"
     ],
     "attacks": [
       {
@@ -4758,7 +4789,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Persian"
+      "Alolan Persian",
+      "Alolan Persian-GX"
     ],
     "attacks": [
       {
@@ -4959,7 +4991,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Sharpedo"
+      "Sharpedo",
+      "Sharpedo ex"
     ],
     "attacks": [
       {
@@ -5296,7 +5329,7 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Dugtrio"
+      "Alolan Dugtrio"
     ],
     "attacks": [
       {
@@ -5814,7 +5847,9 @@
       "Dragon"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "attacks": [
       {
@@ -5876,7 +5911,9 @@
     ],
     "evolvesFrom": "Dratini",
     "evolvesTo": [
-      "Dragonite"
+      "Dragonite",
+      "Dragonite ex",
+      "Dragonite-GX"
     ],
     "attacks": [
       {
@@ -6269,7 +6306,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "abilities": [
       {
@@ -6335,7 +6392,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "abilities": [
       {
@@ -6812,7 +6889,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Gumshoos"
+      "Gumshoos",
+      "Gumshoos-GX"
     ],
     "attacks": [
       {
@@ -6944,7 +7022,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Bewear"
+      "Bewear",
+      "Bewear-GX"
     ],
     "attacks": [
       {

--- a/cards/en/sm10.json
+++ b/cards/en/sm10.json
@@ -268,7 +268,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Gloom"
+      "Gloom",
+      "Dark Gloom"
     ],
     "attacks": [
       {
@@ -329,7 +330,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Gloom"
+      "Gloom",
+      "Dark Gloom"
     ],
     "attacks": [
       {
@@ -382,7 +384,9 @@
     "evolvesFrom": "Oddish",
     "evolvesTo": [
       "Vileplume",
-      "Bellossom"
+      "Bellossom",
+      "Vileplume ex",
+      "Vileplume-GX"
     ],
     "abilities": [
       {
@@ -502,7 +506,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Venomoth"
+      "Venomoth",
+      "Light Venomoth",
+      "Venomoth-GX"
     ],
     "attacks": [
       {
@@ -563,7 +569,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Venomoth"
+      "Venomoth",
+      "Light Venomoth",
+      "Venomoth-GX"
     ],
     "attacks": [
       {
@@ -968,6 +976,9 @@
       "Grass"
     ],
     "evolvesFrom": "Tangela",
+    "evolvesTo": [
+      "Tangrowth LV.X"
+    ],
     "attacks": [
       {
         "name": "Bind Down",
@@ -1228,7 +1239,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -1290,6 +1303,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "attacks": [
       {
         "name": "Grand Flame",
@@ -1652,7 +1668,8 @@
     ],
     "evolvesFrom": "Litten",
     "evolvesTo": [
-      "Incineroar"
+      "Incineroar",
+      "Incineroar-GX"
     ],
     "attacks": [
       {
@@ -1761,7 +1778,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Salazzle"
+      "Salazzle",
+      "Salazzle-GX"
     ],
     "attacks": [
       {
@@ -1930,7 +1948,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wartortle"
+      "Wartortle",
+      "Dark Wartortle"
     ],
     "attacks": [
       {
@@ -1982,7 +2001,9 @@
     ],
     "evolvesFrom": "Squirtle",
     "evolvesTo": [
-      "Blastoise"
+      "Blastoise",
+      "Blastoise ex",
+      "Blastoise-GX"
     ],
     "abilities": [
       {
@@ -2224,7 +2245,8 @@
     "evolvesFrom": "Poliwag",
     "evolvesTo": [
       "Poliwrath",
-      "Politoed"
+      "Politoed",
+      "Politoed ex"
     ],
     "attacks": [
       {
@@ -2461,7 +2483,11 @@
     ],
     "evolvesTo": [
       "Slowbro",
-      "Slowking"
+      "Slowking",
+      "Dark Slowbro",
+      "Dark Slowking",
+      "Light Slowbro",
+      "Slowking ex"
     ],
     "attacks": [
       {
@@ -2584,7 +2610,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Dewgong"
+      "Dewgong",
+      "Light Dewgong"
     ],
     "attacks": [
       {
@@ -3038,7 +3065,9 @@
     ],
     "evolvesFrom": "Froakie",
     "evolvesTo": [
-      "Greninja"
+      "Greninja",
+      "Greninja-GX",
+      "Greninja ex"
     ],
     "attacks": [
       {
@@ -3148,7 +3177,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -3206,6 +3239,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Never Give Up",
@@ -3415,7 +3452,8 @@
     ],
     "evolvesFrom": "Grubbin",
     "evolvesTo": [
-      "Vikavolt"
+      "Vikavolt",
+      "Vikavolt-GX"
     ],
     "abilities": [
       {
@@ -3692,7 +3730,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Arbok"
+      "Arbok",
+      "Dark Arbok",
+      "Arbok ex"
     ],
     "attacks": [
       {
@@ -3814,7 +3854,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Golbat"
+      "Golbat",
+      "Dark Golbat"
     ],
     "attacks": [
       {
@@ -3882,7 +3923,8 @@
     ],
     "evolvesFrom": "Zubat",
     "evolvesTo": [
-      "Crobat"
+      "Crobat",
+      "Crobat ex"
     ],
     "attacks": [
       {
@@ -3950,6 +3992,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Golbat",
+    "evolvesTo": [
+      "Crobat BREAK"
+    ],
     "abilities": [
       {
         "name": "Sound Veil",
@@ -4010,7 +4055,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Haunter",
+      "Dark Haunter"
     ],
     "abilities": [
       {
@@ -4075,7 +4121,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Haunter",
+      "Dark Haunter"
     ],
     "attacks": [
       {
@@ -4133,7 +4180,8 @@
     ],
     "evolvesFrom": "Gastly",
     "evolvesTo": [
-      "Gengar"
+      "Gengar",
+      "Gengar ex"
     ],
     "attacks": [
       {
@@ -4190,6 +4238,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Haunter",
+    "evolvesTo": [
+      "Gengar LV.X"
+    ],
     "abilities": [
       {
         "name": "Shadow Pain",
@@ -4250,7 +4301,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Hypno"
+      "Hypno",
+      "Dark Hypno"
     ],
     "attacks": [
       {
@@ -4372,7 +4424,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Weezing"
+      "Weezing",
+      "Dark Weezing",
+      "Galarian Weezing"
     ],
     "attacks": [
       {
@@ -4481,6 +4535,9 @@
     "hp": "120",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Mewtwo LV.X"
     ],
     "abilities": [
       {
@@ -4978,7 +5035,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Sandslash"
+      "Sandslash",
+      "Dark Sandslash"
     ],
     "attacks": [
       {
@@ -5100,7 +5158,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Dugtrio"
+      "Dugtrio",
+      "Dark Dugtrio"
     ],
     "abilities": [
       {
@@ -5271,7 +5330,8 @@
     ],
     "evolvesFrom": "Geodude",
     "evolvesTo": [
-      "Golem"
+      "Golem",
+      "Golem ex"
     ],
     "attacks": [
       {
@@ -5405,7 +5465,10 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Marowak"
+      "Marowak",
+      "Dark Marowak",
+      "Alolan Marowak-GX",
+      "Alolan Marowak"
     ],
     "attacks": [
       {
@@ -5465,6 +5528,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Cubone",
+    "evolvesTo": [
+      "Marowak BREAK"
+    ],
     "attacks": [
       {
         "name": "Bone Rush",
@@ -5713,6 +5779,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Rhydon",
+    "evolvesTo": [
+      "Rhyperior LV.X"
+    ],
     "attacks": [
       {
         "name": "Hefty Cannon",
@@ -5953,6 +6022,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Gligar",
+    "evolvesTo": [
+      "Gliscor LV.X"
+    ],
     "attacks": [
       {
         "name": "Collect",
@@ -6011,11 +6083,6 @@
     "hp": "60",
     "types": [
       "Fighting"
-    ],
-    "evolvesTo": [
-      "Hitmonlee",
-      "Hitmonchan",
-      "Hitmontop"
     ],
     "abilities": [
       {
@@ -6110,7 +6177,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lucario"
+      "Lucario",
+      "Lucario-GX",
+      "Lucario ex"
     ],
     "attacks": [
       {
@@ -6479,7 +6548,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Honchkrow"
+      "Honchkrow",
+      "Honchkrow-GX"
     ],
     "attacks": [
       {
@@ -6614,7 +6684,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Sharpedo"
+      "Sharpedo",
+      "Sharpedo ex"
     ],
     "attacks": [
       {
@@ -7050,6 +7121,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Frogadier",
+    "evolvesTo": [
+      "Greninja BREAK"
+    ],
     "attacks": [
       {
         "name": "Bring Down",
@@ -7318,7 +7392,7 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Dugtrio"
+      "Alolan Dugtrio"
     ],
     "attacks": [
       {
@@ -7506,7 +7580,8 @@
     ],
     "evolvesFrom": "Aron",
     "evolvesTo": [
-      "Aggron"
+      "Aggron",
+      "Aggron ex"
     ],
     "attacks": [
       {
@@ -7648,6 +7723,9 @@
       "Metal"
     ],
     "evolvesFrom": "Riolu",
+    "evolvesTo": [
+      "Lucario LV.X"
+    ],
     "attacks": [
       {
         "name": "Low Sweep",
@@ -7778,7 +7856,9 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Melmetal"
+      "Melmetal",
+      "Melmetal-GX",
+      "Melmetal ex"
     ],
     "attacks": [
       {
@@ -7984,9 +8064,6 @@
     "types": [
       "Fairy"
     ],
-    "evolvesTo": [
-      "Clefairy"
-    ],
     "abilities": [
       {
         "name": "Excitable Draw",
@@ -8022,7 +8099,8 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Clefable",
+      "Clefable ex"
     ],
     "attacks": [
       {
@@ -8134,7 +8212,11 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Wigglytuff"
+      "Wigglytuff",
+      "Dark Wigglytuff",
+      "Light Wigglytuff",
+      "Wigglytuff ex",
+      "Wigglytuff-GX"
     ],
     "attacks": [
       {
@@ -8259,7 +8341,8 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Togetic"
+      "Togetic",
+      "Light Togetic"
     ],
     "attacks": [
       {
@@ -8447,7 +8530,8 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Whimsicott"
+      "Whimsicott",
+      "Whimsicott-GX"
     ],
     "attacks": [
       {
@@ -8709,7 +8793,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Raticate"
+      "Raticate",
+      "Dark Raticate"
     ],
     "attacks": [
       {
@@ -8760,6 +8845,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Rattata",
+    "evolvesTo": [
+      "Raticate BREAK"
+    ],
     "attacks": [
       {
         "name": "Escaping Incisors",
@@ -8933,7 +9021,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -9367,7 +9457,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Porygon2"
+      "Porygon2",
+      "Dark Porygon2"
     ],
     "attacks": [
       {
@@ -9427,7 +9518,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Porygon2"
+      "Porygon2",
+      "Dark Porygon2"
     ],
     "attacks": [
       {
@@ -9489,7 +9581,8 @@
     ],
     "evolvesFrom": "Porygon",
     "evolvesTo": [
-      "Porygon-Z"
+      "Porygon-Z",
+      "Porygon-Z-GX"
     ],
     "attacks": [
       {
@@ -9551,6 +9644,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Porygon2",
+    "evolvesTo": [
+      "Porygon-Z LV.X"
+    ],
     "abilities": [
       {
         "name": "Crazy Code",
@@ -9608,6 +9704,9 @@
     "hp": "150",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Snorlax LV.X"
     ],
     "abilities": [
       {
@@ -9793,9 +9892,6 @@
     "hp": "60",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Chansey"
     ],
     "abilities": [
       {

--- a/cards/en/sm11.json
+++ b/cards/en/sm11.json
@@ -12,9 +12,6 @@
     "types": [
       "Grass"
     ],
-    "evolvesTo": [
-      "Dartrix"
-    ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -152,6 +149,9 @@
       "Grass"
     ],
     "evolvesFrom": "Yanma",
+    "evolvesTo": [
+      "Yanmega BREAK"
+    ],
     "attacks": [
       {
         "name": "Tackle",
@@ -829,7 +829,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Lurantis"
+      "Lurantis",
+      "Lurantis-GX"
     ],
     "attacks": [
       {
@@ -1009,7 +1010,9 @@
     ],
     "evolvesFrom": "Bounsweet",
     "evolvesTo": [
-      "Tsareena"
+      "Tsareena",
+      "Tsareena-GX",
+      "Tsareena ex"
     ],
     "attacks": [
       {
@@ -1242,6 +1245,9 @@
       "Fire"
     ],
     "evolvesFrom": "Magmar",
+    "evolvesTo": [
+      "Magmortar LV.X"
+    ],
     "attacks": [
       {
         "name": "Smoke Bomb",
@@ -1305,7 +1311,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Camerupt"
+      "Camerupt",
+      "Camerupt ex"
     ],
     "attacks": [
       {
@@ -1820,6 +1827,9 @@
       "Fire"
     ],
     "evolvesFrom": "Fletchinder",
+    "evolvesTo": [
+      "Talonflame BREAK"
+    ],
     "attacks": [
       {
         "name": "Heat Wave",
@@ -1875,7 +1885,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Salazzle"
+      "Salazzle",
+      "Salazzle-GX"
     ],
     "attacks": [
       {
@@ -1976,10 +1987,6 @@
     "hp": "250",
     "types": [
       "Water"
-    ],
-    "evolvesTo": [
-      "Slowbro",
-      "Slowking"
     ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
@@ -2103,7 +2110,8 @@
     ],
     "evolvesTo": [
       "Glalie",
-      "Froslass"
+      "Froslass",
+      "Froslass ex"
     ],
     "attacks": [
       {
@@ -2487,7 +2495,8 @@
     ],
     "evolvesFrom": "Unidentified Fossil",
     "evolvesTo": [
-      "Carracosta"
+      "Carracosta",
+      "Carracosta-GX"
     ],
     "attacks": [
       {
@@ -2852,7 +2861,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golisopod"
+      "Golisopod",
+      "Golisopod-GX",
+      "Golisopod ex"
     ],
     "attacks": [
       {
@@ -3154,7 +3165,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -3221,7 +3236,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -3355,7 +3374,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -3413,7 +3433,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "attacks": [
       {
@@ -3482,6 +3503,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Magneton",
+    "evolvesTo": [
+      "Magnezone LV.X"
+    ],
     "abilities": [
       {
         "name": "Double Type",
@@ -4281,7 +4305,10 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Exeggutor"
+      "Exeggutor",
+      "Dark Exeggutor",
+      "Alolan Exeggutor-GX",
+      "Alolan Exeggutor"
     ],
     "attacks": [
       {
@@ -4514,9 +4541,6 @@
     "hp": "60",
     "types": [
       "Psychic"
-    ],
-    "evolvesTo": [
-      "Wobbuffet"
     ],
     "abilities": [
       {
@@ -4940,6 +4964,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Uxie LV.X"
+    ],
     "abilities": [
       {
         "name": "Secret Territory",
@@ -4996,6 +5023,9 @@
     "hp": "60",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Mesprit LV.X"
     ],
     "attacks": [
       {
@@ -5054,6 +5084,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Azelf LV.X"
+    ],
     "attacks": [
       {
         "name": "Psypower",
@@ -5101,6 +5134,9 @@
     "hp": "130",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Giratina LV.X"
     ],
     "abilities": [
       {
@@ -5164,6 +5200,9 @@
     "hp": "130",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Cresselia LV.X"
     ],
     "attacks": [
       {
@@ -5390,6 +5429,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Elgyem",
+    "evolvesTo": [
+      "Beheeyem BREAK"
+    ],
     "attacks": [
       {
         "name": "Psypunch",
@@ -5576,7 +5618,8 @@
     ],
     "evolvesFrom": "Honedge",
     "evolvesTo": [
-      "Aegislash"
+      "Aegislash",
+      "Aegislash ex"
     ],
     "attacks": [
       {
@@ -5699,7 +5742,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Toxapex"
+      "Toxapex",
+      "Toxapex-GX"
     ],
     "attacks": [
       {
@@ -5802,7 +5846,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Salazzle"
+      "Salazzle",
+      "Salazzle-GX"
     ],
     "attacks": [
       {
@@ -6032,7 +6077,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Naganadel"
+      "Naganadel",
+      "Naganadel-GX"
     ],
     "attacks": [
       {
@@ -6094,7 +6140,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Steelix"
+      "Steelix",
+      "Dark Steelix",
+      "Steelix ex"
     ],
     "attacks": [
       {
@@ -6213,7 +6261,10 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Marowak"
+      "Marowak",
+      "Dark Marowak",
+      "Alolan Marowak-GX",
+      "Alolan Marowak"
     ],
     "attacks": [
       {
@@ -6458,7 +6509,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Medicham"
+      "Medicham",
+      "Medicham ex"
     ],
     "attacks": [
       {
@@ -6688,7 +6740,8 @@
     ],
     "evolvesFrom": "Gible",
     "evolvesTo": [
-      "Garchomp"
+      "Garchomp",
+      "Garchomp ex"
     ],
     "attacks": [
       {
@@ -6749,6 +6802,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Gabite",
+    "evolvesTo": [
+      "Garchomp LV.X"
+    ],
     "abilities": [
       {
         "name": "Avenging Aura",
@@ -6802,7 +6858,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lucario"
+      "Lucario",
+      "Lucario-GX",
+      "Lucario ex"
     ],
     "attacks": [
       {
@@ -6853,7 +6911,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lucario"
+      "Lucario",
+      "Lucario-GX",
+      "Lucario ex"
     ],
     "attacks": [
       {
@@ -6904,6 +6964,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Riolu",
+    "evolvesTo": [
+      "Lucario LV.X"
+    ],
     "abilities": [
       {
         "name": "Tag Coach",
@@ -7526,7 +7589,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Muk"
+      "Alolan Muk",
+      "Alolan Muk-GX"
     ],
     "attacks": [
       {
@@ -7595,7 +7659,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Honchkrow"
+      "Honchkrow",
+      "Honchkrow-GX"
     ],
     "attacks": [
       {
@@ -7652,7 +7717,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Honchkrow"
+      "Honchkrow",
+      "Honchkrow-GX"
     ],
     "attacks": [
       {
@@ -7709,6 +7775,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Murkrow",
+    "evolvesTo": [
+      "Honchkrow LV.X"
+    ],
     "attacks": [
       {
         "name": "Sharpshooting",
@@ -7773,7 +7842,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Weavile"
+      "Weavile",
+      "Weavile-GX"
     ],
     "attacks": [
       {
@@ -7949,6 +8019,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Skorupi",
+    "evolvesTo": [
+      "Drapion LV.X"
+    ],
     "attacks": [
       {
         "name": "Cross Poison",
@@ -8280,6 +8353,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Yveltal BREAK"
+    ],
     "attacks": [
       {
         "name": "Blow Through",
@@ -8556,7 +8632,8 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Whimsicott"
+      "Whimsicott",
+      "Whimsicott-GX"
     ],
     "attacks": [
       {
@@ -8802,7 +8879,9 @@
       "Dragon"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "attacks": [
       {
@@ -8854,7 +8933,9 @@
       "Dragon"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "abilities": [
       {
@@ -8915,7 +8996,9 @@
     ],
     "evolvesFrom": "Dratini",
     "evolvesTo": [
-      "Dragonite"
+      "Dragonite",
+      "Dragonite ex",
+      "Dragonite-GX"
     ],
     "attacks": [
       {
@@ -8969,7 +9052,9 @@
     ],
     "evolvesFrom": "Dratini",
     "evolvesTo": [
-      "Dragonite"
+      "Dragonite",
+      "Dragonite ex",
+      "Dragonite-GX"
     ],
     "attacks": [
       {
@@ -9473,7 +9558,9 @@
       "Dragon"
     ],
     "evolvesTo": [
-      "Noivern"
+      "Noivern",
+      "Noivern-GX",
+      "Noivern ex"
     ],
     "attacks": [
       {
@@ -9525,6 +9612,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Noibat",
+    "evolvesTo": [
+      "Noivern BREAK"
+    ],
     "attacks": [
       {
         "name": "Boomburst",
@@ -9958,6 +10048,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Hoothoot",
+    "evolvesTo": [
+      "Noctowl BREAK"
+    ],
     "attacks": [
       {
         "name": "Blindside",
@@ -10397,9 +10490,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesTo": [
-      "Snorlax"
-    ],
     "abilities": [
       {
         "name": "Snack Search",
@@ -10814,7 +10904,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Gumshoos"
+      "Gumshoos",
+      "Gumshoos-GX"
     ],
     "attacks": [
       {
@@ -10975,6 +11066,10 @@
     "hp": "100",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Silvally",
+      "Silvally-GX"
     ],
     "attacks": [
       {
@@ -11781,6 +11876,20 @@
       "Item"
     ],
     "hp": "60",
+    "evolvesTo": [
+      "Cranidos",
+      "Shieldon",
+      "Amaura",
+      "Tyrunt",
+      "Omanyte",
+      "Kabuto",
+      "Aerodactyl",
+      "Tirtouga",
+      "Aerodactyl-GX",
+      "Archen",
+      "Lileep",
+      "Anorith"
+    ],
     "rules": [
       "Play this card as if it were a 60-HP Colorless Basic Pokémon. At any time during your turn (before your attack), you may discard this card from play.",
       "This card can't retreat.",
@@ -11881,9 +11990,6 @@
     "types": [
       "Grass"
     ],
-    "evolvesTo": [
-      "Dartrix"
-    ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -11960,9 +12066,6 @@
     "hp": "270",
     "types": [
       "Grass"
-    ],
-    "evolvesTo": [
-      "Dartrix"
     ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
@@ -12112,10 +12215,6 @@
     "types": [
       "Water"
     ],
-    "evolvesTo": [
-      "Slowbro",
-      "Slowking"
-    ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -12180,10 +12279,6 @@
     "hp": "250",
     "types": [
       "Water"
-    ],
-    "evolvesTo": [
-      "Slowbro",
-      "Slowking"
     ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
@@ -13257,9 +13352,6 @@
     "types": [
       "Grass"
     ],
-    "evolvesTo": [
-      "Dartrix"
-    ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -13407,10 +13499,6 @@
     "hp": "250",
     "types": [
       "Water"
-    ],
-    "evolvesTo": [
-      "Slowbro",
-      "Slowking"
     ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."

--- a/cards/en/sm115.json
+++ b/cards/en/sm115.json
@@ -227,7 +227,11 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor",
+      "Scizor ex",
+      "Dark Scizor",
+      "Scizor-GX",
+      "Kleavor"
     ],
     "attacks": [
       {
@@ -353,7 +357,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -415,7 +420,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "attacks": [
       {
@@ -600,7 +608,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Golduck",
+      "Dark Golduck",
+      "Light Golduck"
     ],
     "attacks": [
       {
@@ -652,7 +662,11 @@
     ],
     "evolvesTo": [
       "Slowbro",
-      "Slowking"
+      "Slowking",
+      "Dark Slowbro",
+      "Dark Slowking",
+      "Light Slowbro",
+      "Slowking ex"
     ],
     "attacks": [
       {
@@ -704,7 +718,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Starmie"
+      "Starmie",
+      "Starmie-GX"
     ],
     "attacks": [
       {
@@ -823,7 +838,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -1057,7 +1075,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -1196,7 +1218,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {
@@ -1445,7 +1470,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Arbok"
+      "Arbok",
+      "Dark Arbok",
+      "Arbok ex"
     ],
     "attacks": [
       {
@@ -1496,7 +1523,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Arbok"
+      "Arbok",
+      "Dark Arbok",
+      "Arbok ex"
     ],
     "attacks": [
       {
@@ -1607,7 +1636,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Weezing"
+      "Weezing",
+      "Dark Weezing",
+      "Galarian Weezing"
     ],
     "attacks": [
       {
@@ -1941,7 +1972,8 @@
     ],
     "evolvesFrom": "Geodude",
     "evolvesTo": [
-      "Golem"
+      "Golem",
+      "Golem ex"
     ],
     "attacks": [
       {
@@ -2073,9 +2105,6 @@
     "types": [
       "Fighting"
     ],
-    "evolvesTo": [
-      "Steelix"
-    ],
     "rules": [
       "Pokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -2156,7 +2185,10 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Marowak"
+      "Marowak",
+      "Dark Marowak",
+      "Alolan Marowak-GX",
+      "Alolan Marowak"
     ],
     "attacks": [
       {
@@ -2209,7 +2241,8 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Clefable",
+      "Clefable ex"
     ],
     "attacks": [
       {
@@ -2275,7 +2308,8 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Clefable",
+      "Clefable ex"
     ],
     "attacks": [
       {
@@ -2410,7 +2444,11 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Wigglytuff"
+      "Wigglytuff",
+      "Dark Wigglytuff",
+      "Light Wigglytuff",
+      "Wigglytuff ex",
+      "Wigglytuff-GX"
     ],
     "attacks": [
       {
@@ -2686,9 +2724,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesTo": [
-      "Sirfetch'd"
-    ],
     "attacks": [
       {
         "name": "Leek Slap",
@@ -2745,7 +2780,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Blissey"
+      "Blissey",
+      "Blissey ex"
     ],
     "attacks": [
       {
@@ -2856,7 +2892,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -2924,7 +2980,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -2973,6 +3049,9 @@
     "hp": "150",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Snorlax LV.X"
     ],
     "attacks": [
       {

--- a/cards/en/sm12.json
+++ b/cards/en/sm12.json
@@ -12,9 +12,6 @@
     "types": [
       "Grass"
     ],
-    "evolvesTo": [
-      "Servine"
-    ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -90,7 +87,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Gloom"
+      "Gloom",
+      "Dark Gloom"
     ],
     "attacks": [
       {
@@ -143,7 +141,9 @@
     "evolvesFrom": "Oddish",
     "evolvesTo": [
       "Vileplume",
-      "Bellossom"
+      "Bellossom",
+      "Vileplume ex",
+      "Vileplume-GX"
     ],
     "attacks": [
       {
@@ -317,6 +317,9 @@
       "Grass"
     ],
     "evolvesFrom": "Tangela",
+    "evolvesTo": [
+      "Tangrowth LV.X"
+    ],
     "attacks": [
       {
         "name": "Grass Knot",
@@ -379,7 +382,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Sunflora"
+      "Sunflora",
+      "Light Sunflora"
     ],
     "attacks": [
       {
@@ -553,7 +557,8 @@
     ],
     "evolvesFrom": "Unidentified Fossil",
     "evolvesTo": [
-      "Cradily"
+      "Cradily",
+      "Cradily ex"
     ],
     "attacks": [
       {
@@ -1067,7 +1072,10 @@
     ],
     "evolvesFrom": "Rowlet",
     "evolvesTo": [
-      "Decidueye"
+      "Decidueye",
+      "Decidueye-GX",
+      "Hisuian Decidueye",
+      "Decidueye ex"
     ],
     "attacks": [
       {
@@ -1246,9 +1254,6 @@
     "types": [
       "Fire"
     ],
-    "evolvesTo": [
-      "Delphox"
-    ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -1315,7 +1320,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Rapidash"
+      "Rapidash",
+      "Dark Rapidash"
     ],
     "attacks": [
       {
@@ -1489,7 +1495,10 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Magcargo"
+      "Magcargo",
+      "Dark Magcargo",
+      "Magcargo ex",
+      "Magcargo-GX"
     ],
     "attacks": [
       {
@@ -1972,7 +1981,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Volcarona"
+      "Volcarona",
+      "Volcarona-GX"
     ],
     "attacks": [
       {
@@ -2170,6 +2180,9 @@
       "Fire"
     ],
     "evolvesFrom": "Litleo",
+    "evolvesTo": [
+      "Pyroar BREAK"
+    ],
     "attacks": [
       {
         "name": "Swirling Inferno",
@@ -2234,9 +2247,6 @@
     "hp": "270",
     "types": [
       "Water"
-    ],
-    "evolvesTo": [
-      "Prinplup"
     ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
@@ -2305,7 +2315,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Alolan Ninetales",
+      "Alolan Ninetales-GX"
     ],
     "abilities": [
       {
@@ -2363,7 +2374,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Golduck",
+      "Dark Golduck",
+      "Light Golduck"
     ],
     "attacks": [
       {
@@ -2424,6 +2437,9 @@
       "Water"
     ],
     "evolvesFrom": "Psyduck",
+    "evolvesTo": [
+      "Golduck BREAK"
+    ],
     "attacks": [
       {
         "name": "Scratch",
@@ -2542,7 +2558,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Weavile"
+      "Weavile",
+      "Weavile-GX"
     ],
     "attacks": [
       {
@@ -2649,7 +2666,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wailord"
+      "Wailord",
+      "Wailord ex"
     ],
     "attacks": [
       {
@@ -2770,7 +2788,8 @@
     ],
     "evolvesTo": [
       "Glalie",
-      "Froslass"
+      "Froslass",
+      "Froslass ex"
     ],
     "attacks": [
       {
@@ -2822,9 +2841,6 @@
       "Water"
     ],
     "evolvesFrom": "Snorunt",
-    "evolvesTo": [
-      "Froslass"
-    ],
     "attacks": [
       {
         "name": "Ice Fang",
@@ -3004,7 +3020,8 @@
     ],
     "evolvesFrom": "Spheal",
     "evolvesTo": [
-      "Walrein"
+      "Walrein",
+      "Walrein ex"
     ],
     "attacks": [
       {
@@ -3312,6 +3329,10 @@
       "Water"
     ],
     "evolvesFrom": "Prinplup",
+    "evolvesTo": [
+      "Empoleon LV.X",
+      "Empoleon BREAK"
+    ],
     "attacks": [
       {
         "name": "Recall",
@@ -3909,7 +3930,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -3977,6 +4002,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Nuzzle",
@@ -4042,7 +4071,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -4100,7 +4130,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "abilities": [
       {
@@ -4230,7 +4261,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Lanturn"
+      "Lanturn",
+      "Light Lanturn"
     ],
     "attacks": [
       {
@@ -4546,7 +4578,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Weezing"
+      "Weezing",
+      "Dark Weezing",
+      "Galarian Weezing"
     ],
     "abilities": [
       {
@@ -4848,7 +4882,9 @@
     "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
-      "Gallade"
+      "Gallade",
+      "Gardevoir ex",
+      "Gardevoir-GX"
     ],
     "attacks": [
       {
@@ -4967,7 +5003,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Dusclops"
+      "Dusclops",
+      "Dusclops ex"
     ],
     "abilities": [
       {
@@ -5091,6 +5128,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Dusclops",
+    "evolvesTo": [
+      "Dusknoir LV.X"
+    ],
     "abilities": [
       {
         "name": "Grim Marking",
@@ -5652,6 +5692,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Phantump",
+    "evolvesTo": [
+      "Trevenant BREAK"
+    ],
     "attacks": [
       {
         "name": "Perplexing Forest",
@@ -6075,7 +6118,9 @@
     "evolvesFrom": "Cosmog",
     "evolvesTo": [
       "Solgaleo",
-      "Lunala"
+      "Lunala",
+      "Lunala-GX",
+      "Solgaleo-GX"
     ],
     "attacks": [
       {
@@ -6306,7 +6351,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Steelix"
+      "Steelix",
+      "Dark Steelix",
+      "Steelix ex"
     ],
     "attacks": [
       {
@@ -6549,7 +6596,9 @@
     ],
     "evolvesFrom": "Trapinch",
     "evolvesTo": [
-      "Flygon"
+      "Flygon",
+      "Flygon ex",
+      "Flygon-GX"
     ],
     "abilities": [
       {
@@ -6682,7 +6731,8 @@
     ],
     "evolvesFrom": "Unidentified Fossil",
     "evolvesTo": [
-      "Armaldo"
+      "Armaldo",
+      "Armaldo ex"
     ],
     "attacks": [
       {
@@ -7390,7 +7440,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lycanroc"
+      "Lycanroc",
+      "Lycanroc-GX",
+      "Lycanroc ex"
     ],
     "attacks": [
       {
@@ -7570,7 +7622,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Palossand"
+      "Palossand",
+      "Palossand-GX"
     ],
     "attacks": [
       {
@@ -7698,7 +7751,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Persian"
+      "Alolan Persian",
+      "Alolan Persian-GX"
     ],
     "attacks": [
       {
@@ -7844,7 +7898,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Muk"
+      "Alolan Muk",
+      "Alolan Muk-GX"
     ],
     "attacks": [
       {
@@ -7982,7 +8037,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Sharpedo"
+      "Sharpedo",
+      "Sharpedo ex"
     ],
     "attacks": [
       {
@@ -8170,6 +8226,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Pawniard",
+    "evolvesTo": [
+      "Kingambit"
+    ],
     "attacks": [
       {
         "name": "Corner",
@@ -8305,7 +8364,8 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Sandslash"
+      "Alolan Sandslash",
+      "Alolan Sandslash-GX"
     ],
     "attacks": [
       {
@@ -8711,9 +8771,6 @@
     "types": [
       "Fairy"
     ],
-    "evolvesTo": [
-      "Togetic"
-    ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -8787,9 +8844,6 @@
     "types": [
       "Fairy"
     ],
-    "evolvesTo": [
-      "Togetic"
-    ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -8862,7 +8916,8 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Clefable",
+      "Clefable ex"
     ],
     "attacks": [
       {
@@ -8975,9 +9030,6 @@
     "types": [
       "Fairy"
     ],
-    "evolvesTo": [
-      "Marill"
-    ],
     "abilities": [
       {
         "name": "Growing Up",
@@ -9013,7 +9065,8 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Whimsicott"
+      "Whimsicott",
+      "Whimsicott-GX"
     ],
     "attacks": [
       {
@@ -9312,6 +9365,9 @@
       "Fairy"
     ],
     "evolvesFrom": "Floette",
+    "evolvesTo": [
+      "Florges BREAK"
+    ],
     "abilities": [
       {
         "name": "Flower Picking",
@@ -9949,7 +10005,8 @@
     ],
     "evolvesFrom": "Jangmo-o",
     "evolvesTo": [
-      "Kommo-o"
+      "Kommo-o",
+      "Kommo-o-GX"
     ],
     "abilities": [
       {
@@ -10128,9 +10185,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesTo": [
-      "Wigglytuff"
-    ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -10201,7 +10255,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -10269,7 +10343,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -10327,9 +10421,6 @@
     "hp": "60",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Jigglypuff"
     ],
     "abilities": [
       {
@@ -10484,7 +10575,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Ursaring"
+      "Ursaring",
+      "Dark Ursaring"
     ],
     "attacks": [
       {
@@ -10545,6 +10637,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Teddiursa",
+    "evolvesTo": [
+      "Ursaluna"
+    ],
     "attacks": [
       {
         "name": "Hammer In",
@@ -10853,7 +10948,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Braviary"
+      "Braviary",
+      "Hisuian Braviary"
     ],
     "attacks": [
       {
@@ -11099,7 +11195,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Bewear"
+      "Bewear",
+      "Bewear-GX"
     ],
     "attacks": [
       {
@@ -11209,6 +11306,10 @@
     "hp": "110",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Silvally",
+      "Silvally-GX"
     ],
     "attacks": [
       {
@@ -11867,6 +11968,20 @@
       "Item"
     ],
     "hp": "60",
+    "evolvesTo": [
+      "Cranidos",
+      "Shieldon",
+      "Amaura",
+      "Tyrunt",
+      "Omanyte",
+      "Kabuto",
+      "Aerodactyl",
+      "Tirtouga",
+      "Aerodactyl-GX",
+      "Archen",
+      "Lileep",
+      "Anorith"
+    ],
     "rules": [
       "Play this card as if it were a 60-HP Colorless Basic Pokémon. At any time during your turn (before your attack), you may discard this card from play.",
       "This card can't retreat.",
@@ -11942,9 +12057,6 @@
     "hp": "270",
     "types": [
       "Grass"
-    ],
-    "evolvesTo": [
-      "Servine"
     ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
@@ -12092,9 +12204,6 @@
     "types": [
       "Fire"
     ],
-    "evolvesTo": [
-      "Delphox"
-    ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -12234,9 +12343,6 @@
     "types": [
       "Water"
     ],
-    "evolvesTo": [
-      "Prinplup"
-    ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -12304,9 +12410,6 @@
     "hp": "270",
     "types": [
       "Water"
-    ],
-    "evolvesTo": [
-      "Prinplup"
     ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
@@ -13023,9 +13126,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesTo": [
-      "Wigglytuff"
-    ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -13089,9 +13189,6 @@
     "hp": "240",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Wigglytuff"
     ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
@@ -13672,7 +13769,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -13740,7 +13841,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -13797,7 +13899,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Weezing"
+      "Weezing",
+      "Dark Weezing",
+      "Galarian Weezing"
     ],
     "abilities": [
       {
@@ -14158,9 +14262,6 @@
     "types": [
       "Grass"
     ],
-    "evolvesTo": [
-      "Servine"
-    ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -14307,9 +14408,6 @@
     "types": [
       "Fire"
     ],
-    "evolvesTo": [
-      "Delphox"
-    ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -14448,9 +14546,6 @@
     "hp": "270",
     "types": [
       "Water"
-    ],
-    "evolvesTo": [
-      "Prinplup"
     ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
@@ -15025,9 +15120,6 @@
     "hp": "240",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Wigglytuff"
     ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."

--- a/cards/en/sm2.json
+++ b/cards/en/sm2.json
@@ -178,7 +178,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Lilligant"
+      "Lilligant",
+      "Hisuian Lilligant"
     ],
     "attacks": [
       {
@@ -350,6 +351,9 @@
       "Grass"
     ],
     "evolvesFrom": "Phantump",
+    "evolvesTo": [
+      "Trevenant BREAK"
+    ],
     "attacks": [
       {
         "name": "Poltergeist",
@@ -412,7 +416,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Golisopod"
+      "Golisopod",
+      "Golisopod-GX",
+      "Golisopod ex"
     ],
     "attacks": [
       {
@@ -805,7 +811,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Salazzle"
+      "Salazzle",
+      "Salazzle-GX"
     ],
     "attacks": [
       {
@@ -1060,7 +1067,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Sandslash"
+      "Alolan Sandslash",
+      "Alolan Sandslash-GX"
     ],
     "attacks": [
       {
@@ -1122,7 +1130,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Sandslash"
+      "Alolan Sandslash",
+      "Alolan Sandslash-GX"
     ],
     "attacks": [
       {
@@ -1243,7 +1252,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Alolan Ninetales",
+      "Alolan Ninetales-GX"
     ],
     "attacks": [
       {
@@ -1304,7 +1314,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Alolan Ninetales",
+      "Alolan Ninetales-GX"
     ],
     "attacks": [
       {
@@ -1669,7 +1680,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Sharpedo"
+      "Sharpedo",
+      "Sharpedo ex"
     ],
     "attacks": [
       {
@@ -1766,7 +1778,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wailord"
+      "Wailord",
+      "Wailord ex"
     ],
     "attacks": [
       {
@@ -1899,7 +1912,8 @@
     ],
     "evolvesTo": [
       "Glalie",
-      "Froslass"
+      "Froslass",
+      "Froslass ex"
     ],
     "attacks": [
       {
@@ -1961,9 +1975,6 @@
       "Water"
     ],
     "evolvesFrom": "Snorunt",
-    "evolvesTo": [
-      "Froslass"
-    ],
     "attacks": [
       {
         "name": "Crunch",
@@ -2382,7 +2393,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Toxapex"
+      "Toxapex",
+      "Toxapex-GX"
     ],
     "attacks": [
       {
@@ -2442,7 +2454,7 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Graveler"
+      "Alolan Graveler"
     ],
     "attacks": [
       {
@@ -2512,7 +2524,8 @@
     ],
     "evolvesFrom": "Alolan Geodude",
     "evolvesTo": [
-      "Golem"
+      "Alolan Golem",
+      "Alolan Golem-GX"
     ],
     "attacks": [
       {
@@ -2993,7 +3006,11 @@
     ],
     "evolvesTo": [
       "Slowbro",
-      "Slowking"
+      "Slowking",
+      "Dark Slowbro",
+      "Dark Slowking",
+      "Light Slowbro",
+      "Slowking ex"
     ],
     "attacks": [
       {
@@ -3982,7 +3999,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Machoke"
+      "Machoke",
+      "Dark Machoke",
+      "Light Machoke"
     ],
     "attacks": [
       {
@@ -4035,7 +4054,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Machoke"
+      "Machoke",
+      "Dark Machoke",
+      "Light Machoke"
     ],
     "attacks": [
       {
@@ -4089,7 +4110,8 @@
     ],
     "evolvesFrom": "Machop",
     "evolvesTo": [
-      "Machamp"
+      "Machamp",
+      "Machamp-GX"
     ],
     "abilities": [
       {
@@ -4150,6 +4172,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Machoke",
+    "evolvesTo": [
+      "Machamp LV.X",
+      "Machamp BREAK"
+    ],
     "attacks": [
       {
         "name": "Settle the Score",
@@ -4321,6 +4347,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Gligar",
+    "evolvesTo": [
+      "Gliscor LV.X"
+    ],
     "attacks": [
       {
         "name": "Finishing Stinger",
@@ -4626,7 +4655,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lycanroc"
+      "Lycanroc",
+      "Lycanroc-GX",
+      "Lycanroc ex"
     ],
     "attacks": [
       {
@@ -4943,7 +4974,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Honchkrow"
+      "Honchkrow",
+      "Honchkrow-GX"
     ],
     "attacks": [
       {
@@ -5000,6 +5032,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Murkrow",
+    "evolvesTo": [
+      "Honchkrow LV.X"
+    ],
     "attacks": [
       {
         "name": "Feint Attack",
@@ -5309,7 +5344,9 @@
     ],
     "evolvesFrom": "Beldum",
     "evolvesTo": [
-      "Metagross"
+      "Metagross",
+      "Metagross ex",
+      "Metagross-GX"
     ],
     "attacks": [
       {
@@ -5596,7 +5633,8 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Clefable",
+      "Clefable ex"
     ],
     "attacks": [
       {
@@ -5729,7 +5767,8 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Whimsicott"
+      "Whimsicott",
+      "Whimsicott-GX"
     ],
     "attacks": [
       {
@@ -6070,7 +6109,8 @@
       "Dragon"
     ],
     "evolvesTo": [
-      "Sliggoo"
+      "Sliggoo",
+      "Hisuian Sliggoo"
     ],
     "attacks": [
       {
@@ -6378,7 +6418,8 @@
     ],
     "evolvesFrom": "Jangmo-o",
     "evolvesTo": [
-      "Kommo-o"
+      "Kommo-o",
+      "Kommo-o-GX"
     ],
     "attacks": [
       {
@@ -6518,7 +6559,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Blissey"
+      "Blissey",
+      "Blissey ex"
     ],
     "attacks": [
       {
@@ -7146,6 +7188,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Fletchinder",
+    "evolvesTo": [
+      "Talonflame BREAK"
+    ],
     "attacks": [
       {
         "name": "Flame Charge",
@@ -7207,7 +7252,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Bewear"
+      "Bewear",
+      "Bewear-GX"
     ],
     "attacks": [
       {

--- a/cards/en/sm3.json
+++ b/cards/en/sm3.json
@@ -185,7 +185,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Gloom"
+      "Gloom",
+      "Dark Gloom"
     ],
     "attacks": [
       {
@@ -238,7 +239,9 @@
     "evolvesFrom": "Oddish",
     "evolvesTo": [
       "Vileplume",
-      "Bellossom"
+      "Bellossom",
+      "Vileplume ex",
+      "Vileplume-GX"
     ],
     "attacks": [
       {
@@ -412,6 +415,9 @@
       "Grass"
     ],
     "evolvesFrom": "Tangela",
+    "evolvesTo": [
+      "Tangrowth LV.X"
+    ],
     "attacks": [
       {
         "name": "Giga Drain",
@@ -476,7 +482,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ledian"
+      "Ledian",
+      "Light Ledian"
     ],
     "attacks": [
       {
@@ -866,7 +873,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Golisopod"
+      "Golisopod",
+      "Golisopod-GX",
+      "Golisopod ex"
     ],
     "abilities": [
       {
@@ -1004,7 +1013,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -1065,7 +1075,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -1127,7 +1138,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "attacks": [
       {
@@ -1660,7 +1674,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Alolan Ninetales",
+      "Alolan Ninetales-GX"
     ],
     "attacks": [
       {
@@ -1831,7 +1846,9 @@
     ],
     "evolvesFrom": "Horsea",
     "evolvesTo": [
-      "Kingdra"
+      "Kingdra",
+      "Kingdra ex",
+      "Kingdra-GX"
     ],
     "attacks": [
       {
@@ -1940,7 +1957,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -2056,7 +2076,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Azumarill"
+      "Azumarill",
+      "Light Azumarill"
     ],
     "attacks": [
       {
@@ -2476,7 +2497,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -2543,6 +2568,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "abilities": [
       {
         "name": "Evoshock",
@@ -2677,6 +2706,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Electabuzz",
+    "evolvesTo": [
+      "Electivire LV.X"
+    ],
     "attacks": [
       {
         "name": "Thunder Punch",
@@ -3059,6 +3091,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Wobbuffet BREAK"
+    ],
     "attacks": [
       {
         "name": "Shadowy Knot",
@@ -3170,7 +3205,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Dusclops"
+      "Dusclops",
+      "Dusclops ex"
     ],
     "attacks": [
       {
@@ -3308,6 +3344,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Dusclops",
+    "evolvesTo": [
+      "Dusknoir LV.X"
+    ],
     "abilities": [
       {
         "name": "Dark Invitation",
@@ -3374,7 +3413,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Toxicroak"
+      "Toxicroak",
+      "Toxicroak ex"
     ],
     "attacks": [
       {
@@ -3801,7 +3841,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Palossand"
+      "Palossand",
+      "Palossand-GX"
     ],
     "attacks": [
       {
@@ -4215,6 +4256,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Rhydon",
+    "evolvesTo": [
+      "Rhyperior LV.X"
+    ],
     "abilities": [
       {
         "name": "Toppling Wind",
@@ -4391,7 +4435,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lucario"
+      "Lucario",
+      "Lucario-GX",
+      "Lucario ex"
     ],
     "attacks": [
       {
@@ -4452,6 +4498,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Riolu",
+    "evolvesTo": [
+      "Lucario LV.X"
+    ],
     "abilities": [
       {
         "name": "Stance",
@@ -5054,7 +5103,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Raticate"
+      "Alolan Raticate",
+      "Alolan Raticate-GX"
     ],
     "attacks": [
       {
@@ -5186,7 +5236,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Muk"
+      "Alolan Muk",
+      "Alolan Muk-GX"
     ],
     "attacks": [
       {
@@ -5339,7 +5390,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Weavile"
+      "Weavile",
+      "Weavile-GX"
     ],
     "attacks": [
       {
@@ -5465,6 +5517,9 @@
     "hp": "120",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Darkrai LV.X"
     ],
     "attacks": [
       {
@@ -5882,7 +5937,9 @@
     "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
-      "Gallade"
+      "Gallade",
+      "Gardevoir ex",
+      "Gardevoir-GX"
     ],
     "attacks": [
       {
@@ -5951,7 +6008,9 @@
     "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
-      "Gallade"
+      "Gallade",
+      "Gardevoir ex",
+      "Gardevoir-GX"
     ],
     "attacks": [
       {
@@ -6533,7 +6592,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -6642,7 +6703,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Porygon2"
+      "Porygon2",
+      "Dark Porygon2"
     ],
     "attacks": [
       {
@@ -6703,7 +6765,8 @@
     ],
     "evolvesFrom": "Porygon",
     "evolvesTo": [
-      "Porygon-Z"
+      "Porygon-Z",
+      "Porygon-Z-GX"
     ],
     "attacks": [
       {
@@ -6765,6 +6828,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Porygon2",
+    "evolvesTo": [
+      "Porygon-Z LV.X"
+    ],
     "abilities": [
       {
         "name": "Initialize",
@@ -6824,6 +6890,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Porygon2",
+    "evolvesTo": [
+      "Porygon-Z LV.X"
+    ],
     "abilities": [
       {
         "name": "Initialize",
@@ -6950,6 +7019,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Hoothoot",
+    "evolvesTo": [
+      "Noctowl BREAK"
+    ],
     "attacks": [
       {
         "name": "Hypnoblast",
@@ -7077,7 +7149,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Noivern"
+      "Noivern",
+      "Noivern-GX",
+      "Noivern ex"
     ],
     "attacks": [
       {
@@ -7134,7 +7208,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Bewear"
+      "Bewear",
+      "Bewear-GX"
     ],
     "attacks": [
       {

--- a/cards/en/sm35.json
+++ b/cards/en/sm35.json
@@ -11,7 +11,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ivysaur"
+      "Ivysaur",
+      "Dark Ivysaur"
     ],
     "attacks": [
       {
@@ -65,7 +66,8 @@
     ],
     "evolvesFrom": "Bulbasaur",
     "evolvesTo": [
-      "Venusaur"
+      "Venusaur",
+      "Venusaur ex"
     ],
     "attacks": [
       {
@@ -364,6 +366,9 @@
     "hp": "70",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Shaymin LV.X"
     ],
     "attacks": [
       {
@@ -753,7 +758,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Volcarona"
+      "Volcarona",
+      "Volcarona-GX"
     ],
     "attacks": [
       {
@@ -978,7 +984,8 @@
     ],
     "evolvesFrom": "Litten",
     "evolvesTo": [
-      "Incineroar"
+      "Incineroar",
+      "Incineroar-GX"
     ],
     "attacks": [
       {
@@ -1101,7 +1108,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Croconaw"
+      "Croconaw",
+      "Dark Croconaw"
     ],
     "attacks": [
       {
@@ -1163,7 +1171,8 @@
     ],
     "evolvesFrom": "Totodile",
     "evolvesTo": [
-      "Feraligatr"
+      "Feraligatr",
+      "Feraligatr ex"
     ],
     "abilities": [
       {
@@ -1469,6 +1478,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Palkia LV.X"
+    ],
     "attacks": [
       {
         "name": "Spiral Drain",
@@ -1710,7 +1722,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -1848,7 +1864,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {
@@ -2207,7 +2226,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Arbok"
+      "Arbok",
+      "Dark Arbok",
+      "Arbok ex"
     ],
     "attacks": [
       {
@@ -3186,7 +3207,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Zoroark"
+      "Zoroark",
+      "Zoroark-GX"
     ],
     "attacks": [
       {
@@ -3328,6 +3350,9 @@
     "hp": "120",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Yveltal BREAK"
     ],
     "attacks": [
       {

--- a/cards/en/sm4.json
+++ b/cards/en/sm4.json
@@ -169,7 +169,10 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Exeggutor"
+      "Exeggutor",
+      "Dark Exeggutor",
+      "Alolan Exeggutor-GX",
+      "Alolan Exeggutor"
     ],
     "attacks": [
       {
@@ -229,7 +232,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Cacturne"
+      "Cacturne",
+      "Cacturne ex"
     ],
     "attacks": [
       {
@@ -685,7 +689,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Camerupt"
+      "Camerupt",
+      "Camerupt ex"
     ],
     "attacks": [
       {
@@ -805,7 +810,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Starmie"
+      "Starmie",
+      "Starmie-GX"
     ],
     "attacks": [
       {
@@ -856,6 +862,9 @@
       "Water"
     ],
     "evolvesFrom": "Staryu",
+    "evolvesTo": [
+      "Starmie BREAK"
+    ],
     "abilities": [
       {
         "name": "Escape",
@@ -912,7 +921,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "abilities": [
       {
@@ -1051,7 +1063,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Piloswine"
+      "Piloswine",
+      "Light Piloswine"
     ],
     "attacks": [
       {
@@ -1238,7 +1251,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Octillery"
+      "Octillery",
+      "Dark Octillery"
     ],
     "attacks": [
       {
@@ -1350,7 +1364,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Crawdaunt"
+      "Crawdaunt",
+      "Crawdaunt ex"
     ],
     "attacks": [
       {
@@ -1456,7 +1471,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Milotic"
+      "Milotic",
+      "Milotic ex"
     ],
     "attacks": [
       {
@@ -1688,7 +1704,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -1820,7 +1840,7 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Graveler"
+      "Alolan Graveler"
     ],
     "attacks": [
       {
@@ -1889,7 +1909,8 @@
     ],
     "evolvesFrom": "Alolan Geodude",
     "evolvesTo": [
-      "Golem"
+      "Alolan Golem",
+      "Alolan Golem-GX"
     ],
     "attacks": [
       {
@@ -2110,7 +2131,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Haunter",
+      "Dark Haunter"
     ],
     "attacks": [
       {
@@ -2168,7 +2190,8 @@
     ],
     "evolvesFrom": "Gastly",
     "evolvesTo": [
-      "Gengar"
+      "Gengar",
+      "Gengar ex"
     ],
     "attacks": [
       {
@@ -2225,6 +2248,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Haunter",
+    "evolvesTo": [
+      "Gengar LV.X"
+    ],
     "abilities": [
       {
         "name": "Gnawing Curse",
@@ -2691,7 +2717,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Salazzle"
+      "Salazzle",
+      "Salazzle-GX"
     ],
     "attacks": [
       {
@@ -2933,7 +2960,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Primeape"
+      "Primeape",
+      "Dark Primeape"
     ],
     "attacks": [
       {
@@ -2984,6 +3012,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Mankey",
+    "evolvesTo": [
+      "Annihilape ex",
+      "Annihilape"
+    ],
     "attacks": [
       {
         "name": "Low Kick",
@@ -3044,7 +3076,10 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Marowak"
+      "Marowak",
+      "Dark Marowak",
+      "Alolan Marowak-GX",
+      "Alolan Marowak"
     ],
     "attacks": [
       {
@@ -3228,7 +3263,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Bewear"
+      "Bewear",
+      "Bewear-GX"
     ],
     "attacks": [
       {
@@ -3416,7 +3452,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Houndoom",
+      "Dark Houndoom",
+      "Houndoom ex"
     ],
     "attacks": [
       {
@@ -3691,6 +3729,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Zweilous",
+    "evolvesTo": [
+      "Hydreigon BREAK"
+    ],
     "abilities": [
       {
         "name": "Weed Out",
@@ -4063,7 +4104,8 @@
     ],
     "evolvesFrom": "Aron",
     "evolvesTo": [
-      "Aggron"
+      "Aggron",
+      "Aggron ex"
     ],
     "attacks": [
       {
@@ -4416,7 +4458,11 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Wigglytuff"
+      "Wigglytuff",
+      "Dark Wigglytuff",
+      "Light Wigglytuff",
+      "Wigglytuff ex",
+      "Wigglytuff-GX"
     ],
     "attacks": [
       {
@@ -4549,6 +4595,9 @@
     "hp": "130",
     "types": [
       "Fairy"
+    ],
+    "evolvesTo": [
+      "Xerneas BREAK"
     ],
     "attacks": [
       {
@@ -4757,7 +4806,8 @@
     ],
     "evolvesFrom": "Jangmo-o",
     "evolvesTo": [
-      "Kommo-o"
+      "Kommo-o",
+      "Kommo-o-GX"
     ],
     "attacks": [
       {
@@ -4938,7 +4988,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Altaria"
+      "Altaria",
+      "Altaria ex",
+      "Altaria-GX"
     ],
     "attacks": [
       {
@@ -5262,6 +5314,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Regigigas LV.X"
+    ],
     "abilities": [
       {
         "name": "Seal of Antiquity",
@@ -5323,6 +5378,9 @@
     "hp": "180",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Regigigas LV.X"
     ],
     "abilities": [
       {
@@ -5603,6 +5661,10 @@
     "hp": "110",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Silvally",
+      "Silvally-GX"
     ],
     "attacks": [
       {

--- a/cards/en/sm5.json
+++ b/cards/en/sm5.json
@@ -11,7 +11,10 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Exeggutor"
+      "Exeggutor",
+      "Dark Exeggutor",
+      "Alolan Exeggutor-GX",
+      "Alolan Exeggutor"
     ],
     "attacks": [
       {
@@ -120,6 +123,9 @@
       "Grass"
     ],
     "evolvesFrom": "Yanma",
+    "evolvesTo": [
+      "Yanmega BREAK"
+    ],
     "attacks": [
       {
         "name": "Supersonic",
@@ -493,6 +499,9 @@
       "Grass"
     ],
     "evolvesFrom": "Grotle",
+    "evolvesTo": [
+      "Torterra LV.X"
+    ],
     "attacks": [
       {
         "name": "Giga Drain",
@@ -852,6 +861,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Shaymin LV.X"
+    ],
     "attacks": [
       {
         "name": "Coax",
@@ -1084,6 +1096,9 @@
       "Fire"
     ],
     "evolvesFrom": "Magmar",
+    "evolvesTo": [
+      "Magmortar LV.X"
+    ],
     "abilities": [
       {
         "name": "Incandescent Body",
@@ -1294,6 +1309,9 @@
       "Fire"
     ],
     "evolvesFrom": "Monferno",
+    "evolvesTo": [
+      "Infernape LV.X"
+    ],
     "abilities": [
       {
         "name": "Flaming Fighter",
@@ -1408,7 +1426,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Salazzle"
+      "Salazzle",
+      "Salazzle-GX"
     ],
     "attacks": [
       {
@@ -1591,7 +1610,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Sandslash"
+      "Alolan Sandslash",
+      "Alolan Sandslash-GX"
     ],
     "attacks": [
       {
@@ -1702,7 +1722,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Alolan Ninetales",
+      "Alolan Ninetales-GX"
     ],
     "attacks": [
       {
@@ -1937,6 +1958,10 @@
       "Water"
     ],
     "evolvesFrom": "Prinplup",
+    "evolvesTo": [
+      "Empoleon LV.X",
+      "Empoleon BREAK"
+    ],
     "attacks": [
       {
         "name": "Total Command",
@@ -2538,6 +2563,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Electabuzz",
+    "evolvesTo": [
+      "Electivire LV.X"
+    ],
     "attacks": [
       {
         "name": "Steel Short",
@@ -2789,6 +2817,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Luxio",
+    "evolvesTo": [
+      "Luxray BREAK"
+    ],
     "abilities": [
       {
         "name": "Intimidating Fang",
@@ -3221,6 +3252,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Skorupi",
+    "evolvesTo": [
+      "Drapion LV.X"
+    ],
     "attacks": [
       {
         "name": "Dangerous Stinger",
@@ -3275,7 +3309,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Toxicroak"
+      "Toxicroak",
+      "Toxicroak ex"
     ],
     "attacks": [
       {
@@ -3454,6 +3489,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Cresselia LV.X"
+    ],
     "attacks": [
       {
         "name": "Lunar Payback",
@@ -3567,7 +3605,9 @@
     "evolvesFrom": "Cosmog",
     "evolvesTo": [
       "Solgaleo",
-      "Lunala"
+      "Lunala",
+      "Lunala-GX",
+      "Solgaleo-GX"
     ],
     "attacks": [
       {
@@ -3894,7 +3934,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lucario"
+      "Lucario",
+      "Lucario-GX",
+      "Lucario ex"
     ],
     "attacks": [
       {
@@ -3954,6 +3996,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Riolu",
+    "evolvesTo": [
+      "Lucario LV.X"
+    ],
     "abilities": [
       {
         "name": "Precognitive Aura",
@@ -4066,6 +4111,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Hippopotas",
+    "evolvesTo": [
+      "Hippowdon LV.X"
+    ],
     "attacks": [
       {
         "name": "Sand Tomb",
@@ -4188,7 +4236,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Honchkrow"
+      "Honchkrow",
+      "Honchkrow-GX"
     ],
     "attacks": [
       {
@@ -4245,6 +4294,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Murkrow",
+    "evolvesTo": [
+      "Honchkrow LV.X"
+    ],
     "attacks": [
       {
         "name": "Rip and Run",
@@ -4311,7 +4363,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Weavile"
+      "Weavile",
+      "Weavile-GX"
     ],
     "attacks": [
       {
@@ -4637,7 +4690,7 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Dugtrio"
+      "Alolan Dugtrio"
     ],
     "attacks": [
       {
@@ -4749,7 +4802,8 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -4815,7 +4869,8 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "abilities": [
       {
@@ -4881,7 +4936,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "attacks": [
       {
@@ -4950,6 +5006,9 @@
       "Metal"
     ],
     "evolvesFrom": "Magneton",
+    "evolvesTo": [
+      "Magnezone LV.X"
+    ],
     "abilities": [
       {
         "name": "Magnetic Circuit",
@@ -5221,6 +5280,9 @@
       "Metal"
     ],
     "evolvesFrom": "Bronzor",
+    "evolvesTo": [
+      "Bronzong BREAK"
+    ],
     "attacks": [
       {
         "name": "Psy Bolt",
@@ -5287,6 +5349,9 @@
     "hp": "130",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Heatran LV.X"
     ],
     "attacks": [
       {
@@ -5944,7 +6009,8 @@
     ],
     "evolvesFrom": "Gible",
     "evolvesTo": [
-      "Garchomp"
+      "Garchomp",
+      "Garchomp ex"
     ],
     "attacks": [
       {
@@ -6005,6 +6071,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Gabite",
+    "evolvesTo": [
+      "Garchomp LV.X"
+    ],
     "attacks": [
       {
         "name": "Quick Dive",
@@ -6352,7 +6421,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -6410,7 +6499,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -6751,6 +6860,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Shaymin LV.X"
+    ],
     "attacks": [
       {
         "name": "Call for Family",
@@ -6815,7 +6927,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Gumshoos"
+      "Gumshoos",
+      "Gumshoos-GX"
     ],
     "attacks": [
       {
@@ -6996,6 +7109,10 @@
     "hp": "110",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Silvally",
+      "Silvally-GX"
     ],
     "attacks": [
       {
@@ -7636,6 +7753,20 @@
       "Item"
     ],
     "hp": "60",
+    "evolvesTo": [
+      "Cranidos",
+      "Shieldon",
+      "Amaura",
+      "Tyrunt",
+      "Omanyte",
+      "Kabuto",
+      "Aerodactyl",
+      "Tirtouga",
+      "Aerodactyl-GX",
+      "Archen",
+      "Lileep",
+      "Anorith"
+    ],
     "rules": [
       "Play this card as if it were a 60-HP Colorless Basic Pokémon. At any time during your turn (before your attack), you may discard this card from play.",
       "This card can't retreat.",

--- a/cards/en/sm6.json
+++ b/cards/en/sm6.json
@@ -11,7 +11,10 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Exeggutor"
+      "Exeggutor",
+      "Dark Exeggutor",
+      "Alolan Exeggutor-GX",
+      "Alolan Exeggutor"
     ],
     "attacks": [
       {
@@ -736,6 +739,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Heatran LV.X"
+    ],
     "attacks": [
       {
         "name": "Guard Press",
@@ -975,6 +981,9 @@
       "Fire"
     ],
     "evolvesFrom": "Braixen",
+    "evolvesTo": [
+      "Delphox BREAK"
+    ],
     "abilities": [
       {
         "name": "Mystical Torch",
@@ -1088,6 +1097,9 @@
       "Fire"
     ],
     "evolvesFrom": "Litleo",
+    "evolvesTo": [
+      "Pyroar BREAK"
+    ],
     "abilities": [
       {
         "name": "Unnerve",
@@ -1345,7 +1357,9 @@
     ],
     "evolvesFrom": "Froakie",
     "evolvesTo": [
-      "Greninja"
+      "Greninja",
+      "Greninja-GX",
+      "Greninja ex"
     ],
     "abilities": [
       {
@@ -1527,6 +1541,9 @@
       "Water"
     ],
     "evolvesFrom": "Clauncher",
+    "evolvesTo": [
+      "Clawitzer BREAK"
+    ],
     "attacks": [
       {
         "name": "Standing By",
@@ -1718,7 +1735,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Avalugg"
+      "Avalugg",
+      "Hisuian Avalugg"
     ],
     "attacks": [
       {
@@ -2018,7 +2036,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -2085,7 +2104,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "attacks": [
       {
@@ -2154,6 +2174,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Magneton",
+    "evolvesTo": [
+      "Magnezone LV.X"
+    ],
     "abilities": [
       {
         "name": "Magnetic Circuit",
@@ -2481,6 +2504,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Uxie LV.X"
+    ],
     "attacks": [
       {
         "name": "Memory Skip",
@@ -2528,6 +2554,9 @@
     "hp": "70",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Mesprit LV.X"
     ],
     "abilities": [
       {
@@ -2584,6 +2613,9 @@
     "hp": "60",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Azelf LV.X"
     ],
     "attacks": [
       {
@@ -2879,7 +2911,8 @@
     ],
     "evolvesFrom": "Honedge",
     "evolvesTo": [
-      "Aegislash"
+      "Aegislash",
+      "Aegislash ex"
     ],
     "attacks": [
       {
@@ -3280,7 +3313,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Naganadel"
+      "Naganadel",
+      "Naganadel-GX"
     ],
     "attacks": [
       {
@@ -3416,7 +3450,10 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Marowak"
+      "Marowak",
+      "Dark Marowak",
+      "Alolan Marowak-GX",
+      "Alolan Marowak"
     ],
     "attacks": [
       {
@@ -3469,6 +3506,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Grotle",
+    "evolvesTo": [
+      "Torterra LV.X"
+    ],
     "attacks": [
       {
         "name": "Giga Drain",
@@ -3535,6 +3575,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Monferno",
+    "evolvesTo": [
+      "Infernape LV.X"
+    ],
     "abilities": [
       {
         "name": "Flaming Fighter",
@@ -3644,7 +3687,8 @@
     ],
     "evolvesFrom": "Gible",
     "evolvesTo": [
-      "Garchomp"
+      "Garchomp",
+      "Garchomp ex"
     ],
     "attacks": [
       {
@@ -3705,6 +3749,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Gabite",
+    "evolvesTo": [
+      "Garchomp LV.X"
+    ],
     "attacks": [
       {
         "name": "Quick Dive",
@@ -3762,7 +3809,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Toxicroak"
+      "Toxicroak",
+      "Toxicroak ex"
     ],
     "attacks": [
       {
@@ -4485,7 +4533,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lycanroc"
+      "Lycanroc",
+      "Lycanroc-GX",
+      "Lycanroc ex"
     ],
     "attacks": [
       {
@@ -4868,6 +4918,10 @@
       "Metal"
     ],
     "evolvesFrom": "Prinplup",
+    "evolvesTo": [
+      "Empoleon LV.X",
+      "Empoleon BREAK"
+    ],
     "attacks": [
       {
         "name": "Total Command",
@@ -5198,6 +5252,9 @@
       "Fairy"
     ],
     "evolvesFrom": "Floette",
+    "evolvesTo": [
+      "Florges BREAK"
+    ],
     "abilities": [
       {
         "name": "Wondrous Gift",
@@ -5535,7 +5592,8 @@
       "Dragon"
     ],
     "evolvesTo": [
-      "Sliggoo"
+      "Sliggoo",
+      "Hisuian Sliggoo"
     ],
     "abilities": [
       {
@@ -5593,7 +5651,8 @@
       "Dragon"
     ],
     "evolvesTo": [
-      "Sliggoo"
+      "Sliggoo",
+      "Hisuian Sliggoo"
     ],
     "attacks": [
       {
@@ -6078,7 +6137,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Noivern"
+      "Noivern",
+      "Noivern-GX",
+      "Noivern ex"
     ],
     "attacks": [
       {
@@ -6145,6 +6206,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Noibat",
+    "evolvesTo": [
+      "Noivern BREAK"
+    ],
     "attacks": [
       {
         "name": "Supersonic",
@@ -6608,6 +6672,20 @@
       "Item"
     ],
     "hp": "60",
+    "evolvesTo": [
+      "Cranidos",
+      "Shieldon",
+      "Amaura",
+      "Tyrunt",
+      "Omanyte",
+      "Kabuto",
+      "Aerodactyl",
+      "Tirtouga",
+      "Aerodactyl-GX",
+      "Archen",
+      "Lileep",
+      "Anorith"
+    ],
     "rules": [
       "Play this card as if it were a 60-HP Colorless Basic Pokémon. At any time during your turn (before your attack), you may discard this card from play.",
       "This card can't retreat.",

--- a/cards/en/sm7.json
+++ b/cards/en/sm7.json
@@ -184,7 +184,11 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor",
+      "Scizor ex",
+      "Dark Scizor",
+      "Scizor-GX",
+      "Kleavor"
     ],
     "attacks": [
       {
@@ -245,7 +249,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ariados"
+      "Ariados",
+      "Dark Ariados"
     ],
     "attacks": [
       {
@@ -477,7 +482,9 @@
     ],
     "evolvesFrom": "Treecko",
     "evolvesTo": [
-      "Sceptile"
+      "Sceptile",
+      "Sceptile ex",
+      "Sceptile-GX"
     ],
     "attacks": [
       {
@@ -754,7 +761,9 @@
     ],
     "evolvesFrom": "Seedot",
     "evolvesTo": [
-      "Shiftry"
+      "Shiftry",
+      "Shiftry ex",
+      "Shiftry-GX"
     ],
     "attacks": [
       {
@@ -1098,7 +1107,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Cacturne"
+      "Cacturne",
+      "Cacturne ex"
     ],
     "abilities": [
       {
@@ -1335,7 +1345,10 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Magcargo"
+      "Magcargo",
+      "Dark Magcargo",
+      "Magcargo ex",
+      "Magcargo-GX"
     ],
     "attacks": [
       {
@@ -1570,7 +1583,9 @@
     ],
     "evolvesFrom": "Torchic",
     "evolvesTo": [
-      "Blaziken"
+      "Blaziken",
+      "Blaziken ex",
+      "Blaziken-GX"
     ],
     "attacks": [
       {
@@ -2016,7 +2031,8 @@
     ],
     "evolvesFrom": "Mudkip",
     "evolvesTo": [
-      "Swampert"
+      "Swampert",
+      "Swampert ex"
     ],
     "attacks": [
       {
@@ -2311,7 +2327,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wailord"
+      "Wailord",
+      "Wailord ex"
     ],
     "attacks": [
       {
@@ -2767,7 +2784,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "abilities": [
       {
@@ -2908,7 +2928,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Lanturn"
+      "Lanturn",
+      "Light Lanturn"
     ],
     "attacks": [
       {
@@ -3040,7 +3061,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Manectric",
+      "Manectric ex"
     ],
     "attacks": [
       {
@@ -3743,7 +3765,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Banette"
+      "Banette",
+      "Banette ex",
+      "Banette-GX"
     ],
     "attacks": [
       {
@@ -3810,7 +3834,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Banette"
+      "Banette",
+      "Banette ex",
+      "Banette-GX"
     ],
     "attacks": [
       {
@@ -4249,7 +4275,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Steelix"
+      "Steelix",
+      "Dark Steelix",
+      "Steelix ex"
     ],
     "attacks": [
       {
@@ -4311,7 +4339,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Donphan"
+      "Donphan",
+      "Dark Donphan"
     ],
     "attacks": [
       {
@@ -4433,7 +4462,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Pupitar"
+      "Pupitar",
+      "Dark Pupitar"
     ],
     "attacks": [
       {
@@ -4495,7 +4525,9 @@
     ],
     "evolvesFrom": "Larvitar",
     "evolvesTo": [
-      "Tyranitar"
+      "Tyranitar",
+      "Tyranitar ex",
+      "Tyranitar-GX"
     ],
     "attacks": [
       {
@@ -4557,7 +4589,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Medicham"
+      "Medicham",
+      "Medicham ex"
     ],
     "attacks": [
       {
@@ -4678,7 +4711,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Claydol"
+      "Claydol",
+      "Claydol ex"
     ],
     "attacks": [
       {
@@ -5054,7 +5088,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Raticate"
+      "Alolan Raticate",
+      "Alolan Raticate-GX"
     ],
     "attacks": [
       {
@@ -5201,7 +5236,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Weavile"
+      "Weavile",
+      "Weavile-GX"
     ],
     "attacks": [
       {
@@ -5725,7 +5761,9 @@
     ],
     "evolvesFrom": "Beldum",
     "evolvesTo": [
-      "Metagross"
+      "Metagross",
+      "Metagross ex",
+      "Metagross-GX"
     ],
     "attacks": [
       {
@@ -5979,6 +6017,9 @@
     "hp": "130",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Heatran LV.X"
     ],
     "attacks": [
       {
@@ -6418,7 +6459,9 @@
     ],
     "evolvesFrom": "Bagon",
     "evolvesTo": [
-      "Salamence"
+      "Salamence",
+      "Salamence ex",
+      "Salamence-GX"
     ],
     "attacks": [
       {
@@ -6472,6 +6515,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Shelgon",
+    "evolvesTo": [
+      "Salamence LV.X"
+    ],
     "abilities": [
       {
         "name": "Dragon Wind",
@@ -6707,6 +6753,9 @@
     "hp": "50",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Dudunsparce"
     ],
     "attacks": [
       {
@@ -7192,7 +7241,8 @@
     ],
     "evolvesFrom": "Whismur",
     "evolvesTo": [
-      "Exploud"
+      "Exploud",
+      "Exploud ex"
     ],
     "attacks": [
       {
@@ -7313,7 +7363,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Delcatty"
+      "Delcatty",
+      "Delcatty ex"
     ],
     "attacks": [
       {

--- a/cards/en/sm75.json
+++ b/cards/en/sm75.json
@@ -11,7 +11,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -65,7 +66,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "abilities": [
       {
@@ -237,7 +241,9 @@
     ],
     "evolvesFrom": "Torchic",
     "evolvesTo": [
-      "Blaziken"
+      "Blaziken",
+      "Blaziken ex",
+      "Blaziken-GX"
     ],
     "abilities": [
       {
@@ -708,7 +714,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Salazzle"
+      "Salazzle",
+      "Salazzle-GX"
     ],
     "attacks": [
       {
@@ -931,7 +938,9 @@
     ],
     "evolvesFrom": "Horsea",
     "evolvesTo": [
-      "Kingdra"
+      "Kingdra",
+      "Kingdra ex",
+      "Kingdra-GX"
     ],
     "attacks": [
       {
@@ -1053,7 +1062,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -1225,7 +1237,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Croconaw"
+      "Croconaw",
+      "Dark Croconaw"
     ],
     "attacks": [
       {
@@ -1286,7 +1299,8 @@
     ],
     "evolvesFrom": "Totodile",
     "evolvesTo": [
-      "Feraligatr"
+      "Feraligatr",
+      "Feraligatr ex"
     ],
     "attacks": [
       {
@@ -1528,9 +1542,6 @@
     "types": [
       "Water"
     ],
-    "evolvesTo": [
-      "Cursola"
-    ],
     "attacks": [
       {
         "name": "Bubble Shoot",
@@ -1580,7 +1591,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Milotic"
+      "Milotic",
+      "Milotic ex"
     ],
     "abilities": [
       {
@@ -1860,6 +1872,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Zweilous",
+    "evolvesTo": [
+      "Hydreigon BREAK"
+    ],
     "abilities": [
       {
         "name": "Weed Out",
@@ -1925,7 +1940,9 @@
       "Dragon"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "attacks": [
       {
@@ -1977,7 +1994,9 @@
       "Dragon"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "attacks": [
       {
@@ -2031,7 +2050,9 @@
     ],
     "evolvesFrom": "Dratini",
     "evolvesTo": [
-      "Dragonite"
+      "Dragonite",
+      "Dragonite ex",
+      "Dragonite-GX"
     ],
     "attacks": [
       {
@@ -2175,7 +2196,9 @@
     ],
     "evolvesFrom": "Trapinch",
     "evolvesTo": [
-      "Flygon"
+      "Flygon",
+      "Flygon ex",
+      "Flygon-GX"
     ],
     "attacks": [
       {
@@ -2227,6 +2250,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Vibrava",
+    "evolvesTo": [
+      "Flygon LV.X"
+    ],
     "abilities": [
       {
         "name": "Dragon Guard",
@@ -2535,7 +2561,9 @@
     ],
     "evolvesFrom": "Bagon",
     "evolvesTo": [
-      "Salamence"
+      "Salamence",
+      "Salamence ex",
+      "Salamence-GX"
     ],
     "abilities": [
       {
@@ -3161,7 +3189,8 @@
     ],
     "evolvesFrom": "Jangmo-o",
     "evolvesTo": [
-      "Kommo-o"
+      "Kommo-o",
+      "Kommo-o-GX"
     ],
     "attacks": [
       {
@@ -3357,7 +3386,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Altaria"
+      "Altaria",
+      "Altaria ex",
+      "Altaria-GX"
     ],
     "attacks": [
       {
@@ -3424,7 +3455,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Altaria"
+      "Altaria",
+      "Altaria ex",
+      "Altaria-GX"
     ],
     "attacks": [
       {

--- a/cards/en/sm8.json
+++ b/cards/en/sm8.json
@@ -75,6 +75,9 @@
       "Grass"
     ],
     "evolvesFrom": "Tangela",
+    "evolvesTo": [
+      "Tangrowth LV.X"
+    ],
     "attacks": [
       {
         "name": "Hefty Whip",
@@ -140,7 +143,11 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor",
+      "Scizor ex",
+      "Dark Scizor",
+      "Scizor-GX",
+      "Kleavor"
     ],
     "attacks": [
       {
@@ -365,7 +372,8 @@
     ],
     "evolvesFrom": "Chikorita",
     "evolvesTo": [
-      "Meganium"
+      "Meganium",
+      "Meganium ex"
     ],
     "attacks": [
       {
@@ -488,7 +496,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ariados"
+      "Ariados",
+      "Dark Ariados"
     ],
     "attacks": [
       {
@@ -835,7 +844,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Forretress"
+      "Forretress",
+      "Dark Forretress",
+      "Forretress ex"
     ],
     "attacks": [
       {
@@ -1181,7 +1192,9 @@
     ],
     "evolvesFrom": "Treecko",
     "evolvesTo": [
-      "Sceptile"
+      "Sceptile",
+      "Sceptile ex",
+      "Sceptile-GX"
     ],
     "abilities": [
       {
@@ -1538,7 +1551,8 @@
     ],
     "evolvesFrom": "Wurmple",
     "evolvesTo": [
-      "Dustox"
+      "Dustox",
+      "Dustox ex"
     ],
     "attacks": [
       {
@@ -1658,7 +1672,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ninjask"
+      "Ninjask",
+      "Shedinja"
     ],
     "attacks": [
       {
@@ -1709,9 +1724,6 @@
       "Grass"
     ],
     "evolvesFrom": "Nincada",
-    "evolvesTo": [
-      "Shedinja"
-    ],
     "abilities": [
       {
         "name": "Molting",
@@ -1764,7 +1776,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Vespiquen"
+      "Vespiquen",
+      "Vespiquen ex"
     ],
     "attacks": [
       {
@@ -1863,6 +1876,9 @@
     "hp": "70",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Shaymin LV.X"
     ],
     "abilities": [
       {
@@ -2234,7 +2250,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Quilava"
+      "Quilava",
+      "Dark Quilava"
     ],
     "attacks": [
       {
@@ -2285,7 +2302,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Quilava"
+      "Quilava",
+      "Dark Quilava"
     ],
     "attacks": [
       {
@@ -2338,7 +2356,9 @@
     ],
     "evolvesFrom": "Cyndaquil",
     "evolvesTo": [
-      "Typhlosion"
+      "Typhlosion",
+      "Typhlosion ex",
+      "Hisuian Typhlosion"
     ],
     "attacks": [
       {
@@ -2462,7 +2482,10 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Magcargo"
+      "Magcargo",
+      "Dark Magcargo",
+      "Magcargo ex",
+      "Magcargo-GX"
     ],
     "attacks": [
       {
@@ -2599,7 +2622,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Houndoom",
+      "Dark Houndoom",
+      "Houndoom ex"
     ],
     "attacks": [
       {
@@ -2778,6 +2803,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Heatran LV.X"
+    ],
     "attacks": [
       {
         "name": "Lava Burn",
@@ -2953,6 +2981,9 @@
       "Fire"
     ],
     "evolvesFrom": "Litleo",
+    "evolvesTo": [
+      "Pyroar BREAK"
+    ],
     "attacks": [
       {
         "name": "Crunch",
@@ -3087,7 +3118,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Alolan Ninetales",
+      "Alolan Ninetales-GX"
     ],
     "abilities": [
       {
@@ -3147,7 +3179,11 @@
     ],
     "evolvesTo": [
       "Slowbro",
-      "Slowking"
+      "Slowking",
+      "Dark Slowbro",
+      "Dark Slowking",
+      "Light Slowbro",
+      "Slowking ex"
     ],
     "attacks": [
       {
@@ -3862,7 +3898,8 @@
     ],
     "evolvesFrom": "Popplio",
     "evolvesTo": [
-      "Primarina"
+      "Primarina",
+      "Primarina-GX"
     ],
     "attacks": [
       {
@@ -3982,7 +4019,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Toxapex"
+      "Toxapex",
+      "Toxapex-GX"
     ],
     "attacks": [
       {
@@ -4211,6 +4249,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Electabuzz",
+    "evolvesTo": [
+      "Electivire LV.X"
+    ],
     "attacks": [
       {
         "name": "Electrocharge",
@@ -4281,7 +4322,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Lanturn"
+      "Lanturn",
+      "Light Lanturn"
     ],
     "attacks": [
       {
@@ -4414,7 +4456,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Flaaffy"
+      "Flaaffy",
+      "Dark Flaaffy"
     ],
     "abilities": [
       {
@@ -4479,7 +4522,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Flaaffy"
+      "Flaaffy",
+      "Dark Flaaffy"
     ],
     "attacks": [
       {
@@ -4537,7 +4581,9 @@
     ],
     "evolvesFrom": "Mareep",
     "evolvesTo": [
-      "Ampharos"
+      "Ampharos",
+      "Ampharos ex",
+      "Ampharos-GX"
     ],
     "attacks": [
       {
@@ -5504,6 +5550,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Wobbuffet BREAK"
+    ],
     "abilities": [
       {
         "name": "Shady Tail",
@@ -5560,6 +5609,9 @@
     "hp": "90",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Farigiraf"
     ],
     "attacks": [
       {
@@ -5721,6 +5773,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Giratina LV.X"
+    ],
     "abilities": [
       {
         "name": "Distortion Door",
@@ -5865,7 +5920,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Cofagrigus"
+      "Cofagrigus",
+      "Cofagrigus ex"
     ],
     "attacks": [
       {
@@ -6220,7 +6276,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Toxapex"
+      "Toxapex",
+      "Toxapex-GX"
     ],
     "attacks": [
       {
@@ -6340,7 +6397,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Naganadel"
+      "Naganadel",
+      "Naganadel-GX"
     ],
     "attacks": [
       {
@@ -6460,7 +6518,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Steelix"
+      "Steelix",
+      "Dark Steelix",
+      "Steelix ex"
     ],
     "attacks": [
       {
@@ -6566,7 +6626,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Donphan"
+      "Donphan",
+      "Dark Donphan"
     ],
     "attacks": [
       {
@@ -6738,7 +6799,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Pupitar"
+      "Pupitar",
+      "Dark Pupitar"
     ],
     "abilities": [
       {
@@ -6796,7 +6858,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Pupitar"
+      "Pupitar",
+      "Dark Pupitar"
     ],
     "attacks": [
       {
@@ -6849,7 +6912,9 @@
     ],
     "evolvesFrom": "Larvitar",
     "evolvesTo": [
-      "Tyranitar"
+      "Tyranitar",
+      "Tyranitar ex",
+      "Tyranitar-GX"
     ],
     "abilities": [
       {
@@ -6909,6 +6974,9 @@
     "hp": "90",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Carbink BREAK"
     ],
     "attacks": [
       {
@@ -6970,7 +7038,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Persian"
+      "Alolan Persian",
+      "Alolan Persian-GX"
     ],
     "attacks": [
       {
@@ -7227,7 +7296,7 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Dugtrio"
+      "Alolan Dugtrio"
     ],
     "attacks": [
       {
@@ -7539,6 +7608,9 @@
     "hp": "130",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Dialga LV.X"
     ],
     "attacks": [
       {
@@ -7960,7 +8032,11 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Wigglytuff"
+      "Wigglytuff",
+      "Dark Wigglytuff",
+      "Light Wigglytuff",
+      "Wigglytuff ex",
+      "Wigglytuff-GX"
     ],
     "attacks": [
       {
@@ -8096,7 +8172,8 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Azumarill"
+      "Azumarill",
+      "Light Azumarill"
     ],
     "attacks": [
       {
@@ -8417,7 +8494,9 @@
     "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
-      "Gallade"
+      "Gallade",
+      "Gardevoir ex",
+      "Gardevoir-GX"
     ],
     "attacks": [
       {
@@ -8486,6 +8565,9 @@
       "Fairy"
     ],
     "evolvesFrom": "Kirlia",
+    "evolvesTo": [
+      "Gardevoir LV.X"
+    ],
     "attacks": [
       {
         "name": "Brilliant Search",
@@ -8605,6 +8687,9 @@
     "hp": "90",
     "types": [
       "Fairy"
+    ],
+    "evolvesTo": [
+      "Carbink BREAK"
     ],
     "attacks": [
       {
@@ -9166,7 +9251,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Blissey"
+      "Blissey",
+      "Blissey ex"
     ],
     "attacks": [
       {
@@ -9344,7 +9430,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -9393,6 +9499,9 @@
     "hp": "110",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Wyrdeer"
     ],
     "attacks": [
       {
@@ -9644,6 +9753,9 @@
     "hp": "130",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Ho-Oh BREAK"
     ],
     "attacks": [
       {

--- a/cards/en/sm9.json
+++ b/cards/en/sm9.json
@@ -444,7 +444,10 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Exeggutor"
+      "Exeggutor",
+      "Dark Exeggutor",
+      "Alolan Exeggutor-GX",
+      "Alolan Exeggutor"
     ],
     "attacks": [
       {
@@ -606,7 +609,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -667,7 +671,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -719,7 +724,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "attacks": [
       {
@@ -830,7 +838,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {
@@ -881,6 +891,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "abilities": [
       {
         "name": "Nine Temptations",
@@ -939,7 +952,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Rapidash"
+      "Rapidash",
+      "Dark Rapidash"
     ],
     "attacks": [
       {
@@ -1178,7 +1192,8 @@
     ],
     "evolvesFrom": "Litten",
     "evolvesTo": [
-      "Incineroar"
+      "Incineroar",
+      "Incineroar-GX"
     ],
     "attacks": [
       {
@@ -1241,7 +1256,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wartortle"
+      "Wartortle",
+      "Dark Wartortle"
     ],
     "abilities": [
       {
@@ -1300,7 +1316,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wartortle"
+      "Wartortle",
+      "Dark Wartortle"
     ],
     "attacks": [
       {
@@ -1362,7 +1379,9 @@
     ],
     "evolvesFrom": "Squirtle",
     "evolvesTo": [
-      "Blastoise"
+      "Blastoise",
+      "Blastoise ex",
+      "Blastoise-GX"
     ],
     "attacks": [
       {
@@ -1486,7 +1505,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Golduck",
+      "Dark Golduck",
+      "Light Golduck"
     ],
     "attacks": [
       {
@@ -1538,6 +1559,9 @@
       "Water"
     ],
     "evolvesFrom": "Psyduck",
+    "evolvesTo": [
+      "Golduck BREAK"
+    ],
     "attacks": [
       {
         "name": "Amnesia",
@@ -1598,7 +1622,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Starmie"
+      "Starmie",
+      "Starmie-GX"
     ],
     "attacks": [
       {
@@ -1649,7 +1674,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -1886,9 +1914,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesTo": [
-      "Raichu"
-    ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -1962,7 +1987,7 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Graveler"
+      "Alolan Graveler"
     ],
     "attacks": [
       {
@@ -2021,7 +2046,7 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Graveler"
+      "Alolan Graveler"
     ],
     "attacks": [
       {
@@ -2092,7 +2117,8 @@
     ],
     "evolvesFrom": "Alolan Geodude",
     "evolvesTo": [
-      "Golem"
+      "Alolan Golem",
+      "Alolan Golem-GX"
     ],
     "attacks": [
       {
@@ -2235,7 +2261,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {
@@ -2410,7 +2439,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Flaaffy"
+      "Flaaffy",
+      "Dark Flaaffy"
     ],
     "attacks": [
       {
@@ -2468,7 +2498,9 @@
     ],
     "evolvesFrom": "Mareep",
     "evolvesTo": [
-      "Ampharos"
+      "Ampharos",
+      "Ampharos ex",
+      "Ampharos-GX"
     ],
     "attacks": [
       {
@@ -3570,6 +3602,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Nidorino",
+    "evolvesTo": [
+      "Nidoking BREAK"
+    ],
     "attacks": [
       {
         "name": "Drag Off",
@@ -3744,7 +3779,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Muk"
+      "Muk",
+      "Dark Muk",
+      "Muk ex"
     ],
     "attacks": [
       {
@@ -3921,6 +3958,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Staryu",
+    "evolvesTo": [
+      "Starmie BREAK"
+    ],
     "attacks": [
       {
         "name": "Strange Wave",
@@ -4203,7 +4243,9 @@
     "evolvesFrom": "Cosmog",
     "evolvesTo": [
       "Solgaleo",
-      "Lunala"
+      "Lunala",
+      "Lunala-GX",
+      "Solgaleo-GX"
     ],
     "attacks": [
       {
@@ -4256,7 +4298,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Primeape"
+      "Primeape",
+      "Dark Primeape"
     ],
     "attacks": [
       {
@@ -4317,6 +4360,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Mankey",
+    "evolvesTo": [
+      "Annihilape ex",
+      "Annihilape"
+    ],
     "attacks": [
       {
         "name": "Low Kick",
@@ -4547,6 +4594,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Omanyte",
+    "evolvesTo": [
+      "Omastar BREAK"
+    ],
     "abilities": [
       {
         "name": "Fossil Bind",
@@ -4606,7 +4656,8 @@
     ],
     "evolvesFrom": "Unidentified Fossil",
     "evolvesTo": [
-      "Kabutops"
+      "Kabutops",
+      "Kabutops ex"
     ],
     "attacks": [
       {
@@ -4716,7 +4767,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Pupitar"
+      "Pupitar",
+      "Dark Pupitar"
     ],
     "attacks": [
       {
@@ -4770,7 +4822,9 @@
     ],
     "evolvesFrom": "Larvitar",
     "evolvesTo": [
-      "Tyranitar"
+      "Tyranitar",
+      "Tyranitar ex",
+      "Tyranitar-GX"
     ],
     "attacks": [
       {
@@ -4946,7 +5000,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Muk"
+      "Alolan Muk",
+      "Alolan Muk-GX"
     ],
     "attacks": [
       {
@@ -5144,7 +5199,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Mightyena"
+      "Mightyena",
+      "Mightyena ex"
     ],
     "attacks": [
       {
@@ -5389,7 +5445,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Zoroark"
+      "Zoroark",
+      "Zoroark-GX"
     ],
     "attacks": [
       {
@@ -5446,6 +5503,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Zorua",
+    "evolvesTo": [
+      "Zoroark BREAK"
+    ],
     "attacks": [
       {
         "name": "Taunt",
@@ -5579,6 +5639,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Vullaby",
+    "evolvesTo": [
+      "Mandibuzz BREAK"
+    ],
     "attacks": [
       {
         "name": "Trash Crash",
@@ -5716,6 +5779,9 @@
     "hp": "110",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Yveltal BREAK"
     ],
     "attacks": [
       {
@@ -6132,6 +6198,9 @@
       "Metal"
     ],
     "evolvesFrom": "Bronzor",
+    "evolvesTo": [
+      "Bronzong BREAK"
+    ],
     "abilities": [
       {
         "name": "Heatproof",
@@ -6392,6 +6461,9 @@
       "Metal"
     ],
     "evolvesFrom": "Pawniard",
+    "evolvesTo": [
+      "Kingambit"
+    ],
     "attacks": [
       {
         "name": "Single Lunge",
@@ -6592,7 +6664,8 @@
     ],
     "evolvesFrom": "Honedge",
     "evolvesTo": [
-      "Aegislash"
+      "Aegislash",
+      "Aegislash ex"
     ],
     "attacks": [
       {
@@ -7067,7 +7140,9 @@
       "Dragon"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "attacks": [
       {
@@ -7119,7 +7194,9 @@
       "Dragon"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "abilities": [
       {
@@ -7179,7 +7256,9 @@
     ],
     "evolvesFrom": "Dratini",
     "evolvesTo": [
-      "Dragonite"
+      "Dragonite",
+      "Dragonite ex",
+      "Dragonite-GX"
     ],
     "attacks": [
       {
@@ -7292,16 +7371,6 @@
     "hp": "270",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Vaporeon",
-      "Jolteon",
-      "Flareon",
-      "Sylveon",
-      "Espeon",
-      "Umbreon",
-      "Leafeon",
-      "Glaceon"
     ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
@@ -7507,7 +7576,8 @@
     ],
     "evolvesFrom": "Pidgey",
     "evolvesTo": [
-      "Pidgeot"
+      "Pidgeot",
+      "Pidgeot ex"
     ],
     "abilities": [
       {
@@ -7635,7 +7705,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -7753,9 +7825,6 @@
     "hp": "80",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Sirfetch'd"
     ],
     "attacks": [
       {
@@ -7995,6 +8064,9 @@
     "hp": "130",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Lugia BREAK"
     ],
     "attacks": [
       {
@@ -8683,6 +8755,20 @@
       "Item"
     ],
     "hp": "60",
+    "evolvesTo": [
+      "Cranidos",
+      "Shieldon",
+      "Amaura",
+      "Tyrunt",
+      "Omanyte",
+      "Kabuto",
+      "Aerodactyl",
+      "Tirtouga",
+      "Aerodactyl-GX",
+      "Archen",
+      "Lileep",
+      "Anorith"
+    ],
     "rules": [
       "Play this card as if it were a 60-HP Colorless Basic Pokémon. At any time during your turn (before your attack), you may discard this card from play.",
       "This card can't retreat.",
@@ -8869,9 +8955,6 @@
     "types": [
       "Water"
     ],
-    "evolvesTo": [
-      "Gyarados"
-    ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -8941,9 +9024,6 @@
     "types": [
       "Water"
     ],
-    "evolvesTo": [
-      "Gyarados"
-    ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -9012,9 +9092,6 @@
     "hp": "240",
     "types": [
       "Lightning"
-    ],
-    "evolvesTo": [
-      "Raichu"
     ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
@@ -9674,16 +9751,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesTo": [
-      "Vaporeon",
-      "Jolteon",
-      "Flareon",
-      "Sylveon",
-      "Espeon",
-      "Umbreon",
-      "Leafeon",
-      "Glaceon"
-    ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -10081,9 +10148,6 @@
     "types": [
       "Water"
     ],
-    "evolvesTo": [
-      "Gyarados"
-    ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -10152,9 +10216,6 @@
     "hp": "240",
     "types": [
       "Lightning"
-    ],
-    "evolvesTo": [
-      "Raichu"
     ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
@@ -10678,16 +10739,6 @@
     "hp": "270",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Vaporeon",
-      "Jolteon",
-      "Flareon",
-      "Sylveon",
-      "Espeon",
-      "Umbreon",
-      "Leafeon",
-      "Glaceon"
     ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."

--- a/cards/en/sma.json
+++ b/cards/en/sma.json
@@ -11,7 +11,11 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor",
+      "Scizor ex",
+      "Dark Scizor",
+      "Scizor-GX",
+      "Kleavor"
     ],
     "attacks": [
       {
@@ -134,7 +138,10 @@
     ],
     "evolvesFrom": "Rowlet",
     "evolvesTo": [
-      "Decidueye"
+      "Decidueye",
+      "Decidueye-GX",
+      "Hisuian Decidueye",
+      "Decidueye ex"
     ],
     "attacks": [
       {
@@ -196,7 +203,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Golisopod"
+      "Golisopod",
+      "Golisopod-GX",
+      "Golisopod ex"
     ],
     "abilities": [
       {
@@ -314,7 +323,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -368,7 +378,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "abilities": [
       {
@@ -429,7 +442,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Alolan Ninetales",
+      "Alolan Ninetales-GX"
     ],
     "attacks": [
       {
@@ -670,7 +684,9 @@
     ],
     "evolvesFrom": "Froakie",
     "evolvesTo": [
-      "Greninja"
+      "Greninja",
+      "Greninja-GX",
+      "Greninja ex"
     ],
     "abilities": [
       {
@@ -728,7 +744,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "abilities": [
       {
@@ -917,7 +936,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Banette"
+      "Banette",
+      "Banette ex",
+      "Banette-GX"
     ],
     "attacks": [
       {
@@ -1095,7 +1116,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Naganadel"
+      "Naganadel",
+      "Naganadel-GX"
     ],
     "attacks": [
       {
@@ -1213,7 +1235,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lucario"
+      "Lucario",
+      "Lucario-GX",
+      "Lucario ex"
     ],
     "attacks": [
       {
@@ -1273,6 +1297,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Riolu",
+    "evolvesTo": [
+      "Lucario LV.X"
+    ],
     "abilities": [
       {
         "name": "Precognitive Aura",
@@ -1330,7 +1357,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lycanroc"
+      "Lycanroc",
+      "Lycanroc-GX",
+      "Lycanroc ex"
     ],
     "attacks": [
       {
@@ -1443,7 +1472,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Zoroark"
+      "Zoroark",
+      "Zoroark-GX"
     ],
     "attacks": [
       {
@@ -1571,7 +1601,8 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -1638,7 +1669,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "attacks": [
       {
@@ -1707,6 +1739,9 @@
       "Metal"
     ],
     "evolvesFrom": "Magneton",
+    "evolvesTo": [
+      "Magnezone LV.X"
+    ],
     "abilities": [
       {
         "name": "Magnetic Circuit",
@@ -1831,7 +1866,9 @@
     ],
     "evolvesFrom": "Beldum",
     "evolvesTo": [
-      "Metagross"
+      "Metagross",
+      "Metagross ex",
+      "Metagross-GX"
     ],
     "attacks": [
       {
@@ -2078,7 +2115,9 @@
     "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
-      "Gallade"
+      "Gallade",
+      "Gardevoir ex",
+      "Gardevoir-GX"
     ],
     "attacks": [
       {
@@ -2318,7 +2357,8 @@
     ],
     "evolvesFrom": "Gible",
     "evolvesTo": [
-      "Garchomp"
+      "Garchomp",
+      "Garchomp ex"
     ],
     "attacks": [
       {
@@ -2379,6 +2419,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Gabite",
+    "evolvesTo": [
+      "Garchomp LV.X"
+    ],
     "attacks": [
       {
         "name": "Quick Dive",
@@ -2443,7 +2486,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "abilities": [
       {
@@ -2502,7 +2565,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Altaria"
+      "Altaria",
+      "Altaria ex",
+      "Altaria-GX"
     ],
     "attacks": [
       {
@@ -2569,7 +2634,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Noivern"
+      "Noivern",
+      "Noivern-GX",
+      "Noivern ex"
     ],
     "attacks": [
       {
@@ -2682,6 +2749,10 @@
     "hp": "110",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Silvally",
+      "Silvally-GX"
     ],
     "attacks": [
       {

--- a/cards/en/smp.json
+++ b/cards/en/smp.json
@@ -8579,7 +8579,7 @@
     "types": [
       "Fairy"
     ],
-    "evolvesFrom": "Vulpix",
+    "evolvesFrom": "Alolan Vulpix",
     "attacks": [
       {
         "name": "Smash Kick",

--- a/cards/en/smp.json
+++ b/cards/en/smp.json
@@ -165,7 +165,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -315,7 +319,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lycanroc"
+      "Lycanroc",
+      "Lycanroc-GX",
+      "Lycanroc ex"
     ],
     "attacks": [
       {
@@ -2768,7 +2774,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Persian"
+      "Alolan Persian",
+      "Alolan Persian-GX"
     ],
     "attacks": [
       {
@@ -3272,7 +3279,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Persian"
+      "Alolan Persian",
+      "Alolan Persian-GX"
     ],
     "attacks": [
       {
@@ -3461,6 +3469,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Riolu",
+    "evolvesTo": [
+      "Lucario LV.X"
+    ],
     "abilities": [
       {
         "name": "Stance",
@@ -4996,7 +5007,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -5062,6 +5077,9 @@
     "hp": "120",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Mewtwo LV.X"
     ],
     "abilities": [
       {
@@ -5284,7 +5302,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -5421,7 +5443,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Zoroark"
+      "Zoroark",
+      "Zoroark-GX"
     ],
     "attacks": [
       {
@@ -5627,7 +5650,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -5809,6 +5836,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Zorua",
+    "evolvesTo": [
+      "Zoroark BREAK"
+    ],
     "attacks": [
       {
         "name": "Rip Claw",
@@ -6213,6 +6243,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Riolu",
+    "evolvesTo": [
+      "Lucario LV.X"
+    ],
     "abilities": [
       {
         "name": "Precognitive Aura",
@@ -6268,6 +6301,9 @@
     "hp": "130",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Heatran LV.X"
     ],
     "attacks": [
       {
@@ -6400,7 +6436,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -7264,9 +7304,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesTo": [
-      "Raichu"
-    ],
     "attacks": [
       {
         "name": "I Choose You!",
@@ -7331,9 +7368,6 @@
     "hp": "70",
     "types": [
       "Lightning"
-    ],
-    "evolvesTo": [
-      "Raichu"
     ],
     "attacks": [
       {
@@ -7400,9 +7434,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesTo": [
-      "Raichu"
-    ],
     "attacks": [
       {
         "name": "Iron Tail",
@@ -7467,9 +7498,6 @@
     "hp": "70",
     "types": [
       "Lightning"
-    ],
-    "evolvesTo": [
-      "Raichu"
     ],
     "attacks": [
       {
@@ -7536,9 +7564,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesTo": [
-      "Raichu"
-    ],
     "attacks": [
       {
         "name": "Quick Attack",
@@ -7604,9 +7629,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesTo": [
-      "Raichu"
-    ],
     "attacks": [
       {
         "name": "Iron Tail",
@@ -7671,9 +7693,6 @@
     "hp": "70",
     "types": [
       "Lightning"
-    ],
-    "evolvesTo": [
-      "Raichu"
     ],
     "attacks": [
       {
@@ -7984,7 +8003,10 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Exeggutor"
+      "Exeggutor",
+      "Dark Exeggutor",
+      "Alolan Exeggutor-GX",
+      "Alolan Exeggutor"
     ],
     "attacks": [
       {
@@ -8036,7 +8058,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lycanroc"
+      "Lycanroc",
+      "Lycanroc-GX",
+      "Lycanroc ex"
     ],
     "attacks": [
       {
@@ -9402,6 +9426,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Shelgon",
+    "evolvesTo": [
+      "Salamence LV.X"
+    ],
     "abilities": [
       {
         "name": "Dragon Wind",
@@ -10079,6 +10106,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Giratina LV.X"
+    ],
     "abilities": [
       {
         "name": "Distortion Door",
@@ -10260,7 +10290,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Salazzle"
+      "Salazzle",
+      "Salazzle-GX"
     ],
     "attacks": [
       {
@@ -10469,7 +10500,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "abilities": [
       {
@@ -10768,7 +10803,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -11000,9 +11039,6 @@
     "types": [
       "Water"
     ],
-    "evolvesTo": [
-      "Gyarados"
-    ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -11154,9 +11190,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesTo": [
-      "Raichu"
-    ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -11230,16 +11263,6 @@
     "hp": "270",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Vaporeon",
-      "Jolteon",
-      "Flareon",
-      "Sylveon",
-      "Espeon",
-      "Umbreon",
-      "Leafeon",
-      "Glaceon"
     ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
@@ -11318,9 +11341,6 @@
     "hp": "90",
     "types": [
       "Lightning"
-    ],
-    "evolvesTo": [
-      "Raichu"
     ],
     "attacks": [
       {
@@ -11606,16 +11626,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesTo": [
-      "Vaporeon",
-      "Jolteon",
-      "Flareon",
-      "Sylveon",
-      "Espeon",
-      "Umbreon",
-      "Leafeon",
-      "Glaceon"
-    ],
     "rules": [
       "Pokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -11684,16 +11694,6 @@
     "hp": "160",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Vaporeon",
-      "Jolteon",
-      "Flareon",
-      "Sylveon",
-      "Espeon",
-      "Umbreon",
-      "Leafeon",
-      "Glaceon"
     ],
     "rules": [
       "Pokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
@@ -11764,16 +11764,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesTo": [
-      "Vaporeon",
-      "Jolteon",
-      "Flareon",
-      "Sylveon",
-      "Espeon",
-      "Umbreon",
-      "Leafeon",
-      "Glaceon"
-    ],
     "rules": [
       "Pokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -11843,7 +11833,9 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Melmetal"
+      "Melmetal",
+      "Melmetal-GX",
+      "Melmetal ex"
     ],
     "attacks": [
       {
@@ -12232,7 +12224,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -12297,7 +12293,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -12696,9 +12712,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesTo": [
-      "Raichu"
-    ],
     "attacks": [
       {
         "name": "Coffee Break",
@@ -12987,9 +13000,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesTo": [
-      "Raichu"
-    ],
     "attacks": [
       {
         "name": "Brilliant Deduction",
@@ -13273,7 +13283,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ivysaur"
+      "Ivysaur",
+      "Dark Ivysaur"
     ],
     "attacks": [
       {
@@ -13336,7 +13347,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Golduck",
+      "Dark Golduck",
+      "Light Golduck"
     ],
     "attacks": [
       {
@@ -13778,7 +13791,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -14304,6 +14321,9 @@
     "hp": "120",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Mewtwo LV.X"
     ],
     "abilities": [
       {
@@ -15098,7 +15118,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -15219,9 +15243,6 @@
     "types": [
       "Grass"
     ],
-    "evolvesTo": [
-      "Servine"
-    ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -15297,9 +15318,6 @@
     "hp": "270",
     "types": [
       "Fire"
-    ],
-    "evolvesTo": [
-      "Delphox"
     ],
     "rules": [
       "TAG TEAM rule: When your TAG TEAM is Knocked Out, your opponent takes 3 Prize cards."
@@ -15390,9 +15408,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesTo": [
-      "Raichu"
-    ],
     "rules": [
       "Pokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -15472,16 +15487,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesTo": [
-      "Vaporeon",
-      "Jolteon",
-      "Flareon",
-      "Sylveon",
-      "Espeon",
-      "Umbreon",
-      "Leafeon",
-      "Glaceon"
-    ],
     "rules": [
       "Pokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -15551,7 +15556,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -15625,7 +15634,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -15750,6 +15779,9 @@
       "Grass"
     ],
     "evolvesFrom": "Eevee",
+    "evolvesTo": [
+      "Leafeon LV.X"
+    ],
     "attacks": [
       {
         "name": "Aromax",
@@ -15811,6 +15843,9 @@
       "Water"
     ],
     "evolvesFrom": "Eevee",
+    "evolvesTo": [
+      "Glaceon LV.X"
+    ],
     "attacks": [
       {
         "name": "Snow Cloak",
@@ -16084,16 +16119,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesTo": [
-      "Vaporeon",
-      "Jolteon",
-      "Flareon",
-      "Sylveon",
-      "Espeon",
-      "Umbreon",
-      "Leafeon",
-      "Glaceon"
-    ],
     "rules": [
       "Pokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -16161,6 +16186,9 @@
     "hp": "150",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Regigigas LV.X"
     ],
     "attacks": [
       {

--- a/cards/en/sv1.json
+++ b/cards/en/sv1.json
@@ -10,6 +10,11 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Forretress",
+      "Dark Forretress",
+      "Forretress ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -125,6 +130,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Breloom"
+    ],
     "attacks": [
       {
         "cost": [
@@ -225,6 +233,10 @@
     "hp": "60",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Cacturne",
+      "Cacturne ex"
     ],
     "abilities": [
       {
@@ -405,6 +417,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Spewpa"
+    ],
     "abilities": [
       {
         "type": "Ability",
@@ -464,6 +479,9 @@
       "Grass"
     ],
     "evolvesFrom": "Scatterbug",
+    "evolvesTo": [
+      "Vivillon"
+    ],
     "abilities": [
       {
         "type": "Ability",
@@ -584,6 +602,9 @@
     "hp": "60",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Gogoat"
     ],
     "attacks": [
       {
@@ -709,6 +730,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Floragato"
+    ],
     "attacks": [
       {
         "cost": [
@@ -770,6 +794,10 @@
       "Grass"
     ],
     "evolvesFrom": "Sprigatito",
+    "evolvesTo": [
+      "Meowscarada ex",
+      "Meowscarada"
+    ],
     "attacks": [
       {
         "cost": [
@@ -891,6 +919,10 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Spidops",
+      "Spidops ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -950,6 +982,10 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Spidops",
+      "Spidops ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -1000,6 +1036,10 @@
     "hp": "60",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Spidops",
+      "Spidops ex"
     ],
     "attacks": [
       {
@@ -1116,6 +1156,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Dolliv"
+    ],
     "attacks": [
       {
         "cost": [
@@ -1166,6 +1209,9 @@
     "hp": "60",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Dolliv"
     ],
     "attacks": [
       {
@@ -1228,6 +1274,9 @@
       "Grass"
     ],
     "evolvesFrom": "Smoliv",
+    "evolvesTo": [
+      "Arboliva"
+    ],
     "attacks": [
       {
         "cost": [
@@ -1349,6 +1398,10 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Toedscruel",
+      "Toedscruel ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -1398,6 +1451,10 @@
     "hp": "60",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Toedscruel",
+      "Toedscruel ex"
     ],
     "attacks": [
       {
@@ -1523,6 +1580,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Scovillain"
+    ],
     "attacks": [
       {
         "cost": [
@@ -1572,6 +1632,9 @@
     "hp": "70",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Scovillain"
     ],
     "attacks": [
       {
@@ -1696,6 +1759,11 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -1746,6 +1814,11 @@
     "hp": "90",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -1880,6 +1953,11 @@
     "hp": "70",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Houndoom",
+      "Dark Houndoom",
+      "Houndoom ex"
     ],
     "attacks": [
       {
@@ -2068,6 +2146,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Crocalor"
+    ],
     "attacks": [
       {
         "cost": [
@@ -2131,6 +2212,10 @@
       "Fire"
     ],
     "evolvesFrom": "Fuecoco",
+    "evolvesTo": [
+      "Skeledirge ex",
+      "Skeledirge"
+    ],
     "attacks": [
       {
         "cost": [
@@ -2259,6 +2344,11 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Armarouge",
+      "Ceruledge",
+      "Armarouge ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -2308,6 +2398,11 @@
     "hp": "70",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Armarouge",
+      "Ceruledge",
+      "Armarouge ex"
     ],
     "attacks": [
       {
@@ -2421,6 +2516,14 @@
     "hp": "70",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Slowbro",
+      "Dark Slowbro",
+      "Slowking",
+      "Dark Slowking",
+      "Light Slowbro",
+      "Slowking ex"
     ],
     "attacks": [
       {
@@ -2543,6 +2646,12 @@
     "hp": "30",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -2668,6 +2777,9 @@
     "hp": "70",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Floatzel"
     ],
     "attacks": [
       {
@@ -2844,6 +2956,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Clawitzer"
+    ],
     "attacks": [
       {
         "cost": [
@@ -2895,6 +3010,9 @@
       "Water"
     ],
     "evolvesFrom": "Clauncher",
+    "evolvesTo": [
+      "Clawitzer BREAK"
+    ],
     "attacks": [
       {
         "cost": [
@@ -3018,6 +3136,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Quaxwell"
+    ],
     "attacks": [
       {
         "cost": [
@@ -3079,6 +3200,10 @@
       "Water"
     ],
     "evolvesFrom": "Quaxly",
+    "evolvesTo": [
+      "Quaquaval",
+      "Quaquaval ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -3201,6 +3326,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Wugtrio"
+    ],
     "attacks": [
       {
         "cost": [
@@ -3250,6 +3378,9 @@
     "hp": "60",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Wugtrio"
     ],
     "attacks": [
       {
@@ -3374,6 +3505,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Cetitan"
+    ],
     "attacks": [
       {
         "cost": [
@@ -3425,6 +3559,9 @@
     "hp": "100",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Cetitan"
     ],
     "attacks": [
       {
@@ -3679,6 +3816,10 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Magneton",
+      "Dark Magneton"
+    ],
     "attacks": [
       {
         "cost": [
@@ -3739,6 +3880,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Magnemite",
+    "evolvesTo": [
+      "Magnezone",
+      "Magnezone ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -3867,6 +4012,10 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Flaaffy",
+      "Dark Flaaffy"
+    ],
     "attacks": [
       {
         "cost": [
@@ -3929,6 +4078,11 @@
       "Lightning"
     ],
     "evolvesFrom": "Mareep",
+    "evolvesTo": [
+      "Ampharos",
+      "Ampharos ex",
+      "Ampharos-GX"
+    ],
     "attacks": [
       {
         "cost": [
@@ -4158,6 +4312,11 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Light Toxtricity",
+      "Toxtricity",
+      "Toxtricity ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -4274,6 +4433,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Pawmo"
+    ],
     "attacks": [
       {
         "cost": [
@@ -4323,6 +4485,9 @@
     "hp": "60",
     "types": [
       "Lightning"
+    ],
+    "evolvesTo": [
+      "Pawmo"
     ],
     "attacks": [
       {
@@ -4385,6 +4550,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pawmi",
+    "evolvesTo": [
+      "Pawmot",
+      "Pawmot ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -4502,6 +4671,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Kilowattrel"
+    ],
     "attacks": [
       {
         "cost": [
@@ -4567,6 +4739,9 @@
     "hp": "60",
     "types": [
       "Lightning"
+    ],
+    "evolvesTo": [
+      "Kilowattrel"
     ],
     "attacks": [
       {
@@ -4818,6 +4993,10 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Hypno",
+      "Dark Hypno"
+    ],
     "attacks": [
       {
         "cost": [
@@ -4954,6 +5133,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Kirlia"
+    ],
     "attacks": [
       {
         "cost": [
@@ -5012,6 +5194,12 @@
       "Psychic"
     ],
     "evolvesFrom": "Ralts",
+    "evolvesTo": [
+      "Gardevoir",
+      "Gardevoir ex",
+      "Gallade",
+      "Gardevoir-GX"
+    ],
     "attacks": [
       {
         "cost": [
@@ -5151,6 +5339,11 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Banette",
+      "Banette ex",
+      "Banette-GX"
+    ],
     "attacks": [
       {
         "cost": [
@@ -5278,6 +5471,9 @@
     "hp": "70",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Drifblim"
     ],
     "attacks": [
       {
@@ -5415,6 +5611,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Floette"
+    ],
     "attacks": [
       {
         "cost": [
@@ -5466,6 +5665,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Flabébé",
+    "evolvesTo": [
+      "Florges"
+    ],
     "attacks": [
       {
         "cost": [
@@ -5518,6 +5720,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Floette",
+    "evolvesTo": [
+      "Florges BREAK"
+    ],
     "abilities": [
       {
         "type": "Ability",
@@ -5736,6 +5941,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Dachsbun"
+    ],
     "attacks": [
       {
         "cost": [
@@ -5786,6 +5994,9 @@
     "hp": "60",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Dachsbun"
     ],
     "attacks": [
       {
@@ -5909,6 +6120,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Espathra"
+    ],
     "attacks": [
       {
         "cost": [
@@ -5960,6 +6174,9 @@
     "hp": "40",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Espathra"
     ],
     "attacks": [
       {
@@ -6016,6 +6233,9 @@
     "hp": "40",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Espathra"
     ],
     "attacks": [
       {
@@ -6137,6 +6357,10 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Houndstone",
+      "Houndstone ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -6193,6 +6417,10 @@
     "hp": "80",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Houndstone",
+      "Houndstone ex"
     ],
     "attacks": [
       {
@@ -6324,6 +6552,10 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Primeape",
+      "Dark Primeape"
+    ],
     "attacks": [
       {
         "cost": [
@@ -6375,6 +6607,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Mankey",
+    "evolvesTo": [
+      "Annihilape ex",
+      "Annihilape"
+    ],
     "attacks": [
       {
         "cost": [
@@ -6487,6 +6723,10 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Medicham",
+      "Medicham ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -6597,6 +6837,11 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Lucario",
+      "Lucario-GX",
+      "Lucario ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -6656,6 +6901,11 @@
     "hp": "70",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Lucario",
+      "Lucario-GX",
+      "Lucario ex"
     ],
     "attacks": [
       {
@@ -6718,6 +6968,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Riolu",
+    "evolvesTo": [
+      "Lucario LV.X"
+    ],
     "attacks": [
       {
         "cost": [
@@ -6779,6 +7032,9 @@
     "hp": "70",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Krokorok"
     ],
     "attacks": [
       {
@@ -6842,6 +7098,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Sandile",
+    "evolvesTo": [
+      "Krookodile"
+    ],
     "attacks": [
       {
         "cost": [
@@ -7024,6 +7283,9 @@
     "hp": "80",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Sandaconda"
     ],
     "attacks": [
       {
@@ -7465,6 +7727,11 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Muk",
+      "Dark Muk",
+      "Muk ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -7705,6 +7972,10 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Toxicroak",
+      "Toxicroak ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -7833,6 +8104,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Bisharp"
+    ],
     "attacks": [
       {
         "cost": [
@@ -7894,6 +8168,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Pawniard",
+    "evolvesTo": [
+      "Kingambit"
+    ],
     "attacks": [
       {
         "cost": [
@@ -8016,6 +8293,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Mabosstiff"
+    ],
     "attacks": [
       {
         "cost": [
@@ -8076,6 +8356,9 @@
     "hp": "80",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Mabosstiff"
     ],
     "attacks": [
       {
@@ -8328,6 +8611,10 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Revavroom",
+      "Revavroom ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -8383,6 +8670,10 @@
     "hp": "80",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Revavroom",
+      "Revavroom ex"
     ],
     "attacks": [
       {
@@ -8586,6 +8877,10 @@
     "hp": "110",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Blissey ex",
+      "Blissey"
     ],
     "attacks": [
       {
@@ -8824,6 +9119,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Staravia"
+    ],
     "attacks": [
       {
         "cost": [
@@ -8881,6 +9179,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Starly",
+    "evolvesTo": [
+      "Staraptor"
+    ],
     "attacks": [
       {
         "cost": [
@@ -9017,6 +9318,10 @@
     "hp": "60",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Greedent",
+      "Greedent ex"
     ],
     "abilities": [
       {
@@ -9200,6 +9505,10 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Oinkologne",
+      "Oinkologne ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -9259,6 +9568,10 @@
     "hp": "60",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Oinkologne",
+      "Oinkologne ex"
     ],
     "attacks": [
       {
@@ -9320,6 +9633,10 @@
     "hp": "70",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Oinkologne",
+      "Oinkologne ex"
     ],
     "attacks": [
       {
@@ -9504,6 +9821,10 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Maushold",
+      "Maushold ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -9553,6 +9874,10 @@
     "hp": "40",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Maushold",
+      "Maushold ex"
     ],
     "attacks": [
       {
@@ -10733,6 +11058,10 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Spidops",
+      "Spidops ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -10785,6 +11114,9 @@
       "Grass"
     ],
     "evolvesFrom": "Smoliv",
+    "evolvesTo": [
+      "Arboliva"
+    ],
     "attacks": [
       {
         "cost": [
@@ -10844,6 +11176,10 @@
     "hp": "50",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Toedscruel",
+      "Toedscruel ex"
     ],
     "attacks": [
       {
@@ -11018,6 +11354,14 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Slowbro",
+      "Dark Slowbro",
+      "Slowking",
+      "Dark Slowking",
+      "Light Slowbro",
+      "Slowking ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -11079,6 +11423,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Clawitzer"
+    ],
     "attacks": [
       {
         "cost": [
@@ -11128,6 +11475,9 @@
     "hp": "50",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Wugtrio"
     ],
     "attacks": [
       {
@@ -11359,6 +11709,10 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Hypno",
+      "Dark Hypno"
+    ],
     "attacks": [
       {
         "cost": [
@@ -11426,6 +11780,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Kirlia"
+    ],
     "attacks": [
       {
         "cost": [
@@ -11484,6 +11841,12 @@
       "Psychic"
     ],
     "evolvesFrom": "Ralts",
+    "evolvesTo": [
+      "Gardevoir",
+      "Gardevoir ex",
+      "Gallade",
+      "Gardevoir-GX"
+    ],
     "attacks": [
       {
         "cost": [
@@ -11552,6 +11915,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Dachsbun"
+    ],
     "attacks": [
       {
         "cost": [
@@ -11614,6 +11980,10 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Houndstone",
+      "Houndstone ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -11670,6 +12040,11 @@
     "hp": "70",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Lucario",
+      "Lucario-GX",
+      "Lucario ex"
     ],
     "attacks": [
       {
@@ -11730,6 +12105,9 @@
     "hp": "70",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Krokorok"
     ],
     "attacks": [
       {
@@ -12046,6 +12424,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Staravia"
+    ],
     "attacks": [
       {
         "cost": [
@@ -12101,6 +12482,10 @@
     "hp": "60",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Greedent",
+      "Greedent ex"
     ],
     "abilities": [
       {

--- a/cards/en/sv2.json
+++ b/cards/en/sv2.json
@@ -10,6 +10,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Skiploom"
+    ],
     "attacks": [
       {
         "cost": [
@@ -61,6 +64,9 @@
       "Grass"
     ],
     "evolvesFrom": "Hoppip",
+    "evolvesTo": [
+      "Jumpluff"
+    ],
     "abilities": [
       {
         "type": "Ability",
@@ -175,6 +181,11 @@
     "hp": "70",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Forretress",
+      "Dark Forretress",
+      "Forretress ex"
     ],
     "attacks": [
       {
@@ -419,6 +430,10 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Vespiquen",
+      "Vespiquen ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -529,6 +544,9 @@
     "hp": "90",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Abomasnow"
     ],
     "attacks": [
       {
@@ -645,6 +663,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Floragato"
+    ],
     "attacks": [
       {
         "cost": [
@@ -704,6 +725,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Floragato"
+    ],
     "attacks": [
       {
         "cost": [
@@ -756,6 +780,10 @@
       "Grass"
     ],
     "evolvesFrom": "Sprigatito",
+    "evolvesTo": [
+      "Meowscarada ex",
+      "Meowscarada"
+    ],
     "attacks": [
       {
         "cost": [
@@ -879,6 +907,10 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Spidops",
+      "Spidops ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -928,6 +960,10 @@
     "hp": "60",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Spidops",
+      "Spidops ex"
     ],
     "attacks": [
       {
@@ -1045,6 +1081,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Lokix"
+    ],
     "attacks": [
       {
         "cost": [
@@ -1103,6 +1142,9 @@
     "hp": "50",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Lokix"
     ],
     "attacks": [
       {
@@ -1215,6 +1257,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Brambleghast"
+    ],
     "attacks": [
       {
         "cost": [
@@ -1264,6 +1309,9 @@
     "hp": "50",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Brambleghast"
     ],
     "attacks": [
       {
@@ -1379,6 +1427,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Rabsca"
+    ],
     "attacks": [
       {
         "cost": [
@@ -1428,6 +1479,9 @@
     "hp": "50",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Rabsca"
     ],
     "attacks": [
       {
@@ -1614,6 +1668,9 @@
       "Fire"
     ],
     "evolvesFrom": "Fletchling",
+    "evolvesTo": [
+      "Talonflame"
+    ],
     "attacks": [
       {
         "cost": [
@@ -1671,6 +1728,9 @@
       "Fire"
     ],
     "evolvesFrom": "Fletchinder",
+    "evolvesTo": [
+      "Talonflame BREAK"
+    ],
     "attacks": [
       {
         "cost": [
@@ -1736,6 +1796,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Pyroar"
+    ],
     "attacks": [
       {
         "cost": [
@@ -1796,6 +1859,9 @@
       "Fire"
     ],
     "evolvesFrom": "Litleo",
+    "evolvesTo": [
+      "Pyroar BREAK"
+    ],
     "attacks": [
       {
         "cost": [
@@ -1915,6 +1981,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Crocalor"
+    ],
     "attacks": [
       {
         "cost": [
@@ -1965,6 +2034,9 @@
     "hp": "90",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Crocalor"
     ],
     "attacks": [
       {
@@ -2029,6 +2101,10 @@
       "Fire"
     ],
     "evolvesFrom": "Fuecoco",
+    "evolvesTo": [
+      "Skeledirge ex",
+      "Skeledirge"
+    ],
     "attacks": [
       {
         "cost": [
@@ -2157,6 +2233,11 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Armarouge",
+      "Ceruledge",
+      "Armarouge ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -2207,6 +2288,11 @@
     "hp": "80",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Armarouge",
+      "Ceruledge",
+      "Armarouge ex"
     ],
     "attacks": [
       {
@@ -2396,6 +2482,12 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
+    ],
     "attacks": [
       {
         "cost": [
@@ -2513,6 +2605,10 @@
     "hp": "70",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Azumarill",
+      "Light Azumarill"
     ],
     "attacks": [
       {
@@ -2808,6 +2904,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Quaxwell"
+    ],
     "attacks": [
       {
         "cost": [
@@ -2858,6 +2957,9 @@
     "hp": "70",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Quaxwell"
     ],
     "attacks": [
       {
@@ -2910,6 +3012,10 @@
       "Water"
     ],
     "evolvesFrom": "Quaxly",
+    "evolvesTo": [
+      "Quaquaval",
+      "Quaquaval ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -3035,6 +3141,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Cetitan"
+    ],
     "attacks": [
       {
         "cost": [
@@ -3087,6 +3196,9 @@
     "hp": "100",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Cetitan"
     ],
     "attacks": [
       {
@@ -3278,6 +3390,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Arctibax"
+    ],
     "attacks": [
       {
         "cost": [
@@ -3328,6 +3443,9 @@
     "hp": "70",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Arctibax"
     ],
     "attacks": [
       {
@@ -3392,6 +3510,9 @@
       "Water"
     ],
     "evolvesFrom": "Frigibax",
+    "evolvesTo": [
+      "Baxcalibur"
+    ],
     "attacks": [
       {
         "cost": [
@@ -3578,6 +3699,13 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
+    ],
     "attacks": [
       {
         "cost": [
@@ -3699,6 +3827,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "cost": [
@@ -3760,6 +3892,10 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Magneton",
+      "Dark Magneton"
+    ],
     "attacks": [
       {
         "cost": [
@@ -3819,6 +3955,12 @@
     "hp": "70",
     "types": [
       "Lightning"
+    ],
+    "evolvesTo": [
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {
@@ -3942,6 +4084,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Luxio"
+    ],
     "abilities": [
       {
         "type": "Ability",
@@ -3999,6 +4144,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Luxio"
+    ],
     "attacks": [
       {
         "cost": [
@@ -4050,6 +4198,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Shinx",
+    "evolvesTo": [
+      "Luxray"
+    ],
     "attacks": [
       {
         "cost": [
@@ -4112,6 +4263,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Luxio",
+    "evolvesTo": [
+      "Luxray BREAK"
+    ],
     "abilities": [
       {
         "type": "Ability",
@@ -4285,6 +4439,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Pawmo"
+    ],
     "attacks": [
       {
         "cost": [
@@ -4336,6 +4493,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pawmi",
+    "evolvesTo": [
+      "Pawmot",
+      "Pawmot ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -4457,6 +4618,10 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Bellibolt ex",
+      "Bellibolt"
+    ],
     "attacks": [
       {
         "cost": [
@@ -4506,6 +4671,10 @@
     "hp": "60",
     "types": [
       "Lightning"
+    ],
+    "evolvesTo": [
+      "Bellibolt ex",
+      "Bellibolt"
     ],
     "attacks": [
       {
@@ -4635,6 +4804,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Kilowattrel"
+    ],
     "attacks": [
       {
         "cost": [
@@ -4700,6 +4872,9 @@
     "hp": "60",
     "types": [
       "Lightning"
+    ],
+    "evolvesTo": [
+      "Kilowattrel"
     ],
     "attacks": [
       {
@@ -4832,6 +5007,13 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Wigglytuff",
+      "Dark Wigglytuff",
+      "Light Wigglytuff",
+      "Wigglytuff ex",
+      "Wigglytuff-GX"
+    ],
     "attacks": [
       {
         "cost": [
@@ -4952,6 +5134,14 @@
     "hp": "80",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Slowbro",
+      "Dark Slowbro",
+      "Slowking",
+      "Dark Slowking",
+      "Light Slowbro",
+      "Slowking ex"
     ],
     "attacks": [
       {
@@ -5094,6 +5284,9 @@
     "hp": "70",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Mismagius"
     ],
     "attacks": [
       {
@@ -5280,6 +5473,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Gothorita"
+    ],
     "attacks": [
       {
         "cost": [
@@ -5347,6 +5543,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Gothita",
+    "evolvesTo": [
+      "Gothitelle"
+    ],
     "attacks": [
       {
         "cost": [
@@ -5614,6 +5813,10 @@
     "hp": "90",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Palossand",
+      "Palossand-GX"
     ],
     "attacks": [
       {
@@ -5952,6 +6155,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Tinkatuff"
+    ],
     "attacks": [
       {
         "cost": [
@@ -6011,6 +6217,9 @@
     "hp": "60",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Tinkatuff"
     ],
     "attacks": [
       {
@@ -6073,6 +6282,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Tinkatuff"
+    ],
     "attacks": [
       {
         "cost": [
@@ -6124,6 +6336,10 @@
       "Psychic"
     ],
     "evolvesFrom": "Tinkatink",
+    "evolvesTo": [
+      "Tinkaton",
+      "Tinkaton ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -6186,6 +6402,10 @@
       "Psychic"
     ],
     "evolvesFrom": "Tinkatink",
+    "evolvesTo": [
+      "Tinkaton",
+      "Tinkaton ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -6309,6 +6529,10 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Primeape",
+      "Dark Primeape"
+    ],
     "attacks": [
       {
         "cost": [
@@ -6370,6 +6594,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Mankey",
+    "evolvesTo": [
+      "Annihilape ex",
+      "Annihilape"
+    ],
     "attacks": [
       {
         "cost": [
@@ -6555,6 +6783,10 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Pupitar",
+      "Dark Pupitar"
+    ],
     "attacks": [
       {
         "cost": [
@@ -6607,6 +6839,11 @@
       "Fighting"
     ],
     "evolvesFrom": "Larvitar",
+    "evolvesTo": [
+      "Tyranitar",
+      "Tyranitar ex",
+      "Tyranitar-GX"
+    ],
     "attacks": [
       {
         "cost": [
@@ -6657,6 +6894,10 @@
     "hp": "90",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Hariyama",
+      "Hariyama ex"
     ],
     "attacks": [
       {
@@ -6773,6 +7014,10 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Toxicroak",
+      "Toxicroak ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -6883,6 +7128,11 @@
     "hp": "70",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Lycanroc-GX",
+      "Lycanroc",
+      "Lycanroc ex"
     ],
     "attacks": [
       {
@@ -7124,6 +7374,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Naclstack"
+    ],
     "attacks": [
       {
         "cost": [
@@ -7174,6 +7427,9 @@
     "hp": "70",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Naclstack"
     ],
     "attacks": [
       {
@@ -7238,6 +7494,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Nacli",
+    "evolvesTo": [
+      "Garganacl"
+    ],
     "attacks": [
       {
         "cost": [
@@ -7352,6 +7611,10 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Glimmora",
+      "Glimmora ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -7401,6 +7664,10 @@
     "hp": "70",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Glimmora",
+      "Glimmora ex"
     ],
     "attacks": [
       {
@@ -7578,6 +7845,10 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Paldean Clodsire ex",
+      "Paldean Clodsire"
+    ],
     "attacks": [
       {
         "cost": [
@@ -7637,6 +7908,10 @@
     "hp": "60",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Paldean Clodsire ex",
+      "Paldean Clodsire"
     ],
     "attacks": [
       {
@@ -7763,6 +8038,10 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Honchkrow",
+      "Honchkrow-GX"
+    ],
     "attacks": [
       {
         "cost": [
@@ -7829,6 +8108,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Murkrow",
+    "evolvesTo": [
+      "Honchkrow LV.X"
+    ],
     "attacks": [
       {
         "cost": [
@@ -7895,6 +8177,10 @@
     "hp": "70",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Weavile",
+      "Weavile-GX"
     ],
     "attacks": [
       {
@@ -8187,6 +8473,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Zweilous"
+    ],
     "attacks": [
       {
         "cost": [
@@ -8239,6 +8528,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Deino",
+    "evolvesTo": [
+      "Hydreigon"
+    ],
     "attacks": [
       {
         "cost": [
@@ -8302,6 +8594,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Zweilous",
+    "evolvesTo": [
+      "Hydreigon BREAK"
+    ],
     "abilities": [
       {
         "type": "Ability",
@@ -8363,6 +8658,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Mabosstiff"
+    ],
     "attacks": [
       {
         "cost": [
@@ -8412,6 +8710,9 @@
     "hp": "70",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Mabosstiff"
     ],
     "attacks": [
       {
@@ -8541,6 +8842,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Grafaiai"
+    ],
     "attacks": [
       {
         "cost": [
@@ -8599,6 +8903,9 @@
     "hp": "60",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Grafaiai"
     ],
     "attacks": [
       {
@@ -8846,6 +9153,10 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Copperajah",
+      "Copperajah ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -9044,6 +9355,11 @@
     "types": [
       "Dragon"
     ],
+    "evolvesTo": [
+      "Noivern",
+      "Noivern-GX",
+      "Noivern ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -9143,6 +9459,9 @@
     "hp": "100",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Farigiraf"
     ],
     "attacks": [
       {
@@ -9270,6 +9589,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Dudunsparce"
+    ],
     "attacks": [
       {
         "cost": [
@@ -9396,6 +9718,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Pelipper"
+    ],
     "attacks": [
       {
         "cost": [
@@ -9520,6 +9845,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Vigoroth"
+    ],
     "attacks": [
       {
         "cost": [
@@ -9573,6 +9901,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Slakoth",
+    "evolvesTo": [
+      "Slaking"
+    ],
     "attacks": [
       {
         "cost": [
@@ -9699,6 +10030,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Fletchinder"
+    ],
     "attacks": [
       {
         "cost": [
@@ -9754,6 +10088,9 @@
     "hp": "60",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Corvisquire"
     ],
     "attacks": [
       {
@@ -9812,6 +10149,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Rookidee",
+    "evolvesTo": [
+      "Corviknight"
+    ],
     "attacks": [
       {
         "cost": [
@@ -9879,6 +10219,10 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Maushold",
+      "Maushold ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -9939,6 +10283,10 @@
     "hp": "40",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Maushold",
+      "Maushold ex"
     ],
     "attacks": [
       {
@@ -10891,6 +11239,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Floragato"
+    ],
     "attacks": [
       {
         "cost": [
@@ -10951,6 +11302,10 @@
       "Grass"
     ],
     "evolvesFrom": "Sprigatito",
+    "evolvesTo": [
+      "Meowscarada ex",
+      "Meowscarada"
+    ],
     "attacks": [
       {
         "cost": [
@@ -11011,6 +11366,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Brambleghast"
+    ],
     "attacks": [
       {
         "cost": [
@@ -11062,6 +11420,9 @@
       "Fire"
     ],
     "evolvesFrom": "Fletchling",
+    "evolvesTo": [
+      "Talonflame"
+    ],
     "attacks": [
       {
         "cost": [
@@ -11119,6 +11480,9 @@
       "Fire"
     ],
     "evolvesFrom": "Litleo",
+    "evolvesTo": [
+      "Pyroar BREAK"
+    ],
     "attacks": [
       {
         "cost": [
@@ -11179,6 +11543,9 @@
     "hp": "90",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Crocalor"
     ],
     "attacks": [
       {
@@ -11243,6 +11610,10 @@
       "Fire"
     ],
     "evolvesFrom": "Fuecoco",
+    "evolvesTo": [
+      "Skeledirge ex",
+      "Skeledirge"
+    ],
     "attacks": [
       {
         "cost": [
@@ -11305,6 +11676,12 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
+    ],
     "attacks": [
       {
         "cost": [
@@ -11354,6 +11731,10 @@
     "hp": "70",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Azumarill",
+      "Light Azumarill"
     ],
     "attacks": [
       {
@@ -11467,6 +11848,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Quaxwell"
+    ],
     "attacks": [
       {
         "cost": [
@@ -11519,6 +11903,10 @@
       "Water"
     ],
     "evolvesFrom": "Quaxly",
+    "evolvesTo": [
+      "Quaquaval",
+      "Quaquaval ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -11579,6 +11967,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Arctibax"
+    ],
     "attacks": [
       {
         "cost": [
@@ -11631,6 +12022,9 @@
       "Water"
     ],
     "evolvesFrom": "Frigibax",
+    "evolvesTo": [
+      "Baxcalibur"
+    ],
     "attacks": [
       {
         "cost": [
@@ -11756,6 +12150,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "cost": [
@@ -11883,6 +12281,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Gothita",
+    "evolvesTo": [
+      "Gothitelle"
+    ],
     "attacks": [
       {
         "cost": [
@@ -11948,6 +12349,10 @@
     "hp": "90",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Palossand",
+      "Palossand-GX"
     ],
     "attacks": [
       {
@@ -12086,6 +12491,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Tinkatuff"
+    ],
     "attacks": [
       {
         "cost": [
@@ -12148,6 +12556,10 @@
       "Psychic"
     ],
     "evolvesFrom": "Tinkatink",
+    "evolvesTo": [
+      "Tinkaton",
+      "Tinkaton ex"
+    ],
     "attacks": [
       {
         "cost": [
@@ -12335,6 +12747,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Naclstack"
+    ],
     "attacks": [
       {
         "cost": [
@@ -12396,6 +12811,10 @@
     "hp": "60",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Paldean Clodsire ex",
+      "Paldean Clodsire"
     ],
     "attacks": [
       {
@@ -12646,6 +13065,9 @@
     "hp": "60",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Corvisquire"
     ],
     "attacks": [
       {

--- a/cards/en/sv3.json
+++ b/cards/en/sv3.json
@@ -11,7 +11,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Gloom"
+      "Gloom",
+      "Dark Gloom"
     ],
     "attacks": [
       {
@@ -75,7 +76,9 @@
     "evolvesFrom": "Oddish",
     "evolvesTo": [
       "Vileplume",
-      "Bellossom"
+      "Bellossom",
+      "Vileplume ex",
+      "Vileplume-GX"
     ],
     "attacks": [
       {
@@ -199,7 +202,10 @@
     ],
     "evolvesTo": [
       "Scizor",
-      "Kleavor"
+      "Kleavor",
+      "Scizor ex",
+      "Dark Scizor",
+      "Scizor-GX"
     ],
     "attacks": [
       {
@@ -436,7 +442,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Vespiquen"
+      "Vespiquen",
+      "Vespiquen ex"
     ],
     "attacks": [
       {
@@ -669,6 +676,9 @@
       "Grass"
     ],
     "evolvesFrom": "Phantump",
+    "evolvesTo": [
+      "Trevenant BREAK"
+    ],
     "abilities": [
       {
         "name": "Forest Miasma",
@@ -785,7 +795,10 @@
     ],
     "evolvesFrom": "Rowlet",
     "evolvesTo": [
-      "Decidueye"
+      "Decidueye",
+      "Decidueye-GX",
+      "Hisuian Decidueye",
+      "Decidueye ex"
     ],
     "attacks": [
       {
@@ -966,7 +979,9 @@
     ],
     "evolvesFrom": "Bounsweet",
     "evolvesTo": [
-      "Tsareena"
+      "Tsareena",
+      "Tsareena-GX",
+      "Tsareena ex"
     ],
     "attacks": [
       {
@@ -1492,7 +1507,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -1546,7 +1562,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "attacks": [
       {
@@ -1601,7 +1620,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {
@@ -1664,6 +1685,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "attacks": [
       {
         "name": "Will-O-Wisp",
@@ -1785,7 +1809,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Camerupt"
+      "Camerupt",
+      "Camerupt ex"
     ],
     "attacks": [
       {
@@ -2334,7 +2359,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Volcarona"
+      "Volcarona",
+      "Volcarona-GX"
     ],
     "attacks": [
       {
@@ -2520,7 +2546,8 @@
     ],
     "evolvesTo": [
       "Armarouge",
-      "Ceruledge"
+      "Ceruledge",
+      "Armarouge ex"
     ],
     "attacks": [
       {
@@ -2704,7 +2731,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Sharpedo"
+      "Sharpedo",
+      "Sharpedo ex"
     ],
     "attacks": [
       {
@@ -3334,7 +3362,9 @@
     ],
     "evolvesFrom": "Froakie",
     "evolvesTo": [
-      "Greninja"
+      "Greninja",
+      "Greninja-GX",
+      "Greninja ex"
     ],
     "attacks": [
       {
@@ -3672,7 +3702,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -3736,7 +3767,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "attacks": [
       {
@@ -3801,6 +3833,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Magneton",
+    "evolvesTo": [
+      "Magnezone LV.X"
+    ],
     "attacks": [
       {
         "name": "Magnetic Repulsion",
@@ -4185,7 +4220,9 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Toxtricity"
+      "Toxtricity",
+      "Light Toxtricity",
+      "Toxtricity ex"
     ],
     "attacks": [
       {
@@ -4360,7 +4397,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Bellibolt"
+      "Bellibolt",
+      "Bellibolt ex"
     ],
     "attacks": [
       {
@@ -4424,7 +4462,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Bellibolt"
+      "Bellibolt",
+      "Bellibolt ex"
     ],
     "attacks": [
       {
@@ -4478,7 +4517,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Bellibolt"
+      "Bellibolt",
+      "Bellibolt ex"
     ],
     "attacks": [
       {
@@ -4707,9 +4747,6 @@
     "types": [
       "Psychic"
     ],
-    "evolvesTo": [
-      "Clefairy"
-    ],
     "attacks": [
       {
         "name": "Grasping Draw",
@@ -4755,7 +4792,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Clefable",
+      "Clefable ex"
     ],
     "attacks": [
       {
@@ -4873,7 +4911,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Togetic"
+      "Togetic",
+      "Light Togetic"
     ],
     "attacks": [
       {
@@ -5569,7 +5608,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Claydol"
+      "Claydol",
+      "Claydol ex"
     ],
     "attacks": [
       {
@@ -5896,7 +5936,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Houndstone"
+      "Houndstone",
+      "Houndstone ex"
     ],
     "attacks": [
       {
@@ -5966,7 +6007,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Houndstone"
+      "Houndstone",
+      "Houndstone ex"
     ],
     "attacks": [
       {
@@ -6173,7 +6215,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Dugtrio"
+      "Dugtrio",
+      "Dark Dugtrio"
     ],
     "attacks": [
       {
@@ -6277,7 +6320,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Pupitar"
+      "Pupitar",
+      "Dark Pupitar"
     ],
     "attacks": [
       {
@@ -6341,7 +6385,9 @@
     ],
     "evolvesFrom": "Larvitar",
     "evolvesTo": [
-      "Tyranitar"
+      "Tyranitar",
+      "Tyranitar ex",
+      "Tyranitar-GX"
     ],
     "attacks": [
       {
@@ -6596,9 +6642,6 @@
     "hp": "30",
     "types": [
       "Fighting"
-    ],
-    "evolvesTo": [
-      "Sudowoodo"
     ],
     "attacks": [
       {
@@ -6957,7 +7000,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lycanroc"
+      "Lycanroc",
+      "Lycanroc-GX",
+      "Lycanroc ex"
     ],
     "attacks": [
       {
@@ -7073,7 +7118,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Toedscruel"
+      "Toedscruel",
+      "Toedscruel ex"
     ],
     "attacks": [
       {
@@ -7264,7 +7310,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Glimmora"
+      "Glimmora",
+      "Glimmora ex"
     ],
     "attacks": [
       {
@@ -7326,7 +7373,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Glimmora"
+      "Glimmora",
+      "Glimmora ex"
     ],
     "attacks": [
       {
@@ -7575,8 +7623,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Quagsire",
-      "Clodsire"
+      "Paldean Clodsire ex",
+      "Paldean Clodsire"
     ],
     "attacks": [
       {
@@ -7629,8 +7677,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Quagsire",
-      "Clodsire"
+      "Paldean Clodsire ex",
+      "Paldean Clodsire"
     ],
     "attacks": [
       {
@@ -7875,7 +7923,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Houndoom",
+      "Dark Houndoom",
+      "Houndoom ex"
     ],
     "attacks": [
       {
@@ -7938,7 +7988,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Houndoom",
+      "Dark Houndoom",
+      "Houndoom ex"
     ],
     "attacks": [
       {
@@ -8196,6 +8248,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Darkrai LV.X"
+    ],
     "attacks": [
       {
         "name": "Dark Slumber",
@@ -8374,7 +8429,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Salazzle"
+      "Salazzle",
+      "Salazzle-GX"
     ],
     "attacks": [
       {
@@ -8768,6 +8824,9 @@
       "Metal"
     ],
     "evolvesFrom": "Bronzor",
+    "evolvesTo": [
+      "Bronzong BREAK"
+    ],
     "attacks": [
       {
         "name": "Oracle Press",
@@ -9234,7 +9293,9 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Melmetal"
+      "Melmetal",
+      "Melmetal-GX",
+      "Melmetal ex"
     ],
     "attacks": [
       {
@@ -9368,7 +9429,8 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Revavroom"
+      "Revavroom",
+      "Revavroom ex"
     ],
     "attacks": [
       {
@@ -9427,7 +9489,8 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Revavroom"
+      "Revavroom",
+      "Revavroom ex"
     ],
     "attacks": [
       {
@@ -9557,7 +9620,9 @@
       "Dragon"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "attacks": [
       {
@@ -9605,7 +9670,9 @@
     ],
     "evolvesFrom": "Dratini",
     "evolvesTo": [
-      "Dragonite"
+      "Dragonite",
+      "Dragonite ex",
+      "Dragonite-GX"
     ],
     "attacks": [
       {
@@ -9885,7 +9952,8 @@
     ],
     "evolvesFrom": "Pidgey",
     "evolvesTo": [
-      "Pidgeot"
+      "Pidgeot",
+      "Pidgeot ex"
     ],
     "attacks": [
       {
@@ -10077,7 +10145,27 @@
       "Umbreon",
       "Leafeon",
       "Glaceon",
-      "Sylveon"
+      "Sylveon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -10203,9 +10291,6 @@
       "Colorless"
     ],
     "evolvesFrom": "Zigzagoon",
-    "evolvesTo": [
-      "Obstagoon"
-    ],
     "attacks": [
       {
         "name": "Jet Headbutt",
@@ -10264,7 +10349,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Altaria"
+      "Altaria",
+      "Altaria ex",
+      "Altaria-GX"
     ],
     "attacks": [
       {
@@ -10688,7 +10775,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Gumshoos"
+      "Gumshoos",
+      "Gumshoos-GX"
     ],
     "attacks": [
       {
@@ -10803,7 +10891,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Greedent"
+      "Greedent",
+      "Greedent ex"
     ],
     "attacks": [
       {
@@ -10933,7 +11022,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Oinkologne"
+      "Oinkologne",
+      "Oinkologne ex"
     ],
     "attacks": [
       {
@@ -10986,7 +11076,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Oinkologne"
+      "Oinkologne",
+      "Oinkologne ex"
     ],
     "attacks": [
       {
@@ -11041,7 +11132,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Oinkologne"
+      "Oinkologne",
+      "Oinkologne ex"
     ],
     "attacks": [
       {
@@ -11603,7 +11695,9 @@
     "evolvesFrom": "Oddish",
     "evolvesTo": [
       "Vileplume",
-      "Bellossom"
+      "Bellossom",
+      "Vileplume ex",
+      "Vileplume-GX"
     ],
     "attacks": [
       {
@@ -11666,6 +11760,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "attacks": [
       {
         "name": "Will-O-Wisp",
@@ -11850,9 +11947,6 @@
     "types": [
       "Psychic"
     ],
-    "evolvesTo": [
-      "Clefairy"
-    ],
     "attacks": [
       {
         "name": "Grasping Draw",
@@ -11898,7 +11992,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Pupitar"
+      "Pupitar",
+      "Dark Pupitar"
     ],
     "attacks": [
       {
@@ -11961,7 +12056,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Houndoom",
+      "Dark Houndoom",
+      "Houndoom ex"
     ],
     "attacks": [
       {
@@ -12092,7 +12189,8 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Revavroom"
+      "Revavroom",
+      "Revavroom ex"
     ],
     "attacks": [
       {
@@ -12211,7 +12309,8 @@
     ],
     "evolvesFrom": "Pidgey",
     "evolvesTo": [
-      "Pidgeot"
+      "Pidgeot",
+      "Pidgeot ex"
     ],
     "attacks": [
       {
@@ -12271,7 +12370,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Oinkologne"
+      "Oinkologne",
+      "Oinkologne ex"
     ],
     "attacks": [
       {

--- a/cards/en/sv3pt5.json
+++ b/cards/en/sv3pt5.json
@@ -11,7 +11,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ivysaur"
+      "Ivysaur",
+      "Dark Ivysaur"
     ],
     "attacks": [
       {
@@ -67,7 +68,8 @@
     ],
     "evolvesFrom": "Bulbasaur",
     "evolvesTo": [
-      "Venusaur"
+      "Venusaur",
+      "Venusaur ex"
     ],
     "attacks": [
       {
@@ -200,7 +202,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -264,7 +267,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "attacks": [
       {
@@ -396,7 +402,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wartortle"
+      "Wartortle",
+      "Dark Wartortle"
     ],
     "attacks": [
       {
@@ -460,7 +467,9 @@
     ],
     "evolvesFrom": "Squirtle",
     "evolvesTo": [
-      "Blastoise"
+      "Blastoise",
+      "Blastoise ex",
+      "Blastoise-GX"
     ],
     "attacks": [
       {
@@ -1027,7 +1036,8 @@
     ],
     "evolvesFrom": "Pidgey",
     "evolvesTo": [
-      "Pidgeot"
+      "Pidgeot",
+      "Pidgeot ex"
     ],
     "attacks": [
       {
@@ -1146,7 +1156,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Raticate"
+      "Raticate",
+      "Dark Raticate"
     ],
     "attacks": [
       {
@@ -1200,6 +1211,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Rattata",
+    "evolvesTo": [
+      "Raticate BREAK"
+    ],
     "attacks": [
       {
         "name": "Second Bite",
@@ -1376,7 +1390,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Arbok"
+      "Arbok",
+      "Dark Arbok",
+      "Arbok ex"
     ],
     "attacks": [
       {
@@ -1498,7 +1514,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -1562,6 +1582,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "abilities": [
       {
         "name": "Electrical Grounding",
@@ -1622,7 +1646,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Sandslash"
+      "Sandslash",
+      "Dark Sandslash"
     ],
     "abilities": [
       {
@@ -2049,6 +2074,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Nidorino",
+    "evolvesTo": [
+      "Nidoking BREAK"
+    ],
     "abilities": [
       {
         "name": "Enthusiastic King",
@@ -2112,7 +2140,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Clefable",
+      "Clefable ex"
     ],
     "attacks": [
       {
@@ -2238,7 +2267,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {
@@ -2357,7 +2388,11 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Wigglytuff"
+      "Wigglytuff",
+      "Dark Wigglytuff",
+      "Light Wigglytuff",
+      "Wigglytuff ex",
+      "Wigglytuff-GX"
     ],
     "attacks": [
       {
@@ -2485,7 +2520,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Golbat"
+      "Golbat",
+      "Dark Golbat"
     ],
     "abilities": [
       {
@@ -2552,7 +2588,8 @@
     ],
     "evolvesFrom": "Zubat",
     "evolvesTo": [
-      "Crobat"
+      "Crobat",
+      "Crobat ex"
     ],
     "attacks": [
       {
@@ -2611,7 +2648,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Gloom"
+      "Gloom",
+      "Dark Gloom"
     ],
     "attacks": [
       {
@@ -2667,7 +2705,9 @@
     "evolvesFrom": "Oddish",
     "evolvesTo": [
       "Vileplume",
-      "Bellossom"
+      "Bellossom",
+      "Vileplume ex",
+      "Vileplume-GX"
     ],
     "abilities": [
       {
@@ -2915,7 +2955,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Venomoth"
+      "Venomoth",
+      "Light Venomoth",
+      "Venomoth-GX"
     ],
     "attacks": [
       {
@@ -3042,7 +3084,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Dugtrio"
+      "Dugtrio",
+      "Dark Dugtrio"
     ],
     "attacks": [
       {
@@ -3166,7 +3209,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -3289,7 +3334,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Golduck",
+      "Dark Golduck",
+      "Light Golduck"
     ],
     "attacks": [
       {
@@ -3351,6 +3398,9 @@
       "Water"
     ],
     "evolvesFrom": "Psyduck",
+    "evolvesTo": [
+      "Golduck BREAK"
+    ],
     "attacks": [
       {
         "name": "Aquatic Rescue",
@@ -3413,7 +3463,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Primeape"
+      "Primeape",
+      "Dark Primeape"
     ],
     "attacks": [
       {
@@ -3466,6 +3517,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Mankey",
+    "evolvesTo": [
+      "Annihilape ex",
+      "Annihilape"
+    ],
     "attacks": [
       {
         "name": "Rant and Rave",
@@ -3529,7 +3584,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -3583,6 +3640,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "attacks": [
       {
         "name": "Torrid Torrent",
@@ -3704,7 +3764,8 @@
     "evolvesFrom": "Poliwag",
     "evolvesTo": [
       "Poliwrath",
-      "Politoed"
+      "Politoed",
+      "Politoed ex"
     ],
     "attacks": [
       {
@@ -3830,7 +3891,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Kadabra"
+      "Kadabra",
+      "Dark Kadabra"
     ],
     "attacks": [
       {
@@ -3890,7 +3952,8 @@
     ],
     "evolvesFrom": "Abra",
     "evolvesTo": [
-      "Alakazam"
+      "Alakazam",
+      "Alakazam ex"
     ],
     "attacks": [
       {
@@ -4020,7 +4083,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Machoke"
+      "Machoke",
+      "Dark Machoke",
+      "Light Machoke"
     ],
     "attacks": [
       {
@@ -4085,7 +4150,8 @@
     ],
     "evolvesFrom": "Machop",
     "evolvesTo": [
-      "Machamp"
+      "Machamp",
+      "Machamp-GX"
     ],
     "attacks": [
       {
@@ -4140,6 +4206,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Machoke",
+    "evolvesTo": [
+      "Machamp LV.X",
+      "Machamp BREAK"
+    ],
     "abilities": [
       {
         "name": "Guts",
@@ -4583,7 +4653,8 @@
     ],
     "evolvesFrom": "Geodude",
     "evolvesTo": [
-      "Golem"
+      "Golem",
+      "Golem ex"
     ],
     "attacks": [
       {
@@ -4717,7 +4788,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Rapidash"
+      "Rapidash",
+      "Dark Rapidash"
     ],
     "attacks": [
       {
@@ -4844,7 +4916,11 @@
     ],
     "evolvesTo": [
       "Slowbro",
-      "Slowking"
+      "Slowking",
+      "Dark Slowbro",
+      "Dark Slowking",
+      "Light Slowbro",
+      "Slowking ex"
     ],
     "attacks": [
       {
@@ -4983,7 +5059,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -5047,7 +5124,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "attacks": [
       {
@@ -5110,9 +5188,6 @@
     "hp": "90",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Sirfetch'd"
     ],
     "attacks": [
       {
@@ -5303,7 +5378,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Dewgong"
+      "Dewgong",
+      "Light Dewgong"
     ],
     "attacks": [
       {
@@ -5421,7 +5497,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Muk"
+      "Muk",
+      "Dark Muk",
+      "Muk ex"
     ],
     "attacks": [
       {
@@ -5650,7 +5728,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Haunter",
+      "Dark Haunter"
     ],
     "attacks": [
       {
@@ -5710,7 +5789,8 @@
     ],
     "evolvesFrom": "Gastly",
     "evolvesTo": [
-      "Gengar"
+      "Gengar",
+      "Gengar ex"
     ],
     "abilities": [
       {
@@ -5777,6 +5857,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Haunter",
+    "evolvesTo": [
+      "Gengar LV.X"
+    ],
     "attacks": [
       {
         "name": "Poltergeist",
@@ -5840,7 +5923,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Steelix"
+      "Steelix",
+      "Dark Steelix",
+      "Steelix ex"
     ],
     "attacks": [
       {
@@ -5909,7 +5994,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Hypno"
+      "Hypno",
+      "Dark Hypno"
     ],
     "attacks": [
       {
@@ -6168,7 +6254,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {
@@ -6282,7 +6371,10 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Exeggutor"
+      "Exeggutor",
+      "Dark Exeggutor",
+      "Alolan Exeggutor-GX",
+      "Alolan Exeggutor"
     ],
     "attacks": [
       {
@@ -6401,7 +6493,10 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Marowak"
+      "Marowak",
+      "Dark Marowak",
+      "Alolan Marowak-GX",
+      "Alolan Marowak"
     ],
     "abilities": [
       {
@@ -6461,6 +6556,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Cubone",
+    "evolvesTo": [
+      "Marowak BREAK"
+    ],
     "attacks": [
       {
         "name": "Bone Throw",
@@ -6701,7 +6799,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Weezing"
+      "Weezing",
+      "Dark Weezing",
+      "Galarian Weezing"
     ],
     "attacks": [
       {
@@ -6951,7 +7051,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Blissey"
+      "Blissey",
+      "Blissey ex"
     ],
     "abilities": [
       {
@@ -7198,7 +7299,9 @@
     ],
     "evolvesFrom": "Horsea",
     "evolvesTo": [
-      "Kingdra"
+      "Kingdra",
+      "Kingdra ex",
+      "Kingdra-GX"
     ],
     "attacks": [
       {
@@ -7379,7 +7482,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Starmie"
+      "Starmie",
+      "Starmie-GX"
     ],
     "attacks": [
       {
@@ -7433,6 +7537,9 @@
       "Water"
     ],
     "evolvesFrom": "Staryu",
+    "evolvesTo": [
+      "Starmie BREAK"
+    ],
     "abilities": [
       {
         "name": "Mysterious Comet",
@@ -7552,7 +7659,11 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor",
+      "Scizor ex",
+      "Dark Scizor",
+      "Scizor-GX",
+      "Kleavor"
     ],
     "attacks": [
       {
@@ -7932,7 +8043,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -8174,7 +8288,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -8420,7 +8554,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Porygon2"
+      "Porygon2",
+      "Dark Porygon2"
     ],
     "attacks": [
       {
@@ -8529,6 +8664,9 @@
       "Water"
     ],
     "evolvesFrom": "Omanyte",
+    "evolvesTo": [
+      "Omastar BREAK"
+    ],
     "abilities": [
       {
         "name": "Primordial Tentacles",
@@ -8591,7 +8729,8 @@
     ],
     "evolvesFrom": "Antique Dome Fossil",
     "evolvesTo": [
-      "Kabutops"
+      "Kabutops",
+      "Kabutops ex"
     ],
     "attacks": [
       {
@@ -8768,6 +8907,9 @@
     "hp": "150",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Snorlax LV.X"
     ],
     "abilities": [
       {
@@ -9033,7 +9175,9 @@
       "Dragon"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "attacks": [
       {
@@ -9091,7 +9235,9 @@
     ],
     "evolvesFrom": "Dratini",
     "evolvesTo": [
-      "Dragonite"
+      "Dragonite",
+      "Dragonite ex",
+      "Dragonite-GX"
     ],
     "attacks": [
       {
@@ -9202,6 +9348,9 @@
     "hp": "130",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Mewtwo LV.X"
     ],
     "attacks": [
       {
@@ -9333,6 +9482,9 @@
       "Item"
     ],
     "hp": "60",
+    "evolvesTo": [
+      "Kabuto"
+    ],
     "rules": [
       "Play this card as if it were a 60-HP Basic Colorless Pokémon. This card can't be affected by any Special Conditions and can't retreat.  At any time during your turn, you may discard this card from play.",
       "You may play any number of Item cards during your turn."
@@ -9366,6 +9518,9 @@
       "Item"
     ],
     "hp": "60",
+    "evolvesTo": [
+      "Omanyte"
+    ],
     "rules": [
       "Play this card as if it were a 60-HP Basic Colorless Pokémon. This card can't be affected by any Special Conditions and can't retreat.  At any time during your turn, you may discard this card from play.",
       "You may play any number of Item cards during your turn."
@@ -9399,6 +9554,9 @@
       "Item"
     ],
     "hp": "60",
+    "evolvesTo": [
+      "Aerodactyl"
+    ],
     "rules": [
       "Play this card as if it were a 60-HP Basic Colorless Pokémon. This card can't be affected by any Special Conditions and can't retreat.  At any time during your turn, you may discard this card from play.",
       "You may play any number of Item cards during your turn."
@@ -9711,7 +9869,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ivysaur"
+      "Ivysaur",
+      "Dark Ivysaur"
     ],
     "attacks": [
       {
@@ -9767,7 +9926,8 @@
     ],
     "evolvesFrom": "Bulbasaur",
     "evolvesTo": [
-      "Venusaur"
+      "Venusaur",
+      "Venusaur ex"
     ],
     "attacks": [
       {
@@ -9834,7 +9994,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -9898,7 +10059,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "attacks": [
       {
@@ -9963,7 +10127,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wartortle"
+      "Wartortle",
+      "Dark Wartortle"
     ],
     "attacks": [
       {
@@ -10027,7 +10192,9 @@
     ],
     "evolvesFrom": "Squirtle",
     "evolvesTo": [
-      "Blastoise"
+      "Blastoise",
+      "Blastoise ex",
+      "Blastoise-GX"
     ],
     "attacks": [
       {
@@ -10144,7 +10311,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -10208,6 +10379,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Nidorino",
+    "evolvesTo": [
+      "Nidoking BREAK"
+    ],
     "abilities": [
       {
         "name": "Enthusiastic King",
@@ -10271,7 +10445,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Golduck",
+      "Dark Golduck",
+      "Light Golduck"
     ],
     "attacks": [
       {
@@ -10335,7 +10511,8 @@
     "evolvesFrom": "Poliwag",
     "evolvesTo": [
       "Poliwrath",
-      "Politoed"
+      "Politoed",
+      "Politoed ex"
     ],
     "attacks": [
       {
@@ -10399,7 +10576,8 @@
     ],
     "evolvesFrom": "Machop",
     "evolvesTo": [
-      "Machamp"
+      "Machamp",
+      "Machamp-GX"
     ],
     "attacks": [
       {
@@ -10625,7 +10803,9 @@
     ],
     "evolvesFrom": "Dratini",
     "evolvesTo": [
-      "Dragonite"
+      "Dragonite",
+      "Dragonite ex",
+      "Dragonite-GX"
     ],
     "attacks": [
       {

--- a/cards/en/sv3pt5.json
+++ b/cards/en/sv3pt5.json
@@ -1736,7 +1736,7 @@
   },
   {
     "id": "sv3pt5-29",
-    "name": "Nidoran♀",
+    "name": "Nidoran ♀",
     "supertype": "Pokémon",
     "subtypes": [
       "Basic"
@@ -1799,7 +1799,7 @@
     "types": [
       "Darkness"
     ],
-    "evolvesFrom": "Nidoran♀",
+    "evolvesFrom": "Nidoran ♀",
     "evolvesTo": [
       "Nidoqueen"
     ],
@@ -1920,7 +1920,7 @@
   },
   {
     "id": "sv3pt5-32",
-    "name": "Nidoran♂",
+    "name": "Nidoran ♂",
     "supertype": "Pokémon",
     "subtypes": [
       "Basic"
@@ -1982,7 +1982,7 @@
     "types": [
       "Darkness"
     ],
-    "evolvesFrom": "Nidoran♂",
+    "evolvesFrom": "Nidoran ♂",
     "evolvesTo": [
       "Nidoking"
     ],

--- a/cards/en/sv4.json
+++ b/cards/en/sv4.json
@@ -486,7 +486,9 @@
     ],
     "evolvesFrom": "Bounsweet",
     "evolvesTo": [
-      "Tsareena"
+      "Tsareena",
+      "Tsareena-GX",
+      "Tsareena ex"
     ],
     "attacks": [
       {
@@ -728,6 +730,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Lokix"
+    ],
     "attacks": [
       {
         "name": "Gnaw",
@@ -770,6 +775,9 @@
     "hp": "50",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Lokix"
     ],
     "attacks": [
       {
@@ -818,6 +826,10 @@
     "hp": "50",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Toedscruel",
+      "Toedscruel ex"
     ],
     "attacks": [
       {
@@ -875,6 +887,10 @@
     "hp": "60",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Toedscruel",
+      "Toedscruel ex"
     ],
     "attacks": [
       {
@@ -1053,9 +1069,6 @@
     "hp": "30",
     "types": [
       "Fire"
-    ],
-    "evolvesTo": [
-      "Magmar"
     ],
     "attacks": [
       {
@@ -1291,6 +1304,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Crocalor"
+    ],
     "attacks": [
       {
         "name": "Live Coal",
@@ -1350,6 +1366,10 @@
       "Fire"
     ],
     "evolvesFrom": "Fuecoco",
+    "evolvesTo": [
+      "Skeledirge ex",
+      "Skeledirge"
+    ],
     "attacks": [
       {
         "name": "Rolling Fireball",
@@ -1399,6 +1419,11 @@
     "hp": "60",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Armarouge",
+      "Ceruledge",
+      "Armarouge ex"
     ],
     "attacks": [
       {
@@ -1456,6 +1481,11 @@
     "hp": "80",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Armarouge",
+      "Ceruledge",
+      "Armarouge ex"
     ],
     "attacks": [
       {
@@ -1746,7 +1776,9 @@
     ],
     "evolvesFrom": "Horsea",
     "evolvesTo": [
-      "Kingdra"
+      "Kingdra",
+      "Kingdra ex",
+      "Kingdra-GX"
     ],
     "attacks": [
       {
@@ -1861,7 +1893,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Octillery"
+      "Octillery",
+      "Dark Octillery"
     ],
     "attacks": [
       {
@@ -1974,7 +2007,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Milotic"
+      "Milotic",
+      "Milotic ex"
     ],
     "attacks": [
       {
@@ -2088,7 +2122,8 @@
     ],
     "evolvesTo": [
       "Glalie",
-      "Froslass"
+      "Froslass",
+      "Froslass ex"
     ],
     "attacks": [
       {
@@ -2202,9 +2237,6 @@
     "types": [
       "Water"
     ],
-    "evolvesTo": [
-      "Mantine"
-    ],
     "attacks": [
       {
         "name": "Buoyant Healing",
@@ -2250,6 +2282,9 @@
     "hp": "130",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Palkia LV.X"
     ],
     "attacks": [
       {
@@ -2676,7 +2711,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golisopod"
+      "Golisopod",
+      "Golisopod-GX",
+      "Golisopod ex"
     ],
     "attacks": [
       {
@@ -2740,7 +2777,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golisopod"
+      "Golisopod",
+      "Golisopod-GX",
+      "Golisopod ex"
     ],
     "attacks": [
       {
@@ -2935,6 +2974,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Wugtrio"
+    ],
     "attacks": [
       {
         "name": "Fury Headbutt",
@@ -2981,6 +3023,9 @@
     "hp": "60",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Wugtrio"
     ],
     "attacks": [
       {
@@ -3387,9 +3432,6 @@
     "hp": "30",
     "types": [
       "Lightning"
-    ],
-    "evolvesTo": [
-      "Electabuzz"
     ],
     "attacks": [
       {
@@ -3960,7 +4002,9 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Toxtricity"
+      "Toxtricity",
+      "Light Toxtricity",
+      "Toxtricity ex"
     ],
     "attacks": [
       {
@@ -4342,7 +4386,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Cofagrigus"
+      "Cofagrigus",
+      "Cofagrigus ex"
     ],
     "attacks": [
       {
@@ -4608,6 +4653,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Espathra"
+    ],
     "attacks": [
       {
         "name": "Quick Attack",
@@ -4660,6 +4708,9 @@
     "hp": "50",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Espathra"
     ],
     "attacks": [
       {
@@ -4777,6 +4828,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Tinkatuff"
+    ],
     "attacks": [
       {
         "name": "Mountain Scrounging",
@@ -4833,6 +4887,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Tinkatuff"
+    ],
     "attacks": [
       {
         "name": "Boundless Power",
@@ -4882,6 +4939,10 @@
       "Psychic"
     ],
     "evolvesFrom": "Tinkatink",
+    "evolvesTo": [
+      "Tinkaton",
+      "Tinkaton ex"
+    ],
     "attacks": [
       {
         "name": "Alloy Aswing",
@@ -5052,6 +5113,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Gholdengo ex"
+    ],
     "attacks": [
       {
         "name": "Call for Family",
@@ -5114,6 +5178,9 @@
     "hp": "70",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Gholdengo ex"
     ],
     "attacks": [
       {
@@ -5231,7 +5298,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Steelix"
+      "Steelix",
+      "Dark Steelix",
+      "Steelix ex"
     ],
     "attacks": [
       {
@@ -5351,6 +5420,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Gligar",
+    "evolvesTo": [
+      "Gliscor LV.X"
+    ],
     "attacks": [
       {
         "name": "Pierce",
@@ -5531,7 +5603,8 @@
     ],
     "evolvesFrom": "Gible",
     "evolvesTo": [
-      "Garchomp"
+      "Garchomp",
+      "Garchomp ex"
     ],
     "attacks": [
       {
@@ -5902,6 +5975,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Naclstack"
+    ],
     "attacks": [
       {
         "name": "Rock Throw",
@@ -5960,6 +6036,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Naclstack"
+    ],
     "attacks": [
       {
         "name": "Corner",
@@ -6010,6 +6089,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Nacli",
+    "evolvesTo": [
+      "Garganacl"
+    ],
     "attacks": [
       {
         "name": "Rocky Tackle",
@@ -6426,7 +6508,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Golbat"
+      "Golbat",
+      "Dark Golbat"
     ],
     "attacks": [
       {
@@ -6496,7 +6579,8 @@
     ],
     "evolvesFrom": "Zubat",
     "evolvesTo": [
-      "Crobat"
+      "Crobat",
+      "Crobat ex"
     ],
     "attacks": [
       {
@@ -6556,6 +6640,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Golbat",
+    "evolvesTo": [
+      "Crobat BREAK"
+    ],
     "attacks": [
       {
         "name": "Echoing Madness",
@@ -6932,6 +7019,9 @@
     "hp": "130",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Yveltal BREAK"
     ],
     "attacks": [
       {
@@ -7806,7 +7896,8 @@
     ],
     "evolvesFrom": "Honedge",
     "evolvesTo": [
-      "Aegislash"
+      "Aegislash",
+      "Aegislash ex"
     ],
     "attacks": [
       {
@@ -7877,7 +7968,8 @@
     ],
     "evolvesFrom": "Honedge",
     "evolvesTo": [
-      "Aegislash"
+      "Aegislash",
+      "Aegislash ex"
     ],
     "attacks": [
       {
@@ -8084,6 +8176,9 @@
     "hp": "120",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Zacian LV.X"
     ],
     "attacks": [
       {
@@ -8461,7 +8556,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Porygon2"
+      "Porygon2",
+      "Dark Porygon2"
     ],
     "attacks": [
       {
@@ -8515,7 +8611,8 @@
     ],
     "evolvesFrom": "Porygon",
     "evolvesTo": [
-      "Porygon-Z"
+      "Porygon-Z",
+      "Porygon-Z-GX"
     ],
     "attacks": [
       {
@@ -8568,6 +8665,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Porygon2",
+    "evolvesTo": [
+      "Porygon-Z LV.X"
+    ],
     "abilities": [
       {
         "name": "Buggy Turbo",
@@ -8859,7 +8959,8 @@
     ],
     "evolvesFrom": "Whismur",
     "evolvesTo": [
-      "Exploud"
+      "Exploud",
+      "Exploud ex"
     ],
     "attacks": [
       {
@@ -9046,7 +9147,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Altaria"
+      "Altaria",
+      "Altaria ex",
+      "Altaria-GX"
     ],
     "attacks": [
       {
@@ -9114,6 +9217,10 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Maushold",
+      "Maushold ex"
+    ],
     "attacks": [
       {
         "name": "Damage Rush",
@@ -9156,6 +9263,10 @@
     "hp": "40",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Maushold",
+      "Maushold ex"
     ],
     "attacks": [
       {
@@ -10294,9 +10405,6 @@
     "types": [
       "Fire"
     ],
-    "evolvesTo": [
-      "Magmar"
-    ],
     "attacks": [
       {
         "name": "Scorching Heater",
@@ -10403,7 +10511,8 @@
     ],
     "evolvesTo": [
       "Glalie",
-      "Froslass"
+      "Froslass",
+      "Froslass ex"
     ],
     "attacks": [
       {
@@ -10454,9 +10563,6 @@
     "hp": "30",
     "types": [
       "Water"
-    ],
-    "evolvesTo": [
-      "Mantine"
     ],
     "attacks": [
       {
@@ -10561,7 +10667,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golisopod"
+      "Golisopod",
+      "Golisopod-GX",
+      "Golisopod ex"
     ],
     "attacks": [
       {
@@ -10968,6 +11076,9 @@
     "hp": "70",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Gholdengo ex"
     ],
     "attacks": [
       {
@@ -11388,6 +11499,9 @@
     "hp": "130",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Yveltal BREAK"
     ],
     "attacks": [
       {
@@ -11847,7 +11961,8 @@
     ],
     "evolvesFrom": "Whismur",
     "evolvesTo": [
-      "Exploud"
+      "Exploud",
+      "Exploud ex"
     ],
     "attacks": [
       {
@@ -11911,7 +12026,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Altaria"
+      "Altaria",
+      "Altaria ex",
+      "Altaria-GX"
     ],
     "attacks": [
       {
@@ -11980,6 +12097,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Porygon2",
+    "evolvesTo": [
+      "Porygon-Z LV.X"
+    ],
     "abilities": [
       {
         "name": "Buggy Turbo",

--- a/cards/en/svp.json
+++ b/cards/en/svp.json
@@ -10,6 +10,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Floragato"
+    ],
     "attacks": [
       {
         "name": "Mini Drain",
@@ -59,6 +62,9 @@
     "hp": "80",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Crocalor"
     ],
     "attacks": [
       {
@@ -112,6 +118,9 @@
     "hp": "70",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Quaxwell"
     ],
     "attacks": [
       {
@@ -599,6 +608,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "attacks": [
       {
         "name": "Crunch",
@@ -858,6 +870,11 @@
       "Lightning"
     ],
     "evolvesFrom": "Mareep",
+    "evolvesTo": [
+      "Ampharos",
+      "Ampharos ex",
+      "Ampharos-GX"
+    ],
     "attacks": [
       {
         "name": "Static Shock",
@@ -1236,7 +1253,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Honchkrow"
+      "Honchkrow",
+      "Honchkrow-GX"
     ],
     "attacks": [
       {
@@ -1370,6 +1388,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Dolliv"
+    ],
     "attacks": [
       {
         "name": "Nutrients",
@@ -1431,7 +1452,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -1496,6 +1519,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Tinkatuff"
+    ],
     "attacks": [
       {
         "name": "Smithereen Smash",
@@ -1546,6 +1572,10 @@
     "hp": "60",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Revavroom",
+      "Revavroom ex"
     ],
     "attacks": [
       {
@@ -1604,7 +1634,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -2224,9 +2258,6 @@
     "types": [
       "Psychic"
     ],
-    "evolvesTo": [
-      "Clefairy"
-    ],
     "attacks": [
       {
         "name": "Grasping Draw",
@@ -2391,6 +2422,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Pawmo"
+    ],
     "attacks": [
       {
         "name": "Static Slap",
@@ -2443,7 +2477,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Quagsire"
+      "Paldean Clodsire ex",
+      "Paldean Clodsire"
     ],
     "attacks": [
       {
@@ -2585,7 +2620,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -2649,7 +2704,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -2726,6 +2782,10 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Ivysaur",
+      "Dark Ivysaur"
+    ],
     "attacks": [
       {
         "name": "Vine Whip",
@@ -2776,6 +2836,10 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Charmeleon",
+      "Dark Charmeleon"
+    ],
     "attacks": [
       {
         "name": "Ember",
@@ -2823,6 +2887,10 @@
     "hp": "70",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Wartortle",
+      "Dark Wartortle"
     ],
     "attacks": [
       {
@@ -3005,6 +3073,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Snorlax LV.X"
+    ],
     "abilities": [
       {
         "name": "Voraciousness",
@@ -3063,6 +3134,9 @@
     "hp": "130",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Mewtwo LV.X"
     ],
     "attacks": [
       {
@@ -3308,6 +3382,13 @@
     "hp": "70",
     "types": [
       "Lightning"
+    ],
+    "evolvesTo": [
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {

--- a/cards/en/swsh1.json
+++ b/cards/en/swsh1.json
@@ -11,6 +11,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Celebi VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -248,7 +251,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Whimsicott"
+      "Whimsicott",
+      "Whimsicott-GX"
     ],
     "attacks": [
       {
@@ -468,6 +472,9 @@
     "hp": "220",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Dhelmise VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -1253,7 +1260,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {
@@ -1305,6 +1314,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "attacks": [
       {
         "name": "Flame Cloak",
@@ -1434,6 +1446,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Victini VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -1556,7 +1571,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Salazzle"
+      "Salazzle",
+      "Salazzle-GX"
     ],
     "attacks": [
       {
@@ -2857,6 +2873,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Lapras VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -3814,7 +3833,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -3876,6 +3899,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Pain-Full Punch",
@@ -3937,7 +3964,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Lanturn"
+      "Lanturn",
+      "Light Lanturn"
     ],
     "attacks": [
       {
@@ -3990,7 +4018,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Lanturn"
+      "Lanturn",
+      "Light Lanturn"
     ],
     "attacks": [
       {
@@ -4216,6 +4245,9 @@
     "hp": "200",
     "types": [
       "Lightning"
+    ],
+    "evolvesTo": [
+      "Tapu Koko VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -4619,6 +4651,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Morpeko VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -4737,7 +4772,7 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Rapidash"
+      "Galarian Rapidash"
     ],
     "attacks": [
       {
@@ -4859,7 +4894,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Haunter",
+      "Dark Haunter"
     ],
     "attacks": [
       {
@@ -4918,7 +4954,8 @@
     ],
     "evolvesFrom": "Gastly",
     "evolvesTo": [
-      "Gengar"
+      "Gengar",
+      "Gengar ex"
     ],
     "attacks": [
       {
@@ -4986,6 +5023,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Haunter",
+    "evolvesTo": [
+      "Gengar LV.X"
+    ],
     "abilities": [
       {
         "name": "Life Shaker",
@@ -5451,7 +5491,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Dugtrio"
+      "Dugtrio",
+      "Dark Dugtrio"
     ],
     "attacks": [
       {
@@ -5872,6 +5913,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Rhydon",
+    "evolvesTo": [
+      "Rhyperior LV.X"
+    ],
     "attacks": [
       {
         "name": "Rock Tumble",
@@ -5997,7 +6041,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Claydol"
+      "Claydol",
+      "Claydol ex"
     ],
     "attacks": [
       {
@@ -6059,7 +6104,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Claydol"
+      "Claydol",
+      "Claydol ex"
     ],
     "attacks": [
       {
@@ -6812,6 +6858,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Stonjourner VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -6942,7 +6991,7 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Linoone"
+      "Galarian Linoone"
     ],
     "abilities": [
       {
@@ -7003,7 +7052,7 @@
     ],
     "evolvesFrom": "Galarian Zigzagoon",
     "evolvesTo": [
-      "Obstagoon"
+      "Galarian Obstagoon"
     ],
     "attacks": [
       {
@@ -7253,6 +7302,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Skorupi",
+    "evolvesTo": [
+      "Drapion LV.X"
+    ],
     "attacks": [
       {
         "name": "Hard Press",
@@ -7319,7 +7371,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Toxicroak"
+      "Toxicroak",
+      "Toxicroak ex"
     ],
     "attacks": [
       {
@@ -7553,7 +7606,7 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Perrserker"
+      "Galarian Perrserker"
     ],
     "attacks": [
       {
@@ -8011,6 +8064,9 @@
       "Metal"
     ],
     "evolvesFrom": "Pawniard",
+    "evolvesTo": [
+      "Kingambit"
+    ],
     "attacks": [
       {
         "name": "Charge Order",
@@ -8146,7 +8202,8 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Copperajah"
+      "Copperajah",
+      "Copperajah ex"
     ],
     "attacks": [
       {
@@ -8278,6 +8335,9 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Zacian VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -8346,6 +8406,9 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Zamazenta VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -8413,6 +8476,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Snorlax LV.X"
+    ],
     "attacks": [
       {
         "name": "Rolling Tackle",
@@ -8479,6 +8545,9 @@
     "hp": "220",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Snorlax VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -8674,6 +8743,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Hoothoot",
+    "evolvesTo": [
+      "Noctowl BREAK"
+    ],
     "attacks": [
       {
         "name": "Wing Attack",
@@ -9337,6 +9409,9 @@
     "hp": "200",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Cramorant VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10170,6 +10245,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Dhelmise VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10303,6 +10381,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Lapras VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10367,6 +10448,9 @@
     "hp": "170",
     "types": [
       "Lightning"
+    ],
+    "evolvesTo": [
+      "Morpeko VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10571,6 +10655,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Stonjourner VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10699,6 +10786,9 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Zacian VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10766,6 +10856,9 @@
     "hp": "230",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Zamazenta VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10835,6 +10928,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Snorlax VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10903,6 +10999,9 @@
     "hp": "200",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Cramorant VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -11399,6 +11498,9 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Zacian VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -11466,6 +11568,9 @@
     "hp": "230",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Zamazenta VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."

--- a/cards/en/swsh10.json
+++ b/cards/en/swsh10.json
@@ -75,7 +75,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Hisuian Electrode"
     ],
     "attacks": [
       {
@@ -197,7 +197,11 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor",
+      "Scizor ex",
+      "Dark Scizor",
+      "Scizor-GX",
+      "Kleavor"
     ],
     "attacks": [
       {
@@ -250,7 +254,11 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor",
+      "Scizor ex",
+      "Dark Scizor",
+      "Scizor-GX",
+      "Kleavor"
     ],
     "attacks": [
       {
@@ -353,6 +361,9 @@
       "Grass"
     ],
     "evolvesFrom": "Yanma",
+    "evolvesTo": [
+      "Yanmega BREAK"
+    ],
     "attacks": [
       {
         "name": "Razor Wing",
@@ -585,7 +596,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Vespiquen"
+      "Vespiquen",
+      "Vespiquen ex"
     ],
     "attacks": [
       {
@@ -710,6 +722,9 @@
       "Grass"
     ],
     "evolvesFrom": "Eevee",
+    "evolvesTo": [
+      "Leafeon LV.X"
+    ],
     "attacks": [
       {
         "name": "Energy Garden",
@@ -772,6 +787,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Shaymin LV.X"
+    ],
     "attacks": [
       {
         "name": "Encouraging Gift",
@@ -832,7 +850,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Lilligant"
+      "Lilligant",
+      "Hisuian Lilligant"
     ],
     "attacks": [
       {
@@ -947,6 +966,9 @@
     "hp": "200",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Hisuian Lilligant VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -1129,7 +1151,10 @@
     ],
     "evolvesFrom": "Rowlet",
     "evolvesTo": [
-      "Decidueye"
+      "Decidueye",
+      "Decidueye-GX",
+      "Hisuian Decidueye",
+      "Decidueye ex"
     ],
     "attacks": [
       {
@@ -1193,7 +1218,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Rapidash"
+      "Rapidash",
+      "Dark Rapidash"
     ],
     "attacks": [
       {
@@ -1307,7 +1333,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Quilava"
+      "Quilava",
+      "Dark Quilava"
     ],
     "attacks": [
       {
@@ -1370,7 +1397,9 @@
     ],
     "evolvesFrom": "Cyndaquil",
     "evolvesTo": [
-      "Typhlosion"
+      "Typhlosion",
+      "Typhlosion ex",
+      "Hisuian Typhlosion"
     ],
     "attacks": [
       {
@@ -1432,6 +1461,9 @@
     "hp": "220",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Heatran VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -1623,7 +1655,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Golduck",
+      "Dark Golduck",
+      "Light Golduck"
     ],
     "attacks": [
       {
@@ -1686,6 +1720,9 @@
       "Water"
     ],
     "evolvesFrom": "Psyduck",
+    "evolvesTo": [
+      "Golduck BREAK"
+    ],
     "attacks": [
       {
         "name": "Aqua Edge",
@@ -1809,7 +1846,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Piloswine"
+      "Piloswine",
+      "Light Piloswine"
     ],
     "attacks": [
       {
@@ -2257,6 +2295,9 @@
       "Water"
     ],
     "evolvesFrom": "Eevee",
+    "evolvesTo": [
+      "Glaceon LV.X"
+    ],
     "attacks": [
       {
         "name": "Frost Wall",
@@ -2318,6 +2359,9 @@
     "hp": "220",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Origin Forme Palkia VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -2500,7 +2544,8 @@
     ],
     "evolvesFrom": "Oshawott",
     "evolvesTo": [
-      "Samurott"
+      "Samurott",
+      "Hisuian Samurott"
     ],
     "attacks": [
       {
@@ -2551,6 +2596,9 @@
     "hp": "50",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Hisuian Basculegion"
     ],
     "attacks": [
       {
@@ -2798,7 +2846,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Avalugg"
+      "Avalugg",
+      "Hisuian Avalugg"
     ],
     "attacks": [
       {
@@ -3176,6 +3225,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Hisuian Typhlosion VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -3318,7 +3370,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Togetic"
+      "Togetic",
+      "Light Togetic"
     ],
     "abilities": [
       {
@@ -3687,7 +3740,9 @@
     "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
-      "Gallade"
+      "Gallade",
+      "Gardevoir ex",
+      "Gardevoir-GX"
     ],
     "attacks": [
       {
@@ -3928,6 +3983,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Uxie LV.X"
+    ],
     "attacks": [
       {
         "name": "Wise Guidance",
@@ -3993,6 +4051,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Mesprit LV.X"
+    ],
     "abilities": [
       {
         "name": "Mental Shroud",
@@ -4056,6 +4117,9 @@
     "hp": "70",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Azelf LV.X"
     ],
     "attacks": [
       {
@@ -4237,7 +4301,7 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Hisuian Arcanine"
     ],
     "attacks": [
       {
@@ -4364,6 +4428,9 @@
     "hp": "220",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Machamp VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -4748,6 +4815,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Lucario VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -4883,6 +4953,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Hippopotas",
+    "evolvesTo": [
+      "Hippowdon LV.X"
+    ],
     "attacks": [
       {
         "name": "Bite",
@@ -5075,6 +5148,9 @@
     "hp": "220",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Hisuian Decidueye VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -5331,6 +5407,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Kleavor VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -5395,6 +5474,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Hisuian Overqwil"
+    ],
     "attacks": [
       {
         "name": "Ram",
@@ -5454,6 +5536,9 @@
     "hp": "80",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Hisuian Overqwil"
     ],
     "attacks": [
       {
@@ -5631,7 +5716,7 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Weavile"
+      "Hisuian Sneasler"
     ],
     "attacks": [
       {
@@ -5812,7 +5897,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Mightyena"
+      "Mightyena",
+      "Mightyena ex"
     ],
     "attacks": [
       {
@@ -5995,6 +6081,9 @@
     "hp": "210",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Darkrai VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -6184,6 +6273,9 @@
     "hp": "220",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Hisuian Samurott VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -6425,7 +6517,8 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -6495,7 +6588,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "attacks": [
       {
@@ -6555,6 +6649,9 @@
       "Metal"
     ],
     "evolvesFrom": "Magneton",
+    "evolvesTo": [
+      "Magnezone LV.X"
+    ],
     "abilities": [
       {
         "name": "Giga Magnet",
@@ -6894,6 +6991,9 @@
       "Metal"
     ],
     "evolvesFrom": "Bronzor",
+    "evolvesTo": [
+      "Bronzong BREAK"
+    ],
     "abilities": [
       {
         "name": "Heatproof",
@@ -6961,6 +7061,9 @@
     "hp": "220",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Origin Forme Dialga VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -7167,6 +7270,9 @@
       "Metal"
     ],
     "evolvesFrom": "Pawniard",
+    "evolvesTo": [
+      "Kingambit"
+    ],
     "attacks": [
       {
         "name": "Vengeful Cut",
@@ -7355,7 +7461,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "abilities": [
       {
@@ -7483,6 +7609,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Hoothoot",
+    "evolvesTo": [
+      "Noctowl BREAK"
+    ],
     "attacks": [
       {
         "name": "Silent Wing",
@@ -7552,7 +7681,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Ursaring"
+      "Ursaring",
+      "Dark Ursaring"
     ],
     "attacks": [
       {
@@ -7616,6 +7746,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Teddiursa",
+    "evolvesTo": [
+      "Ursaluna"
+    ],
     "attacks": [
       {
         "name": "Continuous Slap",
@@ -7743,6 +7876,9 @@
     "hp": "100",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Wyrdeer"
     ],
     "attacks": [
       {
@@ -8037,6 +8173,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Regigigas LV.X"
+    ],
     "abilities": [
       {
         "name": "Ancient Wisdom",
@@ -8102,7 +8241,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Braviary"
+      "Braviary",
+      "Hisuian Braviary"
     ],
     "attacks": [
       {
@@ -8899,6 +9039,20 @@
     "subtypes": [
       "Item"
     ],
+    "evolvesTo": [
+      "Cranidos",
+      "Shieldon",
+      "Amaura",
+      "Tyrunt",
+      "Omanyte",
+      "Kabuto",
+      "Aerodactyl",
+      "Tirtouga",
+      "Aerodactyl-GX",
+      "Archen",
+      "Lileep",
+      "Anorith"
+    ],
     "rules": [
       "Play this card as if it were a 60-HP Basic Colorless Pokémon. At any time during your turn, you may discard this card from play. This card can't retreat.",
       "You may play any number of Item cards during your turn."
@@ -9107,6 +9261,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Hisuian Lilligant VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -9171,6 +9328,9 @@
     "hp": "200",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Hisuian Lilligant VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -9299,6 +9459,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Heatran VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -9425,6 +9588,9 @@
     "hp": "220",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Origin Forme Palkia VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -9555,6 +9721,9 @@
     "hp": "210",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Hisuian Typhlosion VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -9694,6 +9863,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Machamp VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -9761,6 +9933,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Machamp VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -9827,6 +10002,9 @@
     "hp": "220",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Hisuian Decidueye VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10011,6 +10189,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Hisuian Samurott VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10075,6 +10256,9 @@
     "hp": "220",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Origin Forme Dialga VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."

--- a/cards/en/swsh10tg.json
+++ b/cards/en/swsh10tg.json
@@ -249,6 +249,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Kirlia",
+    "evolvesTo": [
+      "Gardevoir LV.X"
+    ],
     "abilities": [
       {
         "name": "Shining Arcana",
@@ -612,6 +615,9 @@
       "Metal"
     ],
     "evolvesFrom": "Bronzor",
+    "evolvesTo": [
+      "Bronzong BREAK"
+    ],
     "abilities": [
       {
         "name": "Metal Transfer",
@@ -806,6 +812,9 @@
     "hp": "210",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Ice Rider Calyrex VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -1005,6 +1014,9 @@
     "hp": "210",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Shadow Rider Calyrex VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -1272,6 +1284,9 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Zacian VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -1339,6 +1354,9 @@
     "hp": "230",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Zamazenta VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."

--- a/cards/en/swsh11.json
+++ b/cards/en/swsh11.json
@@ -11,7 +11,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Gloom"
+      "Gloom",
+      "Dark Gloom"
     ],
     "attacks": [
       {
@@ -67,7 +68,9 @@
     "evolvesFrom": "Oddish",
     "evolvesTo": [
       "Vileplume",
-      "Bellossom"
+      "Bellossom",
+      "Vileplume ex",
+      "Vileplume-GX"
     ],
     "attacks": [
       {
@@ -491,7 +494,8 @@
     ],
     "evolvesFrom": "Wurmple",
     "evolvesTo": [
-      "Dustox"
+      "Dustox",
+      "Dustox ex"
     ],
     "attacks": [
       {
@@ -673,7 +677,9 @@
     ],
     "evolvesFrom": "Seedot",
     "evolvesTo": [
-      "Shiftry"
+      "Shiftry",
+      "Shiftry ex",
+      "Shiftry-GX"
     ],
     "attacks": [
       {
@@ -956,6 +962,9 @@
       "Grass"
     ],
     "evolvesFrom": "Phantump",
+    "evolvesTo": [
+      "Trevenant BREAK"
+    ],
     "abilities": [
       {
         "name": "Elder Tree Barrier",
@@ -1187,7 +1196,10 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Magcargo"
+      "Magcargo",
+      "Dark Magcargo",
+      "Magcargo ex",
+      "Magcargo-GX"
     ],
     "attacks": [
       {
@@ -1666,6 +1678,9 @@
       "Fire"
     ],
     "evolvesFrom": "Litleo",
+    "evolvesTo": [
+      "Pyroar BREAK"
+    ],
     "abilities": [
       {
         "name": "Scorching Aura",
@@ -1782,7 +1797,8 @@
     "evolvesFrom": "Poliwag",
     "evolvesTo": [
       "Poliwrath",
-      "Politoed"
+      "Politoed",
+      "Politoed ex"
     ],
     "attacks": [
       {
@@ -1912,7 +1928,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Dewgong"
+      "Dewgong",
+      "Light Dewgong"
     ],
     "attacks": [
       {
@@ -2091,7 +2108,9 @@
     ],
     "evolvesFrom": "Horsea",
     "evolvesTo": [
-      "Kingdra"
+      "Kingdra",
+      "Kingdra ex",
+      "Kingdra-GX"
     ],
     "attacks": [
       {
@@ -2590,6 +2609,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Hisuian Basculegion"
+    ],
     "attacks": [
       {
         "name": "Surprise Attack",
@@ -2828,6 +2850,9 @@
     "hp": "220",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Kyurem VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -3081,7 +3106,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "abilities": [
       {
@@ -3143,6 +3172,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Thunder Shock",
@@ -3205,7 +3238,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Manectric",
+      "Manectric ex"
     ],
     "attacks": [
       {
@@ -3330,6 +3364,9 @@
     "hp": "210",
     "types": [
       "Lightning"
+    ],
+    "evolvesTo": [
+      "Magnezone VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -3462,6 +3499,9 @@
     "hp": "190",
     "types": [
       "Lightning"
+    ],
+    "evolvesTo": [
+      "Rotom VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -3711,7 +3751,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Clefable",
+      "Clefable ex"
     ],
     "abilities": [
       {
@@ -3835,7 +3876,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Haunter",
+      "Dark Haunter"
     ],
     "attacks": [
       {
@@ -3891,7 +3933,8 @@
     ],
     "evolvesFrom": "Gastly",
     "evolvesTo": [
-      "Gengar"
+      "Gengar",
+      "Gengar ex"
     ],
     "attacks": [
       {
@@ -3950,6 +3993,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Haunter",
+    "evolvesTo": [
+      "Gengar LV.X"
+    ],
     "abilities": [
       {
         "name": "Netherworld Gate",
@@ -4341,7 +4387,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Banette"
+      "Banette",
+      "Banette ex",
+      "Banette-GX"
     ],
     "attacks": [
       {
@@ -4465,6 +4513,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Cresselia LV.X"
+    ],
     "attacks": [
       {
         "name": "Moonglow Reverse",
@@ -4533,7 +4584,7 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Zoroark"
+      "Hisuian Zoroark"
     ],
     "attacks": [
       {
@@ -5050,7 +5101,7 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Hisuian Arcanine"
     ],
     "attacks": [
       {
@@ -5230,7 +5281,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Machoke"
+      "Machoke",
+      "Dark Machoke",
+      "Light Machoke"
     ],
     "attacks": [
       {
@@ -5285,7 +5338,8 @@
     ],
     "evolvesFrom": "Machop",
     "evolvesTo": [
-      "Machamp"
+      "Machamp",
+      "Machamp-GX"
     ],
     "attacks": [
       {
@@ -5349,6 +5403,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Machoke",
+    "evolvesTo": [
+      "Machamp LV.X",
+      "Machamp BREAK"
+    ],
     "abilities": [
       {
         "name": "Crisis Muscles",
@@ -5534,6 +5592,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Rhydon",
+    "evolvesTo": [
+      "Rhyperior LV.X"
+    ],
     "attacks": [
       {
         "name": "Geo Cannon",
@@ -5599,6 +5660,9 @@
     "hp": "210",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Aerodactyl VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -5844,6 +5908,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Gligar",
+    "evolvesTo": [
+      "Gliscor LV.X"
+    ],
     "attacks": [
       {
         "name": "Hurricane Shock",
@@ -5897,7 +5964,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Hariyama"
+      "Hariyama",
+      "Hariyama ex"
     ],
     "attacks": [
       {
@@ -6018,7 +6086,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Medicham"
+      "Medicham",
+      "Medicham ex"
     ],
     "attacks": [
       {
@@ -6557,6 +6626,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Carbink BREAK"
+    ],
     "attacks": [
       {
         "name": "Lucky Find",
@@ -6619,7 +6691,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lycanroc"
+      "Lycanroc",
+      "Lycanroc-GX",
+      "Lycanroc ex"
     ],
     "attacks": [
       {
@@ -6809,7 +6883,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Ariados"
+      "Ariados",
+      "Dark Ariados"
     ],
     "attacks": [
       {
@@ -6924,7 +6999,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Honchkrow"
+      "Honchkrow",
+      "Honchkrow-GX"
     ],
     "attacks": [
       {
@@ -6993,6 +7069,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Murkrow",
+    "evolvesTo": [
+      "Honchkrow LV.X"
+    ],
     "attacks": [
       {
         "name": "Peck",
@@ -7172,6 +7251,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Drapion VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -7298,6 +7380,9 @@
     "hp": "120",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Darkrai LV.X"
     ],
     "attacks": [
       {
@@ -7684,6 +7769,9 @@
       "Metal"
     ],
     "evolvesFrom": "Bronzor",
+    "evolvesTo": [
+      "Bronzong BREAK"
+    ],
     "attacks": [
       {
         "name": "Ram",
@@ -7960,6 +8048,9 @@
     "types": [
       "Dragon"
     ],
+    "evolvesTo": [
+      "Giratina VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -8079,7 +8170,8 @@
       "Dragon"
     ],
     "evolvesTo": [
-      "Sliggoo"
+      "Sliggoo",
+      "Hisuian Sliggoo"
     ],
     "attacks": [
       {
@@ -8138,7 +8230,7 @@
     ],
     "evolvesFrom": "Goomy",
     "evolvesTo": [
-      "Goodra"
+      "Hisuian Goodra"
     ],
     "attacks": [
       {
@@ -8252,6 +8344,9 @@
     "hp": "220",
     "types": [
       "Dragon"
+    ],
+    "evolvesTo": [
+      "Hisuian Goodra VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -8564,7 +8659,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Porygon2"
+      "Porygon2",
+      "Dark Porygon2"
     ],
     "attacks": [
       {
@@ -8627,7 +8723,8 @@
     ],
     "evolvesFrom": "Porygon",
     "evolvesTo": [
-      "Porygon-Z"
+      "Porygon-Z",
+      "Porygon-Z-GX"
     ],
     "attacks": [
       {
@@ -8680,6 +8777,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Porygon2",
+    "evolvesTo": [
+      "Porygon-Z LV.X"
+    ],
     "attacks": [
       {
         "name": "Downgrading Beam",
@@ -8742,6 +8842,9 @@
     "hp": "150",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Snorlax LV.X"
     ],
     "abilities": [
       {
@@ -8928,6 +9031,9 @@
     "hp": "210",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Hisuian Zoroark VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -9180,7 +9286,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Greedent"
+      "Greedent",
+      "Greedent ex"
     ],
     "attacks": [
       {
@@ -9926,6 +10033,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Kyurem VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -9991,6 +10101,9 @@
     "hp": "210",
     "types": [
       "Lightning"
+    ],
+    "evolvesTo": [
+      "Magnezone VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10058,6 +10171,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Rotom VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10118,6 +10234,9 @@
     "hp": "190",
     "types": [
       "Lightning"
+    ],
+    "evolvesTo": [
+      "Rotom VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10243,6 +10362,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Aerodactyl VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10307,6 +10429,9 @@
     "hp": "210",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Aerodactyl VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10438,6 +10563,9 @@
     "hp": "210",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Drapion VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10643,6 +10771,9 @@
     "types": [
       "Dragon"
     ],
+    "evolvesTo": [
+      "Giratina VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10702,6 +10833,9 @@
     "types": [
       "Dragon"
     ],
+    "evolvesTo": [
+      "Giratina VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10760,6 +10894,9 @@
     "hp": "220",
     "types": [
       "Dragon"
+    ],
+    "evolvesTo": [
+      "Hisuian Goodra VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."

--- a/cards/en/swsh11tg.json
+++ b/cards/en/swsh11tg.json
@@ -252,7 +252,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "abilities": [
       {
@@ -314,6 +318,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Haunter",
+    "evolvesTo": [
+      "Gengar LV.X"
+    ],
     "abilities": [
       {
         "name": "Netherworld Gate",
@@ -568,6 +575,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Snorlax LV.X"
+    ],
     "abilities": [
       {
         "name": "Unfazed Fat",
@@ -685,6 +695,9 @@
     "hp": "180",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Orbeetle VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -808,6 +821,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Centiskorch VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -930,7 +946,7 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Pikachu VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -995,9 +1011,6 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu V",
-    "evolvesTo": [
-      "Raichu"
-    ],
     "rules": [
       "VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -1182,6 +1195,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Crobat VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -1241,6 +1257,9 @@
     "hp": "220",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Eternatus VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -1518,9 +1537,6 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu V",
-    "evolvesTo": [
-      "Raichu"
-    ],
     "rules": [
       "VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize cards."
     ],

--- a/cards/en/swsh12.json
+++ b/cards/en/swsh12.json
@@ -11,7 +11,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Venomoth"
+      "Venomoth",
+      "Light Venomoth",
+      "Venomoth-GX"
     ],
     "attacks": [
       {
@@ -121,7 +123,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ariados"
+      "Ariados",
+      "Dark Ariados"
     ],
     "attacks": [
       {
@@ -234,7 +237,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Sunflora"
+      "Sunflora",
+      "Light Sunflora"
     ],
     "attacks": [
       {
@@ -340,6 +344,9 @@
     "hp": "210",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Serperior VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -465,7 +472,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Lilligant"
+      "Lilligant",
+      "Hisuian Lilligant"
     ],
     "attacks": [
       {
@@ -953,7 +961,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {
@@ -1006,6 +1016,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "attacks": [
       {
         "name": "Hypnotic Gaze",
@@ -1067,7 +1080,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -1132,6 +1147,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "attacks": [
       {
         "name": "Flame Cloak",
@@ -1196,7 +1214,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Rapidash"
+      "Rapidash",
+      "Dark Rapidash"
     ],
     "attacks": [
       {
@@ -1560,6 +1579,9 @@
       "Fire"
     ],
     "evolvesFrom": "Braixen",
+    "evolvesTo": [
+      "Delphox BREAK"
+    ],
     "attacks": [
       {
         "name": "Flare Parade",
@@ -1676,6 +1698,9 @@
       "Fire"
     ],
     "evolvesFrom": "Fletchinder",
+    "evolvesTo": [
+      "Talonflame BREAK"
+    ],
     "attacks": [
       {
         "name": "Quick Dive",
@@ -1801,7 +1826,8 @@
     ],
     "evolvesFrom": "Litten",
     "evolvesTo": [
-      "Incineroar"
+      "Incineroar",
+      "Incineroar-GX"
     ],
     "attacks": [
       {
@@ -1931,7 +1957,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Alolan Vulpix VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -1997,9 +2023,6 @@
       "Water"
     ],
     "evolvesFrom": "Alolan Vulpix V",
-    "evolvesTo": [
-      "Ninetales"
-    ],
     "rules": [
       "VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -2188,7 +2211,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wailord"
+      "Wailord",
+      "Wailord ex"
     ],
     "attacks": [
       {
@@ -2320,7 +2344,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Milotic"
+      "Milotic",
+      "Milotic ex"
     ],
     "attacks": [
       {
@@ -2445,7 +2470,8 @@
     ],
     "evolvesTo": [
       "Glalie",
-      "Froslass"
+      "Froslass",
+      "Froslass ex"
     ],
     "attacks": [
       {
@@ -2508,9 +2534,6 @@
       "Water"
     ],
     "evolvesFrom": "Snorunt",
-    "evolvesTo": [
-      "Froslass"
-    ],
     "attacks": [
       {
         "name": "Bite",
@@ -2935,7 +2958,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -2988,6 +3015,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Ambushing Spark",
@@ -3050,7 +3081,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Lanturn"
+      "Lanturn",
+      "Light Lanturn"
     ],
     "attacks": [
       {
@@ -3413,6 +3445,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Regieleki VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -3604,7 +3639,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Hypno"
+      "Hypno",
+      "Dark Hypno"
     ],
     "attacks": [
       {
@@ -3931,6 +3967,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Unown VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -4126,7 +4165,9 @@
     "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
-      "Gallade"
+      "Gallade",
+      "Gardevoir ex",
+      "Gardevoir-GX"
     ],
     "abilities": [
       {
@@ -4188,6 +4229,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Kirlia",
+    "evolvesTo": [
+      "Gardevoir LV.X"
+    ],
     "abilities": [
       {
         "name": "Refinement",
@@ -4247,6 +4291,9 @@
     "hp": "200",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Mawile VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -4373,7 +4420,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Medicham"
+      "Medicham",
+      "Medicham ex"
     ],
     "abilities": [
       {
@@ -4887,6 +4935,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Elgyem",
+    "evolvesTo": [
+      "Beheeyem BREAK"
+    ],
     "attacks": [
       {
         "name": "Psychic Sphere",
@@ -5592,7 +5643,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Donphan"
+      "Donphan",
+      "Dark Donphan"
     ],
     "attacks": [
       {
@@ -5711,7 +5763,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Claydol"
+      "Claydol",
+      "Claydol ex"
     ],
     "attacks": [
       {
@@ -5835,7 +5888,8 @@
     ],
     "evolvesFrom": "Unidentified Fossil",
     "evolvesTo": [
-      "Armaldo"
+      "Armaldo",
+      "Armaldo ex"
     ],
     "attacks": [
       {
@@ -6072,7 +6126,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Palossand"
+      "Palossand",
+      "Palossand-GX"
     ],
     "attacks": [
       {
@@ -6319,7 +6374,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Golbat"
+      "Golbat",
+      "Dark Golbat"
     ],
     "attacks": [
       {
@@ -6369,7 +6425,8 @@
     ],
     "evolvesFrom": "Zubat",
     "evolvesTo": [
-      "Crobat"
+      "Crobat",
+      "Crobat ex"
     ],
     "attacks": [
       {
@@ -6418,6 +6475,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Golbat",
+    "evolvesTo": [
+      "Crobat BREAK"
+    ],
     "attacks": [
       {
         "name": "Venomous Fang",
@@ -6476,7 +6536,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Honchkrow"
+      "Honchkrow",
+      "Honchkrow-GX"
     ],
     "attacks": [
       {
@@ -6544,6 +6605,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Murkrow",
+    "evolvesTo": [
+      "Honchkrow LV.X"
+    ],
     "attacks": [
       {
         "name": "Triple Draw",
@@ -6679,7 +6743,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Toxicroak"
+      "Toxicroak",
+      "Toxicroak ex"
     ],
     "attacks": [
       {
@@ -6971,7 +7036,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Toxapex"
+      "Toxapex",
+      "Toxapex-GX"
     ],
     "attacks": [
       {
@@ -7207,7 +7273,9 @@
     ],
     "evolvesFrom": "Beldum",
     "evolvesTo": [
-      "Metagross"
+      "Metagross",
+      "Metagross ex",
+      "Metagross-GX"
     ],
     "attacks": [
       {
@@ -7926,7 +7994,9 @@
       "Dragon"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "attacks": [
       {
@@ -7976,7 +8046,9 @@
     ],
     "evolvesFrom": "Dratini",
     "evolvesTo": [
-      "Dragonite"
+      "Dragonite",
+      "Dragonite ex",
+      "Dragonite-GX"
     ],
     "attacks": [
       {
@@ -8096,7 +8168,9 @@
       "Dragon"
     ],
     "evolvesTo": [
-      "Noivern"
+      "Noivern",
+      "Noivern-GX",
+      "Noivern ex"
     ],
     "attacks": [
       {
@@ -8153,6 +8227,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Noibat",
+    "evolvesTo": [
+      "Noivern BREAK"
+    ],
     "attacks": [
       {
         "name": "Radiant Hunt",
@@ -8258,6 +8335,9 @@
     "hp": "220",
     "types": [
       "Dragon"
+    ],
+    "evolvesTo": [
+      "Regidrago VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -8436,6 +8516,9 @@
     "hp": "220",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Lugia VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -8700,7 +8783,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Altaria"
+      "Altaria",
+      "Altaria ex",
+      "Altaria-GX"
     ],
     "attacks": [
       {
@@ -9080,7 +9165,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Braviary"
+      "Braviary",
+      "Hisuian Braviary"
     ],
     "attacks": [
       {
@@ -9614,6 +9700,20 @@
     "subtypes": [
       "Item"
     ],
+    "evolvesTo": [
+      "Cranidos",
+      "Shieldon",
+      "Amaura",
+      "Tyrunt",
+      "Omanyte",
+      "Kabuto",
+      "Aerodactyl",
+      "Tirtouga",
+      "Aerodactyl-GX",
+      "Archen",
+      "Lileep",
+      "Anorith"
+    ],
     "rules": [
       "Play this card as if it were a 60-HP Basic Colorless Pokémon. At any time during your turn, you may discard this card from play. This card can't retreat.",
       "You may play any number of Item cards during your turn."
@@ -9739,6 +9839,9 @@
     "hp": "210",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Serperior VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -9935,7 +10038,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Alolan Vulpix VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10065,6 +10168,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Regieleki VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10128,6 +10234,9 @@
     "hp": "180",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Unown VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10199,6 +10308,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Unown VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10268,6 +10380,9 @@
     "hp": "200",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Mawile VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10600,6 +10715,9 @@
     "types": [
       "Dragon"
     ],
+    "evolvesTo": [
+      "Regidrago VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10660,6 +10778,9 @@
     "types": [
       "Dragon"
     ],
+    "evolvesTo": [
+      "Regidrago VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10719,6 +10840,9 @@
     "hp": "220",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Lugia VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10791,6 +10915,9 @@
     "hp": "220",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Lugia VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -11193,9 +11320,6 @@
       "Water"
     ],
     "evolvesFrom": "Alolan Vulpix V",
-    "evolvesTo": [
-      "Ninetales"
-    ],
     "rules": [
       "VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize cards."
     ],

--- a/cards/en/swsh12pt5.json
+++ b/cards/en/swsh12pt5.json
@@ -11,7 +11,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Gloom"
+      "Gloom",
+      "Dark Gloom"
     ],
     "attacks": [
       {
@@ -66,7 +67,9 @@
     "evolvesFrom": "Oddish",
     "evolvesTo": [
       "Vileplume",
-      "Bellossom"
+      "Bellossom",
+      "Vileplume ex",
+      "Vileplume-GX"
     ],
     "attacks": [
       {
@@ -237,6 +240,9 @@
       "Grass"
     ],
     "evolvesFrom": "Tangela",
+    "evolvesTo": [
+      "Tangrowth LV.X"
+    ],
     "attacks": [
       {
         "name": "Suctioning Vines",
@@ -303,7 +309,11 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor",
+      "Scizor ex",
+      "Dark Scizor",
+      "Scizor-GX",
+      "Kleavor"
     ],
     "attacks": [
       {
@@ -356,7 +366,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Sunflora"
+      "Sunflora",
+      "Light Sunflora"
     ],
     "attacks": [
       {
@@ -474,6 +485,9 @@
       "Grass"
     ],
     "evolvesFrom": "Yanma",
+    "evolvesTo": [
+      "Yanmega BREAK"
+    ],
     "attacks": [
       {
         "name": "Shoot Through",
@@ -697,6 +711,10 @@
     "hp": "210",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Leafeon VSTAR",
+      "Leafeon VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -1014,6 +1032,10 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Charizard VMAX",
+      "Charizard VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -1277,6 +1299,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Simisear VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -1406,7 +1431,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Volcarona"
+      "Volcarona",
+      "Volcarona-GX"
     ],
     "attacks": [
       {
@@ -1587,7 +1613,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Salazzle"
+      "Salazzle",
+      "Salazzle-GX"
     ],
     "attacks": [
       {
@@ -1710,7 +1737,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Dewgong"
+      "Dewgong",
+      "Light Dewgong"
     ],
     "attacks": [
       {
@@ -1771,6 +1799,9 @@
     "hp": "80",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Galarian Mr. Rime"
     ],
     "attacks": [
       {
@@ -1833,7 +1864,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wailord"
+      "Wailord",
+      "Wailord ex"
     ],
     "attacks": [
       {
@@ -1968,7 +2000,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Crawdaunt"
+      "Crawdaunt",
+      "Crawdaunt ex"
     ],
     "attacks": [
       {
@@ -2034,7 +2067,8 @@
     ],
     "evolvesTo": [
       "Glalie",
-      "Froslass"
+      "Froslass",
+      "Froslass ex"
     ],
     "attacks": [
       {
@@ -2279,6 +2313,10 @@
     "hp": "210",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Glaceon VSTAR",
+      "Glaceon VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -2582,6 +2620,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Luxio",
+    "evolvesTo": [
+      "Luxray BREAK"
+    ],
     "attacks": [
       {
         "name": "Electrostep",
@@ -2643,6 +2684,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Luxio",
+    "evolvesTo": [
+      "Luxray BREAK"
+    ],
     "abilities": [
       {
         "name": "Explosiveness",
@@ -2696,6 +2740,9 @@
     "hp": "190",
     "types": [
       "Lightning"
+    ],
+    "evolvesTo": [
+      "Rotom VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -3052,9 +3099,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesTo": [
-      "Vikavolt"
-    ],
     "rules": [
       "Radiant Pokémon Rule: You can't have more than 1 Radiant Pokémon in your deck."
     ],
@@ -3167,6 +3211,10 @@
     "hp": "210",
     "types": [
       "Lightning"
+    ],
+    "evolvesTo": [
+      "Zeraora VMAX",
+      "Zeraora VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -3422,7 +3470,10 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Exeggutor"
+      "Exeggutor",
+      "Dark Exeggutor",
+      "Alolan Exeggutor-GX",
+      "Alolan Exeggutor"
     ],
     "attacks": [
       {
@@ -3550,6 +3601,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Mewtwo LV.X"
+    ],
     "attacks": [
       {
         "name": "Psypump",
@@ -3620,6 +3674,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Mew VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -3683,6 +3740,9 @@
     "hp": "90",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Farigiraf"
     ],
     "attacks": [
       {
@@ -3941,6 +4001,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Hatterene VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -4144,7 +4207,8 @@
     ],
     "evolvesFrom": "Geodude",
     "evolvesTo": [
-      "Golem"
+      "Golem",
+      "Golem ex"
     ],
     "attacks": [
       {
@@ -4269,7 +4333,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Claydol"
+      "Claydol",
+      "Claydol ex"
     ],
     "attacks": [
       {
@@ -4323,7 +4388,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lucario"
+      "Lucario",
+      "Lucario-GX",
+      "Lucario ex"
     ],
     "attacks": [
       {
@@ -4432,7 +4499,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lycanroc"
+      "Lycanroc",
+      "Lycanroc-GX",
+      "Lycanroc ex"
     ],
     "attacks": [
       {
@@ -4547,7 +4616,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Weezing"
+      "Weezing",
+      "Dark Weezing",
+      "Galarian Weezing"
     ],
     "attacks": [
       {
@@ -5082,7 +5153,7 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Persian"
+      "Galarian Perrserker"
     ],
     "attacks": [
       {
@@ -5351,7 +5422,8 @@
     ],
     "evolvesFrom": "Aron",
     "evolvesTo": [
-      "Aggron"
+      "Aggron",
+      "Aggron ex"
     ],
     "attacks": [
       {
@@ -5500,7 +5572,9 @@
     ],
     "evolvesFrom": "Beldum",
     "evolvesTo": [
-      "Metagross"
+      "Metagross",
+      "Metagross ex",
+      "Metagross-GX"
     ],
     "attacks": [
       {
@@ -5679,6 +5753,9 @@
       "Metal"
     ],
     "evolvesFrom": "Pawniard",
+    "evolvesTo": [
+      "Kingambit"
+    ],
     "attacks": [
       {
         "name": "Spike Draw",
@@ -5744,6 +5821,9 @@
     "hp": "130",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Zacian LV.X"
     ],
     "attacks": [
       {
@@ -5813,6 +5893,9 @@
     "hp": "220",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Zacian VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -6025,6 +6108,9 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Zamazenta VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -6163,6 +6249,9 @@
     "hp": "210",
     "types": [
       "Dragon"
+    ],
+    "evolvesTo": [
+      "Rayquaza VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -6336,6 +6425,9 @@
     "hp": "220",
     "types": [
       "Dragon"
+    ],
+    "evolvesTo": [
+      "Duraludon VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -6624,14 +6716,7 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Vaporeon",
-      "Jolteon",
-      "Flareon",
-      "Sylveon",
-      "Espeon",
-      "Umbreon",
-      "Leafeon",
-      "Glaceon"
+      "Eevee VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -6695,6 +6780,9 @@
     "hp": "160",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Snorlax LV.X"
     ],
     "attacks": [
       {
@@ -6932,6 +7020,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Regigigas VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -7063,6 +7154,9 @@
     "hp": "70",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Shaymin LV.X"
     ],
     "attacks": [
       {
@@ -7200,7 +7294,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Gumshoos"
+      "Gumshoos",
+      "Gumshoos-GX"
     ],
     "attacks": [
       {
@@ -7376,6 +7471,9 @@
     "hp": "210",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Greedent VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -8433,7 +8531,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {

--- a/cards/en/swsh12pt5gg.json
+++ b/cards/en/swsh12pt5gg.json
@@ -11,7 +11,7 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Hisuian Electrode"
     ],
     "attacks": [
       {
@@ -132,6 +132,9 @@
       "Fire"
     ],
     "evolvesFrom": "Magmar",
+    "evolvesTo": [
+      "Magmortar LV.X"
+    ],
     "attacks": [
       {
         "name": "Mega Punch",
@@ -426,6 +429,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Electabuzz",
+    "evolvesTo": [
+      "Electivire LV.X"
+    ],
     "attacks": [
       {
         "name": "Explosive Bolt",
@@ -1037,6 +1043,9 @@
       "Metal"
     ],
     "evolvesFrom": "Magneton",
+    "evolvesTo": [
+      "Magnezone LV.X"
+    ],
     "abilities": [
       {
         "name": "Giga Magnet",
@@ -1308,6 +1317,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Dudunsparce"
+    ],
     "abilities": [
       {
         "name": "Mysterious Nest",
@@ -1487,7 +1499,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lucario"
+      "Lucario",
+      "Lucario-GX",
+      "Lucario ex"
     ],
     "attacks": [
       {
@@ -1541,7 +1555,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Altaria"
+      "Altaria",
+      "Altaria ex",
+      "Altaria-GX"
     ],
     "attacks": [
       {
@@ -1600,7 +1616,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Dusclops"
+      "Dusclops",
+      "Dusclops ex"
     ],
     "attacks": [
       {
@@ -1720,7 +1737,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "abilities": [
       {
@@ -1900,7 +1921,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Mightyena"
+      "Mightyena",
+      "Mightyena ex"
     ],
     "attacks": [
       {
@@ -1963,7 +1985,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Flaaffy"
+      "Flaaffy",
+      "Dark Flaaffy"
     ],
     "attacks": [
       {
@@ -2879,6 +2902,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Zacian VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -2941,6 +2967,9 @@
     "hp": "210",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Drapion VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -3067,6 +3096,9 @@
     "hp": "220",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Hisuian Samurott VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -3258,6 +3290,9 @@
     "hp": "220",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Zamazenta VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."

--- a/cards/en/swsh12tg.json
+++ b/cards/en/swsh12tg.json
@@ -138,7 +138,9 @@
     ],
     "evolvesFrom": "Mareep",
     "evolvesTo": [
-      "Ampharos"
+      "Ampharos",
+      "Ampharos ex",
+      "Ampharos-GX"
     ],
     "abilities": [
       {
@@ -266,6 +268,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Kirlia",
+    "evolvesTo": [
+      "Gardevoir LV.X"
+    ],
     "abilities": [
       {
         "name": "Refinement",
@@ -387,7 +392,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lycanroc"
+      "Lycanroc",
+      "Lycanroc-GX",
+      "Lycanroc ex"
     ],
     "attacks": [
       {
@@ -747,6 +754,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Serperior VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -811,6 +821,9 @@
     "hp": "210",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Blaziken VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -945,6 +958,10 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Zeraora VMAX",
+      "Zeraora VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -1000,6 +1017,9 @@
     "hp": "200",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Mawile VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -1064,6 +1084,9 @@
     "hp": "210",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Corviknight VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."

--- a/cards/en/swsh2.json
+++ b/cards/en/swsh2.json
@@ -193,7 +193,11 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Scizor"
+      "Scizor",
+      "Scizor ex",
+      "Dark Scizor",
+      "Scizor-GX",
+      "Kleavor"
     ],
     "attacks": [
       {
@@ -869,6 +873,9 @@
       "Grass"
     ],
     "evolvesFrom": "Phantump",
+    "evolvesTo": [
+      "Trevenant BREAK"
+    ],
     "attacks": [
       {
         "name": "Seed Bomb",
@@ -983,6 +990,9 @@
     "hp": "220",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Rillaboom VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -1176,7 +1186,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Flapple"
+      "Flapple",
+      "Appletun"
     ],
     "attacks": [
       {
@@ -1229,7 +1240,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Flapple"
+      "Flapple",
+      "Appletun"
     ],
     "attacks": [
       {
@@ -1399,7 +1411,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {
@@ -1461,6 +1475,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "attacks": [
       {
         "name": "Hex",
@@ -1589,7 +1606,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -1653,6 +1672,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "abilities": [
       {
         "name": "Warming Up",
@@ -1776,6 +1798,9 @@
       "Fire"
     ],
     "evolvesFrom": "Magmar",
+    "evolvesTo": [
+      "Magmortar LV.X"
+    ],
     "attacks": [
       {
         "name": "Burst Punch",
@@ -2072,6 +2097,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Cinderace VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -2199,7 +2227,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Mr. Rime"
+      "Galarian Mr. Rime"
     ],
     "attacks": [
       {
@@ -2319,7 +2347,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -2814,7 +2845,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Darmanitan"
+      "Galarian Darmanitan"
     ],
     "attacks": [
       {
@@ -2933,6 +2964,9 @@
     "hp": "200",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Inteleon VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -3360,7 +3394,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {
@@ -3532,6 +3569,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Electabuzz",
+    "evolvesTo": [
+      "Electivire LV.X"
+    ],
     "attacks": [
       {
         "name": "Thunder Shock",
@@ -3708,6 +3748,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Luxio",
+    "evolvesTo": [
+      "Luxray BREAK"
+    ],
     "attacks": [
       {
         "name": "Raid",
@@ -3881,7 +3924,8 @@
     ],
     "evolvesFrom": "Grubbin",
     "evolvesTo": [
-      "Vikavolt"
+      "Vikavolt",
+      "Vikavolt-GX"
     ],
     "attacks": [
       {
@@ -4010,6 +4054,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Boltund VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -4073,7 +4120,9 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Toxtricity"
+      "Toxtricity",
+      "Light Toxtricity",
+      "Toxtricity ex"
     ],
     "attacks": [
       {
@@ -4187,6 +4236,9 @@
     "hp": "210",
     "types": [
       "Lightning"
+    ],
+    "evolvesTo": [
+      "Toxtricity VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -4428,7 +4480,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Clefable",
+      "Clefable ex"
     ],
     "attacks": [
       {
@@ -4671,7 +4724,7 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Cursola"
+      "Galarian Cursola"
     ],
     "attacks": [
       {
@@ -4858,7 +4911,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Palossand"
+      "Palossand",
+      "Palossand-GX"
     ],
     "attacks": [
       {
@@ -5564,6 +5618,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Dragapult VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -5700,7 +5757,7 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Sirfetch'd"
+      "Galarian Sirfetch'd"
     ],
     "attacks": [
       {
@@ -5889,7 +5946,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Medicham"
+      "Medicham",
+      "Medicham ex"
     ],
     "attacks": [
       {
@@ -6115,7 +6173,7 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Runerigus"
+      "Galarian Runerigus"
     ],
     "attacks": [
       {
@@ -6534,6 +6592,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Sandaconda VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -6786,7 +6847,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Weezing"
+      "Weezing",
+      "Dark Weezing",
+      "Galarian Weezing"
     ],
     "attacks": [
       {
@@ -7246,6 +7309,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Vullaby",
+    "evolvesTo": [
+      "Mandibuzz BREAK"
+    ],
     "attacks": [
       {
         "name": "Bone Rush",
@@ -7312,6 +7378,9 @@
     "hp": "210",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Malamar VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -7621,7 +7690,7 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Perrserker"
+      "Galarian Perrserker"
     ],
     "abilities": [
       {
@@ -7892,6 +7961,9 @@
       "Metal"
     ],
     "evolvesFrom": "Bronzor",
+    "evolvesTo": [
+      "Bronzong BREAK"
+    ],
     "attacks": [
       {
         "name": "Smack",
@@ -8157,7 +8229,8 @@
     ],
     "evolvesFrom": "Honedge",
     "evolvesTo": [
-      "Aegislash"
+      "Aegislash",
+      "Aegislash ex"
     ],
     "attacks": [
       {
@@ -8294,6 +8367,9 @@
     "hp": "220",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Copperajah VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -8511,6 +8587,9 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Zacian LV.X"
+    ],
     "attacks": [
       {
         "name": "Energy Stream",
@@ -8646,6 +8725,9 @@
     "hp": "150",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Snorlax LV.X"
     ],
     "attacks": [
       {
@@ -9174,7 +9256,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Bewear"
+      "Bewear",
+      "Bewear-GX"
     ],
     "attacks": [
       {
@@ -9304,7 +9387,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Greedent"
+      "Greedent",
+      "Greedent ex"
     ],
     "attacks": [
       {
@@ -9993,6 +10077,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Rillaboom VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10186,6 +10273,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Cinderace VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10315,6 +10405,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Inteleon VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10379,6 +10472,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Boltund VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10441,6 +10537,9 @@
     "hp": "210",
     "types": [
       "Lightning"
+    ],
+    "evolvesTo": [
+      "Toxtricity VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10505,6 +10604,9 @@
     "hp": "210",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Dragapult VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10573,6 +10675,9 @@
     "hp": "220",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Sandaconda VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10701,6 +10806,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Malamar VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10765,6 +10873,9 @@
     "hp": "220",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Copperajah VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."

--- a/cards/en/swsh3.json
+++ b/cards/en/swsh3.json
@@ -11,6 +11,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Butterfree VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -635,7 +638,10 @@
     ],
     "evolvesFrom": "Rowlet",
     "evolvesTo": [
-      "Decidueye"
+      "Decidueye",
+      "Decidueye-GX",
+      "Hisuian Decidueye",
+      "Decidueye ex"
     ],
     "attacks": [
       {
@@ -809,7 +815,9 @@
     ],
     "evolvesFrom": "Bounsweet",
     "evolvesTo": [
-      "Tsareena"
+      "Tsareena",
+      "Tsareena-GX",
+      "Tsareena ex"
     ],
     "attacks": [
       {
@@ -932,7 +940,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Golisopod"
+      "Golisopod",
+      "Golisopod-GX",
+      "Golisopod ex"
     ],
     "attacks": [
       {
@@ -1048,6 +1058,10 @@
     "hp": "220",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Charizard VMAX",
+      "Charizard VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -1311,7 +1325,9 @@
     ],
     "evolvesFrom": "Torchic",
     "evolvesTo": [
-      "Blaziken"
+      "Blaziken",
+      "Blaziken ex",
+      "Blaziken-GX"
     ],
     "attacks": [
       {
@@ -1432,6 +1448,9 @@
     "hp": "130",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Heatran LV.X"
     ],
     "attacks": [
       {
@@ -1684,7 +1703,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Volcarona"
+      "Volcarona",
+      "Volcarona-GX"
     ],
     "attacks": [
       {
@@ -1857,6 +1877,9 @@
       "Fire"
     ],
     "evolvesFrom": "Fletchinder",
+    "evolvesTo": [
+      "Talonflame BREAK"
+    ],
     "abilities": [
       {
         "name": "Scorching Feathers",
@@ -1921,6 +1944,9 @@
     "hp": "210",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Centiskorch VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -2043,7 +2069,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Mr. Rime"
+      "Galarian Mr. Rime"
     ],
     "attacks": [
       {
@@ -2225,7 +2251,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Milotic"
+      "Milotic",
+      "Milotic ex"
     ],
     "attacks": [
       {
@@ -2519,7 +2546,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Darmanitan"
+      "Galarian Darmanitan"
     ],
     "attacks": [
       {
@@ -2997,7 +3024,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Toxapex"
+      "Toxapex",
+      "Toxapex-GX"
     ],
     "attacks": [
       {
@@ -3249,7 +3277,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Flaaffy"
+      "Flaaffy",
+      "Dark Flaaffy"
     ],
     "attacks": [
       {
@@ -3302,7 +3331,9 @@
     ],
     "evolvesFrom": "Mareep",
     "evolvesTo": [
-      "Ampharos"
+      "Ampharos",
+      "Ampharos ex",
+      "Ampharos-GX"
     ],
     "attacks": [
       {
@@ -3415,7 +3446,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Manectric",
+      "Manectric ex"
     ],
     "attacks": [
       {
@@ -3651,7 +3683,9 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Toxtricity"
+      "Toxtricity",
+      "Light Toxtricity",
+      "Toxtricity ex"
     ],
     "attacks": [
       {
@@ -3962,7 +3996,11 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Wigglytuff"
+      "Wigglytuff",
+      "Dark Wigglytuff",
+      "Light Wigglytuff",
+      "Wigglytuff ex",
+      "Wigglytuff-GX"
     ],
     "attacks": [
       {
@@ -4085,6 +4123,9 @@
     "hp": "180",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Mew VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -5033,7 +5074,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Dugtrio"
+      "Dugtrio",
+      "Dark Dugtrio"
     ],
     "attacks": [
       {
@@ -5145,7 +5187,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Pupitar"
+      "Pupitar",
+      "Dark Pupitar"
     ],
     "attacks": [
       {
@@ -5208,7 +5251,9 @@
     ],
     "evolvesFrom": "Larvitar",
     "evolvesTo": [
-      "Tyranitar"
+      "Tyranitar",
+      "Tyranitar ex",
+      "Tyranitar-GX"
     ],
     "attacks": [
       {
@@ -5393,7 +5438,9 @@
     ],
     "evolvesFrom": "Trapinch",
     "evolvesTo": [
-      "Flygon"
+      "Flygon",
+      "Flygon ex",
+      "Flygon-GX"
     ],
     "attacks": [
       {
@@ -5445,6 +5492,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Vibrava",
+    "evolvesTo": [
+      "Flygon LV.X"
+    ],
     "abilities": [
       {
         "name": "Labyrinth of Sand",
@@ -5628,6 +5678,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Hippopotas",
+    "evolvesTo": [
+      "Hippowdon LV.X"
+    ],
     "attacks": [
       {
         "name": "Triple Smash",
@@ -6015,7 +6068,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Muk"
+      "Muk",
+      "Dark Muk",
+      "Muk ex"
     ],
     "attacks": [
       {
@@ -6145,7 +6200,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Ariados"
+      "Ariados",
+      "Dark Ariados"
     ],
     "attacks": [
       {
@@ -6266,6 +6322,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Crobat VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -6324,6 +6383,9 @@
     "hp": "120",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Darkrai LV.X"
     ],
     "abilities": [
       {
@@ -6624,6 +6686,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Zweilous",
+    "evolvesTo": [
+      "Hydreigon BREAK"
+    ],
     "abilities": [
       {
         "name": "Dark Squall",
@@ -6847,6 +6912,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Grimmsnarl VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -6966,6 +7034,9 @@
     "hp": "220",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Eternatus VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -7093,6 +7164,9 @@
     "hp": "210",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Scizor VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -7371,7 +7445,8 @@
     ],
     "evolvesFrom": "Aron",
     "evolvesTo": [
-      "Aggron"
+      "Aggron",
+      "Aggron ex"
     ],
     "attacks": [
       {
@@ -7848,7 +7923,9 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Melmetal"
+      "Melmetal",
+      "Melmetal-GX",
+      "Melmetal ex"
     ],
     "attacks": [
       {
@@ -7987,7 +8064,8 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Copperajah"
+      "Copperajah",
+      "Copperajah ex"
     ],
     "attacks": [
       {
@@ -8341,6 +8419,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Dudunsparce"
+    ],
     "abilities": [
       {
         "name": "Final Dig",
@@ -8398,7 +8479,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Ursaring"
+      "Ursaring",
+      "Dark Ursaring"
     ],
     "attacks": [
       {
@@ -8461,6 +8543,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Teddiursa",
+    "evolvesTo": [
+      "Ursaluna"
+    ],
     "attacks": [
       {
         "name": "Hammer Arm",
@@ -8525,6 +8610,9 @@
     "hp": "130",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Lugia BREAK"
     ],
     "attacks": [
       {
@@ -8594,7 +8682,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Delcatty"
+      "Delcatty",
+      "Delcatty ex"
     ],
     "attacks": [
       {
@@ -8716,6 +8805,9 @@
     "hp": "220",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Salamence VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -9289,7 +9381,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Greedent"
+      "Greedent",
+      "Greedent ex"
     ],
     "attacks": [
       {
@@ -9834,6 +9927,12 @@
       "Item"
     ],
     "hp": "70",
+    "evolvesTo": [
+      "Arctozolt",
+      "Dracovish",
+      "Arctovish",
+      "Dracozolt"
+    ],
     "rules": [
       "Play this card as if it were a 70-HP Basic Colorless Pokémon. At any time during your turn, you may discard this card from play.",
       "This card can't be affected by any Special Conditions, and it can't retreat.",
@@ -10078,6 +10177,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Butterfree VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10203,6 +10305,9 @@
     "hp": "210",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Centiskorch VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10405,6 +10510,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Crobat VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10464,6 +10572,9 @@
     "hp": "210",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Scizor VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10603,6 +10714,9 @@
     "hp": "220",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Salamence VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."

--- a/cards/en/swsh35.json
+++ b/cards/en/swsh35.json
@@ -11,6 +11,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Venusaur VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -296,7 +299,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {
@@ -614,7 +619,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Sharpedo"
+      "Sharpedo",
+      "Sharpedo ex"
     ],
     "attacks": [
       {
@@ -783,6 +789,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Drednaw VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -910,6 +919,9 @@
     "hp": "210",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Gardevoir VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -1300,6 +1312,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Alcremie VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -1428,7 +1443,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Machoke"
+      "Machoke",
+      "Dark Machoke",
+      "Light Machoke"
     ],
     "attacks": [
       {
@@ -1492,7 +1509,8 @@
     ],
     "evolvesFrom": "Machop",
     "evolvesTo": [
-      "Machamp"
+      "Machamp",
+      "Machamp-GX"
     ],
     "attacks": [
       {
@@ -1557,6 +1575,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Machoke",
+    "evolvesTo": [
+      "Machamp LV.X",
+      "Machamp BREAK"
+    ],
     "attacks": [
       {
         "name": "Macho Revenge",
@@ -1620,6 +1642,9 @@
     "hp": "210",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Lucario VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -1748,7 +1773,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lycanroc"
+      "Lycanroc",
+      "Lycanroc-GX",
+      "Lycanroc ex"
     ],
     "attacks": [
       {
@@ -1989,7 +2016,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Arbok"
+      "Arbok",
+      "Dark Arbok",
+      "Arbok ex"
     ],
     "attacks": [
       {
@@ -2111,7 +2140,7 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Linoone"
+      "Galarian Linoone"
     ],
     "attacks": [
       {
@@ -2165,7 +2194,7 @@
     ],
     "evolvesFrom": "Galarian Zigzagoon",
     "evolvesTo": [
-      "Obstagoon"
+      "Galarian Obstagoon"
     ],
     "attacks": [
       {
@@ -2815,6 +2844,9 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Duraludon VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -2884,7 +2916,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Altaria"
+      "Altaria",
+      "Altaria ex",
+      "Altaria-GX"
     ],
     "attacks": [
       {
@@ -3466,6 +3500,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Drednaw VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -3529,6 +3566,9 @@
     "hp": "210",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Gardevoir VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -3984,6 +4024,10 @@
     "hp": "220",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Charizard VMAX",
+      "Charizard VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."

--- a/cards/en/swsh4.json
+++ b/cards/en/swsh4.json
@@ -181,7 +181,10 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Exeggutor"
+      "Exeggutor",
+      "Dark Exeggutor",
+      "Alolan Exeggutor-GX",
+      "Alolan Exeggutor"
     ],
     "attacks": [
       {
@@ -359,6 +362,9 @@
       "Grass"
     ],
     "evolvesFrom": "Yanma",
+    "evolvesTo": [
+      "Yanmega BREAK"
+    ],
     "attacks": [
       {
         "name": "U-turn",
@@ -418,7 +424,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Forretress"
+      "Forretress",
+      "Dark Forretress",
+      "Forretress ex"
     ],
     "attacks": [
       {
@@ -593,7 +601,9 @@
     ],
     "evolvesFrom": "Seedot",
     "evolvesTo": [
-      "Shiftry"
+      "Shiftry",
+      "Shiftry ex",
+      "Shiftry-GX"
     ],
     "attacks": [
       {
@@ -705,7 +715,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ninjask"
+      "Ninjask",
+      "Shedinja"
     ],
     "attacks": [
       {
@@ -757,9 +768,6 @@
       "Grass"
     ],
     "evolvesFrom": "Nincada",
-    "evolvesTo": [
-      "Shedinja"
-    ],
     "abilities": [
       {
         "name": "Cast-off Shell",
@@ -811,6 +819,9 @@
     "hp": "70",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Shaymin LV.X"
     ],
     "attacks": [
       {
@@ -1122,6 +1133,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Orbeetle VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -1307,7 +1321,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -1370,7 +1385,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "attacks": [
       {
@@ -1553,7 +1571,10 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Magcargo"
+      "Magcargo",
+      "Dark Magcargo",
+      "Magcargo ex",
+      "Magcargo-GX"
     ],
     "attacks": [
       {
@@ -1807,7 +1828,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wailord"
+      "Wailord",
+      "Wailord ex"
     ],
     "attacks": [
       {
@@ -1989,7 +2011,8 @@
     ],
     "evolvesFrom": "Oshawott",
     "evolvesTo": [
-      "Samurott"
+      "Samurott",
+      "Hisuian Samurott"
     ],
     "attacks": [
       {
@@ -2112,6 +2135,9 @@
     "hp": "220",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Galarian Darmanitan VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -2535,7 +2561,7 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Pikachu VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -2600,9 +2626,6 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu V",
-    "evolvesTo": [
-      "Raichu"
-    ],
     "rules": [
       "VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -2658,7 +2681,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {
@@ -3013,7 +3039,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Manectric",
+      "Manectric ex"
     ],
     "attacks": [
       {
@@ -3709,7 +3736,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Clefable",
+      "Clefable ex"
     ],
     "attacks": [
       {
@@ -3829,6 +3857,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Farigiraf"
+    ],
     "attacks": [
       {
         "name": "Psypower",
@@ -3947,7 +3978,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Banette"
+      "Banette",
+      "Banette ex",
+      "Banette-GX"
     ],
     "attacks": [
       {
@@ -4069,7 +4102,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Dusclops"
+      "Dusclops",
+      "Dusclops ex"
     ],
     "attacks": [
       {
@@ -4198,6 +4232,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Dusclops",
+    "evolvesTo": [
+      "Dusknoir LV.X"
+    ],
     "abilities": [
       {
         "name": "Spectral Breach",
@@ -4451,7 +4488,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Whimsicott"
+      "Whimsicott",
+      "Whimsicott-GX"
     ],
     "attacks": [
       {
@@ -4605,6 +4643,9 @@
     "hp": "130",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Xerneas BREAK"
     ],
     "attacks": [
       {
@@ -4844,6 +4885,9 @@
     "hp": "110",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Zacian LV.X"
     ],
     "attacks": [
       {
@@ -5091,7 +5135,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Donphan"
+      "Donphan",
+      "Dark Donphan"
     ],
     "attacks": [
       {
@@ -5341,7 +5386,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lucario"
+      "Lucario",
+      "Lucario-GX",
+      "Lucario ex"
     ],
     "attacks": [
       {
@@ -5583,7 +5630,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lycanroc"
+      "Lycanroc",
+      "Lycanroc-GX",
+      "Lycanroc ex"
     ],
     "attacks": [
       {
@@ -5833,6 +5882,9 @@
     "hp": "220",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Coalossal VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -6155,7 +6207,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Mightyena"
+      "Mightyena",
+      "Mightyena ex"
     ],
     "attacks": [
       {
@@ -6336,6 +6389,9 @@
     "hp": "210",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Drapion VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -6720,7 +6776,7 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Perrserker"
+      "Galarian Perrserker"
     ],
     "attacks": [
       {
@@ -7073,7 +7129,9 @@
     ],
     "evolvesFrom": "Beldum",
     "evolvesTo": [
-      "Metagross"
+      "Metagross",
+      "Metagross ex",
+      "Metagross-GX"
     ],
     "attacks": [
       {
@@ -7276,6 +7334,9 @@
       "Metal"
     ],
     "evolvesFrom": "Riolu",
+    "evolvesTo": [
+      "Lucario LV.X"
+    ],
     "attacks": [
       {
         "name": "Spike Draw",
@@ -7342,6 +7403,9 @@
     "hp": "130",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Dialga LV.X"
     ],
     "attacks": [
       {
@@ -7665,6 +7729,9 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Aegislash VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -7939,7 +8006,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -7999,6 +8086,9 @@
     "hp": "130",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Snorlax LV.X"
     ],
     "abilities": [
       {
@@ -8060,6 +8150,9 @@
     "hp": "130",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Lugia BREAK"
     ],
     "attacks": [
       {
@@ -8306,7 +8399,8 @@
     ],
     "evolvesFrom": "Whismur",
     "evolvesTo": [
-      "Exploud"
+      "Exploud",
+      "Exploud ex"
     ],
     "attacks": [
       {
@@ -8556,6 +8650,9 @@
     "hp": "200",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Togekiss VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -9424,6 +9521,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Orbeetle VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -9614,6 +9714,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Galarian Darmanitan VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -9680,7 +9783,7 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Pikachu VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -9879,6 +9982,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Coalossal VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10009,6 +10115,9 @@
     "hp": "210",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Drapion VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10153,6 +10262,9 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Aegislash VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10224,6 +10336,9 @@
     "hp": "200",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Togekiss VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10580,9 +10695,6 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu V",
-    "evolvesTo": [
-      "Raichu"
-    ],
     "rules": [
       "VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize cards."
     ],

--- a/cards/en/swsh45.json
+++ b/cards/en/swsh45.json
@@ -74,6 +74,9 @@
       "Grass"
     ],
     "evolvesFrom": "Yanma",
+    "evolvesTo": [
+      "Yanmega BREAK"
+    ],
     "attacks": [
       {
         "name": "Bug Bite",
@@ -190,7 +193,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Cacturne"
+      "Cacturne",
+      "Cacturne ex"
     ],
     "attacks": [
       {
@@ -367,7 +371,10 @@
     ],
     "evolvesFrom": "Rowlet",
     "evolvesTo": [
-      "Decidueye"
+      "Decidueye",
+      "Decidueye-GX",
+      "Hisuian Decidueye",
+      "Decidueye ex"
     ],
     "attacks": [
       {
@@ -477,6 +484,9 @@
     "hp": "220",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Dhelmise VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -1010,6 +1020,9 @@
     "hp": "210",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Cinderace VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -1869,6 +1882,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Luxio",
+    "evolvesTo": [
+      "Luxray BREAK"
+    ],
     "attacks": [
       {
         "name": "Raid",
@@ -2103,6 +2119,9 @@
     "hp": "170",
     "types": [
       "Lightning"
+    ],
+    "evolvesTo": [
+      "Morpeko VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -2342,7 +2361,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Weezing"
+      "Weezing",
+      "Dark Weezing",
+      "Galarian Weezing"
     ],
     "attacks": [
       {
@@ -2453,7 +2474,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Ariados"
+      "Ariados",
+      "Dark Ariados"
     ],
     "attacks": [
       {
@@ -2514,6 +2536,9 @@
     "hp": "180",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Crobat VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -2637,6 +2662,9 @@
     "hp": "110",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Yveltal BREAK"
     ],
     "attacks": [
       {
@@ -2812,7 +2840,8 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Copperajah"
+      "Copperajah",
+      "Copperajah ex"
     ],
     "attacks": [
       {
@@ -2873,6 +2902,9 @@
     "hp": "170",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Ditto VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -2997,7 +3029,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -3058,6 +3110,9 @@
     "hp": "200",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Greedent VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -3123,6 +3178,9 @@
     "hp": "200",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Cramorant VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -3484,6 +3542,9 @@
     "hp": "170",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Alcremie VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."

--- a/cards/en/swsh45sv.json
+++ b/cards/en/swsh45sv.json
@@ -73,7 +73,10 @@
     ],
     "evolvesFrom": "Rowlet",
     "evolvesTo": [
-      "Decidueye"
+      "Decidueye",
+      "Decidueye-GX",
+      "Hisuian Decidueye",
+      "Decidueye ex"
     ],
     "attacks": [
       {
@@ -653,7 +656,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Flapple"
+      "Flapple",
+      "Appletun"
     ],
     "attacks": [
       {
@@ -1125,7 +1129,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Mr. Rime"
+      "Galarian Mr. Rime"
     ],
     "attacks": [
       {
@@ -1307,7 +1311,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Darmanitan"
+      "Galarian Darmanitan"
     ],
     "attacks": [
       {
@@ -2383,7 +2387,9 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Toxtricity"
+      "Toxtricity",
+      "Light Toxtricity",
+      "Toxtricity ex"
     ],
     "attacks": [
       {
@@ -2743,7 +2749,7 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Rapidash"
+      "Galarian Rapidash"
     ],
     "attacks": [
       {
@@ -2865,7 +2871,7 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Cursola"
+      "Galarian Cursola"
     ],
     "attacks": [
       {
@@ -3737,7 +3743,7 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Sirfetch'd"
+      "Galarian Sirfetch'd"
     ],
     "attacks": [
       {
@@ -3861,7 +3867,7 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Runerigus"
+      "Galarian Runerigus"
     ],
     "attacks": [
       {
@@ -4517,7 +4523,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Weezing"
+      "Weezing",
+      "Dark Weezing",
+      "Galarian Weezing"
     ],
     "attacks": [
       {
@@ -4628,7 +4636,7 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Linoone"
+      "Galarian Linoone"
     ],
     "abilities": [
       {
@@ -4689,7 +4697,7 @@
     ],
     "evolvesFrom": "Galarian Zigzagoon",
     "evolvesTo": [
-      "Obstagoon"
+      "Galarian Obstagoon"
     ],
     "attacks": [
       {
@@ -5113,7 +5121,7 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Perrserker"
+      "Galarian Perrserker"
     ],
     "abilities": [
       {
@@ -5378,7 +5386,8 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Copperajah"
+      "Copperajah",
+      "Copperajah ex"
     ],
     "attacks": [
       {
@@ -5926,7 +5935,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Greedent"
+      "Greedent",
+      "Greedent ex"
     ],
     "attacks": [
       {
@@ -6299,6 +6309,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Rillaboom VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -6500,6 +6513,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Centiskorch VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -6621,6 +6637,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Lapras VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -6741,6 +6760,9 @@
     "hp": "210",
     "types": [
       "Lightning"
+    ],
+    "evolvesTo": [
+      "Toxtricity VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -6991,6 +7013,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Grimmsnarl VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -7110,6 +7135,9 @@
     "hp": "170",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Ditto VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -7288,6 +7316,9 @@
     "hp": "220",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Eternatus VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."

--- a/cards/en/swsh5.json
+++ b/cards/en/swsh5.json
@@ -192,7 +192,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Cacturne"
+      "Cacturne",
+      "Cacturne ex"
     ],
     "attacks": [
       {
@@ -800,7 +801,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Lurantis"
+      "Lurantis",
+      "Lurantis-GX"
     ],
     "attacks": [
       {
@@ -1030,6 +1032,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Flapple VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -1212,6 +1217,9 @@
     "hp": "190",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Victini VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -1603,7 +1611,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Salazzle"
+      "Salazzle",
+      "Salazzle-GX"
     ],
     "attacks": [
       {
@@ -1887,7 +1896,9 @@
     ],
     "evolvesFrom": "Horsea",
     "evolvesTo": [
-      "Kingdra"
+      "Kingdra",
+      "Kingdra ex",
+      "Kingdra-GX"
     ],
     "attacks": [
       {
@@ -1998,7 +2009,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Mr. Rime"
+      "Galarian Mr. Rime"
     ],
     "attacks": [
       {
@@ -2126,7 +2137,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Octillery"
+      "Octillery",
+      "Dark Octillery"
     ],
     "attacks": [
       {
@@ -2251,7 +2263,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Crawdaunt"
+      "Crawdaunt",
+      "Crawdaunt ex"
     ],
     "attacks": [
       {
@@ -2670,6 +2683,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Electabuzz",
+    "evolvesTo": [
+      "Electivire LV.X"
+    ],
     "attacks": [
       {
         "name": "Tumbling Attack",
@@ -2857,6 +2873,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Luxio",
+    "evolvesTo": [
+      "Luxray BREAK"
+    ],
     "attacks": [
       {
         "name": "Electrostep",
@@ -2977,6 +2996,9 @@
     "hp": "210",
     "types": [
       "Lightning"
+    ],
+    "evolvesTo": [
+      "Tapu Koko VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -3220,8 +3242,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Slowbro",
-      "Slowking"
+      "Galarian Slowbro",
+      "Galarian Slowking"
     ],
     "attacks": [
       {
@@ -3421,7 +3443,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Claydol"
+      "Claydol",
+      "Claydol ex"
     ],
     "attacks": [
       {
@@ -3740,6 +3763,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Mimikyu VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -4019,7 +4045,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Primeape"
+      "Primeape",
+      "Dark Primeape"
     ],
     "attacks": [
       {
@@ -4074,6 +4101,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Mankey",
+    "evolvesTo": [
+      "Annihilape ex",
+      "Annihilape"
+    ],
     "attacks": [
       {
         "name": "Field Crush",
@@ -4136,7 +4167,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Steelix"
+      "Steelix",
+      "Dark Steelix",
+      "Steelix ex"
     ],
     "attacks": [
       {
@@ -4207,7 +4240,10 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Marowak"
+      "Marowak",
+      "Dark Marowak",
+      "Alolan Marowak-GX",
+      "Alolan Marowak"
     ],
     "attacks": [
       {
@@ -4270,6 +4306,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Cubone",
+    "evolvesTo": [
+      "Marowak BREAK"
+    ],
     "abilities": [
       {
         "name": "Battle Armor",
@@ -4384,6 +4423,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Gligar",
+    "evolvesTo": [
+      "Gliscor LV.X"
+    ],
     "attacks": [
       {
         "name": "Acrobatics",
@@ -5192,6 +5234,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Single Strike Urshifu VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -5328,6 +5373,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Rapid Strike Urshifu VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -5459,7 +5507,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Golbat"
+      "Golbat",
+      "Dark Golbat"
     ],
     "attacks": [
       {
@@ -5523,7 +5572,8 @@
     ],
     "evolvesFrom": "Zubat",
     "evolvesTo": [
-      "Crobat"
+      "Crobat",
+      "Crobat ex"
     ],
     "abilities": [
       {
@@ -5584,6 +5634,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Golbat",
+    "evolvesTo": [
+      "Crobat BREAK"
+    ],
     "abilities": [
       {
         "name": "Drastic Draw",
@@ -5703,7 +5756,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Honchkrow"
+      "Honchkrow",
+      "Honchkrow-GX"
     ],
     "attacks": [
       {
@@ -5772,6 +5826,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Murkrow",
+    "evolvesTo": [
+      "Honchkrow LV.X"
+    ],
     "abilities": [
       {
         "name": "Insomnia",
@@ -5840,7 +5897,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Houndoom"
+      "Houndoom",
+      "Dark Houndoom",
+      "Houndoom ex"
     ],
     "attacks": [
       {
@@ -6286,6 +6345,9 @@
       "Metal"
     ],
     "evolvesFrom": "Bronzor",
+    "evolvesTo": [
+      "Bronzong BREAK"
+    ],
     "abilities": [
       {
         "name": "Metal Transfer",
@@ -6422,6 +6484,9 @@
       "Metal"
     ],
     "evolvesFrom": "Pawniard",
+    "evolvesTo": [
+      "Kingambit"
+    ],
     "attacks": [
       {
         "name": "Slash",
@@ -6551,7 +6616,8 @@
     ],
     "evolvesFrom": "Honedge",
     "evolvesTo": [
-      "Aegislash"
+      "Aegislash",
+      "Aegislash ex"
     ],
     "attacks": [
       {
@@ -6746,6 +6812,9 @@
     "hp": "210",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Corviknight VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -8137,6 +8206,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Flapple VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -8200,6 +8272,9 @@
     "hp": "190",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Victini VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -8392,6 +8467,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Tapu Koko VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -8455,6 +8533,9 @@
     "hp": "160",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Mimikyu VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -8596,6 +8677,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Single Strike Urshifu VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -8661,6 +8745,9 @@
     "hp": "220",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Single Strike Urshifu VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -8728,6 +8815,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Rapid Strike Urshifu VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -8793,6 +8883,9 @@
     "hp": "220",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Rapid Strike Urshifu VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -8998,6 +9091,9 @@
     "hp": "210",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Corviknight VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."

--- a/cards/en/swsh6.json
+++ b/cards/en/swsh6.json
@@ -183,7 +183,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ledian"
+      "Ledian",
+      "Light Ledian"
     ],
     "attacks": [
       {
@@ -369,6 +370,9 @@
     "hp": "190",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Celebi VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -794,7 +798,9 @@
     ],
     "evolvesFrom": "Bounsweet",
     "evolvesTo": [
-      "Tsareena"
+      "Tsareena",
+      "Tsareena-GX",
+      "Tsareena ex"
     ],
     "attacks": [
       {
@@ -1163,6 +1169,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Blaziken VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -1350,7 +1359,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Volcarona"
+      "Volcarona",
+      "Volcarona-GX"
     ],
     "attacks": [
       {
@@ -1768,7 +1778,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Weavile"
+      "Weavile",
+      "Weavile-GX"
     ],
     "attacks": [
       {
@@ -2052,7 +2063,8 @@
     ],
     "evolvesTo": [
       "Glalie",
-      "Froslass"
+      "Froslass",
+      "Froslass ex"
     ],
     "attacks": [
       {
@@ -2220,7 +2232,8 @@
     ],
     "evolvesFrom": "Spheal",
     "evolvesTo": [
-      "Walrein"
+      "Walrein",
+      "Walrein ex"
     ],
     "attacks": [
       {
@@ -2659,6 +2672,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Ice Rider Calyrex VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -2789,7 +2805,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Flaaffy"
+      "Flaaffy",
+      "Dark Flaaffy"
     ],
     "attacks": [
       {
@@ -2854,7 +2871,9 @@
     ],
     "evolvesFrom": "Mareep",
     "evolvesTo": [
-      "Ampharos"
+      "Ampharos",
+      "Ampharos ex",
+      "Ampharos-GX"
     ],
     "attacks": [
       {
@@ -3150,6 +3169,10 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Zeraora VMAX",
+      "Zeraora VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -3206,8 +3229,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Slowbro",
-      "Slowking"
+      "Galarian Slowbro",
+      "Galarian Slowking"
     ],
     "attacks": [
       {
@@ -3277,7 +3300,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Haunter",
+      "Dark Haunter"
     ],
     "attacks": [
       {
@@ -3337,7 +3361,8 @@
     ],
     "evolvesFrom": "Gastly",
     "evolvesTo": [
-      "Gengar"
+      "Gengar",
+      "Gengar ex"
     ],
     "attacks": [
       {
@@ -3396,6 +3421,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Haunter",
+    "evolvesTo": [
+      "Gengar LV.X"
+    ],
     "abilities": [
       {
         "name": "Last Gift",
@@ -3586,7 +3614,9 @@
     "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
-      "Gallade"
+      "Gallade",
+      "Gardevoir ex",
+      "Gardevoir-GX"
     ],
     "attacks": [
       {
@@ -3639,6 +3669,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Kirlia",
+    "evolvesTo": [
+      "Gardevoir LV.X"
+    ],
     "abilities": [
       {
         "name": "Shining Arcana",
@@ -3701,7 +3734,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Banette"
+      "Banette",
+      "Banette ex",
+      "Banette-GX"
     ],
     "attacks": [
       {
@@ -3826,6 +3861,9 @@
     "hp": "120",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Cresselia LV.X"
     ],
     "attacks": [
       {
@@ -4461,6 +4499,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Shadow Rider Calyrex VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -4602,7 +4643,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Dugtrio"
+      "Dugtrio",
+      "Dark Dugtrio"
     ],
     "attacks": [
       {
@@ -4709,7 +4751,7 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Sirfetch'd"
+      "Galarian Sirfetch'd"
     ],
     "attacks": [
       {
@@ -4951,7 +4993,7 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Cofagrigus"
+      "Galarian Runerigus"
     ],
     "attacks": [
       {
@@ -5201,7 +5243,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lycanroc"
+      "Lycanroc",
+      "Lycanroc-GX",
+      "Lycanroc ex"
     ],
     "attacks": [
       {
@@ -5366,6 +5410,9 @@
     "hp": "220",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Sandaconda VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -5613,7 +5660,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Urshifu"
+      "Rapid Strike Urshifu",
+      "Single Strike Urshifu"
     ],
     "attacks": [
       {
@@ -5677,7 +5725,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Weezing"
+      "Weezing",
+      "Dark Weezing",
+      "Galarian Weezing"
     ],
     "attacks": [
       {
@@ -5978,6 +6028,9 @@
     "hp": "220",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Galarian Slowking VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -6658,7 +6711,8 @@
     ],
     "evolvesFrom": "Aron",
     "evolvesTo": [
-      "Aggron"
+      "Aggron",
+      "Aggron ex"
     ],
     "attacks": [
       {
@@ -6807,6 +6861,9 @@
     "hp": "220",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Metagross VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -7083,7 +7140,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Porygon2"
+      "Porygon2",
+      "Dark Porygon2"
     ],
     "attacks": [
       {
@@ -7138,7 +7196,8 @@
     ],
     "evolvesFrom": "Porygon",
     "evolvesTo": [
-      "Porygon-Z"
+      "Porygon-Z",
+      "Porygon-Z-GX"
     ],
     "attacks": [
       {
@@ -7193,6 +7252,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Porygon2",
+    "evolvesTo": [
+      "Porygon-Z LV.X"
+    ],
     "abilities": [
       {
         "name": "Bug Transmission",
@@ -7486,6 +7548,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Shaymin LV.X"
+    ],
     "attacks": [
       {
         "name": "Return",
@@ -7553,6 +7618,9 @@
     "hp": "210",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Tornadus VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -7761,7 +7829,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Greedent"
+      "Greedent",
+      "Greedent ex"
     ],
     "attacks": [
       {
@@ -8698,6 +8767,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Celebi VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -8761,6 +8833,9 @@
     "hp": "210",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Blaziken VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -8897,6 +8972,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Ice Rider Calyrex VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -8961,6 +9039,9 @@
     "hp": "210",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Ice Rider Calyrex VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -9028,6 +9109,10 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Zeraora VMAX",
+      "Zeraora VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -9084,6 +9169,10 @@
     "hp": "210",
     "types": [
       "Lightning"
+    ],
+    "evolvesTo": [
+      "Zeraora VMAX",
+      "Zeraora VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -9419,6 +9508,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Shadow Rider Calyrex VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -9489,6 +9581,9 @@
     "hp": "210",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Shadow Rider Calyrex VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -9687,6 +9782,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Sandaconda VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -9877,6 +9975,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Galarian Slowking VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -9942,6 +10043,9 @@
     "hp": "220",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Galarian Slowking VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10070,6 +10174,9 @@
     "hp": "220",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Metagross VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10269,6 +10376,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Tornadus VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10341,6 +10451,9 @@
     "hp": "210",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Tornadus VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -11834,6 +11947,9 @@
       "Metal"
     ],
     "evolvesFrom": "Bronzor",
+    "evolvesTo": [
+      "Bronzong BREAK"
+    ],
     "abilities": [
       {
         "name": "Metal Transfer",
@@ -11900,6 +12016,9 @@
     "hp": "130",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Snorlax LV.X"
     ],
     "abilities": [
       {

--- a/cards/en/swsh7.json
+++ b/cards/en/swsh7.json
@@ -351,6 +351,10 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Leafeon VSTAR",
+      "Leafeon VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -479,7 +483,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Lilligant"
+      "Lilligant",
+      "Hisuian Lilligant"
     ],
     "attacks": [
       {
@@ -713,6 +718,9 @@
     "hp": "210",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Trevenant VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -958,7 +966,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Flapple"
+      "Flapple",
+      "Appletun"
     ],
     "attacks": [
       {
@@ -1301,6 +1310,9 @@
       "Fire"
     ],
     "evolvesFrom": "Litleo",
+    "evolvesTo": [
+      "Pyroar BREAK"
+    ],
     "attacks": [
       {
         "name": "Combustion",
@@ -1363,7 +1375,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Golduck",
+      "Dark Golduck",
+      "Light Golduck"
     ],
     "attacks": [
       {
@@ -1417,6 +1431,9 @@
       "Water"
     ],
     "evolvesFrom": "Psyduck",
+    "evolvesTo": [
+      "Golduck BREAK"
+    ],
     "attacks": [
       {
         "name": "Psybeam",
@@ -1595,6 +1612,9 @@
     "hp": "220",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Gyarados VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -2041,7 +2061,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Sharpedo"
+      "Sharpedo",
+      "Sharpedo ex"
     ],
     "attacks": [
       {
@@ -2166,7 +2187,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Milotic"
+      "Milotic",
+      "Milotic ex"
     ],
     "attacks": [
       {
@@ -2338,6 +2360,10 @@
     "hp": "210",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Glaceon VSTAR",
+      "Glaceon VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -2581,7 +2607,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Avalugg"
+      "Avalugg",
+      "Hisuian Avalugg"
     ],
     "attacks": [
       {
@@ -2902,7 +2929,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -2966,6 +2997,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Big Sparking",
@@ -3079,7 +3114,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Lanturn"
+      "Lanturn",
+      "Light Lanturn"
     ],
     "attacks": [
       {
@@ -3196,7 +3232,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Flaaffy"
+      "Flaaffy",
+      "Dark Flaaffy"
     ],
     "attacks": [
       {
@@ -3260,7 +3297,9 @@
     ],
     "evolvesFrom": "Mareep",
     "evolvesTo": [
-      "Ampharos"
+      "Ampharos",
+      "Ampharos ex",
+      "Ampharos-GX"
     ],
     "abilities": [
       {
@@ -3432,6 +3471,9 @@
     "hp": "220",
     "types": [
       "Lightning"
+    ],
+    "evolvesTo": [
+      "Dracozolt VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -3628,7 +3670,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Hypno"
+      "Hypno",
+      "Dark Hypno"
     ],
     "attacks": [
       {
@@ -3821,6 +3864,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Espeon VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -3959,6 +4005,9 @@
     "hp": "120",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Wobbuffet BREAK"
     ],
     "attacks": [
       {
@@ -4418,6 +4467,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Floette",
+    "evolvesTo": [
+      "Florges BREAK"
+    ],
     "abilities": [
       {
         "name": "Rapid Strike Connection",
@@ -4479,6 +4531,9 @@
     "hp": "200",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Sylveon VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -5147,6 +5202,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Hippopotas",
+    "evolvesTo": [
+      "Hippowdon LV.X"
+    ],
     "attacks": [
       {
         "name": "Hammer In",
@@ -5545,6 +5603,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Lycanroc VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -5734,6 +5795,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Umbreon VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -5864,7 +5928,9 @@
     ],
     "evolvesFrom": "Seedot",
     "evolvesTo": [
-      "Shiftry"
+      "Shiftry",
+      "Shiftry ex",
+      "Shiftry-GX"
     ],
     "attacks": [
       {
@@ -6098,6 +6164,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Garbodor VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -6228,7 +6297,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Zoroark"
+      "Zoroark",
+      "Zoroark-GX"
     ],
     "attacks": [
       {
@@ -6282,6 +6352,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Zorua",
+    "evolvesTo": [
+      "Zoroark BREAK"
+    ],
     "abilities": [
       {
         "name": "Phantom Transformation",
@@ -6563,7 +6636,9 @@
     ],
     "evolvesFrom": "Bagon",
     "evolvesTo": [
-      "Salamence"
+      "Salamence",
+      "Salamence ex",
+      "Salamence-GX"
     ],
     "attacks": [
       {
@@ -6613,6 +6688,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Shelgon",
+    "evolvesTo": [
+      "Salamence LV.X"
+    ],
     "abilities": [
       {
         "name": "Intimidating Roar",
@@ -6667,6 +6745,9 @@
     "hp": "210",
     "types": [
       "Dragon"
+    ],
+    "evolvesTo": [
+      "Rayquaza VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -6782,6 +6863,9 @@
     "hp": "130",
     "types": [
       "Dragon"
+    ],
+    "evolvesTo": [
+      "Dialga LV.X"
     ],
     "attacks": [
       {
@@ -6962,6 +7046,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Zweilous",
+    "evolvesTo": [
+      "Hydreigon BREAK"
+    ],
     "attacks": [
       {
         "name": "Dragon Counter",
@@ -7347,6 +7434,9 @@
     "types": [
       "Dragon"
     ],
+    "evolvesTo": [
+      "Duraludon VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -7531,7 +7621,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -7594,7 +7704,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Ursaring"
+      "Ursaring",
+      "Dark Ursaring"
     ],
     "attacks": [
       {
@@ -7648,6 +7759,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Teddiursa",
+    "evolvesTo": [
+      "Ursaluna"
+    ],
     "attacks": [
       {
         "name": "Slash",
@@ -7948,7 +8062,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Altaria"
+      "Altaria",
+      "Altaria ex",
+      "Altaria-GX"
     ],
     "attacks": [
       {
@@ -8199,7 +8315,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Braviary"
+      "Braviary",
+      "Hisuian Braviary"
     ],
     "attacks": [
       {
@@ -8454,6 +8571,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Fletchinder",
+    "evolvesTo": [
+      "Talonflame BREAK"
+    ],
     "attacks": [
       {
         "name": "Clutch",
@@ -9159,6 +9279,10 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Leafeon VSTAR",
+      "Leafeon VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -9221,6 +9345,10 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Leafeon VSTAR",
+      "Leafeon VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -9282,6 +9410,9 @@
     "hp": "210",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Trevenant VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -9349,6 +9480,9 @@
     "hp": "210",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Flareon VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -9480,6 +9614,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Gyarados VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -9549,6 +9686,9 @@
     "hp": "210",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Vaporeon VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -9677,6 +9817,10 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Glaceon VSTAR",
+      "Glaceon VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -9741,6 +9885,10 @@
     "hp": "210",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Glaceon VSTAR",
+      "Glaceon VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -9875,6 +10023,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Jolteon VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -9934,6 +10085,9 @@
     "hp": "220",
     "types": [
       "Lightning"
+    ],
+    "evolvesTo": [
+      "Dracozolt VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10000,6 +10154,9 @@
     "hp": "200",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Espeon VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10070,6 +10227,9 @@
     "hp": "200",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Espeon VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10294,6 +10454,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Sylveon VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10355,6 +10518,9 @@
     "hp": "200",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Sylveon VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10551,6 +10717,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Lycanroc VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10615,6 +10784,9 @@
     "hp": "200",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Umbreon VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10682,6 +10854,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Umbreon VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10746,6 +10921,9 @@
     "hp": "210",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Garbodor VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10814,6 +10992,9 @@
     "types": [
       "Dragon"
     ],
+    "evolvesTo": [
+      "Dragonite VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10874,6 +11055,9 @@
     "hp": "230",
     "types": [
       "Dragon"
+    ],
+    "evolvesTo": [
+      "Dragonite VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -10937,6 +11121,9 @@
     "types": [
       "Dragon"
     ],
+    "evolvesTo": [
+      "Rayquaza VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -10995,6 +11182,9 @@
     "hp": "210",
     "types": [
       "Dragon"
+    ],
+    "evolvesTo": [
+      "Rayquaza VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -11161,6 +11351,9 @@
     "types": [
       "Dragon"
     ],
+    "evolvesTo": [
+      "Duraludon VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -11221,6 +11414,9 @@
     "hp": "220",
     "types": [
       "Dragon"
+    ],
+    "evolvesTo": [
+      "Duraludon VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -12730,6 +12926,9 @@
     "hp": "120",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Cresselia LV.X"
     ],
     "attacks": [
       {

--- a/cards/en/swsh8.json
+++ b/cards/en/swsh8.json
@@ -979,6 +979,9 @@
       "Grass"
     ],
     "evolvesFrom": "Phantump",
+    "evolvesTo": [
+      "Trevenant BREAK"
+    ],
     "attacks": [
       {
         "name": "Gentle Slap",
@@ -1279,6 +1282,9 @@
     "hp": "220",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Rillaboom VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -1638,7 +1644,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {
@@ -1692,7 +1700,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {
@@ -1745,6 +1755,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "attacks": [
       {
         "name": "Supernatural Flames",
@@ -1797,6 +1810,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "abilities": [
       {
         "name": "Byway of the Nine-Tailed Fox",
@@ -1857,7 +1873,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -1922,6 +1940,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "attacks": [
       {
         "name": "Fire Claws",
@@ -1985,7 +2006,10 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Magcargo"
+      "Magcargo",
+      "Dark Magcargo",
+      "Magcargo ex",
+      "Magcargo-GX"
     ],
     "attacks": [
       {
@@ -2287,6 +2311,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Chandelure VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -2534,6 +2561,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Cinderace VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -2590,6 +2620,9 @@
     "hp": "210",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Cinderace VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -3091,7 +3124,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Starmie"
+      "Starmie",
+      "Starmie-GX"
     ],
     "attacks": [
       {
@@ -3154,6 +3188,9 @@
       "Water"
     ],
     "evolvesFrom": "Staryu",
+    "evolvesTo": [
+      "Starmie BREAK"
+    ],
     "attacks": [
       {
         "name": "Multishot Star",
@@ -3268,7 +3305,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Croconaw"
+      "Croconaw",
+      "Dark Croconaw"
     ],
     "attacks": [
       {
@@ -3322,7 +3360,8 @@
     ],
     "evolvesFrom": "Totodile",
     "evolvesTo": [
-      "Feraligatr"
+      "Feraligatr",
+      "Feraligatr ex"
     ],
     "attacks": [
       {
@@ -3449,7 +3488,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Azumarill"
+      "Azumarill",
+      "Light Azumarill"
     ],
     "attacks": [
       {
@@ -3762,7 +3802,8 @@
     ],
     "evolvesFrom": "Mudkip",
     "evolvesTo": [
-      "Swampert"
+      "Swampert",
+      "Swampert ex"
     ],
     "attacks": [
       {
@@ -4233,7 +4274,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Darmanitan"
+      "Galarian Darmanitan"
     ],
     "attacks": [
       {
@@ -4481,6 +4522,9 @@
       "Water"
     ],
     "evolvesFrom": "Clauncher",
+    "evolvesTo": [
+      "Clawitzer BREAK"
+    ],
     "attacks": [
       {
         "name": "Snipe Shot",
@@ -4670,6 +4714,9 @@
     "hp": "200",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Inteleon VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -5131,7 +5178,7 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Pikachu VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -5198,7 +5245,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {
@@ -5541,6 +5591,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Luxio",
+    "evolvesTo": [
+      "Luxray BREAK"
+    ],
     "attacks": [
       {
         "name": "Thunder Claws",
@@ -5966,7 +6019,8 @@
     ],
     "evolvesFrom": "Grubbin",
     "evolvesTo": [
-      "Vikavolt"
+      "Vikavolt",
+      "Vikavolt-GX"
     ],
     "attacks": [
       {
@@ -6145,6 +6199,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Boltund VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -6275,7 +6332,9 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Toxtricity"
+      "Toxtricity",
+      "Light Toxtricity",
+      "Toxtricity ex"
     ],
     "attacks": [
       {
@@ -6330,7 +6389,9 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Toxtricity"
+      "Toxtricity",
+      "Light Toxtricity",
+      "Toxtricity ex"
     ],
     "attacks": [
       {
@@ -6558,7 +6619,11 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Wigglytuff"
+      "Wigglytuff",
+      "Dark Wigglytuff",
+      "Light Wigglytuff",
+      "Wigglytuff ex",
+      "Wigglytuff-GX"
     ],
     "attacks": [
       {
@@ -6750,6 +6815,9 @@
     "hp": "180",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Mew VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -7008,7 +7076,7 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Cursola"
+      "Galarian Cursola"
     ],
     "attacks": [
       {
@@ -7500,7 +7568,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Palossand"
+      "Palossand",
+      "Palossand-GX"
     ],
     "attacks": [
       {
@@ -7907,7 +7976,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Sandslash"
+      "Sandslash",
+      "Dark Sandslash"
     ],
     "attacks": [
       {
@@ -8023,7 +8093,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Primeape"
+      "Primeape",
+      "Dark Primeape"
     ],
     "attacks": [
       {
@@ -8076,6 +8147,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Mankey",
+    "evolvesTo": [
+      "Annihilape ex",
+      "Annihilape"
+    ],
     "attacks": [
       {
         "name": "Gut Punch",
@@ -8193,7 +8268,8 @@
     ],
     "evolvesFrom": "Geodude",
     "evolvesTo": [
-      "Golem"
+      "Golem",
+      "Golem ex"
     ],
     "attacks": [
       {
@@ -8323,7 +8399,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Steelix"
+      "Steelix",
+      "Dark Steelix",
+      "Steelix ex"
     ],
     "attacks": [
       {
@@ -8520,6 +8598,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Gligar",
+    "evolvesTo": [
+      "Gliscor LV.X"
+    ],
     "attacks": [
       {
         "name": "Cut Down",
@@ -8584,7 +8665,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Hariyama"
+      "Hariyama",
+      "Hariyama ex"
     ],
     "attacks": [
       {
@@ -8714,7 +8796,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Claydol"
+      "Claydol",
+      "Claydol ex"
     ],
     "attacks": [
       {
@@ -8830,6 +8913,9 @@
     "hp": "210",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Lucario VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -9067,7 +9153,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Bewear"
+      "Bewear",
+      "Bewear-GX"
     ],
     "attacks": [
       {
@@ -9437,6 +9524,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Gengar VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -9641,7 +9731,7 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Linoone"
+      "Galarian Linoone"
     ],
     "attacks": [
       {
@@ -9694,6 +9784,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Galarian Zigzagoon",
+    "evolvesTo": [
+      "Galarian Obstagoon"
+    ],
     "attacks": [
       {
         "name": "Rear Kick",
@@ -9806,7 +9899,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Sharpedo"
+      "Sharpedo",
+      "Sharpedo ex"
     ],
     "attacks": [
       {
@@ -9973,7 +10067,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Toxicroak"
+      "Toxicroak",
+      "Toxicroak ex"
     ],
     "attacks": [
       {
@@ -10086,6 +10181,9 @@
     "hp": "110",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Darkrai LV.X"
     ],
     "attacks": [
       {
@@ -10269,7 +10367,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Zoroark"
+      "Zoroark",
+      "Zoroark-GX"
     ],
     "attacks": [
       {
@@ -10332,6 +10431,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Zorua",
+    "evolvesTo": [
+      "Zoroark BREAK"
+    ],
     "attacks": [
       {
         "name": "Double Claw",
@@ -10464,6 +10566,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Vullaby",
+    "evolvesTo": [
+      "Mandibuzz BREAK"
+    ],
     "attacks": [
       {
         "name": "Bone Block",
@@ -10599,6 +10704,9 @@
     "hp": "130",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Yveltal BREAK"
     ],
     "attacks": [
       {
@@ -10905,7 +11013,7 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Persian"
+      "Galarian Perrserker"
     ],
     "attacks": [
       {
@@ -11434,7 +11542,9 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Melmetal"
+      "Melmetal",
+      "Melmetal-GX",
+      "Melmetal ex"
     ],
     "attacks": [
       {
@@ -11648,7 +11758,8 @@
       "Metal"
     ],
     "evolvesTo": [
-      "Copperajah"
+      "Copperajah",
+      "Copperajah ex"
     ],
     "attacks": [
       {
@@ -11905,7 +12016,8 @@
       "Dragon"
     ],
     "evolvesTo": [
-      "Sliggoo"
+      "Sliggoo",
+      "Hisuian Sliggoo"
     ],
     "attacks": [
       {
@@ -12135,7 +12247,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -12320,7 +12434,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Blissey"
+      "Blissey",
+      "Blissey ex"
     ],
     "attacks": [
       {
@@ -12517,7 +12632,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -12568,6 +12703,9 @@
     "hp": "160",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Snorlax LV.X"
     ],
     "attacks": [
       {
@@ -12622,6 +12760,9 @@
     "hp": "60",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Dudunsparce"
     ],
     "abilities": [
       {
@@ -12680,6 +12821,9 @@
     "hp": "110",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Wyrdeer"
     ],
     "attacks": [
       {
@@ -12804,7 +12948,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Delcatty"
+      "Delcatty",
+      "Delcatty ex"
     ],
     "attacks": [
       {
@@ -13213,6 +13358,9 @@
     "hp": "210",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Greedent VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -14180,6 +14328,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Celebi VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -14297,6 +14448,9 @@
     "hp": "200",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Chandelure VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -14429,6 +14583,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Boltund VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -14493,6 +14650,9 @@
     "hp": "180",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Mew VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -14560,6 +14720,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Mew VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -14624,6 +14787,9 @@
     "hp": "220",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Sandaconda VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -14892,6 +15058,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Greedent VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -14957,6 +15126,9 @@
     "hp": "210",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Greedent VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -15908,7 +16080,9 @@
     ],
     "evolvesFrom": "Mareep",
     "evolvesTo": [
-      "Ampharos"
+      "Ampharos",
+      "Ampharos ex",
+      "Ampharos-GX"
     ],
     "abilities": [
       {

--- a/cards/en/swsh9.json
+++ b/cards/en/swsh9.json
@@ -11,7 +11,10 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Exeggutor"
+      "Exeggutor",
+      "Dark Exeggutor",
+      "Alolan Exeggutor-GX",
+      "Alolan Exeggutor"
     ],
     "attacks": [
       {
@@ -442,6 +445,9 @@
       "Grass"
     ],
     "evolvesFrom": "Grotle",
+    "evolvesTo": [
+      "Torterra LV.X"
+    ],
     "attacks": [
       {
         "name": "Evopress",
@@ -754,6 +760,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Shaymin VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -996,6 +1005,10 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Charizard VMAX",
+      "Charizard VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -1198,6 +1211,9 @@
       "Fire"
     ],
     "evolvesFrom": "Magmar",
+    "evolvesTo": [
+      "Magmortar LV.X"
+    ],
     "attacks": [
       {
         "name": "Mega Punch",
@@ -1556,6 +1572,9 @@
       "Fire"
     ],
     "evolvesFrom": "Monferno",
+    "evolvesTo": [
+      "Infernape LV.X"
+    ],
     "attacks": [
       {
         "name": "Infernal Vortex",
@@ -1616,6 +1635,9 @@
     "hp": "210",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Simisear VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -1680,6 +1702,9 @@
     "hp": "220",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Kingler VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -1813,7 +1838,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Starmie"
+      "Starmie",
+      "Starmie-GX"
     ],
     "attacks": [
       {
@@ -1919,7 +1945,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Crawdaunt"
+      "Crawdaunt",
+      "Crawdaunt ex"
     ],
     "attacks": [
       {
@@ -2049,7 +2076,8 @@
     ],
     "evolvesTo": [
       "Glalie",
-      "Froslass"
+      "Froslass",
+      "Froslass ex"
     ],
     "attacks": [
       {
@@ -2220,6 +2248,10 @@
       "Water"
     ],
     "evolvesFrom": "Prinplup",
+    "evolvesTo": [
+      "Empoleon LV.X",
+      "Empoleon BREAK"
+    ],
     "abilities": [
       {
         "name": "Emergency Surfacing",
@@ -2821,6 +2853,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Electabuzz",
+    "evolvesTo": [
+      "Electivire LV.X"
+    ],
     "attacks": [
       {
         "name": "Explosive Bolt",
@@ -3049,6 +3084,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Luxio",
+    "evolvesTo": [
+      "Luxray BREAK"
+    ],
     "attacks": [
       {
         "name": "Energy Crush",
@@ -3160,7 +3198,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Clefable",
+      "Clefable ex"
     ],
     "attacks": [
       {
@@ -3285,6 +3324,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Staryu",
+    "evolvesTo": [
+      "Starmie BREAK"
+    ],
     "attacks": [
       {
         "name": "Psychic",
@@ -3345,6 +3387,9 @@
     "hp": "130",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Mewtwo LV.X"
     ],
     "attacks": [
       {
@@ -3481,7 +3526,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Claydol"
+      "Claydol",
+      "Claydol ex"
     ],
     "attacks": [
       {
@@ -3611,7 +3657,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Dusclops"
+      "Dusclops",
+      "Dusclops ex"
     ],
     "attacks": [
       {
@@ -3731,6 +3778,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Dusclops",
+    "evolvesTo": [
+      "Dusknoir LV.X"
+    ],
     "abilities": [
       {
         "name": "Special Transfer",
@@ -3864,6 +3914,9 @@
     "hp": "190",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Whimsicott VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -4108,6 +4161,9 @@
     "hp": "160",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Mimikyu VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -4538,7 +4594,9 @@
     ],
     "evolvesFrom": "Trapinch",
     "evolvesTo": [
-      "Flygon"
+      "Flygon",
+      "Flygon ex",
+      "Flygon-GX"
     ],
     "attacks": [
       {
@@ -4591,6 +4649,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Vibrava",
+    "evolvesTo": [
+      "Flygon LV.X"
+    ],
     "attacks": [
       {
         "name": "Desert Pillar",
@@ -4716,7 +4777,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lucario"
+      "Lucario",
+      "Lucario-GX",
+      "Lucario ex"
     ],
     "attacks": [
       {
@@ -4770,6 +4833,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Riolu",
+    "evolvesTo": [
+      "Lucario LV.X"
+    ],
     "abilities": [
       {
         "name": "Roaring Resolve",
@@ -5076,7 +5142,9 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Muk"
+      "Muk",
+      "Dark Muk",
+      "Muk ex"
     ],
     "attacks": [
       {
@@ -5193,7 +5261,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Weavile"
+      "Weavile",
+      "Weavile-GX"
     ],
     "attacks": [
       {
@@ -5747,6 +5816,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Morpeko VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -5811,6 +5883,9 @@
     "hp": "230",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Aggron VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -6106,6 +6181,9 @@
     "hp": "140",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Heatran LV.X"
     ],
     "attacks": [
       {
@@ -6455,6 +6533,9 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Zamazenta VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -6634,7 +6715,8 @@
     ],
     "evolvesFrom": "Gible",
     "evolvesTo": [
-      "Garchomp"
+      "Garchomp",
+      "Garchomp ex"
     ],
     "attacks": [
       {
@@ -6682,6 +6764,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Gabite",
+    "evolvesTo": [
+      "Garchomp LV.X"
+    ],
     "abilities": [
       {
         "name": "Sonic Slip",
@@ -7013,9 +7098,6 @@
     "hp": "80",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Sirfetch'd"
     ],
     "attacks": [
       {
@@ -7440,6 +7522,9 @@
     "hp": "220",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Arceus VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -8469,6 +8554,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Shaymin VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -8531,6 +8619,10 @@
     "hp": "220",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Charizard VMAX",
+      "Charizard VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -8599,6 +8691,10 @@
     "hp": "220",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Charizard VMAX",
+      "Charizard VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -8793,7 +8889,7 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Pikachu VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -8978,6 +9074,9 @@
     "hp": "190",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Whimsicott VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -9179,6 +9278,9 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Zamazenta VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -9309,6 +9411,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Arceus VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -9374,6 +9479,9 @@
     "hp": "220",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Arceus VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."

--- a/cards/en/swsh9tg.json
+++ b/cards/en/swsh9tg.json
@@ -314,6 +314,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Dusclops",
+    "evolvesTo": [
+      "Dusknoir LV.X"
+    ],
     "abilities": [
       {
         "name": "Spectral Breach",
@@ -616,7 +619,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -738,6 +761,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Boltund VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -801,6 +827,9 @@
     "hp": "200",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Sylveon VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -928,6 +957,9 @@
     "hp": "160",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Mimikyu VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -1067,6 +1099,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Single Strike Urshifu VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -1203,6 +1238,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Rapid Strike Urshifu VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -1334,6 +1372,9 @@
     "hp": "200",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Umbreon VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."

--- a/cards/en/swshp.json
+++ b/cards/en/swshp.json
@@ -170,7 +170,7 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Meowth VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -236,9 +236,6 @@
       "Colorless"
     ],
     "evolvesFrom": "Meowth V",
-    "evolvesTo": [
-      "Persian"
-    ],
     "rules": [
       "VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -704,7 +701,7 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Rapidash"
+      "Galarian Rapidash"
     ],
     "attacks": [
       {
@@ -772,6 +769,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Rillaboom VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -838,6 +838,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Cinderace VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -899,6 +902,9 @@
     "hp": "200",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Inteleon VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -964,6 +970,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Toxtricity VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -1027,6 +1036,9 @@
     "hp": "220",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Zacian VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -1096,6 +1108,9 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Zamazenta VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -1164,7 +1179,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -1353,6 +1372,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Luxio",
+    "evolvesTo": [
+      "Luxray BREAK"
+    ],
     "attacks": [
       {
         "name": "Raid",
@@ -1595,6 +1617,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Hoothoot",
+    "evolvesTo": [
+      "Noctowl BREAK"
+    ],
     "attacks": [
       {
         "name": "Wing Attack",
@@ -1801,6 +1826,9 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Copperajah VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -1934,6 +1962,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Snorlax LV.X"
+    ],
     "attacks": [
       {
         "name": "Rolling Tackle",
@@ -1999,6 +2030,9 @@
     "hp": "130",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Zacian LV.X"
     ],
     "attacks": [
       {
@@ -2255,6 +2289,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Zweilous",
+    "evolvesTo": [
+      "Hydreigon BREAK"
+    ],
     "abilities": [
       {
         "name": "Dark Squall",
@@ -2378,7 +2415,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -2578,7 +2619,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -2701,6 +2762,9 @@
     "hp": "220",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Eternatus VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -3080,6 +3144,10 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Charizard VMAX",
+      "Charizard VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -3202,6 +3270,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Haunter",
+    "evolvesTo": [
+      "Gengar LV.X"
+    ],
     "abilities": [
       {
         "name": "Life Shaker",
@@ -3268,6 +3339,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Machoke",
+    "evolvesTo": [
+      "Machamp LV.X",
+      "Machamp BREAK"
+    ],
     "attacks": [
       {
         "name": "Macho Revenge",
@@ -3395,6 +3470,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Hatterene VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -3466,6 +3544,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Morpeko VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -3529,6 +3610,9 @@
     "hp": "220",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Grimmsnarl VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -3781,7 +3865,7 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Pikachu VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -3846,9 +3930,6 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu V",
-    "evolvesTo": [
-      "Raichu"
-    ],
     "rules": [
       "VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -3905,7 +3986,7 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Pikachu VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -3968,6 +4049,9 @@
     "hp": "220",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Eternatus VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -4035,14 +4119,7 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Vaporeon",
-      "Jolteon",
-      "Flareon",
-      "Sylveon",
-      "Espeon",
-      "Umbreon",
-      "Leafeon",
-      "Glaceon"
+      "Eevee VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -4230,6 +4307,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Snorlax LV.X"
+    ],
     "abilities": [
       {
         "name": "Gormandize",
@@ -4290,6 +4370,9 @@
     "hp": "130",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Lugia BREAK"
     ],
     "attacks": [
       {
@@ -4595,9 +4678,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesTo": [
-      "Raichu"
-    ],
     "attacks": [
       {
         "name": "Happy Delivery",
@@ -4721,6 +4801,9 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Zacian VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -4789,6 +4872,9 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Zamazenta VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -4856,6 +4942,9 @@
     "hp": "180",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Orbeetle VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -5275,6 +5364,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Boltund VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -5337,6 +5429,9 @@
     "hp": "200",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Cramorant VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -5407,16 +5502,6 @@
       "Colorless"
     ],
     "evolvesFrom": "Eevee V",
-    "evolvesTo": [
-      "Vaporeon",
-      "Jolteon",
-      "Flareon",
-      "Sylveon",
-      "Espeon",
-      "Umbreon",
-      "Leafeon",
-      "Glaceon"
-    ],
     "rules": [
       "VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize cards."
     ],
@@ -5656,6 +5741,9 @@
       "Metal"
     ],
     "evolvesFrom": "Bronzor",
+    "evolvesTo": [
+      "Bronzong BREAK"
+    ],
     "abilities": [
       {
         "name": "Metal Transfer",
@@ -5724,7 +5812,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -5912,7 +6001,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -5974,6 +6083,9 @@
     "hp": "210",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Dragapult VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -6111,6 +6223,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Crobat VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -6235,6 +6350,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Venusaur VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -6301,6 +6419,9 @@
     "hp": "220",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Blastoise VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -6506,6 +6627,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Victini VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -6568,6 +6692,9 @@
     "hp": "210",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Gardevoir VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -6633,6 +6760,9 @@
     "hp": "220",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Single Strike Urshifu VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -6700,6 +6830,9 @@
     "hp": "220",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Rapid Strike Urshifu VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -6900,6 +7033,9 @@
     "hp": "180",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Crobat VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -7150,6 +7286,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Cresselia LV.X"
+    ],
     "attacks": [
       {
         "name": "Crescent Glow",
@@ -7334,7 +7473,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Donphan"
+      "Donphan",
+      "Dark Donphan"
     ],
     "attacks": [
       {
@@ -7404,7 +7544,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -7465,6 +7625,9 @@
     "hp": "140",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Snorlax LV.X"
     ],
     "attacks": [
       {
@@ -7581,7 +7744,9 @@
     ],
     "evolvesFrom": "Mareep",
     "evolvesTo": [
-      "Ampharos"
+      "Ampharos",
+      "Ampharos ex",
+      "Ampharos-GX"
     ],
     "abilities": [
       {
@@ -7825,8 +7990,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Slowbro",
-      "Slowking"
+      "Galarian Slowbro",
+      "Galarian Slowking"
     ],
     "attacks": [
       {
@@ -7904,7 +8069,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -8092,6 +8277,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Ice Rider Calyrex VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -8157,6 +8345,9 @@
     "hp": "210",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Shadow Rider Calyrex VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -8669,9 +8860,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesTo": [
-      "Raichu"
-    ],
     "rules": [
       "How to play a Pokémon V-UNION: Once per game during your turn, combine 4 different Pikachu V-UNION from your discard pile and put them onto your Bench.",
       "V-UNION rule: When your Pokémon V-UNION is Knocked Out, your opponent takes 3 Prize cards."
@@ -8756,9 +8944,6 @@
     "hp": "300",
     "types": [
       "Lightning"
-    ],
-    "evolvesTo": [
-      "Raichu"
     ],
     "rules": [
       "How to play a Pokémon V-UNION: Once per game during your turn, combine 4 different Pikachu V-UNION from your discard pile and put them onto your Bench.",
@@ -8845,9 +9030,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesTo": [
-      "Raichu"
-    ],
     "rules": [
       "How to play a Pokémon V-UNION: Once per game during your turn, combine 4 different Pikachu V-UNION from your discard pile and put them onto your Bench.",
       "V-UNION rule: When your Pokémon V-UNION is Knocked Out, your opponent takes 3 Prize cards."
@@ -8932,9 +9114,6 @@
     "hp": "300",
     "types": [
       "Lightning"
-    ],
-    "evolvesTo": [
-      "Raichu"
     ],
     "rules": [
       "How to play a Pokémon V-UNION: Once per game during your turn, combine 4 different Pikachu V-UNION from your discard pile and put them onto your Bench.",
@@ -9023,7 +9202,7 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Pikachu VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -9141,7 +9320,7 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Pikachu VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -9223,6 +9402,9 @@
     "hp": "210",
     "types": [
       "Dragon"
+    ],
+    "evolvesTo": [
+      "Rayquaza VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -9336,6 +9518,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Flareon VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -9402,6 +9587,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Vaporeon VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -9466,6 +9654,9 @@
     "hp": "190",
     "types": [
       "Lightning"
+    ],
+    "evolvesTo": [
+      "Jolteon VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -9552,7 +9743,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -9604,6 +9799,9 @@
     "hp": "230",
     "types": [
       "Dragon"
+    ],
+    "evolvesTo": [
+      "Dragonite VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -11307,7 +11505,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -11523,6 +11741,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Flareon VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -11645,6 +11866,9 @@
     "hp": "210",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Vaporeon VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -11776,6 +12000,9 @@
     "hp": "190",
     "types": [
       "Lightning"
+    ],
+    "evolvesTo": [
+      "Jolteon VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -11937,6 +12164,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Riolu",
+    "evolvesTo": [
+      "Lucario LV.X"
+    ],
     "abilities": [
       {
         "name": "Roaring Resolve",
@@ -12179,7 +12409,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -12243,6 +12493,9 @@
       "Grass"
     ],
     "evolvesFrom": "Eevee",
+    "evolvesTo": [
+      "Leafeon LV.X"
+    ],
     "attacks": [
       {
         "name": "Leaf Guard",
@@ -12304,6 +12557,9 @@
       "Water"
     ],
     "evolvesFrom": "Eevee",
+    "evolvesTo": [
+      "Glaceon LV.X"
+    ],
     "attacks": [
       {
         "name": "Hail",
@@ -12419,6 +12675,10 @@
     "hp": "210",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Leafeon VSTAR",
+      "Leafeon VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -12547,6 +12807,10 @@
     "hp": "210",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Glaceon VSTAR",
+      "Glaceon VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -12681,7 +12945,7 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Pikachu VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -12737,6 +13001,9 @@
     "hp": "200",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Lycanroc VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -12801,6 +13068,9 @@
     "hp": "210",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Corviknight VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -12871,6 +13141,9 @@
     "hp": "200",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Espeon VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -12943,6 +13216,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Sylveon VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -13004,6 +13280,9 @@
     "hp": "200",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Umbreon VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -13069,6 +13348,9 @@
     "hp": "220",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Arceus VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -13326,6 +13608,9 @@
       "Metal"
     ],
     "evolvesFrom": "Magneton",
+    "evolvesTo": [
+      "Magnezone LV.X"
+    ],
     "abilities": [
       {
         "name": "Giga Magnet",
@@ -13394,7 +13679,9 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Toxtricity"
+      "Toxtricity",
+      "Light Toxtricity",
+      "Toxtricity ex"
     ],
     "attacks": [
       {
@@ -13592,7 +13879,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -13655,6 +13962,9 @@
     "hp": "210",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Lucario VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -14132,6 +14442,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Boltund VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -14249,7 +14562,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Quilava"
+      "Quilava",
+      "Dark Quilava"
     ],
     "attacks": [
       {
@@ -14364,6 +14678,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Mewtwo VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -14435,6 +14752,9 @@
     "hp": "220",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Melmetal VMAX"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -14650,6 +14970,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Mewtwo VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -14722,16 +15045,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesTo": [
-      "Vaporeon",
-      "Jolteon",
-      "Flareon",
-      "Sylveon",
-      "Espeon",
-      "Umbreon",
-      "Leafeon",
-      "Glaceon"
-    ],
     "rules": [
       "Radiant Pokémon Rule: You can't have more than 1 Radiant Pokémon in your deck."
     ],
@@ -14797,7 +15110,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ivysaur"
+      "Ivysaur",
+      "Dark Ivysaur"
     ],
     "attacks": [
       {
@@ -14861,7 +15175,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -14914,7 +15229,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Wartortle"
+      "Wartortle",
+      "Dark Wartortle"
     ],
     "attacks": [
       {
@@ -14967,7 +15283,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -15030,6 +15350,9 @@
     "hp": "230",
     "types": [
       "Dragon"
+    ],
+    "evolvesTo": [
+      "Dragonite VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -15151,6 +15474,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Hisuian Typhlosion VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -15222,6 +15548,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Hisuian Decidueye VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -15286,6 +15615,9 @@
     "hp": "220",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Hisuian Samurott VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -15412,6 +15744,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Haunter",
+    "evolvesTo": [
+      "Gengar LV.X"
+    ],
     "abilities": [
       {
         "name": "Netherworld Gate",
@@ -15535,6 +15870,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Machoke",
+    "evolvesTo": [
+      "Machamp LV.X",
+      "Machamp BREAK"
+    ],
     "abilities": [
       {
         "name": "Crisis Muscles",
@@ -15659,7 +15998,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Toxicroak"
+      "Toxicroak",
+      "Toxicroak ex"
     ],
     "attacks": [
       {
@@ -15773,6 +16113,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Regigigas LV.X"
+    ],
     "attacks": [
       {
         "name": "Limber Up",
@@ -15838,6 +16181,9 @@
     "hp": "210",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Kleavor VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -16115,6 +16461,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Origin Forme Palkia VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -16241,6 +16590,9 @@
     "hp": "220",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Origin Forme Dialga VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -16388,6 +16740,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Rotom VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -16518,6 +16873,9 @@
     "types": [
       "Dragon"
     ],
+    "evolvesTo": [
+      "Giratina VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -16576,6 +16934,10 @@
     "hp": "220",
     "types": [
       "Fire"
+    ],
+    "evolvesTo": [
+      "Charizard VMAX",
+      "Charizard VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -16782,6 +17144,10 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Zeraora VMAX",
+      "Zeraora VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -16975,6 +17341,10 @@
     "hp": "210",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Deoxys VMAX",
+      "Deoxys VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -17303,7 +17673,9 @@
     "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
-      "Gallade"
+      "Gallade",
+      "Gardevoir ex",
+      "Gardevoir-GX"
     ],
     "abilities": [
       {
@@ -17429,6 +17801,9 @@
     "hp": "50",
     "types": [
       "Water"
+    ],
+    "evolvesTo": [
+      "Hisuian Basculegion"
     ],
     "attacks": [
       {
@@ -17864,6 +18239,9 @@
     "types": [
       "Lightning"
     ],
+    "evolvesTo": [
+      "Regieleki VMAX"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -17927,6 +18305,9 @@
     "hp": "220",
     "types": [
       "Dragon"
+    ],
+    "evolvesTo": [
+      "Regidrago VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -18579,6 +18960,9 @@
     "types": [
       "Metal"
     ],
+    "evolvesTo": [
+      "Zacian VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -18646,6 +19030,9 @@
     "hp": "230",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Zamazenta VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
@@ -18864,6 +19251,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Hisuian Zoroark VSTAR"
+    ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -19016,7 +19406,8 @@
       "Grass"
     ],
     "evolvesTo": [
-	  "Ivysaur"
+	  "Ivysaur",
+	  "Dark Ivysaur"
 	],
     "attacks": [
       {
@@ -19070,6 +19461,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "attacks": [
       {
         "name": "Sun-Drenched Tackle",
@@ -19125,6 +19519,9 @@
       "Water"
     ],
     "evolvesFrom": "Frogadier",
+    "evolvesTo": [
+      "Greninja BREAK"
+    ],
     "attacks": [
       {
         "name": "Coordinated Shuriken",
@@ -19177,6 +19574,9 @@
     "hp": "220",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Arceus VSTAR"
     ],
     "rules": [
       "V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards."

--- a/cards/en/tk1a.json
+++ b/cards/en/tk1a.json
@@ -64,7 +64,9 @@
     ],
     "evolvesFrom": "Torchic",
     "evolvesTo": [
-      "Blaziken"
+      "Blaziken",
+      "Blaziken ex",
+      "Blaziken-GX"
     ],
     "attacks": [
       {
@@ -237,7 +239,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Camerupt"
+      "Camerupt",
+      "Camerupt ex"
     ],
     "attacks": [
       {
@@ -295,7 +298,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Delcatty"
+      "Delcatty",
+      "Delcatty ex"
     ],
     "attacks": [
       {

--- a/cards/en/tk1b.json
+++ b/cards/en/tk1b.json
@@ -11,7 +11,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Manectric",
+      "Manectric ex"
     ],
     "attacks": [
       {
@@ -178,7 +179,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -243,7 +245,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "attacks": [
       {
@@ -303,7 +306,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {

--- a/cards/en/tk2a.json
+++ b/cards/en/tk2a.json
@@ -68,7 +68,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Manectric",
+      "Manectric ex"
     ],
     "attacks": [
       {
@@ -182,7 +183,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -241,7 +244,9 @@
     ],
     "evolvesFrom": "Beldum",
     "evolvesTo": [
-      "Metagross"
+      "Metagross",
+      "Metagross ex",
+      "Metagross-GX"
     ],
     "attacks": [
       {

--- a/cards/en/tk2b.json
+++ b/cards/en/tk2b.json
@@ -11,6 +11,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "attacks": [
       {
         "name": "Flare",
@@ -70,7 +73,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -129,7 +133,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "attacks": [
       {
@@ -190,7 +197,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -250,7 +259,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Flaaffy"
+      "Flaaffy",
+      "Dark Flaaffy"
     ],
     "attacks": [
       {
@@ -369,7 +379,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {

--- a/cards/en/xy0.json
+++ b/cards/en/xy0.json
@@ -245,6 +245,9 @@
       "Grass"
     ],
     "evolvesFrom": "Quilladin",
+    "evolvesTo": [
+      "Chesnaught BREAK"
+    ],
     "attacks": [
       {
         "name": "Needle Arm",
@@ -310,7 +313,10 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Magcargo"
+      "Magcargo",
+      "Dark Magcargo",
+      "Magcargo ex",
+      "Magcargo-GX"
     ],
     "attacks": [
       {
@@ -545,6 +551,9 @@
       "Fire"
     ],
     "evolvesFrom": "Braixen",
+    "evolvesTo": [
+      "Delphox BREAK"
+    ],
     "attacks": [
       {
         "name": "Will-O-Wisp",
@@ -728,7 +737,9 @@
     ],
     "evolvesFrom": "Froakie",
     "evolvesTo": [
-      "Greninja"
+      "Greninja",
+      "Greninja-GX",
+      "Greninja ex"
     ],
     "attacks": [
       {
@@ -789,6 +800,9 @@
       "Water"
     ],
     "evolvesFrom": "Frogadier",
+    "evolvesTo": [
+      "Greninja BREAK"
+    ],
     "attacks": [
       {
         "name": "Mat Block",
@@ -899,7 +913,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Mightyena"
+      "Mightyena",
+      "Mightyena ex"
     ],
     "attacks": [
       {
@@ -1133,6 +1148,9 @@
       "Metal"
     ],
     "evolvesFrom": "Pawniard",
+    "evolvesTo": [
+      "Kingambit"
+    ],
     "attacks": [
       {
         "name": "Wicked Jab",
@@ -1437,9 +1455,6 @@
     "types": [
       "Colorless"
     ],
-    "evolvesTo": [
-      "Sirfetch'd"
-    ],
     "attacks": [
       {
         "name": "Slash",
@@ -1492,6 +1507,9 @@
     "hp": "120",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Snorlax LV.X"
     ],
     "attacks": [
       {
@@ -1609,7 +1627,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Delcatty"
+      "Delcatty",
+      "Delcatty ex"
     ],
     "attacks": [
       {

--- a/cards/en/xy1.json
+++ b/cards/en/xy1.json
@@ -304,7 +304,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ledian"
+      "Ledian",
+      "Light Ledian"
     ],
     "attacks": [
       {
@@ -769,6 +770,9 @@
       "Grass"
     ],
     "evolvesFrom": "Quilladin",
+    "evolvesTo": [
+      "Chesnaught BREAK"
+    ],
     "abilities": [
       {
         "name": "Spiky Shield",
@@ -1131,7 +1135,10 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Magcargo"
+      "Magcargo",
+      "Dark Magcargo",
+      "Magcargo ex",
+      "Magcargo-GX"
     ],
     "attacks": [
       {
@@ -1482,6 +1489,9 @@
       "Fire"
     ],
     "evolvesFrom": "Braixen",
+    "evolvesTo": [
+      "Delphox BREAK"
+    ],
     "abilities": [
       {
         "name": "Mystical Fire",
@@ -1609,6 +1619,9 @@
       "Fire"
     ],
     "evolvesFrom": "Fletchinder",
+    "evolvesTo": [
+      "Talonflame BREAK"
+    ],
     "attacks": [
       {
         "name": "Devastating Wind",
@@ -1910,7 +1923,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Starmie"
+      "Starmie",
+      "Starmie-GX"
     ],
     "attacks": [
       {
@@ -1962,6 +1976,9 @@
       "Water"
     ],
     "evolvesFrom": "Staryu",
+    "evolvesTo": [
+      "Starmie BREAK"
+    ],
     "attacks": [
       {
         "name": "Recover",
@@ -2312,7 +2329,9 @@
     ],
     "evolvesFrom": "Froakie",
     "evolvesTo": [
-      "Greninja"
+      "Greninja",
+      "Greninja-GX",
+      "Greninja ex"
     ],
     "attacks": [
       {
@@ -2364,6 +2383,9 @@
       "Water"
     ],
     "evolvesFrom": "Frogadier",
+    "evolvesTo": [
+      "Greninja BREAK"
+    ],
     "abilities": [
       {
         "name": "Water Shuriken",
@@ -2420,7 +2442,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -2487,6 +2513,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Circle Circuit",
@@ -2550,7 +2580,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "abilities": [
       {
@@ -2731,7 +2764,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Arbok"
+      "Arbok",
+      "Dark Arbok",
+      "Arbok ex"
     ],
     "attacks": [
       {
@@ -3198,6 +3233,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Phantump",
+    "evolvesTo": [
+      "Trevenant BREAK"
+    ],
     "abilities": [
       {
         "name": "Forest's Curse",
@@ -3388,7 +3426,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Dugtrio"
+      "Dugtrio",
+      "Dark Dugtrio"
     ],
     "attacks": [
       {
@@ -3641,6 +3680,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Rhydon",
+    "evolvesTo": [
+      "Rhyperior LV.X"
+    ],
     "attacks": [
       {
         "name": "Rock Black",
@@ -4270,7 +4312,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Zoroark"
+      "Zoroark",
+      "Zoroark-GX"
     ],
     "attacks": [
       {
@@ -4337,6 +4380,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Zorua",
+    "evolvesTo": [
+      "Zoroark BREAK"
+    ],
     "attacks": [
       {
         "name": "Corner",
@@ -4666,6 +4712,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Yveltal BREAK"
+    ],
     "attacks": [
       {
         "name": "Oblivion Wing",
@@ -4939,6 +4988,9 @@
       "Metal"
     ],
     "evolvesFrom": "Pawniard",
+    "evolvesTo": [
+      "Kingambit"
+    ],
     "attacks": [
       {
         "name": "Metal Sound",
@@ -5064,7 +5116,8 @@
     ],
     "evolvesFrom": "Honedge",
     "evolvesTo": [
-      "Aegislash"
+      "Aegislash",
+      "Aegislash ex"
     ],
     "attacks": [
       {
@@ -5257,7 +5310,11 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Wigglytuff"
+      "Wigglytuff",
+      "Dark Wigglytuff",
+      "Light Wigglytuff",
+      "Wigglytuff ex",
+      "Wigglytuff-GX"
     ],
     "attacks": [
       {
@@ -5323,7 +5380,11 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Wigglytuff"
+      "Wigglytuff",
+      "Dark Wigglytuff",
+      "Light Wigglytuff",
+      "Wigglytuff ex",
+      "Wigglytuff-GX"
     ],
     "attacks": [
       {
@@ -5844,6 +5905,9 @@
     "types": [
       "Fairy"
     ],
+    "evolvesTo": [
+      "Xerneas BREAK"
+    ],
     "attacks": [
       {
         "name": "Geomancy",
@@ -6167,6 +6231,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Dudunsparce"
+    ],
     "attacks": [
       {
         "name": "Glare",
@@ -6344,7 +6411,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Delcatty"
+      "Delcatty",
+      "Delcatty ex"
     ],
     "attacks": [
       {

--- a/cards/en/xy10.json
+++ b/cards/en/xy10.json
@@ -69,7 +69,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Wormadam"
+      "Wormadam",
+      "Mothim"
     ],
     "attacks": [
       {
@@ -701,6 +702,9 @@
       "Fire"
     ],
     "evolvesFrom": "Braixen",
+    "evolvesTo": [
+      "Delphox BREAK"
+    ],
     "attacks": [
       {
         "name": "Flickering Flames",
@@ -799,7 +803,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Dewgong"
+      "Dewgong",
+      "Light Dewgong"
     ],
     "attacks": [
       {
@@ -970,6 +975,9 @@
       "Water"
     ],
     "evolvesFrom": "Omanyte",
+    "evolvesTo": [
+      "Omastar BREAK"
+    ],
     "abilities": [
       {
         "name": "Restoring Beam",
@@ -1485,7 +1493,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Weezing"
+      "Weezing",
+      "Dark Weezing",
+      "Galarian Weezing"
     ],
     "attacks": [
       {
@@ -1969,7 +1979,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Dugtrio"
+      "Dugtrio",
+      "Dark Dugtrio"
     ],
     "attacks": [
       {
@@ -2016,6 +2027,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Cubone",
+    "evolvesTo": [
+      "Marowak BREAK"
+    ],
     "abilities": [
       {
         "name": "Bodyguard",
@@ -2075,7 +2089,8 @@
     ],
     "evolvesFrom": "Dome Fossil Kabuto",
     "evolvesTo": [
-      "Kabutops"
+      "Kabutops",
+      "Kabutops ex"
     ],
     "rules": [
       "Put this card onto your Bench only with the effect of Dome Fossil Kabuto"
@@ -2191,7 +2206,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Pupitar"
+      "Pupitar",
+      "Dark Pupitar"
     ],
     "attacks": [
       {
@@ -2242,7 +2258,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Pupitar"
+      "Pupitar",
+      "Dark Pupitar"
     ],
     "attacks": [
       {
@@ -2304,7 +2321,9 @@
     ],
     "evolvesFrom": "Larvitar",
     "evolvesTo": [
-      "Tyranitar"
+      "Tyranitar",
+      "Tyranitar ex",
+      "Tyranitar-GX"
     ],
     "attacks": [
       {
@@ -2540,7 +2559,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lucario"
+      "Lucario",
+      "Lucario-GX",
+      "Lucario ex"
     ],
     "attacks": [
       {
@@ -2591,7 +2612,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Lucario"
+      "Lucario",
+      "Lucario-GX",
+      "Lucario ex"
     ],
     "attacks": [
       {
@@ -2642,6 +2665,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Riolu",
+    "evolvesTo": [
+      "Lucario LV.X"
+    ],
     "attacks": [
       {
         "name": "Beatdown",
@@ -2765,6 +2791,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Carbink BREAK"
+    ],
     "abilities": [
       {
         "name": "Energy Keeper",
@@ -2821,6 +2850,9 @@
     "hp": "90",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Carbink BREAK"
     ],
     "abilities": [
       {
@@ -3393,6 +3425,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Vullaby",
+    "evolvesTo": [
+      "Mandibuzz BREAK"
+    ],
     "attacks": [
       {
         "name": "Bone Drop",
@@ -3594,6 +3629,9 @@
       "Metal"
     ],
     "evolvesFrom": "Bronzor",
+    "evolvesTo": [
+      "Bronzong BREAK"
+    ],
     "abilities": [
       {
         "name": "Metal Fortress",
@@ -3702,6 +3740,9 @@
       "Metal"
     ],
     "evolvesFrom": "Riolu",
+    "evolvesTo": [
+      "Lucario LV.X"
+    ],
     "attacks": [
       {
         "name": "Vacuum Wave",
@@ -3835,7 +3876,11 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Wigglytuff"
+      "Wigglytuff",
+      "Dark Wigglytuff",
+      "Light Wigglytuff",
+      "Wigglytuff ex",
+      "Wigglytuff-GX"
     ],
     "attacks": [
       {
@@ -4156,7 +4201,8 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Whimsicott"
+      "Whimsicott",
+      "Whimsicott-GX"
     ],
     "attacks": [
       {
@@ -4397,7 +4443,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -4575,6 +4623,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Snorlax LV.X"
+    ],
     "attacks": [
       {
         "name": "Toss and Turn",
@@ -4639,6 +4690,9 @@
     "hp": "120",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Lugia BREAK"
     ],
     "abilities": [
       {
@@ -4812,7 +4866,8 @@
     ],
     "evolvesFrom": "Whismur",
     "evolvesTo": [
-      "Exploud"
+      "Exploud",
+      "Exploud ex"
     ],
     "attacks": [
       {
@@ -5492,6 +5547,9 @@
     "subtypes": [
       "Item"
     ],
+    "evolvesTo": [
+      "Kabuto"
+    ],
     "rules": [
       "Look at the bottom 7 cards of your deck. You may reveal a Kabuto you find there and put it onto your Bench. Shuffle the other cards back into your deck.",
       "You may play as many Item cards as you like during your turn (before your attack)."
@@ -5631,6 +5689,9 @@
     "subtypes": [
       "Item"
     ],
+    "evolvesTo": [
+      "Omanyte"
+    ],
     "rules": [
       "Look at the bottom 7 cards of your deck. You may reveal an Omanyte you find there and put it onto your Bench. Shuffle the other cards back into your deck.",
       "You may play as many Item cards as you like during your turn (before your attack)."
@@ -5745,6 +5806,9 @@
     "supertype": "Trainer",
     "subtypes": [
       "Item"
+    ],
+    "evolvesTo": [
+      "Aerodactyl"
     ],
     "rules": [
       "Look at the bottom 7 cards of your deck. You may reveal an Aerodactyl you find there and put it onto your Bench. Shuffle the other cards back into your deck.",

--- a/cards/en/xy11.json
+++ b/cards/en/xy11.json
@@ -76,6 +76,9 @@
       "Grass"
     ],
     "evolvesFrom": "Tangela",
+    "evolvesTo": [
+      "Tangrowth LV.X"
+    ],
     "attacks": [
       {
         "name": "Leaf Storm",
@@ -371,6 +374,9 @@
       "Grass"
     ],
     "evolvesFrom": "Yanma",
+    "evolvesTo": [
+      "Yanmega BREAK"
+    ],
     "abilities": [
       {
         "name": "Sonic Vision",
@@ -526,7 +532,9 @@
     ],
     "evolvesFrom": "Seedot",
     "evolvesTo": [
-      "Shiftry"
+      "Shiftry",
+      "Shiftry ex",
+      "Shiftry-GX"
     ],
     "attacks": [
       {
@@ -766,7 +774,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Volcarona"
+      "Volcarona",
+      "Volcarona-GX"
     ],
     "attacks": [
       {
@@ -880,7 +889,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Rapidash"
+      "Rapidash",
+      "Dark Rapidash"
     ],
     "attacks": [
       {
@@ -1122,6 +1132,9 @@
       "Fire"
     ],
     "evolvesFrom": "Monferno",
+    "evolvesTo": [
+      "Infernape LV.X"
+    ],
     "attacks": [
       {
         "name": "Flare Blitz",
@@ -1276,6 +1289,9 @@
       "Fire"
     ],
     "evolvesFrom": "Litleo",
+    "evolvesTo": [
+      "Pyroar BREAK"
+    ],
     "attacks": [
       {
         "name": "Flame Charge",
@@ -1735,7 +1751,8 @@
     ],
     "evolvesFrom": "Oshawott",
     "evolvesTo": [
-      "Samurott"
+      "Samurott",
+      "Hisuian Samurott"
     ],
     "attacks": [
       {
@@ -1901,6 +1918,9 @@
       "Water"
     ],
     "evolvesFrom": "Clauncher",
+    "evolvesTo": [
+      "Clawitzer BREAK"
+    ],
     "abilities": [
       {
         "name": "Mega Boost",
@@ -2001,7 +2021,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Avalugg"
+      "Avalugg",
+      "Hisuian Avalugg"
     ],
     "attacks": [
       {
@@ -2127,7 +2148,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Flaaffy"
+      "Flaaffy",
+      "Dark Flaaffy"
     ],
     "attacks": [
       {
@@ -2195,7 +2217,9 @@
     ],
     "evolvesFrom": "Mareep",
     "evolvesTo": [
-      "Ampharos"
+      "Ampharos",
+      "Ampharos ex",
+      "Ampharos-GX"
     ],
     "attacks": [
       {
@@ -2573,6 +2597,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Nidorino",
+    "evolvesTo": [
+      "Nidoking BREAK"
+    ],
     "abilities": [
       {
         "name": "King's Palace",
@@ -3006,7 +3033,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Primeape"
+      "Primeape",
+      "Dark Primeape"
     ],
     "attacks": [
       {
@@ -3066,6 +3094,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Mankey",
+    "evolvesTo": [
+      "Annihilape ex",
+      "Annihilape"
+    ],
     "attacks": [
       {
         "name": "Swagger",
@@ -3252,7 +3284,8 @@
     ],
     "evolvesFrom": "Claw Fossil Anorith",
     "evolvesTo": [
-      "Armaldo"
+      "Armaldo",
+      "Armaldo ex"
     ],
     "rules": [
       "Put this card onto your Bench only with the effect of Claw Fossil Anorith"
@@ -3374,7 +3407,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Toxicroak"
+      "Toxicroak",
+      "Toxicroak ex"
     ],
     "attacks": [
       {
@@ -3483,7 +3517,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Weavile"
+      "Weavile",
+      "Weavile-GX"
     ],
     "attacks": [
       {
@@ -3713,6 +3748,9 @@
       "Metal"
     ],
     "evolvesFrom": "Pawniard",
+    "evolvesTo": [
+      "Kingambit"
+    ],
     "attacks": [
       {
         "name": "Retaliate",
@@ -3777,6 +3815,9 @@
     "hp": "130",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Yveltal BREAK"
     ],
     "attacks": [
       {
@@ -4505,7 +4546,8 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Azumarill"
+      "Azumarill",
+      "Light Azumarill"
     ],
     "attacks": [
       {
@@ -4827,6 +4869,9 @@
     "types": [
       "Fairy"
     ],
+    "evolvesTo": [
+      "Xerneas BREAK"
+    ],
     "attacks": [
       {
         "name": "Geomancy",
@@ -5124,6 +5169,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Zweilous",
+    "evolvesTo": [
+      "Hydreigon BREAK"
+    ],
     "attacks": [
       {
         "name": "Cruel Fang",
@@ -5231,7 +5279,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -5472,7 +5522,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Braviary"
+      "Braviary",
+      "Hisuian Braviary"
     ],
     "attacks": [
       {
@@ -5712,6 +5763,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Fletchinder",
+    "evolvesTo": [
+      "Talonflame BREAK"
+    ],
     "abilities": [
       {
         "name": "Gale Wings",
@@ -5827,6 +5881,9 @@
     "subtypes": [
       "Item"
     ],
+    "evolvesTo": [
+      "Shieldon"
+    ],
     "rules": [
       "Look at the bottom 7 cards of your deck. You may reveal a Shieldon you find there and put it onto your Bench. Shuffle the other cards back into your deck.",
       "You may play as many Item cards as you like during your turn (before your attack)."
@@ -5872,6 +5929,9 @@
     "supertype": "Trainer",
     "subtypes": [
       "Item"
+    ],
+    "evolvesTo": [
+      "Anorith"
     ],
     "rules": [
       "Look at the bottom 7 cards of your deck. You may reveal an Anorith you find there and put it onto your Bench. Shuffle the other cards back into your deck.",

--- a/cards/en/xy12.json
+++ b/cards/en/xy12.json
@@ -497,7 +497,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Charmeleon"
+      "Charmeleon",
+      "Dark Charmeleon"
     ],
     "attacks": [
       {
@@ -560,7 +561,10 @@
     ],
     "evolvesFrom": "Charmander",
     "evolvesTo": [
-      "Charizard"
+      "Charizard",
+      "Charizard ex",
+      "Charizard-GX",
+      "Special Delivery Charizard"
     ],
     "attacks": [
       {
@@ -819,7 +823,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {
@@ -872,6 +878,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "attacks": [
       {
         "name": "Lure",
@@ -975,7 +984,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -1038,6 +1049,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "abilities": [
       {
         "name": "Burning Road",
@@ -1099,7 +1113,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Rapidash"
+      "Rapidash",
+      "Dark Rapidash"
     ],
     "attacks": [
       {
@@ -1407,7 +1422,8 @@
     "evolvesFrom": "Poliwag",
     "evolvesTo": [
       "Poliwrath",
-      "Politoed"
+      "Politoed",
+      "Politoed ex"
     ],
     "attacks": [
       {
@@ -1658,7 +1674,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Dewgong"
+      "Dewgong",
+      "Light Dewgong"
     ],
     "attacks": [
       {
@@ -1784,7 +1801,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Starmie"
+      "Starmie",
+      "Starmie-GX"
     ],
     "attacks": [
       {
@@ -1836,6 +1854,9 @@
       "Water"
     ],
     "evolvesFrom": "Staryu",
+    "evolvesTo": [
+      "Starmie BREAK"
+    ],
     "abilities": [
       {
         "name": "Space Beacon",
@@ -1935,7 +1956,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -2053,7 +2077,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -2121,6 +2149,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Energize",
@@ -2188,7 +2220,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -2257,7 +2290,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "attacks": [
       {
@@ -2327,7 +2361,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {
@@ -2701,6 +2738,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Nidorino",
+    "evolvesTo": [
+      "Nidoking BREAK"
+    ],
     "attacks": [
       {
         "name": "Rumble",
@@ -2808,7 +2848,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Haunter",
+      "Dark Haunter"
     ],
     "attacks": [
       {
@@ -2877,7 +2918,8 @@
     ],
     "evolvesFrom": "Gastly",
     "evolvesTo": [
-      "Gengar"
+      "Gengar",
+      "Gengar ex"
     ],
     "attacks": [
       {
@@ -2945,7 +2987,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Hypno"
+      "Hypno",
+      "Dark Hypno"
     ],
     "attacks": [
       {
@@ -3007,7 +3050,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Weezing"
+      "Weezing",
+      "Dark Weezing",
+      "Galarian Weezing"
     ],
     "attacks": [
       {
@@ -3058,6 +3103,9 @@
     "hp": "130",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Mewtwo LV.X"
     ],
     "attacks": [
       {
@@ -3254,7 +3302,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Sandslash"
+      "Sandslash",
+      "Dark Sandslash"
     ],
     "attacks": [
       {
@@ -3306,7 +3355,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Dugtrio"
+      "Dugtrio",
+      "Dark Dugtrio"
     ],
     "abilities": [
       {
@@ -3428,7 +3478,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Machoke"
+      "Machoke",
+      "Dark Machoke",
+      "Light Machoke"
     ],
     "attacks": [
       {
@@ -3483,7 +3535,8 @@
     ],
     "evolvesFrom": "Machop",
     "evolvesTo": [
-      "Machamp"
+      "Machamp",
+      "Machamp-GX"
     ],
     "attacks": [
       {
@@ -3548,6 +3601,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Machoke",
+    "evolvesTo": [
+      "Machamp LV.X",
+      "Machamp BREAK"
+    ],
     "abilities": [
       {
         "name": "Counterattack",
@@ -3651,7 +3708,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Steelix"
+      "Steelix",
+      "Dark Steelix",
+      "Steelix ex"
     ],
     "attacks": [
       {
@@ -3776,7 +3835,8 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Clefable",
+      "Clefable ex"
     ],
     "attacks": [
       {
@@ -3973,7 +4033,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Raticate"
+      "Raticate",
+      "Dark Raticate"
     ],
     "abilities": [
       {
@@ -4032,6 +4093,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Rattata",
+    "evolvesTo": [
+      "Raticate BREAK"
+    ],
     "attacks": [
       {
         "name": "Crunch",
@@ -4089,9 +4153,6 @@
     "hp": "70",
     "types": [
       "Colorless"
-    ],
-    "evolvesTo": [
-      "Sirfetch'd"
     ],
     "attacks": [
       {
@@ -4218,7 +4279,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Blissey"
+      "Blissey",
+      "Blissey ex"
     ],
     "attacks": [
       {
@@ -4285,7 +4347,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Porygon2"
+      "Porygon2",
+      "Dark Porygon2"
     ],
     "attacks": [
       {
@@ -5539,9 +5602,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesTo": [
-      "Raichu"
-    ],
     "attacks": [
       {
         "name": "Thunder Shock",
@@ -5601,9 +5661,6 @@
     "hp": "50",
     "types": [
       "Lightning"
-    ],
-    "evolvesTo": [
-      "Raichu"
     ],
     "attacks": [
       {

--- a/cards/en/xy2.json
+++ b/cards/en/xy2.json
@@ -196,7 +196,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Forretress"
+      "Forretress",
+      "Dark Forretress",
+      "Forretress ex"
     ],
     "attacks": [
       {
@@ -301,7 +303,9 @@
     ],
     "evolvesFrom": "Seedot",
     "evolvesTo": [
-      "Shiftry"
+      "Shiftry",
+      "Shiftry ex",
+      "Shiftry-GX"
     ],
     "attacks": [
       {
@@ -794,7 +798,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Rapidash"
+      "Rapidash",
+      "Dark Rapidash"
     ],
     "attacks": [
       {
@@ -1135,6 +1140,9 @@
       "Fire"
     ],
     "evolvesFrom": "Litleo",
+    "evolvesTo": [
+      "Pyroar BREAK"
+    ],
     "abilities": [
       {
         "name": "Intimidating Mane",
@@ -1250,7 +1258,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Milotic"
+      "Milotic",
+      "Milotic ex"
     ],
     "attacks": [
       {
@@ -1414,7 +1423,8 @@
     ],
     "evolvesFrom": "Spheal",
     "evolvesTo": [
-      "Walrein"
+      "Walrein",
+      "Walrein ex"
     ],
     "attacks": [
       {
@@ -1723,7 +1733,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Avalugg"
+      "Avalugg",
+      "Hisuian Avalugg"
     ],
     "attacks": [
       {
@@ -1988,6 +1999,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Luxio",
+    "evolvesTo": [
+      "Luxray BREAK"
+    ],
     "attacks": [
       {
         "name": "Fang Snipe",
@@ -2259,7 +2273,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Dusclops"
+      "Dusclops",
+      "Dusclops ex"
     ],
     "attacks": [
       {
@@ -2395,6 +2410,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Dusclops",
+    "evolvesTo": [
+      "Dusknoir LV.X"
+    ],
     "abilities": [
       {
         "name": "Shadow Void",
@@ -2759,7 +2777,8 @@
     ],
     "evolvesFrom": "Geodude",
     "evolvesTo": [
-      "Golem"
+      "Golem",
+      "Golem ex"
     ],
     "attacks": [
       {
@@ -3007,7 +3026,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Weavile"
+      "Weavile",
+      "Weavile-GX"
     ],
     "attacks": [
       {
@@ -3074,7 +3094,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Weavile"
+      "Weavile",
+      "Weavile-GX"
     ],
     "attacks": [
       {
@@ -4042,6 +4063,9 @@
       "Fairy"
     ],
     "evolvesFrom": "Floette",
+    "evolvesTo": [
+      "Florges BREAK"
+    ],
     "attacks": [
       {
         "name": "Brilliant Search",
@@ -4171,6 +4195,9 @@
     "hp": "70",
     "types": [
       "Fairy"
+    ],
+    "evolvesTo": [
+      "Carbink BREAK"
     ],
     "attacks": [
       {
@@ -4418,7 +4445,8 @@
       "Dragon"
     ],
     "evolvesTo": [
-      "Sliggoo"
+      "Sliggoo",
+      "Hisuian Sliggoo"
     ],
     "attacks": [
       {
@@ -4663,7 +4691,8 @@
     ],
     "evolvesFrom": "Pidgey",
     "evolvesTo": [
-      "Pidgeot"
+      "Pidgeot",
+      "Pidgeot ex"
     ],
     "attacks": [
       {
@@ -4919,6 +4948,9 @@
     "hp": "130",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Snorlax LV.X"
     ],
     "abilities": [
       {

--- a/cards/en/xy3.json
+++ b/cards/en/xy3.json
@@ -372,6 +372,9 @@
       "Grass"
     ],
     "evolvesFrom": "Eevee",
+    "evolvesTo": [
+      "Leafeon LV.X"
+    ],
     "attacks": [
       {
         "name": "Soothing Scent",
@@ -602,6 +605,9 @@
       "Fire"
     ],
     "evolvesFrom": "Magmar",
+    "evolvesTo": [
+      "Magmortar LV.X"
+    ],
     "attacks": [
       {
         "name": "Flame Charge",
@@ -718,7 +724,9 @@
     ],
     "evolvesFrom": "Torchic",
     "evolvesTo": [
-      "Blaziken"
+      "Blaziken",
+      "Blaziken ex",
+      "Blaziken-GX"
     ],
     "attacks": [
       {
@@ -908,7 +916,8 @@
     "evolvesFrom": "Poliwag",
     "evolvesTo": [
       "Poliwrath",
-      "Politoed"
+      "Politoed",
+      "Politoed ex"
     ],
     "attacks": [
       {
@@ -1093,6 +1102,9 @@
       "Water"
     ],
     "evolvesFrom": "Eevee",
+    "evolvesTo": [
+      "Glaceon LV.X"
+    ],
     "attacks": [
       {
         "name": "Blizzard",
@@ -1408,6 +1420,9 @@
       "Water"
     ],
     "evolvesFrom": "Clauncher",
+    "evolvesTo": [
+      "Clawitzer BREAK"
+    ],
     "attacks": [
       {
         "name": "Reverse Thrust",
@@ -1598,7 +1613,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -1656,6 +1675,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Thunder Shock",
@@ -1791,6 +1814,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Electabuzz",
+    "evolvesTo": [
+      "Electivire LV.X"
+    ],
     "attacks": [
       {
         "name": "Tag Team Spark",
@@ -2115,7 +2141,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Hypno"
+      "Hypno",
+      "Dark Hypno"
     ],
     "attacks": [
       {
@@ -2683,7 +2710,9 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Machoke"
+      "Machoke",
+      "Dark Machoke",
+      "Light Machoke"
     ],
     "attacks": [
       {
@@ -2736,7 +2765,8 @@
     ],
     "evolvesFrom": "Machop",
     "evolvesTo": [
-      "Machamp"
+      "Machamp",
+      "Machamp-GX"
     ],
     "attacks": [
       {
@@ -2789,6 +2819,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Machoke",
+    "evolvesTo": [
+      "Machamp LV.X",
+      "Machamp BREAK"
+    ],
     "abilities": [
       {
         "name": "Fighting Fury",
@@ -3087,7 +3121,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Hariyama"
+      "Hariyama",
+      "Hariyama ex"
     ],
     "attacks": [
       {
@@ -4011,6 +4046,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Skorupi",
+    "evolvesTo": [
+      "Drapion LV.X"
+    ],
     "attacks": [
       {
         "name": "Venoshock",
@@ -4275,7 +4313,8 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Clefable",
+      "Clefable ex"
     ],
     "attacks": [
       {
@@ -4342,7 +4381,8 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Clefable",
+      "Clefable ex"
     ],
     "attacks": [
       {
@@ -4656,7 +4696,9 @@
     ],
     "evolvesFrom": "Trapinch",
     "evolvesTo": [
-      "Flygon"
+      "Flygon",
+      "Flygon ex",
+      "Flygon-GX"
     ],
     "attacks": [
       {
@@ -4717,6 +4759,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Vibrava",
+    "evolvesTo": [
+      "Flygon LV.X"
+    ],
     "attacks": [
       {
         "name": "Rainbow Shower",
@@ -4777,6 +4822,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Noibat",
+    "evolvesTo": [
+      "Noivern BREAK"
+    ],
     "abilities": [
       {
         "name": "Echolocation",
@@ -4963,7 +5011,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "abilities": [
       {
@@ -5382,7 +5450,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Noivern"
+      "Noivern",
+      "Noivern-GX",
+      "Noivern ex"
     ],
     "attacks": [
       {
@@ -5584,6 +5654,9 @@
     "subtypes": [
       "Item"
     ],
+    "evolvesTo": [
+      "Tyrunt"
+    ],
     "rules": [
       "Look at the bottom 7 cards of your deck. You may reveal a Tyrunt you find there and put it onto your Bench. Shuffle the other cards back into your deck.",
       "You may play as many Item cards as you like during your turn (before your attack)."
@@ -5675,6 +5748,9 @@
     "supertype": "Trainer",
     "subtypes": [
       "Item"
+    ],
+    "evolvesTo": [
+      "Amaura"
     ],
     "rules": [
       "Look at the bottom 7 cards of your deck. You may reveal an Amaura you find there and put it onto your Bench. Shuffle the other cards back into your deck.",

--- a/cards/en/xy4.json
+++ b/cards/en/xy4.json
@@ -11,7 +11,9 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Venomoth"
+      "Venomoth",
+      "Light Venomoth",
+      "Venomoth-GX"
     ],
     "attacks": [
       {
@@ -181,6 +183,9 @@
       "Grass"
     ],
     "evolvesFrom": "Yanma",
+    "evolvesTo": [
+      "Yanmega BREAK"
+    ],
     "attacks": [
       {
         "name": "Windfall",
@@ -557,6 +562,9 @@
       "Fire"
     ],
     "evolvesFrom": "Fletchinder",
+    "evolvesTo": [
+      "Talonflame BREAK"
+    ],
     "attacks": [
       {
         "name": "Acrobatics",
@@ -685,6 +693,9 @@
       "Fire"
     ],
     "evolvesFrom": "Litleo",
+    "evolvesTo": [
+      "Pyroar BREAK"
+    ],
     "abilities": [
       {
         "name": "Flare Command",
@@ -871,7 +882,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Croconaw"
+      "Croconaw",
+      "Dark Croconaw"
     ],
     "attacks": [
       {
@@ -923,7 +935,8 @@
     ],
     "evolvesFrom": "Totodile",
     "evolvesTo": [
-      "Feraligatr"
+      "Feraligatr",
+      "Feraligatr ex"
     ],
     "attacks": [
       {
@@ -1908,7 +1921,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Golbat"
+      "Golbat",
+      "Dark Golbat"
     ],
     "attacks": [
       {
@@ -1966,7 +1980,8 @@
     ],
     "evolvesFrom": "Zubat",
     "evolvesTo": [
-      "Crobat"
+      "Crobat",
+      "Crobat ex"
     ],
     "abilities": [
       {
@@ -2026,6 +2041,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Golbat",
+    "evolvesTo": [
+      "Crobat BREAK"
+    ],
     "abilities": [
       {
         "name": "Surprise Bite",
@@ -2215,6 +2233,9 @@
     "hp": "110",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Wobbuffet BREAK"
     ],
     "abilities": [
       {
@@ -2901,6 +2922,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Gligar",
+    "evolvesTo": [
+      "Gliscor LV.X"
+    ],
     "attacks": [
       {
         "name": "Submission Hold",
@@ -3141,7 +3165,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Honchkrow"
+      "Honchkrow",
+      "Honchkrow-GX"
     ],
     "attacks": [
       {
@@ -3209,6 +3234,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Murkrow",
+    "evolvesTo": [
+      "Honchkrow LV.X"
+    ],
     "attacks": [
       {
         "name": "Hypnoblast",
@@ -3275,7 +3303,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Mightyena"
+      "Mightyena",
+      "Mightyena ex"
     ],
     "attacks": [
       {
@@ -3772,6 +3801,9 @@
       "Metal"
     ],
     "evolvesFrom": "Bronzor",
+    "evolvesTo": [
+      "Bronzong BREAK"
+    ],
     "abilities": [
       {
         "name": "Metal Links",
@@ -3908,6 +3940,9 @@
     "hp": "130",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Heatran LV.X"
     ],
     "attacks": [
       {
@@ -4683,6 +4718,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Zweilous",
+    "evolvesTo": [
+      "Hydreigon BREAK"
+    ],
     "abilities": [
       {
         "name": "Dark Impulse",
@@ -4744,7 +4782,8 @@
       "Dragon"
     ],
     "evolvesTo": [
-      "Sliggoo"
+      "Sliggoo",
+      "Hisuian Sliggoo"
     ],
     "attacks": [
       {
@@ -5056,7 +5095,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Blissey"
+      "Blissey",
+      "Blissey ex"
     ],
     "attacks": [
       {
@@ -5184,6 +5224,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Farigiraf"
+    ],
     "attacks": [
       {
         "name": "Tackle",
@@ -5297,7 +5340,8 @@
     ],
     "evolvesFrom": "Whismur",
     "evolvesTo": [
-      "Exploud"
+      "Exploud",
+      "Exploud ex"
     ],
     "attacks": [
       {
@@ -5423,6 +5467,9 @@
     "hp": "130",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Regigigas LV.X"
     ],
     "attacks": [
       {

--- a/cards/en/xy5.json
+++ b/cards/en/xy5.json
@@ -235,6 +235,9 @@
       "Grass"
     ],
     "evolvesFrom": "Tangela",
+    "evolvesTo": [
+      "Tangrowth LV.X"
+    ],
     "attacks": [
       {
         "name": "Mega Drain",
@@ -353,7 +356,9 @@
     ],
     "evolvesFrom": "Treecko",
     "evolvesTo": [
-      "Sceptile"
+      "Sceptile",
+      "Sceptile ex",
+      "Sceptile-GX"
     ],
     "attacks": [
       {
@@ -1115,7 +1120,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Ninetales"
+      "Ninetales",
+      "Light Ninetales",
+      "Ninetales ex"
     ],
     "attacks": [
       {
@@ -1175,6 +1182,9 @@
       "Fire"
     ],
     "evolvesFrom": "Vulpix",
+    "evolvesTo": [
+      "Ninetales BREAK"
+    ],
     "abilities": [
       {
         "name": "Barrier Shrine",
@@ -1233,7 +1243,10 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Magcargo"
+      "Magcargo",
+      "Dark Magcargo",
+      "Magcargo ex",
+      "Magcargo-GX"
     ],
     "attacks": [
       {
@@ -1543,7 +1556,9 @@
     ],
     "evolvesFrom": "Torchic",
     "evolvesTo": [
-      "Blaziken"
+      "Blaziken",
+      "Blaziken ex",
+      "Blaziken-GX"
     ],
     "attacks": [
       {
@@ -1785,7 +1800,9 @@
     ],
     "evolvesFrom": "Horsea",
     "evolvesTo": [
-      "Kingdra"
+      "Kingdra",
+      "Kingdra ex",
+      "Kingdra-GX"
     ],
     "attacks": [
       {
@@ -1846,7 +1863,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Starmie"
+      "Starmie",
+      "Starmie-GX"
     ],
     "attacks": [
       {
@@ -1959,7 +1977,8 @@
     ],
     "evolvesFrom": "Mudkip",
     "evolvesTo": [
-      "Swampert"
+      "Swampert",
+      "Swampert ex"
     ],
     "attacks": [
       {
@@ -2468,7 +2487,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Crawdaunt"
+      "Crawdaunt",
+      "Crawdaunt ex"
     ],
     "attacks": [
       {
@@ -2529,7 +2549,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Milotic"
+      "Milotic",
+      "Milotic ex"
     ],
     "attacks": [
       {
@@ -2746,7 +2767,8 @@
     ],
     "evolvesFrom": "Spheal",
     "evolvesTo": [
-      "Walrein"
+      "Walrein",
+      "Walrein ex"
     ],
     "attacks": [
       {
@@ -3162,6 +3184,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Primal Kyogre-EX"
+    ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -3349,7 +3374,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Lanturn"
+      "Lanturn",
+      "Light Lanturn"
     ],
     "attacks": [
       {
@@ -3476,7 +3502,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Manectric",
+      "Manectric ex"
     ],
     "attacks": [
       {
@@ -3543,7 +3570,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Manectric",
+      "Manectric ex"
     ],
     "ancientTrait": {
       "name": "Ω Barrier",
@@ -4352,6 +4380,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Staryu",
+    "evolvesTo": [
+      "Starmie BREAK"
+    ],
     "attacks": [
       {
         "name": "Synchro Star",
@@ -4520,6 +4551,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Rhydon",
+    "evolvesTo": [
+      "Rhyperior LV.X"
+    ],
     "attacks": [
       {
         "name": "Rock Shower",
@@ -4586,6 +4620,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Rhydon",
+    "evolvesTo": [
+      "Rhyperior LV.X"
+    ],
     "ancientTrait": {
       "name": "Ω Barrier",
       "text": "Whenever your opponent plays a Trainer card (excluding Pokémon Tools and Stadium cards), prevent all effects of that card done to this Pokémon."
@@ -4717,7 +4754,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Medicham"
+      "Medicham",
+      "Medicham ex"
     ],
     "attacks": [
       {
@@ -5074,6 +5112,9 @@
     "types": [
       "Fighting"
     ],
+    "evolvesTo": [
+      "Primal Groudon-EX"
+    ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -5269,6 +5310,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Hippopotas",
+    "evolvesTo": [
+      "Hippowdon LV.X"
+    ],
     "attacks": [
       {
         "name": "Resistance Desert",
@@ -5988,7 +6032,8 @@
     ],
     "evolvesFrom": "Honedge",
     "evolvesTo": [
-      "Aegislash"
+      "Aegislash",
+      "Aegislash ex"
     ],
     "attacks": [
       {
@@ -6189,7 +6234,8 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Azumarill"
+      "Azumarill",
+      "Light Azumarill"
     ],
     "attacks": [
       {
@@ -6655,7 +6701,9 @@
     ],
     "evolvesFrom": "Trapinch",
     "evolvesTo": [
-      "Flygon"
+      "Flygon",
+      "Flygon ex",
+      "Flygon-GX"
     ],
     "attacks": [
       {
@@ -6717,6 +6765,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Vibrava",
+    "evolvesTo": [
+      "Flygon LV.X"
+    ],
     "abilities": [
       {
         "name": "Sand Flap",
@@ -6896,7 +6947,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Delcatty"
+      "Delcatty",
+      "Delcatty ex"
     ],
     "attacks": [
       {
@@ -8173,6 +8225,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Primal Kyogre-EX"
+    ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -8302,6 +8357,9 @@
     "hp": "180",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Primal Groudon-EX"
     ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."

--- a/cards/en/xy6.json
+++ b/cards/en/xy6.json
@@ -11,7 +11,10 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Exeggutor"
+      "Exeggutor",
+      "Dark Exeggutor",
+      "Alolan Exeggutor-GX",
+      "Alolan Exeggutor"
     ],
     "attacks": [
       {
@@ -304,7 +307,8 @@
     ],
     "evolvesFrom": "Wurmple",
     "evolvesTo": [
-      "Dustox"
+      "Dustox",
+      "Dustox ex"
     ],
     "attacks": [
       {
@@ -494,7 +498,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ninjask"
+      "Ninjask",
+      "Shedinja"
     ],
     "attacks": [
       {
@@ -545,9 +550,6 @@
       "Grass"
     ],
     "evolvesFrom": "Nincada",
-    "evolvesTo": [
-      "Shedinja"
-    ],
     "abilities": [
       {
         "name": "Wing Buzz",
@@ -822,6 +824,9 @@
       "Fire"
     ],
     "evolvesFrom": "Fletchinder",
+    "evolvesTo": [
+      "Talonflame BREAK"
+    ],
     "attacks": [
       {
         "name": "Grand Loop",
@@ -1139,7 +1144,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -1206,7 +1215,10 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Electrode"
+      "Electrode",
+      "Dark Electrode",
+      "Electrode ex",
+      "Electrode-GX"
     ],
     "attacks": [
       {
@@ -1405,7 +1417,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Manectric"
+      "Manectric",
+      "Manectric ex"
     ],
     "attacks": [
       {
@@ -1763,7 +1776,9 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Banette"
+      "Banette",
+      "Banette ex",
+      "Banette-GX"
     ],
     "attacks": [
       {
@@ -2185,6 +2200,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Gligar",
+    "evolvesTo": [
+      "Gliscor LV.X"
+    ],
     "attacks": [
       {
         "name": "Rock Slide",
@@ -2565,7 +2583,8 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Togetic"
+      "Togetic",
+      "Light Togetic"
     ],
     "attacks": [
       {
@@ -2825,6 +2844,9 @@
     "types": [
       "Fairy"
     ],
+    "evolvesTo": [
+      "Carbink BREAK"
+    ],
     "abilities": [
       {
         "name": "Jewel Armor",
@@ -2954,7 +2976,9 @@
       "Dragon"
     ],
     "evolvesTo": [
-      "Dragonair"
+      "Dragonair",
+      "Dark Dragonair",
+      "Light Dragonair"
     ],
     "attacks": [
       {
@@ -3016,7 +3040,9 @@
     ],
     "evolvesFrom": "Dratini",
     "evolvesTo": [
-      "Dragonite"
+      "Dragonite",
+      "Dragonite ex",
+      "Dragonite-GX"
     ],
     "attacks": [
       {
@@ -3381,7 +3407,9 @@
     ],
     "evolvesFrom": "Bagon",
     "evolvesTo": [
-      "Salamence"
+      "Salamence",
+      "Salamence ex",
+      "Salamence-GX"
     ],
     "abilities": [
       {
@@ -3443,6 +3471,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Shelgon",
+    "evolvesTo": [
+      "Salamence LV.X"
+    ],
     "attacks": [
       {
         "name": "Shatter",
@@ -4073,7 +4104,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -4133,6 +4166,9 @@
     "hp": "60",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Dudunsparce"
     ],
     "attacks": [
       {
@@ -4446,7 +4482,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Altaria"
+      "Altaria",
+      "Altaria ex",
+      "Altaria-GX"
     ],
     "attacks": [
       {

--- a/cards/en/xy7.json
+++ b/cards/en/xy7.json
@@ -11,7 +11,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Gloom"
+      "Gloom",
+      "Dark Gloom"
     ],
     "attacks": [
       {
@@ -64,7 +65,9 @@
     "evolvesFrom": "Oddish",
     "evolvesTo": [
       "Vileplume",
-      "Bellossom"
+      "Bellossom",
+      "Vileplume ex",
+      "Vileplume-GX"
     ],
     "attacks": [
       {
@@ -235,7 +238,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Ariados"
+      "Ariados",
+      "Dark Ariados"
     ],
     "attacks": [
       {
@@ -466,7 +470,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Vespiquen"
+      "Vespiquen",
+      "Vespiquen ex"
     ],
     "attacks": [
       {
@@ -876,7 +881,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Volcarona"
+      "Volcarona",
+      "Volcarona-GX"
     ],
     "attacks": [
       {
@@ -1053,7 +1059,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -1799,7 +1808,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Claydol"
+      "Claydol",
+      "Claydol ex"
     ],
     "attacks": [
       {
@@ -1860,7 +1870,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Claydol"
+      "Claydol",
+      "Claydol ex"
     ],
     "ancientTrait": {
       "name": "θ Stop",
@@ -2873,7 +2884,9 @@
     ],
     "evolvesFrom": "Beldum",
     "evolvesTo": [
-      "Metagross"
+      "Metagross",
+      "Metagross ex",
+      "Metagross-GX"
     ],
     "attacks": [
       {
@@ -3224,7 +3237,9 @@
     "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
-      "Gallade"
+      "Gallade",
+      "Gardevoir ex",
+      "Gardevoir-GX"
     ],
     "attacks": [
       {
@@ -3292,6 +3307,9 @@
       "Fairy"
     ],
     "evolvesFrom": "Kirlia",
+    "evolvesTo": [
+      "Gardevoir LV.X"
+    ],
     "abilities": [
       {
         "name": "Bright Heal",
@@ -3357,7 +3375,8 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Whimsicott"
+      "Whimsicott",
+      "Whimsicott-GX"
     ],
     "attacks": [
       {
@@ -3542,7 +3561,8 @@
       "Dragon"
     ],
     "evolvesTo": [
-      "Sliggoo"
+      "Sliggoo",
+      "Hisuian Sliggoo"
     ],
     "abilities": [
       {
@@ -3730,7 +3750,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -3847,7 +3869,27 @@
       "Espeon",
       "Umbreon",
       "Leafeon",
-      "Glaceon"
+      "Glaceon",
+      "Dark Flareon",
+      "Dark Jolteon",
+      "Dark Vaporeon",
+      "Dark Espeon",
+      "Light Flareon",
+      "Light Jolteon",
+      "Light Vaporeon",
+      "Espeon ex",
+      "Umbreon ex",
+      "Flareon ex",
+      "Jolteon ex",
+      "Vaporeon ex",
+      "Espeon-GX",
+      "Umbreon-GX",
+      "Leafeon-GX",
+      "Glaceon-GX",
+      "Flareon-GX",
+      "Vaporeon-GX",
+      "Jolteon-GX",
+      "Sylveon-GX"
     ],
     "attacks": [
       {
@@ -3908,7 +3950,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Porygon2"
+      "Porygon2",
+      "Dark Porygon2"
     ],
     "attacks": [
       {
@@ -3970,7 +4013,8 @@
     ],
     "evolvesFrom": "Porygon",
     "evolvesTo": [
-      "Porygon-Z"
+      "Porygon-Z",
+      "Porygon-Z-GX"
     ],
     "attacks": [
       {
@@ -4033,6 +4077,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Porygon2",
+    "evolvesTo": [
+      "Porygon-Z LV.X"
+    ],
     "attacks": [
       {
         "name": "Cyber Crush",
@@ -4094,6 +4141,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Porygon2",
+    "evolvesTo": [
+      "Porygon-Z LV.X"
+    ],
     "ancientTrait": {
       "name": "θ Stop",
       "text": "Prevent all effects of your opponent's Pokémon's Abilities done to this Pokémon."

--- a/cards/en/xy8.json
+++ b/cards/en/xy8.json
@@ -182,7 +182,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Cacturne"
+      "Cacturne",
+      "Cacturne ex"
     ],
     "attacks": [
       {
@@ -595,6 +596,9 @@
       "Grass"
     ],
     "evolvesFrom": "Quilladin",
+    "evolvesTo": [
+      "Chesnaught BREAK"
+    ],
     "attacks": [
       {
         "name": "Spike Lariat",
@@ -1010,7 +1014,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Quilava"
+      "Quilava",
+      "Dark Quilava"
     ],
     "attacks": [
       {
@@ -1072,7 +1077,9 @@
     ],
     "evolvesFrom": "Cyndaquil",
     "evolvesTo": [
-      "Typhlosion"
+      "Typhlosion",
+      "Typhlosion ex",
+      "Hisuian Typhlosion"
     ],
     "attacks": [
       {
@@ -1631,7 +1638,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Starmie"
+      "Starmie",
+      "Starmie-GX"
     ],
     "attacks": [
       {
@@ -1682,6 +1690,9 @@
       "Water"
     ],
     "evolvesFrom": "Staryu",
+    "evolvesTo": [
+      "Starmie BREAK"
+    ],
     "attacks": [
       {
         "name": "Deep Sea Swirl",
@@ -1741,7 +1752,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Octillery"
+      "Octillery",
+      "Dark Octillery"
     ],
     "attacks": [
       {
@@ -1802,7 +1814,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Octillery"
+      "Octillery",
+      "Dark Octillery"
     ],
     "attacks": [
       {
@@ -1923,7 +1936,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Froslass"
+      "M Glalie-EX"
     ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
@@ -1990,9 +2003,6 @@
       "Water"
     ],
     "evolvesFrom": "Glalie-EX",
-    "evolvesTo": [
-      "Froslass"
-    ],
     "rules": [
       "Mega Evolution rule: When 1 of your Pokémon becomes a Mega Evolution Pokémon, your turn ends.",
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
@@ -2154,6 +2164,10 @@
       "Water"
     ],
     "evolvesFrom": "Prinplup",
+    "evolvesTo": [
+      "Empoleon LV.X",
+      "Empoleon BREAK"
+    ],
     "abilities": [
       {
         "name": "Dignified Fighter",
@@ -2689,7 +2703,9 @@
     ],
     "evolvesFrom": "Froakie",
     "evolvesTo": [
-      "Greninja"
+      "Greninja",
+      "Greninja-GX",
+      "Greninja ex"
     ],
     "attacks": [
       {
@@ -2741,7 +2757,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -2808,6 +2828,10 @@
       "Lightning"
     ],
     "evolvesFrom": "Pikachu",
+    "evolvesTo": [
+      "Raichu LV.X",
+      "Raichu BREAK"
+    ],
     "attacks": [
       {
         "name": "Thunderclap Shot",
@@ -2914,7 +2938,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "abilities": [
       {
@@ -2979,7 +3004,8 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Magneton"
+      "Magneton",
+      "Dark Magneton"
     ],
     "attacks": [
       {
@@ -3047,7 +3073,8 @@
     ],
     "evolvesFrom": "Magnemite",
     "evolvesTo": [
-      "Magnezone"
+      "Magnezone",
+      "Magnezone ex"
     ],
     "attacks": [
       {
@@ -3115,6 +3142,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Magneton",
+    "evolvesTo": [
+      "Magnezone LV.X"
+    ],
     "abilities": [
       {
         "name": "Magnetic Circuit",
@@ -3366,7 +3396,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Haunter",
+      "Dark Haunter"
     ],
     "attacks": [
       {
@@ -3424,7 +3455,8 @@
     ],
     "evolvesFrom": "Gastly",
     "evolvesTo": [
-      "Gengar"
+      "Gengar",
+      "Gengar ex"
     ],
     "abilities": [
       {
@@ -3489,6 +3521,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Haunter",
+    "evolvesTo": [
+      "Gengar LV.X"
+    ],
     "attacks": [
       {
         "name": "Sinister Fog",
@@ -3917,6 +3952,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Wobbuffet BREAK"
+    ],
     "attacks": [
       {
         "name": "Mirror Barrier",
@@ -4042,7 +4080,9 @@
     "evolvesFrom": "Ralts",
     "evolvesTo": [
       "Gardevoir",
-      "Gallade"
+      "Gallade",
+      "Gardevoir ex",
+      "Gardevoir-GX"
     ],
     "attacks": [
       {
@@ -4101,6 +4141,9 @@
     "hp": "110",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Cresselia LV.X"
     ],
     "abilities": [
       {
@@ -4342,6 +4385,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Elgyem",
+    "evolvesTo": [
+      "Beheeyem BREAK"
+    ],
     "attacks": [
       {
         "name": "Mind Bullet",
@@ -4401,7 +4447,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Sandslash"
+      "Sandslash",
+      "Dark Sandslash"
     ],
     "attacks": [
       {
@@ -4522,7 +4569,10 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Marowak"
+      "Marowak",
+      "Dark Marowak",
+      "Alolan Marowak-GX",
+      "Alolan Marowak"
     ],
     "attacks": [
       {
@@ -4575,6 +4625,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Cubone",
+    "evolvesTo": [
+      "Marowak BREAK"
+    ],
     "attacks": [
       {
         "name": "Sharpshooting",
@@ -4677,7 +4730,8 @@
       "Fighting"
     ],
     "evolvesTo": [
-      "Piloswine"
+      "Piloswine",
+      "Light Piloswine"
     ],
     "attacks": [
       {
@@ -5221,7 +5275,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Zoroark"
+      "Zoroark",
+      "Zoroark-GX"
     ],
     "attacks": [
       {
@@ -5288,7 +5343,8 @@
       "Darkness"
     ],
     "evolvesTo": [
-      "Zoroark"
+      "Zoroark",
+      "Zoroark-GX"
     ],
     "attacks": [
       {
@@ -5355,6 +5411,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Zorua",
+    "evolvesTo": [
+      "Zoroark BREAK"
+    ],
     "abilities": [
       {
         "name": "Stand In",
@@ -5517,6 +5576,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Yveltal BREAK"
+    ],
     "abilities": [
       {
         "name": "Fright Night",
@@ -5641,6 +5703,9 @@
       "Metal"
     ],
     "evolvesFrom": "Bronzor",
+    "evolvesTo": [
+      "Bronzong BREAK"
+    ],
     "attacks": [
       {
         "name": "Pain Amplifier",
@@ -6102,6 +6167,9 @@
       "Fairy"
     ],
     "evolvesFrom": "Floette",
+    "evolvesTo": [
+      "Florges BREAK"
+    ],
     "abilities": [
       {
         "name": "Calming Aroma",
@@ -6322,6 +6390,9 @@
     "hp": "120",
     "types": [
       "Fairy"
+    ],
+    "evolvesTo": [
+      "Xerneas BREAK"
     ],
     "attacks": [
       {
@@ -6653,6 +6724,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Noibat",
+    "evolvesTo": [
+      "Noivern BREAK"
+    ],
     "attacks": [
       {
         "name": "Tuning",
@@ -6756,7 +6830,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Persian"
+      "Persian",
+      "Dark Persian",
+      "Persian-GX"
     ],
     "attacks": [
       {
@@ -7004,6 +7080,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Snorlax LV.X"
+    ],
     "abilities": [
       {
         "name": "Plump Body",
@@ -7124,6 +7203,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Hoothoot",
+    "evolvesTo": [
+      "Noctowl BREAK"
+    ],
     "attacks": [
       {
         "name": "High Flight",
@@ -7191,7 +7273,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Ursaring"
+      "Ursaring",
+      "Dark Ursaring"
     ],
     "attacks": [
       {
@@ -7244,6 +7327,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Teddiursa",
+    "evolvesTo": [
+      "Ursaluna"
+    ],
     "attacks": [
       {
         "name": "Drag Off",
@@ -7365,7 +7451,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Altaria"
+      "Altaria",
+      "Altaria ex",
+      "Altaria-GX"
     ],
     "attacks": [
       {
@@ -7678,7 +7766,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Braviary"
+      "Braviary",
+      "Hisuian Braviary"
     ],
     "attacks": [
       {
@@ -7805,7 +7894,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Noivern"
+      "Noivern",
+      "Noivern-GX",
+      "Noivern ex"
     ],
     "attacks": [
       {
@@ -7862,7 +7953,9 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Noivern"
+      "Noivern",
+      "Noivern-GX",
+      "Noivern ex"
     ],
     "attacks": [
       {
@@ -8541,7 +8634,7 @@
       "Water"
     ],
     "evolvesTo": [
-      "Froslass"
+      "M Glalie-EX"
     ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
@@ -8608,9 +8701,6 @@
       "Water"
     ],
     "evolvesFrom": "Glalie-EX",
-    "evolvesTo": [
-      "Froslass"
-    ],
     "rules": [
       "Mega Evolution rule: When 1 of your Pokémon becomes a Mega Evolution Pokémon, your turn ends.",
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."

--- a/cards/en/xy9.json
+++ b/cards/en/xy9.json
@@ -73,7 +73,8 @@
     ],
     "evolvesFrom": "Chikorita",
     "evolvesTo": [
-      "Meganium"
+      "Meganium",
+      "Meganium ex"
     ],
     "attacks": [
       {
@@ -355,7 +356,8 @@
       "Grass"
     ],
     "evolvesTo": [
-      "Lilligant"
+      "Lilligant",
+      "Hisuian Lilligant"
     ],
     "attacks": [
       {
@@ -523,7 +525,9 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Arcanine"
+      "Arcanine",
+      "Light Arcanine",
+      "Arcanine ex"
     ],
     "attacks": [
       {
@@ -576,6 +580,9 @@
       "Fire"
     ],
     "evolvesFrom": "Growlithe",
+    "evolvesTo": [
+      "Arcanine BREAK"
+    ],
     "attacks": [
       {
         "name": "Flop",
@@ -637,7 +644,8 @@
       "Fire"
     ],
     "evolvesTo": [
-      "Camerupt"
+      "Camerupt",
+      "Camerupt ex"
     ],
     "attacks": [
       {
@@ -891,7 +899,9 @@
       "Water"
     ],
     "evolvesTo": [
-      "Golduck"
+      "Golduck",
+      "Dark Golduck",
+      "Light Golduck"
     ],
     "attacks": [
       {
@@ -943,6 +953,9 @@
       "Water"
     ],
     "evolvesFrom": "Psyduck",
+    "evolvesTo": [
+      "Golduck BREAK"
+    ],
     "attacks": [
       {
         "name": "Derail",
@@ -1041,7 +1054,11 @@
     ],
     "evolvesTo": [
       "Slowbro",
-      "Slowking"
+      "Slowking",
+      "Dark Slowbro",
+      "Dark Slowking",
+      "Light Slowbro",
+      "Slowking ex"
     ],
     "attacks": [
       {
@@ -1387,7 +1404,8 @@
       "Water"
     ],
     "evolvesTo": [
-      "Starmie"
+      "Starmie",
+      "Starmie-GX"
     ],
     "attacks": [
       {
@@ -1618,9 +1636,6 @@
     "hp": "80",
     "types": [
       "Water"
-    ],
-    "evolvesTo": [
-      "Cursola"
     ],
     "attacks": [
       {
@@ -2225,7 +2240,9 @@
     ],
     "evolvesFrom": "Froakie",
     "evolvesTo": [
-      "Greninja"
+      "Greninja",
+      "Greninja-GX",
+      "Greninja ex"
     ],
     "attacks": [
       {
@@ -2276,6 +2293,9 @@
       "Water"
     ],
     "evolvesFrom": "Frogadier",
+    "evolvesTo": [
+      "Greninja BREAK"
+    ],
     "attacks": [
       {
         "name": "Shadow Stitching",
@@ -2420,6 +2440,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Electabuzz",
+    "evolvesTo": [
+      "Electivire LV.X"
+    ],
     "attacks": [
       {
         "name": "Knuckle Punch",
@@ -2617,6 +2640,9 @@
       "Lightning"
     ],
     "evolvesFrom": "Luxio",
+    "evolvesTo": [
+      "Luxray BREAK"
+    ],
     "attacks": [
       {
         "name": "Bite",
@@ -2848,7 +2874,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Hypno"
+      "Hypno",
+      "Dark Hypno"
     ],
     "attacks": [
       {
@@ -3083,6 +3110,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Skorupi",
+    "evolvesTo": [
+      "Drapion LV.X"
+    ],
     "attacks": [
       {
         "name": "Poison Claws",
@@ -3495,7 +3525,8 @@
     ],
     "evolvesFrom": "Honedge",
     "evolvesTo": [
-      "Aegislash"
+      "Aegislash",
+      "Aegislash ex"
     ],
     "attacks": [
       {
@@ -3734,6 +3765,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Phantump",
+    "evolvesTo": [
+      "Trevenant BREAK"
+    ],
     "abilities": [
       {
         "name": "Nervous Seed",
@@ -3944,7 +3978,8 @@
     ],
     "evolvesFrom": "Gible",
     "evolvesTo": [
-      "Garchomp"
+      "Garchomp",
+      "Garchomp ex"
     ],
     "attacks": [
       {
@@ -3995,6 +4030,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Gabite",
+    "evolvesTo": [
+      "Garchomp LV.X"
+    ],
     "attacks": [
       {
         "name": "Turbo Assault",
@@ -4113,7 +4151,9 @@
     ],
     "evolvesFrom": "Seedot",
     "evolvesTo": [
-      "Shiftry"
+      "Shiftry",
+      "Shiftry ex",
+      "Shiftry-GX"
     ],
     "attacks": [
       {
@@ -4710,7 +4750,8 @@
       "Fairy"
     ],
     "evolvesTo": [
-      "Clefable"
+      "Clefable",
+      "Clefable ex"
     ],
     "attacks": [
       {
@@ -5094,7 +5135,8 @@
       "Colorless"
     ],
     "evolvesTo": [
-      "Raticate"
+      "Raticate",
+      "Dark Raticate"
     ],
     "attacks": [
       {
@@ -5145,6 +5187,9 @@
       "Colorless"
     ],
     "evolvesFrom": "Rattata",
+    "evolvesTo": [
+      "Raticate BREAK"
+    ],
     "abilities": [
       {
         "name": "Antibodies",
@@ -5238,6 +5283,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Dudunsparce"
+    ],
     "attacks": [
       {
         "name": "Call for Family",
@@ -5294,6 +5342,9 @@
     "hp": "90",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Wyrdeer"
     ],
     "attacks": [
       {

--- a/cards/en/xyp.json
+++ b/cards/en/xyp.json
@@ -8643,7 +8643,7 @@
     "types": [
       "Fairy"
     ],
-    "evolvesFrom": "Flabebe",
+    "evolvesFrom": "Flabébé",
     "evolvesTo": [
       "Florges"
     ],

--- a/cards/en/xyp.json
+++ b/cards/en/xyp.json
@@ -259,6 +259,9 @@
     "types": [
       "Fairy"
     ],
+    "evolvesTo": [
+      "Xerneas BREAK"
+    ],
     "attacks": [
       {
         "name": "Geomancy",
@@ -324,6 +327,9 @@
     "hp": "130",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Yveltal BREAK"
     ],
     "attacks": [
       {
@@ -780,6 +786,10 @@
       "Fighting"
     ],
     "evolvesFrom": "Machoke",
+    "evolvesTo": [
+      "Machamp LV.X",
+      "Machamp BREAK"
+    ],
     "abilities": [
       {
         "name": "Fighting Fury",
@@ -839,6 +849,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Phantump",
+    "evolvesTo": [
+      "Trevenant BREAK"
+    ],
     "attacks": [
       {
         "name": "Eerie Wave",
@@ -1301,6 +1314,9 @@
       "Metal"
     ],
     "evolvesFrom": "Bronzor",
+    "evolvesTo": [
+      "Bronzong BREAK"
+    ],
     "abilities": [
       {
         "name": "Metal Links",
@@ -1365,6 +1381,9 @@
     "hp": "120",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Darkrai LV.X"
     ],
     "attacks": [
       {
@@ -1494,6 +1513,9 @@
       "Darkness"
     ],
     "evolvesFrom": "Frogadier",
+    "evolvesTo": [
+      "Greninja BREAK"
+    ],
     "abilities": [
       {
         "name": "Mist Concealment",
@@ -1630,6 +1652,9 @@
       "Fire"
     ],
     "evolvesFrom": "Litleo",
+    "evolvesTo": [
+      "Pyroar BREAK"
+    ],
     "attacks": [
       {
         "name": "Crunch",
@@ -1921,6 +1946,9 @@
     "types": [
       "Fairy"
     ],
+    "evolvesTo": [
+      "Xerneas BREAK"
+    ],
     "attacks": [
       {
         "name": "Aurora Gain",
@@ -1989,6 +2017,9 @@
     "hp": "130",
     "types": [
       "Darkness"
+    ],
+    "evolvesTo": [
+      "Yveltal BREAK"
     ],
     "attacks": [
       {
@@ -2507,6 +2538,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Primal Kyogre-EX"
+    ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -2573,6 +2607,9 @@
     "hp": "180",
     "types": [
       "Fighting"
+    ],
+    "evolvesTo": [
+      "Primal Groudon-EX"
     ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
@@ -3693,6 +3730,9 @@
       "Dragon"
     ],
     "evolvesFrom": "Shelgon",
+    "evolvesTo": [
+      "Salamence LV.X"
+    ],
     "ancientTrait": {
       "name": "Δ Evolution",
       "text": "You may play this card from your hand to evolve a Pokémon during your first turn or the turn you play that Pokémon."
@@ -4344,6 +4384,9 @@
       "Grass"
     ],
     "evolvesFrom": "Quilladin",
+    "evolvesTo": [
+      "Chesnaught BREAK"
+    ],
     "attacks": [
       {
         "name": "Spike Lariat",
@@ -4804,6 +4847,9 @@
     "types": [
       "Water"
     ],
+    "evolvesTo": [
+      "Palkia LV.X"
+    ],
     "attacks": [
       {
         "name": "Wave Splash",
@@ -4933,6 +4979,9 @@
     "hp": "120",
     "types": [
       "Metal"
+    ],
+    "evolvesTo": [
+      "Dialga LV.X"
     ],
     "attacks": [
       {
@@ -5249,6 +5298,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Regigigas LV.X"
+    ],
     "abilities": [
       {
         "name": "Earthen Awakening",
@@ -5310,6 +5362,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Arceus LV.X"
+    ],
     "attacks": [
       {
         "name": "Gather Light",
@@ -5370,9 +5425,6 @@
     "hp": "130",
     "types": [
       "Lightning"
-    ],
-    "evolvesTo": [
-      "Raichu"
     ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
@@ -5673,7 +5725,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -5939,6 +5995,9 @@
       "Psychic"
     ],
     "evolvesFrom": "Phantump",
+    "evolvesTo": [
+      "Trevenant BREAK"
+    ],
     "abilities": [
       {
         "name": "Nervous Seed",
@@ -6005,7 +6064,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {
@@ -6296,6 +6359,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Mewtwo LV.X"
+    ],
     "attacks": [
       {
         "name": "Psy Bolt",
@@ -6357,6 +6423,9 @@
     "hp": "120",
     "types": [
       "Psychic"
+    ],
+    "evolvesTo": [
+      "Mewtwo LV.X"
     ],
     "attacks": [
       {
@@ -7144,6 +7213,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Darkrai LV.X"
+    ],
     "attacks": [
       {
         "name": "Dark Cutter",
@@ -7211,6 +7283,9 @@
     "types": [
       "Grass"
     ],
+    "evolvesTo": [
+      "Shaymin LV.X"
+    ],
     "attacks": [
       {
         "name": "Aromatherapy",
@@ -7270,6 +7345,9 @@
     "hp": "130",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Arceus LV.X"
     ],
     "attacks": [
       {
@@ -7781,9 +7859,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesTo": [
-      "Raichu"
-    ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -8287,7 +8362,8 @@
       "Psychic"
     ],
     "evolvesTo": [
-      "Haunter"
+      "Haunter",
+      "Dark Haunter"
     ],
     "attacks": [
       {
@@ -8712,6 +8788,9 @@
       "Fighting"
     ],
     "evolvesFrom": "Riolu",
+    "evolvesTo": [
+      "Lucario LV.X"
+    ],
     "attacks": [
       {
         "name": "Bone Rush",
@@ -8834,6 +8913,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Azelf LV.X"
+    ],
     "attacks": [
       {
         "name": "Shining Eyes",
@@ -8894,7 +8976,10 @@
       "Water"
     ],
     "evolvesTo": [
-      "Gyarados"
+      "Gyarados",
+      "Dark Gyarados",
+      "Gyarados ex",
+      "Gyarados-GX"
     ],
     "attacks": [
       {
@@ -8945,6 +9030,9 @@
       "Grass"
     ],
     "evolvesFrom": "Yanma",
+    "evolvesTo": [
+      "Yanmega BREAK"
+    ],
     "abilities": [
       {
         "name": "Sonic Vision",
@@ -9065,6 +9153,9 @@
       "Water"
     ],
     "evolvesFrom": "Clauncher",
+    "evolvesTo": [
+      "Clawitzer BREAK"
+    ],
     "abilities": [
       {
         "name": "Mega Boost",
@@ -9591,6 +9682,9 @@
     "types": [
       "Fire"
     ],
+    "evolvesTo": [
+      "Ho-Oh BREAK"
+    ],
     "attacks": [
       {
         "name": "Stoke",
@@ -9744,6 +9838,9 @@
     "hp": "120",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Lugia BREAK"
     ],
     "attacks": [
       {
@@ -10078,6 +10175,9 @@
       "Water"
     ],
     "evolvesFrom": "Frogadier",
+    "evolvesTo": [
+      "Greninja BREAK"
+    ],
     "attacks": [
       {
         "name": "Aqua Shower",
@@ -10741,9 +10841,6 @@
     "types": [
       "Lightning"
     ],
-    "evolvesTo": [
-      "Raichu"
-    ],
     "rules": [
       "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
     ],
@@ -11011,6 +11108,9 @@
     "types": [
       "Colorless"
     ],
+    "evolvesTo": [
+      "Snorlax LV.X"
+    ],
     "abilities": [
       {
         "name": "Immunity",
@@ -11266,6 +11366,9 @@
     "types": [
       "Psychic"
     ],
+    "evolvesTo": [
+      "Giratina LV.X"
+    ],
     "abilities": [
       {
         "name": "Devour Light",
@@ -11515,6 +11618,9 @@
     "hp": "70",
     "types": [
       "Grass"
+    ],
+    "evolvesTo": [
+      "Shaymin LV.X"
     ],
     "attacks": [
       {
@@ -11866,6 +11972,9 @@
     "types": [
       "Darkness"
     ],
+    "evolvesTo": [
+      "Darkrai LV.X"
+    ],
     "attacks": [
       {
         "name": "Dark Cutter",
@@ -12063,6 +12172,9 @@
     "hp": "130",
     "types": [
       "Colorless"
+    ],
+    "evolvesTo": [
+      "Arceus LV.X"
     ],
     "attacks": [
       {
@@ -12395,7 +12507,11 @@
       "Lightning"
     ],
     "evolvesTo": [
-      "Raichu"
+      "Raichu",
+      "Dark Raichu",
+      "Raichu ex",
+      "Alolan Raichu",
+      "Raichu-GX"
     ],
     "attacks": [
       {


### PR DESCRIPTION
A card named "X" or "X δ" now has "Y" into its "evolvesTo" if and only if one of the following conditions is met:

- There is a card named "Y" or "Y δ" that has "evolvesFrom" equal to "X"
- The card named "X" has the "Baby" subtype, and "Y" was in the "evolvesTo" before this pull request
- "X" is either "Chansey" or "Chansey ex", and "Y" is "Blissey ex" (see #335)
- "X" is either "Scyther" or "Scyther ex", and "Y" is "Scizor ex" (again, see #335)

This pull request includes commits from #473 (which has not been merged yet) because a few evolvesFrom were fixed in that pr.

A few things to note:

- Antique Old Amber (id:sv3pt5-154) does not have "Aerodactyl ex" in its "evolvesTo", despite it being printed on the card that it can evolve into it. It was [ruled](https://compendium.pokegym.net/ruling/1917/) that that card cannot evolve into the old Aerodactyl ex, and no new ones have been released yet
- Level X Pokémon had "evolvesFrom" set to their previous level. I left that as it is, even though it is not technically an evolution
- Restored Pokémon had "evolvesFrom" set to the card needed to put them into play. I left that as it is, even though it is not technically an evolution
- I think Machamp Lv.X can technically evolve into Machamp BREAK, but this pr does not reflect that