### PR TITLE
Add sv6 to sets/en.json

### DIFF
--- a/sets/en.json
+++ b/sets/en.json
@@ -2795,5 +2795,24 @@
       "symbol": "https://images.pokemontcg.io/sv5/symbol.png",
       "logo": "https://images.pokemontcg.io/sv5/logo.png"
     }
+  },
+  {
+    "id": "sv6",
+    "name": "Twilight Masquerade",
+    "series": "Scarlet & Violet",
+    "printedTotal": 167,
+    "total": 226,
+    "legalities": {
+      "unlimited": "Legal",
+      "standard": "Legal",
+      "expanded": "Legal"
+    },
+    "ptcgoCode": "TWM",
+    "releaseDate": "2024/05/24",
+    "updatedAt": "2024/05/24 15:00:00",
+    "images": {
+      "symbol": "https://images.pokemontcg.io/sv6/symbol.png",
+      "logo": "https://images.pokemontcg.io/sv6/logo.png"
+    }
   }
 ]


### PR DESCRIPTION
I noticed that in 348e17d the sets/en.json file was not updated with the new set entry for Twilight Masquerade. This PR does such.