### PR TITLE
Add Numberless Energy set data

### DIFF
--- a/cards/en/bwe1.json
+++ b/cards/en/bwe1.json
@@ -1,0 +1,138 @@
+[
+  {
+    "id": "bwe1-1",
+    "name": "Grass Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/bwe1/1.png",
+      "large": "https://images.pokemontcg.io/bwe1/1_hires.png"
+    }
+  },
+  {
+    "id": "bwe1-2",
+    "name": "Fire Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/bwe1/2.png",
+      "large": "https://images.pokemontcg.io/bwe1/2_hires.png"
+    }
+  },
+  {
+    "id": "bwe1-3",
+    "name": "Water Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/bwe1/3.png",
+      "large": "https://images.pokemontcg.io/bwe1/3_hires.png"
+    }
+  },
+  {
+    "id": "bwe1-4",
+    "name": "Lightning Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/bwe1/4.png",
+      "large": "https://images.pokemontcg.io/bwe1/4_hires.png"
+    }
+  },
+  {
+    "id": "bwe1-5",
+    "name": "Psychic Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/bwe1/5.png",
+      "large": "https://images.pokemontcg.io/bwe1/5_hires.png"
+    }
+  },
+  {
+    "id": "bwe1-6",
+    "name": "Fighting Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/bwe1/6.png",
+      "large": "https://images.pokemontcg.io/bwe1/6_hires.png"
+    }
+  },
+  {
+    "id": "bwe1-7",
+    "name": "Darkness Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/bwe1/7.png",
+      "large": "https://images.pokemontcg.io/bwe1/7_hires.png"
+    }
+  },
+  {
+    "id": "bwe1-8",
+    "name": "Metal Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/bwe1/8.png",
+      "large": "https://images.pokemontcg.io/bwe1/8_hires.png"
+    }
+  }
+]

--- a/cards/en/dpe1.json
+++ b/cards/en/dpe1.json
@@ -1,0 +1,138 @@
+[
+  {
+    "id": "dpe1-1",
+    "name": "Grass Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/dpe1/1.png",
+      "large": "https://images.pokemontcg.io/dpe1/1_hires.png"
+    }
+  },
+  {
+    "id": "dpe1-2",
+    "name": "Fire Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/dpe1/2.png",
+      "large": "https://images.pokemontcg.io/dpe1/2_hires.png"
+    }
+  },
+  {
+    "id": "dpe1-3",
+    "name": "Water Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/dpe1/3.png",
+      "large": "https://images.pokemontcg.io/dpe1/3_hires.png"
+    }
+  },
+  {
+    "id": "dpe1-4",
+    "name": "Lightning Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/dpe1/4.png",
+      "large": "https://images.pokemontcg.io/dpe1/4_hires.png"
+    }
+  },
+  {
+    "id": "dpe1-5",
+    "name": "Psychic Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/dpe1/5.png",
+      "large": "https://images.pokemontcg.io/dpe1/5_hires.png"
+    }
+  },
+  {
+    "id": "dpe1-6",
+    "name": "Fighting Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/dpe1/6.png",
+      "large": "https://images.pokemontcg.io/dpe1/6_hires.png"
+    }
+  },
+  {
+    "id": "dpe1-7",
+    "name": "Darkness Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/dpe1/7.png",
+      "large": "https://images.pokemontcg.io/dpe1/7_hires.png"
+    }
+  },
+  {
+    "id": "dpe1-8",
+    "name": "Metal Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/dpe1/8.png",
+      "large": "https://images.pokemontcg.io/dpe1/8_hires.png"
+    }
+  }
+]

--- a/cards/en/exe1.json
+++ b/cards/en/exe1.json
@@ -1,0 +1,104 @@
+[
+  {
+    "id": "exe1-1",
+    "name": "Grass Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/exe1/1.png",
+      "large": "https://images.pokemontcg.io/exe1/1_hires.png"
+    }
+  },
+  {
+    "id": "exe1-2",
+    "name": "Fire Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/exe1/2.png",
+      "large": "https://images.pokemontcg.io/exe1/2_hires.png"
+    }
+  },
+  {
+    "id": "exe1-3",
+    "name": "Water Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/exe1/3.png",
+      "large": "https://images.pokemontcg.io/exe1/3_hires.png"
+    }
+  },
+  {
+    "id": "exe1-4",
+    "name": "Lightning Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/exe1/4.png",
+      "large": "https://images.pokemontcg.io/exe1/4_hires.png"
+    }
+  },
+  {
+    "id": "exe1-5",
+    "name": "Psychic Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/exe1/5.png",
+      "large": "https://images.pokemontcg.io/exe1/5_hires.png"
+    }
+  },
+  {
+    "id": "exe1-6",
+    "name": "Fighting Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/exe1/6.png",
+      "large": "https://images.pokemontcg.io/exe1/6_hires.png"
+    }
+  }
+]

--- a/cards/en/hgsse1.json
+++ b/cards/en/hgsse1.json
@@ -1,0 +1,138 @@
+[
+  {
+    "id": "hgsse1-1",
+    "name": "Grass Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/hgsse1/1.png",
+      "large": "https://images.pokemontcg.io/hgsse1/1_hires.png"
+    }
+  },
+  {
+    "id": "hgsse1-2",
+    "name": "Fire Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/hgsse1/2.png",
+      "large": "https://images.pokemontcg.io/hgsse1/2_hires.png"
+    }
+  },
+  {
+    "id": "hgsse1-3",
+    "name": "Water Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/hgsse1/3.png",
+      "large": "https://images.pokemontcg.io/hgsse1/3_hires.png"
+    }
+  },
+  {
+    "id": "hgsse1-4",
+    "name": "Lightning Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/hgsse1/4.png",
+      "large": "https://images.pokemontcg.io/hgsse1/4_hires.png"
+    }
+  },
+  {
+    "id": "hgsse1-5",
+    "name": "Psychic Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/hgsse1/5.png",
+      "large": "https://images.pokemontcg.io/hgsse1/5_hires.png"
+    }
+  },
+  {
+    "id": "hgsse1-6",
+    "name": "Fighting Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/hgsse1/6.png",
+      "large": "https://images.pokemontcg.io/hgsse1/6_hires.png"
+    }
+  },
+  {
+    "id": "hgsse1-7",
+    "name": "Darkness Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/hgsse1/7.png",
+      "large": "https://images.pokemontcg.io/hgsse1/7_hires.png"
+    }
+  },
+  {
+    "id": "hgsse1-8",
+    "name": "Metal Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/hgsse1/8.png",
+      "large": "https://images.pokemontcg.io/hgsse1/8_hires.png"
+    }
+  }
+]

--- a/cards/en/sme1.json
+++ b/cards/en/sme1.json
@@ -1,0 +1,306 @@
+[
+  {
+    "id": "sme1-1",
+    "name": "Grass Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/sme1/1.png",
+      "large": "https://images.pokemontcg.io/sme1/1_hires.png"
+    }
+  },
+  {
+    "id": "sme1-2",
+    "name": "Fire Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/sme1/2.png",
+      "large": "https://images.pokemontcg.io/sme1/2_hires.png"
+    }
+  },
+  {
+    "id": "sme1-3",
+    "name": "Water Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/sme1/3.png",
+      "large": "https://images.pokemontcg.io/sme1/3_hires.png"
+    }
+  },
+  {
+    "id": "sme1-4",
+    "name": "Lightning Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/sme1/4.png",
+      "large": "https://images.pokemontcg.io/sme1/4_hires.png"
+    }
+  },
+  {
+    "id": "sme1-5",
+    "name": "Psychic Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/sme1/5.png",
+      "large": "https://images.pokemontcg.io/sme1/5_hires.png"
+    }
+  },
+  {
+    "id": "sme1-6",
+    "name": "Fighting Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/sme1/6.png",
+      "large": "https://images.pokemontcg.io/sme1/6_hires.png"
+    }
+  },
+  {
+    "id": "sme1-7",
+    "name": "Darkness Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/sme1/7.png",
+      "large": "https://images.pokemontcg.io/sme1/7_hires.png"
+    }
+  },
+  {
+    "id": "sme1-8",
+    "name": "Metal Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/sme1/8.png",
+      "large": "https://images.pokemontcg.io/sme1/8_hires.png"
+    }
+  },
+  {
+    "id": "sme1-9",
+    "name": "Fairy Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/sme1/9.png",
+      "large": "https://images.pokemontcg.io/sme1/9_hires.png"
+    }
+  },
+  {
+    "id": "sme1-10",
+    "name": "Grass Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/sme1/10.png",
+      "large": "https://images.pokemontcg.io/sme1/10_hires.png"
+    }
+  },
+  {
+    "id": "sme1-11",
+    "name": "Fire Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/sme1/11.png",
+      "large": "https://images.pokemontcg.io/sme1/11_hires.png"
+    }
+  },
+  {
+    "id": "sme1-12",
+    "name": "Water Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/sme1/12.png",
+      "large": "https://images.pokemontcg.io/sme1/12_hires.png"
+    }
+  },
+  {
+    "id": "sme1-13",
+    "name": "Lightning Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/sme1/13.png",
+      "large": "https://images.pokemontcg.io/sme1/13_hires.png"
+    }
+  },
+  {
+    "id": "sme1-14",
+    "name": "Psychic Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/sme1/14.png",
+      "large": "https://images.pokemontcg.io/sme1/14_hires.png"
+    }
+  },
+  {
+    "id": "sme1-15",
+    "name": "Fighting Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/sme1/15.png",
+      "large": "https://images.pokemontcg.io/sme1/15_hires.png"
+    }
+  },
+  {
+    "id": "sme1-16",
+    "name": "Darkness Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/sme1/16.png",
+      "large": "https://images.pokemontcg.io/sme1/16_hires.png"
+    }
+  },
+  {
+    "id": "sme1-17",
+    "name": "Metal Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/sme1/17.png",
+      "large": "https://images.pokemontcg.io/sme1/17_hires.png"
+    }
+  },
+  {
+    "id": "sme1-18",
+    "name": "Fairy Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/sme1/18.png",
+      "large": "https://images.pokemontcg.io/sme1/18_hires.png"
+    }
+  }
+]

--- a/cards/en/swshe1.json
+++ b/cards/en/swshe1.json
@@ -1,0 +1,290 @@
+[
+  {
+    "id": "swshe1-1",
+    "name": "Grass Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/swshe1/1.png",
+      "large": "https://images.pokemontcg.io/swshe1/1_hires.png"
+    }
+  },
+  {
+    "id": "swshe1-2",
+    "name": "Fire Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/swshe1/2.png",
+      "large": "https://images.pokemontcg.io/swshe1/2_hires.png"
+    }
+  },
+  {
+    "id": "swshe1-3",
+    "name": "Water Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/swshe1/3.png",
+      "large": "https://images.pokemontcg.io/swshe1/3_hires.png"
+    }
+  },
+  {
+    "id": "swshe1-4",
+    "name": "Lightning Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/swshe1/4.png",
+      "large": "https://images.pokemontcg.io/swshe1/4_hires.png"
+    }
+  },
+  {
+    "id": "swshe1-5",
+    "name": "Psychic Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/swshe1/5.png",
+      "large": "https://images.pokemontcg.io/swshe1/5_hires.png"
+    }
+  },
+  {
+    "id": "swshe1-6",
+    "name": "Fighting Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/swshe1/6.png",
+      "large": "https://images.pokemontcg.io/swshe1/6_hires.png"
+    }
+  },
+  {
+    "id": "swshe1-7",
+    "name": "Darkness Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/swshe1/7.png",
+      "large": "https://images.pokemontcg.io/swshe1/7_hires.png"
+    }
+  },
+  {
+    "id": "swshe1-8",
+    "name": "Metal Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/swshe1/8.png",
+      "large": "https://images.pokemontcg.io/swshe1/8_hires.png"
+    }
+  },
+  {
+    "id": "swshe1-9",
+    "name": "Fairy Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/swshe1/9.png",
+      "large": "https://images.pokemontcg.io/swshe1/9_hires.png"
+    }
+  },
+  {
+    "id": "swshe1-10",
+    "name": "Grass Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/swshe1/10.png",
+      "large": "https://images.pokemontcg.io/swshe1/10_hires.png"
+    }
+  },
+  {
+    "id": "swshe1-11",
+    "name": "Fire Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/swshe1/11.png",
+      "large": "https://images.pokemontcg.io/swshe1/11_hires.png"
+    }
+  },
+  {
+    "id": "swshe1-12",
+    "name": "Water Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/swshe1/12.png",
+      "large": "https://images.pokemontcg.io/swshe1/12_hires.png"
+    }
+  },
+  {
+    "id": "swshe1-13",
+    "name": "Lightning Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/swshe1/13.png",
+      "large": "https://images.pokemontcg.io/swshe1/13_hires.png"
+    }
+  },
+  {
+    "id": "swshe1-14",
+    "name": "Psychic Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/swshe1/14.png",
+      "large": "https://images.pokemontcg.io/swshe1/14_hires.png"
+    }
+  },
+  {
+    "id": "swshe1-15",
+    "name": "Fighting Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/swshe1/15.png",
+      "large": "https://images.pokemontcg.io/swshe1/15_hires.png"
+    }
+  },
+  {
+    "id": "swshe1-16",
+    "name": "Darkness Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/swshe1/16.png",
+      "large": "https://images.pokemontcg.io/swshe1/16_hires.png"
+    }
+  },
+  {
+    "id": "swshe1-17",
+    "name": "Metal Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/swshe1/17.png",
+      "large": "https://images.pokemontcg.io/swshe1/17_hires.png"
+    }
+  }
+]

--- a/cards/en/xye1.json
+++ b/cards/en/xye1.json
@@ -1,0 +1,154 @@
+[
+  {
+    "id": "xye1-1",
+    "name": "Grass Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/xye1/1.png",
+      "large": "https://images.pokemontcg.io/xye1/1_hires.png"
+    }
+  },
+  {
+    "id": "xye1-2",
+    "name": "Fire Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/xye1/2.png",
+      "large": "https://images.pokemontcg.io/xye1/2_hires.png"
+    }
+  },
+  {
+    "id": "xye1-3",
+    "name": "Water Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/xye1/3.png",
+      "large": "https://images.pokemontcg.io/xye1/3_hires.png"
+    }
+  },
+  {
+    "id": "xye1-4",
+    "name": "Lightning Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/xye1/4.png",
+      "large": "https://images.pokemontcg.io/xye1/4_hires.png"
+    }
+  },
+  {
+    "id": "xye1-5",
+    "name": "Psychic Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/xye1/5.png",
+      "large": "https://images.pokemontcg.io/xye1/5_hires.png"
+    }
+  },
+  {
+    "id": "xye1-6",
+    "name": "Fighting Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/xye1/6.png",
+      "large": "https://images.pokemontcg.io/xye1/6_hires.png"
+    }
+  },
+  {
+    "id": "xye1-7",
+    "name": "Darkness Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/xye1/7.png",
+      "large": "https://images.pokemontcg.io/xye1/7_hires.png"
+    }
+  },
+  {
+    "id": "xye1-8",
+    "name": "Metal Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/xye1/8.png",
+      "large": "https://images.pokemontcg.io/xye1/8_hires.png"
+    }
+  },
+  {
+    "id": "xye1-9",
+    "name": "Fairy Energy",
+    "supertype": "Energy",
+    "subtypes": [
+      "Basic"
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/xye1/9.png",
+      "large": "https://images.pokemontcg.io/xye1/9_hires.png"
+    }
+  }
+]

--- a/sets/en.json
+++ b/sets/en.json
@@ -540,6 +540,17 @@
     }
   },
   {
+    "id": "exe1",
+    "name": "EX Numberless Energy",
+    "series": "EX",
+    "total": 6,
+    "legalities": {
+      "unlimited": "Legal"
+    },
+    "releaseDate": "2005/08/01",
+    "updatedAt": "2020/10/3 16:42:00"
+  },
+  {
     "id": "pop2",
     "name": "POP Series 2",
     "series": "POP",
@@ -753,6 +764,17 @@
       "symbol": "https://images.pokemontcg.io/dp1/symbol.png",
       "logo": "https://images.pokemontcg.io/dp1/logo.png"
     }
+  },
+  {
+    "id": "dpe1",
+    "name": "DP Numberless Energy",
+    "series": "Diamond & Pearl",
+    "total": 8,
+    "legalities": {
+      "unlimited": "Legal"
+    },
+    "releaseDate": "2007/08/01",
+    "updatedAt": "2020/10/3 16:42:00"
   },
   {
     "id": "dpp",
@@ -1158,6 +1180,18 @@
       "symbol": "https://images.pokemontcg.io/bw1/symbol.png",
       "logo": "https://images.pokemontcg.io/bw1/logo.png"
     }
+  },
+  {
+    "id": "bwe1",
+    "name": "BW Numberless Energy",
+    "series": "Black & White",
+    "total": 8,
+    "legalities": {
+      "unlimited": "Legal",
+      "expanded": "Legal"
+    },
+    "releaseDate": "2011/04/25",
+    "updatedAt": "2020/10/3 16:42:00",
   },
   {
     "id": "mcd11",
@@ -1749,6 +1783,19 @@
     }
   },
   {
+    "id": "sme1",
+    "name": "SM Numberless Energy",
+    "series": "Sun & Moon",
+    "total": 18,
+    "legalities": {
+      "unlimited": "Legal",
+      "expanded": "Legal"
+    },
+    "ptcgoCode": "SMEnergy",
+    "releaseDate": "2017/02/03",
+    "updatedAt": "2020/01/12 19:59:00",
+  },
+  {
     "id": "smp",
     "name": "SM Black Star Promos",
     "series": "Sun & Moon",
@@ -2140,6 +2187,19 @@
       "symbol": "https://images.pokemontcg.io/swsh1/symbol.png",
       "logo": "https://images.pokemontcg.io/swsh1/logo.png"
     }
+  },
+  {
+    "id": "swshe1",
+    "name": "SWSH Numberless Energy",
+    "series": "Sword & Shield",
+    "total": 17,
+    "legalities": {
+      "unlimited": "Legal",
+      "expanded": "Legal"
+    },
+    "ptcgoCode": "SWSHEnergy",
+    "releaseDate": "2020/02/07",
+    "updatedAt": "2020/01/12 19:59:00",
   },
   {
     "id": "swsh2",


### PR DESCRIPTION
Attempt 2 of #260 , with some changes to bring things in line with PTCGO decklist exports. 

Images exist in the old PR but need re-sorting, all numberless energy should be accounted for now.

Compared to the old PR this PR uses numbers for the energy, like PTCGO decklists do, and gives them codes which they had, or for older sets some in the same style as the ones that existed. Also like PTCGO, where 2 energy sets appeared in a gen they were merged into a single set with the second art counting after the first.