### PR TITLE
Add evolvesTo fields for fossils in sv3pt5

### DIFF
--- a/cards/en/sv3pt5.json
+++ b/cards/en/sv3pt5.json
@@ -9336,6 +9336,9 @@
       "Item"
     ],
     "hp": "60",
+    "evolvesTo": [
+      "Kabuto"
+    ],
     "rules": [
       "Play this card as if it were a 60-HP Basic Colorless Pokémon. This card can't be affected by any Special Conditions and can't retreat.  At any time during your turn, you may discard this card from play.",
       "You may play any number of Item cards during your turn."
@@ -9369,6 +9372,9 @@
       "Item"
     ],
     "hp": "60",
+    "evolvesTo": [
+      "Omanyte"
+    ],
     "rules": [
       "Play this card as if it were a 60-HP Basic Colorless Pokémon. This card can't be affected by any Special Conditions and can't retreat.  At any time during your turn, you may discard this card from play.",
       "You may play any number of Item cards during your turn."
@@ -9402,6 +9408,10 @@
       "Item"
     ],
     "hp": "60",
+    "evolvesTo": [
+      "Aerodactyl",
+      "Aerodactyl ex"
+    ],
     "rules": [
       "Play this card as if it were a 60-HP Basic Colorless Pokémon. This card can't be affected by any Special Conditions and can't retreat.  At any time during your turn, you may discard this card from play.",
       "You may play any number of Item cards during your turn."


### PR DESCRIPTION
Closes https://github.com/PokemonTCG/pokemon-tcg-data/issues/530. Adds `evolvesTo` fields for fossils:
- Antique Dome Fossil to Kabuto
- Antique Helix Fossil to Omanyte
- Antique Old Amber to Aerodactyl or Aerodactyl ex