### PR TITLE
Fixed missing empty attack texts for consistency

### DIFF
--- a/cards/en/sv3pt5.json
+++ b/cards/en/sv3pt5.json
@@ -89,7 +89,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -220,7 +220,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -274,7 +274,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": null
+        "text": ""
       },
       {
         "name": "Fire Blast",
@@ -416,7 +416,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -480,7 +480,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -652,7 +652,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": null
+        "text": ""
       },
       {
         "name": "Defensive Posture",
@@ -778,7 +778,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": null
+        "text": ""
       },
       {
         "name": "Bug Bite",
@@ -788,7 +788,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -850,7 +850,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -914,7 +914,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "110",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -977,7 +977,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -1037,7 +1037,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -1090,7 +1090,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "40",
-        "text": null
+        "text": ""
       },
       {
         "name": "Fly",
@@ -1265,7 +1265,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -1331,7 +1331,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "50",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -1519,7 +1519,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -1640,7 +1640,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -1821,7 +1821,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -1885,7 +1885,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "160",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -1940,7 +1940,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -1994,7 +1994,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": null
+        "text": ""
       },
       {
         "name": "Superpowered Horns",
@@ -2005,7 +2005,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -2132,7 +2132,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -2502,7 +2502,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -2622,7 +2622,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -2685,7 +2685,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -2745,7 +2745,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -2799,7 +2799,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": null
+        "text": ""
       },
       {
         "name": "Spore Ball",
@@ -2871,7 +2871,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -2925,7 +2925,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": null
+        "text": ""
       },
       {
         "name": "Beam",
@@ -2936,7 +2936,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -2999,7 +2999,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -3052,7 +3052,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": null
+        "text": ""
       },
       {
         "name": "Mud-Slap",
@@ -3062,7 +3062,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -3113,7 +3113,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "40",
-        "text": null
+        "text": ""
       },
       {
         "name": "Mud Bomb",
@@ -3123,7 +3123,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "80",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -3186,7 +3186,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -3246,7 +3246,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -3308,7 +3308,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -3370,7 +3370,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "120",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -3714,7 +3714,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": null
+        "text": ""
       },
       {
         "name": "Frog Hop",
@@ -3840,7 +3840,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -4040,7 +4040,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -4210,7 +4210,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": null
+        "text": ""
       },
       {
         "name": "Bind Down",
@@ -4274,7 +4274,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": null
+        "text": ""
       },
       {
         "name": "Spray Fluid",
@@ -4284,7 +4284,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -4336,7 +4336,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "50",
-        "text": null
+        "text": ""
       },
       {
         "name": "Slow-Acting Acid",
@@ -4401,7 +4401,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": null
+        "text": ""
       },
       {
         "name": "Watering",
@@ -4411,7 +4411,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -4538,7 +4538,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -4604,7 +4604,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -4738,7 +4738,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "30",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -4864,7 +4864,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -4993,7 +4993,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": null
+        "text": ""
       },
       {
         "name": "Big Explosion",
@@ -5068,7 +5068,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "60",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -5131,7 +5131,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -5313,7 +5313,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -5377,7 +5377,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -5495,7 +5495,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "180",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -5660,7 +5660,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -5728,7 +5728,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -5863,7 +5863,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "100",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -5920,7 +5920,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -5987,7 +5987,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "110",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -6058,7 +6058,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -6123,7 +6123,7 @@
         ],
         "convertedEnergyCost": 4,
         "damage": "220",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -6239,7 +6239,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "70",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -6356,7 +6356,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "130",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -6541,7 +6541,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "100",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -6837,7 +6837,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -6894,7 +6894,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": null
+        "text": ""
       },
       {
         "name": "Charismatic Drill",
@@ -6970,7 +6970,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -7143,7 +7143,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": null
+        "text": ""
       },
       {
         "name": "Sharp Fin",
@@ -7154,7 +7154,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "40",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -7273,7 +7273,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -7449,7 +7449,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -7576,7 +7576,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "70",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -7702,7 +7702,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -7756,7 +7756,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": null
+        "text": ""
       },
       {
         "name": "Flare Combo",
@@ -7819,7 +7819,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": null
+        "text": ""
       },
       {
         "name": "Reckless Throw",
@@ -8070,7 +8070,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "90",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -8127,7 +8127,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -8196,7 +8196,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -8718,7 +8718,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": null
+        "text": ""
       },
       {
         "name": "Devolution Ray",
@@ -9046,7 +9046,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": null
+        "text": ""
       },
       {
         "name": "Draconic Whip",
@@ -9056,7 +9056,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "40",
-        "text": null
+        "text": ""
       }
     ],
     "retreatCost": [
@@ -9104,7 +9104,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": null
+        "text": ""
       },
       {
         "name": "Aqua Slash",
@@ -9792,7 +9792,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "80",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -9857,7 +9857,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -9911,7 +9911,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": null
+        "text": ""
       },
       {
         "name": "Fire Blast",
@@ -9986,7 +9986,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "20",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -10050,7 +10050,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "50",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -10168,7 +10168,7 @@
         ],
         "convertedEnergyCost": 3,
         "damage": "50",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -10293,7 +10293,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "10",
-        "text": null
+        "text": ""
       }
     ],
     "weaknesses": [
@@ -10348,7 +10348,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": null
+        "text": ""
       },
       {
         "name": "Frog Hop",
@@ -10641,7 +10641,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "20",
-        "text": null
+        "text": ""
       },
       {
         "name": "Aqua Slash",

--- a/cards/en/svp.json
+++ b/cards/en/svp.json
@@ -865,7 +865,8 @@
           "Lightning"
         ],
         "convertedEnergyCost": 1,
-        "damage": "30"
+        "damage": "30",
+        "text": ""
       },
       {
         "name": "Extreme Current",
@@ -931,7 +932,8 @@
           "Lightning"
         ],
         "convertedEnergyCost": 1,
-        "damage": "60"
+        "damage": "60",
+        "text": ""
       },
       {
         "name": "Thunderstrike Tail",
@@ -997,7 +999,8 @@
           "Colorless"
         ],
         "convertedEnergyCost": 2,
-        "damage": "60"
+        "damage": "60",
+        "text": ""
       },
       {
         "name": "Aura Sphere",


### PR DESCRIPTION
Most attacks with no text had `"text": ""`. The only exceptions were attacks in `sv3pt5` that had `"text": null`, and a few in `svp` that had no `"text"`