### PR TITLE
Fix missing natdex entries for four sv4pt5 cards

### DIFF
--- a/cards/en/sv4pt5.json
+++ b/cards/en/sv4pt5.json
@@ -1915,6 +1915,9 @@
     "artist": "HYOGONOSUKE",
     "rarity": "Common",
     "flavorText": "In an attempt to confuse its enemy, it mimics the enemy's movements. Then it wastes no time in making itself scarce!",
+    "nationalPokedexNumbers": [
+      439
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -3211,6 +3214,9 @@
     "number": "53",
     "artist": "kawayoo",
     "rarity": "Double Rare",
+    "nationalPokedexNumbers": [
+      984
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -4015,6 +4021,9 @@
     "number": "66",
     "artist": "toriyufu",
     "rarity": "Double Rare",
+    "nationalPokedexNumbers": [
+      990
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",
@@ -8904,6 +8913,9 @@
     "artist": "Saya Tsuruta",
     "rarity": "Shiny Rare",
     "flavorText": "In an attempt to confuse its enemy, it mimics the enemy's movements. Then it wastes no time in making itself scarce!",
+    "nationalPokedexNumbers": [
+      439
+    ],
     "legalities": {
       "unlimited": "Legal",
       "standard": "Legal",


### PR DESCRIPTION
sv4pt5-31, sv4pt5-53, sv4pt5-66, and sv4pt5-157 are all missing entries for nationalPokedexNumbers.