### PR TITLE
Changed delta species to subtype

### DIFF
--- a/cards/en/cel25c.json
+++ b/cards/en/cel25c.json
@@ -713,11 +713,12 @@
   },
   {
     "id": "cel25c-93_A",
-    "name": "Gardevoir ex δ",
+    "name": "Gardevoir ex",
     "supertype": "Pokémon",
     "subtypes": [
       "Stage 2",
-      "ex"
+      "ex",
+      "DELTA SPECIES"
     ],
     "hp": "150",
     "types": [

--- a/cards/en/ex11.json
+++ b/cards/en/ex11.json
@@ -1,10 +1,11 @@
 [
   {
     "id": "ex11-1",
-    "name": "Beedrill δ",
+    "name": "Beedrill",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "DELTA SPECIES"
     ],
     "hp": "90",
     "types": [
@@ -57,10 +58,11 @@
   },
   {
     "id": "ex11-2",
-    "name": "Crobat δ",
+    "name": "Crobat",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "DELTA SPECIES"
     ],
     "hp": "90",
     "types": [
@@ -116,10 +118,11 @@
   },
   {
     "id": "ex11-3",
-    "name": "Dragonite δ",
+    "name": "Dragonite",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "DELTA SPECIES"
     ],
     "hp": "100",
     "types": [
@@ -198,10 +201,11 @@
   },
   {
     "id": "ex11-4",
-    "name": "Espeon δ",
+    "name": "Espeon",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -257,10 +261,11 @@
   },
   {
     "id": "ex11-5",
-    "name": "Flareon δ",
+    "name": "Flareon",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -319,10 +324,11 @@
   },
   {
     "id": "ex11-6",
-    "name": "Gardevoir δ",
+    "name": "Gardevoir",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "DELTA SPECIES"
     ],
     "hp": "100",
     "types": [
@@ -390,10 +396,11 @@
   },
   {
     "id": "ex11-7",
-    "name": "Jolteon δ",
+    "name": "Jolteon",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -458,10 +465,11 @@
   },
   {
     "id": "ex11-8",
-    "name": "Latias δ",
+    "name": "Latias",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -539,10 +547,11 @@
   },
   {
     "id": "ex11-9",
-    "name": "Latios δ",
+    "name": "Latios",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "80",
     "types": [
@@ -621,10 +630,11 @@
   },
   {
     "id": "ex11-10",
-    "name": "Marowak δ",
+    "name": "Marowak",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "80",
     "types": [
@@ -684,10 +694,11 @@
   },
   {
     "id": "ex11-11",
-    "name": "Metagross δ",
+    "name": "Metagross",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "DELTA SPECIES"
     ],
     "hp": "100",
     "types": [
@@ -751,10 +762,11 @@
   },
   {
     "id": "ex11-12",
-    "name": "Mewtwo δ",
+    "name": "Mewtwo",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -809,10 +821,11 @@
   },
   {
     "id": "ex11-13",
-    "name": "Rayquaza δ",
+    "name": "Rayquaza",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "90",
     "types": [
@@ -890,10 +903,11 @@
   },
   {
     "id": "ex11-14",
-    "name": "Salamence δ",
+    "name": "Salamence",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "DELTA SPECIES"
     ],
     "hp": "110",
     "types": [
@@ -964,10 +978,11 @@
   },
   {
     "id": "ex11-15",
-    "name": "Starmie δ",
+    "name": "Starmie",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "60",
     "types": [
@@ -1027,10 +1042,11 @@
   },
   {
     "id": "ex11-16",
-    "name": "Tyranitar δ",
+    "name": "Tyranitar",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "DELTA SPECIES"
     ],
     "hp": "120",
     "types": [
@@ -1088,10 +1104,11 @@
   },
   {
     "id": "ex11-17",
-    "name": "Umbreon δ",
+    "name": "Umbreon",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -1153,10 +1170,11 @@
   },
   {
     "id": "ex11-18",
-    "name": "Vaporeon δ",
+    "name": "Vaporeon",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -1215,10 +1233,11 @@
   },
   {
     "id": "ex11-19",
-    "name": "Azumarill δ",
+    "name": "Azumarill",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "80",
     "types": [
@@ -1506,10 +1525,11 @@
   },
   {
     "id": "ex11-24",
-    "name": "Mightyena δ",
+    "name": "Mightyena",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -1687,10 +1707,11 @@
   },
   {
     "id": "ex11-27",
-    "name": "Sandslash δ",
+    "name": "Sandslash",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "80",
     "types": [
@@ -1867,10 +1888,11 @@
   },
   {
     "id": "ex11-30",
-    "name": "Starmie δ",
+    "name": "Starmie",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -2485,10 +2507,11 @@
   },
   {
     "id": "ex11-41",
-    "name": "Dragonair δ",
+    "name": "Dragonair",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -2557,10 +2580,11 @@
   },
   {
     "id": "ex11-42",
-    "name": "Dragonair δ",
+    "name": "Dragonair",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -2999,10 +3023,11 @@
   },
   {
     "id": "ex11-49",
-    "name": "Metang δ",
+    "name": "Metang",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "80",
     "types": [
@@ -3123,10 +3148,11 @@
   },
   {
     "id": "ex11-51",
-    "name": "Pupitar δ",
+    "name": "Pupitar",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -3233,10 +3259,11 @@
   },
   {
     "id": "ex11-53",
-    "name": "Shelgon δ",
+    "name": "Shelgon",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "80",
     "types": [
@@ -3305,10 +3332,11 @@
   },
   {
     "id": "ex11-54",
-    "name": "Shelgon δ",
+    "name": "Shelgon",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -3497,10 +3525,11 @@
   },
   {
     "id": "ex11-57",
-    "name": "Bagon δ",
+    "name": "Bagon",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "50",
     "types": [
@@ -3556,10 +3585,11 @@
   },
   {
     "id": "ex11-58",
-    "name": "Bagon δ",
+    "name": "Bagon",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "50",
     "types": [
@@ -3616,10 +3646,11 @@
   },
   {
     "id": "ex11-59",
-    "name": "Beldum δ",
+    "name": "Beldum",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "50",
     "types": [
@@ -3954,10 +3985,11 @@
   },
   {
     "id": "ex11-65",
-    "name": "Dratini δ",
+    "name": "Dratini",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "50",
     "types": [
@@ -4023,10 +4055,11 @@
   },
   {
     "id": "ex11-66",
-    "name": "Dratini δ",
+    "name": "Dratini",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "50",
     "types": [
@@ -4141,10 +4174,11 @@
   },
   {
     "id": "ex11-68",
-    "name": "Eevee δ",
+    "name": "Eevee",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "50",
     "types": [
@@ -4432,10 +4466,11 @@
   },
   {
     "id": "ex11-73",
-    "name": "Larvitar δ",
+    "name": "Larvitar",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "50",
     "types": [

--- a/cards/en/ex12.json
+++ b/cards/en/ex12.json
@@ -5325,10 +5325,11 @@
   },
   {
     "id": "ex12-93",
-    "name": "Pikachu δ",
+    "name": "Pikachu",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [

--- a/cards/en/ex13.json
+++ b/cards/en/ex13.json
@@ -1,10 +1,11 @@
 [
   {
     "id": "ex13-1",
-    "name": "Armaldo δ",
+    "name": "Armaldo",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "DELTA SPECIES"
     ],
     "hp": "110",
     "types": [
@@ -66,10 +67,11 @@
   },
   {
     "id": "ex13-2",
-    "name": "Cradily δ",
+    "name": "Cradily",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "DELTA SPECIES"
     ],
     "hp": "100",
     "types": [
@@ -130,10 +132,11 @@
   },
   {
     "id": "ex13-3",
-    "name": "Deoxys δ",
+    "name": "Deoxys",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -185,10 +188,11 @@
   },
   {
     "id": "ex13-4",
-    "name": "Deoxys δ",
+    "name": "Deoxys",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "80",
     "types": [
@@ -240,10 +244,11 @@
   },
   {
     "id": "ex13-5",
-    "name": "Deoxys δ",
+    "name": "Deoxys",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -294,10 +299,11 @@
   },
   {
     "id": "ex13-6",
-    "name": "Deoxys δ",
+    "name": "Deoxys",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "60",
     "types": [
@@ -347,10 +353,11 @@
   },
   {
     "id": "ex13-7",
-    "name": "Flygon δ",
+    "name": "Flygon",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "DELTA SPECIES"
     ],
     "hp": "110",
     "types": [
@@ -418,10 +425,11 @@
   },
   {
     "id": "ex13-8",
-    "name": "Gyarados δ",
+    "name": "Gyarados",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "90",
     "types": [
@@ -491,10 +499,11 @@
   },
   {
     "id": "ex13-9",
-    "name": "Kabutops δ",
+    "name": "Kabutops",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "DELTA SPECIES"
     ],
     "hp": "100",
     "types": [
@@ -550,10 +559,11 @@
   },
   {
     "id": "ex13-10",
-    "name": "Kingdra δ",
+    "name": "Kingdra",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "DELTA SPECIES"
     ],
     "hp": "110",
     "types": [
@@ -622,10 +632,11 @@
   },
   {
     "id": "ex13-11",
-    "name": "Latias δ",
+    "name": "Latias",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -696,10 +707,11 @@
   },
   {
     "id": "ex13-12",
-    "name": "Latios δ",
+    "name": "Latios",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "80",
     "types": [
@@ -770,10 +782,11 @@
   },
   {
     "id": "ex13-13",
-    "name": "Omastar δ",
+    "name": "Omastar",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "DELTA SPECIES"
     ],
     "hp": "110",
     "types": [
@@ -830,10 +843,11 @@
   },
   {
     "id": "ex13-14",
-    "name": "Pidgeot δ",
+    "name": "Pidgeot",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "DELTA SPECIES"
     ],
     "hp": "100",
     "types": [
@@ -896,10 +910,11 @@
   },
   {
     "id": "ex13-15",
-    "name": "Raichu δ",
+    "name": "Raichu",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -950,10 +965,11 @@
   },
   {
     "id": "ex13-16",
-    "name": "Rayquaza δ",
+    "name": "Rayquaza",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "80",
     "types": [
@@ -1030,10 +1046,11 @@
   },
   {
     "id": "ex13-17",
-    "name": "Vileplume δ",
+    "name": "Vileplume",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "DELTA SPECIES"
     ],
     "hp": "90",
     "types": [
@@ -1151,10 +1168,11 @@
   },
   {
     "id": "ex13-19",
-    "name": "Bellossom δ",
+    "name": "Bellossom",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "DELTA SPECIES"
     ],
     "hp": "100",
     "types": [
@@ -1271,10 +1289,11 @@
   },
   {
     "id": "ex13-21",
-    "name": "Latias δ",
+    "name": "Latias",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -1339,10 +1358,11 @@
   },
   {
     "id": "ex13-22",
-    "name": "Latios δ",
+    "name": "Latios",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "80",
     "types": [
@@ -1470,10 +1490,11 @@
   },
   {
     "id": "ex13-24",
-    "name": "Mewtwo δ",
+    "name": "Mewtwo",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -1586,10 +1607,11 @@
   },
   {
     "id": "ex13-26",
-    "name": "Rayquaza δ",
+    "name": "Rayquaza",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "80",
     "types": [
@@ -2100,10 +2122,11 @@
   },
   {
     "id": "ex13-35",
-    "name": "Aerodactyl δ",
+    "name": "Aerodactyl",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -2217,10 +2240,11 @@
   },
   {
     "id": "ex13-37",
-    "name": "Chimecho δ",
+    "name": "Chimecho",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "60",
     "types": [
@@ -2449,10 +2473,11 @@
   },
   {
     "id": "ex13-41",
-    "name": "Exeggutor δ",
+    "name": "Exeggutor",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "80",
     "types": [
@@ -2508,10 +2533,11 @@
   },
   {
     "id": "ex13-42",
-    "name": "Gloom δ",
+    "name": "Gloom",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -2569,10 +2595,11 @@
   },
   {
     "id": "ex13-43",
-    "name": "Golduck δ",
+    "name": "Golduck",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -2859,10 +2886,11 @@
   },
   {
     "id": "ex13-48",
-    "name": "Persian δ",
+    "name": "Persian",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -2917,10 +2945,11 @@
   },
   {
     "id": "ex13-49",
-    "name": "Pidgeotto δ",
+    "name": "Pidgeotto",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -2974,10 +3003,11 @@
   },
   {
     "id": "ex13-50",
-    "name": "Primeape δ",
+    "name": "Primeape",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -3088,10 +3118,11 @@
   },
   {
     "id": "ex13-52",
-    "name": "Seadra δ",
+    "name": "Seadra",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -3150,10 +3181,11 @@
   },
   {
     "id": "ex13-53",
-    "name": "Sharpedo δ",
+    "name": "Sharpedo",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -3205,10 +3237,11 @@
   },
   {
     "id": "ex13-54",
-    "name": "Vibrava δ",
+    "name": "Vibrava",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "80",
     "types": [
@@ -3392,10 +3425,11 @@
   },
   {
     "id": "ex13-57",
-    "name": "Anorith δ",
+    "name": "Anorith",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -3635,10 +3669,11 @@
   },
   {
     "id": "ex13-61",
-    "name": "Carvanha δ",
+    "name": "Carvanha",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -3867,10 +3902,11 @@
   },
   {
     "id": "ex13-65",
-    "name": "Exeggcute δ",
+    "name": "Exeggcute",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "50",
     "types": [
@@ -3926,10 +3962,11 @@
   },
   {
     "id": "ex13-66",
-    "name": "Horsea δ",
+    "name": "Horsea",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "50",
     "types": [
@@ -3985,10 +4022,11 @@
   },
   {
     "id": "ex13-67",
-    "name": "Kabuto δ",
+    "name": "Kabuto",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -4046,10 +4084,11 @@
   },
   {
     "id": "ex13-68",
-    "name": "Lileep δ",
+    "name": "Lileep",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "80",
     "types": [
@@ -4107,10 +4146,11 @@
   },
   {
     "id": "ex13-69",
-    "name": "Magikarp δ",
+    "name": "Magikarp",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "30",
     "types": [
@@ -4156,10 +4196,11 @@
   },
   {
     "id": "ex13-70",
-    "name": "Mankey δ",
+    "name": "Mankey",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "50",
     "types": [
@@ -4215,10 +4256,11 @@
   },
   {
     "id": "ex13-71",
-    "name": "Meowth δ",
+    "name": "Meowth",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "50",
     "types": [
@@ -4337,10 +4379,11 @@
   },
   {
     "id": "ex13-73",
-    "name": "Oddish δ",
+    "name": "Oddish",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -4395,10 +4438,11 @@
   },
   {
     "id": "ex13-74",
-    "name": "Omanyte δ",
+    "name": "Omanyte",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -4513,10 +4557,11 @@
   },
   {
     "id": "ex13-76",
-    "name": "Pichu δ",
+    "name": "Pichu",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "50",
     "types": [
@@ -4569,10 +4614,11 @@
   },
   {
     "id": "ex13-77",
-    "name": "Pidgey δ",
+    "name": "Pidgey",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -4683,10 +4729,11 @@
   },
   {
     "id": "ex13-79",
-    "name": "Pikachu δ",
+    "name": "Pikachu",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "50",
     "types": [
@@ -4808,10 +4855,11 @@
   },
   {
     "id": "ex13-81",
-    "name": "Psyduck δ",
+    "name": "Psyduck",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "50",
     "types": [
@@ -4974,10 +5022,11 @@
   },
   {
     "id": "ex13-84",
-    "name": "Trapinch δ",
+    "name": "Trapinch",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "50",
     "types": [
@@ -5563,11 +5612,12 @@
   },
   {
     "id": "ex13-102",
-    "name": "Gyarados ★ δ",
+    "name": "Gyarados ★",
     "supertype": "Pokémon",
     "subtypes": [
       "Basic",
-      "Star"
+      "Star",
+      "DELTA SPECIES"
     ],
     "hp": "80",
     "types": [

--- a/cards/en/ex14.json
+++ b/cards/en/ex14.json
@@ -62,10 +62,11 @@
   },
   {
     "id": "ex14-2",
-    "name": "Blastoise δ",
+    "name": "Blastoise",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "DELTA SPECIES"
     ],
     "hp": "110",
     "types": [
@@ -201,10 +202,11 @@
   },
   {
     "id": "ex14-4",
-    "name": "Charizard δ",
+    "name": "Charizard",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "DELTA SPECIES"
     ],
     "hp": "120",
     "types": [
@@ -329,10 +331,11 @@
   },
   {
     "id": "ex14-6",
-    "name": "Ludicolo δ",
+    "name": "Ludicolo",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "DELTA SPECIES"
     ],
     "hp": "100",
     "types": [
@@ -875,10 +878,11 @@
   },
   {
     "id": "ex14-15",
-    "name": "Cacturne δ",
+    "name": "Cacturne",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "80",
     "types": [
@@ -1075,10 +1079,11 @@
   },
   {
     "id": "ex14-18",
-    "name": "Fearow δ",
+    "name": "Fearow",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "60",
     "types": [
@@ -1136,10 +1141,11 @@
   },
   {
     "id": "ex14-19",
-    "name": "Grovyle δ",
+    "name": "Grovyle",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -1311,10 +1317,11 @@
   },
   {
     "id": "ex14-22",
-    "name": "Kingler δ",
+    "name": "Kingler",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "80",
     "types": [
@@ -1565,10 +1572,11 @@
   },
   {
     "id": "ex14-26",
-    "name": "Pelipper δ",
+    "name": "Pelipper",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -1824,10 +1832,11 @@
   },
   {
     "id": "ex14-30",
-    "name": "Charmeleon δ",
+    "name": "Charmeleon",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -2996,10 +3005,11 @@
   },
   {
     "id": "ex14-49",
-    "name": "Charmander δ",
+    "name": "Charmander",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "50",
     "types": [
@@ -4063,10 +4073,11 @@
   },
   {
     "id": "ex14-68",
-    "name": "Treecko δ",
+    "name": "Treecko",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -5102,11 +5113,12 @@
   },
   {
     "id": "ex14-96",
-    "name": "Sceptile ex δ",
+    "name": "Sceptile ex",
     "supertype": "Pokémon",
     "subtypes": [
       "Stage 2",
-      "ex"
+      "ex",
+      "DELTA SPECIES"
     ],
     "hp": "140",
     "types": [

--- a/cards/en/ex15.json
+++ b/cards/en/ex15.json
@@ -1,10 +1,11 @@
 [
   {
     "id": "ex15-1",
-    "name": "Ampharos δ",
+    "name": "Ampharos",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "DELTA SPECIES"
     ],
     "hp": "120",
     "types": [
@@ -58,10 +59,11 @@
   },
   {
     "id": "ex15-2",
-    "name": "Feraligatr δ",
+    "name": "Feraligatr",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "DELTA SPECIES"
     ],
     "hp": "120",
     "types": [
@@ -125,10 +127,11 @@
   },
   {
     "id": "ex15-3",
-    "name": "Heracross δ",
+    "name": "Heracross",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -188,10 +191,11 @@
   },
   {
     "id": "ex15-4",
-    "name": "Meganium δ",
+    "name": "Meganium",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "DELTA SPECIES"
     ],
     "hp": "110",
     "types": [
@@ -261,10 +265,11 @@
   },
   {
     "id": "ex15-5",
-    "name": "Milotic δ",
+    "name": "Milotic",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "90",
     "types": [
@@ -318,10 +323,11 @@
   },
   {
     "id": "ex15-6",
-    "name": "Nidoking δ",
+    "name": "Nidoking",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "DELTA SPECIES"
     ],
     "hp": "120",
     "types": [
@@ -379,10 +385,11 @@
   },
   {
     "id": "ex15-7",
-    "name": "Nidoqueen δ",
+    "name": "Nidoqueen",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "DELTA SPECIES"
     ],
     "hp": "100",
     "types": [
@@ -436,10 +443,11 @@
   },
   {
     "id": "ex15-8",
-    "name": "Ninetales δ",
+    "name": "Ninetales",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -487,10 +495,11 @@
   },
   {
     "id": "ex15-9",
-    "name": "Pinsir δ",
+    "name": "Pinsir",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "60",
     "types": [
@@ -551,10 +560,11 @@
   },
   {
     "id": "ex15-10",
-    "name": "Snorlax δ",
+    "name": "Snorlax",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "80",
     "types": [
@@ -600,10 +610,11 @@
   },
   {
     "id": "ex15-11",
-    "name": "Togetic δ",
+    "name": "Togetic",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "60",
     "types": [
@@ -663,10 +674,11 @@
   },
   {
     "id": "ex15-12",
-    "name": "Typhlosion δ",
+    "name": "Typhlosion",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 2"
+      "Stage 2",
+      "DELTA SPECIES"
     ],
     "hp": "100",
     "types": [
@@ -719,10 +731,11 @@
   },
   {
     "id": "ex15-13",
-    "name": "Arbok δ",
+    "name": "Arbok",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "80",
     "types": [
@@ -777,10 +790,11 @@
   },
   {
     "id": "ex15-14",
-    "name": "Cloyster δ",
+    "name": "Cloyster",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -831,10 +845,11 @@
   },
   {
     "id": "ex15-15",
-    "name": "Dewgong δ",
+    "name": "Dewgong",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "80",
     "types": [
@@ -898,10 +913,11 @@
   },
   {
     "id": "ex15-16",
-    "name": "Gligar δ",
+    "name": "Gligar",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "60",
     "types": [
@@ -956,10 +972,11 @@
   },
   {
     "id": "ex15-17",
-    "name": "Jynx δ",
+    "name": "Jynx",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "60",
     "types": [
@@ -1010,10 +1027,11 @@
   },
   {
     "id": "ex15-18",
-    "name": "Ledian δ",
+    "name": "Ledian",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -1061,10 +1079,11 @@
   },
   {
     "id": "ex15-19",
-    "name": "Lickitung δ",
+    "name": "Lickitung",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "60",
     "types": [
@@ -1119,10 +1138,11 @@
   },
   {
     "id": "ex15-20",
-    "name": "Mantine δ",
+    "name": "Mantine",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "50",
     "types": [
@@ -1172,10 +1192,11 @@
   },
   {
     "id": "ex15-21",
-    "name": "Quagsire δ",
+    "name": "Quagsire",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "80",
     "types": [
@@ -1228,10 +1249,11 @@
   },
   {
     "id": "ex15-22",
-    "name": "Seadra δ",
+    "name": "Seadra",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -1290,10 +1312,11 @@
   },
   {
     "id": "ex15-23",
-    "name": "Tropius δ",
+    "name": "Tropius",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -1343,10 +1366,11 @@
   },
   {
     "id": "ex15-24",
-    "name": "Vibrava δ",
+    "name": "Vibrava",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -1412,10 +1436,11 @@
   },
   {
     "id": "ex15-25",
-    "name": "Xatu δ",
+    "name": "Xatu",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -1467,10 +1492,11 @@
   },
   {
     "id": "ex15-26",
-    "name": "Bayleef δ",
+    "name": "Bayleef",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -1524,10 +1550,11 @@
   },
   {
     "id": "ex15-27",
-    "name": "Croconaw δ",
+    "name": "Croconaw",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -1585,10 +1612,11 @@
   },
   {
     "id": "ex15-28",
-    "name": "Dragonair δ",
+    "name": "Dragonair",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -1641,10 +1669,11 @@
   },
   {
     "id": "ex15-29",
-    "name": "Electabuzz δ",
+    "name": "Electabuzz",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "60",
     "types": [
@@ -1698,10 +1727,11 @@
   },
   {
     "id": "ex15-30",
-    "name": "Flaaffy δ",
+    "name": "Flaaffy",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -1749,10 +1779,11 @@
   },
   {
     "id": "ex15-31",
-    "name": "Horsea δ",
+    "name": "Horsea",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -1871,10 +1902,11 @@
   },
   {
     "id": "ex15-33",
-    "name": "Kirlia δ",
+    "name": "Kirlia",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -1934,10 +1966,11 @@
   },
   {
     "id": "ex15-34",
-    "name": "Nidorina δ",
+    "name": "Nidorina",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -1996,10 +2029,11 @@
   },
   {
     "id": "ex15-35",
-    "name": "Nidorino δ",
+    "name": "Nidorino",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -2058,10 +2092,11 @@
   },
   {
     "id": "ex15-36",
-    "name": "Quilava δ",
+    "name": "Quilava",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -2120,10 +2155,11 @@
   },
   {
     "id": "ex15-37",
-    "name": "Seadra δ",
+    "name": "Seadra",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -2182,10 +2218,11 @@
   },
   {
     "id": "ex15-38",
-    "name": "Shelgon δ",
+    "name": "Shelgon",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -2239,10 +2276,11 @@
   },
   {
     "id": "ex15-39",
-    "name": "Smeargle δ",
+    "name": "Smeargle",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "60",
     "types": [
@@ -2294,10 +2332,11 @@
   },
   {
     "id": "ex15-40",
-    "name": "Swellow δ",
+    "name": "Swellow",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -2351,10 +2390,11 @@
   },
   {
     "id": "ex15-41",
-    "name": "Togepi δ",
+    "name": "Togepi",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -2400,10 +2440,11 @@
   },
   {
     "id": "ex15-42",
-    "name": "Vibrava δ",
+    "name": "Vibrava",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -2454,10 +2495,11 @@
   },
   {
     "id": "ex15-43",
-    "name": "Bagon δ",
+    "name": "Bagon",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -2497,10 +2539,11 @@
   },
   {
     "id": "ex15-44",
-    "name": "Chikorita δ",
+    "name": "Chikorita",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -2562,10 +2605,11 @@
   },
   {
     "id": "ex15-45",
-    "name": "Cyndaquil δ",
+    "name": "Cyndaquil",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -2612,10 +2656,11 @@
   },
   {
     "id": "ex15-46",
-    "name": "Dratini δ",
+    "name": "Dratini",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -2655,10 +2700,11 @@
   },
   {
     "id": "ex15-47",
-    "name": "Ekans δ",
+    "name": "Ekans",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "50",
     "types": [
@@ -2714,10 +2760,11 @@
   },
   {
     "id": "ex15-48",
-    "name": "Elekid δ",
+    "name": "Elekid",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -2770,10 +2817,11 @@
   },
   {
     "id": "ex15-49",
-    "name": "Feebas δ",
+    "name": "Feebas",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "30",
     "types": [
@@ -2819,10 +2867,11 @@
   },
   {
     "id": "ex15-50",
-    "name": "Horsea δ",
+    "name": "Horsea",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -2927,10 +2976,11 @@
   },
   {
     "id": "ex15-52",
-    "name": "Larvitar δ",
+    "name": "Larvitar",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "50",
     "types": [
@@ -2986,10 +3036,11 @@
   },
   {
     "id": "ex15-53",
-    "name": "Ledyba δ",
+    "name": "Ledyba",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -3044,10 +3095,11 @@
   },
   {
     "id": "ex15-54",
-    "name": "Mareep δ",
+    "name": "Mareep",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -3093,10 +3145,11 @@
   },
   {
     "id": "ex15-55",
-    "name": "Natu δ",
+    "name": "Natu",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -3142,10 +3195,11 @@
   },
   {
     "id": "ex15-56",
-    "name": "Nidoran ♀ δ",
+    "name": "Nidoran ♀",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -3200,10 +3254,11 @@
   },
   {
     "id": "ex15-57",
-    "name": "Nidoran ♂ δ",
+    "name": "Nidoran ♂",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -3308,10 +3363,11 @@
   },
   {
     "id": "ex15-59",
-    "name": "Pupitar δ",
+    "name": "Pupitar",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -3417,10 +3473,11 @@
   },
   {
     "id": "ex15-61",
-    "name": "Ralts δ",
+    "name": "Ralts",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "50",
     "types": [
@@ -3476,10 +3533,11 @@
   },
   {
     "id": "ex15-62",
-    "name": "Seel δ",
+    "name": "Seel",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -3535,10 +3593,11 @@
   },
   {
     "id": "ex15-63",
-    "name": "Shellder δ",
+    "name": "Shellder",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -3584,10 +3643,11 @@
   },
   {
     "id": "ex15-64",
-    "name": "Smoochum δ",
+    "name": "Smoochum",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -3640,10 +3700,11 @@
   },
   {
     "id": "ex15-65",
-    "name": "Swablu δ",
+    "name": "Swablu",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -3695,10 +3756,11 @@
   },
   {
     "id": "ex15-66",
-    "name": "Taillow δ",
+    "name": "Taillow",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -3750,10 +3812,11 @@
   },
   {
     "id": "ex15-67",
-    "name": "Totodile δ",
+    "name": "Totodile",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -3809,10 +3872,11 @@
   },
   {
     "id": "ex15-68",
-    "name": "Trapinch δ",
+    "name": "Trapinch",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -3868,10 +3932,11 @@
   },
   {
     "id": "ex15-69",
-    "name": "Trapinch δ",
+    "name": "Trapinch",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -3917,10 +3982,11 @@
   },
   {
     "id": "ex15-70",
-    "name": "Vulpix δ",
+    "name": "Vulpix",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "50",
     "types": [
@@ -3976,10 +4042,11 @@
   },
   {
     "id": "ex15-71",
-    "name": "Wooper δ",
+    "name": "Wooper",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -4432,11 +4499,12 @@
   },
   {
     "id": "ex15-90",
-    "name": "Altaria ex δ",
+    "name": "Altaria ex",
     "supertype": "Pokémon",
     "subtypes": [
       "Stage 1",
-      "ex"
+      "ex",
+      "DELTA SPECIES"
     ],
     "hp": "100",
     "types": [
@@ -4502,11 +4570,12 @@
   },
   {
     "id": "ex15-91",
-    "name": "Dragonite ex δ",
+    "name": "Dragonite ex",
     "supertype": "Pokémon",
     "subtypes": [
       "Stage 2",
-      "ex"
+      "ex",
+      "DELTA SPECIES"
     ],
     "hp": "150",
     "types": [
@@ -4561,11 +4630,12 @@
   },
   {
     "id": "ex15-92",
-    "name": "Flygon ex δ",
+    "name": "Flygon ex",
     "supertype": "Pokémon",
     "subtypes": [
       "Stage 2",
-      "ex"
+      "ex",
+      "DELTA SPECIES"
     ],
     "hp": "150",
     "types": [
@@ -4616,11 +4686,12 @@
   },
   {
     "id": "ex15-93",
-    "name": "Gardevoir ex δ",
+    "name": "Gardevoir ex",
     "supertype": "Pokémon",
     "subtypes": [
       "Stage 2",
-      "ex"
+      "ex",
+      "DELTA SPECIES"
     ],
     "hp": "150",
     "types": [
@@ -4677,11 +4748,12 @@
   },
   {
     "id": "ex15-94",
-    "name": "Kingdra ex δ",
+    "name": "Kingdra ex",
     "supertype": "Pokémon",
     "subtypes": [
       "Stage 2",
-      "ex"
+      "ex",
+      "DELTA SPECIES"
     ],
     "hp": "140",
     "types": [
@@ -4747,11 +4819,12 @@
   },
   {
     "id": "ex15-95",
-    "name": "Latias ex δ",
+    "name": "Latias ex",
     "supertype": "Pokémon",
     "subtypes": [
       "Basic",
-      "ex"
+      "ex",
+      "DELTA SPECIES"
     ],
     "hp": "100",
     "types": [
@@ -4807,11 +4880,12 @@
   },
   {
     "id": "ex15-96",
-    "name": "Latios ex δ",
+    "name": "Latios ex",
     "supertype": "Pokémon",
     "subtypes": [
       "Basic",
-      "ex"
+      "ex",
+      "DELTA SPECIES"
     ],
     "hp": "100",
     "types": [
@@ -4877,11 +4951,12 @@
   },
   {
     "id": "ex15-97",
-    "name": "Rayquaza ex δ",
+    "name": "Rayquaza ex",
     "supertype": "Pokémon",
     "subtypes": [
       "Basic",
-      "ex"
+      "ex",
+      "DELTA SPECIES"
     ],
     "hp": "110",
     "types": [
@@ -4942,11 +5017,12 @@
   },
   {
     "id": "ex15-98",
-    "name": "Salamence ex δ",
+    "name": "Salamence ex",
     "supertype": "Pokémon",
     "subtypes": [
       "Stage 2",
-      "ex"
+      "ex",
+      "DELTA SPECIES"
     ],
     "hp": "160",
     "types": [
@@ -5025,11 +5101,12 @@
   },
   {
     "id": "ex15-99",
-    "name": "Tyranitar ex δ",
+    "name": "Tyranitar ex",
     "supertype": "Pokémon",
     "subtypes": [
       "Stage 2",
-      "ex"
+      "ex",
+      "DELTA SPECIES"
     ],
     "hp": "150",
     "types": [
@@ -5101,11 +5178,12 @@
   },
   {
     "id": "ex15-100",
-    "name": "Charizard ★ δ",
+    "name": "Charizard ★",
     "supertype": "Pokémon",
     "subtypes": [
       "Basic",
-      "Star"
+      "Star",
+      "DELTA SPECIES"
     ],
     "hp": "90",
     "types": [
@@ -5167,11 +5245,12 @@
   },
   {
     "id": "ex15-101",
-    "name": "Mew ★ δ",
+    "name": "Mew ★",
     "supertype": "Pokémon",
     "subtypes": [
       "Basic",
-      "Star"
+      "Star",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [

--- a/cards/en/np.json
+++ b/cards/en/np.json
@@ -1936,10 +1936,11 @@
   },
   {
     "id": "np-35",
-    "name": "Pikachu δ",
+    "name": "Pikachu",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [

--- a/cards/en/pop4.json
+++ b/cards/en/pop4.json
@@ -1,10 +1,11 @@
 [
   {
     "id": "pop4-1",
-    "name": "Chimecho δ",
+    "name": "Chimecho",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "60",
     "types": [
@@ -57,10 +58,11 @@
   },
   {
     "id": "pop4-2",
-    "name": "Deoxys δ",
+    "name": "Deoxys",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -700,10 +702,11 @@
   },
   {
     "id": "pop4-15",
-    "name": "Treecko δ",
+    "name": "Treecko",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [

--- a/cards/en/pop5.json
+++ b/cards/en/pop5.json
@@ -120,10 +120,11 @@
   },
   {
     "id": "pop5-3",
-    "name": "Mew δ",
+    "name": "Mew",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "60",
     "types": [
@@ -196,10 +197,11 @@
   },
   {
     "id": "pop5-5",
-    "name": "Charmeleon δ",
+    "name": "Charmeleon",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -346,10 +348,11 @@
   },
   {
     "id": "pop5-10",
-    "name": "Charmander δ",
+    "name": "Charmander",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "50",
     "types": [
@@ -405,10 +408,11 @@
   },
   {
     "id": "pop5-11",
-    "name": "Meowth δ",
+    "name": "Meowth",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -514,10 +518,11 @@
   },
   {
     "id": "pop5-13",
-    "name": "Pikachu δ",
+    "name": "Pikachu",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "40",
     "types": [
@@ -573,10 +578,11 @@
   },
   {
     "id": "pop5-14",
-    "name": "Pelipper δ",
+    "name": "Pelipper",
     "supertype": "Pokémon",
     "subtypes": [
-      "Stage 1"
+      "Stage 1",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [
@@ -631,10 +637,11 @@
   },
   {
     "id": "pop5-15",
-    "name": "Zangoose δ",
+    "name": "Zangoose",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [

--- a/cards/en/swshp.json
+++ b/cards/en/swshp.json
@@ -8473,10 +8473,11 @@
   },
   {
     "id": "swshp-SWSH136",
-    "name": "Mimikyu δ",
+    "name": "Mimikyu",
     "supertype": "Pokémon",
     "subtypes": [
-      "Basic"
+      "Basic",
+      "DELTA SPECIES"
     ],
     "hp": "70",
     "types": [


### PR DESCRIPTION
A few people on Discord (including myself) agreed that delta species Pokémon should not have a δ at the end of their name, but should have a subtype instead. This pr implements this. I chose `"DELTA SPECIES"` in all caps as the subtype, since it's how it's written on the cards, and I didn't include the δ in the subtype because I didn't want to introduce unnecessary special characters.