### PR TITLE
Fixed typo in poké-body of ex11-33

### DIFF
--- a/cards/en/ex11.json
+++ b/cards/en/ex11.json
@@ -2057,7 +2057,7 @@
     "abilities": [
       {
         "name": "Body Odor",
-        "text": "As long as Weezing is the Active Pokémon, put 1 counter on each of your opponent's Pokémon that has any Poké-Bodies between turns.",
+        "text": "As long as Weezing is the Active Pokémon, put 1 damage counter on each of your opponent's Pokémon that has any Poké-Bodies between turns.",
         "type": "Poké-Body"
       }
     ],


### PR DESCRIPTION
It said "counter" instead of "damage counter"