### PR TITLE
Fix ex9 deck 'Wildfire' Manectric rare ID incorrectly referencing rare holo

### DIFF
--- a/decks/en/ex9.json
+++ b/decks/en/ex9.json
@@ -2,10 +2,7 @@
   {
     "id": "d-ex9-1",
     "name": "Hydrobloom",
-    "types": [
-      "Water",
-      "Grass"
-    ],
+    "types": ["Water", "Grass"],
     "cards": [
       {
         "id": "ex9-50",
@@ -120,10 +117,7 @@
   {
     "id": "d-ex9-2",
     "name": "Wildfire",
-    "types": [
-      "Lightning",
-      "Fire"
-    ],
+    "types": ["Lightning", "Fire"],
     "cards": [
       {
         "id": "ex9-47",
@@ -138,7 +132,7 @@
         "count": 1
       },
       {
-        "id": "ex9-7",
+        "id": "ex9-16",
         "name": "Manectric",
         "rarity": "Rare",
         "count": 1

--- a/decks/en/ex9.json
+++ b/decks/en/ex9.json
@@ -2,7 +2,10 @@
   {
     "id": "d-ex9-1",
     "name": "Hydrobloom",
-    "types": ["Water", "Grass"],
+    "types": [
+      "Water",
+      "Grass"
+    ],
     "cards": [
       {
         "id": "ex9-50",
@@ -117,7 +120,10 @@
   {
     "id": "d-ex9-2",
     "name": "Wildfire",
-    "types": ["Lightning", "Fire"],
+    "types": [
+      "Lightning",
+      "Fire"
+    ],
     "cards": [
       {
         "id": "ex9-47",


### PR DESCRIPTION
Fix: `ex9` (Emerald) Wildflire decklist incorrectly references Holo `Manectric` `ex9-7` twice instead of one inclusion of `ex9-7` & `ex9-16` respectively.