### PR TITLE
Fixed typo in pl2-84

### DIFF
--- a/cards/en/pl2.json
+++ b/cards/en/pl2.json
@@ -5386,7 +5386,7 @@
     "abilities": [
       {
         "name": "Gather Sand",
-        "text": "Once during your turn (before your attack), if Trapinch is your Active Pokémon, you may search your discard pile for a basic Fighting card and attach it to Trapinch.",
+        "text": "Once during your turn (before your attack), if Trapinch is your Active Pokémon, you may search your discard pile for a basic Fighting Energy card and attach it to Trapinch.",
         "type": "Poké-Power"
       }
     ],


### PR DESCRIPTION
Its Poké-POWER said "basic Fighting card" instead of "basic Fighting Energy card"