### PR TITLE
Royal Guard - Life Herb missing correct ID

### DIFF
--- a/decks/en/hgss4.json
+++ b/decks/en/hgss4.json
@@ -276,7 +276,7 @@
         "count": 2
       },
       {
-        "id": "hgss2",
+        "id": "hgss2-79",
         "name": "Life Herb",
         "rarity": "Uncommon",
         "count": 2


### PR DESCRIPTION
`Life Herb` entry in `Royal Guard` deck is missing the correct id of `hgss2-79`.