### PR TITLE
Fixed text for FFI Herbal Energy

### DIFF
--- a/cards/en/xy3.json
+++ b/cards/en/xy3.json
@@ -5793,7 +5793,9 @@
       "Special"
     ],
     "rules": [
-      "You can only attach this card to a Grass Pokémon. This card provides Grass Energy. When you play this card from your hand, heal 30 damage from the Grass Pokémon you attach this card to. Discard this card if the Pokémon this card is attached to is no longer Grass."
+      "This card can only be attached to Grass Pokémon. This card provides Grass Energy only while this card is attached to a Grass Pokémon.",
+      "When you attach this card from your hand to 1 of your Grass Pokémon, heal 30 damage from that Pokémon.",
+      "(If this card is attached to anything other than a Grass Pokémon, discard this card.)"
     ],
     "number": "103",
     "artist": "5ban Graphics",


### PR DESCRIPTION
The original text came from an early translation, before this card was even released in English. Therefore, it doesn't match what's printed on the card.