### PR TITLE
Add ptcgoCode for Hidden Fates Shiny Vault

### DIFF
--- a/sets/en.json
+++ b/sets/en.json
@@ -2062,6 +2062,7 @@
       "unlimited": "Legal",
       "expanded": "Legal"
     },
+    "ptcgoCode": "HIF",
     "releaseDate": "2019/08/23",
     "updatedAt": "2021/09/01 05:37:00",
     "images": {


### PR DESCRIPTION
I believe this change makes sense.

For reference: https://www.pokellector.com/Hidden-Fates-Expansion/

https://github.com/PokemonTCG/pokemon-tcg-data/blob/master/cards/en/sma.json