### PR TITLE
Added ptcgoCode to sve, sv3pt5, sv4

### DIFF
--- a/sets/en.json
+++ b/sets/en.json
@@ -2655,6 +2655,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "ptcgoCode": "SVE",
     "releaseDate": "2023/03/31",
     "updatedAt": "2023/07/20 15:45:00",
     "images": {
@@ -2727,6 +2728,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "ptcgoCode": "MEW",
     "releaseDate": "2023/09/22",
     "updatedAt": "2023/09/22 15:00:00",
     "images": {
@@ -2745,6 +2747,7 @@
       "standard": "Legal",
       "expanded": "Legal"
     },
+    "ptcgoCode": "PAR",
     "releaseDate": "2023/11/03",
     "updatedAt": "2023/11/03 15:00:00",
     "images": {


### PR DESCRIPTION
By popular demand I added the set codes SVE, MEW and PAR to those sets as ptcgoCode. Set codes for sv1, sv2, sv3 are added in #476